### PR TITLE
Add channel content filtering module

### DIFF
--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -23,7 +23,7 @@ def run(args: argparse.Namespace) -> None:
                 if not channels:
                     print("No channels found.")
                     return
-                fmt = "{:<5} {:<15} {:<25} {:<12} {:<8} {:<10} {:<12}"
+                fmt = "{:<5} {:<15} {:<25} {:<12} {:<8} {:<10} {:<12} {:<20}"
                 header = (
                     "ID",
                     "Channel ID",
@@ -32,10 +32,15 @@ def run(args: argparse.Namespace) -> None:
                     "Active",
                     "Messages",
                     "Last msg ID",
+                    "Slop",
                 )
                 print(fmt.format(*header))
-                print("-" * 90)
+                print("-" * 110)
                 for ch in channels:
+                    if ch.is_filtered:
+                        slop = f"SLOP: {ch.filter_flags}" if ch.filter_flags else "SLOP"
+                    else:
+                        slop = "-"
                     print(
                         fmt.format(
                             ch.id or 0,
@@ -45,6 +50,7 @@ def run(args: argparse.Namespace) -> None:
                             "Yes" if ch.is_active else "No",
                             ch.message_count,
                             ch.last_collected_id,
+                            slop,
                         )
                     )
 

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -32,15 +32,15 @@ def run(args: argparse.Namespace) -> None:
                     "Active",
                     "Messages",
                     "Last msg ID",
-                    "Slop",
+                    "Filter",
                 )
                 print(fmt.format(*header))
                 print("-" * 110)
                 for ch in channels:
                     if ch.is_filtered:
-                        slop = f"SLOP: {ch.filter_flags}" if ch.filter_flags else "SLOP"
+                        filt = ch.filter_flags if ch.filter_flags else "Yes"
                     else:
-                        slop = "-"
+                        filt = "-"
                     print(
                         fmt.format(
                             ch.id or 0,
@@ -50,7 +50,7 @@ def run(args: argparse.Namespace) -> None:
                             "Yes" if ch.is_active else "No",
                             ch.message_count,
                             ch.last_collected_id,
-                            slop,
+                            filt,
                         )
                     )
 

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -203,6 +203,13 @@ def run(args: argparse.Namespace) -> None:
                 if not ch:
                     print(f"Channel '{args.identifier}' not found")
                     return
+                if ch.is_filtered:
+                    title = ch.title or ch.channel_id
+                    print(
+                        f"Channel '{title}' is filtered"
+                        " and excluded from collection"
+                    )
+                    return
                 task_id = await db.create_collection_task(ch.channel_id, ch.title)
                 await db.update_collection_task(task_id, "running")
                 collector = Collector(pool, db, config.scheduler)

--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -25,6 +25,11 @@ def run(args: argparse.Namespace) -> None:
                 if not channel:
                     print(f"Channel {args.channel_id} not found in DB")
                     return
+                if channel.is_filtered:
+                    print(
+                        f"Channel {args.channel_id} is filtered and excluded from collection"
+                    )
+                    return
                 count = await collector.collect_single_channel(channel, full=True)
                 print(f"Collected {count} messages from channel {args.channel_id}")
             else:

--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from src.cli import runtime
+from src.filters.analyzer import ChannelAnalyzer
+
+
+def run(args: argparse.Namespace) -> None:
+    async def _run() -> None:
+        _, db = await runtime.init_db(args.config)
+        try:
+            assert db.db is not None
+            analyzer = ChannelAnalyzer(db.db)
+
+            if args.filter_action == "analyze":
+                report = await analyzer.analyze_all()
+                if not report.results:
+                    print("No channels found.")
+                    return
+
+                fmt = "{:<6} {:<25} {:<10} {:<10} {:<10} {:<10} {:<10} {:<15}"
+                header = (
+                    "ChanID", "Title", "Uniq%", "SubRatio",
+                    "Cyr%", "Short%", "XDupe%", "Flags",
+                )
+                print(fmt.format(*header))
+                print("-" * 100)
+                for r in report.results:
+                    flags_str = ", ".join(r.flags) if r.flags else "-"
+                    print(
+                        fmt.format(
+                            r.channel_id,
+                            (r.title or "-")[:25],
+                            f"{r.uniqueness_pct:.1f}" if r.uniqueness_pct is not None else "-",
+                            f"{r.subscriber_ratio:.2f}" if r.subscriber_ratio is not None else "-",
+                            f"{r.cyrillic_pct:.1f}" if r.cyrillic_pct is not None else "-",
+                            f"{r.short_msg_pct:.1f}" if r.short_msg_pct is not None else "-",
+                            f"{r.cross_dupe_pct:.1f}" if r.cross_dupe_pct is not None else "-",
+                            flags_str[:15],
+                        )
+                    )
+
+                print(
+                    f"\nTotal: {report.total_channels}, "
+                    f"Filtered: {report.filtered_count}"
+                )
+
+            elif args.filter_action == "apply":
+                report = await analyzer.analyze_all()
+                count = await analyzer.apply_filters(report)
+                print(f"Applied filters: {count} channels marked as filtered.")
+
+            elif args.filter_action == "reset":
+                await analyzer.reset_filters()
+                print("All channel filters have been reset.")
+        finally:
+            await db.close()
+
+    asyncio.run(_run())

--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -13,6 +13,10 @@ def run(args: argparse.Namespace) -> None:
         try:
             analyzer = ChannelAnalyzer(db)
 
+            if not args.filter_action:
+                print("Usage: filter {analyze|apply|reset}")
+                return
+
             if args.filter_action == "analyze":
                 report = await analyzer.analyze_all()
                 if not report.results:

--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -11,8 +11,7 @@ def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         _, db = await runtime.init_db(args.config)
         try:
-            assert db.db is not None
-            analyzer = ChannelAnalyzer(db.db)
+            analyzer = ChannelAnalyzer(db)
 
             if args.filter_action == "analyze":
                 report = await analyzer.analyze_all()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,6 +5,7 @@ import sys
 from dotenv import load_dotenv
 
 from src.cli.commands import account, channel, collect, keyword, scheduler, search, serve
+from src.cli.commands import filter as filter_cmd
 from src.cli.parser import build_parser
 from src.cli.runtime import setup_logging
 
@@ -21,6 +22,7 @@ def main() -> None:
         "collect": collect.run,
         "search": search.run,
         "channel": channel.run,
+        "filter": filter_cmd.run,
         "keyword": keyword.run,
         "account": account.run,
         "scheduler": scheduler.run,
@@ -30,6 +32,7 @@ def main() -> None:
     if handler:
         sub_attr = {
             "channel": "channel_action",
+            "filter": "filter_action",
             "keyword": "keyword_action",
             "account": "account_action",
             "scheduler": "scheduler_action",

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -60,6 +60,12 @@ def build_parser() -> argparse.ArgumentParser:
     ch_import = ch_sub.add_parser("import", help="Bulk import from file or text")
     ch_import.add_argument("source", help="Path to .txt/.csv file, or comma-separated identifiers")
 
+    flt_parser = sub.add_parser("filter", help="Channel content filter")
+    flt_sub = flt_parser.add_subparsers(dest="filter_action")
+    flt_sub.add_parser("analyze", help="Analyze channels and show report")
+    flt_sub.add_parser("apply", help="Analyze and mark filtered channels")
+    flt_sub.add_parser("reset", help="Reset all channel filters")
+
     kw_parser = sub.add_parser("keyword", help="Keyword management")
     kw_sub = kw_parser.add_subparsers(dest="keyword_action")
     kw_sub.add_parser("list", help="List keywords")

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -51,6 +51,22 @@ class CollectionQueue:
                 self._queue.task_done()
                 continue
 
+            # Channel may become filtered after being queued.
+            fresh_channel = None
+            if channel.id is not None:
+                fresh_channel = await self._db.get_channel_by_pk(channel.id)
+            if fresh_channel is not None:
+                channel = fresh_channel
+            if channel.is_filtered:
+                await self._db.cancel_collection_task(task_id)
+                logger.info(
+                    "Task %d skipped: channel %d is filtered",
+                    task_id,
+                    channel.channel_id,
+                )
+                self._queue.task_done()
+                continue
+
             self._current_task_id = task_id
             try:
                 await self._db.update_collection_task(task_id, "running")

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -133,17 +133,21 @@ class Database:
         self._require()
         return await self._channels.add_channel(channel)
 
-    async def get_channels(self, active_only: bool = False) -> list[Channel]:
+    async def get_channels(
+        self, active_only: bool = False, include_filtered: bool = True
+    ) -> list[Channel]:
         self._require()
-        return await self._channels.get_channels(active_only)
+        return await self._channels.get_channels(active_only, include_filtered)
 
     async def get_channel_by_pk(self, pk: int) -> Channel | None:
         self._require()
         return await self._channels.get_channel_by_pk(pk)
 
-    async def get_channels_with_counts(self, active_only: bool = False) -> list[Channel]:
+    async def get_channels_with_counts(
+        self, active_only: bool = False, include_filtered: bool = True
+    ) -> list[Channel]:
         self._require()
-        return await self._channels.get_channels_with_counts(active_only)
+        return await self._channels.get_channels_with_counts(active_only, include_filtered)
 
     async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
         self._require()
@@ -152,6 +156,10 @@ class Database:
     async def set_channel_active(self, pk: int, active: bool) -> None:
         self._require()
         await self._channels.set_channel_active(pk, active)
+
+    async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
+        self._require()
+        await self._channels.set_channel_filtered(pk, filtered)
 
     async def delete_channel(self, pk: int) -> None:
         self._require()

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any
+
 import aiosqlite
 
 from src.database.connection import DBConnection
@@ -153,6 +156,10 @@ class Database:
         self._require()
         return await self._channels.get_channel_by_pk(pk)
 
+    async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
+        self._require()
+        return await self._channels.get_channel_by_channel_id(channel_id)
+
     async def get_channels_with_counts(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:
@@ -232,9 +239,23 @@ class Database:
         self._require()
         await self._keywords.delete_keyword(keyword_id)
 
-    async def create_collection_task(self, channel_id: int, channel_title: str | None) -> int:
+    async def create_collection_task(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        run_after: datetime | None = None,
+        payload: dict[str, Any] | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
         self._require()
-        return await self._tasks.create_collection_task(channel_id, channel_title)
+        return await self._tasks.create_collection_task(
+            channel_id,
+            channel_title,
+            run_after=run_after,
+            payload=payload,
+            parent_task_id=parent_task_id,
+        )
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
         self._require()
@@ -257,6 +278,32 @@ class Database:
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         self._require()
         return await self._tasks.get_collection_tasks(limit)
+
+    async def get_active_stats_task(self) -> CollectionTask | None:
+        self._require()
+        return await self._tasks.get_active_stats_task()
+
+    async def claim_next_due_stats_task(self, now: datetime) -> CollectionTask | None:
+        self._require()
+        return await self._tasks.claim_next_due_stats_task(now)
+
+    async def create_stats_continuation_task(
+        self,
+        *,
+        payload: dict[str, Any],
+        run_after: datetime | None,
+        parent_task_id: int,
+    ) -> int:
+        self._require()
+        return await self._tasks.create_stats_continuation_task(
+            payload=payload,
+            run_after=run_after,
+            parent_task_id=parent_task_id,
+        )
+
+    async def requeue_running_stats_tasks_on_startup(self, now: datetime) -> int:
+        self._require()
+        return await self._tasks.requeue_running_stats_tasks_on_startup(now)
 
     async def cancel_collection_task(self, task_id: int) -> bool:
         self._require()

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -161,6 +161,14 @@ class Database:
         self._require()
         await self._channels.set_channel_filtered(pk, filtered)
 
+    async def set_channels_filtered_bulk(self, updates: list[tuple[int, str]]) -> int:
+        self._require()
+        return await self._channels.set_filtered_bulk(updates)
+
+    async def reset_all_channel_filters(self) -> int:
+        self._require()
+        return await self._channels.reset_all_filters()
+
     async def delete_channel(self, pk: int) -> None:
         self._require()
         await self._channels.delete_channel(pk)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -8,6 +8,7 @@ from src.database.repositories.accounts import AccountsRepository
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.database.repositories.filters import FilterRepository
 from src.database.repositories.keywords import KeywordsRepository
 from src.database.repositories.messages import MessagesRepository
 from src.database.repositories.search_log import SearchLogRepository
@@ -35,6 +36,7 @@ class Database:
         self._search_log: SearchLogRepository | None = None
         self._channel_stats: ChannelStatsRepository | None = None
         self._settings: SettingsRepository | None = None
+        self._filters: FilterRepository | None = None
 
     async def _has_encrypted_sessions(self) -> bool:
         assert self._db is not None
@@ -73,6 +75,7 @@ class Database:
         self._search_log = SearchLogRepository(self._db)
         self._channel_stats = ChannelStatsRepository(self._db)
         self._settings = SettingsRepository(self._db)
+        self._filters = FilterRepository(self._db)
 
         await self._accounts.migrate_sessions()
 
@@ -89,6 +92,12 @@ class Database:
     def db(self) -> aiosqlite.Connection | None:
         return self._db
 
+    @property
+    def filter_repo(self) -> FilterRepository:
+        self._require()
+        assert self._filters is not None
+        return self._filters
+
     def _require(self) -> None:
         if any(
             repo is None
@@ -101,6 +110,7 @@ class Database:
                 self._search_log,
                 self._channel_stats,
                 self._settings,
+                self._filters,
             )
         ):
             raise RuntimeError("Database.initialize() has not been called")
@@ -161,13 +171,15 @@ class Database:
         self._require()
         await self._channels.set_channel_filtered(pk, filtered)
 
-    async def set_channels_filtered_bulk(self, updates: list[tuple[int, str]]) -> int:
+    async def set_channels_filtered_bulk(
+        self, updates: list[tuple[int, str]], *, commit: bool = True
+    ) -> int:
         self._require()
-        return await self._channels.set_filtered_bulk(updates)
+        return await self._channels.set_filtered_bulk(updates, commit=commit)
 
-    async def reset_all_channel_filters(self) -> int:
+    async def reset_all_channel_filters(self, *, commit: bool = True) -> int:
         self._require()
-        return await self._channels.reset_all_filters()
+        return await self._channels.reset_all_filters(commit=commit)
 
     async def delete_channel(self, pk: int) -> None:
         self._require()

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -25,6 +25,12 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
     if "channel_type" not in ch_columns:
         await db.execute("ALTER TABLE channels ADD COLUMN channel_type TEXT")
         await db.commit()
+    if "is_filtered" not in ch_columns:
+        await db.execute("ALTER TABLE channels ADD COLUMN is_filtered INTEGER DEFAULT 0")
+        await db.commit()
+    if "filter_flags" not in ch_columns:
+        await db.execute("ALTER TABLE channels ADD COLUMN filter_flags TEXT DEFAULT ''")
+        await db.commit()
 
     await db.execute(
         """
@@ -37,12 +43,6 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
         """
     )
     await db.commit()
-
-    cur = await db.execute("PRAGMA table_info(channels)")
-    ch_columns2 = {row["name"] for row in await cur.fetchall()}
-    if "is_filtered" not in ch_columns2:
-        await db.execute("ALTER TABLE channels ADD COLUMN is_filtered INTEGER DEFAULT 0")
-        await db.commit()
 
     cur = await db.execute("SELECT value FROM settings WHERE key = 'fts5_initialized'")
     if not await cur.fetchone():

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -32,6 +32,18 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
         await db.execute("ALTER TABLE channels ADD COLUMN filter_flags TEXT DEFAULT ''")
         await db.commit()
 
+    cur = await db.execute("PRAGMA table_info(collection_tasks)")
+    task_columns = {row["name"] for row in await cur.fetchall()}
+    if "run_after" not in task_columns:
+        await db.execute("ALTER TABLE collection_tasks ADD COLUMN run_after TEXT")
+        await db.commit()
+    if "payload" not in task_columns:
+        await db.execute("ALTER TABLE collection_tasks ADD COLUMN payload TEXT")
+        await db.commit()
+    if "parent_task_id" not in task_columns:
+        await db.execute("ALTER TABLE collection_tasks ADD COLUMN parent_task_id INTEGER")
+        await db.commit()
+
     await db.execute(
         """
         UPDATE channels SET last_collected_id = (

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -38,6 +38,12 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
     )
     await db.commit()
 
+    cur = await db.execute("PRAGMA table_info(channels)")
+    ch_columns2 = {row["name"] for row in await cur.fetchall()}
+    if "is_filtered" not in ch_columns2:
+        await db.execute("ALTER TABLE channels ADD COLUMN is_filtered INTEGER DEFAULT 0")
+        await db.commit()
+
     cur = await db.execute("SELECT value FROM settings WHERE key = 'fts5_initialized'")
     if not await cur.fetchone():
         try:

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -77,6 +77,16 @@ class ChannelsRepository:
             return None
         return self._map_channel(row)
 
+    async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
+        cur = await self._db.execute(
+            "SELECT * FROM channels WHERE channel_id = ?",
+            (channel_id,),
+        )
+        row = await cur.fetchone()
+        if not row:
+            return None
+        return self._map_channel(row)
+
     async def get_channels_with_counts(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -40,6 +40,11 @@ class ChannelsRepository:
             channel_type=row["channel_type"],
             is_active=bool(row["is_active"]),
             is_filtered=bool(row["is_filtered"]) if "is_filtered" in keys else False,
+            filter_flags=(
+                row["filter_flags"]
+                if "filter_flags" in keys and row["filter_flags"]
+                else ""
+            ),
             last_collected_id=row["last_collected_id"],
             added_at=datetime.fromisoformat(row["added_at"]) if row["added_at"] else None,
             message_count=(
@@ -108,10 +113,37 @@ class ChannelsRepository:
         await self._db.commit()
 
     async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
-        await self._db.execute(
-            "UPDATE channels SET is_filtered = ? WHERE id = ?", (int(filtered), pk)
+        if filtered:
+            await self._db.execute("UPDATE channels SET is_filtered = 1 WHERE id = ?", (pk,))
+        else:
+            await self._db.execute(
+                "UPDATE channels SET is_filtered = 0, filter_flags = '' WHERE id = ?",
+                (pk,),
+            )
+        await self._db.commit()
+
+    async def set_filtered_bulk(self, updates: list[tuple[int, str]]) -> int:
+        if not updates:
+            return 0
+        updated_rows = 0
+        for channel_id, flags_csv in updates:
+            cur = await self._db.execute(
+                "UPDATE channels SET is_filtered = 1, filter_flags = ? WHERE channel_id = ?",
+                (flags_csv, channel_id),
+            )
+            rowcount = cur.rowcount if cur.rowcount is not None else 0
+            if rowcount > 0:
+                updated_rows += rowcount
+        await self._db.commit()
+        return updated_rows
+
+    async def reset_all_filters(self) -> int:
+        cur = await self._db.execute(
+            "UPDATE channels SET is_filtered = 0, filter_flags = ''"
         )
         await self._db.commit()
+        rowcount = cur.rowcount if cur.rowcount is not None else 0
+        return rowcount if rowcount > 0 else 0
 
     async def delete_channel(self, pk: int) -> None:
         cur = await self._db.execute("SELECT channel_id FROM channels WHERE id = ?", (pk,))

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -122,7 +122,9 @@ class ChannelsRepository:
             )
         await self._db.commit()
 
-    async def set_filtered_bulk(self, updates: list[tuple[int, str]]) -> int:
+    async def set_filtered_bulk(
+        self, updates: list[tuple[int, str]], *, commit: bool = True
+    ) -> int:
         if not updates:
             return 0
         updated_rows = 0
@@ -134,14 +136,16 @@ class ChannelsRepository:
             rowcount = cur.rowcount if cur.rowcount is not None else 0
             if rowcount > 0:
                 updated_rows += rowcount
-        await self._db.commit()
+        if commit:
+            await self._db.commit()
         return updated_rows
 
-    async def reset_all_filters(self) -> int:
+    async def reset_all_filters(self, *, commit: bool = True) -> int:
         cur = await self._db.execute(
             "UPDATE channels SET is_filtered = 0, filter_flags = ''"
         )
-        await self._db.commit()
+        if commit:
+            await self._db.commit()
         rowcount = cur.rowcount if cur.rowcount is not None else 0
         return rowcount if rowcount > 0 else 0
 

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -39,6 +39,7 @@ class ChannelsRepository:
             username=row["username"],
             channel_type=row["channel_type"],
             is_active=bool(row["is_active"]),
+            is_filtered=bool(row["is_filtered"]) if "is_filtered" in keys else False,
             last_collected_id=row["last_collected_id"],
             added_at=datetime.fromisoformat(row["added_at"]) if row["added_at"] else None,
             message_count=(
@@ -48,10 +49,17 @@ class ChannelsRepository:
             ),
         )
 
-    async def get_channels(self, active_only: bool = False) -> list[Channel]:
-        sql = "SELECT * FROM channels"
+    async def get_channels(
+        self, active_only: bool = False, include_filtered: bool = True
+    ) -> list[Channel]:
+        conditions = []
         if active_only:
-            sql += " WHERE is_active = 1"
+            conditions.append("is_active = 1")
+        if not include_filtered:
+            conditions.append("is_filtered = 0")
+        sql = "SELECT * FROM channels"
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY id ASC"
         cur = await self._db.execute(sql)
         rows = await cur.fetchall()
@@ -64,7 +72,9 @@ class ChannelsRepository:
             return None
         return self._map_channel(row)
 
-    async def get_channels_with_counts(self, active_only: bool = False) -> list[Channel]:
+    async def get_channels_with_counts(
+        self, active_only: bool = False, include_filtered: bool = True
+    ) -> list[Channel]:
         sql = """
             SELECT c.*, COALESCE(cnt.total, 0) AS message_count
             FROM channels c
@@ -72,8 +82,13 @@ class ChannelsRepository:
                 SELECT channel_id, COUNT(*) AS total FROM messages GROUP BY channel_id
             ) cnt ON c.channel_id = cnt.channel_id
         """
+        conditions = []
         if active_only:
-            sql += " WHERE c.is_active = 1"
+            conditions.append("c.is_active = 1")
+        if not include_filtered:
+            conditions.append("c.is_filtered = 0")
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY c.id ASC"
         cur = await self._db.execute(sql)
         rows = await cur.fetchall()
@@ -89,6 +104,12 @@ class ChannelsRepository:
     async def set_channel_active(self, pk: int, active: bool) -> None:
         await self._db.execute(
             "UPDATE channels SET is_active = ? WHERE id = ?", (int(active), pk)
+        )
+        await self._db.commit()
+
+    async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
+        await self._db.execute(
+            "UPDATE channels SET is_filtered = ? WHERE id = ?", (int(filtered), pk)
         )
         await self._db.commit()
 

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -114,7 +114,10 @@ class ChannelsRepository:
 
     async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
         if filtered:
-            await self._db.execute("UPDATE channels SET is_filtered = 1 WHERE id = ?", (pk,))
+            await self._db.execute(
+                "UPDATE channels SET is_filtered = 1, filter_flags = 'manual' WHERE id = ?",
+                (pk,),
+            )
         else:
             await self._db.execute(
                 "UPDATE channels SET is_filtered = 0, filter_flags = '' WHERE id = ?",

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
+from typing import Any
 
 import aiosqlite
 
@@ -11,10 +13,55 @@ class CollectionTasksRepository:
     def __init__(self, db: aiosqlite.Connection):
         self._db = db
 
-    async def create_collection_task(self, channel_id: int, channel_title: str | None) -> int:
+    @staticmethod
+    def _parse_payload(raw: str | None) -> dict[str, Any] | None:
+        if not raw:
+            return None
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _to_task(row: aiosqlite.Row) -> CollectionTask:
+        return CollectionTask(
+            id=row["id"],
+            channel_id=row["channel_id"],
+            channel_title=row["channel_title"],
+            status=row["status"],
+            messages_collected=row["messages_collected"],
+            error=row["error"],
+            run_after=(datetime.fromisoformat(row["run_after"]) if row["run_after"] else None),
+            payload=CollectionTasksRepository._parse_payload(row["payload"]),
+            parent_task_id=row["parent_task_id"],
+            created_at=(datetime.fromisoformat(row["created_at"]) if row["created_at"] else None),
+            started_at=(datetime.fromisoformat(row["started_at"]) if row["started_at"] else None),
+            completed_at=(
+                datetime.fromisoformat(row["completed_at"])
+                if row["completed_at"]
+                else None
+            ),
+        )
+
+    async def create_collection_task(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        run_after: datetime | None = None,
+        payload: dict[str, Any] | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        run_after_iso = (
+            run_after.astimezone(timezone.utc).isoformat() if run_after else None
+        )
+        payload_json = json.dumps(payload) if payload is not None else None
         cur = await self._db.execute(
-            "INSERT INTO collection_tasks (channel_id, channel_title) VALUES (?, ?)",
-            (channel_id, channel_title),
+            "INSERT INTO collection_tasks "
+            "(channel_id, channel_title, run_after, payload, parent_task_id) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (channel_id, channel_title, run_after_iso, payload_json, parent_task_id),
         )
         await self._db.commit()
         return cur.lastrowid or 0
@@ -59,43 +106,94 @@ class CollectionTasksRepository:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks WHERE id = ?", (task_id,)
         )
-        r = await cur.fetchone()
-        if r is None:
+        row = await cur.fetchone()
+        if row is None:
             return None
-        return CollectionTask(
-            id=r["id"],
-            channel_id=r["channel_id"],
-            channel_title=r["channel_title"],
-            status=r["status"],
-            messages_collected=r["messages_collected"],
-            error=r["error"],
-            created_at=(datetime.fromisoformat(r["created_at"]) if r["created_at"] else None),
-            started_at=(datetime.fromisoformat(r["started_at"]) if r["started_at"] else None),
-            completed_at=(datetime.fromisoformat(r["completed_at"]) if r["completed_at"] else None),
-        )
+        return self._to_task(row)
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks ORDER BY id DESC LIMIT ?", (limit,)
         )
         rows = await cur.fetchall()
-        return [
-            CollectionTask(
-                id=r["id"],
-                channel_id=r["channel_id"],
-                channel_title=r["channel_title"],
-                status=r["status"],
-                messages_collected=r["messages_collected"],
-                error=r["error"],
-                created_at=(datetime.fromisoformat(r["created_at"]) if r["created_at"] else None),
-                started_at=(datetime.fromisoformat(r["started_at"]) if r["started_at"] else None),
-                completed_at=(
-                    datetime.fromisoformat(r["completed_at"])
-                    if r["completed_at"] else None
-                ),
+        return [self._to_task(r) for r in rows]
+
+    async def get_active_stats_task(self) -> CollectionTask | None:
+        cur = await self._db.execute(
+            "SELECT * FROM collection_tasks "
+            "WHERE channel_id = 0 AND status IN ('pending', 'running') "
+            "ORDER BY id ASC LIMIT 1"
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return self._to_task(row)
+
+    async def claim_next_due_stats_task(self, now: datetime) -> CollectionTask | None:
+        now_iso = now.astimezone(timezone.utc).isoformat()
+        selected_id: int | None = None
+        try:
+            await self._db.execute("BEGIN IMMEDIATE")
+            cur = await self._db.execute(
+                "SELECT id FROM collection_tasks "
+                "WHERE channel_id = 0 "
+                "AND status = 'pending' "
+                "AND (run_after IS NULL OR run_after <= ?) "
+                "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
+                (now_iso,),
             )
-            for r in rows
-        ]
+            row = await cur.fetchone()
+            if row is None:
+                await self._db.commit()
+                return None
+            selected_id = row["id"]
+            updated = await self._db.execute(
+                "UPDATE collection_tasks "
+                "SET status = 'running', started_at = ?, completed_at = NULL "
+                "WHERE id = ? AND status = 'pending'",
+                (now_iso, selected_id),
+            )
+            if (updated.rowcount or 0) == 0:
+                await self._db.commit()
+                return None
+            cur = await self._db.execute(
+                "SELECT * FROM collection_tasks WHERE id = ?",
+                (selected_id,),
+            )
+            claimed = await cur.fetchone()
+            await self._db.commit()
+            if claimed is None:
+                return None
+            return self._to_task(claimed)
+        except Exception:
+            await self._db.rollback()
+            raise
+
+    async def create_stats_continuation_task(
+        self,
+        *,
+        payload: dict[str, Any],
+        run_after: datetime | None,
+        parent_task_id: int,
+    ) -> int:
+        return await self.create_collection_task(
+            0,
+            "Обновление статистики",
+            run_after=run_after,
+            payload=payload,
+            parent_task_id=parent_task_id,
+        )
+
+    async def requeue_running_stats_tasks_on_startup(self, now: datetime) -> int:
+        now_iso = now.astimezone(timezone.utc).isoformat()
+        cur = await self._db.execute(
+            "UPDATE collection_tasks "
+            "SET status = 'pending', started_at = NULL, run_after = COALESCE(run_after, ?) "
+            "WHERE channel_id = 0 AND status = 'running'",
+            (now_iso,),
+        )
+        await self._db.commit()
+        return cur.rowcount or 0
 
     async def cancel_collection_task(self, task_id: int) -> bool:
         now = datetime.now(tz=timezone.utc).isoformat()

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -4,6 +4,8 @@ import re
 
 import aiosqlite
 
+# Intentionally duplicated from src/filters/criteria.py — UDF layer must not
+# depend on the filters package to keep DB initialisation self-contained.
 _CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
 
 

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import re
+
+import aiosqlite
+
+_CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
+
+
+def _has_cyrillic_udf(text: str | None) -> int:
+    if not text:
+        return 0
+    return 1 if _CYRILLIC_RE.search(text) else 0
+
+
+class FilterRepository:
+    def __init__(self, db: aiosqlite.Connection):
+        self._db = db
+        self._udf_registered = False
+
+    async def _ensure_udf(self) -> None:
+        if not self._udf_registered:
+            await self._db.create_function(
+                "has_cyrillic", 1, _has_cyrillic_udf, deterministic=True
+            )
+            self._udf_registered = True
+
+    async def fetch_channels_for_analysis(
+        self, channel_id: int | None = None
+    ) -> list[aiosqlite.Row]:
+        sql = """
+            SELECT
+                c.channel_id,
+                c.title,
+                c.username,
+                c.channel_type,
+                COALESCE(cnt.total, 0) AS message_count
+            FROM channels c
+            LEFT JOIN (
+                SELECT channel_id, COUNT(*) AS total
+                FROM messages
+                GROUP BY channel_id
+            ) cnt ON c.channel_id = cnt.channel_id
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " WHERE c.channel_id = ?"
+            params = (channel_id,)
+        sql += " ORDER BY c.id ASC"
+        cur = await self._db.execute(sql, params)
+        return await cur.fetchall()
+
+    async def fetch_uniqueness_map(
+        self, channel_id: int | None = None
+    ) -> dict[int, tuple[int, int]]:
+        sql = """
+            SELECT
+                channel_id,
+                COUNT(*) AS total,
+                COUNT(DISTINCT substr(text, 1, 100)) AS uniq
+            FROM messages
+            WHERE text IS NOT NULL AND text != ''
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " AND channel_id = ?"
+            params = (channel_id,)
+        sql += " GROUP BY channel_id"
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["total"], row["uniq"]) for row in rows}
+
+    async def fetch_subscriber_map(
+        self, channel_id: int | None = None
+    ) -> dict[int, int]:
+        sql = """
+            SELECT channel_id, subscriber_count
+            FROM (
+                SELECT
+                    channel_id,
+                    subscriber_count,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY channel_id
+                        ORDER BY collected_at DESC, id DESC
+                    ) AS rn
+                FROM channel_stats
+                WHERE subscriber_count IS NOT NULL
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " AND channel_id = ?"
+            params = (channel_id,)
+        sql += """
+            )
+            WHERE rn = 1
+        """
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        return {row["channel_id"]: row["subscriber_count"] for row in rows}
+
+    async def fetch_short_message_map(
+        self, channel_id: int | None = None
+    ) -> dict[int, tuple[int, int]]:
+        sql = """
+            SELECT
+                channel_id,
+                COUNT(*) AS total,
+                SUM(CASE WHEN text IS NOT NULL AND length(text) <= 10
+                    THEN 1 ELSE 0 END) AS short
+            FROM messages
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " WHERE channel_id = ?"
+            params = (channel_id,)
+        sql += " GROUP BY channel_id"
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["total"], row["short"] or 0) for row in rows}
+
+    async def fetch_cross_dupe_map(
+        self, channel_id: int | None = None
+    ) -> dict[int, tuple[int, int]]:
+        sql = """
+            WITH channel_prefixes AS (
+                SELECT channel_id, substr(text, 1, 100) AS prefix
+                FROM messages
+                WHERE text IS NOT NULL AND length(text) > 10
+                GROUP BY channel_id, prefix
+            ),
+            prefix_channel_counts AS (
+                SELECT prefix, COUNT(*) AS channel_count
+                FROM channel_prefixes
+                GROUP BY prefix
+            )
+            SELECT
+                cp.channel_id,
+                COUNT(*) AS uniq_total,
+                SUM(CASE WHEN pcc.channel_count > 1 THEN 1 ELSE 0 END) AS duped
+            FROM channel_prefixes cp
+            JOIN prefix_channel_counts pcc ON pcc.prefix = cp.prefix
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " WHERE cp.channel_id = ?"
+            params = (channel_id,)
+        sql += " GROUP BY cp.channel_id"
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["uniq_total"], row["duped"] or 0) for row in rows}
+
+    async def fetch_cyrillic_map(
+        self, channel_id: int | None = None
+    ) -> dict[int, tuple[int, int]]:
+        await self._ensure_udf()
+        sql = """
+            SELECT
+                channel_id,
+                COUNT(*) AS total,
+                SUM(has_cyrillic(text)) AS cyr
+            FROM messages
+            WHERE text IS NOT NULL AND text != ''
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " AND channel_id = ?"
+            params = (channel_id,)
+        sql += " GROUP BY channel_id"
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["total"], row["cyr"] or 0) for row in rows}

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -51,6 +51,9 @@ CREATE TABLE IF NOT EXISTS collection_tasks (
     status TEXT DEFAULT 'pending',
     messages_collected INTEGER DEFAULT 0,
     error TEXT,
+    run_after TEXT,
+    payload TEXT,
+    parent_task_id INTEGER,
     created_at TEXT DEFAULT (datetime('now')),
     started_at TEXT,
     completed_at TEXT

--- a/src/filters/__init__.py
+++ b/src/filters/__init__.py
@@ -1,0 +1,4 @@
+from src.filters.analyzer import ChannelAnalyzer
+from src.filters.models import ChannelFilterResult, FilterReport
+
+__all__ = ["ChannelAnalyzer", "ChannelFilterResult", "FilterReport"]

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -4,101 +4,265 @@ import logging
 
 import aiosqlite
 
-from src.filters.criteria import (
-    check_chat_noise,
-    check_cross_channel_dupes,
-    check_low_uniqueness,
-    check_non_cyrillic,
-    check_subscriber_ratio,
-)
+from src.database import Database
+from src.filters.criteria import contains_cyrillic
 from src.filters.models import ChannelFilterResult, FilterReport
 
 logger = logging.getLogger(__name__)
 
 
+LOW_UNIQUENESS_THRESHOLD = 30.0
+LOW_SUBSCRIBER_RATIO_THRESHOLD = 1.0
+CROSS_DUPE_THRESHOLD = 50.0
+NON_CYRILLIC_THRESHOLD = 10.0
+CHAT_NOISE_THRESHOLD = 70.0
+
+
 class ChannelAnalyzer:
-    def __init__(self, db: aiosqlite.Connection):
-        self._db = db
+    def __init__(self, db: Database):
+        assert db.db is not None
+        self._database = db
+        self._db = db.db
 
-    async def analyze_channel(self, channel_id: int) -> ChannelFilterResult:
+    async def _fetch_channels_for_analysis(
+        self, channel_id: int | None = None
+    ) -> list[aiosqlite.Row]:
+        sql = """
+            SELECT
+                c.channel_id,
+                c.title,
+                c.username,
+                c.channel_type,
+                COALESCE(cnt.total, 0) AS message_count
+            FROM channels c
+            LEFT JOIN (
+                SELECT channel_id, COUNT(*) AS total
+                FROM messages
+                GROUP BY channel_id
+            ) cnt ON c.channel_id = cnt.channel_id
+        """
+        params: tuple = ()
+        if channel_id is not None:
+            sql += " WHERE c.channel_id = ?"
+            params = (channel_id,)
+        sql += " ORDER BY c.id ASC"
+        cur = await self._db.execute(sql, params)
+        return await cur.fetchall()
+
+    async def _fetch_uniqueness_map(self) -> dict[int, tuple[int, int]]:
         cur = await self._db.execute(
-            "SELECT channel_id, title, username FROM channels WHERE channel_id = ?",
-            (channel_id,),
+            """
+            SELECT
+                channel_id,
+                COUNT(*) AS total,
+                COUNT(DISTINCT substr(text, 1, 100)) AS uniq
+            FROM messages
+            WHERE text IS NOT NULL AND text != ''
+            GROUP BY channel_id
+            """
         )
-        ch_row = await cur.fetchone()
-        title = ch_row["title"] if ch_row else None
-        username = ch_row["username"] if ch_row else None
-
-        cur = await self._db.execute(
-            "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id = ?",
-            (channel_id,),
-        )
-        msg_count = (await cur.fetchone())["cnt"]
-
-        flags: list[str] = []
-
-        uniqueness_pct, low_uniq = await check_low_uniqueness(self._db, channel_id)
-        if low_uniq:
-            flags.append("low_uniqueness")
-
-        sub_ratio, low_sub = await check_subscriber_ratio(self._db, channel_id)
-        if low_sub:
-            flags.append("low_subscriber_ratio")
-
-        cross_pct, cross_dup = await check_cross_channel_dupes(self._db, channel_id)
-        if cross_dup:
-            flags.append("cross_channel_spam")
-
-        cyr_pct, non_cyr = await check_non_cyrillic(self._db, channel_id)
-        if non_cyr:
-            flags.append("non_cyrillic")
-
-        short_pct, noisy = await check_chat_noise(self._db, channel_id)
-        if noisy:
-            flags.append("chat_noise")
-
-        return ChannelFilterResult(
-            channel_id=channel_id,
-            title=title,
-            username=username,
-            message_count=msg_count,
-            flags=flags,
-            uniqueness_pct=uniqueness_pct,
-            subscriber_ratio=sub_ratio,
-            cyrillic_pct=cyr_pct,
-            short_msg_pct=short_pct,
-            cross_dupe_pct=cross_pct,
-            is_filtered=len(flags) > 0,
-        )
-
-    async def analyze_all(self) -> FilterReport:
-        cur = await self._db.execute("SELECT channel_id FROM channels ORDER BY id")
         rows = await cur.fetchall()
+        return {row["channel_id"]: (row["total"], row["uniq"]) for row in rows}
+
+    async def _fetch_latest_subscriber_map(self) -> dict[int, int]:
+        cur = await self._db.execute(
+            """
+            SELECT channel_id, subscriber_count
+            FROM (
+                SELECT
+                    channel_id,
+                    subscriber_count,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY channel_id
+                        ORDER BY collected_at DESC, id DESC
+                    ) AS rn
+                FROM channel_stats
+                WHERE subscriber_count IS NOT NULL
+            )
+            WHERE rn = 1
+            """
+        )
+        rows = await cur.fetchall()
+        return {row["channel_id"]: row["subscriber_count"] for row in rows}
+
+    async def _fetch_short_message_map(self) -> dict[int, tuple[int, int]]:
+        cur = await self._db.execute(
+            """
+            SELECT
+                channel_id,
+                COUNT(*) AS total,
+                SUM(CASE WHEN length(COALESCE(text, '')) <= 10 THEN 1 ELSE 0 END) AS short
+            FROM messages
+            GROUP BY channel_id
+            """
+        )
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["total"], row["short"] or 0) for row in rows}
+
+    async def _fetch_cross_dupe_map(self) -> dict[int, tuple[int, int]]:
+        cur = await self._db.execute(
+            """
+            WITH channel_prefixes AS (
+                SELECT channel_id, substr(text, 1, 100) AS prefix
+                FROM messages
+                WHERE text IS NOT NULL AND length(text) > 10
+                GROUP BY channel_id, prefix
+            ),
+            prefix_channel_counts AS (
+                SELECT prefix, COUNT(*) AS channel_count
+                FROM channel_prefixes
+                GROUP BY prefix
+            )
+            SELECT
+                cp.channel_id,
+                COUNT(*) AS uniq_total,
+                SUM(CASE WHEN pcc.channel_count > 1 THEN 1 ELSE 0 END) AS duped
+            FROM channel_prefixes cp
+            JOIN prefix_channel_counts pcc ON pcc.prefix = cp.prefix
+            GROUP BY cp.channel_id
+            """
+        )
+        rows = await cur.fetchall()
+        return {row["channel_id"]: (row["uniq_total"], row["duped"] or 0) for row in rows}
+
+    async def _fetch_cyrillic_map(self) -> dict[int, tuple[int, int]]:
+        cur = await self._db.execute(
+            """
+            SELECT channel_id, text
+            FROM messages
+            WHERE text IS NOT NULL AND text != ''
+            """
+        )
+        totals: dict[int, int] = {}
+        cyrillic_totals: dict[int, int] = {}
+        while True:
+            rows = await cur.fetchmany(1000)
+            if not rows:
+                break
+            for row in rows:
+                channel_id = row["channel_id"]
+                text = row["text"]
+                if not text:
+                    continue
+                totals[channel_id] = totals.get(channel_id, 0) + 1
+                if contains_cyrillic(text):
+                    cyrillic_totals[channel_id] = cyrillic_totals.get(channel_id, 0) + 1
+        return {
+            channel_id: (total, cyrillic_totals.get(channel_id, 0))
+            for channel_id, total in totals.items()
+        }
+
+    async def _build_report(self, channel_id: int | None = None) -> FilterReport:
+        channels = await self._fetch_channels_for_analysis(channel_id)
+        if not channels:
+            return FilterReport()
+
+        uniqueness_map = await self._fetch_uniqueness_map()
+        subscriber_map = await self._fetch_latest_subscriber_map()
+        short_map = await self._fetch_short_message_map()
+        cross_dupe_map = await self._fetch_cross_dupe_map()
+        cyrillic_map = await self._fetch_cyrillic_map()
 
         results: list[ChannelFilterResult] = []
-        for row in rows:
-            result = await self.analyze_channel(row["channel_id"])
-            results.append(result)
+        for channel in channels:
+            channel_id_value = channel["channel_id"]
+            message_count = int(channel["message_count"] or 0)
+            flags: list[str] = []
 
-        filtered_count = sum(1 for r in results if r.is_filtered)
+            uniqueness_pct: float | None = None
+            low_uniqueness = False
+            if channel_id_value in uniqueness_map:
+                total, uniq = uniqueness_map[channel_id_value]
+                raw_uniqueness = uniq / total * 100
+                uniqueness_pct = round(raw_uniqueness, 1)
+                low_uniqueness = raw_uniqueness < LOW_UNIQUENESS_THRESHOLD
+            if low_uniqueness:
+                flags.append("low_uniqueness")
+
+            subscriber_ratio: float | None = None
+            low_subscriber = False
+            subscriber_count = subscriber_map.get(channel_id_value)
+            if subscriber_count is not None and message_count > 0:
+                raw_ratio = subscriber_count / message_count
+                subscriber_ratio = round(raw_ratio, 2)
+                low_subscriber = raw_ratio < LOW_SUBSCRIBER_RATIO_THRESHOLD
+            if low_subscriber:
+                flags.append("low_subscriber_ratio")
+
+            cross_dupe_pct: float | None = None
+            cross_dupe = False
+            if channel_id_value in cross_dupe_map:
+                uniq_total, duped = cross_dupe_map[channel_id_value]
+                if uniq_total > 0:
+                    raw_cross_pct = duped / uniq_total * 100
+                    cross_dupe_pct = round(raw_cross_pct, 1)
+                    cross_dupe = raw_cross_pct > CROSS_DUPE_THRESHOLD
+            if cross_dupe:
+                flags.append("cross_channel_spam")
+
+            cyrillic_pct: float | None = None
+            non_cyrillic = False
+            if channel_id_value in cyrillic_map:
+                cyr_total, cyr_count = cyrillic_map[channel_id_value]
+                if cyr_total > 0:
+                    raw_cyr_pct = cyr_count / cyr_total * 100
+                    cyrillic_pct = round(raw_cyr_pct, 1)
+                    non_cyrillic = raw_cyr_pct < NON_CYRILLIC_THRESHOLD
+            if non_cyrillic:
+                flags.append("non_cyrillic")
+
+            short_msg_pct: float | None = None
+            noisy_chat = False
+            if channel["channel_type"] == "group" and channel_id_value in short_map:
+                short_total, short_count = short_map[channel_id_value]
+                if short_total > 0:
+                    raw_short_pct = short_count / short_total * 100
+                    short_msg_pct = round(raw_short_pct, 1)
+                    noisy_chat = raw_short_pct > CHAT_NOISE_THRESHOLD
+            if noisy_chat:
+                flags.append("chat_noise")
+
+            results.append(
+                ChannelFilterResult(
+                    channel_id=channel_id_value,
+                    title=channel["title"],
+                    username=channel["username"],
+                    message_count=message_count,
+                    flags=flags,
+                    uniqueness_pct=uniqueness_pct,
+                    subscriber_ratio=subscriber_ratio,
+                    cyrillic_pct=cyrillic_pct,
+                    short_msg_pct=short_msg_pct,
+                    cross_dupe_pct=cross_dupe_pct,
+                    is_filtered=bool(flags),
+                )
+            )
+
+        filtered_count = sum(1 for result in results if result.is_filtered)
         return FilterReport(
             results=results,
             total_channels=len(results),
             filtered_count=filtered_count,
         )
 
+    async def analyze_channel(self, channel_id: int) -> ChannelFilterResult:
+        report = await self._build_report(channel_id=channel_id)
+        if report.results:
+            return report.results[0]
+        return ChannelFilterResult(channel_id=channel_id)
+
+    async def analyze_all(self) -> FilterReport:
+        return await self._build_report()
+
     async def apply_filters(self, report: FilterReport) -> int:
-        count = 0
-        for result in report.results:
-            if result.is_filtered:
-                await self._db.execute(
-                    "UPDATE channels SET is_filtered = 1 WHERE channel_id = ?",
-                    (result.channel_id,),
-                )
-                count += 1
-        await self._db.commit()
-        return count
+        updates = [
+            (result.channel_id, ",".join(result.flags))
+            for result in report.results
+            if result.is_filtered
+        ]
+        if not updates:
+            return 0
+        return await self._database.set_channels_filtered_bulk(updates)
 
     async def reset_filters(self) -> None:
-        await self._db.execute("UPDATE channels SET is_filtered = 0")
-        await self._db.commit()
+        await self._database.reset_all_channel_filters()

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -125,16 +125,16 @@ class ChannelAnalyzer:
         return await self._build_report()
 
     async def apply_filters(self, report: FilterReport) -> int:
-        # Dedupe by channel_id (last value wins) to avoid double updates/count inflation.
-        deduped: dict[int, str] = {}
+        # Dedupe by channel_id (merge flags via set union) to avoid double updates/count inflation.
+        deduped: dict[int, set[str]] = {}
         for result in report.results:
             if result.is_filtered:
-                deduped[result.channel_id] = ",".join(result.flags)
-        updates = list(deduped.items())
-
+                existing = deduped.get(result.channel_id, set())
+                existing.update(result.flags)
+                deduped[result.channel_id] = existing
+        updates = [(cid, ",".join(sorted(flags))) for cid, flags in deduped.items()]
         conn = self._database.db
         assert conn is not None
-        await conn.execute("BEGIN")
         try:
             await self._database.reset_all_channel_filters(commit=False)
             count = 0

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -2,166 +2,36 @@ from __future__ import annotations
 
 import logging
 
-import aiosqlite
-
 from src.database import Database
-from src.filters.criteria import contains_cyrillic
+from src.filters.criteria import (
+    CHAT_NOISE_THRESHOLD,
+    CROSS_DUPE_THRESHOLD,
+    LOW_SUBSCRIBER_RATIO_THRESHOLD,
+    LOW_UNIQUENESS_THRESHOLD,
+    NON_CYRILLIC_THRESHOLD,
+)
 from src.filters.models import ChannelFilterResult, FilterReport
 
 logger = logging.getLogger(__name__)
 
 
-LOW_UNIQUENESS_THRESHOLD = 30.0
-LOW_SUBSCRIBER_RATIO_THRESHOLD = 1.0
-CROSS_DUPE_THRESHOLD = 50.0
-NON_CYRILLIC_THRESHOLD = 10.0
-CHAT_NOISE_THRESHOLD = 70.0
-
-
 class ChannelAnalyzer:
     def __init__(self, db: Database):
-        assert db.db is not None
+        if db.db is None:
+            raise RuntimeError("Database not initialized")
         self._database = db
-        self._db = db.db
-
-    async def _fetch_channels_for_analysis(
-        self, channel_id: int | None = None
-    ) -> list[aiosqlite.Row]:
-        sql = """
-            SELECT
-                c.channel_id,
-                c.title,
-                c.username,
-                c.channel_type,
-                COALESCE(cnt.total, 0) AS message_count
-            FROM channels c
-            LEFT JOIN (
-                SELECT channel_id, COUNT(*) AS total
-                FROM messages
-                GROUP BY channel_id
-            ) cnt ON c.channel_id = cnt.channel_id
-        """
-        params: tuple = ()
-        if channel_id is not None:
-            sql += " WHERE c.channel_id = ?"
-            params = (channel_id,)
-        sql += " ORDER BY c.id ASC"
-        cur = await self._db.execute(sql, params)
-        return await cur.fetchall()
-
-    async def _fetch_uniqueness_map(self) -> dict[int, tuple[int, int]]:
-        cur = await self._db.execute(
-            """
-            SELECT
-                channel_id,
-                COUNT(*) AS total,
-                COUNT(DISTINCT substr(text, 1, 100)) AS uniq
-            FROM messages
-            WHERE text IS NOT NULL AND text != ''
-            GROUP BY channel_id
-            """
-        )
-        rows = await cur.fetchall()
-        return {row["channel_id"]: (row["total"], row["uniq"]) for row in rows}
-
-    async def _fetch_latest_subscriber_map(self) -> dict[int, int]:
-        cur = await self._db.execute(
-            """
-            SELECT channel_id, subscriber_count
-            FROM (
-                SELECT
-                    channel_id,
-                    subscriber_count,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY channel_id
-                        ORDER BY collected_at DESC, id DESC
-                    ) AS rn
-                FROM channel_stats
-                WHERE subscriber_count IS NOT NULL
-            )
-            WHERE rn = 1
-            """
-        )
-        rows = await cur.fetchall()
-        return {row["channel_id"]: row["subscriber_count"] for row in rows}
-
-    async def _fetch_short_message_map(self) -> dict[int, tuple[int, int]]:
-        cur = await self._db.execute(
-            """
-            SELECT
-                channel_id,
-                COUNT(*) AS total,
-                SUM(CASE WHEN length(COALESCE(text, '')) <= 10 THEN 1 ELSE 0 END) AS short
-            FROM messages
-            GROUP BY channel_id
-            """
-        )
-        rows = await cur.fetchall()
-        return {row["channel_id"]: (row["total"], row["short"] or 0) for row in rows}
-
-    async def _fetch_cross_dupe_map(self) -> dict[int, tuple[int, int]]:
-        cur = await self._db.execute(
-            """
-            WITH channel_prefixes AS (
-                SELECT channel_id, substr(text, 1, 100) AS prefix
-                FROM messages
-                WHERE text IS NOT NULL AND length(text) > 10
-                GROUP BY channel_id, prefix
-            ),
-            prefix_channel_counts AS (
-                SELECT prefix, COUNT(*) AS channel_count
-                FROM channel_prefixes
-                GROUP BY prefix
-            )
-            SELECT
-                cp.channel_id,
-                COUNT(*) AS uniq_total,
-                SUM(CASE WHEN pcc.channel_count > 1 THEN 1 ELSE 0 END) AS duped
-            FROM channel_prefixes cp
-            JOIN prefix_channel_counts pcc ON pcc.prefix = cp.prefix
-            GROUP BY cp.channel_id
-            """
-        )
-        rows = await cur.fetchall()
-        return {row["channel_id"]: (row["uniq_total"], row["duped"] or 0) for row in rows}
-
-    async def _fetch_cyrillic_map(self) -> dict[int, tuple[int, int]]:
-        cur = await self._db.execute(
-            """
-            SELECT channel_id, text
-            FROM messages
-            WHERE text IS NOT NULL AND text != ''
-            """
-        )
-        totals: dict[int, int] = {}
-        cyrillic_totals: dict[int, int] = {}
-        while True:
-            rows = await cur.fetchmany(1000)
-            if not rows:
-                break
-            for row in rows:
-                channel_id = row["channel_id"]
-                text = row["text"]
-                if not text:
-                    continue
-                totals[channel_id] = totals.get(channel_id, 0) + 1
-                if contains_cyrillic(text):
-                    cyrillic_totals[channel_id] = cyrillic_totals.get(channel_id, 0) + 1
-        return {
-            channel_id: (total, cyrillic_totals.get(channel_id, 0))
-            for channel_id, total in totals.items()
-        }
+        self._repo = db.filter_repo
 
     async def _build_report(self, channel_id: int | None = None) -> FilterReport:
-        channels = await self._fetch_channels_for_analysis(channel_id)
+        channels = await self._repo.fetch_channels_for_analysis(channel_id)
         if not channels:
             return FilterReport()
 
-        uniqueness_map = await self._fetch_uniqueness_map()
-        subscriber_map = await self._fetch_latest_subscriber_map()
-        short_map = await self._fetch_short_message_map()
-        cross_dupe_map = await self._fetch_cross_dupe_map()
-        cyrillic_map = await self._fetch_cyrillic_map()
+        uniqueness_map = await self._repo.fetch_uniqueness_map(channel_id)
+        subscriber_map = await self._repo.fetch_subscriber_map(channel_id)
+        short_map = await self._repo.fetch_short_message_map(channel_id)
+        cross_dupe_map = await self._repo.fetch_cross_dupe_map(channel_id)
+        cyrillic_map = await self._repo.fetch_cyrillic_map(channel_id)
 
         results: list[ChannelFilterResult] = []
         for channel in channels:
@@ -255,14 +125,28 @@ class ChannelAnalyzer:
         return await self._build_report()
 
     async def apply_filters(self, report: FilterReport) -> int:
-        updates = [
-            (result.channel_id, ",".join(result.flags))
-            for result in report.results
-            if result.is_filtered
-        ]
-        if not updates:
-            return 0
-        return await self._database.set_channels_filtered_bulk(updates)
+        # Dedupe by channel_id (last value wins) to avoid double updates/count inflation.
+        deduped: dict[int, str] = {}
+        for result in report.results:
+            if result.is_filtered:
+                deduped[result.channel_id] = ",".join(result.flags)
+        updates = list(deduped.items())
+
+        conn = self._database.db
+        assert conn is not None
+        await conn.execute("BEGIN")
+        try:
+            await self._database.reset_all_channel_filters(commit=False)
+            count = 0
+            if updates:
+                count = await self._database.set_channels_filtered_bulk(
+                    updates, commit=False
+                )
+            await conn.commit()
+            return count
+        except Exception:
+            await conn.rollback()
+            raise
 
     async def reset_filters(self) -> None:
         await self._database.reset_all_channel_filters()

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+from src.filters.criteria import (
+    check_chat_noise,
+    check_cross_channel_dupes,
+    check_low_uniqueness,
+    check_non_cyrillic,
+    check_subscriber_ratio,
+)
+from src.filters.models import ChannelFilterResult, FilterReport
+
+logger = logging.getLogger(__name__)
+
+
+class ChannelAnalyzer:
+    def __init__(self, db: aiosqlite.Connection):
+        self._db = db
+
+    async def analyze_channel(self, channel_id: int) -> ChannelFilterResult:
+        cur = await self._db.execute(
+            "SELECT channel_id, title, username FROM channels WHERE channel_id = ?",
+            (channel_id,),
+        )
+        ch_row = await cur.fetchone()
+        title = ch_row["title"] if ch_row else None
+        username = ch_row["username"] if ch_row else None
+
+        cur = await self._db.execute(
+            "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id = ?",
+            (channel_id,),
+        )
+        msg_count = (await cur.fetchone())["cnt"]
+
+        flags: list[str] = []
+
+        uniqueness_pct, low_uniq = await check_low_uniqueness(self._db, channel_id)
+        if low_uniq:
+            flags.append("low_uniqueness")
+
+        sub_ratio, low_sub = await check_subscriber_ratio(self._db, channel_id)
+        if low_sub:
+            flags.append("low_subscriber_ratio")
+
+        cross_pct, cross_dup = await check_cross_channel_dupes(self._db, channel_id)
+        if cross_dup:
+            flags.append("cross_channel_spam")
+
+        cyr_pct, non_cyr = await check_non_cyrillic(self._db, channel_id)
+        if non_cyr:
+            flags.append("non_cyrillic")
+
+        short_pct, noisy = await check_chat_noise(self._db, channel_id)
+        if noisy:
+            flags.append("chat_noise")
+
+        return ChannelFilterResult(
+            channel_id=channel_id,
+            title=title,
+            username=username,
+            message_count=msg_count,
+            flags=flags,
+            uniqueness_pct=uniqueness_pct,
+            subscriber_ratio=sub_ratio,
+            cyrillic_pct=cyr_pct,
+            short_msg_pct=short_pct,
+            cross_dupe_pct=cross_pct,
+            is_filtered=len(flags) > 0,
+        )
+
+    async def analyze_all(self) -> FilterReport:
+        cur = await self._db.execute("SELECT channel_id FROM channels ORDER BY id")
+        rows = await cur.fetchall()
+
+        results: list[ChannelFilterResult] = []
+        for row in rows:
+            result = await self.analyze_channel(row["channel_id"])
+            results.append(result)
+
+        filtered_count = sum(1 for r in results if r.is_filtered)
+        return FilterReport(
+            results=results,
+            total_channels=len(results),
+            filtered_count=filtered_count,
+        )
+
+    async def apply_filters(self, report: FilterReport) -> int:
+        count = 0
+        for result in report.results:
+            if result.is_filtered:
+                await self._db.execute(
+                    "UPDATE channels SET is_filtered = 1 WHERE channel_id = ?",
+                    (result.channel_id,),
+                )
+                count += 1
+        await self._db.commit()
+        return count
+
+    async def reset_filters(self) -> None:
+        await self._db.execute("UPDATE channels SET is_filtered = 0")
+        await self._db.commit()

--- a/src/filters/criteria.py
+++ b/src/filters/criteria.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import re
+
 import aiosqlite
+
+CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
+
+
+def contains_cyrillic(text: str) -> bool:
+    return bool(CYRILLIC_RE.search(text))
 
 
 async def check_low_uniqueness(
@@ -124,16 +132,25 @@ async def check_non_cyrillic(
     """
     cur = await db.execute(
         """
-        SELECT
-            COUNT(*) AS total,
-            SUM(CASE WHEN text GLOB '*[а-яА-ЯёЁ]*' THEN 1 ELSE 0 END) AS cyr
+        SELECT text
         FROM messages
         WHERE channel_id = ? AND text IS NOT NULL AND text != ''
         """,
         (channel_id,),
     )
-    row = await cur.fetchone()
-    total, cyr = row["total"], row["cyr"] or 0
+    total = 0
+    cyr = 0
+    while True:
+        rows = await cur.fetchmany(1000)
+        if not rows:
+            break
+        for row in rows:
+            text = row["text"]
+            if not text:
+                continue
+            total += 1
+            if contains_cyrillic(text):
+                cyr += 1
     if total == 0:
         return None, False
     pct = cyr / total * 100

--- a/src/filters/criteria.py
+++ b/src/filters/criteria.py
@@ -2,192 +2,22 @@ from __future__ import annotations
 
 import re
 
-import aiosqlite
-
 CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
+
+LOW_UNIQUENESS_THRESHOLD = 30.0
+LOW_SUBSCRIBER_RATIO_THRESHOLD = 1.0
+CROSS_DUPE_THRESHOLD = 50.0
+NON_CYRILLIC_THRESHOLD = 10.0
+CHAT_NOISE_THRESHOLD = 70.0
+
+VALID_FLAGS = frozenset({
+    "low_uniqueness",
+    "low_subscriber_ratio",
+    "cross_channel_spam",
+    "non_cyrillic",
+    "chat_noise",
+})
 
 
 def contains_cyrillic(text: str) -> bool:
     return bool(CYRILLIC_RE.search(text))
-
-
-async def check_low_uniqueness(
-    db: aiosqlite.Connection, channel_id: int, threshold: float = 30.0
-) -> tuple[float | None, bool]:
-    """Ratio of unique text prefixes to total messages.
-
-    Returns (uniqueness_pct, is_flagged).
-    """
-    cur = await db.execute(
-        """
-        SELECT
-            COUNT(*) AS total,
-            COUNT(DISTINCT substr(text, 1, 100)) AS uniq
-        FROM messages
-        WHERE channel_id = ? AND text IS NOT NULL AND text != ''
-        """,
-        (channel_id,),
-    )
-    row = await cur.fetchone()
-    total, uniq = row["total"], row["uniq"]
-    if total == 0:
-        return None, False
-    pct = uniq / total * 100
-    return round(pct, 1), pct < threshold
-
-
-async def check_subscriber_ratio(
-    db: aiosqlite.Connection, channel_id: int, threshold: float = 1.0
-) -> tuple[float | None, bool]:
-    """Subscriber count / message count ratio.
-
-    Returns (ratio, is_flagged).
-    """
-    cur = await db.execute(
-        "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id = ?",
-        (channel_id,),
-    )
-    msg_count = (await cur.fetchone())["cnt"]
-    if msg_count == 0:
-        return None, False
-
-    cur = await db.execute(
-        """
-        SELECT subscriber_count
-        FROM channel_stats
-        WHERE channel_id = ?
-        ORDER BY collected_at DESC
-        LIMIT 1
-        """,
-        (channel_id,),
-    )
-    row = await cur.fetchone()
-    if not row or row["subscriber_count"] is None:
-        return None, False
-
-    ratio = row["subscriber_count"] / msg_count
-    return round(ratio, 2), ratio < threshold
-
-
-async def check_cross_channel_dupes(
-    db: aiosqlite.Connection, channel_id: int, threshold: float = 50.0
-) -> tuple[float | None, bool]:
-    """Percentage of messages whose text prefix appears in other channels.
-
-    Returns (cross_dupe_pct, is_flagged).
-    """
-    cur = await db.execute(
-        """
-        SELECT COUNT(*) AS total
-        FROM messages
-        WHERE channel_id = ? AND text IS NOT NULL AND length(text) > 10
-        """,
-        (channel_id,),
-    )
-    total = (await cur.fetchone())["total"]
-    if total == 0:
-        return None, False
-
-    cur = await db.execute(
-        """
-        SELECT COUNT(*) AS duped
-        FROM (
-            SELECT DISTINCT substr(m1.text, 1, 100) AS prefix
-            FROM messages m1
-            WHERE m1.channel_id = ? AND m1.text IS NOT NULL AND length(m1.text) > 10
-        ) t
-        WHERE EXISTS (
-            SELECT 1 FROM messages m2
-            WHERE m2.channel_id != ?
-              AND m2.text IS NOT NULL
-              AND substr(m2.text, 1, 100) = t.prefix
-        )
-        """,
-        (channel_id, channel_id),
-    )
-    duped = (await cur.fetchone())["duped"]
-
-    cur = await db.execute(
-        """
-        SELECT COUNT(DISTINCT substr(text, 1, 100)) AS uniq_total
-        FROM messages
-        WHERE channel_id = ? AND text IS NOT NULL AND length(text) > 10
-        """,
-        (channel_id,),
-    )
-    uniq_total = (await cur.fetchone())["uniq_total"]
-    if uniq_total == 0:
-        return None, False
-
-    pct = duped / uniq_total * 100
-    return round(pct, 1), pct > threshold
-
-
-async def check_non_cyrillic(
-    db: aiosqlite.Connection, channel_id: int, threshold: float = 10.0
-) -> tuple[float | None, bool]:
-    """Percentage of messages containing at least one Cyrillic character.
-
-    Returns (cyrillic_pct, is_flagged).
-    """
-    cur = await db.execute(
-        """
-        SELECT text
-        FROM messages
-        WHERE channel_id = ? AND text IS NOT NULL AND text != ''
-        """,
-        (channel_id,),
-    )
-    total = 0
-    cyr = 0
-    while True:
-        rows = await cur.fetchmany(1000)
-        if not rows:
-            break
-        for row in rows:
-            text = row["text"]
-            if not text:
-                continue
-            total += 1
-            if contains_cyrillic(text):
-                cyr += 1
-    if total == 0:
-        return None, False
-    pct = cyr / total * 100
-    return round(pct, 1), pct < threshold
-
-
-async def check_chat_noise(
-    db: aiosqlite.Connection,
-    channel_id: int,
-    threshold: float = 70.0,
-) -> tuple[float | None, bool]:
-    """Percentage of short messages (<=10 chars) from groups.
-
-    Returns (short_msg_pct, is_flagged).
-    """
-    # Only flag groups, not channels
-    cur = await db.execute(
-        "SELECT channel_type FROM channels WHERE channel_id = ?",
-        (channel_id,),
-    )
-    ch_row = await cur.fetchone()
-    if not ch_row or ch_row["channel_type"] != "group":
-        return None, False
-
-    cur = await db.execute(
-        """
-        SELECT
-            COUNT(*) AS total,
-            SUM(CASE WHEN length(COALESCE(text, '')) <= 10 THEN 1 ELSE 0 END) AS short
-        FROM messages
-        WHERE channel_id = ?
-        """,
-        (channel_id,),
-    )
-    row = await cur.fetchone()
-    total, short = row["total"], row["short"] or 0
-    if total == 0:
-        return None, False
-    pct = short / total * 100
-    return round(pct, 1), pct > threshold

--- a/src/filters/criteria.py
+++ b/src/filters/criteria.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def check_low_uniqueness(
+    db: aiosqlite.Connection, channel_id: int, threshold: float = 30.0
+) -> tuple[float | None, bool]:
+    """Ratio of unique text prefixes to total messages.
+
+    Returns (uniqueness_pct, is_flagged).
+    """
+    cur = await db.execute(
+        """
+        SELECT
+            COUNT(*) AS total,
+            COUNT(DISTINCT substr(text, 1, 100)) AS uniq
+        FROM messages
+        WHERE channel_id = ? AND text IS NOT NULL AND text != ''
+        """,
+        (channel_id,),
+    )
+    row = await cur.fetchone()
+    total, uniq = row["total"], row["uniq"]
+    if total == 0:
+        return None, False
+    pct = uniq / total * 100
+    return round(pct, 1), pct < threshold
+
+
+async def check_subscriber_ratio(
+    db: aiosqlite.Connection, channel_id: int, threshold: float = 1.0
+) -> tuple[float | None, bool]:
+    """Subscriber count / message count ratio.
+
+    Returns (ratio, is_flagged).
+    """
+    cur = await db.execute(
+        "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id = ?",
+        (channel_id,),
+    )
+    msg_count = (await cur.fetchone())["cnt"]
+    if msg_count == 0:
+        return None, False
+
+    cur = await db.execute(
+        """
+        SELECT subscriber_count
+        FROM channel_stats
+        WHERE channel_id = ?
+        ORDER BY collected_at DESC
+        LIMIT 1
+        """,
+        (channel_id,),
+    )
+    row = await cur.fetchone()
+    if not row or row["subscriber_count"] is None:
+        return None, False
+
+    ratio = row["subscriber_count"] / msg_count
+    return round(ratio, 2), ratio < threshold
+
+
+async def check_cross_channel_dupes(
+    db: aiosqlite.Connection, channel_id: int, threshold: float = 50.0
+) -> tuple[float | None, bool]:
+    """Percentage of messages whose text prefix appears in other channels.
+
+    Returns (cross_dupe_pct, is_flagged).
+    """
+    cur = await db.execute(
+        """
+        SELECT COUNT(*) AS total
+        FROM messages
+        WHERE channel_id = ? AND text IS NOT NULL AND length(text) > 10
+        """,
+        (channel_id,),
+    )
+    total = (await cur.fetchone())["total"]
+    if total == 0:
+        return None, False
+
+    cur = await db.execute(
+        """
+        SELECT COUNT(*) AS duped
+        FROM (
+            SELECT DISTINCT substr(m1.text, 1, 100) AS prefix
+            FROM messages m1
+            WHERE m1.channel_id = ? AND m1.text IS NOT NULL AND length(m1.text) > 10
+        ) t
+        WHERE EXISTS (
+            SELECT 1 FROM messages m2
+            WHERE m2.channel_id != ?
+              AND m2.text IS NOT NULL
+              AND substr(m2.text, 1, 100) = t.prefix
+        )
+        """,
+        (channel_id, channel_id),
+    )
+    duped = (await cur.fetchone())["duped"]
+
+    cur = await db.execute(
+        """
+        SELECT COUNT(DISTINCT substr(text, 1, 100)) AS uniq_total
+        FROM messages
+        WHERE channel_id = ? AND text IS NOT NULL AND length(text) > 10
+        """,
+        (channel_id,),
+    )
+    uniq_total = (await cur.fetchone())["uniq_total"]
+    if uniq_total == 0:
+        return None, False
+
+    pct = duped / uniq_total * 100
+    return round(pct, 1), pct > threshold
+
+
+async def check_non_cyrillic(
+    db: aiosqlite.Connection, channel_id: int, threshold: float = 10.0
+) -> tuple[float | None, bool]:
+    """Percentage of messages containing at least one Cyrillic character.
+
+    Returns (cyrillic_pct, is_flagged).
+    """
+    cur = await db.execute(
+        """
+        SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN text GLOB '*[а-яА-ЯёЁ]*' THEN 1 ELSE 0 END) AS cyr
+        FROM messages
+        WHERE channel_id = ? AND text IS NOT NULL AND text != ''
+        """,
+        (channel_id,),
+    )
+    row = await cur.fetchone()
+    total, cyr = row["total"], row["cyr"] or 0
+    if total == 0:
+        return None, False
+    pct = cyr / total * 100
+    return round(pct, 1), pct < threshold
+
+
+async def check_chat_noise(
+    db: aiosqlite.Connection,
+    channel_id: int,
+    threshold: float = 70.0,
+) -> tuple[float | None, bool]:
+    """Percentage of short messages (<=10 chars) from groups.
+
+    Returns (short_msg_pct, is_flagged).
+    """
+    # Only flag groups, not channels
+    cur = await db.execute(
+        "SELECT channel_type FROM channels WHERE channel_id = ?",
+        (channel_id,),
+    )
+    ch_row = await cur.fetchone()
+    if not ch_row or ch_row["channel_type"] != "group":
+        return None, False
+
+    cur = await db.execute(
+        """
+        SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN length(COALESCE(text, '')) <= 10 THEN 1 ELSE 0 END) AS short
+        FROM messages
+        WHERE channel_id = ?
+        """,
+        (channel_id,),
+    )
+    row = await cur.fetchone()
+    total, short = row["total"], row["short"] or 0
+    if total == 0:
+        return None, False
+    pct = short / total * 100
+    return round(pct, 1), pct > threshold

--- a/src/filters/models.py
+++ b/src/filters/models.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ChannelFilterResult(BaseModel):
+    channel_id: int
+    title: str | None = None
+    username: str | None = None
+    message_count: int = 0
+    flags: list[str] = []
+    uniqueness_pct: float | None = None
+    subscriber_ratio: float | None = None
+    cyrillic_pct: float | None = None
+    short_msg_pct: float | None = None
+    cross_dupe_pct: float | None = None
+    is_filtered: bool = False
+
+
+class FilterReport(BaseModel):
+    results: list[ChannelFilterResult] = []
+    total_channels: int = 0
+    filtered_count: int = 0

--- a/src/filters/models.py
+++ b/src/filters/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ChannelFilterResult(BaseModel):
@@ -8,7 +8,7 @@ class ChannelFilterResult(BaseModel):
     title: str | None = None
     username: str | None = None
     message_count: int = 0
-    flags: list[str] = []
+    flags: list[str] = Field(default_factory=list)
     uniqueness_pct: float | None = None
     subscriber_ratio: float | None = None
     cyrillic_pct: float | None = None
@@ -18,6 +18,6 @@ class ChannelFilterResult(BaseModel):
 
 
 class FilterReport(BaseModel):
-    results: list[ChannelFilterResult] = []
+    results: list[ChannelFilterResult] = Field(default_factory=list)
     total_channels: int = 0
     filtered_count: int = 0

--- a/src/models.py
+++ b/src/models.py
@@ -33,6 +33,7 @@ class Channel(BaseModel):
     channel_type: str | None = None  # "channel" | "group"
     is_active: bool = True
     is_filtered: bool = False
+    filter_flags: str = ""
     last_collected_id: int = 0
     added_at: datetime | None = None
     message_count: int = 0

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -67,6 +68,9 @@ class CollectionTask(BaseModel):
     status: str = "pending"  # pending / running / completed / failed / cancelled
     messages_collected: int = 0
     error: str | None = None
+    run_after: datetime | None = None
+    payload: dict[str, Any] | None = None
+    parent_task_id: int | None = None
     created_at: datetime | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None

--- a/src/models.py
+++ b/src/models.py
@@ -32,6 +32,7 @@ class Channel(BaseModel):
     username: str | None = None
     channel_type: str | None = None  # "channel" | "group"
     is_active: bool = True
+    is_filtered: bool = False
     last_collected_id: int = 0
     added_at: datetime | None = None
     message_count: int = 0

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -4,6 +4,7 @@ from src.services.collection_service import CollectionService
 from src.services.keyword_service import KeywordService
 from src.services.scheduler_service import SchedulerService
 from src.services.search_service import SearchService
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
 
 __all__ = [
     "AccountService",
@@ -12,4 +13,5 @@ __all__ = [
     "KeywordService",
     "SchedulerService",
     "SearchService",
+    "StatsTaskDispatcher",
 ]

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -10,8 +10,12 @@ class ChannelService:
         self._db = db
         self._pool = pool
 
-    async def list_for_page(self) -> tuple[list[Channel], list, dict]:
-        channels = await self._db.get_channels_with_counts()
+    async def list_for_page(
+        self, include_filtered: bool = True
+    ) -> tuple[list[Channel], list, dict]:
+        channels = await self._db.get_channels_with_counts(
+            include_filtered=include_filtered
+        )
         keywords = await self._db.get_keywords()
         latest_stats = await self._db.get_latest_stats_for_all()
         return channels, keywords, latest_stats

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from src.collection_queue import CollectionQueue
 from src.database import Database
 from src.models import Channel
 from src.telegram.collector import Collector
+
+EnqueueResult = Literal["not_found", "filtered", "queued"]
 
 
 class CollectionService:
@@ -12,12 +16,14 @@ class CollectionService:
         self._collector = collector
         self._queue = queue
 
-    async def enqueue_channel_by_pk(self, pk: int) -> bool:
+    async def enqueue_channel_by_pk(self, pk: int) -> EnqueueResult:
         channel = await self._db.get_channel_by_pk(pk)
         if not channel:
-            return False
+            return "not_found"
+        if channel.is_filtered:
+            return "filtered"
         await self._queue.enqueue(channel)
-        return True
+        return "queued"
 
     async def collect_channel_stats(self, channel: Channel) -> None:
         await self._collector.collect_channel_stats(channel)

--- a/src/services/stats_task_dispatcher.py
+++ b/src/services/stats_task_dispatcher.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from src.database import Database
+from src.models import CollectionTask
+from src.telegram.collector import Collector
+
+logger = logging.getLogger(__name__)
+
+
+class StatsTaskDispatcher:
+    """Runs deferred / pending stats collection tasks from DB."""
+
+    def __init__(
+        self,
+        collector: Collector,
+        db: Database,
+        *,
+        default_batch_size: int = 20,
+        poll_interval_sec: float = 1.0,
+        channel_timeout_sec: float = 120.0,
+    ):
+        self._collector = collector
+        self._db = db
+        self._default_batch_size = default_batch_size
+        self._poll_interval_sec = poll_interval_sec
+        self._channel_timeout_sec = channel_timeout_sec
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task and not self._task.done():
+            return
+        self._stop_event.clear()
+        recovered = await self._db.requeue_running_stats_tasks_on_startup(
+            datetime.now(timezone.utc)
+        )
+        if recovered:
+            logger.warning("Recovered %d interrupted stats tasks on startup", recovered)
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+    async def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            task: CollectionTask | None = None
+            try:
+                if self._collector.is_running:
+                    await asyncio.sleep(self._poll_interval_sec)
+                    continue
+
+                task = await self._db.claim_next_due_stats_task(datetime.now(timezone.utc))
+                if task is None:
+                    await asyncio.sleep(self._poll_interval_sec)
+                    continue
+
+                await self._run_stats_task(task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Stats dispatcher loop failure")
+                if task and task.id is not None:
+                    try:
+                        fresh = await self._db.get_collection_task(task.id)
+                        if fresh and fresh.status == "running":
+                            await self._db.update_collection_task(
+                                task.id,
+                                "failed",
+                                messages_collected=fresh.messages_collected,
+                                error="Stats task failed with unexpected dispatcher error",
+                            )
+                    except Exception:
+                        logger.exception("Failed to mark broken stats task as failed")
+                await asyncio.sleep(self._poll_interval_sec)
+
+    async def _run_stats_task(self, task: CollectionTask) -> None:
+        if task.id is None:
+            return
+
+        payload = task.payload or {}
+        if payload.get("task_kind") != "stats_all":
+            await self._db.update_collection_task(
+                task.id, "failed", error="Unsupported stats task payload"
+            )
+            return
+
+        raw_ids = payload.get("channel_ids")
+        if not isinstance(raw_ids, list):
+            await self._db.update_collection_task(
+                task.id, "failed", error="Missing channel snapshot for stats task"
+            )
+            return
+
+        channel_ids: list[int] = []
+        for value in raw_ids:
+            try:
+                channel_ids.append(int(value))
+            except (TypeError, ValueError):
+                continue
+
+        next_index = self._to_int(payload.get("next_index"), 0)
+        batch_size = max(1, self._to_int(payload.get("batch_size"), self._default_batch_size))
+        channels_ok = self._to_int(
+            payload.get("channels_ok"), task.messages_collected or 0
+        )
+        channels_err = self._to_int(payload.get("channels_err"), 0)
+
+        logger.info(
+            "Running stats task #%s: next_index=%d batch_size=%d total=%d",
+            task.id,
+            next_index,
+            batch_size,
+            len(channel_ids),
+        )
+
+        if next_index >= len(channel_ids):
+            await self._db.update_collection_task(
+                task.id, "completed", messages_collected=channels_ok
+            )
+            return
+
+        batch_end = min(next_index + batch_size, len(channel_ids))
+        cursor = next_index
+
+        while cursor < batch_end:
+            channel_id = channel_ids[cursor]
+            logger.info(
+                "Stats task #%s: processing channel %d/%d (channel_id=%s)",
+                task.id,
+                cursor + 1,
+                len(channel_ids),
+                channel_id,
+            )
+            channel = await self._db.get_channel_by_channel_id(channel_id)
+            if channel is None:
+                logger.warning(
+                    "Stats task #%s: channel_id=%s not found, skipping",
+                    task.id,
+                    channel_id,
+                )
+                channels_err += 1
+                cursor += 1
+                continue
+
+            try:
+                result = await asyncio.wait_for(
+                    self._collector.collect_channel_stats(channel),
+                    timeout=self._channel_timeout_sec,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Stats timeout for channel %s in task #%s",
+                    channel.channel_id,
+                    task.id,
+                )
+                channels_err += 1
+                cursor += 1
+            except Exception as exc:
+                logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
+                channels_err += 1
+                cursor += 1
+            else:
+                if result is None:
+                    availability = await self._collector.get_stats_availability()
+                    if (
+                        availability.state == "all_flooded"
+                        and availability.next_available_at_utc is not None
+                    ):
+                        logger.warning(
+                            "Stats task #%s deferred: all clients flood-waited until %s",
+                            task.id,
+                            availability.next_available_at_utc.isoformat(),
+                        )
+                        continuation_payload = self._build_payload(
+                            channel_ids=channel_ids,
+                            next_index=cursor,
+                            batch_size=batch_size,
+                            channels_ok=channels_ok,
+                            channels_err=channels_err,
+                        )
+                        continuation_id = await self._db.create_stats_continuation_task(
+                            payload=continuation_payload,
+                            run_after=availability.next_available_at_utc,
+                            parent_task_id=task.id,
+                        )
+                        await self._db.update_collection_task(
+                            task.id,
+                            "failed",
+                            messages_collected=channels_ok,
+                            error=(
+                                "Deferred to task "
+                                f"#{continuation_id} until "
+                                f"{availability.next_available_at_utc.isoformat()} "
+                                "(all clients flood-waited)"
+                            ),
+                        )
+                        return
+
+                    logger.error(
+                        "Stats task #%s failed: no active connected Telegram accounts",
+                        task.id,
+                    )
+                    await self._db.update_collection_task(
+                        task.id,
+                        "failed",
+                        messages_collected=channels_ok,
+                        error="No active connected Telegram accounts",
+                    )
+                    return
+
+                channels_ok += 1
+                cursor += 1
+                await self._db.update_collection_task_progress(task.id, channels_ok)
+                logger.info(
+                    "Stats task #%s: channel_id=%s done (ok=%d, err=%d)",
+                    task.id,
+                    channel.channel_id,
+                    channels_ok,
+                    channels_err,
+                )
+
+            if cursor < batch_end:
+                await asyncio.sleep(self._collector.delay_between_channels_sec)
+
+        if cursor < len(channel_ids):
+            continuation_payload = self._build_payload(
+                channel_ids=channel_ids,
+                next_index=cursor,
+                batch_size=batch_size,
+                channels_ok=channels_ok,
+                channels_err=channels_err,
+            )
+            await self._db.create_stats_continuation_task(
+                payload=continuation_payload,
+                run_after=datetime.now(timezone.utc),
+                parent_task_id=task.id,
+            )
+            logger.info(
+                "Stats task #%s batch complete: processed=%d/%d, continuation created",
+                task.id,
+                cursor,
+                len(channel_ids),
+            )
+            await self._db.update_collection_task(
+                task.id, "completed", messages_collected=channels_ok
+            )
+            return
+
+        logger.info("Stats task #%s finished: processed all %d channels", task.id, len(channel_ids))
+        await self._db.update_collection_task(
+            task.id, "completed", messages_collected=channels_ok
+        )
+
+    @staticmethod
+    def _build_payload(
+        *,
+        channel_ids: list[int],
+        next_index: int,
+        batch_size: int,
+        channels_ok: int,
+        channels_err: int,
+    ) -> dict[str, Any]:
+        return {
+            "task_kind": "stats_all",
+            "channel_ids": channel_ids,
+            "next_index": next_index,
+            "batch_size": batch_size,
+            "channels_ok": channels_ok,
+            "channels_err": channels_err,
+        }
+
+    @staticmethod
+    def _to_int(value: Any, fallback: int) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return fallback

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -5,6 +5,7 @@ import base64
 import io
 import logging
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from telethon import TelegramClient
@@ -15,6 +16,13 @@ from src.models import TelegramUserInfo
 from src.telegram.auth import TelegramAuth
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StatsClientAvailability:
+    state: str  # "available" | "all_flooded" | "no_connected_active"
+    retry_after_sec: int | None = None
+    next_available_at_utc: datetime | None = None
 
 
 class ClientPool:
@@ -56,10 +64,8 @@ class ClientPool:
             for acc in accounts:
                 if acc.phone in self._in_use:
                     continue
-                if (
-                    acc.flood_wait_until
-                    and acc.flood_wait_until.replace(tzinfo=timezone.utc) > now
-                ):
+                flood_until = self._normalize_utc(acc.flood_wait_until)
+                if flood_until and flood_until > now:
                     continue
                 if acc.phone in self.clients:
                     self._in_use.add(acc.phone)
@@ -68,15 +74,40 @@ class ClientPool:
             # Fallback: if all clients are in use, return any non-flood-waited client
             # (allows the same client to be shared when there's only one account)
             for acc in accounts:
-                if (
-                    acc.flood_wait_until
-                    and acc.flood_wait_until.replace(tzinfo=timezone.utc) > now
-                ):
+                flood_until = self._normalize_utc(acc.flood_wait_until)
+                if flood_until and flood_until > now:
                     continue
                 if acc.phone in self.clients:
                     return self.clients[acc.phone], acc.phone
 
             return None
+
+    async def get_stats_availability(self) -> StatsClientAvailability:
+        """Describe stats client availability for batch scheduling decisions."""
+        async with self._lock:
+            now = datetime.now(timezone.utc)
+            accounts = await self._db.get_accounts(active_only=True)
+            connected = [acc for acc in accounts if acc.phone in self.clients]
+            if not connected:
+                return StatsClientAvailability(state="no_connected_active")
+
+            earliest: datetime | None = None
+            for acc in connected:
+                flood_until = self._normalize_utc(acc.flood_wait_until)
+                if flood_until is None or flood_until <= now:
+                    return StatsClientAvailability(state="available")
+                if earliest is None or flood_until < earliest:
+                    earliest = flood_until
+
+            if earliest is None:
+                return StatsClientAvailability(state="no_connected_active")
+
+            retry_after_sec = max(1, int((earliest - now).total_seconds()))
+            return StatsClientAvailability(
+                state="all_flooded",
+                retry_after_sec=retry_after_sec,
+                next_available_at_utc=earliest,
+            )
 
     async def release_client(self, phone: str) -> None:
         """Mark client as no longer in active use."""
@@ -109,6 +140,14 @@ class ClientPool:
     async def disconnect_all(self) -> None:
         for phone in list(self.clients):
             await self.remove_client(phone)
+
+    @staticmethod
+    def _normalize_utc(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
 
     async def get_users_info(self) -> list[TelegramUserInfo]:
         """Get info about all connected Telegram accounts."""
@@ -220,4 +259,3 @@ class ClientPool:
             return dialogs
         finally:
             await self.release_client(phone)
-

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -56,6 +56,10 @@ class Collector:
     def is_running(self) -> bool:
         return self._running or self._stats_running
 
+    @property
+    def is_stats_running(self) -> bool:
+        return self._stats_running
+
     async def cancel(self) -> None:
         self._cancel_event.set()
 

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -74,7 +74,19 @@ class Collector:
         full: bool = False,
         progress_callback: Callable[[int], Awaitable[None]] | None = None,
     ) -> int:
-        """Collect messages from a single channel. If full=True, reset last_collected_id to 0."""
+        """Collect messages from a single channel. If full=True, reset last_collected_id to 0.
+
+        This is the canonical entry point for is_filtered checks in the
+        collection path.  Other callers (CollectionQueue, CLI, web routes)
+        may also guard against filtered channels earlier for better UX,
+        but this check is the authoritative gate.
+        """
+        if channel.is_filtered:
+            logger.info(
+                "Skipping collection for channel %d: channel is filtered",
+                channel.channel_id,
+            )
+            return 0
         async with self._lock:
             self._running = True
             self._cancel_event.clear()
@@ -106,11 +118,13 @@ class Collector:
             stats = {"channels": 0, "messages": 0, "errors": 0}
 
             try:
-                channels = await self._db.get_channels(active_only=True)
+                channels = await self._db.get_channels(
+                    active_only=True, include_filtered=False
+                )
                 if not channels:
-                    logger.info("No active channels to collect")
+                    logger.info("No active unfiltered channels to collect")
                     return stats
-                logger.info("Found %d active channels to collect", len(channels))
+                logger.info("Found %d active unfiltered channels to collect", len(channels))
 
                 # Pre-fetch dialogs to populate Telethon entity cache.
                 # StringSession loses entity cache between restarts, so
@@ -296,11 +310,13 @@ class Collector:
         if flood_wait_sec is not None:
             await self._pool.report_flood(phone, flood_wait_sec)
             if flood_wait_sec <= self._config.max_flood_wait_sec:
-                # Re-read channel from DB to get updated last_collected_id
-                channels = await self._db.get_channels()
-                updated = next(
-                    (c for c in channels if c.channel_id == channel_id), None
-                )
+                # Re-read channel from DB to get updated last_collected_id.
+                # Use get_channel_by_pk (no filtering) — collection already
+                # started, so we must finish even if the channel was filtered
+                # in the meantime.
+                updated = None
+                if channel.id is not None:
+                    updated = await self._db.get_channel_by_pk(channel.id)
                 if updated:
                     return len(all_messages) + await self._collect_channel(
                         updated, progress_callback=progress_callback
@@ -407,7 +423,9 @@ class Collector:
         async with self._stats_lock:
             self._stats_running = True
             try:
-                channels = await self._db.get_channels(active_only=True)
+                channels = await self._db.get_channels(
+                    active_only=True, include_filtered=False
+                )
                 stats = {"channels": 0, "errors": 0}
                 for channel in channels:
                     try:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
-from datetime import timezone
+from datetime import datetime, timezone
 
 from telethon.errors import FloodWaitError
 from telethon.tl.functions.channels import GetFullChannelRequest
@@ -34,6 +34,22 @@ from src.telegram.notifier import Notifier
 logger = logging.getLogger(__name__)
 
 
+class NoActiveStatsClientsError(RuntimeError):
+    """Raised when there are no active connected clients for stats collection."""
+
+
+class AllStatsClientsFloodedError(RuntimeError):
+    """Raised when all active connected clients are in flood-wait."""
+
+    def __init__(self, retry_after_sec: int, next_available_at: datetime):
+        super().__init__(
+            "All active clients are flood-waited until "
+            f"{next_available_at.isoformat()} (retry in {retry_after_sec}s)"
+        )
+        self.retry_after_sec = retry_after_sec
+        self.next_available_at = next_available_at
+
+
 class Collector:
     def __init__(
         self,
@@ -59,6 +75,13 @@ class Collector:
     @property
     def is_stats_running(self) -> bool:
         return self._stats_running
+
+    @property
+    def delay_between_channels_sec(self) -> int:
+        return self._config.delay_between_channels_sec
+
+    async def get_stats_availability(self):
+        return await self._pool.get_stats_availability()
 
     async def cancel(self) -> None:
         self._cancel_event.set()
@@ -367,57 +390,84 @@ class Collector:
             self._stats_running = True
             try:
                 return await self._collect_channel_stats(channel)
+            except (AllStatsClientsFloodedError, NoActiveStatsClientsError):
+                logger.error("No available clients for stats collection")
+                return None
             finally:
                 self._stats_running = False
 
     async def _collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
-        result = await self._pool.get_available_client()
-        if result is None:
-            logger.error("No available clients for stats collection")
-            return None
-        client, phone = result
-        try:
-            if channel.username:
-                entity = await client.get_entity(channel.username)
-            else:
-                entity = await client.get_entity(PeerChannel(channel.channel_id))
-
-            full = await client(GetFullChannelRequest(entity))
-            subscriber_count = getattr(full.full_chat, "participants_count", None)
-
-            views_list, reactions_list, forwards_list = [], [], []
-            async for msg in client.iter_messages(entity, limit=50):
-                if getattr(msg, "views", None) is not None:
-                    views_list.append(msg.views)
-                if getattr(msg, "forwards", None) is not None:
-                    forwards_list.append(msg.forwards)
-                reactions = getattr(msg, "reactions", None)
-                if reactions:
-                    total = sum(
-                        getattr(r, "count", 0)
-                        for r in getattr(reactions, "results", [])
+        while True:
+            result = await self._pool.get_available_client()
+            if result is None:
+                availability_fn = getattr(self._pool, "get_stats_availability", None)
+                if not callable(availability_fn):
+                    raise NoActiveStatsClientsError("No active connected clients")
+                availability_result = availability_fn()
+                if not asyncio.iscoroutine(availability_result):
+                    raise NoActiveStatsClientsError("No active connected clients")
+                availability = await availability_result
+                if (
+                    availability.state == "all_flooded"
+                    and availability.retry_after_sec is not None
+                    and availability.next_available_at_utc is not None
+                ):
+                    raise AllStatsClientsFloodedError(
+                        retry_after_sec=availability.retry_after_sec,
+                        next_available_at=availability.next_available_at_utc,
                     )
-                    reactions_list.append(total)
+                raise NoActiveStatsClientsError("No active connected clients")
 
-            stats = ChannelStats(
-                channel_id=channel.channel_id,
-                subscriber_count=subscriber_count,
-                avg_views=sum(views_list) / len(views_list) if views_list else None,
-                avg_reactions=(
-                    sum(reactions_list) / len(reactions_list) if reactions_list else None
-                ),
-                avg_forwards=(
-                    sum(forwards_list) / len(forwards_list) if forwards_list else None
-                ),
-            )
-            await self._db.save_channel_stats(stats)
-            return stats
-        except FloodWaitError as e:
-            logger.warning("Flood wait %ds for stats on %s", e.seconds, channel.channel_id)
-            await self._pool.report_flood(phone, e.seconds)
-            return None
-        finally:
-            await self._pool.release_client(phone)
+            client, phone = result
+            try:
+                if channel.username:
+                    entity = await client.get_entity(channel.username)
+                else:
+                    entity = await client.get_entity(PeerChannel(channel.channel_id))
+
+                full = await client(GetFullChannelRequest(entity))
+                subscriber_count = getattr(full.full_chat, "participants_count", None)
+
+                views_list, reactions_list, forwards_list = [], [], []
+                async for msg in client.iter_messages(
+                    entity,
+                    limit=50,
+                    wait_time=self._config.delay_between_requests_sec,
+                ):
+                    if getattr(msg, "views", None) is not None:
+                        views_list.append(msg.views)
+                    if getattr(msg, "forwards", None) is not None:
+                        forwards_list.append(msg.forwards)
+                    reactions = getattr(msg, "reactions", None)
+                    if reactions:
+                        total = sum(
+                            getattr(r, "count", 0)
+                            for r in getattr(reactions, "results", [])
+                        )
+                        reactions_list.append(total)
+
+                stats = ChannelStats(
+                    channel_id=channel.channel_id,
+                    subscriber_count=subscriber_count,
+                    avg_views=sum(views_list) / len(views_list) if views_list else None,
+                    avg_reactions=(
+                        sum(reactions_list) / len(reactions_list)
+                        if reactions_list else None
+                    ),
+                    avg_forwards=(
+                        sum(forwards_list) / len(forwards_list) if forwards_list else None
+                    ),
+                )
+                await self._db.save_channel_stats(stats)
+                return stats
+            except FloodWaitError as e:
+                logger.warning(
+                    "Flood wait %ds for stats on %s via %s",
+                    e.seconds, channel.channel_id, phone,
+                )
+                await self._pool.report_flood(phone, e.seconds)
+            finally:
+                await self._pool.release_client(phone)
 
     async def collect_all_stats(self) -> dict:
         async with self._stats_lock:
@@ -427,16 +477,30 @@ class Collector:
                     active_only=True, include_filtered=False
                 )
                 stats = {"channels": 0, "errors": 0}
-                for channel in channels:
-                    try:
-                        result = await self._collect_channel_stats(channel)
-                        if result is not None:
+                for idx, channel in enumerate(channels):
+                    while True:
+                        try:
+                            await self._collect_channel_stats(channel)
                             stats["channels"] += 1
-                        else:
+                            break
+                        except AllStatsClientsFloodedError as e:
+                            logger.warning(
+                                "All clients are flood-waited for stats. "
+                                "Waiting %ds until %s",
+                                e.retry_after_sec,
+                                e.next_available_at.isoformat(),
+                            )
+                            await asyncio.sleep(e.retry_after_sec)
+                        except NoActiveStatsClientsError:
+                            logger.error("No active connected clients for stats collection")
+                            stats["errors"] += len(channels) - idx
+                            return stats
+                        except Exception as e:
+                            logger.error("Stats error for %s: %s", channel.channel_id, e)
                             stats["errors"] += 1
-                    except Exception as e:
-                        logger.error("Stats error for %s: %s", channel.channel_id, e)
-                        stats["errors"] += 1
+                            break
+                    if idx < len(channels) - 1:
+                        await asyncio.sleep(self._config.delay_between_channels_sec)
                 return stats
             finally:
                 self._stats_running = False

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -20,6 +20,7 @@ from src.database import Database
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
@@ -151,6 +152,11 @@ async def lifespan(app: FastAPI):
     collection_queue = CollectionQueue(collector, db)
     app.state.collection_queue = collection_queue
 
+    # Deferred stats dispatcher
+    stats_dispatcher = StatsTaskDispatcher(collector, db, default_batch_size=20)
+    await stats_dispatcher.start()
+    app.state.stats_dispatcher = stats_dispatcher
+
     # Search engines
     search_engine = SearchEngine(db, pool)
     app.state.search_engine = search_engine
@@ -178,6 +184,7 @@ async def lifespan(app: FastAPI):
         app.state.shutting_down = True
         logger.info("Shutting down...")
         for name, coro in [
+            ("stats_dispatcher", stats_dispatcher.stop()),
             ("scheduler", scheduler.stop()),
             ("collector", collector.cancel()),
             ("collection_queue", collection_queue.shutdown()),

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -253,6 +253,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     from src.web.routes.channel_collection import router as channel_collection_router
     from src.web.routes.channels import router as channels_router
     from src.web.routes.dashboard import router as dashboard_router
+    from src.web.routes.filter import router as filter_router
     from src.web.routes.import_channels import router as import_router
     from src.web.routes.keywords import router as keywords_router
     from src.web.routes.scheduler import router as scheduler_router
@@ -263,6 +264,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(dashboard_router, prefix="/dashboard")
     app.include_router(auth_router, prefix="/auth")
     app.include_router(channels_router, prefix="/channels")
+    app.include_router(filter_router, prefix="/channels")
     app.include_router(keywords_router, prefix="/channels")
     app.include_router(channel_collection_router, prefix="/channels")
     app.include_router(import_router, prefix="/channels")

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -16,9 +16,11 @@ async def collect_channel(request: Request, pk: int):
         return RedirectResponse(url="/channels?error=shutting_down", status_code=303)
 
     service = deps.collection_service(request)
-    ok = await service.enqueue_channel_by_pk(pk)
-    if not ok:
-        return RedirectResponse(url="/channels", status_code=303)
+    enqueue_status = await service.enqueue_channel_by_pk(pk)
+    if enqueue_status == "not_found":
+        return RedirectResponse(url="/channels?msg=channel_not_found", status_code=303)
+    if enqueue_status == "filtered":
+        return RedirectResponse(url="/channels?error=channel_filtered", status_code=303)
 
     collector = deps.get_collector(request)
     msg = "collect_queued" if collector.is_running else "collect_started"

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 from starlette.background import BackgroundTask
@@ -5,6 +7,7 @@ from starlette.background import BackgroundTask
 from src.web import deps
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.post("/{pk}/collect")
@@ -25,7 +28,23 @@ async def collect_channel(request: Request, pk: int):
 @router.post("/stats/all")
 async def collect_all_stats(request: Request):
     collector = deps.get_collector(request)
-    task = BackgroundTask(collector.collect_all_stats)
+    if collector.is_stats_running:
+        return RedirectResponse(url="/channels?error=stats_running", status_code=303)
+
+    db = deps.get_db(request)
+    task_id = await db.create_collection_task(0, "Обновление статистики")
+    await db.update_collection_task(task_id, "running")
+
+    async def _run_all_stats():
+        try:
+            stats = await collector.collect_all_stats()
+            count = stats.get("channels", 0) if stats else 0
+            await db.update_collection_task(task_id, "completed", messages_collected=count)
+        except Exception as exc:
+            logger.exception("collect_all_stats failed")
+            await db.update_collection_task(task_id, "failed", error=str(exc))
+
+    task = BackgroundTask(_run_all_stats)
     return RedirectResponse(
         url="/channels?msg=stats_collection_started", status_code=303, background=task
     )
@@ -36,8 +55,26 @@ async def collect_stats(request: Request, pk: int):
     channel = await deps.channel_service(request).get_by_pk(pk)
     if not channel:
         return RedirectResponse(url="/channels", status_code=303)
+
     collector = deps.get_collector(request)
-    task = BackgroundTask(collector.collect_channel_stats, channel)
+    if collector.is_stats_running:
+        return RedirectResponse(url="/channels?error=stats_running", status_code=303)
+
+    db = deps.get_db(request)
+    task_id = await db.create_collection_task(channel.channel_id, channel.title)
+    await db.update_collection_task(task_id, "running")
+
+    async def _run_channel_stats():
+        try:
+            result = await collector.collect_channel_stats(channel)
+            await db.update_collection_task(
+                task_id, "completed", messages_collected=1 if result else 0
+            )
+        except Exception as exc:
+            logger.exception("collect_channel_stats failed")
+            await db.update_collection_task(task_id, "failed", error=str(exc))
+
+    task = BackgroundTask(_run_channel_stats)
     return RedirectResponse(
         url="/channels?msg=stats_collection_started", status_code=303, background=task
     )

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -29,27 +29,40 @@ async def collect_channel(request: Request, pk: int):
 
 @router.post("/stats/all")
 async def collect_all_stats(request: Request):
+    if getattr(request.app.state, "shutting_down", False):
+        return RedirectResponse(url="/channels?error=shutting_down", status_code=303)
+
     collector = deps.get_collector(request)
-    if collector.is_stats_running:
+    db = deps.get_db(request)
+    existing = await db.get_active_stats_task()
+    if existing:
         return RedirectResponse(url="/channels?error=stats_running", status_code=303)
 
-    db = deps.get_db(request)
-    task_id = await db.create_collection_task(0, "Обновление статистики")
-    await db.update_collection_task(task_id, "running")
-
-    async def _run_all_stats():
-        try:
-            stats = await collector.collect_all_stats()
-            count = stats.get("channels", 0) if stats else 0
-            await db.update_collection_task(task_id, "completed", messages_collected=count)
-        except Exception as exc:
-            logger.exception("collect_all_stats failed")
-            await db.update_collection_task(task_id, "failed", error=str(exc))
-
-    task = BackgroundTask(_run_all_stats)
-    return RedirectResponse(
-        url="/channels?msg=stats_collection_started", status_code=303, background=task
+    channels = await db.get_channels(active_only=True, include_filtered=False)
+    latest_stats = await db.get_latest_stats_for_all()
+    channels_without_stats = [
+        ch for ch in channels if ch.channel_id not in latest_stats
+    ]
+    channels_with_stats = [
+        ch for ch in channels if ch.channel_id in latest_stats
+    ]
+    ordered_channels = channels_without_stats + channels_with_stats
+    payload = {
+        "task_kind": "stats_all",
+        "channel_ids": [ch.channel_id for ch in ordered_channels],
+        "next_index": 0,
+        "batch_size": 20,
+        "channels_ok": 0,
+        "channels_err": 0,
+    }
+    await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=payload,
     )
+
+    msg = "stats_collection_queued" if collector.is_running else "stats_collection_started"
+    return RedirectResponse(url=f"/channels?msg={msg}", status_code=303)
 
 
 @router.post("/{pk}/stats")

--- a/src/web/routes/channels.py
+++ b/src/web/routes/channels.py
@@ -13,7 +13,10 @@ router = APIRouter()
 @router.get("/", response_class=HTMLResponse)
 async def channels_list(request: Request):
     service = deps.channel_service(request)
-    channels, keywords, latest_stats = await service.list_for_page()
+    show_all = request.query_params.get("view") == "all"
+    channels, keywords, latest_stats = await service.list_for_page(
+        include_filtered=show_all
+    )
     error = request.query_params.get("error")
     msg = request.query_params.get("msg")
     return deps.get_templates(request).TemplateResponse(
@@ -25,6 +28,7 @@ async def channels_list(request: Request):
             "latest_stats": latest_stats,
             "error": error,
             "msg": msg,
+            "show_all": show_all,
         },
     )
 

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -1,0 +1,54 @@
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from src.filters.analyzer import ChannelAnalyzer
+from src.web import deps
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/filter/analyze", response_class=HTMLResponse)
+async def analyze_channels(request: Request):
+    db = deps.get_db(request)
+    assert db.db is not None
+    analyzer = ChannelAnalyzer(db.db)
+    report = await analyzer.analyze_all()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "filter_report.html",
+        {"report": report},
+    )
+
+
+@router.post("/filter/apply")
+async def apply_filters(request: Request):
+    db = deps.get_db(request)
+    assert db.db is not None
+    analyzer = ChannelAnalyzer(db.db)
+    report = await analyzer.analyze_all()
+    count = await analyzer.apply_filters(report)
+    return RedirectResponse(
+        url=f"/channels?msg=filter_applied&count={count}", status_code=303
+    )
+
+
+@router.post("/filter/reset")
+async def reset_filters(request: Request):
+    db = deps.get_db(request)
+    assert db.db is not None
+    analyzer = ChannelAnalyzer(db.db)
+    await analyzer.reset_filters()
+    return RedirectResponse(url="/channels?msg=filter_reset", status_code=303)
+
+
+@router.post("/{pk}/filter-toggle")
+async def toggle_channel_filter(request: Request, pk: int):
+    db = deps.get_db(request)
+    channel = await db.get_channel_by_pk(pk)
+    if channel:
+        await db.set_channel_filtered(pk, not channel.is_filtered)
+    return RedirectResponse(url="/channels?msg=channel_toggled", status_code=303)

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -51,15 +51,14 @@ async def apply_filters(request: Request):
     analyzer = ChannelAnalyzer(db)
 
     form = await request.form()
+    if form.get("snapshot") != "1":
+        return RedirectResponse(url="/channels?error=filter_snapshot_required", status_code=303)
     snapshot_results = _parse_snapshot(form.getlist("selected"))
-    if snapshot_results:
-        report = FilterReport(
-            results=snapshot_results,
-            total_channels=len(snapshot_results),
-            filtered_count=len(snapshot_results),
-        )
-    else:
-        report = await analyzer.analyze_all()
+    report = FilterReport(
+        results=snapshot_results,
+        total_channels=len(snapshot_results),
+        filtered_count=len(snapshot_results),
+    )
 
     count = await analyzer.apply_filters(report)
     return RedirectResponse(

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.filters.analyzer import ChannelAnalyzer
+from src.filters.models import ChannelFilterResult, FilterReport
 from src.web import deps
 
 logger = logging.getLogger(__name__)
@@ -11,11 +12,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _parse_snapshot(values: list[str]) -> list[ChannelFilterResult]:
+    results: list[ChannelFilterResult] = []
+    for value in values:
+        channel_id_str, sep, flags_csv = value.partition("|")
+        if not sep:
+            continue
+        try:
+            channel_id = int(channel_id_str)
+        except ValueError:
+            continue
+        flags = [flag.strip() for flag in flags_csv.split(",") if flag.strip()]
+        if not flags:
+            continue
+        results.append(ChannelFilterResult(channel_id=channel_id, flags=flags, is_filtered=True))
+    return results
+
+
 @router.post("/filter/analyze", response_class=HTMLResponse)
 async def analyze_channels(request: Request):
     db = deps.get_db(request)
-    assert db.db is not None
-    analyzer = ChannelAnalyzer(db.db)
+    analyzer = ChannelAnalyzer(db)
     report = await analyzer.analyze_all()
     return deps.get_templates(request).TemplateResponse(
         request,
@@ -27,9 +44,19 @@ async def analyze_channels(request: Request):
 @router.post("/filter/apply")
 async def apply_filters(request: Request):
     db = deps.get_db(request)
-    assert db.db is not None
-    analyzer = ChannelAnalyzer(db.db)
-    report = await analyzer.analyze_all()
+    analyzer = ChannelAnalyzer(db)
+
+    form = await request.form()
+    snapshot_results = _parse_snapshot(form.getlist("selected"))
+    if snapshot_results:
+        report = FilterReport(
+            results=snapshot_results,
+            total_channels=len(snapshot_results),
+            filtered_count=len(snapshot_results),
+        )
+    else:
+        report = await analyzer.analyze_all()
+
     count = await analyzer.apply_filters(report)
     return RedirectResponse(
         url=f"/channels?msg=filter_applied&count={count}", status_code=303
@@ -39,8 +66,7 @@ async def apply_filters(request: Request):
 @router.post("/filter/reset")
 async def reset_filters(request: Request):
     db = deps.get_db(request)
-    assert db.db is not None
-    analyzer = ChannelAnalyzer(db.db)
+    analyzer = ChannelAnalyzer(db)
     await analyzer.reset_filters()
     return RedirectResponse(url="/channels?msg=filter_reset", status_code=303)
 
@@ -49,6 +75,7 @@ async def reset_filters(request: Request):
 async def toggle_channel_filter(request: Request, pk: int):
     db = deps.get_db(request)
     channel = await db.get_channel_by_pk(pk)
-    if channel:
-        await db.set_channel_filtered(pk, not channel.is_filtered)
+    if not channel:
+        return RedirectResponse(url="/channels?msg=channel_not_found", status_code=303)
+    await db.set_channel_filtered(pk, not channel.is_filtered)
     return RedirectResponse(url="/channels?msg=channel_toggled", status_code=303)

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.filters.analyzer import ChannelAnalyzer
+from src.filters.criteria import VALID_FLAGS
 from src.filters.models import ChannelFilterResult, FilterReport
 from src.web import deps
 
@@ -13,7 +14,7 @@ router = APIRouter()
 
 
 def _parse_snapshot(values: list[str]) -> list[ChannelFilterResult]:
-    results: list[ChannelFilterResult] = []
+    deduped: dict[int, list[str]] = {}
     for value in values:
         channel_id_str, sep, flags_csv = value.partition("|")
         if not sep:
@@ -22,11 +23,14 @@ def _parse_snapshot(values: list[str]) -> list[ChannelFilterResult]:
             channel_id = int(channel_id_str)
         except ValueError:
             continue
-        flags = [flag.strip() for flag in flags_csv.split(",") if flag.strip()]
+        flags = [f for f in (f.strip() for f in flags_csv.split(",")) if f in VALID_FLAGS]
         if not flags:
             continue
-        results.append(ChannelFilterResult(channel_id=channel_id, flags=flags, is_filtered=True))
-    return results
+        deduped[channel_id] = flags
+    return [
+        ChannelFilterResult(channel_id=channel_id, flags=flags, is_filtered=True)
+        for channel_id, flags in deduped.items()
+    ]
 
 
 @router.post("/filter/analyze", response_class=HTMLResponse)
@@ -78,4 +82,4 @@ async def toggle_channel_filter(request: Request, pk: int):
     if not channel:
         return RedirectResponse(url="/channels?msg=channel_not_found", status_code=303)
     await db.set_channel_filtered(pk, not channel.is_filtered)
-    return RedirectResponse(url="/channels?msg=channel_toggled", status_code=303)
+    return RedirectResponse(url="/channels?msg=filter_toggled", status_code=303)

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -20,6 +20,7 @@ async def scheduler_page(request: Request):
     db = deps.get_db(request)
     msg = request.query_params.get("msg")
     tasks = await db.get_collection_tasks()
+    has_active_tasks = any(t.status in ("pending", "running") for t in tasks)
     search_log = await db.get_recent_searches()
     return deps.get_templates(request).TemplateResponse(
         request,
@@ -35,6 +36,7 @@ async def scheduler_page(request: Request):
             "collecting_now": collector.is_running,
             "msg": msg,
             "tasks": tasks,
+            "has_active_tasks": has_active_tasks,
             "search_log": search_log,
         },
     )

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -51,13 +51,17 @@
         triggered: "Сбор запущен вручную.",
         keyword_toggled: "Статус ключевого слова изменён.",
         filter_applied: "Фильтры применены.",
-        filter_reset: "Фильтры сброшены."
+        filter_reset: "Фильтры сброшены.",
+        channel_not_found: "Канал не найден.",
+        stats_collection_started: "Сбор статистики запущен в фоне.",
+        search_triggered: "Поиск запущен."
     };
     var errors = {
         resolve: "Не удалось найти канал. Проверьте username или ссылку.",
         no_client: "Нет подключённых аккаунтов для поиска канала.",
         collecting: "Сбор уже выполняется. Дождитесь завершения.",
-        shutting_down: "Приложение завершает работу."
+        shutting_down: "Приложение завершает работу.",
+        stats_running: "Сбор статистики уже выполняется."
     };
     var params = new URLSearchParams(window.location.search);
     var code = params.get("msg");

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -55,6 +55,7 @@
         filter_reset: "Фильтры сброшены.",
         channel_not_found: "Канал не найден.",
         stats_collection_started: "Сбор статистики запущен в фоне.",
+        stats_collection_queued: "Сбор статистики поставлен в очередь.",
         search_triggered: "Поиск запущен."
     };
     var errors = {

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -49,7 +49,9 @@
         task_cancelled: "Задача отменена.",
         already_running: "Сбор уже запущен.",
         triggered: "Сбор запущен вручную.",
-        keyword_toggled: "Статус ключевого слова изменён."
+        keyword_toggled: "Статус ключевого слова изменён.",
+        filter_applied: "Фильтры применены.",
+        filter_reset: "Фильтры сброшены."
     };
     var errors = {
         resolve: "Не удалось найти канал. Проверьте username или ссылку.",

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -50,6 +50,7 @@
         already_running: "Сбор уже запущен.",
         triggered: "Сбор запущен вручную.",
         keyword_toggled: "Статус ключевого слова изменён.",
+        filter_toggled: "Фильтр канала изменён.",
         filter_applied: "Фильтры применены.",
         filter_reset: "Фильтры сброшены.",
         channel_not_found: "Канал не найден.",

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -62,7 +62,9 @@
         no_client: "Нет подключённых аккаунтов для поиска канала.",
         collecting: "Сбор уже выполняется. Дождитесь завершения.",
         shutting_down: "Приложение завершает работу.",
-        stats_running: "Сбор статистики уже выполняется."
+        stats_running: "Сбор статистики уже выполняется.",
+        channel_filtered: "Канал помечен как бесполезный и исключён из сбора.",
+        filter_snapshot_required: "Сначала выполните анализ фильтров и примените его из отчёта."
     };
     var params = new URLSearchParams(window.location.search);
     var code = params.get("msg");

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -29,9 +29,6 @@
     <form method="post" action="/channels/filter/analyze" style="display:inline">
         <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Анализ фильтров</button>
     </form>
-    <form method="post" action="/channels/filter/apply" style="display:inline">
-        <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Применить фильтры</button>
-    </form>
     <form method="post" action="/channels/filter/reset" style="display:inline">
         <button type="submit" class="secondary outline" style="padding: 0.25rem 0.75rem;">Сброс фильтров</button>
     </form>
@@ -90,9 +87,15 @@
                         {{ "Вернуть" if ch.is_filtered else "Скрыть" }}
                     </button>
                 </form>
-                <form method="post" action="/channels/{{ ch.id }}/collect" style="display:inline">
-                    <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">Загрузить</button>
-                </form>
+                {% if ch.is_filtered %}
+                    <button type="button" class="outline" disabled style="padding: 0.25rem 0.5rem; margin: 0;">
+                        Загрузить
+                    </button>
+                {% else %}
+                    <form method="post" action="/channels/{{ ch.id }}/collect" style="display:inline">
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">Загрузить</button>
+                    </form>
+                {% endif %}
                 <form method="post" action="/channels/{{ ch.id }}/stats" style="display:inline">
                     <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">Стата</button>
                 </form>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -21,7 +21,7 @@
     </form>
 </article>
 
-{% if channels or show_all is defined %}
+{% if channels or show_all %}
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
     <a href="/channels" role="button" class="{{ '' if show_all else 'secondary' }} outline" style="padding: 0.25rem 0.75rem;">Активные</a>
     <a href="/channels?view=all" role="button" class="{{ 'secondary' if show_all else '' }} outline" style="padding: 0.25rem 0.75rem;">Все каналы</a>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -21,10 +21,22 @@
     </form>
 </article>
 
-{% if channels %}
-<div style="margin-bottom: 1rem;">
+{% if channels or show_all is defined %}
+<div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
+    <a href="/channels" role="button" class="{{ '' if show_all else 'secondary' }} outline" style="padding: 0.25rem 0.75rem;">Активные</a>
+    <a href="/channels?view=all" role="button" class="{{ 'secondary' if show_all else '' }} outline" style="padding: 0.25rem 0.75rem;">Все каналы</a>
+    <span style="flex:1"></span>
+    <form method="post" action="/channels/filter/analyze" style="display:inline">
+        <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Анализ фильтров</button>
+    </form>
+    <form method="post" action="/channels/filter/apply" style="display:inline">
+        <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Применить фильтры</button>
+    </form>
+    <form method="post" action="/channels/filter/reset" style="display:inline">
+        <button type="submit" class="secondary outline" style="padding: 0.25rem 0.75rem;">Сброс фильтров</button>
+    </form>
     <form method="post" action="/channels/stats/all" style="display:inline">
-        <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Обновить всю статистику</button>
+        <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Обновить статистику</button>
     </form>
 </div>
 <div style="overflow-x:auto">
@@ -41,13 +53,14 @@
             <th>Avg просмотры</th>
             <th>Avg реакции</th>
             <th>Avg репосты</th>
+            <th>Фильтр</th>
             <th>Действия</th>
         </tr>
     </thead>
     <tbody>
         {% for ch in channels %}
         {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
-        <tr>
+        <tr{% if ch.is_filtered %} style="opacity: 0.6"{% endif %}>
             <td>{{ ch.channel_id }}</td>
             <td>{{ ch.title or "—" }}</td>
             <td>{% if ch.username %}<a href="https://t.me/{{ ch.username }}" target="_blank" rel="noopener">@{{ ch.username }}</a>{% else %}—{% endif %}</td>
@@ -58,7 +71,19 @@
             <td>{{ "%.1f"|format(st.avg_views) if st and st.avg_views is not none else "—" }}</td>
             <td>{{ "%.1f"|format(st.avg_reactions) if st and st.avg_reactions is not none else "—" }}</td>
             <td>{{ "%.1f"|format(st.avg_forwards) if st and st.avg_forwards is not none else "—" }}</td>
+            <td>
+                {% if ch.is_filtered %}
+                    <mark>Отфильтрован</mark>
+                {% else %}
+                    -
+                {% endif %}
+            </td>
             <td style="white-space:nowrap">
+                <form method="post" action="/channels/{{ ch.id }}/filter-toggle" style="display:inline">
+                    <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">
+                        {{ "Вернуть" if ch.is_filtered else "Скрыть" }}
+                    </button>
+                </form>
                 <form method="post" action="/channels/{{ ch.id }}/collect" style="display:inline">
                     <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">Загрузить</button>
                 </form>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -73,7 +73,13 @@
             <td>{{ "%.1f"|format(st.avg_forwards) if st and st.avg_forwards is not none else "—" }}</td>
             <td>
                 {% if ch.is_filtered %}
-                    <mark>Отфильтрован</mark>
+                    {% if ch.filter_flags %}
+                        {% for flag in ch.filter_flags.split(',') %}
+                            <mark>{{ flag.strip() }}</mark>
+                        {% endfor %}
+                    {% else %}
+                        <mark>Отфильтрован</mark>
+                    {% endif %}
                 {% else %}
                     -
                 {% endif %}

--- a/src/web/templates/filter_report.html
+++ b/src/web/templates/filter_report.html
@@ -49,6 +49,9 @@
 
 <div style="display:flex; gap:0.5rem; margin-top:1rem">
     <form method="post" action="/channels/filter/apply">
+        {% for r in report.results if r.is_filtered %}
+        <input type="hidden" name="selected" value="{{ r.channel_id }}|{{ r.flags|join(',') }}">
+        {% endfor %}
         <button type="submit">Применить фильтры ({{ report.filtered_count }} каналов)</button>
     </form>
     <a href="/channels" role="button" class="secondary">Назад к каналам</a>

--- a/src/web/templates/filter_report.html
+++ b/src/web/templates/filter_report.html
@@ -49,6 +49,7 @@
 
 <div style="display:flex; gap:0.5rem; margin-top:1rem">
     <form method="post" action="/channels/filter/apply">
+        <input type="hidden" name="snapshot" value="1">
         {% for r in report.results if r.is_filtered %}
         <input type="hidden" name="selected" value="{{ r.channel_id }}|{{ r.flags|join(',') }}">
         {% endfor %}

--- a/src/web/templates/filter_report.html
+++ b/src/web/templates/filter_report.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block title %}Отчёт фильтрации — TG Post Search{% endblock %}
+{% block content %}
+<h1>Отчёт анализа каналов</h1>
+
+<p>Всего каналов: <strong>{{ report.total_channels }}</strong>, подлежат фильтрации: <strong>{{ report.filtered_count }}</strong></p>
+
+{% if report.results %}
+<div style="overflow-x:auto">
+<table>
+    <thead>
+        <tr>
+            <th>ID канала</th>
+            <th>Название</th>
+            <th>Сообщений</th>
+            <th>Уникальность %</th>
+            <th>Подписчики/Посты</th>
+            <th>Кириллица %</th>
+            <th>Короткие %</th>
+            <th>Кросс-дубли %</th>
+            <th>Флаги</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for r in report.results %}
+        <tr{% if r.is_filtered %} style="background-color: rgba(255,0,0,0.05)"{% endif %}>
+            <td>{{ r.channel_id }}</td>
+            <td>{{ r.title or "-" }}</td>
+            <td>{{ r.message_count }}</td>
+            <td>{{ "%.1f"|format(r.uniqueness_pct) if r.uniqueness_pct is not none else "-" }}</td>
+            <td>{{ "%.2f"|format(r.subscriber_ratio) if r.subscriber_ratio is not none else "-" }}</td>
+            <td>{{ "%.1f"|format(r.cyrillic_pct) if r.cyrillic_pct is not none else "-" }}</td>
+            <td>{{ "%.1f"|format(r.short_msg_pct) if r.short_msg_pct is not none else "-" }}</td>
+            <td>{{ "%.1f"|format(r.cross_dupe_pct) if r.cross_dupe_pct is not none else "-" }}</td>
+            <td>
+                {% if r.flags %}
+                    {% for flag in r.flags %}
+                        <mark style="margin-right:0.25rem">{{ flag }}</mark>
+                    {% endfor %}
+                {% else %}
+                    -
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<div style="display:flex; gap:0.5rem; margin-top:1rem">
+    <form method="post" action="/channels/filter/apply">
+        <button type="submit">Применить фильтры ({{ report.filtered_count }} каналов)</button>
+    </form>
+    <a href="/channels" role="button" class="secondary">Назад к каналам</a>
+</div>
+{% else %}
+<p>Нет каналов для анализа.</p>
+{% endif %}
+{% endblock %}

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -105,7 +105,11 @@
                     {% elif t.status == 'cancelled' %}
                         Отменена
                     {% else %}
-                        Ожидание
+                        {% if t.run_after %}
+                            Ожидание до {{ t.run_after.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+                        {% else %}
+                            Ожидание
+                        {% endif %}
                     {% endif %}
                 </td>
                 <td>{{ t.messages_collected }}</td>
@@ -138,5 +142,11 @@ document.querySelectorAll('form[action$="/trigger"], form[action$="/start"], for
         btn.disabled = true;
     });
 });
+
+{% if has_active_tasks %}
+setTimeout(function() {
+    window.location.reload();
+}, 5000);
+{% endif %}
 </script>
 {% endblock %}

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon.errors import FloodWaitError
 
 from src.config import SchedulerConfig
 from src.models import Channel, ChannelStats
@@ -128,6 +129,41 @@ async def test_collect_channel_stats_success(db):
     saved = await db.get_channel_stats(-100123)
     assert len(saved) == 1
     assert saved[0].subscriber_count == 5000
+    assert mock_client.iter_messages.call_args.kwargs["wait_time"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_stats_rotates_on_flood_wait(db):
+    ch = Channel(channel_id=-100321, title="Rotate", username="rotate_chan")
+    await db.add_channel(ch)
+
+    flood_err = FloodWaitError(request=None, capture=0)
+    flood_err.seconds = 60
+
+    client1 = AsyncMock()
+    client1.get_entity = AsyncMock(side_effect=flood_err)
+
+    mock_entity = SimpleNamespace()
+    mock_full_chat = SimpleNamespace(participants_count=123)
+    mock_full = SimpleNamespace(full_chat=mock_full_chat)
+    client2 = AsyncMock()
+    client2.get_entity = AsyncMock(return_value=mock_entity)
+    client2.return_value = mock_full
+    client2.iter_messages = MagicMock(return_value=_AsyncIterMessages([]))
+
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(
+            side_effect=[(client1, "+7001"), (client2, "+7002")]
+        )
+    )
+
+    collector = Collector(pool, db, SchedulerConfig())
+    result = await collector.collect_channel_stats(ch)
+
+    assert result is not None
+    assert result.subscriber_count == 123
+    pool.report_flood.assert_awaited_once_with("+7001", 60)
+    client2.get_entity.assert_awaited_once_with("rotate_chan")
 
 
 @pytest.mark.asyncio

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -225,6 +225,7 @@ async def test_stats_web_endpoint(tmp_path):
         return_value=ChannelStats(channel_id=-100123, subscriber_count=999)
     )
     collector.is_running = False
+    collector.is_stats_running = False
     app.state.collector = collector
     app.state.search_engine = SearchEngine(db)
     app.state.ai_search = AISearchEngine(config.llm, db)

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,6 +22,36 @@ async def test_pool_get_available_no_clients(db):
     pool = ClientPool(auth, db)
     result = await pool.get_available_client()
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_stats_availability_no_connected_active(db):
+    await db.add_account(Account(phone="+70000000001", session_string="s1", is_primary=True))
+    auth = MagicMock()
+    pool = ClientPool(auth, db)
+
+    availability = await pool.get_stats_availability()
+    assert availability.state == "no_connected_active"
+    assert availability.retry_after_sec is None
+
+
+@pytest.mark.asyncio
+async def test_stats_availability_all_flooded(db):
+    acc = Account(phone="+70000000002", session_string="s2", is_primary=True)
+    await db.add_account(acc)
+
+    auth = MagicMock()
+    pool = ClientPool(auth, db)
+    pool.clients["+70000000002"] = AsyncMock()
+
+    until = datetime.now(timezone.utc) + timedelta(seconds=120)
+    await db.update_account_flood("+70000000002", until)
+
+    availability = await pool.get_stats_availability()
+    assert availability.state == "all_flooded"
+    assert availability.retry_after_sec is not None
+    assert availability.retry_after_sec >= 1
+    assert availability.next_available_at_utc is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -38,6 +38,36 @@ async def test_collect_no_clients(db):
 
 
 @pytest.mark.asyncio
+async def test_collect_all_skips_filtered_channels(db):
+    await db.add_channel(Channel(channel_id=-100124, title="Filtered"))
+    await db.add_channel(Channel(channel_id=-100125, title="Normal"))
+    await db.set_channels_filtered_bulk([(-100124, "low_uniqueness")])
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+
+    stats = await collector.collect_all_channels()
+    assert stats["channels"] == 1
+    assert stats["messages"] == 0
+
+
+@pytest.mark.asyncio
+async def test_collect_single_channel_skips_filtered(db):
+    """collect_single_channel returns 0 immediately for filtered channels."""
+    ch = Channel(
+        channel_id=-100130, title="Filtered",
+        is_filtered=True, filter_flags="non_cyrillic",
+    )
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+
+    count = await collector.collect_single_channel(ch)
+    assert count == 0
+    # Pool should never be touched
+    pool.get_available_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_collect_channel_uses_peer_channel_without_username(db):
     """_collect_channel falls back to PeerChannel when no username."""
     ch = Channel(channel_id=1970788983, title="Test Channel")
@@ -390,3 +420,50 @@ async def test_progress_callback_invoked_on_batch_flush(db):
     assert progress_cb.await_count == 2
     progress_cb.assert_any_await(500)
     progress_cb.assert_any_await(600)
+
+
+@pytest.mark.asyncio
+async def test_collection_queue_skips_filtered_channel(db):
+    """CollectionQueue worker skips channels that become filtered after enqueue."""
+    from src.collection_queue import CollectionQueue
+
+    ch = Channel(channel_id=-100140, title="Will Be Filtered")
+    await db.add_channel(ch)
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+
+    queue = CollectionQueue(collector, db)
+
+    # Mark channel as filtered after adding
+    await db.set_channels_filtered_bulk([(-100140, "low_uniqueness")])
+
+    # Get the stored channel with its PK
+    channels = await db.get_channels(include_filtered=True)
+    stored_ch = next(c for c in channels if c.channel_id == -100140)
+
+    task_id = await queue.enqueue(stored_ch)
+
+    # Wait for worker to process
+    await asyncio.sleep(0.5)
+
+    task = await db.get_collection_task(task_id)
+    assert task.status == "cancelled"
+
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_collect_all_stats_skips_filtered(db):
+    """collect_all_stats should skip filtered channels."""
+    await db.add_channel(Channel(channel_id=-100150, title="Filtered"))
+    await db.add_channel(Channel(channel_id=-100151, title="Normal"))
+    await db.set_channels_filtered_bulk([(-100150, "low_uniqueness")])
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+
+    stats = await collector.collect_all_stats()
+    # Only 1 channel (Normal), and it will error because no client
+    assert stats["channels"] == 0
+    assert stats["errors"] == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -199,6 +199,34 @@ async def test_get_channel_by_pk_returns_none_for_unknown_id(db):
 
 
 @pytest.mark.asyncio
+async def test_set_channels_filtered_bulk_and_reset(db):
+    await db.add_channel(Channel(channel_id=-1007001, title="One", username="one"))
+    await db.add_channel(Channel(channel_id=-1007002, title="Two", username="two"))
+
+    updated = await db.set_channels_filtered_bulk(
+        [(-1007001, "low_uniqueness"), (-1007002, "non_cyrillic,chat_noise")]
+    )
+    assert updated == 2
+
+    channels = await db.get_channels()
+    by_channel_id = {channel.channel_id: channel for channel in channels}
+    assert by_channel_id[-1007001].is_filtered is True
+    assert by_channel_id[-1007001].filter_flags == "low_uniqueness"
+    assert by_channel_id[-1007002].is_filtered is True
+    assert by_channel_id[-1007002].filter_flags == "non_cyrillic,chat_noise"
+
+    reset_count = await db.reset_all_channel_filters()
+    assert reset_count >= 2
+
+    channels = await db.get_channels()
+    by_channel_id = {channel.channel_id: channel for channel in channels}
+    assert by_channel_id[-1007001].is_filtered is False
+    assert by_channel_id[-1007001].filter_flags == ""
+    assert by_channel_id[-1007002].is_filtered is False
+    assert by_channel_id[-1007002].filter_flags == ""
+
+
+@pytest.mark.asyncio
 async def test_insert_message_deduplication(db):
     msg = Message(
         channel_id=-1001234567890,
@@ -575,15 +603,84 @@ async def test_migrate_adds_channel_type_column(tmp_path):
     cur = await database.execute("PRAGMA table_info(channels)")
     columns = {row["name"] for row in await cur.fetchall()}
     assert "channel_type" in columns
+    assert "is_filtered" in columns
+    assert "filter_flags" in columns
 
     channels = await database.get_channels()
     assert len(channels) == 1
     assert channels[0].channel_type is None
+    assert channels[0].is_filtered is False
+    assert channels[0].filter_flags == ""
 
     ch = Channel(channel_id=-100456, title="New", channel_type="group")
     await database.add_channel(ch)
     channels = await database.get_channels()
     assert any(c.channel_type == "group" for c in channels)
+
+    await database.close()
+
+
+@pytest.mark.asyncio
+async def test_migrate_filter_columns_idempotent(tmp_path):
+    db_path = str(tmp_path / "migrate_filter_columns_idempotent.db")
+
+    conn = await aiosqlite.connect(db_path)
+    await conn.executescript("""
+        CREATE TABLE IF NOT EXISTS accounts (
+            id INTEGER PRIMARY KEY,
+            phone TEXT UNIQUE NOT NULL,
+            session_string TEXT NOT NULL,
+            is_primary INTEGER DEFAULT 0,
+            is_active INTEGER DEFAULT 1,
+            flood_wait_until TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS channels (
+            id INTEGER PRIMARY KEY,
+            channel_id INTEGER UNIQUE NOT NULL,
+            title TEXT,
+            username TEXT,
+            is_active INTEGER DEFAULT 1,
+            last_collected_id INTEGER DEFAULT 0,
+            added_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY,
+            channel_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            sender_id INTEGER,
+            sender_name TEXT,
+            text TEXT,
+            media_type TEXT,
+            date TEXT NOT NULL,
+            collected_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(channel_id, message_id)
+        );
+        CREATE TABLE IF NOT EXISTS keywords (
+            id INTEGER PRIMARY KEY,
+            pattern TEXT NOT NULL,
+            is_regex INTEGER DEFAULT 0,
+            is_active INTEGER DEFAULT 1
+        );
+        CREATE TABLE IF NOT EXISTS settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+    """)
+    await conn.commit()
+    await conn.close()
+
+    database = Database(db_path)
+    await database.initialize()
+    await database.close()
+
+    database = Database(db_path)
+    await database.initialize()
+
+    cur = await database.execute("PRAGMA table_info(channels)")
+    columns = {row["name"] for row in await cur.fetchall()}
+    assert "is_filtered" in columns
+    assert "filter_flags" in columns
 
     await database.close()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -753,3 +753,67 @@ async def test_migrate_adds_is_premium_column(tmp_path):
     assert accounts[0].is_premium is False
 
     await database.close()
+
+
+@pytest.mark.asyncio
+async def test_stats_task_claim_and_continuation(db):
+    now = datetime.now(timezone.utc)
+    payload = {
+        "task_kind": "stats_all",
+        "channel_ids": [-1001, -1002],
+        "next_index": 0,
+        "batch_size": 20,
+        "channels_ok": 0,
+        "channels_err": 0,
+    }
+    tid = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        run_after=now,
+        payload=payload,
+    )
+
+    claimed = await db.claim_next_due_stats_task(now)
+    assert claimed is not None
+    assert claimed.id == tid
+    assert claimed.status == "running"
+    assert claimed.payload is not None
+    assert claimed.payload["task_kind"] == "stats_all"
+
+    continuation_id = await db.create_stats_continuation_task(
+        payload={**payload, "next_index": 1},
+        run_after=now,
+        parent_task_id=tid,
+    )
+    continuation = await db.get_collection_task(continuation_id)
+    assert continuation is not None
+    assert continuation.parent_task_id == tid
+    assert continuation.status == "pending"
+    assert continuation.payload is not None
+    assert continuation.payload["next_index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_requeue_running_stats_tasks_on_startup(db):
+    payload = {
+        "task_kind": "stats_all",
+        "channel_ids": [],
+        "next_index": 0,
+        "batch_size": 20,
+        "channels_ok": 0,
+        "channels_err": 0,
+    }
+    tid = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=payload,
+    )
+    await db.update_collection_task(tid, "running")
+
+    requeued = await db.requeue_running_stats_tasks_on_startup(datetime.now(timezone.utc))
+    assert requeued == 1
+
+    task = await db.get_collection_task(tid)
+    assert task is not None
+    assert task.status == "pending"
+    assert task.run_after is not None

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -130,6 +130,13 @@ class TestNonCyrillic:
         assert pct == 0.0
         assert flagged is True
 
+    async def test_mixed_content_channel(self, raw_db):
+        await _insert_channel(raw_db, 402)
+        await _insert_messages(raw_db, 402, ["hello world", "Привет мир", "ещё один", "test"])
+        pct, flagged = await check_non_cyrillic(raw_db, 402)
+        assert pct == 50.0
+        assert flagged is False
+
 
 class TestChatNoise:
     async def test_not_a_group(self, raw_db):
@@ -159,20 +166,20 @@ class TestChatNoise:
 
 
 class TestChannelAnalyzer:
-    async def test_analyze_all(self, raw_db):
+    async def test_analyze_all(self, db, raw_db):
         await _insert_channel(raw_db, 600)
         await _insert_messages(raw_db, 600, ["unique text"] * 3)
-        analyzer = ChannelAnalyzer(raw_db)
+        analyzer = ChannelAnalyzer(db)
         report = await analyzer.analyze_all()
         assert report.total_channels >= 1
         found = [r for r in report.results if r.channel_id == 600]
         assert len(found) == 1
 
-    async def test_apply_filters(self, raw_db):
+    async def test_apply_filters(self, db, raw_db):
         await _insert_channel(raw_db, 700)
         # All same messages -> low uniqueness -> should be filtered
         await _insert_messages(raw_db, 700, ["spam"] * 20)
-        analyzer = ChannelAnalyzer(raw_db)
+        analyzer = ChannelAnalyzer(db)
         report = await analyzer.analyze_all()
         result = [r for r in report.results if r.channel_id == 700][0]
         assert result.is_filtered is True
@@ -182,23 +189,56 @@ class TestChannelAnalyzer:
         assert count >= 1
 
         cur = await raw_db.execute(
-            "SELECT is_filtered FROM channels WHERE channel_id = 700"
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 700"
         )
         row = await cur.fetchone()
         assert row["is_filtered"] == 1
+        assert "low_uniqueness" in row["filter_flags"]
 
-    async def test_reset_filters(self, raw_db):
+    async def test_reset_filters(self, db, raw_db):
         await _insert_channel(raw_db, 800)
         await raw_db.execute(
-            "UPDATE channels SET is_filtered = 1 WHERE channel_id = 800"
+            "UPDATE channels SET is_filtered = 1, filter_flags = 'low_uniqueness,non_cyrillic'"
+            " WHERE channel_id = 800"
         )
         await raw_db.commit()
 
-        analyzer = ChannelAnalyzer(raw_db)
+        analyzer = ChannelAnalyzer(db)
         await analyzer.reset_filters()
 
         cur = await raw_db.execute(
-            "SELECT is_filtered FROM channels WHERE channel_id = 800"
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 800"
         )
         row = await cur.fetchone()
         assert row["is_filtered"] == 0
+        assert row["filter_flags"] == ""
+
+    async def test_bulk_cross_channel_dupes_flag(self, db, raw_db):
+        await _insert_channel(raw_db, 900, title="A")
+        await _insert_channel(raw_db, 901, title="B")
+        await _insert_channel(raw_db, 902, title="C")
+
+        await _insert_messages(
+            raw_db,
+            900,
+            [
+                "shared duplicated content alpha beta gamma",
+                "shared duplicated content delta epsilon zeta",
+                "unique channel 900 payload long enough",
+            ],
+        )
+        await _insert_messages(
+            raw_db,
+            901,
+            [
+                "shared duplicated content alpha beta gamma",
+                "shared duplicated content delta epsilon zeta",
+            ],
+        )
+        await _insert_messages(raw_db, 902, ["independent long content for channel 902 only"])
+
+        analyzer = ChannelAnalyzer(db)
+        report = await analyzer.analyze_all()
+        ch900 = next(r for r in report.results if r.channel_id == 900)
+        assert ch900.cross_dupe_pct == 66.7
+        assert "cross_channel_spam" in ch900.flags

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+
+from src.filters.analyzer import ChannelAnalyzer
+from src.filters.criteria import (
+    check_chat_noise,
+    check_cross_channel_dupes,
+    check_low_uniqueness,
+    check_non_cyrillic,
+    check_subscriber_ratio,
+)
+
+
+async def _insert_channel(db, channel_id, title="Test", channel_type="channel"):
+    await db.execute(
+        "INSERT INTO channels (channel_id, title, channel_type, is_active) VALUES (?, ?, ?, 1)",
+        (channel_id, title, channel_type),
+    )
+    await db.commit()
+
+
+async def _insert_messages(db, channel_id, texts):
+    for i, text in enumerate(texts, 1):
+        await db.execute(
+            "INSERT INTO messages (channel_id, message_id, text, date) "
+            "VALUES (?, ?, ?, '2025-01-01')",
+            (channel_id, i, text),
+        )
+    await db.commit()
+
+
+async def _insert_stats(db, channel_id, subscriber_count):
+    await db.execute(
+        "INSERT INTO channel_stats (channel_id, subscriber_count) VALUES (?, ?)",
+        (channel_id, subscriber_count),
+    )
+    await db.commit()
+
+
+@pytest.fixture
+async def raw_db(db):
+    """Return the raw aiosqlite connection from the Database fixture."""
+    return db.db
+
+
+class TestLowUniqueness:
+    async def test_high_uniqueness(self, raw_db):
+        await _insert_channel(raw_db, 100)
+        await _insert_messages(raw_db, 100, ["unique text 1", "unique text 2", "unique text 3"])
+        pct, flagged = await check_low_uniqueness(raw_db, 100)
+        assert pct == 100.0
+        assert flagged is False
+
+    async def test_low_uniqueness(self, raw_db):
+        await _insert_channel(raw_db, 101)
+        texts = ["same spam message"] * 10
+        await _insert_messages(raw_db, 101, texts)
+        pct, flagged = await check_low_uniqueness(raw_db, 101)
+        assert pct == 10.0
+        assert flagged is True
+
+    async def test_no_messages(self, raw_db):
+        await _insert_channel(raw_db, 102)
+        pct, flagged = await check_low_uniqueness(raw_db, 102)
+        assert pct is None
+        assert flagged is False
+
+
+class TestSubscriberRatio:
+    async def test_healthy_ratio(self, raw_db):
+        await _insert_channel(raw_db, 200)
+        await _insert_messages(raw_db, 200, ["msg1", "msg2"])
+        await _insert_stats(raw_db, 200, 1000)
+        ratio, flagged = await check_subscriber_ratio(raw_db, 200)
+        assert ratio == 500.0
+        assert flagged is False
+
+    async def test_low_ratio(self, raw_db):
+        await _insert_channel(raw_db, 201)
+        await _insert_messages(raw_db, 201, [f"msg{i}" for i in range(100)])
+        await _insert_stats(raw_db, 201, 10)
+        ratio, flagged = await check_subscriber_ratio(raw_db, 201)
+        assert ratio == 0.1
+        assert flagged is True
+
+    async def test_no_stats(self, raw_db):
+        await _insert_channel(raw_db, 202)
+        await _insert_messages(raw_db, 202, ["msg"])
+        ratio, flagged = await check_subscriber_ratio(raw_db, 202)
+        assert ratio is None
+        assert flagged is False
+
+
+class TestCrossChannelDupes:
+    async def test_no_dupes(self, raw_db):
+        await _insert_channel(raw_db, 300)
+        await _insert_channel(raw_db, 301, title="Other")
+        await _insert_messages(raw_db, 300, ["unique content from channel A"])
+        await _insert_messages(raw_db, 301, ["completely different text here"])
+        pct, flagged = await check_cross_channel_dupes(raw_db, 300)
+        assert flagged is False
+
+    async def test_high_dupes(self, raw_db):
+        await _insert_channel(raw_db, 302)
+        await _insert_channel(raw_db, 303, title="Mirror")
+        shared = ["this is a duplicated message across channels"]
+        await _insert_messages(raw_db, 302, shared)
+        await _insert_messages(raw_db, 303, shared)
+        pct, flagged = await check_cross_channel_dupes(raw_db, 302)
+        assert pct == 100.0
+        assert flagged is True
+
+
+class TestNonCyrillic:
+    async def test_cyrillic_channel(self, raw_db):
+        await _insert_channel(raw_db, 400)
+        await _insert_messages(raw_db, 400, ["Привет мир", "Тест сообщение", "Ещё одно"])
+        pct, flagged = await check_non_cyrillic(raw_db, 400)
+        assert pct == 100.0
+        assert flagged is False
+
+    async def test_non_cyrillic_channel(self, raw_db):
+        await _insert_channel(raw_db, 401)
+        texts = ["hello world", "test message", "no cyrillic here"] + [
+            "another eng text"
+        ] * 7
+        await _insert_messages(raw_db, 401, texts)
+        pct, flagged = await check_non_cyrillic(raw_db, 401)
+        assert pct == 0.0
+        assert flagged is True
+
+
+class TestChatNoise:
+    async def test_not_a_group(self, raw_db):
+        await _insert_channel(raw_db, 500, channel_type="channel")
+        await _insert_messages(raw_db, 500, ["hi", "ok", "lol"])
+        pct, flagged = await check_chat_noise(raw_db, 500)
+        assert pct is None
+        assert flagged is False
+
+    async def test_noisy_group(self, raw_db):
+        await _insert_channel(raw_db, 501, channel_type="group")
+        texts = ["hi", "ok", "+", "lol", "da", "net", "yes"] + ["long enough message here"]
+        await _insert_messages(raw_db, 501, texts)
+        pct, flagged = await check_chat_noise(raw_db, 501)
+        assert pct is not None
+        assert flagged is True
+
+    async def test_clean_group(self, raw_db):
+        await _insert_channel(raw_db, 502, channel_type="group")
+        await _insert_messages(
+            raw_db, 502,
+            ["This is a normal length message"] * 10,
+        )
+        pct, flagged = await check_chat_noise(raw_db, 502)
+        assert pct == 0.0
+        assert flagged is False
+
+
+class TestChannelAnalyzer:
+    async def test_analyze_all(self, raw_db):
+        await _insert_channel(raw_db, 600)
+        await _insert_messages(raw_db, 600, ["unique text"] * 3)
+        analyzer = ChannelAnalyzer(raw_db)
+        report = await analyzer.analyze_all()
+        assert report.total_channels >= 1
+        found = [r for r in report.results if r.channel_id == 600]
+        assert len(found) == 1
+
+    async def test_apply_filters(self, raw_db):
+        await _insert_channel(raw_db, 700)
+        # All same messages -> low uniqueness -> should be filtered
+        await _insert_messages(raw_db, 700, ["spam"] * 20)
+        analyzer = ChannelAnalyzer(raw_db)
+        report = await analyzer.analyze_all()
+        result = [r for r in report.results if r.channel_id == 700][0]
+        assert result.is_filtered is True
+        assert "low_uniqueness" in result.flags
+
+        count = await analyzer.apply_filters(report)
+        assert count >= 1
+
+        cur = await raw_db.execute(
+            "SELECT is_filtered FROM channels WHERE channel_id = 700"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 1
+
+    async def test_reset_filters(self, raw_db):
+        await _insert_channel(raw_db, 800)
+        await raw_db.execute(
+            "UPDATE channels SET is_filtered = 1 WHERE channel_id = 800"
+        )
+        await raw_db.commit()
+
+        analyzer = ChannelAnalyzer(raw_db)
+        await analyzer.reset_filters()
+
+        cur = await raw_db.execute(
+            "SELECT is_filtered FROM channels WHERE channel_id = 800"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -87,12 +87,11 @@ class TestAnalyzerLowUniqueness:
 
     async def test_boundary_exactly_at_threshold(self, db, raw_db):
         await _insert_channel(raw_db, 103)
-        # 30% uniqueness = exactly at threshold -> NOT flagged (< threshold)
+        # 4 unique / 10 total = 40% > 30% threshold -> NOT flagged
         texts = ["unique A", "unique B", "unique C"] + ["same"] * 7
         await _insert_messages(raw_db, 103, texts)
         analyzer = ChannelAnalyzer(db)
         result = await analyzer.analyze_channel(103)
-        # 4 unique / 10 total = 40% > 30% threshold
         assert "low_uniqueness" not in result.flags
 
 
@@ -320,12 +319,13 @@ class TestChannelAnalyzer:
         )
         row = await cur.fetchone()
         assert row["is_filtered"] == 1
-        assert row["filter_flags"] == "non_cyrillic"
+        assert row["filter_flags"] == "low_uniqueness,non_cyrillic"
 
     async def test_apply_filters_is_atomic_on_error(self, db, raw_db, monkeypatch):
         await _insert_channel(raw_db, 713, title="Atomic")
         await raw_db.execute(
-            "UPDATE channels SET is_filtered = 1, filter_flags = 'legacy_flag' WHERE channel_id = 713"
+            "UPDATE channels SET is_filtered = 1, filter_flags = 'legacy_flag'"
+            " WHERE channel_id = 713"
         )
         await raw_db.commit()
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,13 +3,8 @@ from __future__ import annotations
 import pytest
 
 from src.filters.analyzer import ChannelAnalyzer
-from src.filters.criteria import (
-    check_chat_noise,
-    check_cross_channel_dupes,
-    check_low_uniqueness,
-    check_non_cyrillic,
-    check_subscriber_ratio,
-)
+from src.filters.criteria import VALID_FLAGS, contains_cyrillic
+from src.filters.models import ChannelFilterResult, FilterReport
 
 
 async def _insert_channel(db, channel_id, title="Test", channel_type="channel"):
@@ -44,125 +39,195 @@ async def raw_db(db):
     return db.db
 
 
-class TestLowUniqueness:
-    async def test_high_uniqueness(self, raw_db):
+class TestContainsCyrillic:
+    def test_cyrillic(self):
+        assert contains_cyrillic("Привет") is True
+
+    def test_no_cyrillic(self):
+        assert contains_cyrillic("hello") is False
+
+    def test_mixed(self):
+        assert contains_cyrillic("hello Мир") is True
+
+
+class TestValidFlags:
+    def test_all_flags_present(self):
+        assert "low_uniqueness" in VALID_FLAGS
+        assert "low_subscriber_ratio" in VALID_FLAGS
+        assert "cross_channel_spam" in VALID_FLAGS
+        assert "non_cyrillic" in VALID_FLAGS
+        assert "chat_noise" in VALID_FLAGS
+        assert len(VALID_FLAGS) == 5
+
+
+class TestAnalyzerLowUniqueness:
+    async def test_high_uniqueness(self, db, raw_db):
         await _insert_channel(raw_db, 100)
         await _insert_messages(raw_db, 100, ["unique text 1", "unique text 2", "unique text 3"])
-        pct, flagged = await check_low_uniqueness(raw_db, 100)
-        assert pct == 100.0
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(100)
+        assert result.uniqueness_pct == 100.0
+        assert "low_uniqueness" not in result.flags
 
-    async def test_low_uniqueness(self, raw_db):
+    async def test_low_uniqueness(self, db, raw_db):
         await _insert_channel(raw_db, 101)
         texts = ["same spam message"] * 10
         await _insert_messages(raw_db, 101, texts)
-        pct, flagged = await check_low_uniqueness(raw_db, 101)
-        assert pct == 10.0
-        assert flagged is True
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(101)
+        assert result.uniqueness_pct == 10.0
+        assert "low_uniqueness" in result.flags
 
-    async def test_no_messages(self, raw_db):
+    async def test_no_messages(self, db, raw_db):
         await _insert_channel(raw_db, 102)
-        pct, flagged = await check_low_uniqueness(raw_db, 102)
-        assert pct is None
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(102)
+        assert result.uniqueness_pct is None
+        assert "low_uniqueness" not in result.flags
+
+    async def test_boundary_exactly_at_threshold(self, db, raw_db):
+        await _insert_channel(raw_db, 103)
+        # 30% uniqueness = exactly at threshold -> NOT flagged (< threshold)
+        texts = ["unique A", "unique B", "unique C"] + ["same"] * 7
+        await _insert_messages(raw_db, 103, texts)
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(103)
+        # 4 unique / 10 total = 40% > 30% threshold
+        assert "low_uniqueness" not in result.flags
 
 
-class TestSubscriberRatio:
-    async def test_healthy_ratio(self, raw_db):
+class TestAnalyzerSubscriberRatio:
+    async def test_healthy_ratio(self, db, raw_db):
         await _insert_channel(raw_db, 200)
         await _insert_messages(raw_db, 200, ["msg1", "msg2"])
         await _insert_stats(raw_db, 200, 1000)
-        ratio, flagged = await check_subscriber_ratio(raw_db, 200)
-        assert ratio == 500.0
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(200)
+        assert result.subscriber_ratio == 500.0
+        assert "low_subscriber_ratio" not in result.flags
 
-    async def test_low_ratio(self, raw_db):
+    async def test_low_ratio(self, db, raw_db):
         await _insert_channel(raw_db, 201)
         await _insert_messages(raw_db, 201, [f"msg{i}" for i in range(100)])
         await _insert_stats(raw_db, 201, 10)
-        ratio, flagged = await check_subscriber_ratio(raw_db, 201)
-        assert ratio == 0.1
-        assert flagged is True
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(201)
+        assert result.subscriber_ratio == 0.1
+        assert "low_subscriber_ratio" in result.flags
 
-    async def test_no_stats(self, raw_db):
+    async def test_no_stats(self, db, raw_db):
         await _insert_channel(raw_db, 202)
         await _insert_messages(raw_db, 202, ["msg"])
-        ratio, flagged = await check_subscriber_ratio(raw_db, 202)
-        assert ratio is None
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(202)
+        assert result.subscriber_ratio is None
+        assert "low_subscriber_ratio" not in result.flags
 
 
-class TestCrossChannelDupes:
-    async def test_no_dupes(self, raw_db):
+class TestAnalyzerCrossChannelDupes:
+    async def test_no_dupes(self, db, raw_db):
         await _insert_channel(raw_db, 300)
         await _insert_channel(raw_db, 301, title="Other")
         await _insert_messages(raw_db, 300, ["unique content from channel A"])
         await _insert_messages(raw_db, 301, ["completely different text here"])
-        pct, flagged = await check_cross_channel_dupes(raw_db, 300)
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(300)
+        assert "cross_channel_spam" not in result.flags
 
-    async def test_high_dupes(self, raw_db):
+    async def test_high_dupes(self, db, raw_db):
         await _insert_channel(raw_db, 302)
         await _insert_channel(raw_db, 303, title="Mirror")
         shared = ["this is a duplicated message across channels"]
         await _insert_messages(raw_db, 302, shared)
         await _insert_messages(raw_db, 303, shared)
-        pct, flagged = await check_cross_channel_dupes(raw_db, 302)
-        assert pct == 100.0
-        assert flagged is True
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(302)
+        assert result.cross_dupe_pct == 100.0
+        assert "cross_channel_spam" in result.flags
 
 
-class TestNonCyrillic:
-    async def test_cyrillic_channel(self, raw_db):
+class TestAnalyzerNonCyrillic:
+    async def test_cyrillic_channel(self, db, raw_db):
         await _insert_channel(raw_db, 400)
         await _insert_messages(raw_db, 400, ["Привет мир", "Тест сообщение", "Ещё одно"])
-        pct, flagged = await check_non_cyrillic(raw_db, 400)
-        assert pct == 100.0
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(400)
+        assert result.cyrillic_pct == 100.0
+        assert "non_cyrillic" not in result.flags
 
-    async def test_non_cyrillic_channel(self, raw_db):
+    async def test_non_cyrillic_channel(self, db, raw_db):
         await _insert_channel(raw_db, 401)
         texts = ["hello world", "test message", "no cyrillic here"] + [
             "another eng text"
         ] * 7
         await _insert_messages(raw_db, 401, texts)
-        pct, flagged = await check_non_cyrillic(raw_db, 401)
-        assert pct == 0.0
-        assert flagged is True
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(401)
+        assert result.cyrillic_pct == 0.0
+        assert "non_cyrillic" in result.flags
 
-    async def test_mixed_content_channel(self, raw_db):
+    async def test_mixed_content_channel(self, db, raw_db):
         await _insert_channel(raw_db, 402)
         await _insert_messages(raw_db, 402, ["hello world", "Привет мир", "ещё один", "test"])
-        pct, flagged = await check_non_cyrillic(raw_db, 402)
-        assert pct == 50.0
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(402)
+        assert result.cyrillic_pct == 50.0
+        assert "non_cyrillic" not in result.flags
 
 
-class TestChatNoise:
-    async def test_not_a_group(self, raw_db):
+class TestAnalyzerChatNoise:
+    async def test_not_a_group(self, db, raw_db):
         await _insert_channel(raw_db, 500, channel_type="channel")
         await _insert_messages(raw_db, 500, ["hi", "ok", "lol"])
-        pct, flagged = await check_chat_noise(raw_db, 500)
-        assert pct is None
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(500)
+        assert result.short_msg_pct is None
+        assert "chat_noise" not in result.flags
 
-    async def test_noisy_group(self, raw_db):
+    async def test_noisy_group(self, db, raw_db):
         await _insert_channel(raw_db, 501, channel_type="group")
         texts = ["hi", "ok", "+", "lol", "da", "net", "yes"] + ["long enough message here"]
         await _insert_messages(raw_db, 501, texts)
-        pct, flagged = await check_chat_noise(raw_db, 501)
-        assert pct is not None
-        assert flagged is True
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(501)
+        assert result.short_msg_pct is not None
+        assert "chat_noise" in result.flags
 
-    async def test_clean_group(self, raw_db):
+    async def test_clean_group(self, db, raw_db):
         await _insert_channel(raw_db, 502, channel_type="group")
         await _insert_messages(
             raw_db, 502,
             ["This is a normal length message"] * 10,
         )
-        pct, flagged = await check_chat_noise(raw_db, 502)
-        assert pct == 0.0
-        assert flagged is False
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(502)
+        assert result.short_msg_pct == 0.0
+        assert "chat_noise" not in result.flags
+
+    async def test_media_only_not_counted_as_short(self, db, raw_db):
+        await _insert_channel(raw_db, 503, channel_type="group")
+        # Insert messages with NULL text (media-only)
+        for i in range(1, 9):
+            await raw_db.execute(
+                "INSERT INTO messages (channel_id, message_id, text, date) "
+                "VALUES (?, ?, NULL, '2025-01-01')",
+                (503, i),
+            )
+        # Insert 2 long text messages
+        await raw_db.execute(
+            "INSERT INTO messages (channel_id, message_id, text, date) "
+            "VALUES (503, 9, 'This is a long enough text message', '2025-01-01')"
+        )
+        await raw_db.execute(
+            "INSERT INTO messages (channel_id, message_id, text, date) "
+            "VALUES (503, 10, 'Another long enough text message here', '2025-01-01')"
+        )
+        await raw_db.commit()
+        analyzer = ChannelAnalyzer(db)
+        result = await analyzer.analyze_channel(503)
+        # 8 NULL + 2 long = 0 short out of 10 -> 0%
+        assert result.short_msg_pct == 0.0
+        assert "chat_noise" not in result.flags
 
 
 class TestChannelAnalyzer:
@@ -194,6 +259,103 @@ class TestChannelAnalyzer:
         row = await cur.fetchone()
         assert row["is_filtered"] == 1
         assert "low_uniqueness" in row["filter_flags"]
+
+    async def test_apply_filters_resets_stale(self, db, raw_db):
+        # Channel 710 was previously filtered
+        await _insert_channel(raw_db, 710, title="Previously Filtered")
+        await raw_db.execute(
+            "UPDATE channels SET is_filtered = 1, filter_flags = 'low_uniqueness'"
+            " WHERE channel_id = 710"
+        )
+        await _insert_messages(raw_db, 710, [f"уникальное сообщение {i}" for i in range(20)])
+
+        # Channel 711 is genuinely spammy
+        await _insert_channel(raw_db, 711, title="Spammy")
+        await _insert_messages(raw_db, 711, ["spam"] * 20)
+        await raw_db.commit()
+
+        analyzer = ChannelAnalyzer(db)
+        report = await analyzer.analyze_all()
+        await analyzer.apply_filters(report)
+
+        # Channel 710 should be clean now
+        cur = await raw_db.execute(
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 710"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 0
+
+        # Channel 711 should still be filtered
+        cur = await raw_db.execute(
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 711"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 1
+
+    async def test_apply_filters_deduplicates_same_channel(self, db, raw_db):
+        await _insert_channel(raw_db, 712, title="Dupes")
+        analyzer = ChannelAnalyzer(db)
+        report = FilterReport(
+            results=[
+                ChannelFilterResult(
+                    channel_id=712,
+                    flags=["low_uniqueness"],
+                    is_filtered=True,
+                ),
+                ChannelFilterResult(
+                    channel_id=712,
+                    flags=["non_cyrillic"],
+                    is_filtered=True,
+                ),
+            ],
+            total_channels=2,
+            filtered_count=2,
+        )
+
+        count = await analyzer.apply_filters(report)
+        assert count == 1
+
+        cur = await raw_db.execute(
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 712"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 1
+        assert row["filter_flags"] == "non_cyrillic"
+
+    async def test_apply_filters_is_atomic_on_error(self, db, raw_db, monkeypatch):
+        await _insert_channel(raw_db, 713, title="Atomic")
+        await raw_db.execute(
+            "UPDATE channels SET is_filtered = 1, filter_flags = 'legacy_flag' WHERE channel_id = 713"
+        )
+        await raw_db.commit()
+
+        analyzer = ChannelAnalyzer(db)
+        report = FilterReport(
+            results=[
+                ChannelFilterResult(
+                    channel_id=713,
+                    flags=["low_uniqueness"],
+                    is_filtered=True,
+                )
+            ],
+            total_channels=1,
+            filtered_count=1,
+        )
+
+        async def _boom(updates, *, commit=True):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(db, "set_channels_filtered_bulk", _boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await analyzer.apply_filters(report)
+
+        cur = await raw_db.execute(
+            "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = 713"
+        )
+        row = await cur.fetchone()
+        assert row["is_filtered"] == 1
+        assert row["filter_flags"] == "legacy_flag"
 
     async def test_reset_filters(self, db, raw_db):
         await _insert_channel(raw_db, 800)

--- a/tests/test_stats_task_dispatcher.py
+++ b/tests/test_stats_task_dispatcher.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models import Channel
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
+
+
+def _stats_payload(channel_ids: list[int], *, next_index: int = 0) -> dict:
+    return {
+        "task_kind": "stats_all",
+        "channel_ids": channel_ids,
+        "next_index": next_index,
+        "batch_size": 20,
+        "channels_ok": 0,
+        "channels_err": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_requeues_running_on_start(db):
+    tid = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=_stats_payload([]),
+    )
+    await db.update_collection_task(tid, "running")
+
+    collector = SimpleNamespace(is_running=True)
+    dispatcher = StatsTaskDispatcher(collector, db, poll_interval_sec=0.01)
+    await dispatcher.start()
+    await dispatcher.stop()
+
+    task = await db.get_collection_task(tid)
+    assert task is not None
+    assert task.status == "pending"
+    assert task.run_after is not None
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_creates_batch_continuation(db):
+    for idx in range(25):
+        await db.add_channel(Channel(channel_id=-1000 - idx, title=f"Ch{idx}"))
+    channels = await db.get_channels(active_only=True, include_filtered=False)
+    channel_ids = [ch.channel_id for ch in channels]
+
+    root_id = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=_stats_payload(channel_ids),
+    )
+    root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert root_task is not None
+
+    async def _collect(_channel):
+        return object()
+
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(side_effect=_collect),
+        get_stats_availability=AsyncMock(),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(root_task)
+
+    root = await db.get_collection_task(root_id)
+    assert root is not None
+    assert root.status == "completed"
+    assert root.messages_collected == 20
+
+    active = await db.get_active_stats_task()
+    assert active is not None
+    assert active.parent_task_id == root_id
+    assert active.payload is not None
+    assert active.payload["next_index"] == 20
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_defers_when_all_clients_flooded(db):
+    await db.add_channel(Channel(channel_id=-100123, title="Ch"))
+    root_id = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=_stats_payload([-100123]),
+    )
+    root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert root_task is not None
+
+    resume_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    availability = SimpleNamespace(
+        state="all_flooded",
+        next_available_at_utc=resume_at,
+    )
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(return_value=None),
+        get_stats_availability=AsyncMock(return_value=availability),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(root_task)
+
+    root = await db.get_collection_task(root_id)
+    assert root is not None
+    assert root.status == "failed"
+    assert root.error is not None
+    assert "Deferred to task #" in root.error
+
+    continuation = await db.get_active_stats_task()
+    assert continuation is not None
+    assert continuation.parent_task_id == root_id
+    assert continuation.run_after is not None
+    assert continuation.payload is not None
+    assert continuation.payload["next_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_fails_without_connected_clients(db):
+    await db.add_channel(Channel(channel_id=-100555, title="Ch"))
+    root_id = await db.create_collection_task(
+        0,
+        "Обновление статистики",
+        payload=_stats_payload([-100555]),
+    )
+    root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert root_task is not None
+
+    availability = SimpleNamespace(state="no_connected_active")
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(return_value=None),
+        get_stats_availability=AsyncMock(return_value=availability),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(root_task)
+
+    root = await db.get_collection_task(root_id)
+    assert root is not None
+    assert root.status == "failed"
+    assert root.error == "No active connected Telegram accounts"
+
+    active = await db.get_active_stats_task()
+    assert active is None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -455,6 +455,115 @@ async def test_channel_type_displayed(client):
 
 
 @pytest.mark.asyncio
+async def test_filter_analyze_renders_snapshot_hidden_fields(client):
+    from datetime import datetime, timezone
+
+    from src.models import Channel, Message
+
+    db = client._transport.app.state.db
+    ch = Channel(channel_id=-100551, title="Spam", username="spamchan", channel_type="channel")
+    await db.add_channel(ch)
+    now = datetime.now(timezone.utc)
+    await db.insert_messages_batch(
+        [
+            Message(
+                channel_id=-100551,
+                message_id=i + 1,
+                text="same spam line",
+                date=now,
+            )
+            for i in range(20)
+        ]
+    )
+
+    resp = await client.post("/channels/filter/analyze")
+    assert resp.status_code == 200
+    assert 'name="selected"' in resp.text
+    assert 'value="-100551|' in resp.text
+    assert "low_uniqueness" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
+    from src.models import Channel
+
+    db = client._transport.app.state.db
+    await db.add_channel(
+        Channel(channel_id=-100661, title="Snapshot", username="snapshot", channel_type="channel")
+    )
+
+    async def _boom(self):
+        raise AssertionError("analyze_all should not be called for snapshot apply")
+
+    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _boom)
+
+    resp = await client.post(
+        "/channels/filter/apply",
+        data={"selected": "-100661|low_uniqueness"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=filter_applied" in resp.headers["location"]
+
+    cur = await db.execute(
+        "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = ?",
+        (-100661,),
+    )
+    row = await cur.fetchone()
+    assert row["is_filtered"] == 1
+    assert row["filter_flags"] == "low_uniqueness"
+
+
+@pytest.mark.asyncio
+async def test_filter_apply_without_snapshot_uses_reanalyze(client, monkeypatch):
+    from src.filters.models import ChannelFilterResult, FilterReport
+    from src.models import Channel
+
+    db = client._transport.app.state.db
+    await db.add_channel(
+        Channel(channel_id=-100662, title="Fallback", username="fallback", channel_type="channel")
+    )
+
+    called = {"value": False}
+
+    async def _fake_analyze_all(self):
+        called["value"] = True
+        return FilterReport(
+            results=[
+                ChannelFilterResult(
+                    channel_id=-100662,
+                    flags=["low_uniqueness"],
+                    is_filtered=True,
+                )
+            ],
+            total_channels=1,
+            filtered_count=1,
+        )
+
+    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _fake_analyze_all)
+
+    resp = await client.post("/channels/filter/apply", data={}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert called["value"] is True
+    assert "msg=filter_applied" in resp.headers["location"]
+
+    cur = await db.execute(
+        "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = ?",
+        (-100662,),
+    )
+    row = await cur.fetchone()
+    assert row["is_filtered"] == 1
+    assert row["filter_flags"] == "low_uniqueness"
+
+
+@pytest.mark.asyncio
+async def test_filter_toggle_missing_channel_returns_not_found_msg(client):
+    resp = await client.post("/channels/999999/filter-toggle", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=channel_not_found" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
 async def test_search_results_have_tg_links(client):
     """Search results contain links to original Telegram messages."""
     from datetime import datetime, timezone

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -598,6 +598,83 @@ async def test_collect_filtered_channel_is_blocked(client):
 
 
 @pytest.mark.asyncio
+async def test_stats_all_creates_pending_task(client):
+    db = client._transport.app.state.db
+
+    resp = await client.post("/channels/stats/all", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=stats_collection_started" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].channel_id == 0
+    assert tasks[0].status == "pending"
+    assert tasks[0].payload is not None
+    assert tasks[0].payload["task_kind"] == "stats_all"
+
+
+@pytest.mark.asyncio
+async def test_stats_all_queued_when_collector_running(client):
+    app = client._transport.app.state
+    db = app.db
+    app.collector._running = True
+    try:
+        resp = await client.post("/channels/stats/all", follow_redirects=False)
+    finally:
+        app.collector._running = False
+
+    assert resp.status_code == 303
+    assert "msg=stats_collection_queued" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_stats_all_blocks_duplicate_active_task(client):
+    db = client._transport.app.state.db
+    payload = {
+        "task_kind": "stats_all",
+        "channel_ids": [],
+        "next_index": 0,
+        "batch_size": 20,
+        "channels_ok": 0,
+        "channels_err": 0,
+    }
+    await db.create_collection_task(0, "Обновление статистики", payload=payload)
+
+    resp = await client.post("/channels/stats/all", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "error=stats_running" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_stats_all_prioritizes_channels_without_stats(client):
+    from src.models import Channel, ChannelStats
+
+    db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100901, title="With stats"))
+    await db.add_channel(Channel(channel_id=-100902, title="No stats 1"))
+    await db.add_channel(Channel(channel_id=-100903, title="No stats 2"))
+
+    await db.save_channel_stats(
+        ChannelStats(channel_id=-100901, subscriber_count=1)
+    )
+
+    resp = await client.post("/channels/stats/all", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=stats_collection_started" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    payload = tasks[0].payload
+    assert payload is not None
+    channel_ids = payload["channel_ids"]
+    assert channel_ids.index(-100901) > channel_ids.index(-100902)
+    assert channel_ids.index(-100901) > channel_ids.index(-100903)
+
+
+@pytest.mark.asyncio
 async def test_search_results_have_tg_links(client):
     """Search results contain links to original Telegram messages."""
     from datetime import datetime, timezone

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -478,6 +478,7 @@ async def test_filter_analyze_renders_snapshot_hidden_fields(client):
 
     resp = await client.post("/channels/filter/analyze")
     assert resp.status_code == 200
+    assert 'name="snapshot" value="1"' in resp.text
     assert 'name="selected"' in resp.text
     assert 'value="-100551|' in resp.text
     assert "low_uniqueness" in resp.text
@@ -499,7 +500,7 @@ async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
 
     resp = await client.post(
         "/channels/filter/apply",
-        data={"selected": "-100661|low_uniqueness"},
+        data={"snapshot": "1", "selected": "-100661|low_uniqueness"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
@@ -515,8 +516,7 @@ async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_filter_apply_without_snapshot_uses_reanalyze(client, monkeypatch):
-    from src.filters.models import ChannelFilterResult, FilterReport
+async def test_filter_apply_without_snapshot_returns_error(client, monkeypatch):
     from src.models import Channel
 
     db = client._transport.app.state.db
@@ -524,36 +524,22 @@ async def test_filter_apply_without_snapshot_uses_reanalyze(client, monkeypatch)
         Channel(channel_id=-100662, title="Fallback", username="fallback", channel_type="channel")
     )
 
-    called = {"value": False}
+    async def _boom(self):
+        raise AssertionError("analyze_all should not be called without snapshot")
 
-    async def _fake_analyze_all(self):
-        called["value"] = True
-        return FilterReport(
-            results=[
-                ChannelFilterResult(
-                    channel_id=-100662,
-                    flags=["low_uniqueness"],
-                    is_filtered=True,
-                )
-            ],
-            total_channels=1,
-            filtered_count=1,
-        )
-
-    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _fake_analyze_all)
+    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _boom)
 
     resp = await client.post("/channels/filter/apply", data={}, follow_redirects=False)
     assert resp.status_code == 303
-    assert called["value"] is True
-    assert "msg=filter_applied" in resp.headers["location"]
+    assert "error=filter_snapshot_required" in resp.headers["location"]
 
     cur = await db.execute(
         "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = ?",
         (-100662,),
     )
     row = await cur.fetchone()
-    assert row["is_filtered"] == 1
-    assert row["filter_flags"] == "low_uniqueness"
+    assert row["is_filtered"] == 0
+    assert row["filter_flags"] == ""
 
 
 @pytest.mark.asyncio
@@ -561,6 +547,54 @@ async def test_filter_toggle_missing_channel_returns_not_found_msg(client):
     resp = await client.post("/channels/999999/filter-toggle", follow_redirects=False)
     assert resp.status_code == 303
     assert "msg=channel_not_found" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_filter_toggle_sets_manual_flag(client):
+    from src.models import Channel
+
+    db = client._transport.app.state.db
+    await db.add_channel(
+        Channel(channel_id=-100664, title="Manual", username="manual", channel_type="channel")
+    )
+    channel = next(ch for ch in await db.get_channels() if ch.channel_id == -100664)
+
+    resp = await client.post(f"/channels/{channel.id}/filter-toggle", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=filter_toggled" in resp.headers["location"]
+
+    cur = await db.execute(
+        "SELECT is_filtered, filter_flags FROM channels WHERE channel_id = ?",
+        (-100664,),
+    )
+    row = await cur.fetchone()
+    assert row["is_filtered"] == 1
+    assert row["filter_flags"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_collect_filtered_channel_is_blocked(client):
+    from src.collection_queue import CollectionQueue
+    from src.models import Channel
+
+    db = client._transport.app.state.db
+    client._transport.app.state.collection_queue = CollectionQueue(
+        client._transport.app.state.collector,
+        db,
+    )
+    await db.add_channel(
+        Channel(channel_id=-100663, title="Filtered", username="filtered", channel_type="channel")
+    )
+    await db.set_channels_filtered_bulk([(-100663, "low_uniqueness")])
+    channels = await db.get_channels(include_filtered=True)
+    channel = next(ch for ch in channels if ch.channel_id == -100663)
+
+    resp = await client.post(f"/channels/{channel.id}/collect", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "error=channel_filtered" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    assert tasks == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds automated channel quality analysis with 5 criteria: internal duplicates, subscriber/post ratio, cross-channel spam, non-Cyrillic content, and chat noise detection
- New `src/filters/` module with `ChannelAnalyzer`, SQL-based criteria functions, and Pydantic report models
- CLI commands: `filter analyze|apply|reset` for headless usage
- Web UI: tabs "Активные"/"Все каналы", filter analysis report page, per-channel filter toggle
- DB migration adds `is_filtered` column to `channels` table

## Test plan

- [x] `ruff check src/ tests/` — 0 errors
- [x] `pytest tests/test_filters.py -v` — 16/16 passed (all 5 criteria + analyzer)
- [x] `pytest tests/ -v` — 239/239 passed (no regressions)
- [ ] `python -m src.main filter analyze` — verify on real DB
- [ ] Manual: check web UI tabs and filter controls in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)