### PR TITLE
fix: mobile UX audit, deploy crash fix, test fixtures

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -276,10 +276,10 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
 
     # Register routes
     from src.web.routes.auth import router as auth_router
-    from src.web.routes.debug import router as debug_router
     from src.web.routes.channel_collection import router as channel_collection_router
     from src.web.routes.channels import router as channels_router
     from src.web.routes.dashboard import router as dashboard_router
+    from src.web.routes.debug import router as debug_router
     from src.web.routes.filter import router as filter_router
     from src.web.routes.import_channels import router as import_router
     from src.web.routes.keywords import router as keywords_router

--- a/src/web/log_handler.py
+++ b/src/web/log_handler.py
@@ -11,7 +11,7 @@ class LogBuffer(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         self._records.append({
-            "time": self.formatTime(record, "%Y-%m-%d %H:%M:%S"),
+            "time": logging.Formatter().formatTime(record, "%Y-%m-%d %H:%M:%S"),
             "level": record.levelname,
             "logger": record.name,
             "message": self.format(record),

--- a/src/web/log_handler.py
+++ b/src/web/log_handler.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from collections import deque
 
+_FORMATTER = logging.Formatter()
+
 
 class LogBuffer(logging.Handler):
     def __init__(self, maxlen: int = 500):
@@ -11,7 +13,7 @@ class LogBuffer(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         self._records.append({
-            "time": logging.Formatter().formatTime(record, "%Y-%m-%d %H:%M:%S"),
+            "time": _FORMATTER.formatTime(record, "%Y-%m-%d %H:%M:%S"),
             "level": record.levelname,
             "logger": record.name,
             "message": self.format(record),

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -56,7 +56,7 @@ td, th {
 
 .emoji-btn {
     padding: 0.35rem 0.5rem !important;
-    min-height: 36px;
+    min-height: 44px;
     font-size: 1rem;
     line-height: 1;
     margin: 0 1px;

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -49,15 +49,20 @@ td, th {
 .channels-table td:nth-child(7) { width: 85px; }    /* Подписчики */
 
 .channels-table th:nth-child(8),
-.channels-table td:nth-child(8) { width: 145px; }   /* Действия */
+.channels-table td:nth-child(8) { width: 80px; }    /* Фильтр */
+
+.channels-table th:nth-child(9),
+.channels-table td:nth-child(9) { width: 145px; }   /* Действия */
 
 .emoji-btn {
-    padding: 0.1rem 0.3rem !important;
+    padding: 0.35rem 0.5rem !important;
+    min-height: 36px;
     font-size: 1rem;
     line-height: 1;
     margin: 0 1px;
     width: auto !important;
     display: inline-flex !important;
+    align-items: center;
 }
 
 .channels-table td:nth-child(1),
@@ -138,5 +143,7 @@ form button[style*="padding"] {
     flex-wrap: nowrap;
     padding-bottom: 0.25rem;
     -webkit-overflow-scrolling: touch;
+    -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+    mask-image: linear-gradient(to right, black 85%, transparent 100%);
   }
 }

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -13,7 +13,7 @@
                 <small>Форматы: <code>@username</code>, <code>t.me/username</code>, <code>https://t.me/username</code>, <code>https://t.me/+invite_hash</code>, <code>числовой ID</code></small>
             </label>
         </div>
-        <div style="display:flex;gap:0.5rem">
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap">
             <button type="submit" style="flex:1">Добавить</button>
             <button type="button" class="secondary" onclick="openSubscriptions()" style="white-space:nowrap">Мои подписки</button>
             <a href="/channels/import" role="button" class="secondary outline" style="white-space:nowrap">Импорт</a>
@@ -149,7 +149,7 @@
             <button aria-label="Close" rel="prev" onclick="this.closest('dialog').close()"></button>
             <h3>Мои подписки</h3>
         </header>
-        <div id="subscriptions-list">Загрузка...</div>
+        <div id="subscriptions-list" style="overflow-x:auto">Загрузка...</div>
         <footer>
             <button class="secondary" onclick="this.closest('dialog').close()">Отмена</button>
             <button onclick="addSelected()">Добавить выбранные</button>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -50,7 +50,7 @@
 {% if search_log %}
 <article>
     <header>Лог поиска</header>
-    <figure>
+    <figure style="overflow-x:auto">
     <table>
         <thead>
             <tr>
@@ -79,7 +79,7 @@
 <article>
     <header>Задачи сбора</header>
     <p><small>Здесь отображаются и ручные задачи из кнопки «Загрузить все», и одиночные загрузки каналов.</small></p>
-    <figure>
+    <figure style="overflow-x:auto">
     <table>
         <thead>
             <tr>

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -60,7 +60,7 @@
             AI-поиск
         </label>
         {% endif %}
-        <button type="submit" style="margin-bottom: 0;">Найти</button>
+        <button type="submit" style="margin-bottom: 0; margin-left: auto;">Найти</button>
     </fieldset>
 </form>
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,7 @@ from httpx import ASGITransport, AsyncClient
 from src.cli.runtime import init_pool
 from src.config import AppConfig, SchedulerConfig, load_config
 from src.database import Database
-from src.models import Channel, Keyword, Message
+from src.models import Account, Channel, Keyword, Message
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -78,6 +78,8 @@ async def app_with_db(tmp_path):
     app.state.search_engine = SearchEngine(db)
     app.state.ai_search = AISearchEngine(config.llm, db)
     app.state.scheduler = SchedulerManager(collector, config.scheduler)
+
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
 
     yield app, db
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -76,6 +76,8 @@ async def client(tmp_path):
     app.state.scheduler = SchedulerManager(collector, config.scheduler)
     app.state.session_secret = "test_secret_key"
 
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
     async with AsyncClient(
@@ -355,6 +357,9 @@ async def test_settings_shows_accounts(tmp_path):
 @pytest.mark.asyncio
 async def test_settings_no_accounts(client):
     """Settings page shows 'no accounts' message when DB has no accounts."""
+    db = client._transport.app.state.db
+    for acc in await db.get_accounts(active_only=False):
+        await db.delete_account(acc.id)
     resp = await client.get("/settings/")
     assert resp.status_code == 200
     assert "Добавьте первый аккаунт" in resp.text


### PR DESCRIPTION
## Summary

- **fix deploy crash**: `LogBuffer.emit` called `self.formatTime` which doesn't exist on `logging.Handler`; replaced with `logging.Formatter().formatTime` — was crashing app startup in production
- **fix test fixtures**: `client` / `app_with_db` fixtures had no account in DB, causing `/` to redirect to `/settings` (onboarding flow) and failing all search-related tests; added seed account to both fixtures; `test_settings_no_accounts` now clears accounts before asserting
- **mobile UX**: channels-table CSS 8→9 nth-child columns (Filter column was missing), emoji-btn touch target increased, nav scroll fade, flex-wrap on add-channel buttons, overflow-x on subscriptions modal and scheduler figures, search button margin-left:auto

## Test plan
- [ ] `pytest tests/ -q` → 369 passed
- [ ] `docker build` + `docker run` → `/health` returns `{"status":"healthy"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)