### PR TITLE
feat: кнопка "Загрузить все" и настройка интервала планировщика

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ scheduler:
   collect_interval_minutes: 30
   delay_between_channels_sec: 2
   delay_between_requests_sec: 1
-  messages_per_channel: 100
   max_flood_wait_sec: 300
 
 notifications:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from src.settings_utils import parse_int_setting
 from src.config import load_config, resolve_session_encryption_secret
 from src.database import Database
 from src.telegram.auth import TelegramAuth
@@ -33,7 +34,12 @@ async def init_pool(config, db: Database):
         stored_id = await db.get_setting("tg_api_id")
         stored_hash = await db.get_setting("tg_api_hash")
         if stored_id and stored_hash:
-            api_id = int(stored_id)
+            api_id = parse_int_setting(
+                stored_id,
+                setting_name="tg_api_id",
+                default=0,
+                logger=logging.getLogger(__name__),
+            )
             api_hash = stored_hash
 
     auth = TelegramAuth(api_id, api_hash)

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 
-from src.settings_utils import parse_int_setting
 from src.config import load_config, resolve_session_encryption_secret
 from src.database import Database
+from src.settings_utils import parse_int_setting
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 

--- a/src/config.py
+++ b/src/config.py
@@ -95,13 +95,24 @@ def load_config(path: str | Path = "config.yaml") -> AppConfig:
     """Load application config from YAML, substituting env variables."""
     path = Path(path)
     if not path.exists():
-        return AppConfig()
+        config = AppConfig()
+    else:
+        with open(path) as f:
+            raw = yaml.safe_load(f) or {}
 
-    with open(path) as f:
-        raw = yaml.safe_load(f) or {}
+        substituted = _walk_and_substitute(raw)
+        config = AppConfig.model_validate(substituted)
 
-    substituted = _walk_and_substitute(raw)
-    return AppConfig.model_validate(substituted)
+    # Direct environment fallback for Telegram credentials keeps the app usable
+    # even when config.yaml omits placeholders or the file is absent.
+    if config.telegram.api_id == 0:
+        env_api_id = os.environ.get("TG_API_ID", "").strip()
+        if env_api_id.isdigit():
+            config.telegram.api_id = int(env_api_id)
+    if not config.telegram.api_hash:
+        config.telegram.api_hash = os.environ.get("TG_API_HASH", "").strip()
+
+    return config
 
 
 def resolve_session_encryption_secret(config: AppConfig) -> str | None:

--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,7 @@ class WebConfig(BaseModel):
 
 
 class SchedulerConfig(BaseModel):
-    collect_interval_minutes: int = 30
+    collect_interval_minutes: int = 60
     search_interval_minutes: int = 60
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,6 @@ class SchedulerConfig(BaseModel):
     search_interval_minutes: int = 60
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1
-    messages_per_channel: int = 100
     max_flood_wait_sec: int = 300
 
 

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -12,6 +12,7 @@ from src.filters.criteria import (
     NON_CYRILLIC_THRESHOLD,
 )
 from src.filters.models import ChannelFilterResult, FilterReport
+from src.settings_utils import parse_int_setting
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,14 @@ class ChannelAnalyzer:
             raise RuntimeError("Database not initialized")
         self._database = db
         self._repo = db.filter_repo
+
+    async def _load_min_subscribers_filter(self) -> int:
+        return parse_int_setting(
+            await self._database.get_setting("min_subscribers_filter"),
+            setting_name="min_subscribers_filter",
+            default=0,
+            logger=logger,
+        )
 
     async def _build_report(self, channel_id: int | None = None) -> FilterReport:
         channels = await self._repo.fetch_channels_for_analysis(channel_id)
@@ -34,8 +43,7 @@ class ChannelAnalyzer:
         cross_dupe_map = await self._repo.fetch_cross_dupe_map(channel_id)
         cyrillic_map = await self._repo.fetch_cyrillic_map(channel_id)
 
-        min_subs_raw = await self._database.get_setting("min_subscribers_filter")
-        min_subs = int(min_subs_raw) if min_subs_raw else 0
+        min_subs = await self._load_min_subscribers_filter()
 
         results: list[ChannelFilterResult] = []
         for channel in channels:
@@ -190,8 +198,7 @@ class ChannelAnalyzer:
                 to_filter.append((channel.channel_id, "low_subscriber_ratio"))
 
         # Применить ручной порог min_subscribers_filter
-        min_subs_raw = await self._database.get_setting("min_subscribers_filter")
-        min_subs = int(min_subs_raw) if min_subs_raw else 0
+        min_subs = await self._load_min_subscribers_filter()
         if min_subs > 0:
             already = {cid for cid, _ in to_filter}
             for channel in channels:

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -83,9 +83,15 @@ class SchedulerManager:
         saved_interval = (
             await self._db.get_setting("collect_interval_minutes") if self._db else None
         )
-        collect_interval = (
-            int(saved_interval) if saved_interval else self._config.collect_interval_minutes
-        )
+        try:
+            collect_interval = (
+                int(saved_interval) if saved_interval else self._config.collect_interval_minutes
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid collect_interval_minutes in DB (%r), using config default", saved_interval
+            )
+            collect_interval = self._config.collect_interval_minutes
         self._current_interval_minutes = collect_interval
         self._scheduler.add_job(
             self._run_collection,

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -74,8 +74,12 @@ class SchedulerManager:
             return
 
         self._scheduler = AsyncIOScheduler()
-        saved_interval = await self._db.get_setting("collect_interval_minutes") if self._db else None
-        collect_interval = int(saved_interval) if saved_interval else self._config.collect_interval_minutes
+        saved_interval = (
+            await self._db.get_setting("collect_interval_minutes") if self._db else None
+        )
+        collect_interval = (
+            int(saved_interval) if saved_interval else self._config.collect_interval_minutes
+        )
         self._scheduler.add_job(
             self._run_collection,
             IntervalTrigger(minutes=collect_interval),

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -74,9 +74,11 @@ class SchedulerManager:
             return
 
         self._scheduler = AsyncIOScheduler()
+        saved_interval = await self._db.get_setting("collect_interval_minutes") if self._db else None
+        collect_interval = int(saved_interval) if saved_interval else self._config.collect_interval_minutes
         self._scheduler.add_job(
             self._run_collection,
-            IntervalTrigger(minutes=self._config.collect_interval_minutes),
+            IntervalTrigger(minutes=collect_interval),
             id=self._job_id,
             replace_existing=True,
         )
@@ -96,7 +98,7 @@ class SchedulerManager:
         self._scheduler.start()
         logger.info(
             "Scheduler started: collecting every %d minutes",
-            self._config.collect_interval_minutes,
+            collect_interval,
         )
 
     async def stop(self) -> None:
@@ -115,6 +117,12 @@ class SchedulerManager:
         self._scheduler.shutdown(wait=False)
         self._scheduler = None
         logger.info("Scheduler stopped")
+
+    def update_interval(self, minutes: int) -> None:
+        """Reschedule the collection job with a new interval."""
+        if self._scheduler and self._scheduler.running:
+            self._scheduler.reschedule_job(self._job_id, trigger=IntervalTrigger(minutes=minutes))
+            logger.info("Collection interval updated to %d minutes", minutes)
 
     async def trigger_now(self) -> dict:
         """Trigger immediate collection run."""

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -9,6 +9,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from src.config import SchedulerConfig
+from src.settings_utils import parse_int_setting
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
@@ -83,15 +84,12 @@ class SchedulerManager:
         saved_interval = (
             await self._db.get_setting("collect_interval_minutes") if self._db else None
         )
-        try:
-            collect_interval = (
-                int(saved_interval) if saved_interval else self._config.collect_interval_minutes
-            )
-        except (TypeError, ValueError):
-            logger.warning(
-                "Invalid collect_interval_minutes in DB (%r), using config default", saved_interval
-            )
-            collect_interval = self._config.collect_interval_minutes
+        collect_interval = parse_int_setting(
+            saved_interval,
+            setting_name="collect_interval_minutes",
+            default=self._config.collect_interval_minutes,
+            logger=logger,
+        )
         self._current_interval_minutes = collect_interval
         self._scheduler.add_job(
             self._run_collection,
@@ -152,7 +150,7 @@ class SchedulerManager:
 
     async def trigger_background(self) -> None:
         """Fire-and-forget collection run."""
-        if self._collector.is_running:
+        if self._collector.is_running or (self._bg_task and not self._bg_task.done()):
             return
         self._bg_task = asyncio.create_task(self._run_collection())
 

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -39,10 +39,15 @@ class SchedulerManager:
         self._last_search_stats: dict | None = None
         self._bg_task: asyncio.Task | None = None
         self._search_bg_task: asyncio.Task | None = None
+        self._current_interval_minutes: int = config.collect_interval_minutes
 
     @property
     def is_running(self) -> bool:
         return self._scheduler is not None and self._scheduler.running
+
+    @property
+    def is_collecting(self) -> bool:
+        return self._collector.is_running
 
     @property
     def last_run(self) -> datetime | None:
@@ -62,7 +67,7 @@ class SchedulerManager:
 
     @property
     def interval_minutes(self) -> int:
-        return self._config.collect_interval_minutes
+        return self._current_interval_minutes
 
     @property
     def search_interval_minutes(self) -> int:
@@ -80,6 +85,7 @@ class SchedulerManager:
         collect_interval = (
             int(saved_interval) if saved_interval else self._config.collect_interval_minutes
         )
+        self._current_interval_minutes = collect_interval
         self._scheduler.add_job(
             self._run_collection,
             IntervalTrigger(minutes=collect_interval),
@@ -124,9 +130,14 @@ class SchedulerManager:
 
     def update_interval(self, minutes: int) -> None:
         """Reschedule the collection job with a new interval."""
+        self._current_interval_minutes = minutes
         if self._scheduler and self._scheduler.running:
             self._scheduler.reschedule_job(self._job_id, trigger=IntervalTrigger(minutes=minutes))
             logger.info("Collection interval updated to %d minutes", minutes)
+        else:
+            logger.debug(
+                "Scheduler not running; interval %d minutes will apply on next start", minutes
+            )
 
     async def trigger_now(self) -> dict:
         """Trigger immediate collection run."""

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -67,6 +67,7 @@ class SchedulerManager:
 
     @property
     def interval_minutes(self) -> int:
+        # Before start() is called, reflects config default (not yet loaded from DB).
         return self._current_interval_minutes
 
     @property

--- a/src/settings_utils.py
+++ b/src/settings_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import logging
+
+
+def parse_int_setting(
+    raw_value: object,
+    *,
+    setting_name: str,
+    default: int,
+    logger: logging.Logger,
+) -> int:
+    if raw_value in (None, ""):
+        return default
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s in settings DB (%r), using %d", setting_name, raw_value, default)
+        return default

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -36,6 +36,7 @@ from src.filters.criteria import (
     PRECHECK_CROSS_DUPE_SAMPLE,
 )
 from src.models import Channel, ChannelStats, Message
+from src.settings_utils import parse_int_setting
 from src.telegram.client_pool import ClientPool
 from src.telegram.notifier import Notifier
 
@@ -98,6 +99,14 @@ class Collector:
     def is_cancelled(self) -> bool:
         return self._cancel_event.is_set()
 
+    async def _load_min_subscribers_filter(self) -> int:
+        return parse_int_setting(
+            await self._db.get_setting("min_subscribers_filter"),
+            setting_name="min_subscribers_filter",
+            default=0,
+            logger=logger,
+        )
+
     async def collect_single_channel(
         self,
         channel: Channel,
@@ -126,8 +135,7 @@ class Collector:
                 if full:
                     channel = Channel(**{**channel.model_dump(), "last_collected_id": 0})
 
-                min_subs_raw = await self._db.get_setting("min_subscribers_filter")
-                min_subs = int(min_subs_raw) if min_subs_raw else 0
+                min_subs = await self._load_min_subscribers_filter()
                 return await self._collect_channel(
                     channel, progress_callback=progress_callback, force=force, min_subs=min_subs
                 )
@@ -150,8 +158,7 @@ class Collector:
                     return stats
                 logger.info("Found %d active unfiltered channels to collect", len(channels))
 
-                min_subs_raw = await self._db.get_setting("min_subscribers_filter")
-                min_subs = int(min_subs_raw) if min_subs_raw else 0
+                min_subs = await self._load_min_subscribers_filter()
 
                 for channel in channels:
                     if self._cancel_event.is_set():

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -247,7 +247,7 @@ class Collector:
 
         is_first_run = channel.last_collected_id == 0
         should_notify_keywords = self._notifier is not None and not is_first_run
-        limit = None if is_first_run else self._config.messages_per_channel
+        limit = None  # first_run: все; incremental: все новые (диапазон ограничен min_id)
         logger.info(
             "Collecting channel %d (%s), first_run=%s, min_id=%d, limit=%s",
             channel_id, channel.username or channel.title, is_first_run, min_id, limit,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -21,6 +21,7 @@ from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
 from src.services.notification_target_service import NotificationTargetService
+from src.settings_utils import parse_int_setting
 from src.services.stats_task_dispatcher import StatsTaskDispatcher
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
@@ -129,7 +130,12 @@ async def lifespan(app: FastAPI):
         stored_id = await db.get_setting("tg_api_id")
         stored_hash = await db.get_setting("tg_api_hash")
         if stored_id and stored_hash:
-            api_id = int(stored_id)
+            api_id = parse_int_setting(
+                stored_id,
+                setting_name="tg_api_id",
+                default=0,
+                logger=logger,
+            )
             api_hash = stored_hash
 
     auth = TelegramAuth(api_id, api_hash)

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -21,8 +21,8 @@ from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
 from src.services.notification_target_service import NotificationTargetService
-from src.settings_utils import parse_int_setting
 from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.settings_utils import parse_int_setting
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -3,9 +3,9 @@ import logging
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-logger = logging.getLogger(__name__)
-
 from src.models import Account
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -10,6 +10,28 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+@router.post("/collect-all")
+async def collect_all_channels(request: Request):
+    is_htmx = request.headers.get("HX-Request") == "true"
+
+    if getattr(request.app.state, "shutting_down", False):
+        if is_htmx:
+            return HTMLResponse('<span id="collect-all-btn" title="Сервер останавливается">⚠️</span>')
+        return RedirectResponse(url="/channels?error=shutting_down", status_code=303)
+
+    scheduler = getattr(request.app.state, "scheduler", None)
+    if scheduler:
+        await scheduler.trigger_background()
+
+    if is_htmx:
+        return HTMLResponse(
+            '<span id="collect-all-btn">'
+            '<button class="outline" disabled title="Запущен">⏳ Загрузка...</button>'
+            '</span>'
+        )
+    return RedirectResponse(url="/channels?msg=collect_all_started", status_code=303)
+
+
 @router.post("/{pk}/collect")
 async def collect_channel(request: Request, pk: int):
     is_htmx = request.headers.get("HX-Request") == "true"

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -9,6 +9,9 @@ from src.web import deps
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+# NOTE: _COLLECT_ALL_BTN and _COLLECT_ALL_SPINNER must stay in sync with the
+# corresponding fragment in templates/channels.html (the initial page render uses
+# the Jinja template; HTMX responses use these Python constants).
 _COLLECT_ALL_BTN = (
     '<span id="collect-all-btn">'
     '<form method="post" action="/channels/collect-all" style="display:inline"'

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -9,6 +9,33 @@ from src.web import deps
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+_COLLECT_ALL_BTN = (
+    '<span id="collect-all-btn">'
+    '<form method="post" action="/channels/collect-all" style="display:inline"'
+    ' hx-post="/channels/collect-all" hx-target="#collect-all-btn" hx-swap="outerHTML">'
+    '<button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Загрузить все</button>'
+    '</form>'
+    '</span>'
+)
+
+_COLLECT_ALL_SPINNER = (
+    '<span id="collect-all-btn"'
+    ' hx-get="/channels/collect-all/status"'
+    ' hx-trigger="every 3s"'
+    ' hx-target="#collect-all-btn"'
+    ' hx-swap="outerHTML">'
+    '<button class="outline" disabled title="Запущен">⏳ Загрузка...</button>'
+    '</span>'
+)
+
+
+@router.get("/collect-all/status")
+async def collect_all_status(request: Request):
+    scheduler = getattr(request.app.state, "scheduler", None)
+    if scheduler and scheduler.is_collecting:
+        return HTMLResponse(_COLLECT_ALL_SPINNER)
+    return HTMLResponse(_COLLECT_ALL_BTN)
+
 
 @router.post("/collect-all")
 async def collect_all_channels(request: Request):
@@ -26,11 +53,7 @@ async def collect_all_channels(request: Request):
         await scheduler.trigger_background()
 
     if is_htmx:
-        return HTMLResponse(
-            '<span id="collect-all-btn">'
-            '<button class="outline" disabled title="Запущен">⏳ Загрузка...</button>'
-            '</span>'
-        )
+        return HTMLResponse(_COLLECT_ALL_SPINNER)
     return RedirectResponse(url="/channels?msg=collect_all_started", status_code=303)
 
 

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -31,6 +31,12 @@ _COLLECT_ALL_SPINNER = (
     '</span>'
 )
 
+_COLLECT_ALL_UNAVAILABLE = (
+    '<span id="collect-all-btn" title="Планировщик недоступен">'
+    '<button class="outline" disabled>⚠️ Недоступно</button>'
+    '</span>'
+)
+
 
 @router.get("/collect-all/status")
 async def collect_all_status(request: Request):
@@ -52,11 +58,13 @@ async def collect_all_channels(request: Request):
         return RedirectResponse(url="/channels?error=shutting_down", status_code=303)
 
     scheduler = getattr(request.app.state, "scheduler", None)
+    if is_htmx:
+        if not scheduler:
+            return HTMLResponse(_COLLECT_ALL_UNAVAILABLE)
+        await scheduler.trigger_background()
+        return HTMLResponse(_COLLECT_ALL_SPINNER)
     if scheduler:
         await scheduler.trigger_background()
-
-    if is_htmx:
-        return HTMLResponse(_COLLECT_ALL_SPINNER)
     return RedirectResponse(url="/channels?msg=collect_all_started", status_code=303)
 
 

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -16,7 +16,9 @@ async def collect_all_channels(request: Request):
 
     if getattr(request.app.state, "shutting_down", False):
         if is_htmx:
-            return HTMLResponse('<span id="collect-all-btn" title="Сервер останавливается">⚠️</span>')
+            return HTMLResponse(
+                '<span id="collect-all-btn" title="Сервер останавливается">⚠️</span>'
+            )
         return RedirectResponse(url="/channels?error=shutting_down", status_code=303)
 
     scheduler = getattr(request.app.state, "scheduler", None)

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -31,6 +31,9 @@ async def settings_page(request: Request):
     api_id_raw = await db.get_setting("tg_api_id") or ""
     api_hash_raw = await db.get_setting("tg_api_hash") or ""
     min_subscribers_filter = int(await db.get_setting("min_subscribers_filter") or 0)
+    saved_interval = await db.get_setting("collect_interval_minutes")
+    config = request.app.state.config
+    collect_interval_minutes = int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
     accounts = await db.get_accounts()
     connected_phones = set(pool.clients.keys())
     notification_target = await deps.get_notification_target_service(request).describe_target()
@@ -58,8 +61,22 @@ async def settings_page(request: Request):
             "notification_selected_phone": notification_target.configured_phone or "",
             "notification_bot": notification_bot,
             "notification_bot_error": notification_bot_error,
+            "collect_interval_minutes": collect_interval_minutes,
         },
     )
+
+
+@router.post("/save-scheduler")
+async def save_scheduler_settings(request: Request):
+    form = await request.form()
+    interval = int(form.get("collect_interval_minutes", 60))
+    interval = max(1, min(1440, interval))
+    db = deps.get_db(request)
+    await db.set_setting("collect_interval_minutes", str(interval))
+    scheduler = getattr(request.app.state, "scheduler", None)
+    if scheduler:
+        scheduler.update_interval(interval)
+    return RedirectResponse(url="/settings?msg=scheduler_saved", status_code=303)
 
 
 @router.post("/save-filters")

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -1,10 +1,14 @@
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from src.settings_utils import parse_int_setting
 from src.services.notification_service import NotificationService
 from src.web import deps
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 CREDENTIALS_MASK = "••••••••"
 
@@ -30,15 +34,20 @@ async def settings_page(request: Request):
     pool = deps.get_pool(request)
     api_id_raw = await db.get_setting("tg_api_id") or ""
     api_hash_raw = await db.get_setting("tg_api_hash") or ""
-    min_subscribers_filter = int(await db.get_setting("min_subscribers_filter") or 0)
+    min_subscribers_filter = parse_int_setting(
+        await db.get_setting("min_subscribers_filter"),
+        setting_name="min_subscribers_filter",
+        default=0,
+        logger=logger,
+    )
     saved_interval = await db.get_setting("collect_interval_minutes")
     config = request.app.state.config
-    try:
-        collect_interval_minutes = (
-            int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
-        )
-    except (TypeError, ValueError):
-        collect_interval_minutes = config.scheduler.collect_interval_minutes
+    collect_interval_minutes = parse_int_setting(
+        saved_interval,
+        setting_name="collect_interval_minutes",
+        default=config.scheduler.collect_interval_minutes,
+        logger=logger,
+    )
     accounts = await db.get_accounts()
     connected_phones = set(pool.clients.keys())
     notification_target = await deps.get_notification_target_service(request).describe_target()

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -71,7 +71,10 @@ async def settings_page(request: Request):
 @router.post("/save-scheduler")
 async def save_scheduler_settings(request: Request):
     form = await request.form()
-    interval = int(form.get("collect_interval_minutes", 60))
+    try:
+        interval = int(form.get("collect_interval_minutes", 60))
+    except (TypeError, ValueError):
+        return RedirectResponse(url="/settings?error=invalid_value", status_code=303)
     interval = max(1, min(1440, interval))
     db = deps.get_db(request)
     await db.set_setting("collect_interval_minutes", str(interval))

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -1,10 +1,11 @@
 import logging
+import os
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
-from src.settings_utils import parse_int_setting
 from src.services.notification_service import NotificationService
+from src.settings_utils import parse_int_setting
 from src.web import deps
 
 router = APIRouter()
@@ -42,6 +43,9 @@ async def settings_page(request: Request):
     )
     saved_interval = await db.get_setting("collect_interval_minutes")
     config = request.app.state.config
+    telegram_credentials_from_env = bool(
+        os.environ.get("TG_API_ID", "").strip() and os.environ.get("TG_API_HASH", "").strip()
+    )
     collect_interval_minutes = parse_int_setting(
         saved_interval,
         setting_name="collect_interval_minutes",
@@ -65,6 +69,7 @@ async def settings_page(request: Request):
         "settings.html",
         {
             "is_configured": auth.is_configured,
+            "telegram_credentials_from_env": telegram_credentials_from_env,
             "api_id": CREDENTIALS_MASK if api_id_raw else "",
             "api_hash": CREDENTIALS_MASK if api_hash_raw else "",
             "min_subscribers_filter": min_subscribers_filter,

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -33,9 +33,12 @@ async def settings_page(request: Request):
     min_subscribers_filter = int(await db.get_setting("min_subscribers_filter") or 0)
     saved_interval = await db.get_setting("collect_interval_minutes")
     config = request.app.state.config
-    collect_interval_minutes = (
-        int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
-    )
+    try:
+        collect_interval_minutes = (
+            int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
+        )
+    except (TypeError, ValueError):
+        collect_interval_minutes = config.scheduler.collect_interval_minutes
     accounts = await db.get_accounts()
     connected_phones = set(pool.clients.keys())
     notification_target = await deps.get_notification_target_service(request).describe_target()

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -44,7 +44,8 @@ async def settings_page(request: Request):
     saved_interval = await db.get_setting("collect_interval_minutes")
     config = request.app.state.config
     telegram_credentials_from_env = bool(
-        os.environ.get("TG_API_ID", "").strip() and os.environ.get("TG_API_HASH", "").strip()
+        os.environ.get("TG_API_ID", "").strip().isdigit()
+        and os.environ.get("TG_API_HASH", "").strip()
     )
     collect_interval_minutes = parse_int_setting(
         saved_interval,

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -33,7 +33,9 @@ async def settings_page(request: Request):
     min_subscribers_filter = int(await db.get_setting("min_subscribers_filter") or 0)
     saved_interval = await db.get_setting("collect_interval_minutes")
     config = request.app.state.config
-    collect_interval_minutes = int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
+    collect_interval_minutes = (
+        int(saved_interval) if saved_interval else config.scheduler.collect_interval_minutes
+    )
     accounts = await db.get_accounts()
     connected_phones = set(pool.clients.keys())
     notification_target = await deps.get_notification_target_service(request).describe_target()

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -35,6 +35,14 @@
     <form method="post" action="/channels/stats/all" style="display:inline">
         <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Обновить статистику</button>
     </form>
+    <span id="collect-all-btn">
+        <form method="post" action="/channels/collect-all" style="display:inline"
+              hx-post="/channels/collect-all"
+              hx-target="#collect-all-btn"
+              hx-swap="outerHTML">
+            <button type="submit" class="outline" style="padding: 0.25rem 0.75rem;">Загрузить все</button>
+        </form>
+    </span>
 </div>
 <div style="overflow-x:auto">
 <table class="channels-table">

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -41,6 +41,18 @@
 </article>
 
 <article>
+    <header>Планировщик</header>
+    <form method="post" action="/settings/save-scheduler" class="settings-form">
+        <label for="collect_interval_minutes">Интервал сбора сообщений (минуты)
+            <input type="number" id="collect_interval_minutes" name="collect_interval_minutes"
+                   min="1" max="1440" value="{{ collect_interval_minutes }}">
+            <small>Как часто планировщик автоматически собирает новые сообщения из каналов. Диапазон: 1–1440 минут.</small>
+        </label>
+        <button type="submit">Сохранить</button>
+    </form>
+</article>
+
+<article>
     <header>Фильтры каналов</header>
     <form method="post" action="/settings/save-filters" class="settings-form">
         <label for="min_subscribers_filter">Минимальное количество подписчиков

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -4,6 +4,62 @@
 <h1>Настройки</h1>
 
 <article>
+    <header>Telegram-аккаунты</header>
+
+    <p><a href="/auth/login" role="button">Добавить аккаунт</a></p>
+
+    {% if accounts %}
+    <div style="overflow-x:auto">
+    <table>
+        <thead>
+            <tr>
+                <th>Телефон</th>
+                <th>Статус</th>
+                <th>Premium</th>
+                <th>Primary</th>
+                <th>Подключён</th>
+                <th>Flood wait</th>
+                <th>Добавлен</th>
+                <th>Действия</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for acc in accounts %}
+            <tr>
+                <td>{{ acc.phone }}</td>
+                <td>{% if acc.is_active %}<span class="badge-active">● Активен</span>{% else %}<span class="badge-inactive">● Отключён</span>{% endif %}</td>
+                <td>{% if acc.is_premium %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
+                <td>{% if acc.is_primary %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
+                <td>{% if acc.phone in connected_phones %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
+                <td>{{ acc.flood_wait_until.strftime('%H:%M:%S') if acc.flood_wait_until else "—" }}</td>
+                <td>{{ acc.created_at.strftime('%Y-%m-%d') if acc.created_at else "—" }}</td>
+                <td>
+                    <form method="post" action="/settings/{{ acc.id }}/toggle" style="display:inline">
+                        <button type="submit" class="secondary outline emoji-btn" title="{{ 'Отключить' if acc.is_active else 'Включить' }}">
+                            {{ "⏸️" if acc.is_active else "▶️" }}
+                        </button>
+                    </form>
+                    <form method="post" action="/settings/{{ acc.id }}/delete" style="display:inline" onsubmit="return confirm('Вы уверены, что хотите удалить этот аккаунт?')">
+                        <button type="submit" class="contrast outline emoji-btn" title="Удалить">🗑️</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% else %}
+    <p>Нет подключённых аккаунтов. <a href="/auth/login">Добавьте первый аккаунт</a>.</p>
+    {% endif %}
+</article>
+
+{% if telegram_credentials_from_env %}
+<article>
+    <header>Telegram API credentials</header>
+    <p><mark>Управляется через окружение</mark> — `TG_API_ID` и `TG_API_HASH` заданы во внешней конфигурации, поэтому эта форма скрыта.</p>
+</article>
+{% else %}
+<article>
     <header>Telegram API credentials</header>
     {% if is_configured %}
     <p><mark>Настроено</mark> — API credentials сохранены.</p>
@@ -39,6 +95,7 @@
         <button type="submit">Сохранить</button>
     </form>
 </article>
+{% endif %}
 
 <article>
     <header>Планировщик</header>
@@ -110,53 +167,4 @@
     {% endif %}
 </article>
 
-<article>
-    <header>Telegram-аккаунты</header>
-
-    <p><a href="/auth/login" role="button">Добавить аккаунт</a></p>
-
-    {% if accounts %}
-    <div style="overflow-x:auto">
-    <table>
-        <thead>
-            <tr>
-                <th>Телефон</th>
-                <th>Статус</th>
-                <th>Premium</th>
-                <th>Primary</th>
-                <th>Подключён</th>
-                <th>Flood wait</th>
-                <th>Добавлен</th>
-                <th>Действия</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for acc in accounts %}
-            <tr>
-                <td>{{ acc.phone }}</td>
-                <td>{% if acc.is_active %}<span class="badge-active">● Активен</span>{% else %}<span class="badge-inactive">● Отключён</span>{% endif %}</td>
-                <td>{% if acc.is_premium %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
-                <td>{% if acc.is_primary %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
-                <td>{% if acc.phone in connected_phones %}<span class="badge-active">●</span>{% else %}<span class="badge-inactive">●</span>{% endif %}</td>
-                <td>{{ acc.flood_wait_until.strftime('%H:%M:%S') if acc.flood_wait_until else "—" }}</td>
-                <td>{{ acc.created_at.strftime('%Y-%m-%d') if acc.created_at else "—" }}</td>
-                <td>
-                    <form method="post" action="/settings/{{ acc.id }}/toggle" style="display:inline">
-                        <button type="submit" class="secondary outline emoji-btn" title="{{ 'Отключить' if acc.is_active else 'Включить' }}">
-                            {{ "⏸️" if acc.is_active else "▶️" }}
-                        </button>
-                    </form>
-                    <form method="post" action="/settings/{{ acc.id }}/delete" style="display:inline" onsubmit="return confirm('Вы уверены, что хотите удалить этот аккаунт?')">
-                        <button type="submit" class="contrast outline emoji-btn" title="Удалить">🗑️</button>
-                    </form>
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    </div>
-    {% else %}
-    <p>Нет подключённых аккаунтов. <a href="/auth/login">Добавьте первый аккаунт</a>.</p>
-    {% endif %}
-</article>
 {% endblock %}

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -94,6 +95,100 @@ def _make_mock_msg(msg_id, views=100, forwards=5, reactions_count=10):
         forwards=forwards,
         reactions=reactions,
     )
+
+
+class _FakeRouteStatsCollector:
+    def __init__(
+        self,
+        *,
+        result: ChannelStats | None = None,
+        error: Exception | None = None,
+    ):
+        self.is_running = False
+        self.is_stats_running = False
+        self.calls: list[Channel] = []
+        self._result = result
+        self._error = error
+
+    async def collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
+        self.calls.append(channel)
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+async def _wait_for_task_status(db, task_id: int, status: str, *, timeout: float = 1.0):
+    async def _poll():
+        while True:
+            task = await db.get_collection_task(task_id)
+            if task is not None and task.status == status:
+                return task
+            await asyncio.sleep(0.01)
+
+    return await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+async def _create_stats_web_test_context(tmp_path, collector):
+    from src.config import AppConfig
+    from src.database import Database
+    from src.scheduler.manager import SchedulerManager
+    from src.search.ai_search import AISearchEngine
+    from src.search.engine import SearchEngine
+    from src.web.app import create_app
+
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    ch = Channel(channel_id=-100123, title="Test Channel", username="test")
+    await db.add_channel(ch)
+    channels = await db.get_channels()
+    pk = channels[0].id
+
+    async def _no_users(self):
+        return []
+
+    async def _resolve_channel(self, identifier):
+        return {
+            "channel_id": -100123,
+            "title": "Test Channel",
+            "username": "test",
+            "channel_type": "channel",
+        }
+
+    async def _get_dialogs(self):
+        return []
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {},
+            "get_users_info": _no_users,
+            "resolve_channel": _resolve_channel,
+            "get_dialogs": _get_dialogs,
+        },
+    )()
+
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+    app.state.collector = collector
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(
+        Collector(app.state.pool, db, config.scheduler), config.scheduler
+    )
+    app.state.session_secret = "test_secret_key"
+    return app, db, pk
 
 
 @pytest.mark.asyncio
@@ -202,86 +297,73 @@ async def test_stats_web_endpoint(tmp_path):
     import base64
 
     from httpx import ASGITransport, AsyncClient
-
-    from src.config import AppConfig
-    from src.database import Database
-    from src.scheduler.manager import SchedulerManager
-    from src.search.ai_search import AISearchEngine
-    from src.search.engine import SearchEngine
-    from src.web.app import create_app
-
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
-    ch = Channel(channel_id=-100123, title="Test Channel", username="test")
-    await db.add_channel(ch)
-    channels = await db.get_channels()
-    pk = channels[0].id
-
-    async def _no_users(self):
-        return []
-
-    async def _resolve_channel(self, identifier):
-        return {
-            "channel_id": -100123,
-            "title": "Test Channel",
-            "username": "test",
-            "channel_type": "channel",
-        }
-
-    async def _get_dialogs(self):
-        return []
-
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "get_users_info": _no_users,
-            "resolve_channel": _resolve_channel,
-            "get_dialogs": _get_dialogs,
-        },
-    )()
-
-    from src.telegram.auth import TelegramAuth
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-
-    collector = MagicMock()
-    collector.collect_channel_stats = AsyncMock(
-        return_value=ChannelStats(channel_id=-100123, subscriber_count=999)
+    collector = _FakeRouteStatsCollector(
+        result=ChannelStats(channel_id=-100123, subscriber_count=999)
     )
-    collector.is_running = False
-    collector.is_stats_running = False
-    app.state.collector = collector
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(
-        Collector(app.state.pool, db, config.scheduler), config.scheduler
-    )
-    app.state.session_secret = "test_secret_key"
+    app, db, pk = await _create_stats_web_test_context(tmp_path, collector)
 
-    transport = ASGITransport(app=app)
-    auth_header = base64.b64encode(b":testpass").decode()
-    async with AsyncClient(
-        transport=transport,
-        base_url="http://test",
-        follow_redirects=False,
-        headers={"Authorization": f"Basic {auth_header}"},
-    ) as c:
-        resp = await c.post(f"/channels/{pk}/stats")
-        assert resp.status_code == 303
-        assert "msg=stats_collection_started" in resp.headers["location"]
-    await db.close()
+    try:
+        transport = ASGITransport(app=app)
+        auth_header = base64.b64encode(b":testpass").decode()
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth_header}"},
+        ) as c:
+            resp = await c.post(f"/channels/{pk}/stats")
+            assert resp.status_code == 303
+            assert "msg=stats_collection_started" in resp.headers["location"]
+
+        tasks = await db.get_collection_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].channel_id == -100123
+        assert tasks[0].channel_username == "test"
+        assert tasks[0].id is not None
+
+        task = await _wait_for_task_status(db, tasks[0].id, "completed")
+        assert task.messages_collected == 1
+        assert len(collector.calls) == 1
+        assert collector.calls[0].channel_id == -100123
+        assert collector.calls[0].username == "test"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stats_web_endpoint_marks_task_failed(tmp_path):
+    import base64
+
+    from httpx import ASGITransport, AsyncClient
+
+    collector = _FakeRouteStatsCollector(error=RuntimeError("stats route failed"))
+    app, db, pk = await _create_stats_web_test_context(tmp_path, collector)
+
+    try:
+        transport = ASGITransport(app=app)
+        auth_header = base64.b64encode(b":testpass").decode()
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth_header}"},
+        ) as c:
+            resp = await c.post(f"/channels/{pk}/stats")
+            assert resp.status_code == 303
+            assert "msg=stats_collection_started" in resp.headers["location"]
+
+        tasks = await db.get_collection_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].id is not None
+
+        task = await _wait_for_task_status(db, tasks[0].id, "failed")
+        assert task.error == "stats route failed"
+        assert task.messages_collected == 0
+        assert len(collector.calls) == 1
+        assert collector.calls[0].channel_id == -100123
+        assert collector.calls[0].username == "test"
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -453,7 +453,9 @@ async def test_backfill_does_not_send_keyword_notifications(db):
 
     mock_client = AsyncMock()
     mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
-    mock_client.iter_messages = MagicMock(side_effect=lambda *a, **kw: _AsyncIterMessages(mock_msgs))
+    mock_client.iter_messages = MagicMock(
+        side_effect=lambda *a, **kw: _AsyncIterMessages(mock_msgs)
+    )
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
     notifier = AsyncMock()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -338,8 +338,8 @@ async def test_backfill_uses_no_limit(db):
 
 
 @pytest.mark.asyncio
-async def test_incremental_uses_configured_limit(db):
-    """Subsequent runs (last_collected_id>0) should use configured limit."""
+async def test_incremental_uses_no_limit(db):
+    """Subsequent runs (last_collected_id>0) should use limit=None (all new messages)."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=50)
     await db.add_channel(ch)
 
@@ -354,7 +354,7 @@ async def test_incremental_uses_configured_limit(db):
     await collector._collect_channel(ch)
 
     call_kwargs = mock_client.iter_messages.call_args
-    assert call_kwargs[1].get("limit") == 200 or call_kwargs.kwargs.get("limit") == 200
+    assert call_kwargs[1].get("limit") is None or call_kwargs.kwargs.get("limit") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -53,6 +53,20 @@ async def test_collect_all_skips_filtered_channels(db):
 
 
 @pytest.mark.asyncio
+async def test_collect_all_invalid_min_subscribers_setting_falls_back_to_zero(db):
+    await db.set_setting("min_subscribers_filter", "broken")
+    ch = Channel(channel_id=-100124, title="Normal")
+    await db.add_channel(ch)
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+
+    stats = await collector.collect_all_channels()
+    assert stats["channels"] == 1
+    assert stats["errors"] == 0
+
+
+@pytest.mark.asyncio
 async def test_collect_single_channel_skips_filtered(db):
     """collect_single_channel returns 0 immediately for filtered channels."""
     ch = Channel(
@@ -328,7 +342,7 @@ async def test_backfill_uses_no_limit(db):
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
 
-    config = SchedulerConfig(messages_per_channel=100, delay_between_requests_sec=0)
+    config = SchedulerConfig(delay_between_requests_sec=0)
     collector = Collector(pool, db, config)
     await collector._collect_channel(ch)
 
@@ -349,7 +363,7 @@ async def test_incremental_uses_no_limit(db):
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
 
-    config = SchedulerConfig(messages_per_channel=200, delay_between_requests_sec=0)
+    config = SchedulerConfig(delay_between_requests_sec=0)
     collector = Collector(pool, db, config)
     await collector._collect_channel(ch)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,31 @@ def test_load_config_with_empty_env(tmp_path, monkeypatch):
     assert config.llm.api_key == ""
 
 
+def test_load_config_reads_telegram_credentials_directly_from_env_without_placeholders(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("TG_API_ID", "77777")
+    monkeypatch.setenv("TG_API_HASH", "hash-from-env")
+    config_file = tmp_path / "test_config.yaml"
+    config_file.write_text("web:\n  port: 9090\n")
+
+    config = load_config(config_file)
+
+    assert config.web.port == 9090
+    assert config.telegram.api_id == 77777
+    assert config.telegram.api_hash == "hash-from-env"
+
+
+def test_load_config_reads_telegram_credentials_from_env_when_config_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("TG_API_ID", "88888")
+    monkeypatch.setenv("TG_API_HASH", "missing-file-hash")
+
+    config = load_config(tmp_path / "missing.yaml")
+
+    assert config.telegram.api_id == 88888
+    assert config.telegram.api_hash == "missing-file-hash"
+
+
 def test_resolve_session_encryption_secret_prefers_explicit_key():
     config = AppConfig()
     config.security.session_encryption_key = "explicit-session-key"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from src.config import AppConfig, load_config, resolve_session_encryption_secret
 def test_default_config():
     config = AppConfig()
     assert config.web.port == 8080
-    assert config.scheduler.collect_interval_minutes == 30
+    assert config.scheduler.collect_interval_minutes == 60
     assert config.database.path == "data/tg_search.db"
     assert config.llm.enabled is False
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -262,6 +262,18 @@ class TestChannelAnalyzer:
         assert row["is_filtered"] == 1
         assert "low_uniqueness" in row["filter_flags"]
 
+    async def test_analyze_all_invalid_min_subscribers_setting_falls_back_to_zero(self, db, raw_db):
+        await db.set_setting("min_subscribers_filter", "broken")
+        await _insert_channel(raw_db, 601)
+        await _insert_messages(raw_db, 601, ["hello world", "hello again"])
+
+        analyzer = ChannelAnalyzer(db)
+        report = await analyzer.analyze_all()
+
+        found = [result for result in report.results if result.channel_id == 601]
+        assert len(found) == 1
+        assert "low_subscriber_manual" not in found[0].flags
+
     async def test_apply_filters_resets_stale(self, db, raw_db):
         # Channel 710 was previously filtered
         await _insert_channel(raw_db, 710, title="Previously Filtered")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -24,6 +24,7 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.web.app import create_app
+from src.cli.runtime import init_pool
 from tests.helpers import make_mock_pool as _make_pool
 
 # ---------------------------------------------------------------------------
@@ -802,6 +803,38 @@ class TestGracefulShutdown:
         await manager.stop()
         assert manager._bg_task is None
 
+    @pytest.mark.asyncio
+    async def test_trigger_background_deduplicates_racing_calls(self, test_db):
+        await test_db.add_channel(
+            Channel(channel_id=-100876, title="Race Channel", username="race_channel")
+        )
+        pool = _make_pool(get_available_client=AsyncMock(return_value=None))
+        config = SchedulerConfig(delay_between_requests_sec=0)
+        collector = Collector(pool, test_db, config)
+        manager = SchedulerManager(collector, config)
+
+        started_event = asyncio.Event()
+        release_event = asyncio.Event()
+        call_count = 0
+
+        async def _blocking_collect(_channel, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            started_event.set()
+            await release_event.wait()
+            return 0
+
+        collector._collect_channel = AsyncMock(side_effect=_blocking_collect)
+
+        try:
+            await asyncio.gather(manager.trigger_background(), manager.trigger_background())
+            await asyncio.wait_for(started_event.wait(), timeout=1.0)
+            assert manager._bg_task is not None
+            assert call_count == 1
+        finally:
+            release_event.set()
+            await manager.stop()
+
 
 class TestAPICredentialsFallback:
     """When config has no API creds, lifespan loads them from DB settings."""
@@ -830,3 +863,42 @@ class TestAPICredentialsFallback:
                 assert app.state.auth.is_configured is True
                 assert app.state.auth._api_id == 99999
                 assert app.state.auth._api_hash == "hash_from_db"
+
+    @pytest.mark.asyncio
+    async def test_invalid_api_id_in_db_does_not_crash_lifespan(self, tmp_path):
+        from src.web.app import lifespan
+
+        db_path = str(tmp_path / "bad-web.db")
+        db = Database(db_path)
+        await db.initialize()
+        await db.set_setting("tg_api_id", "not-a-number")
+        await db.set_setting("tg_api_hash", "hash_from_db")
+        await db.close()
+
+        config = AppConfig()
+        config.database.path = db_path
+
+        with patch.object(ClientPool, "initialize", new_callable=AsyncMock) as initialize:
+            app = create_app(config)
+            async with lifespan(app):
+                assert app.state.auth.is_configured is False
+                initialize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_api_id_in_db_does_not_crash_cli_pool_init(self, tmp_path):
+        db_path = str(tmp_path / "bad-cli.db")
+        db = Database(db_path)
+        await db.initialize()
+        await db.set_setting("tg_api_id", "not-a-number")
+        await db.set_setting("tg_api_hash", "hash_from_db")
+
+        config = AppConfig()
+        config.database.path = db_path
+
+        with patch.object(ClientPool, "initialize", new_callable=AsyncMock) as initialize:
+            auth, pool = await init_pool(config, db)
+
+        assert auth.is_configured is False
+        assert isinstance(pool, ClientPool)
+        initialize.assert_awaited_once()
+        await db.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from src.cli.runtime import init_pool
 from src.config import AppConfig, SchedulerConfig, load_config
 from src.database import Database
 from src.models import Channel, Keyword, Message
@@ -24,7 +25,6 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.web.app import create_app
-from src.cli.runtime import init_pool
 from tests.helpers import make_mock_pool as _make_pool
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -424,22 +424,56 @@ class TestSchedulerStartStop:
     async def test_trigger_returns_immediately(self, app_with_db):
         """POST /scheduler/trigger returns redirect with ?msg=triggered instantly."""
         app, _ = app_with_db
-        collector = app.state.collector
-        collector.collect_all_channels = AsyncMock(return_value={
-            "channels": 0, "messages": 0, "errors": 0,
-        })
+        scheduler = None
+
+        class BlockingCollector:
+            def __init__(self):
+                self.started_event = asyncio.Event()
+                self.release_event = asyncio.Event()
+                self._running = False
+
+            @property
+            def is_running(self):
+                return self._running
+
+            async def collect_all_channels(self):
+                self._running = True
+                self.started_event.set()
+                try:
+                    await self.release_event.wait()
+                    return {"channels": 0, "messages": 0, "errors": 0}
+                finally:
+                    self._running = False
+
+        collector = BlockingCollector()
+        scheduler = SchedulerManager(collector, SchedulerConfig())
+        app.state.collector = collector
+        app.state.scheduler = scheduler
 
         transport = ASGITransport(app=app)
         auth_header = base64.b64encode(b":testpass").decode()
-        async with AsyncClient(
-            transport=transport,
-            base_url="http://test",
-            follow_redirects=False,
-            headers={"Authorization": f"Basic {auth_header}"},
-        ) as c:
-            resp = await c.post("/scheduler/trigger")
-            assert resp.status_code == 303
-            assert "msg=triggered" in resp.headers["location"]
+        try:
+            async with AsyncClient(
+                transport=transport,
+                base_url="http://test",
+                follow_redirects=False,
+                headers={"Authorization": f"Basic {auth_header}"},
+            ) as c:
+                resp = await c.post("/scheduler/trigger")
+                assert resp.status_code == 303
+                assert "msg=triggered" in resp.headers["location"]
+
+            await asyncio.wait_for(collector.started_event.wait(), timeout=1.0)
+            assert scheduler._bg_task is not None
+            assert not scheduler._bg_task.done()
+            assert collector.is_running is True
+        finally:
+            collector.release_event.set()
+            if scheduler is not None:
+                await scheduler.stop()
+
+        assert scheduler._bg_task is None
+        assert collector.is_running is False
 
     @pytest.mark.asyncio
     async def test_trigger_while_collecting(self, app_with_db):
@@ -716,26 +750,45 @@ class TestGracefulShutdown:
     @pytest.mark.asyncio
     async def test_trigger_task_cancelled_on_stop(self, test_db):
         """trigger_background -> stop -> task is cancelled, collector not running."""
+        await test_db.add_channel(
+            Channel(channel_id=-100765, title="Blocking Channel", username="blocking_channel")
+        )
         pool = _make_pool(get_available_client=AsyncMock(return_value=None))
 
-        config = SchedulerConfig()
+        config = SchedulerConfig(delay_between_requests_sec=0)
         collector = Collector(pool, test_db, config)
         manager = SchedulerManager(collector, config)
 
-        # Use a slow coroutine so the task is still running when we stop
-        async def _slow_collect():
-            await asyncio.sleep(10)
-            return {"channels": 0, "messages": 0, "errors": 0}
+        started_event = asyncio.Event()
+        release_event = asyncio.Event()
+        cancelled_event = asyncio.Event()
 
-        collector.collect_all_channels = AsyncMock(side_effect=_slow_collect)
+        async def _blocking_collect(_channel, **_kwargs):
+            started_event.set()
+            try:
+                await release_event.wait()
+                return 0
+            except asyncio.CancelledError:
+                cancelled_event.set()
+                raise
 
-        await manager.trigger_background()
-        assert manager._bg_task is not None
-        assert not manager._bg_task.done()
+        collector._collect_channel = AsyncMock(side_effect=_blocking_collect)
 
-        await manager.stop()
+        try:
+            await manager.trigger_background()
+            assert manager._bg_task is not None
+            await asyncio.wait_for(started_event.wait(), timeout=1.0)
+            assert not manager._bg_task.done()
+            assert collector.is_running is True
+
+            await manager.stop()
+            await asyncio.wait_for(cancelled_event.wait(), timeout=1.0)
+        finally:
+            release_event.set()
+
         assert manager._bg_task is None
         assert collector.is_running is False
+        assert cancelled_event.is_set()
 
     @pytest.mark.asyncio
     async def test_stop_without_bg_task_is_safe(self, test_db):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,8 +1,12 @@
+import asyncio
 import base64
+import re
+from pathlib import Path
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from src.collection_queue import CollectionQueue
 from src.config import AppConfig
 from src.database import Database
 from src.models import Account
@@ -11,6 +15,7 @@ from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
 from src.telegram.collector import Collector
 from src.web.app import create_app
+from src.web.routes.channel_collection import _COLLECT_ALL_BTN
 from src.web.session import COOKIE_NAME, create_session_token
 
 
@@ -66,6 +71,7 @@ async def client(tmp_path):
     app.state.notifier = None
     collector = Collector(app.state.pool, db, config.scheduler)
     app.state.collector = collector
+    app.state.collection_queue = CollectionQueue(collector, db)
     app.state.search_engine = SearchEngine(db)
     app.state.ai_search = AISearchEngine(config.llm, db)
     app.state.scheduler = SchedulerManager(collector, config.scheduler)
@@ -81,6 +87,7 @@ async def client(tmp_path):
     ) as c:
         yield c
 
+    await app.state.collection_queue.shutdown()
     await db.close()
 
 
@@ -113,6 +120,21 @@ async def test_settings_page(client):
     resp = await client.get("/settings/")
     assert resp.status_code == 200
     assert "Аккаунт для уведомлений" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
+    db = client._transport.app.state.db
+    await db.set_setting("min_subscribers_filter", "broken")
+    await db.set_setting("collect_interval_minutes", "oops")
+
+    resp = await client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert 'name="min_subscribers_filter"' in resp.text
+    assert 'value="0"' in resp.text
+    assert 'name="collect_interval_minutes"' in resp.text
+    assert 'value="60"' in resp.text
 
 
 @pytest.mark.asyncio
@@ -800,7 +822,6 @@ async def test_filter_toggle_sets_manual_flag(client):
 @pytest.mark.asyncio
 async def test_collect_filtered_channel_is_allowed(client):
     """Manual collect (web UI) must proceed even when channel is filtered."""
-    from src.collection_queue import CollectionQueue
     from src.models import Channel
 
     db = client._transport.app.state.db
@@ -1003,11 +1024,89 @@ async def test_collect_all_htmx_returns_spinner(client):
 
 
 @pytest.mark.asyncio
-async def test_collect_all_non_htmx_redirects(client):
-    """POST /channels/collect-all without HTMX header redirects."""
-    resp = await client.post("/channels/collect-all", follow_redirects=False)
-    assert resp.status_code == 303
-    assert "msg=collect_all_started" in resp.headers["location"]
+async def test_collect_all_htmx_without_scheduler_returns_unavailable(client):
+    app = client._transport.app.state
+    scheduler = app.scheduler
+    app.scheduler = None
+    try:
+        resp = await client.post(
+            "/channels/collect-all",
+            headers={"HX-Request": "true"},
+            follow_redirects=False,
+        )
+    finally:
+        app.scheduler = scheduler
+
+    assert resp.status_code == 200
+    assert "Недоступно" in resp.text
+    assert "hx-trigger" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_collect_all_non_htmx_redirects_and_starts_background(client):
+    """POST /channels/collect-all without HTMX header redirects and starts collection."""
+    app = client._transport.app.state
+    scheduler = None
+
+    class BlockingCollector:
+        def __init__(self):
+            self.started_event = asyncio.Event()
+            self.release_event = asyncio.Event()
+            self._running = False
+
+        @property
+        def is_running(self):
+            return self._running
+
+        async def collect_all_channels(self):
+            self._running = True
+            self.started_event.set()
+            try:
+                await self.release_event.wait()
+                return {"channels": 0, "messages": 0, "errors": 0}
+            finally:
+                self._running = False
+
+    collector = BlockingCollector()
+    scheduler = SchedulerManager(collector, AppConfig().scheduler)
+    original_collector = app.collector
+    original_scheduler = app.scheduler
+    app.collector = collector
+    app.scheduler = scheduler
+    try:
+        resp = await client.post("/channels/collect-all", follow_redirects=False)
+        assert resp.status_code == 303
+        assert "msg=collect_all_started" in resp.headers["location"]
+
+        await asyncio.wait_for(collector.started_event.wait(), timeout=1.0)
+        assert scheduler._bg_task is not None
+        assert not scheduler._bg_task.done()
+    finally:
+        collector.release_event.set()
+        await scheduler.stop()
+        app.collector = original_collector
+        app.scheduler = original_scheduler
+
+
+@pytest.mark.asyncio
+async def test_channels_page_collect_all_button_matches_htmx_fragment(client):
+    template_path = Path("src/web/templates/channels.html")
+    template_text = template_path.read_text(encoding="utf-8")
+    match = re.search(r'(<span id="collect-all-btn">.*?</span>)', template_text, re.S)
+    assert match is not None
+    template_fragment = match.group(1)
+
+    for expected in (
+        'id="collect-all-btn"',
+        'action="/channels/collect-all"',
+        'hx-post="/channels/collect-all"',
+        'hx-target="#collect-all-btn"',
+        'hx-swap="outerHTML"',
+        'class="outline"',
+        'Загрузить все',
+    ):
+        assert expected in template_fragment
+        assert expected in _COLLECT_ALL_BTN
 
 
 @pytest.mark.asyncio

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -143,6 +143,18 @@ async def test_settings_page_hides_credentials_form_when_env_credentials_configu
 
 
 @pytest.mark.asyncio
+async def test_settings_page_keeps_credentials_form_for_invalid_env_api_id(client, monkeypatch):
+    monkeypatch.setenv("TG_API_ID", "not-a-number")
+    monkeypatch.setenv("TG_API_HASH", "env-hash")
+
+    resp = await client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert "Управляется через окружение" not in resp.text
+    assert 'action="/settings/save-credentials"' in resp.text
+
+
+@pytest.mark.asyncio
 async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
     db = client._transport.app.state.db
     await db.set_setting("min_subscribers_filter", "broken")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -964,3 +964,47 @@ async def test_search_results_private_channel_link(client):
     resp = await client.get("/?q=Secret&mode=local")
     assert resp.status_code == 200
     assert "t.me/c/-100999/7" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_collect_all_status_idle(client):
+    """GET /channels/collect-all/status when idle returns original button."""
+    resp = await client.get("/channels/collect-all/status")
+    assert resp.status_code == 200
+    assert 'Загрузить все' in resp.text
+    assert 'disabled' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_collect_all_status_running(client):
+    """GET /channels/collect-all/status when collecting returns spinner with polling attrs."""
+    app = client._transport.app.state
+    app.collector._running = True
+    try:
+        resp = await client.get("/channels/collect-all/status")
+    finally:
+        app.collector._running = False
+    assert resp.status_code == 200
+    assert 'disabled' in resp.text
+    assert 'hx-trigger="every 3s"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_collect_all_htmx_returns_spinner(client):
+    """POST /channels/collect-all with HTMX header returns spinner fragment."""
+    resp = await client.post(
+        "/channels/collect-all",
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 200
+    assert 'disabled' in resp.text
+    assert 'hx-trigger="every 3s"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_collect_all_non_htmx_redirects(client):
+    """POST /channels/collect-all without HTMX header redirects."""
+    resp = await client.post("/channels/collect-all", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=collect_all_started" in resp.headers["location"]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1008,3 +1008,57 @@ async def test_collect_all_non_htmx_redirects(client):
     resp = await client.post("/channels/collect-all", follow_redirects=False)
     assert resp.status_code == 303
     assert "msg=collect_all_started" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_save_scheduler_valid(client):
+    """POST /settings/save-scheduler with valid interval persists and redirects."""
+    resp = await client.post(
+        "/settings/save-scheduler",
+        data={"collect_interval_minutes": "30"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=scheduler_saved" in resp.headers["location"]
+    db = client._transport.app.state.db
+    assert await db.get_setting("collect_interval_minutes") == "30"
+
+
+@pytest.mark.asyncio
+async def test_save_scheduler_invalid_value(client):
+    """POST /settings/save-scheduler with non-numeric value redirects to error."""
+    resp = await client.post(
+        "/settings/save-scheduler",
+        data={"collect_interval_minutes": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=invalid_value" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_save_scheduler_clamps_to_min(client):
+    """POST /settings/save-scheduler clamps value below 1 to 1."""
+    resp = await client.post(
+        "/settings/save-scheduler",
+        data={"collect_interval_minutes": "0"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=scheduler_saved" in resp.headers["location"]
+    db = client._transport.app.state.db
+    assert await db.get_setting("collect_interval_minutes") == "1"
+
+
+@pytest.mark.asyncio
+async def test_save_scheduler_clamps_to_max(client):
+    """POST /settings/save-scheduler clamps value above 1440 to 1440."""
+    resp = await client.post(
+        "/settings/save-scheduler",
+        data={"collect_interval_minutes": "9999"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=scheduler_saved" in resp.headers["location"]
+    db = client._transport.app.state.db
+    assert await db.get_setting("collect_interval_minutes") == "1440"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -123,6 +123,26 @@ async def test_settings_page(client):
 
 
 @pytest.mark.asyncio
+async def test_settings_page_hides_credentials_form_when_env_credentials_configured(
+    client, monkeypatch
+):
+    monkeypatch.setenv("TG_API_ID", "12345")
+    monkeypatch.setenv("TG_API_HASH", "env-hash")
+
+    resp = await client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert "Управляется через окружение" in resp.text
+    assert 'action="/settings/save-credentials"' not in resp.text
+    assert "Telegram-аккаунты" in resp.text
+    assert 'href="/auth/login" role="button">Добавить аккаунт</a>' in resp.text
+    template_text = Path("src/web/templates/settings.html").read_text(encoding="utf-8")
+    assert template_text.index("<header>Telegram-аккаунты</header>") < template_text.index(
+        "<header>Планировщик</header>"
+    )
+
+
+@pytest.mark.asyncio
 async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
     db = client._transport.app.state.db
     await db.set_setting("min_subscribers_filter", "broken")


### PR DESCRIPTION
## Summary

- **POST /channels/collect-all** — новый маршрут запускает `collect_all_channels()` через `scheduler.trigger_background()`; кнопка "Загрузить все" на странице каналов с HTMX-обратной связью
- **POST /settings/save-scheduler** — сохраняет интервал сбора (1–1440 мин) в DB и обновляет планировщик на лету через `SchedulerManager.update_interval()`; секция "Планировщик" добавлена на `/settings`
- **SchedulerManager**: при `start()` читает `collect_interval_minutes` из DB (приоритет над конфигом), добавлен метод `update_interval()` для перепланирования без перезапуска
- Дефолт `collect_interval_minutes` изменён с 30 на 60
- **Поведение `limit` при incremental-сборе**: `limit = None` для всех запусков (ранее incremental использовал `messages_per_channel`); диапазон ограничен `min_id`, поэтому новые сообщения не теряются даже при больших всплесках активности в канале

## Test plan

- [ ] `/channels` → кнопка "Загрузить все" → сбор запускается (лог / статус)
- [ ] `/settings` → изменить интервал → `SELECT value FROM settings WHERE key='collect_interval_minutes'` показывает новое значение
- [ ] Перезапустить сервер → планировщик использует сохранённый интервал из DB
- [ ] `pytest tests/ -v` — все тесты зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)