### PR TITLE
feat: My Telegram — просмотр диалогов аккаунта (Web + CLI)

### DIFF
--- a/src/cli/commands/my_telegram.py
+++ b/src/cli/commands/my_telegram.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from src.cli import runtime
+from src.services.channel_service import ChannelService
+
+
+def run(args: argparse.Namespace) -> None:
+    async def _run() -> None:
+        config, db = await runtime.init_db(args.config)
+        _, pool = await runtime.init_pool(config, db)
+        try:
+            if args.my_telegram_action == "list":
+                accounts = sorted(pool.clients.keys())
+                if not accounts:
+                    print("No connected accounts.")
+                    return
+                phone = args.phone or accounts[0]
+                if phone not in pool.clients:
+                    print(f"Account {phone} not connected.")
+                    return
+                svc = ChannelService(db, pool, None)  # type: ignore[arg-type]
+                dialogs = await svc.get_my_dialogs(phone)
+                if not dialogs:
+                    print("No dialogs found.")
+                    return
+                fmt = "{:<12} {:<40} {:<20} {:<8}"
+                print(fmt.format("Type", "Title", "Username", "In DB"))
+                print("-" * 84)
+                for d in dialogs:
+                    print(fmt.format(
+                        d["channel_type"],
+                        d["title"][:40],
+                        ("@" + d["username"]) if d.get("username") else "",
+                        "Yes" if d.get("already_added") else "-",
+                    ))
+        finally:
+            await pool.disconnect_all()
+            await db.close()
+
+    asyncio.run(_run())

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -15,6 +15,7 @@ from src.cli.commands import (
     serve,
 )
 from src.cli.commands import filter as filter_cmd
+from src.cli.commands import my_telegram as my_telegram_cmd
 from src.cli.parser import build_parser
 from src.cli.runtime import setup_logging
 
@@ -36,6 +37,7 @@ def main() -> None:
         "account": account.run,
         "scheduler": scheduler.run,
         "notification": notification.run,
+        "my-telegram": my_telegram_cmd.run,
     }
 
     handler = commands.get(args.command)
@@ -47,6 +49,7 @@ def main() -> None:
             "account": "account_action",
             "scheduler": "scheduler_action",
             "notification": "notification_action",
+            "my-telegram": "my_telegram_action",
         }
         if args.command in sub_attr and not getattr(args, sub_attr[args.command], None):
             parser.parse_args([args.command, "--help"])

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -99,6 +99,11 @@ def build_parser() -> argparse.ArgumentParser:
     sched_sub.add_parser("trigger", help="Trigger one-shot collection")
     sched_sub.add_parser("search", help="Run keyword search now")
 
+    my_tg_parser = sub.add_parser("my-telegram", help="View account dialogs")
+    my_tg_sub = my_tg_parser.add_subparsers(dest="my_telegram_action")
+    my_tg_list = my_tg_sub.add_parser("list", help="List all dialogs for an account")
+    my_tg_list.add_argument("--phone", default=None, help="Account phone (default: first connected)")  # noqa: E501
+
     notif_parser = sub.add_parser("notification", help="Personal notification bot management")
     notif_sub = notif_parser.add_subparsers(dest="notification_action")
     notif_sub.add_parser("setup", help="Create personal notification bot via BotFather")

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -64,6 +64,14 @@ class ChannelService:
                 )
             )
 
+    async def get_my_dialogs(self, phone: str) -> list[dict]:
+        """Get all dialogs for a specific account, enriched with already_added flag."""
+        existing_ids = {ch.channel_id for ch in await self._db.get_channels()}
+        dialogs = await self._pool.get_dialogs_for_phone(phone, include_dm=True)
+        for d in dialogs:
+            d["already_added"] = d["channel_id"] in existing_ids
+        return dialogs
+
     async def toggle(self, pk: int) -> None:
         channel = await self._db.get_channel_by_pk(pk)
         if not channel:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -338,6 +338,62 @@ class ClientPool:
         logger.warning("resolve_channel: all clients flood-waited for '%s'", identifier)
         return None
 
+    async def get_dialogs_for_phone(self, phone: str, include_dm: bool = True) -> list[dict]:
+        """Get all dialogs for a specific connected account."""
+        result = await self.get_client_by_phone(phone)
+        if not result:
+            return []
+        client, phone = result
+        try:
+            async def _iter() -> list[dict]:
+                items: list[dict] = []
+                async for dialog in client.iter_dialogs():
+                    entity = dialog.entity
+                    if dialog.is_channel or dialog.is_group:
+                        if getattr(entity, "scam", False):
+                            channel_type = "scam"
+                        elif getattr(entity, "fake", False):
+                            channel_type = "fake"
+                        elif getattr(entity, "restricted", False):
+                            channel_type = "restricted"
+                        elif getattr(entity, "monoforum", False):
+                            channel_type = "monoforum"
+                        elif getattr(entity, "forum", False):
+                            channel_type = "forum"
+                        elif getattr(entity, "gigagroup", False):
+                            channel_type = "gigagroup"
+                        elif getattr(entity, "megagroup", False):
+                            channel_type = "supergroup"
+                        elif getattr(entity, "broadcast", False):
+                            channel_type = "channel"
+                        else:
+                            channel_type = "group"
+                        deactivate = channel_type in ("scam", "fake", "restricted")
+                        items.append({
+                            "channel_id": entity.id,
+                            "title": dialog.title,
+                            "username": getattr(entity, "username", None),
+                            "channel_type": channel_type,
+                            "deactivate": deactivate,
+                        })
+                    elif include_dm:
+                        items.append({
+                            "channel_id": entity.id,
+                            "title": dialog.title,
+                            "username": getattr(entity, "username", None),
+                            "channel_type": "dm",
+                            "deactivate": False,
+                        })
+                return items
+
+            try:
+                return await asyncio.wait_for(_iter(), timeout=60.0)
+            except asyncio.TimeoutError:
+                logger.warning("get_dialogs_for_phone: timed out for %s", phone)
+                return []
+        finally:
+            await self.release_client(phone)
+
     async def get_dialogs(self) -> list[dict]:
         """Get list of subscribed channels and groups."""
         result = await self.get_available_client()

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -282,33 +282,7 @@ class ClientPool:
                     return None
                 if isinstance(entity, ChannelForbidden):
                     return None
-                scam = getattr(entity, "scam", False)
-                fake = getattr(entity, "fake", False)
-                restricted = getattr(entity, "restricted", False)
-                monoforum = getattr(entity, "monoforum", False)
-                forum = getattr(entity, "forum", False)
-                megagroup = getattr(entity, "megagroup", False)
-                gigagroup = getattr(entity, "gigagroup", False)
-                broadcast = getattr(entity, "broadcast", False)
-                deactivate = False
-                if scam:
-                    channel_type, deactivate = "scam", True
-                elif fake:
-                    channel_type, deactivate = "fake", True
-                elif restricted:
-                    channel_type, deactivate = "restricted", True
-                elif monoforum:
-                    channel_type = "monoforum"
-                elif forum:
-                    channel_type = "forum"
-                elif gigagroup:
-                    channel_type = "gigagroup"
-                elif megagroup:
-                    channel_type = "supergroup"
-                elif broadcast:
-                    channel_type = "channel"
-                else:
-                    channel_type = "group"
+                channel_type, deactivate = self._classify_entity(entity)
                 return {
                     "channel_id": entity.id,
                     "title": entity.title,

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -338,7 +338,30 @@ class ClientPool:
         logger.warning("resolve_channel: all clients flood-waited for '%s'", identifier)
         return None
 
-    async def get_dialogs_for_phone(self, phone: str, include_dm: bool = True) -> list[dict]:
+    @staticmethod
+    def _classify_entity(entity) -> tuple[str, bool]:
+        """Return (channel_type, deactivate) for a Telegram channel/group entity."""
+        if getattr(entity, "scam", False):
+            channel_type = "scam"
+        elif getattr(entity, "fake", False):
+            channel_type = "fake"
+        elif getattr(entity, "restricted", False):
+            channel_type = "restricted"
+        elif getattr(entity, "monoforum", False):
+            channel_type = "monoforum"
+        elif getattr(entity, "forum", False):
+            channel_type = "forum"
+        elif getattr(entity, "gigagroup", False):
+            channel_type = "gigagroup"
+        elif getattr(entity, "megagroup", False):
+            channel_type = "supergroup"
+        elif getattr(entity, "broadcast", False):
+            channel_type = "channel"
+        else:
+            channel_type = "group"
+        return channel_type, channel_type in ("scam", "fake", "restricted")
+
+    async def get_dialogs_for_phone(self, phone: str, include_dm: bool = False) -> list[dict]:
         """Get all dialogs for a specific connected account."""
         result = await self.get_client_by_phone(phone)
         if not result:
@@ -350,25 +373,7 @@ class ClientPool:
                 async for dialog in client.iter_dialogs():
                     entity = dialog.entity
                     if dialog.is_channel or dialog.is_group:
-                        if getattr(entity, "scam", False):
-                            channel_type = "scam"
-                        elif getattr(entity, "fake", False):
-                            channel_type = "fake"
-                        elif getattr(entity, "restricted", False):
-                            channel_type = "restricted"
-                        elif getattr(entity, "monoforum", False):
-                            channel_type = "monoforum"
-                        elif getattr(entity, "forum", False):
-                            channel_type = "forum"
-                        elif getattr(entity, "gigagroup", False):
-                            channel_type = "gigagroup"
-                        elif getattr(entity, "megagroup", False):
-                            channel_type = "supergroup"
-                        elif getattr(entity, "broadcast", False):
-                            channel_type = "channel"
-                        else:
-                            channel_type = "group"
-                        deactivate = channel_type in ("scam", "fake", "restricted")
+                        channel_type, deactivate = self._classify_entity(entity)
                         items.append({
                             "channel_id": entity.id,
                             "title": dialog.title,
@@ -406,25 +411,7 @@ class ClientPool:
                 async for dialog in client.iter_dialogs():
                     if dialog.is_channel or dialog.is_group:
                         entity = dialog.entity
-                        if getattr(entity, "scam", False):
-                            channel_type = "scam"
-                        elif getattr(entity, "fake", False):
-                            channel_type = "fake"
-                        elif getattr(entity, "restricted", False):
-                            channel_type = "restricted"
-                        elif getattr(entity, "monoforum", False):
-                            channel_type = "monoforum"
-                        elif getattr(entity, "forum", False):
-                            channel_type = "forum"
-                        elif getattr(entity, "gigagroup", False):
-                            channel_type = "gigagroup"
-                        elif getattr(entity, "megagroup", False):
-                            channel_type = "supergroup"
-                        elif getattr(entity, "broadcast", False):
-                            channel_type = "channel"
-                        else:
-                            channel_type = "group"
-                        deactivate = channel_type in ("scam", "fake", "restricted")
+                        channel_type, deactivate = self._classify_entity(entity)
                         result.append({
                             "channel_id": entity.id,
                             "title": dialog.title,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -283,6 +283,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     from src.web.routes.filter import router as filter_router
     from src.web.routes.import_channels import router as import_router
     from src.web.routes.keywords import router as keywords_router
+    from src.web.routes.my_telegram import router as my_telegram_router
     from src.web.routes.scheduler import router as scheduler_router
     from src.web.routes.search import router as search_router
     from src.web.routes.settings import router as settings_router
@@ -297,6 +298,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(import_router, prefix="/channels")
     app.include_router(scheduler_router, prefix="/scheduler")
     app.include_router(settings_router, prefix="/settings")
+    app.include_router(my_telegram_router, prefix="/my-telegram")
     app.include_router(debug_router, prefix="/debug")
 
     return app

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from src.web import deps
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+async def my_telegram_page(request: Request, phone: str | None = None):
+    pool = deps.get_pool(request)
+    accounts = sorted(pool.clients.keys())
+    selected_phone = phone or (accounts[0] if accounts else None)
+    dialogs = []
+    if selected_phone and selected_phone in pool.clients:
+        dialogs = await deps.channel_service(request).get_my_dialogs(selected_phone)
+    return deps.get_templates(request).TemplateResponse(
+        request, "my_telegram.html", {
+            "accounts": accounts,
+            "selected_phone": selected_phone,
+            "dialogs": dialogs,
+        }
+    )

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -19,6 +19,7 @@
             <li><a href="/dashboard">Панель</a></li>
             <li><a href="/channels">Каналы</a></li>
             <li><a href="/keywords">Ключевые слова</a></li>
+            <li><a href="/my-telegram">Мой Телеграм</a></li>
             <li><a href="/scheduler">Планировщик</a></li>
             <li><a href="/debug">Дебаг</a></li>
             <li><a href="/settings">Настройки</a></li>

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -11,7 +11,7 @@
       hx-get="/my-telegram" hx-target="body" hx-push-url="true" hx-indicator="#dialogs-loading">
     <label>
         Аккаунт
-        <select name="phone" onchange="this.form.submit()">
+        <select name="phone" onchange="htmx.trigger(this.form, 'submit')">
             {% for acc in accounts %}
             <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
             {% endfor %}

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+{% block title %}Мой Телеграм — TG Post Search{% endblock %}
+{% block content %}
+<h1>Мой Телеграм</h1>
+
+{% if not accounts %}
+<p>Нет подключённых аккаунтов. Добавьте аккаунт в <a href="/settings">Настройках</a>.</p>
+{% else %}
+
+<form method="get" action="/my-telegram" style="max-width:400px;margin-bottom:1.5rem">
+    <label>
+        Аккаунт
+        <select name="phone" onchange="this.form.submit()">
+            {% for acc in accounts %}
+            <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
+            {% endfor %}
+        </select>
+    </label>
+</form>
+
+{% if dialogs %}
+<p style="color:var(--pico-muted-color)">Всего диалогов: <strong>{{ dialogs|length }}</strong></p>
+<div style="overflow-x:auto">
+<table>
+    <thead>
+        <tr>
+            <th>Тип</th>
+            <th>Название</th>
+            <th>Username</th>
+            <th>В базе</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for d in dialogs %}
+        <tr>
+            <td>
+                {% if d.channel_type == "channel" %}
+                <span class="badge-active">channel</span>
+                {% elif d.channel_type == "supergroup" %}
+                <span class="badge-active">supergroup</span>
+                {% elif d.channel_type == "group" %}
+                <span class="badge-inactive">group</span>
+                {% elif d.channel_type == "dm" %}
+                <span class="badge-inactive">dm</span>
+                {% elif d.channel_type == "forum" %}
+                <span class="badge-active">forum</span>
+                {% elif d.channel_type == "gigagroup" %}
+                <span class="badge-active">gigagroup</span>
+                {% elif d.channel_type == "monoforum" %}
+                <span class="badge-active">monoforum</span>
+                {% else %}
+                <span class="badge-inactive">{{ d.channel_type }}</span>
+                {% endif %}
+            </td>
+            <td>{{ d.title }}</td>
+            <td>{% if d.username %}<a href="https://t.me/{{ d.username }}" target="_blank" rel="noopener">@{{ d.username }}</a>{% else %}<span style="color:var(--pico-muted-color)">—</span>{% endif %}</td>
+            <td>{% if d.already_added %}<span class="badge-active">✓</span>{% else %}<span style="color:var(--pico-muted-color)">—</span>{% endif %}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% else %}
+<p>Нет диалогов.</p>
+{% endif %}
+
+{% endif %}
+{% endblock %}

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -7,7 +7,8 @@
 <p>Нет подключённых аккаунтов. Добавьте аккаунт в <a href="/settings">Настройках</a>.</p>
 {% else %}
 
-<form method="get" action="/my-telegram" style="max-width:400px;margin-bottom:1.5rem">
+<form method="get" action="/my-telegram" style="max-width:400px;margin-bottom:1.5rem"
+      hx-get="/my-telegram" hx-target="body" hx-push-url="true" hx-indicator="#dialogs-loading">
     <label>
         Аккаунт
         <select name="phone" onchange="this.form.submit()">
@@ -17,6 +18,7 @@
         </select>
     </label>
 </form>
+<span id="dialogs-loading" class="htmx-indicator" aria-label="Загрузка…">⏳ Загрузка диалогов…</span>
 
 {% if dialogs %}
 <p style="color:var(--pico-muted-color)">Всего диалогов: <strong>{{ dialogs|length }}</strong></p>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,6 +59,9 @@ async def app_with_db(tmp_path):
     async def _get_dialogs(self):
         return []
 
+    async def _get_dialogs_for_phone(self, phone, include_dm=False):
+        return []
+
     pool = type(
         "Pool",
         (),
@@ -67,6 +70,7 @@ async def app_with_db(tmp_path):
             "get_users_info": _no_users,
             "resolve_channel": _resolve_channel,
             "get_dialogs": _get_dialogs,
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
         },
     )()
     app.state.pool = pool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -164,7 +164,7 @@ class TestAuthFlow:
 
     @pytest.mark.asyncio
     async def test_all_protected_pages_require_auth(self, noauth_client):
-        for path in ["/settings/", "/channels/", "/dashboard/", "/scheduler/", "/keywords/"]:
+        for path in ["/settings/", "/channels/", "/dashboard/", "/scheduler/", "/keywords/", "/my-telegram/"]:
             resp = await noauth_client.get(path, follow_redirects=False)
             assert resp.status_code == 401, f"{path} should require auth"
 

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -118,7 +118,7 @@ async def test_my_telegram_page_requires_auth(tmp_path):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
         resp = await c.get("/my-telegram/")
-    assert resp.status_code in (401, 302, 303)
+    assert resp.status_code == 401
     await db.close()
 
 

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.collection_queue import CollectionQueue
+from src.config import AppConfig
+from src.database import Database
+from src.models import Account
+from src.scheduler.manager import SchedulerManager
+from src.search.ai_search import AISearchEngine
+from src.search.engine import SearchEngine
+from src.services.channel_service import ChannelService
+from src.telegram.collector import Collector
+from src.web.app import create_app
+
+_FAKE_DIALOGS = [
+    {"channel_id": -100111, "title": "My Channel", "username": "mychan", "channel_type": "channel", "deactivate": False},
+    {"channel_id": -100222, "title": "My Group", "username": None, "channel_type": "supergroup", "deactivate": False},
+    {"channel_id": 999, "title": "Some User", "username": "someuser", "channel_type": "dm", "deactivate": False},
+]
+
+
+@pytest.fixture
+async def client(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    async def _get_dialogs_for_phone(self, phone, include_dm=False):
+        return _FAKE_DIALOGS
+
+    async def _get_dialogs(self):
+        return []
+
+    async def _no_users(self):
+        return []
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {"+1234567890": MagicMock()},
+            "get_users_info": _no_users,
+            "get_dialogs": _get_dialogs,
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
+        },
+    )()
+
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+    collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.collector = collector
+    app.state.collection_queue = CollectionQueue(collector, db)
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(collector, config.scheduler)
+    app.state.session_secret = "test_secret_key"
+
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as c:
+        yield c
+
+    await app.state.collection_queue.shutdown()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_my_telegram_page_renders(client):
+    resp = await client.get("/my-telegram/")
+    assert resp.status_code == 200
+    assert "Мой Телеграм" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_my_telegram_page_shows_dialogs(client):
+    resp = await client.get("/my-telegram/?phone=%2B1234567890")
+    assert resp.status_code == 200
+    assert "My Channel" in resp.text
+    assert "My Group" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_my_telegram_page_requires_auth(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+    app.state.pool = type("Pool", (), {"clients": {}})()
+    app.state.session_secret = "test_secret_key"
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
+        resp = await c.get("/my-telegram/")
+    assert resp.status_code in (401, 302, 303)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_my_dialogs_enriches_already_added(db):
+    """get_my_dialogs() marks dialogs already in the channel DB."""
+    from src.models import Channel
+    await db.add_channel(Channel(
+        channel_id=-100111,
+        title="My Channel",
+        username="mychan",
+        channel_type="channel",
+        is_active=True,
+    ))
+
+    pool = MagicMock()
+    pool.get_dialogs_for_phone = AsyncMock(return_value=list(_FAKE_DIALOGS))
+    queue = MagicMock()
+
+    service = ChannelService(db, pool, queue)
+    dialogs = await service.get_my_dialogs("+1234567890")
+
+    pool.get_dialogs_for_phone.assert_awaited_once_with("+1234567890", include_dm=True)
+    by_id = {d["channel_id"]: d for d in dialogs}
+    assert by_id[-100111]["already_added"] is True
+    assert by_id[-100222]["already_added"] is False
+    assert by_id[999]["already_added"] is False


### PR DESCRIPTION
## Summary

- Новый пункт меню **Мой Телеграм** (`/my-telegram`): dropdown для выбора подключённого аккаунта и таблица всех его диалогов (каналы, группы, DM) с флагом «В базе»
- CLI-команда `my-telegram list [--phone PHONE]` для паритета
- Новый метод `ClientPool.get_dialogs_for_phone(phone, include_dm)` — per-account вариант существующего `get_dialogs()`
- Новый метод `ChannelService.get_my_dialogs(phone)` — обогащает диалоги флагом `already_added`

## Changed files

| File | Change |
|------|--------|
| `src/telegram/client_pool.py` | + `get_dialogs_for_phone()` |
| `src/services/channel_service.py` | + `get_my_dialogs()` |
| `src/web/routes/my_telegram.py` | new router |
| `src/web/templates/my_telegram.html` | new template |
| `src/web/app.py` | register router |
| `src/web/templates/base.html` | nav item |
| `src/cli/commands/my_telegram.py` | new CLI command |
| `src/cli/parser.py` | new subparser |
| `src/cli/main.py` | register command |

## Test plan

- [ ] `ruff check src/ tests/` — no errors
- [ ] `pytest tests/ -v` — all pass
- [ ] Web: nav item «Мой Телеграм» виден, dropdown работает, диалоги загружаются, флаг «В базе» корректен
- [ ] CLI: `python -m src.main my-telegram list` выводит таблицу диалогов

@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)