### PR TITLE
refactor bootstrap/container and replace smoke-test with test command

### DIFF
--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from src.cli import runtime
 from src.cli.commands.common import resolve_channel
-from src.models import Channel
+from src.models import Channel, CollectionTaskStatus
 from src.parsers import deduplicate_identifiers, parse_file, parse_identifiers
 from src.telegram.collector import Collector
 
@@ -262,14 +262,22 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Channel '{args.identifier}' not found")
                     return
                 task_id = await db.create_collection_task(ch.channel_id, ch.title)
-                await db.update_collection_task(task_id, "running")
+                await db.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
                 collector = Collector(pool, db, config.scheduler)
                 try:
                     count = await collector.collect_single_channel(ch, full=True, force=True)
-                    await db.update_collection_task(task_id, "completed", messages_collected=count)
+                    await db.update_collection_task(
+                        task_id,
+                        CollectionTaskStatus.COMPLETED,
+                        messages_collected=count,
+                    )
                     print(f"Collected {count} messages from channel {ch.channel_id}")
                 except Exception as exc:
-                    await db.update_collection_task(task_id, "failed", error=str(exc)[:500])
+                    await db.update_collection_task(
+                        task_id,
+                        CollectionTaskStatus.FAILED,
+                        error=str(exc)[:500],
+                    )
                     raise
         finally:
             if pool:

--- a/src/cli/commands/smoke_test.py
+++ b/src/cli/commands/smoke_test.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import timezone
+from enum import Enum
+
+from src.cli import runtime
+from src.database import Database
+from src.filters.analyzer import ChannelAnalyzer
+from src.models import Keyword, Message
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_TIMEOUT = 30
+
+
+class Status(Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Status
+    detail: str
+
+
+def _print_result(r: CheckResult) -> None:
+    tag = {
+        Status.PASS: "\033[32m[PASS]\033[0m",
+        Status.FAIL: "\033[31m[FAIL]\033[0m",
+        Status.SKIP: "\033[33m[SKIP]\033[0m",
+    }[r.status]
+    print(f"{tag} {r.name:<22} {r.detail}")
+
+
+# ---------------------------------------------------------------------------
+# Read checks
+# ---------------------------------------------------------------------------
+
+async def _check_get_stats(db) -> CheckResult:
+    try:
+        stats = await db.get_stats()
+        parts = ", ".join(f"{k}={v}" for k, v in stats.items())
+        return CheckResult("get_stats", Status.PASS, parts)
+    except Exception as exc:
+        return CheckResult("get_stats", Status.FAIL, str(exc))
+
+
+async def _check_account_list(db) -> CheckResult:
+    try:
+        accounts = await db.get_accounts()
+        return CheckResult("account_list", Status.PASS, f"{len(accounts)} accounts")
+    except Exception as exc:
+        return CheckResult("account_list", Status.FAIL, str(exc))
+
+
+async def _check_channel_list(db) -> CheckResult:
+    try:
+        channels = await db.get_channels_with_counts()
+        return CheckResult("channel_list", Status.PASS, f"{len(channels)} channels")
+    except Exception as exc:
+        return CheckResult("channel_list", Status.FAIL, str(exc))
+
+
+async def _check_keyword_list(db) -> CheckResult:
+    try:
+        keywords = await db.get_keywords()
+        if not keywords:
+            return CheckResult("keyword_list", Status.SKIP, "No keywords configured")
+        return CheckResult("keyword_list", Status.PASS, f"{len(keywords)} keywords")
+    except Exception as exc:
+        return CheckResult("keyword_list", Status.FAIL, str(exc))
+
+
+async def _check_local_search(db) -> CheckResult:
+    try:
+        messages, total = await db.search_messages("test", limit=5)
+        return CheckResult("local_search", Status.PASS, f"Query OK ({total} results)")
+    except Exception as exc:
+        return CheckResult("local_search", Status.FAIL, str(exc))
+
+
+async def _check_collection_tasks(db) -> CheckResult:
+    try:
+        tasks = await db.get_collection_tasks(limit=5)
+        return CheckResult("collection_tasks", Status.PASS, f"{len(tasks)} tasks")
+    except Exception as exc:
+        return CheckResult("collection_tasks", Status.FAIL, str(exc))
+
+
+async def _check_recent_searches(db) -> CheckResult:
+    try:
+        searches = await db.get_recent_searches(limit=5)
+        if not searches:
+            return CheckResult("recent_searches", Status.SKIP, "No search history")
+        return CheckResult("recent_searches", Status.PASS, f"{len(searches)} entries")
+    except Exception as exc:
+        return CheckResult("recent_searches", Status.FAIL, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Write checks (operate on a temporary copy of the DB)
+# ---------------------------------------------------------------------------
+
+async def _init_db_copy(config_path: str) -> tuple[Database, str, object]:
+    """Copy live DB to a temp file, return (copy_db, tmp_path, config)."""
+    config, live_db = await runtime.init_db(config_path)
+    live_path = live_db._db_path
+    encryption_secret = live_db._session_encryption_secret
+    await live_db.close()
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmp.close()
+    shutil.copy2(live_path, tmp.name)
+
+    copy_db = Database(tmp.name, session_encryption_secret=encryption_secret)
+    await copy_db.initialize()
+    return copy_db, tmp.name, config
+
+
+async def _run_write_checks(config_path: str) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    tmp_path: str | None = None
+    copy_db: Database | None = None
+
+    # 1. write_db_copy
+    try:
+        copy_db, tmp_path, _ = await _init_db_copy(config_path)
+        stats = await copy_db.get_stats()
+        parts = ", ".join(f"{k}={v}" for k, v in stats.items())
+        results.append(
+            CheckResult("write_db_copy", Status.PASS, f"Copied to {tmp_path} ({parts})"),
+        )
+    except Exception as exc:
+        results.append(CheckResult("write_db_copy", Status.FAIL, str(exc)))
+        return results
+
+    try:
+        # 2. account_toggle
+        try:
+            accounts = await copy_db.get_accounts()
+            if not accounts:
+                results.append(
+                    CheckResult("account_toggle", Status.SKIP, "No accounts in DB"),
+                )
+            else:
+                acc = accounts[0]
+                original = acc.is_active
+                await copy_db.set_account_active(acc.id, not original)
+                refreshed = await copy_db.get_accounts()
+                toggled = next(a for a in refreshed if a.id == acc.id)
+                assert toggled.is_active is (not original)
+                results.append(CheckResult(
+                    "account_toggle", Status.PASS,
+                    f"id={acc.id} active: {original} -> {not original}",
+                ))
+        except Exception as exc:
+            results.append(CheckResult("account_toggle", Status.FAIL, str(exc)))
+
+        # 3. keyword_add
+        added_kw_id: int | None = None
+        try:
+            added_kw_id = await copy_db.add_keyword(
+                Keyword(pattern="__smoke_test__"),
+            )
+            keywords = await copy_db.get_keywords()
+            found = any(k.id == added_kw_id for k in keywords)
+            assert found, "keyword not found after add"
+            results.append(CheckResult(
+                "keyword_add", Status.PASS,
+                f'Added id={added_kw_id} pattern="__smoke_test__"',
+            ))
+        except Exception as exc:
+            results.append(CheckResult("keyword_add", Status.FAIL, str(exc)))
+
+        # 4. keyword_toggle
+        if added_kw_id is not None:
+            try:
+                await copy_db.set_keyword_active(added_kw_id, False)
+                keywords = await copy_db.get_keywords()
+                kw = next(k for k in keywords if k.id == added_kw_id)
+                assert kw.is_active is False
+                results.append(CheckResult(
+                    "keyword_toggle", Status.PASS,
+                    f"id={added_kw_id} active: True -> False",
+                ))
+            except Exception as exc:
+                results.append(CheckResult("keyword_toggle", Status.FAIL, str(exc)))
+        else:
+            results.append(
+                CheckResult("keyword_toggle", Status.SKIP, "keyword_add failed"),
+            )
+
+        # 5. keyword_delete
+        if added_kw_id is not None:
+            try:
+                await copy_db.delete_keyword(added_kw_id)
+                keywords = await copy_db.get_keywords()
+                found = any(k.id == added_kw_id for k in keywords)
+                assert not found, "keyword still present after delete"
+                results.append(CheckResult(
+                    "keyword_delete", Status.PASS,
+                    f"id={added_kw_id} deleted, verified absent",
+                ))
+            except Exception as exc:
+                results.append(CheckResult("keyword_delete", Status.FAIL, str(exc)))
+        else:
+            results.append(
+                CheckResult("keyword_delete", Status.SKIP, "keyword_add failed"),
+            )
+
+        # 6. channel_toggle
+        try:
+            channels = await copy_db.get_channels_with_counts()
+            if not channels:
+                results.append(
+                    CheckResult("channel_toggle", Status.SKIP, "No channels in DB"),
+                )
+            else:
+                ch = channels[0]
+                original = ch.is_active
+                await copy_db.set_channel_active(ch.pk, not original)
+                refreshed = await copy_db.get_channels_with_counts()
+                toggled = next(c for c in refreshed if c.pk == ch.pk)
+                assert toggled.is_active is (not original)
+                results.append(CheckResult(
+                    "channel_toggle", Status.PASS,
+                    f"pk={ch.pk} active: {original} -> {not original}",
+                ))
+        except Exception as exc:
+            results.append(CheckResult("channel_toggle", Status.FAIL, str(exc)))
+
+        # 7. filter_apply
+        try:
+            analyzer = ChannelAnalyzer(copy_db)
+            report = await analyzer.analyze_all()
+            count = await analyzer.apply_filters(report)
+            results.append(CheckResult(
+                "filter_apply", Status.PASS, f"{count} channels filtered",
+            ))
+        except Exception as exc:
+            results.append(CheckResult("filter_apply", Status.FAIL, str(exc)))
+
+        # 8. filter_reset
+        try:
+            analyzer = ChannelAnalyzer(copy_db)
+            await analyzer.reset_filters()
+            results.append(CheckResult("filter_reset", Status.PASS, "Filters cleared"))
+        except Exception as exc:
+            results.append(CheckResult("filter_reset", Status.FAIL, str(exc)))
+
+    finally:
+        if copy_db:
+            await copy_db.close()
+
+    # 9. write_cleanup
+    try:
+        if tmp_path:
+            os.unlink(tmp_path)
+            assert not os.path.exists(tmp_path)
+        results.append(CheckResult("write_cleanup", Status.PASS, "Temp DB removed"))
+    except Exception as exc:
+        results.append(CheckResult("write_cleanup", Status.FAIL, str(exc)))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Telegram live checks (operate on a temporary copy of the DB)
+# ---------------------------------------------------------------------------
+
+async def _tg_call(coro, timeout: int = TELEGRAM_TIMEOUT):
+    """Wrap a Telegram API call with a timeout."""
+    return await asyncio.wait_for(coro, timeout=timeout)
+
+
+async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
+    from src.search.engine import SearchEngine
+    from src.telegram.collector import Collector
+
+    results: list[CheckResult] = []
+    copy_db: Database | None = None
+    tmp_path: str | None = None
+    pool = None
+
+    # 1. tg_db_copy
+    try:
+        copy_db, tmp_path, config = await _init_db_copy(config_path)
+        results.append(CheckResult("tg_db_copy", Status.PASS, f"Copied to {tmp_path}"))
+    except Exception as exc:
+        results.append(CheckResult("tg_db_copy", Status.FAIL, str(exc)))
+        return results
+
+    # 2. tg_pool_init
+    try:
+        _, pool = await _tg_call(runtime.init_pool(config, copy_db))
+        clients = pool.clients if hasattr(pool, "clients") else {}
+        if not clients:
+            results.append(CheckResult("tg_pool_init", Status.SKIP, "No accounts connected"))
+            await _cleanup_telegram(pool, copy_db, tmp_path, results)
+            return results
+        results.append(
+            CheckResult("tg_pool_init", Status.PASS, f"{len(clients)} clients connected"),
+        )
+    except Exception as exc:
+        results.append(CheckResult("tg_pool_init", Status.FAIL, str(exc)))
+        await _cleanup_telegram(pool, copy_db, tmp_path, results)
+        return results
+
+    # 3. tg_users_info
+    try:
+        users = await _tg_call(pool.get_users_info())
+        names = ", ".join(u.phone for u in users)
+        results.append(CheckResult("tg_users_info", Status.PASS, names))
+    except Exception as exc:
+        results.append(CheckResult("tg_users_info", Status.FAIL, str(exc)))
+
+    # 4. tg_get_dialogs
+    try:
+        dialogs = await _tg_call(pool.get_dialogs())
+        results.append(
+            CheckResult("tg_get_dialogs", Status.PASS, f"{len(dialogs)} dialogs"),
+        )
+    except Exception as exc:
+        results.append(CheckResult("tg_get_dialogs", Status.FAIL, str(exc)))
+
+    # 5. tg_resolve_channel
+    channels = await copy_db.get_channels(active_only=True)
+    target_with_username = next((ch for ch in channels if ch.username), None)
+    if not target_with_username:
+        results.append(
+            CheckResult("tg_resolve_channel", Status.SKIP, "No channels with username"),
+        )
+    else:
+        try:
+            entity = await _tg_call(pool.resolve_channel(target_with_username.username))
+            if entity:
+                results.append(CheckResult(
+                    "tg_resolve_channel", Status.PASS,
+                    f"@{target_with_username.username} resolved OK",
+                ))
+            else:
+                results.append(CheckResult(
+                    "tg_resolve_channel", Status.FAIL,
+                    f"@{target_with_username.username} not resolved",
+                ))
+        except Exception as exc:
+            results.append(CheckResult("tg_resolve_channel", Status.FAIL, str(exc)))
+
+    # Refresh entity cache (StringSession loses it between restarts)
+    try:
+        client_tuple = await pool.get_available_client()
+        if client_tuple:
+            client, phone = client_tuple
+            try:
+                await _tg_call(client.get_dialogs())
+            finally:
+                await pool.release_client(phone)
+    except Exception:
+        pass  # non-critical, best effort
+
+    # 6. tg_iter_messages — single channel, 10 messages
+    active_channels = [ch for ch in channels if ch.is_active]
+    if not active_channels:
+        results.append(
+            CheckResult("tg_iter_messages", Status.SKIP, "No active channels"),
+        )
+    else:
+        try:
+            ch = active_channels[0]
+            client_tuple = await pool.get_available_client()
+            if not client_tuple:
+                results.append(
+                    CheckResult("tg_iter_messages", Status.SKIP, "No available client"),
+                )
+            else:
+                client, phone = client_tuple
+                try:
+                    entity = await _tg_call(client.get_entity(ch.channel_id))
+                    msg_count = 0
+                    async for msg in client.iter_messages(entity, limit=10):
+                        if msg.text or msg.media:
+                            message = Message(
+                                channel_id=ch.channel_id,
+                                message_id=msg.id,
+                                sender_id=msg.sender_id,
+                                sender_name=Collector._get_sender_name(msg),
+                                text=msg.text,
+                                media_type=Collector._get_media_type(msg),
+                                date=msg.date.replace(tzinfo=timezone.utc)
+                                if msg.date and msg.date.tzinfo is None
+                                else msg.date,
+                            )
+                            await copy_db.insert_message(message)
+                            msg_count += 1
+                    results.append(CheckResult(
+                        "tg_iter_messages", Status.PASS,
+                        f"{msg_count} msgs from ch={ch.channel_id}",
+                    ))
+                finally:
+                    await pool.release_client(phone)
+        except Exception as exc:
+            results.append(CheckResult("tg_iter_messages", Status.FAIL, str(exc)))
+
+    # 7. tg_collect_multi — iter_messages(limit=10) across up to 10 channels
+    if not active_channels:
+        results.append(
+            CheckResult("tg_collect_multi", Status.SKIP, "No active channels"),
+        )
+    else:
+        try:
+            batch = active_channels[:10]
+            total_msgs = 0
+            ok_channels = 0
+            client_tuple = await pool.get_available_client()
+            if not client_tuple:
+                results.append(
+                    CheckResult("tg_collect_multi", Status.SKIP, "No available client"),
+                )
+            else:
+                client, phone = client_tuple
+                try:
+                    for ch in batch:
+                        try:
+                            entity = await _tg_call(client.get_entity(ch.channel_id))
+                            ch_count = 0
+                            async for msg in client.iter_messages(entity, limit=10):
+                                if msg.text or msg.media:
+                                    message = Message(
+                                        channel_id=ch.channel_id,
+                                        message_id=msg.id,
+                                        sender_id=msg.sender_id,
+                                        sender_name=Collector._get_sender_name(msg),
+                                        text=msg.text,
+                                        media_type=Collector._get_media_type(msg),
+                                        date=msg.date.replace(tzinfo=timezone.utc)
+                                        if msg.date and msg.date.tzinfo is None
+                                        else msg.date,
+                                    )
+                                    await copy_db.insert_message(message)
+                                    ch_count += 1
+                            total_msgs += ch_count
+                            ok_channels += 1
+                        except Exception as ch_exc:
+                            logger.warning(
+                                "tg_collect_multi: ch=%d error: %s",
+                                ch.channel_id, ch_exc,
+                            )
+                finally:
+                    await pool.release_client(phone)
+                results.append(CheckResult(
+                    "tg_collect_multi", Status.PASS,
+                    f"{total_msgs} msgs from {ok_channels}/{len(batch)} channels",
+                ))
+        except Exception as exc:
+            results.append(CheckResult("tg_collect_multi", Status.FAIL, str(exc)))
+
+    # 8. tg_channel_stats
+    if not active_channels:
+        results.append(
+            CheckResult("tg_channel_stats", Status.SKIP, "No active channels"),
+        )
+    else:
+        try:
+            ch = active_channels[0]
+            collector = Collector(pool, copy_db, config.scheduler)
+            stats = await _tg_call(collector.collect_channel_stats(ch))
+            if stats:
+                results.append(CheckResult(
+                    "tg_channel_stats", Status.PASS,
+                    f"ch={ch.channel_id} subs={stats.subscriber_count}",
+                ))
+            else:
+                results.append(CheckResult(
+                    "tg_channel_stats", Status.PASS,
+                    f"ch={ch.channel_id} stats=None (no data)",
+                ))
+        except Exception as exc:
+            results.append(CheckResult("tg_channel_stats", Status.FAIL, str(exc)))
+
+    # 9. tg_search_my_chats
+    try:
+        engine = SearchEngine(copy_db, pool)
+        result = await _tg_call(engine.search_my_chats("test", limit=5))
+        results.append(CheckResult(
+            "tg_search_my_chats", Status.PASS,
+            f"{result.total} results",
+        ))
+    except Exception as exc:
+        results.append(CheckResult("tg_search_my_chats", Status.FAIL, str(exc)))
+
+    # 10. tg_search_in_channel
+    if not channels:
+        results.append(
+            CheckResult("tg_search_in_channel", Status.SKIP, "No channels"),
+        )
+    else:
+        try:
+            ch = channels[0]
+            engine = SearchEngine(copy_db, pool)
+            result = await _tg_call(
+                engine.search_in_channel(ch.channel_id, "test", limit=5),
+            )
+            results.append(CheckResult(
+                "tg_search_in_channel", Status.PASS,
+                f"ch={ch.channel_id}: {result.total} results",
+            ))
+        except Exception as exc:
+            results.append(CheckResult("tg_search_in_channel", Status.FAIL, str(exc)))
+
+    # 11. tg_search_premium
+    try:
+        premium = await pool.get_premium_client()
+        if premium is None:
+            results.append(
+                CheckResult("tg_search_premium", Status.SKIP, "No premium account"),
+            )
+        else:
+            engine = SearchEngine(copy_db, pool)
+            result = await _tg_call(engine.search_telegram("test", limit=5))
+            results.append(CheckResult(
+                "tg_search_premium", Status.PASS,
+                f"{result.total} results",
+            ))
+    except Exception as exc:
+        results.append(CheckResult("tg_search_premium", Status.FAIL, str(exc)))
+
+    # 12. tg_search_quota
+    try:
+        premium = await pool.get_premium_client()
+        if premium is None:
+            results.append(
+                CheckResult("tg_search_quota", Status.SKIP, "No premium account"),
+            )
+        else:
+            engine = SearchEngine(copy_db, pool)
+            quota = await _tg_call(engine.check_search_quota("test"))
+            detail = str(quota) if quota else "No quota info"
+            results.append(CheckResult("tg_search_quota", Status.PASS, detail))
+    except Exception as exc:
+        results.append(CheckResult("tg_search_quota", Status.FAIL, str(exc)))
+
+    # 13. tg_cleanup
+    await _cleanup_telegram(pool, copy_db, tmp_path, results)
+
+    return results
+
+
+async def _cleanup_telegram(pool, copy_db, tmp_path, results) -> None:
+    try:
+        if pool:
+            await pool.disconnect_all()
+        if copy_db:
+            await copy_db.close()
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        results.append(CheckResult("tg_cleanup", Status.PASS, "Resources released"))
+    except Exception as exc:
+        results.append(CheckResult("tg_cleanup", Status.FAIL, str(exc)))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def run(args: argparse.Namespace) -> None:
+    async def _run() -> None:
+        results: list[CheckResult] = []
+
+        action = args.test_action  # "all", "read", "write", "telegram"
+        run_read = action in ("all", "read")
+        run_write = action in ("all", "write")
+        run_telegram = action in ("all", "telegram")
+
+        if run_read:
+            print("=== Read Tests ===")
+            try:
+                config, db = await runtime.init_db(args.config)
+            except Exception as exc:
+                r = CheckResult("db_init", Status.FAIL, f"Cannot init DB: {exc}")
+                _print_result(r)
+                print(
+                    "\n--- Test Summary ---\n"
+                    "0 passed, 1 failed, 0 skipped (1 total)",
+                )
+                sys.exit(1)
+
+            results.append(CheckResult("db_init", Status.PASS, "Database initialized"))
+            _print_result(results[-1])
+
+            try:
+                db_checks = [
+                    _check_get_stats(db),
+                    _check_account_list(db),
+                    _check_channel_list(db),
+                    _check_keyword_list(db),
+                    _check_local_search(db),
+                    _check_collection_tasks(db),
+                    _check_recent_searches(db),
+                ]
+                for coro in db_checks:
+                    r = await coro
+                    results.append(r)
+                    _print_result(r)
+            finally:
+                await db.close()
+
+        if run_write:
+            print("\n=== Write Tests (on DB copy) ===")
+            write_results = await _run_write_checks(args.config)
+            for r in write_results:
+                results.append(r)
+                _print_result(r)
+
+        if run_telegram:
+            print("\n=== Telegram Live Tests (on DB copy) ===")
+            tg_results = await _run_telegram_live_checks(args.config)
+            for r in tg_results:
+                results.append(r)
+                _print_result(r)
+
+        passed = sum(1 for r in results if r.status == Status.PASS)
+        failed = sum(1 for r in results if r.status == Status.FAIL)
+        skipped = sum(1 for r in results if r.status == Status.SKIP)
+        total = len(results)
+
+        print("\n--- Test Summary ---")
+        print(f"{passed} passed, {failed} failed, {skipped} skipped ({total} total)")
+
+        if failed:
+            sys.exit(1)
+
+    asyncio.run(_run())

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -171,14 +171,14 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
         added_kw_id: int | None = None
         try:
             added_kw_id = await copy_db.add_keyword(
-                Keyword(pattern="__smoke_test__"),
+                Keyword(pattern="__test_cli__"),
             )
             keywords = await copy_db.get_keywords()
             found = any(k.id == added_kw_id for k in keywords)
             assert found, "keyword not found after add"
             results.append(CheckResult(
                 "keyword_add", Status.PASS,
-                f'Added id={added_kw_id} pattern="__smoke_test__"',
+                f'Added id={added_kw_id} pattern="__test_cli__"',
             ))
         except Exception as exc:
             results.append(CheckResult("keyword_add", Status.FAIL, str(exc)))
@@ -229,13 +229,13 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
             else:
                 ch = channels[0]
                 original = ch.is_active
-                await copy_db.set_channel_active(ch.pk, not original)
+                await copy_db.set_channel_active(ch.id, not original)
                 refreshed = await copy_db.get_channels_with_counts()
-                toggled = next(c for c in refreshed if c.pk == ch.pk)
+                toggled = next(c for c in refreshed if c.id == ch.id)
                 assert toggled.is_active is (not original)
                 results.append(CheckResult(
                     "channel_toggle", Status.PASS,
-                    f"pk={ch.pk} active: {original} -> {not original}",
+                    f"id={ch.id} active: {original} -> {not original}",
                 ))
         except Exception as exc:
             results.append(CheckResult("channel_toggle", Status.FAIL, str(exc)))
@@ -412,60 +412,7 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         except Exception as exc:
             results.append(CheckResult("tg_iter_messages", Status.FAIL, str(exc)))
 
-    # 7. tg_collect_multi — iter_messages(limit=10) across up to 10 channels
-    if not active_channels:
-        results.append(
-            CheckResult("tg_collect_multi", Status.SKIP, "No active channels"),
-        )
-    else:
-        try:
-            batch = active_channels[:10]
-            total_msgs = 0
-            ok_channels = 0
-            client_tuple = await pool.get_available_client()
-            if not client_tuple:
-                results.append(
-                    CheckResult("tg_collect_multi", Status.SKIP, "No available client"),
-                )
-            else:
-                client, phone = client_tuple
-                try:
-                    for ch in batch:
-                        try:
-                            entity = await _tg_call(client.get_entity(ch.channel_id))
-                            ch_count = 0
-                            async for msg in client.iter_messages(entity, limit=10):
-                                if msg.text or msg.media:
-                                    message = Message(
-                                        channel_id=ch.channel_id,
-                                        message_id=msg.id,
-                                        sender_id=msg.sender_id,
-                                        sender_name=Collector._get_sender_name(msg),
-                                        text=msg.text,
-                                        media_type=Collector._get_media_type(msg),
-                                        date=msg.date.replace(tzinfo=timezone.utc)
-                                        if msg.date and msg.date.tzinfo is None
-                                        else msg.date,
-                                    )
-                                    await copy_db.insert_message(message)
-                                    ch_count += 1
-                            total_msgs += ch_count
-                            ok_channels += 1
-                        except Exception as ch_exc:
-                            logger.warning(
-                                "tg_collect_multi: ch=%d error: %s",
-                                ch.channel_id, ch_exc,
-                            )
-                finally:
-                    await pool.release_client(phone)
-                results.append(CheckResult(
-                    "tg_collect_multi", Status.PASS,
-                    f"{total_msgs} msgs from {ok_channels}/{len(batch)} channels",
-                ))
-        except Exception as exc:
-            results.append(CheckResult("tg_collect_multi", Status.FAIL, str(exc)))
-
-    # 8. tg_channel_stats
+    # 7. tg_channel_stats
     if not active_channels:
         results.append(
             CheckResult("tg_channel_stats", Status.SKIP, "No active channels"),
@@ -488,7 +435,7 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         except Exception as exc:
             results.append(CheckResult("tg_channel_stats", Status.FAIL, str(exc)))
 
-    # 9. tg_search_my_chats
+    # 8. tg_search_my_chats
     try:
         engine = SearchEngine(copy_db, pool)
         result = await _tg_call(engine.search_my_chats("test", limit=5))
@@ -499,7 +446,7 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
     except Exception as exc:
         results.append(CheckResult("tg_search_my_chats", Status.FAIL, str(exc)))
 
-    # 10. tg_search_in_channel
+    # 9. tg_search_in_channel
     if not channels:
         results.append(
             CheckResult("tg_search_in_channel", Status.SKIP, "No channels"),
@@ -518,39 +465,37 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         except Exception as exc:
             results.append(CheckResult("tg_search_in_channel", Status.FAIL, str(exc)))
 
-    # 11. tg_search_premium
+    # 10. tg_search_premium
     try:
-        premium = await pool.get_premium_client()
-        if premium is None:
+        engine = SearchEngine(copy_db, pool)
+        result = await _tg_call(engine.search_telegram("test", limit=5))
+        if result.error and "Premium" in result.error:
             results.append(
-                CheckResult("tg_search_premium", Status.SKIP, "No premium account"),
+                CheckResult("tg_search_premium", Status.SKIP, result.error),
             )
         else:
-            engine = SearchEngine(copy_db, pool)
-            result = await _tg_call(engine.search_telegram("test", limit=5))
             results.append(CheckResult(
                 "tg_search_premium", Status.PASS,
-                f"{result.total} results",
+                result.error or f"{result.total} results",
             ))
     except Exception as exc:
         results.append(CheckResult("tg_search_premium", Status.FAIL, str(exc)))
 
-    # 12. tg_search_quota
+    # 11. tg_search_quota
     try:
-        premium = await pool.get_premium_client()
-        if premium is None:
+        engine = SearchEngine(copy_db, pool)
+        quota = await _tg_call(engine.check_search_quota("test"))
+        if quota is None:
             results.append(
-                CheckResult("tg_search_quota", Status.SKIP, "No premium account"),
+                CheckResult("tg_search_quota", Status.SKIP, "No premium account or quota unavailable"),
             )
         else:
-            engine = SearchEngine(copy_db, pool)
-            quota = await _tg_call(engine.check_search_quota("test"))
             detail = str(quota) if quota else "No quota info"
             results.append(CheckResult("tg_search_quota", Status.PASS, detail))
     except Exception as exc:
         results.append(CheckResult("tg_search_quota", Status.FAIL, str(exc)))
 
-    # 13. tg_cleanup
+    # 12. tg_cleanup
     await _cleanup_telegram(pool, copy_db, tmp_path, results)
 
     return results

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -276,7 +276,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
     try:
         if tmp_path:
             os.unlink(tmp_path)
-            assert not os.path.exists(tmp_path)
+            if os.path.exists(tmp_path):
+                raise RuntimeError(f"Temp file still exists after unlink: {tmp_path}")
         results.append(CheckResult("write_cleanup", Status.PASS, "Temp DB removed"))
     except Exception as exc:
         results.append(CheckResult("write_cleanup", Status.FAIL, str(exc)))

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -163,7 +163,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
                 await copy_db.set_account_active(acc.id, not original)
                 refreshed = await copy_db.get_accounts()
                 toggled = next(a for a in refreshed if a.id == acc.id)
-                assert toggled.is_active is (not original)
+                if toggled.is_active is not (not original):
+                    raise RuntimeError("account active state did not change")
                 results.append(CheckResult(
                     "account_toggle", Status.PASS,
                     f"id={acc.id} active: {original} -> {not original}",
@@ -179,7 +180,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
             )
             keywords = await copy_db.get_keywords()
             found = any(k.id == added_kw_id for k in keywords)
-            assert found, "keyword not found after add"
+            if not found:
+                raise RuntimeError("keyword not found after add")
             results.append(CheckResult(
                 "keyword_add", Status.PASS,
                 f'Added id={added_kw_id} pattern="__test_cli__"',
@@ -193,7 +195,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
                 await copy_db.set_keyword_active(added_kw_id, False)
                 keywords = await copy_db.get_keywords()
                 kw = next(k for k in keywords if k.id == added_kw_id)
-                assert kw.is_active is False
+                if kw.is_active is not False:
+                    raise RuntimeError("keyword active state did not change")
                 results.append(CheckResult(
                     "keyword_toggle", Status.PASS,
                     f"id={added_kw_id} active: True -> False",
@@ -211,7 +214,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
                 await copy_db.delete_keyword(added_kw_id)
                 keywords = await copy_db.get_keywords()
                 found = any(k.id == added_kw_id for k in keywords)
-                assert not found, "keyword still present after delete"
+                if found:
+                    raise RuntimeError("keyword still present after delete")
                 results.append(CheckResult(
                     "keyword_delete", Status.PASS,
                     f"id={added_kw_id} deleted, verified absent",
@@ -236,7 +240,8 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
                 await copy_db.set_channel_active(ch.id, not original)
                 refreshed = await copy_db.get_channels_with_counts()
                 toggled = next(c for c in refreshed if c.id == ch.id)
-                assert toggled.is_active is (not original)
+                if toggled.is_active is not (not original):
+                    raise RuntimeError("channel active state did not change")
                 results.append(CheckResult(
                     "channel_toggle", Status.PASS,
                     f"id={ch.id} active: {original} -> {not original}",
@@ -320,6 +325,8 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         results.append(CheckResult("tg_pool_init", Status.FAIL, str(exc)))
         await _cleanup_telegram(pool, copy_db, tmp_path, results)
         return results
+
+    engine = SearchEngine(copy_db, pool)
 
     # 3. tg_users_info
     try:
@@ -441,7 +448,6 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
 
     # 8. tg_search_my_chats
     try:
-        engine = SearchEngine(copy_db, pool)
         result = await _tg_call(engine.search_my_chats("test", limit=5))
         results.append(CheckResult(
             "tg_search_my_chats", Status.PASS,
@@ -458,7 +464,6 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
     else:
         try:
             ch = channels[0]
-            engine = SearchEngine(copy_db, pool)
             result = await _tg_call(
                 engine.search_in_channel(ch.channel_id, "test", limit=5),
             )
@@ -471,7 +476,6 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
 
     # 10. tg_search_premium
     try:
-        engine = SearchEngine(copy_db, pool)
         result = await _tg_call(engine.search_telegram("test", limit=5))
         if result.error and "Premium" in result.error:
             results.append(
@@ -487,7 +491,6 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
 
     # 11. tg_search_quota
     try:
-        engine = SearchEngine(copy_db, pool)
         quota = await _tg_call(engine.check_search_quota("test"))
         if quota is None:
             results.append(

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -121,11 +121,15 @@ async def _init_db_copy(config_path: str) -> tuple[Database, str, object]:
 
     tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
     tmp.close()
-    shutil.copy2(live_path, tmp.name)
-
-    copy_db = Database(tmp.name, session_encryption_secret=encryption_secret)
-    await copy_db.initialize()
-    return copy_db, tmp.name, config
+    try:
+        shutil.copy2(live_path, tmp.name)
+        copy_db = Database(tmp.name, session_encryption_secret=encryption_secret)
+        await copy_db.initialize()
+        return copy_db, tmp.name, config
+    except Exception:
+        if os.path.exists(tmp.name):
+            os.unlink(tmp.name)
+        raise
 
 
 async def _run_write_checks(config_path: str) -> list[CheckResult]:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -16,6 +16,7 @@ from src.cli.commands import (
 )
 from src.cli.commands import filter as filter_cmd
 from src.cli.commands import my_telegram as my_telegram_cmd
+from src.cli.commands import smoke_test as smoke_test_cmd
 from src.cli.parser import build_parser
 from src.cli.runtime import setup_logging
 
@@ -38,6 +39,7 @@ def main() -> None:
         "scheduler": scheduler.run,
         "notification": notification.run,
         "my-telegram": my_telegram_cmd.run,
+        "test": smoke_test_cmd.run,
     }
 
     handler = commands.get(args.command)
@@ -50,6 +52,7 @@ def main() -> None:
             "scheduler": "scheduler_action",
             "notification": "notification_action",
             "my-telegram": "my_telegram_action",
+            "test": "test_action",
         }
         if args.command in sub_attr and not getattr(args, sub_attr[args.command], None):
             parser.parse_args([args.command, "--help"])

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -13,10 +13,10 @@ from src.cli.commands import (
     scheduler,
     search,
     serve,
+    test as test_cmd,
 )
 from src.cli.commands import filter as filter_cmd
 from src.cli.commands import my_telegram as my_telegram_cmd
-from src.cli.commands import smoke_test as smoke_test_cmd
 from src.cli.parser import build_parser
 from src.cli.runtime import setup_logging
 
@@ -39,7 +39,7 @@ def main() -> None:
         "scheduler": scheduler.run,
         "notification": notification.run,
         "my-telegram": my_telegram_cmd.run,
-        "test": smoke_test_cmd.run,
+        "test": test_cmd.run,
     }
 
     handler = commands.get(args.command)

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -110,4 +110,11 @@ def build_parser() -> argparse.ArgumentParser:
     notif_sub.add_parser("status", help="Show notification bot status")
     notif_sub.add_parser("delete", help="Delete notification bot via BotFather")
 
+    test_parser = sub.add_parser("test", help="Run diagnostic tests")
+    test_sub = test_parser.add_subparsers(dest="test_action")
+    test_sub.add_parser("all", help="Run all test sections (read + write + telegram)")
+    test_sub.add_parser("read", help="Read-only DB checks")
+    test_sub.add_parser("write", help="Write DB checks on a temporary DB copy")
+    test_sub.add_parser("telegram", help="Live Telegram API tests on a temporary DB copy")
+
     return parser

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -4,16 +4,19 @@ import asyncio
 import logging
 
 from src.database import Database
-from src.models import Channel
+from src.database.bundles import ChannelBundle
+from src.models import Channel, CollectionTaskStatus
 from src.telegram.collector import Collector
 
 logger = logging.getLogger(__name__)
 
 
 class CollectionQueue:
-    def __init__(self, collector: Collector, db: Database):
+    def __init__(self, collector: Collector, channels: ChannelBundle | Database):
         self._collector = collector
-        self._db = db
+        if isinstance(channels, Database):
+            channels = ChannelBundle.from_database(channels)
+        self._channels = channels
         self._queue: asyncio.Queue[tuple[int, Channel, bool, bool]] = asyncio.Queue()
         self._worker: asyncio.Task | None = None
         self._current_task_id: int | None = None
@@ -24,7 +27,7 @@ class CollectionQueue:
             payload["force"] = True
         if not full:
             payload["full"] = False
-        task_id = await self._db.create_collection_task(
+        task_id = await self._channels.create_collection_task(
             channel.channel_id, channel.title, channel_username=channel.username,
             payload=payload or None,
         )
@@ -35,7 +38,7 @@ class CollectionQueue:
     async def cancel_task(self, task_id: int, note: str | None = None) -> bool:
         if task_id == self._current_task_id:
             await self._collector.cancel()
-        return await self._db.cancel_collection_task(task_id, note=note)
+        return await self._channels.cancel_collection_task(task_id, note=note)
 
     def _ensure_worker(self) -> None:
         if self._worker is None or self._worker.done():
@@ -55,17 +58,17 @@ class CollectionQueue:
                 break
 
             # Check if task was cancelled while waiting in queue
-            task = await self._db.get_collection_task(task_id)
-            if task and task.status == "cancelled":
+            task = await self._channels.get_collection_task(task_id)
+            if task and task.status == CollectionTaskStatus.CANCELLED:
                 self._queue.task_done()
                 continue
 
             # Channel may become filtered after being queued.
             fresh_channel = None
             if channel.id is not None:
-                fresh_channel = await self._db.get_channel_by_pk(channel.id)
+                fresh_channel = await self._channels.get_by_pk(channel.id)
                 if fresh_channel is None:
-                    await self._db.cancel_collection_task(
+                    await self._channels.cancel_collection_task(
                         task_id,
                         note="Канал удалён до начала сбора.",
                     )
@@ -79,7 +82,7 @@ class CollectionQueue:
             if fresh_channel is not None:
                 channel = fresh_channel
             if channel.is_filtered and not force:
-                await self._db.cancel_collection_task(
+                await self._channels.cancel_collection_task(
                     task_id,
                     note="Канал отфильтрован до начала сбора.",
                 )
@@ -93,16 +96,16 @@ class CollectionQueue:
 
             self._current_task_id = task_id
             try:
-                await self._db.update_collection_task(task_id, "running")
+                await self._channels.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
 
                 async def _progress(count: int) -> None:
-                    await self._db.update_collection_task_progress(task_id, count)
+                    await self._channels.update_collection_task_progress(task_id, count)
 
                 count = await self._collector.collect_single_channel(
                     channel, full=full, progress_callback=_progress, force=force
                 )
                 if self._collector.is_cancelled:
-                    await self._db.cancel_collection_task(
+                    await self._channels.cancel_collection_task(
                         task_id,
                         note="Задача отменена во время сбора.",
                     )
@@ -110,22 +113,27 @@ class CollectionQueue:
                 else:
                     note = None
                     if count == 0 and not force and channel.id is not None:
-                        after_ch = await self._db.get_channel_by_pk(channel.id)
+                        after_ch = await self._channels.get_by_pk(channel.id)
                         if after_ch and after_ch.is_filtered and not channel.is_filtered:
                             before_flags = set((channel.filter_flags or "").split(",")) - {""}
                             after_flags = set((after_ch.filter_flags or "").split(",")) - {""}
                             new_flags = after_flags - before_flags
                             reason = next(iter(new_flags), "low_subscriber_ratio")
                             note = f"Пропущен: {reason}"
-                    await self._db.update_collection_task(
-                        task_id, "completed", messages_collected=count, note=note
+                    await self._channels.update_collection_task(
+                        task_id,
+                        CollectionTaskStatus.COMPLETED,
+                        messages_collected=count,
+                        note=note,
                     )
                     logger.info(
                         "Collected %d messages from channel %d", count, channel.channel_id
                     )
             except Exception as exc:
-                await self._db.update_collection_task(
-                    task_id, "failed", error=str(exc)[:500]
+                await self._channels.update_collection_task(
+                    task_id,
+                    CollectionTaskStatus.FAILED,
+                    error=str(exc)[:500],
                 )
                 logger.exception(
                     "Collection failed for channel %d", channel.channel_id
@@ -136,12 +144,13 @@ class CollectionQueue:
 
     async def requeue_startup_tasks(self) -> int:
         """Re-enqueue pending collection tasks that survived a server restart."""
-        pending = await self._db.get_pending_channel_tasks()
+        pending = await self._channels.get_pending_channel_tasks()
         count = 0
         for task in pending:
-            channel = await self._db.get_channel_by_channel_id(task.channel_id)
+            assert task.channel_id is not None
+            channel = await self._channels.get_by_channel_id(task.channel_id)
             if channel is None:
-                await self._db.cancel_collection_task(task.id)
+                await self._channels.cancel_collection_task(task.id)
                 logger.warning(
                     "Cancelled orphaned task %d: channel %d not found",
                     task.id, task.channel_id,

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -147,7 +147,9 @@ class CollectionQueue:
         pending = await self._channels.get_pending_channel_tasks()
         count = 0
         for task in pending:
-            assert task.channel_id is not None
+            if task.channel_id is None:
+                logger.warning("Skipping task %d: channel_id is None", task.id)
+                continue
             channel = await self._channels.get_by_channel_id(task.channel_id)
             if channel is None:
                 await self._channels.cancel_collection_task(task.id)

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -43,6 +43,7 @@ class DatabaseRepositories:
     filters: FilterRepository
     notification_bots: NotificationBotsRepository
 
+
 @dataclass(frozen=True)
 class AccountBundle:
     accounts: AccountsRepository

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -43,11 +43,6 @@ class DatabaseRepositories:
     filters: FilterRepository
     notification_bots: NotificationBotsRepository
 
-    @classmethod
-    def from_database(cls, db: "Database") -> "DatabaseRepositories":
-        return db.repos
-
-
 @dataclass(frozen=True)
 class AccountBundle:
     accounts: AccountsRepository
@@ -271,13 +266,6 @@ class CollectionBundle:
             repos.channel_stats,
         )
 
-    @property
-    def filter_repo(self) -> FilterRepository:
-        return self.filters
-
-    async def execute(self, query: str, params: tuple | list = ()):
-        return await self.messages._db.execute(query, tuple(params))
-
     async def list_channels(
         self,
         active_only: bool = False,
@@ -288,27 +276,11 @@ class CollectionBundle:
     async def get_by_pk(self, pk: int) -> Channel | None:
         return await self.channels.get_channel_by_pk(pk)
 
-    async def get_channels(
-        self,
-        active_only: bool = False,
-        include_filtered: bool = True,
-    ) -> list[Channel]:
-        return await self.list_channels(active_only=active_only, include_filtered=include_filtered)
-
     async def get_by_channel_id(self, channel_id: int) -> Channel | None:
         return await self.channels.get_channel_by_channel_id(channel_id)
 
-    async def get_channel_by_pk(self, pk: int) -> Channel | None:
-        return await self.get_by_pk(pk)
-
-    async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
-        return await self.get_by_channel_id(channel_id)
-
     async def update_last_id(self, channel_id: int, last_id: int) -> None:
         await self.channels.update_channel_last_id(channel_id, last_id)
-
-    async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
-        await self.update_last_id(channel_id, last_id)
 
     async def update_meta(
         self,
@@ -319,26 +291,11 @@ class CollectionBundle:
     ) -> None:
         await self.channels.update_channel_meta(channel_id, username=username, title=title)
 
-    async def update_channel_meta(
-        self,
-        channel_id: int,
-        *,
-        username: str | None,
-        title: str | None,
-    ) -> None:
-        await self.update_meta(channel_id, username=username, title=title)
-
     async def set_active(self, pk: int, active: bool) -> None:
         await self.channels.set_channel_active(pk, active)
 
-    async def set_channel_active(self, pk: int, active: bool) -> None:
-        await self.set_active(pk, active)
-
     async def set_type(self, channel_id: int, channel_type: str) -> None:
         await self.channels.set_channel_type(channel_id, channel_type)
-
-    async def set_channel_type(self, channel_id: int, channel_type: str) -> None:
-        await self.set_type(channel_id, channel_type)
 
     async def set_filtered_bulk(
         self,
@@ -347,14 +304,6 @@ class CollectionBundle:
         commit: bool = True,
     ) -> int:
         return await self.channels.set_filtered_bulk(updates, commit=commit)
-
-    async def set_channels_filtered_bulk(
-        self,
-        updates: list[tuple[int, str]],
-        *,
-        commit: bool = True,
-    ) -> int:
-        return await self.set_filtered_bulk(updates, commit=commit)
 
     async def reset_all_filters(self, *, commit: bool = True) -> int:
         return await self.channels.reset_all_filters(commit=commit)
@@ -408,9 +357,6 @@ class CollectionBundle:
     async def list_keywords(self, active_only: bool = False) -> list[Keyword]:
         return await self.keywords.get_keywords(active_only)
 
-    async def get_keywords(self, active_only: bool = False) -> list[Keyword]:
-        return await self.list_keywords(active_only)
-
     async def set_keyword_active(self, keyword_id: int, active: bool) -> None:
         await self.keywords.set_keyword_active(keyword_id, active)
 
@@ -419,9 +365,6 @@ class CollectionBundle:
 
     async def get_channel_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
         return await self.channel_stats.get_channel_stats(channel_id, limit)
-
-    async def save_channel_stats(self, stats: ChannelStats) -> int:
-        return await self.channel_stats.save_channel_stats(stats)
 
     async def create_collection_task(
         self,

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -276,7 +276,7 @@ class CollectionBundle:
         return self.filters
 
     async def execute(self, query: str, params: tuple | list = ()):
-        return await self.channels._db.execute(query, tuple(params))
+        return await self.messages._db.execute(query, tuple(params))
 
     async def list_channels(
         self,

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from src.database.repositories.accounts import AccountsRepository
+from src.database.repositories.channel_stats import ChannelStatsRepository
+from src.database.repositories.channels import ChannelsRepository
+from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.database.repositories.filters import FilterRepository
+from src.database.repositories.keywords import KeywordsRepository
+from src.database.repositories.messages import MessagesRepository
+from src.database.repositories.notification_bots import NotificationBotsRepository
+from src.database.repositories.search_log import SearchLogRepository
+from src.database.repositories.settings import SettingsRepository
+from src.models import (
+    Account,
+    Channel,
+    ChannelStats,
+    CollectionTask,
+    CollectionTaskStatus,
+    Keyword,
+    Message,
+    NotificationBot,
+    StatsAllTaskPayload,
+)
+
+if TYPE_CHECKING:
+    from src.database.facade import Database
+
+
+@dataclass(frozen=True)
+class DatabaseRepositories:
+    accounts: AccountsRepository
+    channels: ChannelsRepository
+    messages: MessagesRepository
+    keywords: KeywordsRepository
+    tasks: CollectionTasksRepository
+    search_log: SearchLogRepository
+    channel_stats: ChannelStatsRepository
+    settings: SettingsRepository
+    filters: FilterRepository
+    notification_bots: NotificationBotsRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "DatabaseRepositories":
+        return db.repos
+
+
+@dataclass(frozen=True)
+class AccountBundle:
+    accounts: AccountsRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "AccountBundle":
+        return cls(db.repos.accounts)
+
+    async def list_accounts(self, active_only: bool = False) -> list[Account]:
+        return await self.accounts.get_accounts(active_only)
+
+    async def add_account(self, account: Account) -> int:
+        return await self.accounts.add_account(account)
+
+    async def set_active(self, account_id: int, active: bool) -> None:
+        await self.accounts.set_account_active(account_id, active)
+
+    async def delete_account(self, account_id: int) -> None:
+        await self.accounts.delete_account(account_id)
+
+    async def update_flood(self, phone: str, until) -> None:
+        await self.accounts.update_account_flood(phone, until)
+
+    async def update_premium(self, phone: str, is_premium: bool) -> None:
+        await self.accounts.update_account_premium(phone, is_premium)
+
+
+@dataclass(frozen=True)
+class ChannelBundle:
+    channels: ChannelsRepository
+    channel_stats: ChannelStatsRepository
+    tasks: CollectionTasksRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "ChannelBundle":
+        repos = db.repos
+        return cls(repos.channels, repos.channel_stats, repos.tasks)
+
+    async def add_channel(self, channel: Channel) -> int:
+        return await self.channels.add_channel(channel)
+
+    async def list_channels(
+        self,
+        active_only: bool = False,
+        include_filtered: bool = True,
+    ) -> list[Channel]:
+        return await self.channels.get_channels(active_only, include_filtered)
+
+    async def list_channels_with_counts(
+        self,
+        active_only: bool = False,
+        include_filtered: bool = True,
+    ) -> list[Channel]:
+        return await self.channels.get_channels_with_counts(active_only, include_filtered)
+
+    async def get_by_pk(self, pk: int) -> Channel | None:
+        return await self.channels.get_channel_by_pk(pk)
+
+    async def get_by_channel_id(self, channel_id: int) -> Channel | None:
+        return await self.channels.get_channel_by_channel_id(channel_id)
+
+    async def set_active(self, pk: int, active: bool) -> None:
+        await self.channels.set_channel_active(pk, active)
+
+    async def set_type(self, channel_id: int, channel_type: str) -> None:
+        await self.channels.set_channel_type(channel_id, channel_type)
+
+    async def update_last_id(self, channel_id: int, last_id: int) -> None:
+        await self.channels.update_channel_last_id(channel_id, last_id)
+
+    async def update_meta(
+        self,
+        channel_id: int,
+        *,
+        username: str | None,
+        title: str | None,
+    ) -> None:
+        await self.channels.update_channel_meta(channel_id, username=username, title=title)
+
+    async def set_filtered_bulk(
+        self,
+        updates: list[tuple[int, str]],
+        *,
+        commit: bool = True,
+    ) -> int:
+        return await self.channels.set_filtered_bulk(updates, commit=commit)
+
+    async def reset_all_filters(self, *, commit: bool = True) -> int:
+        return await self.channels.reset_all_filters(commit=commit)
+
+    async def delete_channel(self, pk: int) -> None:
+        await self.channels.delete_channel(pk)
+
+    async def save_stats(self, stats: ChannelStats) -> int:
+        return await self.channel_stats.save_channel_stats(stats)
+
+    async def get_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
+        return await self.channel_stats.get_channel_stats(channel_id, limit)
+
+    async def get_latest_stats_for_all(self) -> dict[int, ChannelStats]:
+        return await self.channel_stats.get_latest_stats_for_all()
+
+    async def create_collection_task(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        channel_username: str | None = None,
+        run_after: datetime | None = None,
+        payload: dict | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        return await self.tasks.create_collection_task(
+            channel_id,
+            channel_title,
+            channel_username=channel_username,
+            run_after=run_after,
+            payload=payload,
+            parent_task_id=parent_task_id,
+        )
+
+    async def update_collection_task(
+        self,
+        task_id: int,
+        status: CollectionTaskStatus | str,
+        messages_collected: int | None = None,
+        error: str | None = None,
+        note: str | None = None,
+    ) -> None:
+        await self.tasks.update_collection_task(
+            task_id,
+            status,
+            messages_collected,
+            error,
+            note,
+        )
+
+    async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
+        await self.tasks.update_collection_task_progress(task_id, messages_collected)
+
+    async def get_collection_task(self, task_id: int) -> CollectionTask | None:
+        return await self.tasks.get_collection_task(task_id)
+
+    async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
+        return await self.tasks.get_collection_tasks(limit)
+
+    async def get_active_collection_tasks_for_channel(
+        self,
+        channel_id: int,
+    ) -> list[CollectionTask]:
+        return await self.tasks.get_active_collection_tasks_for_channel(channel_id)
+
+    async def get_channel_ids_with_active_tasks(self) -> set[int]:
+        return await self.tasks.get_channel_ids_with_active_tasks()
+
+    async def get_active_stats_task(self) -> CollectionTask | None:
+        return await self.tasks.get_active_stats_task()
+
+    async def claim_next_due_stats_task(self, now: datetime) -> CollectionTask | None:
+        return await self.tasks.claim_next_due_stats_task(now)
+
+    async def create_stats_task(
+        self,
+        payload: StatsAllTaskPayload,
+        *,
+        run_after: datetime | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        return await self.tasks.create_stats_task(
+            payload,
+            run_after=run_after,
+            parent_task_id=parent_task_id,
+        )
+
+    async def create_stats_continuation_task(
+        self,
+        *,
+        payload: StatsAllTaskPayload,
+        run_after: datetime | None,
+        parent_task_id: int,
+    ) -> int:
+        return await self.tasks.create_stats_continuation_task(
+            payload=payload,
+            run_after=run_after,
+            parent_task_id=parent_task_id,
+        )
+
+    async def get_pending_channel_tasks(self) -> list[CollectionTask]:
+        return await self.tasks.get_pending_channel_tasks()
+
+    async def fail_running_collection_tasks_on_startup(self) -> int:
+        return await self.tasks.fail_running_collection_tasks_on_startup()
+
+    async def requeue_running_stats_tasks_on_startup(self, now: datetime) -> int:
+        return await self.tasks.requeue_running_stats_tasks_on_startup(now)
+
+    async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
+        return await self.tasks.cancel_collection_task(task_id, note=note)
+
+
+@dataclass(frozen=True)
+class CollectionBundle:
+    channels: ChannelsRepository
+    messages: MessagesRepository
+    filters: FilterRepository
+    settings: SettingsRepository
+    keywords: KeywordsRepository
+    tasks: CollectionTasksRepository
+    channel_stats: ChannelStatsRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "CollectionBundle":
+        repos = db.repos
+        return cls(
+            repos.channels,
+            repos.messages,
+            repos.filters,
+            repos.settings,
+            repos.keywords,
+            repos.tasks,
+            repos.channel_stats,
+        )
+
+    @property
+    def filter_repo(self) -> FilterRepository:
+        return self.filters
+
+    async def execute(self, query: str, params: tuple | list = ()):
+        return await self.channels._db.execute(query, tuple(params))
+
+    async def list_channels(
+        self,
+        active_only: bool = False,
+        include_filtered: bool = True,
+    ) -> list[Channel]:
+        return await self.channels.get_channels(active_only, include_filtered)
+
+    async def get_by_pk(self, pk: int) -> Channel | None:
+        return await self.channels.get_channel_by_pk(pk)
+
+    async def get_channels(
+        self,
+        active_only: bool = False,
+        include_filtered: bool = True,
+    ) -> list[Channel]:
+        return await self.list_channels(active_only=active_only, include_filtered=include_filtered)
+
+    async def get_by_channel_id(self, channel_id: int) -> Channel | None:
+        return await self.channels.get_channel_by_channel_id(channel_id)
+
+    async def get_channel_by_pk(self, pk: int) -> Channel | None:
+        return await self.get_by_pk(pk)
+
+    async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
+        return await self.get_by_channel_id(channel_id)
+
+    async def update_last_id(self, channel_id: int, last_id: int) -> None:
+        await self.channels.update_channel_last_id(channel_id, last_id)
+
+    async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
+        await self.update_last_id(channel_id, last_id)
+
+    async def update_meta(
+        self,
+        channel_id: int,
+        *,
+        username: str | None,
+        title: str | None,
+    ) -> None:
+        await self.channels.update_channel_meta(channel_id, username=username, title=title)
+
+    async def update_channel_meta(
+        self,
+        channel_id: int,
+        *,
+        username: str | None,
+        title: str | None,
+    ) -> None:
+        await self.update_meta(channel_id, username=username, title=title)
+
+    async def set_active(self, pk: int, active: bool) -> None:
+        await self.channels.set_channel_active(pk, active)
+
+    async def set_channel_active(self, pk: int, active: bool) -> None:
+        await self.set_active(pk, active)
+
+    async def set_type(self, channel_id: int, channel_type: str) -> None:
+        await self.channels.set_channel_type(channel_id, channel_type)
+
+    async def set_channel_type(self, channel_id: int, channel_type: str) -> None:
+        await self.set_type(channel_id, channel_type)
+
+    async def set_filtered_bulk(
+        self,
+        updates: list[tuple[int, str]],
+        *,
+        commit: bool = True,
+    ) -> int:
+        return await self.channels.set_filtered_bulk(updates, commit=commit)
+
+    async def set_channels_filtered_bulk(
+        self,
+        updates: list[tuple[int, str]],
+        *,
+        commit: bool = True,
+    ) -> int:
+        return await self.set_filtered_bulk(updates, commit=commit)
+
+    async def reset_all_filters(self, *, commit: bool = True) -> int:
+        return await self.channels.reset_all_filters(commit=commit)
+
+    async def insert_message(self, msg: Message) -> bool:
+        return await self.messages.insert_message(msg)
+
+    async def insert_messages_batch(self, messages: list[Message]) -> int:
+        return await self.messages.insert_messages_batch(messages)
+
+    async def search_messages(
+        self,
+        query: str = "",
+        channel_id: int | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Message], int]:
+        return await self.messages.search_messages(
+            query=query,
+            channel_id=channel_id,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def delete_messages_for_channel(self, channel_id: int) -> int:
+        return await self.messages.delete_messages_for_channel(channel_id)
+
+    async def get_message_stats(self) -> dict:
+        return await self.messages.get_stats()
+
+    async def count_matching_prefixes_in_other_channels(
+        self,
+        channel_id: int,
+        prefixes: list[str],
+    ) -> int:
+        return await self.filters.count_matching_prefixes_in_other_channels(channel_id, prefixes)
+
+    async def get_setting(self, key: str) -> str | None:
+        return await self.settings.get_setting(key)
+
+    async def set_setting(self, key: str, value: str) -> None:
+        await self.settings.set_setting(key, value)
+
+    async def add_keyword(self, keyword: Keyword) -> int:
+        return await self.keywords.add_keyword(keyword)
+
+    async def list_keywords(self, active_only: bool = False) -> list[Keyword]:
+        return await self.keywords.get_keywords(active_only)
+
+    async def get_keywords(self, active_only: bool = False) -> list[Keyword]:
+        return await self.list_keywords(active_only)
+
+    async def set_keyword_active(self, keyword_id: int, active: bool) -> None:
+        await self.keywords.set_keyword_active(keyword_id, active)
+
+    async def delete_keyword(self, keyword_id: int) -> None:
+        await self.keywords.delete_keyword(keyword_id)
+
+    async def get_channel_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
+        return await self.channel_stats.get_channel_stats(channel_id, limit)
+
+    async def save_channel_stats(self, stats: ChannelStats) -> int:
+        return await self.channel_stats.save_channel_stats(stats)
+
+    async def create_collection_task(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        channel_username: str | None = None,
+        run_after: datetime | None = None,
+        payload: dict | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        return await self.tasks.create_collection_task(
+            channel_id,
+            channel_title,
+            channel_username=channel_username,
+            run_after=run_after,
+            payload=payload,
+            parent_task_id=parent_task_id,
+        )
+
+
+@dataclass(frozen=True)
+class NotificationBundle:
+    accounts: AccountsRepository
+    settings: SettingsRepository
+    notification_bots: NotificationBotsRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "NotificationBundle":
+        repos = db.repos
+        return cls(repos.accounts, repos.settings, repos.notification_bots)
+
+    async def list_accounts(self, active_only: bool = False) -> list[Account]:
+        return await self.accounts.get_accounts(active_only)
+
+    async def get_setting(self, key: str) -> str | None:
+        return await self.settings.get_setting(key)
+
+    async def set_setting(self, key: str, value: str) -> None:
+        await self.settings.set_setting(key, value)
+
+    async def get_bot(self, tg_user_id: int) -> NotificationBot | None:
+        return await self.notification_bots.get_bot(tg_user_id)
+
+    async def save_bot(self, bot: NotificationBot) -> int:
+        return await self.notification_bots.save_bot(bot)
+
+    async def delete_bot(self, tg_user_id: int) -> None:
+        await self.notification_bots.delete_bot(tg_user_id)
+
+
+@dataclass(frozen=True)
+class SearchBundle:
+    messages: MessagesRepository
+    search_log: SearchLogRepository
+    channels: ChannelsRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "SearchBundle":
+        repos = db.repos
+        return cls(repos.messages, repos.search_log, repos.channels)
+
+    async def search_messages(
+        self,
+        query: str = "",
+        channel_id: int | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Message], int]:
+        return await self.messages.search_messages(
+            query=query,
+            channel_id=channel_id,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def add_channel(self, channel: Channel) -> int:
+        return await self.channels.add_channel(channel)
+
+    async def insert_messages_batch(self, messages: list[Message]) -> int:
+        return await self.messages.insert_messages_batch(messages)
+
+    async def log_search(self, phone: str, query: str, results_count: int) -> None:
+        await self.search_log.log_search(phone, query, results_count)
+
+    async def get_recent_searches(self, limit: int = 20) -> list[dict]:
+        return await self.search_log.get_recent_searches(limit)
+
+
+@dataclass(frozen=True)
+class SchedulerBundle:
+    settings: SettingsRepository
+    keywords: KeywordsRepository
+    tasks: CollectionTasksRepository
+    search_log: SearchLogRepository
+
+    @classmethod
+    def from_database(cls, db: "Database") -> "SchedulerBundle":
+        repos = db.repos
+        return cls(repos.settings, repos.keywords, repos.tasks, repos.search_log)
+
+    async def get_setting(self, key: str) -> str | None:
+        return await self.settings.get_setting(key)
+
+    async def set_setting(self, key: str, value: str) -> None:
+        await self.settings.set_setting(key, value)
+
+    async def list_keywords(self, active_only: bool = False) -> list[Keyword]:
+        return await self.keywords.get_keywords(active_only)
+
+    async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
+        return await self.tasks.get_collection_tasks(limit)
+
+    async def get_recent_searches(self, limit: int = 20) -> list[dict]:
+        return await self.search_log.get_recent_searches(limit)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -5,9 +5,9 @@ from typing import Any
 
 import aiosqlite
 
+from src.database.bundles import DatabaseRepositories
 from src.database.connection import DBConnection
 from src.database.migrations import run_migrations
-from src.database.bundles import DatabaseRepositories
 from src.database.repositories.accounts import AccountsRepository
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.database.repositories.channels import ChannelsRepository

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -7,6 +7,7 @@ import aiosqlite
 
 from src.database.connection import DBConnection
 from src.database.migrations import run_migrations
+from src.database.bundles import DatabaseRepositories
 from src.database.repositories.accounts import AccountsRepository
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.database.repositories.channels import ChannelsRepository
@@ -23,9 +24,11 @@ from src.models import (
     Channel,
     ChannelStats,
     CollectionTask,
+    CollectionTaskStatus,
     Keyword,
     Message,
     NotificationBot,
+    StatsAllTaskPayload,
 )
 from src.security import SessionCipher
 
@@ -50,6 +53,7 @@ class Database:
         self._settings: SettingsRepository | None = None
         self._filters: FilterRepository | None = None
         self._notification_bots: NotificationBotsRepository | None = None
+        self._repos: DatabaseRepositories | None = None
 
     async def _has_encrypted_sessions(self) -> bool:
         assert self._db is not None
@@ -90,6 +94,18 @@ class Database:
         self._settings = SettingsRepository(self._db)
         self._filters = FilterRepository(self._db)
         self._notification_bots = NotificationBotsRepository(self._db)
+        self._repos = DatabaseRepositories(
+            accounts=self._accounts,
+            channels=self._channels,
+            messages=self._messages,
+            keywords=self._keywords,
+            tasks=self._tasks,
+            search_log=self._search_log,
+            channel_stats=self._channel_stats,
+            settings=self._settings,
+            filters=self._filters,
+            notification_bots=self._notification_bots,
+        )
 
         await self._accounts.migrate_sessions()
 
@@ -111,6 +127,12 @@ class Database:
         self._require()
         assert self._filters is not None
         return self._filters
+
+    @property
+    def repos(self) -> DatabaseRepositories:
+        self._require()
+        assert self._repos is not None
+        return self._repos
 
     def _require(self) -> None:
         if any(
@@ -292,7 +314,7 @@ class Database:
     async def update_collection_task(
         self,
         task_id: int,
-        status: str,
+        status: CollectionTaskStatus | str,
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
@@ -327,10 +349,24 @@ class Database:
         self._require()
         return await self._tasks.claim_next_due_stats_task(now)
 
+    async def create_stats_task(
+        self,
+        payload: StatsAllTaskPayload,
+        *,
+        run_after: datetime | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        self._require()
+        return await self._tasks.create_stats_task(
+            payload,
+            run_after=run_after,
+            parent_task_id=parent_task_id,
+        )
+
     async def create_stats_continuation_task(
         self,
         *,
-        payload: dict[str, Any],
+        payload: StatsAllTaskPayload,
         run_after: datetime | None,
         parent_task_id: int,
     ) -> int:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -33,7 +33,9 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
         await db.commit()
 
     cur = await db.execute("PRAGMA table_info(collection_tasks)")
-    task_columns = {row["name"] for row in await cur.fetchall()}
+    task_rows = await cur.fetchall()
+    task_columns = {row["name"] for row in task_rows}
+    task_column_meta = {row["name"]: row for row in task_rows}
     if "run_after" not in task_columns:
         await db.execute("ALTER TABLE collection_tasks ADD COLUMN run_after TEXT")
         await db.commit()
@@ -49,6 +51,78 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
     if "note" not in task_columns:
         await db.execute("ALTER TABLE collection_tasks ADD COLUMN note TEXT")
         await db.commit()
+    channel_id_row = task_column_meta.get("channel_id")
+    channel_id_notnull = bool(channel_id_row["notnull"]) if channel_id_row is not None else False
+    if "task_type" not in task_columns or channel_id_notnull:
+        await db.execute(
+            """
+            CREATE TABLE collection_tasks_tmp (
+                id INTEGER PRIMARY KEY,
+                channel_id INTEGER,
+                channel_title TEXT,
+                channel_username TEXT,
+                task_type TEXT NOT NULL DEFAULT 'channel_collect',
+                status TEXT DEFAULT 'pending',
+                messages_collected INTEGER DEFAULT 0,
+                error TEXT,
+                note TEXT,
+                run_after TEXT,
+                payload TEXT,
+                parent_task_id INTEGER,
+                created_at TEXT DEFAULT (datetime('now')),
+                started_at TEXT,
+                completed_at TEXT
+            )
+            """
+        )
+        await db.execute(
+            """
+            INSERT INTO collection_tasks_tmp (
+                id,
+                channel_id,
+                channel_title,
+                channel_username,
+                task_type,
+                status,
+                messages_collected,
+                error,
+                note,
+                run_after,
+                payload,
+                parent_task_id,
+                created_at,
+                started_at,
+                completed_at
+            )
+            SELECT
+                id,
+                CASE WHEN channel_id = 0 THEN NULL ELSE channel_id END,
+                channel_title,
+                channel_username,
+                CASE WHEN channel_id = 0 THEN 'stats_all' ELSE 'channel_collect' END,
+                status,
+                messages_collected,
+                error,
+                note,
+                run_after,
+                payload,
+                parent_task_id,
+                created_at,
+                started_at,
+                completed_at
+            FROM collection_tasks
+            """
+        )
+        await db.execute("DROP TABLE collection_tasks")
+        await db.execute("ALTER TABLE collection_tasks_tmp RENAME TO collection_tasks")
+        await db.commit()
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_collection_tasks_type_status_run_after
+        ON collection_tasks(task_type, status, run_after)
+        """
+    )
+    await db.commit()
 
     await db.execute("UPDATE channels SET channel_type='supergroup' WHERE channel_type='group'")
     await db.execute("UPDATE channels SET channel_type='group' WHERE channel_type='chat'")

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import aiosqlite
 
-from src.models import CollectionTask
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    StatsAllTaskPayload,
+)
 
 
 class CollectionTasksRepository:
@@ -14,14 +19,28 @@ class CollectionTasksRepository:
         self._db = db
 
     @staticmethod
-    def _parse_payload(raw: str | None) -> dict[str, Any] | None:
+    def _deserialize_payload(
+        raw: str | None,
+    ) -> dict[str, Any] | StatsAllTaskPayload | None:
         if not raw:
             return None
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
             return None
-        return parsed if isinstance(parsed, dict) else None
+        if not isinstance(parsed, dict):
+            return None
+        if parsed.get("task_kind") == CollectionTaskType.STATS_ALL.value:
+            return StatsAllTaskPayload.model_validate(parsed)
+        return parsed
+
+    @staticmethod
+    def _serialize_payload(payload: dict[str, Any] | StatsAllTaskPayload | None) -> str | None:
+        if payload is None:
+            return None
+        if isinstance(payload, StatsAllTaskPayload):
+            return payload.model_dump_json()
+        return json.dumps(payload)
 
     @staticmethod
     def _to_task(row: aiosqlite.Row) -> CollectionTask:
@@ -30,12 +49,13 @@ class CollectionTasksRepository:
             channel_id=row["channel_id"],
             channel_title=row["channel_title"],
             channel_username=row["channel_username"],
-            status=row["status"],
+            task_type=CollectionTaskType(row["task_type"]),
+            status=CollectionTaskStatus(row["status"]),
             messages_collected=row["messages_collected"],
             error=row["error"],
             note=row["note"],
             run_after=(datetime.fromisoformat(row["run_after"]) if row["run_after"] else None),
-            payload=CollectionTasksRepository._parse_payload(row["payload"]),
+            payload=CollectionTasksRepository._deserialize_payload(row["payload"]),
             parent_task_id=row["parent_task_id"],
             created_at=(datetime.fromisoformat(row["created_at"]) if row["created_at"] else None),
             started_at=(datetime.fromisoformat(row["started_at"]) if row["started_at"] else None),
@@ -59,14 +79,44 @@ class CollectionTasksRepository:
         run_after_iso = (
             run_after.astimezone(timezone.utc).isoformat() if run_after else None
         )
-        payload_json = json.dumps(payload) if payload is not None else None
+        payload_json = self._serialize_payload(payload)
         cur = await self._db.execute(
             "INSERT INTO collection_tasks "
-            "(channel_id, channel_title, channel_username, run_after, payload, parent_task_id) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "(channel_id, channel_title, channel_username, task_type, run_after, payload, parent_task_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
-                channel_id, channel_title, channel_username,
-                run_after_iso, payload_json, parent_task_id,
+                channel_id,
+                channel_title,
+                channel_username,
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                run_after_iso,
+                payload_json,
+                parent_task_id,
+            ),
+        )
+        await self._db.commit()
+        return cur.lastrowid or 0
+
+    async def create_stats_task(
+        self,
+        payload: StatsAllTaskPayload,
+        *,
+        run_after: datetime | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
+        cur = await self._db.execute(
+            "INSERT INTO collection_tasks "
+            "(channel_id, channel_title, channel_username, task_type, run_after, payload, parent_task_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                None,
+                "Обновление статистики",
+                None,
+                CollectionTaskType.STATS_ALL.value,
+                run_after_iso,
+                self._serialize_payload(payload),
+                parent_task_id,
             ),
         )
         await self._db.commit()
@@ -82,18 +132,19 @@ class CollectionTasksRepository:
     async def update_collection_task(
         self,
         task_id: int,
-        status: str,
+        status: CollectionTaskStatus | str,
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
     ) -> None:
+        status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = ?"]
-        params: list = [status]
-        if status == "running":
+        params: list[Any] = [status_value]
+        if status_value == CollectionTaskStatus.RUNNING.value:
             sets.append("started_at = ?")
             params.append(now)
-        if status in ("completed", "failed"):
+        if status_value in (CollectionTaskStatus.COMPLETED.value, CollectionTaskStatus.FAILED.value):
             sets.append("completed_at = ?")
             params.append(now)
         if messages_collected is not None:
@@ -134,9 +185,14 @@ class CollectionTasksRepository:
     ) -> list[CollectionTask]:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
-            "WHERE channel_id = ? AND status IN ('pending', 'running') "
+            "WHERE task_type = ? AND channel_id = ? AND status IN (?, ?) "
             "ORDER BY id ASC",
-            (channel_id,),
+            (
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                channel_id,
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         rows = await cur.fetchall()
         return [self._to_task(r) for r in rows]
@@ -144,7 +200,12 @@ class CollectionTasksRepository:
     async def get_channel_ids_with_active_tasks(self) -> set[int]:
         cur = await self._db.execute(
             "SELECT DISTINCT channel_id FROM collection_tasks "
-            "WHERE channel_id != 0 AND status IN ('pending', 'running')"
+            "WHERE task_type = ? AND status IN (?, ?) AND channel_id IS NOT NULL",
+            (
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         rows = await cur.fetchall()
         return {int(row["channel_id"]) for row in rows}
@@ -152,8 +213,13 @@ class CollectionTasksRepository:
     async def get_active_stats_task(self) -> CollectionTask | None:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
-            "WHERE channel_id = 0 AND status IN ('pending', 'running') "
-            "ORDER BY id ASC LIMIT 1"
+            "WHERE task_type = ? AND status IN (?, ?) "
+            "ORDER BY id ASC LIMIT 1",
+            (
+                CollectionTaskType.STATS_ALL.value,
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         row = await cur.fetchone()
         if row is None:
@@ -162,16 +228,19 @@ class CollectionTasksRepository:
 
     async def claim_next_due_stats_task(self, now: datetime) -> CollectionTask | None:
         now_iso = now.astimezone(timezone.utc).isoformat()
-        selected_id: int | None = None
         try:
             await self._db.execute("BEGIN IMMEDIATE")
             cur = await self._db.execute(
                 "SELECT id FROM collection_tasks "
-                "WHERE channel_id = 0 "
-                "AND status = 'pending' "
+                "WHERE task_type = ? "
+                "AND status = ? "
                 "AND (run_after IS NULL OR run_after <= ?) "
                 "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
-                (now_iso,),
+                (
+                    CollectionTaskType.STATS_ALL.value,
+                    CollectionTaskStatus.PENDING.value,
+                    now_iso,
+                ),
             )
             row = await cur.fetchone()
             if row is None:
@@ -181,8 +250,8 @@ class CollectionTasksRepository:
             updated = await self._db.execute(
                 "UPDATE collection_tasks "
                 "SET status = 'running', started_at = ?, completed_at = NULL "
-                "WHERE id = ? AND status = 'pending'",
-                (now_iso, selected_id),
+                "WHERE id = ? AND status = ?",
+                (now_iso, selected_id, CollectionTaskStatus.PENDING.value),
             )
             if (updated.rowcount or 0) == 0:
                 await self._db.commit()
@@ -203,23 +272,25 @@ class CollectionTasksRepository:
     async def create_stats_continuation_task(
         self,
         *,
-        payload: dict[str, Any],
+        payload: StatsAllTaskPayload,
         run_after: datetime | None,
         parent_task_id: int,
     ) -> int:
-        return await self.create_collection_task(
-            0,
-            "Обновление статистики",
+        return await self.create_stats_task(
+            payload,
             run_after=run_after,
-            payload=payload,
             parent_task_id=parent_task_id,
         )
 
     async def get_pending_channel_tasks(self) -> list[CollectionTask]:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
-            "WHERE channel_id != 0 AND status = 'pending' "
-            "ORDER BY id ASC"
+            "WHERE task_type = ? AND status = ? "
+            "ORDER BY id ASC",
+            (
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                CollectionTaskStatus.PENDING.value,
+            ),
         )
         rows = await cur.fetchall()
         return [self._to_task(r) for r in rows]
@@ -229,8 +300,12 @@ class CollectionTasksRepository:
         cur = await self._db.execute(
             "UPDATE collection_tasks "
             "SET status = 'failed', completed_at = ? "
-            "WHERE channel_id != 0 AND status = 'running'",
-            (now,),
+            "WHERE task_type = ? AND status = ?",
+            (
+                now,
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         await self._db.commit()
         return cur.rowcount or 0
@@ -240,8 +315,12 @@ class CollectionTasksRepository:
         cur = await self._db.execute(
             "UPDATE collection_tasks "
             "SET status = 'pending', started_at = NULL, run_after = COALESCE(run_after, ?) "
-            "WHERE channel_id = 0 AND status = 'running'",
-            (now_iso,),
+            "WHERE task_type = ? AND status = ?",
+            (
+                now_iso,
+                CollectionTaskType.STATS_ALL.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         await self._db.commit()
         return cur.rowcount or 0
@@ -249,15 +328,19 @@ class CollectionTasksRepository:
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = 'cancelled'", "completed_at = ?"]
-        params: list = [now]
+        params: list[Any] = [now]
         if note is not None:
             sets.append("note = ?")
             params.append(note)
         params.append(task_id)
         cur = await self._db.execute(
             f"UPDATE collection_tasks SET {', '.join(sets)} "
-            "WHERE id = ? AND status IN ('pending', 'running')",
-            tuple(params),
+            "WHERE id = ? AND status IN (?, ?)",
+            (
+                *params,
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
         )
         await self._db.commit()
         return cur.rowcount > 0

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -46,11 +46,14 @@ CREATE TABLE IF NOT EXISTS settings (
 
 CREATE TABLE IF NOT EXISTS collection_tasks (
     id INTEGER PRIMARY KEY,
-    channel_id INTEGER NOT NULL,
+    channel_id INTEGER,
     channel_title TEXT,
+    channel_username TEXT,
+    task_type TEXT NOT NULL DEFAULT 'channel_collect',
     status TEXT DEFAULT 'pending',
     messages_collected INTEGER DEFAULT 0,
     error TEXT,
+    note TEXT,
     run_after TEXT,
     payload TEXT,
     parent_task_id INTEGER,

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import argparse
 
 from src.cli import runtime
-from src.cli.commands import account, channel, collect, keyword, scheduler, search, serve
+from src.cli.commands import (
+    account,
+    channel,
+    collect,
+    keyword,
+    scheduler,
+    search,
+    serve,
+    smoke_test,
+)
 from src.cli.main import main
 
 _init_db = runtime.init_db
@@ -55,6 +64,10 @@ def cmd_account(args: argparse.Namespace) -> None:
 
 def cmd_scheduler(args: argparse.Namespace) -> None:
     _run_with_legacy_runtime(scheduler.run, args)
+
+
+def cmd_smoke_test(args: argparse.Namespace) -> None:
+    _run_with_legacy_runtime(smoke_test.run, args)
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from src.cli.commands import (
     scheduler,
     search,
     serve,
-    smoke_test,
+    test as test_cmd,
 )
 from src.cli.main import main
 
@@ -66,8 +66,8 @@ def cmd_scheduler(args: argparse.Namespace) -> None:
     _run_with_legacy_runtime(scheduler.run, args)
 
 
-def cmd_smoke_test(args: argparse.Namespace) -> None:
-    _run_with_legacy_runtime(smoke_test.run, args)
+def cmd_test(args: argparse.Namespace) -> None:
+    _run_with_legacy_runtime(test_cmd.run, args)
 
 
 if __name__ == "__main__":

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -61,17 +62,40 @@ class Keyword(BaseModel):
     is_active: bool = True
 
 
+class CollectionTaskStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class CollectionTaskType(StrEnum):
+    CHANNEL_COLLECT = "channel_collect"
+    STATS_ALL = "stats_all"
+
+
+class StatsAllTaskPayload(BaseModel):
+    task_kind: str = CollectionTaskType.STATS_ALL.value
+    channel_ids: list[int]
+    next_index: int = 0
+    batch_size: int = 20
+    channels_ok: int = 0
+    channels_err: int = 0
+
+
 class CollectionTask(BaseModel):
     id: int | None = None
-    channel_id: int
+    channel_id: int | None = None
     channel_title: str | None = None
     channel_username: str | None = None
-    status: str = "pending"  # pending / running / completed / failed / cancelled
+    task_type: CollectionTaskType = CollectionTaskType.CHANNEL_COLLECT
+    status: CollectionTaskStatus = CollectionTaskStatus.PENDING
     messages_collected: int = 0
     error: str | None = None
     note: str | None = None
     run_after: datetime | None = None
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any] | StatsAllTaskPayload | None = None
     parent_task_id: int | None = None
     created_at: datetime | None = None
     started_at: datetime | None = None

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -9,14 +9,26 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from src.config import SchedulerConfig
+from src.database import Database
+from src.database.bundles import SchedulerBundle
 from src.settings_utils import parse_int_setting
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
-    from src.database import Database
     from src.search.engine import SearchEngine
 
 logger = logging.getLogger(__name__)
+
+
+class _LegacySchedulerBundle:
+    def __init__(self, store):
+        self._store = store
+
+    async def get_setting(self, key: str) -> str | None:
+        return await self._store.get_setting(key)
+
+    async def list_keywords(self, active_only: bool = False):
+        return await self._store.get_keywords(active_only=active_only)
 
 
 class SchedulerManager:
@@ -24,13 +36,19 @@ class SchedulerManager:
         self,
         collector: Collector,
         config: SchedulerConfig,
+        scheduler_bundle: SchedulerBundle | Database | None = None,
         search_engine: SearchEngine | None = None,
-        db: Database | None = None,
     ):
         self._collector = collector
         self._config = config
+        if scheduler_bundle is None:
+            scheduler_bundle = getattr(collector, "_db", None)
+        if isinstance(scheduler_bundle, Database):
+            scheduler_bundle = SchedulerBundle.from_database(scheduler_bundle)
+        elif not isinstance(scheduler_bundle, SchedulerBundle):
+            scheduler_bundle = _LegacySchedulerBundle(scheduler_bundle)
+        self._scheduler_bundle = scheduler_bundle
         self._search_engine = search_engine
-        self._db = db
         self._scheduler: AsyncIOScheduler | None = None
         self._job_id = "collect_all"
         self._search_job_id = "keyword_search"
@@ -81,9 +99,7 @@ class SchedulerManager:
             return
 
         self._scheduler = AsyncIOScheduler()
-        saved_interval = (
-            await self._db.get_setting("collect_interval_minutes") if self._db else None
-        )
+        saved_interval = await self._scheduler_bundle.get_setting("collect_interval_minutes")
         collect_interval = parse_int_setting(
             saved_interval,
             setting_name="collect_interval_minutes",
@@ -98,7 +114,7 @@ class SchedulerManager:
             replace_existing=True,
         )
 
-        if self._search_engine and self._db:
+        if self._search_engine:
             self._scheduler.add_job(
                 self._run_keyword_search,
                 IntervalTrigger(minutes=self._config.search_interval_minutes),
@@ -177,11 +193,11 @@ class SchedulerManager:
 
     async def _run_keyword_search(self) -> dict:
         """Search by active keywords using search_telegram, respecting quotas."""
-        if not self._search_engine or not self._db:
+        if not self._search_engine:
             return {"keywords": 0, "results": 0, "errors": 0}
 
         logger.info("Starting scheduled keyword search")
-        keywords = await self._db.get_keywords(active_only=True)
+        keywords = await self._scheduler_bundle.list_keywords(active_only=True)
         total_results = 0
         searched = 0
         errors = 0

--- a/src/search/ai_search.py
+++ b/src/search/ai_search.py
@@ -5,6 +5,7 @@ import logging
 
 from src.config import LLMConfig
 from src.database import Database
+from src.database.bundles import SearchBundle
 from src.models import SearchResult
 
 logger = logging.getLogger(__name__)
@@ -16,9 +17,11 @@ _SYSTEM_PROMPT = """Ты — ассистент для поиска по Telegra
 
 
 class AISearchEngine:
-    def __init__(self, config: LLMConfig, db: Database):
+    def __init__(self, config: LLMConfig, search: SearchBundle | Database):
         self._config = config
-        self._db = db
+        if isinstance(search, Database):
+            search = SearchBundle.from_database(search)
+        self._search = search
         self._agent = None
 
     @property
@@ -33,7 +36,7 @@ class AISearchEngine:
         try:
             from deepagents import create_deep_agent
 
-            db = self._db
+            search = self._search
 
             def search_posts_tool(query: str) -> str:
                 """Search collected posts in the database."""
@@ -42,10 +45,10 @@ class AISearchEngine:
                 try:
                     asyncio.get_running_loop()
                     with concurrent.futures.ThreadPoolExecutor() as executor:
-                        future = executor.submit(asyncio.run, db.search_messages(query, limit=20))
+                        future = executor.submit(asyncio.run, search.search_messages(query, limit=20))
                         messages, total = future.result()
                 except RuntimeError:
-                    messages, total = asyncio.run(db.search_messages(query, limit=20))
+                    messages, total = asyncio.run(search.search_messages(query, limit=20))
 
                 if not messages:
                     return f"No results found for: {query}"
@@ -74,7 +77,7 @@ class AISearchEngine:
         """Run AI-powered search."""
         if not self._agent:
             # Fallback to basic local search
-            messages, total = await self._db.search_messages(query, limit=20)
+            messages, total = await self._search.search_messages(query, limit=20)
             return SearchResult(
                 messages=messages,
                 total=total,
@@ -87,7 +90,7 @@ class AISearchEngine:
             summary = str(response)
 
             # Also get raw messages for display
-            messages, total = await self._db.search_messages(query, limit=20)
+            messages, total = await self._search.search_messages(query, limit=20)
 
             return SearchResult(
                 messages=messages,
@@ -97,7 +100,7 @@ class AISearchEngine:
             )
         except Exception as e:
             logger.error("AI search error: %s", e)
-            messages, total = await self._db.search_messages(query, limit=20)
+            messages, total = await self._search.search_messages(query, limit=20)
             return SearchResult(
                 messages=messages,
                 total=total,

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.database import Database
+from src.database.bundles import SearchBundle
 from src.models import SearchResult
 from src.search.local_search import LocalSearch
 from src.search.persistence import SearchPersistence
@@ -11,9 +12,11 @@ from src.telegram.client_pool import ClientPool
 class SearchEngine:
     """Facade for local and Telegram-based search strategies."""
 
-    def __init__(self, db: Database, pool: ClientPool | None = None):
-        self._local = LocalSearch(db)
-        self._telegram = TelegramSearch(pool, SearchPersistence(db))
+    def __init__(self, search: SearchBundle | Database, pool: ClientPool | None = None):
+        if isinstance(search, Database):
+            search = SearchBundle.from_database(search)
+        self._local = LocalSearch(search)
+        self._telegram = TelegramSearch(pool, SearchPersistence(search))
 
     async def search_local(
         self,

--- a/src/search/local_search.py
+++ b/src/search/local_search.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from src.database import Database
+from src.database.bundles import SearchBundle
 from src.models import SearchResult
 
 
 class LocalSearch:
-    def __init__(self, db: Database):
-        self._db = db
+    def __init__(self, search: SearchBundle):
+        self._search = search
 
     async def search(
         self,
@@ -17,7 +17,7 @@ class LocalSearch:
         limit: int = 50,
         offset: int = 0,
     ) -> SearchResult:
-        messages, total = await self._db.search_messages(
+        messages, total = await self._search.search_messages(
             query=query,
             channel_id=channel_id,
             date_from=date_from,

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from src.database import Database
+from src.database.bundles import SearchBundle
 from src.models import Channel, Message
 
 
 class SearchPersistence:
-    def __init__(self, db: Database):
-        self._db = db
+    def __init__(self, search: SearchBundle):
+        self._search = search
 
     async def cache_search_results(
         self,
@@ -16,12 +16,12 @@ class SearchPersistence:
         query: str,
     ) -> None:
         for ch in channels.values():
-            await self._db.add_channel(ch)
+            await self._search.add_channel(ch)
 
         if messages:
-            await self._db.insert_messages_batch(messages)
+            await self._search.insert_messages_batch(messages)
 
-        await self._db.log_search(phone, query, len(messages))
+        await self._search.log_search(phone, query, len(messages))
 
     async def cache_messages_and_channels(
         self,
@@ -29,6 +29,6 @@ class SearchPersistence:
         messages: list[Message],
     ) -> None:
         for ch in channels.values():
-            await self._db.add_channel(ch)
+            await self._search.add_channel(ch)
         if messages:
-            await self._db.insert_messages_batch(messages)
+            await self._search.insert_messages_batch(messages)

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -278,22 +278,44 @@ class TelegramSearch:
 
         client, phone = result
         try:
+            await asyncio.wait_for(client.get_dialogs(), timeout=30.0)
+
             entity = None
             if channel_id:
                 try:
                     entity = await asyncio.wait_for(
-                        client.get_entity(PeerChannel(channel_id)), timeout=30.0
+                        client.get_entity(PeerChannel(channel_id)), timeout=30.0,
                     )
-                except Exception as exc:
-                    logger.warning("Cannot resolve channel %s: %s", channel_id, exc)
-                    return SearchResult(
-                        messages=[],
-                        total=0,
-                        query=query,
-                        error=f"Не удалось найти канал {channel_id}: {exc}",
+                except Exception:
+                    logger.debug(
+                        "PeerChannel(%s) not in cache, trying username fallback",
+                        channel_id,
                     )
-            else:
-                await asyncio.wait_for(client.get_dialogs(), timeout=30.0)
+                    ch_record = await self._persistence._search.channels \
+                        .get_channel_by_channel_id(channel_id)
+                    username = ch_record.username if ch_record else None
+                    if username:
+                        try:
+                            entity = await asyncio.wait_for(
+                                client.get_entity(username), timeout=30.0,
+                            )
+                        except Exception as exc2:
+                            logger.warning(
+                                "Cannot resolve channel %s (@%s): %s",
+                                channel_id, username, exc2,
+                            )
+                            return SearchResult(
+                                messages=[], total=0, query=query,
+                                error=f"Не удалось найти канал {channel_id}: {exc2}",
+                            )
+                    else:
+                        return SearchResult(
+                            messages=[], total=0, query=query,
+                            error=(
+                                f"Не удалось найти канал {channel_id}"
+                                " (нет username для fallback)"
+                            ),
+                        )
 
             async def _collect_in_channel() -> tuple[list[Message], dict[int, Channel]]:
                 collected: list[Message] = []

--- a/src/services/account_service.py
+++ b/src/services/account_service.py
@@ -3,24 +3,27 @@ from __future__ import annotations
 import logging
 
 from src.database import Database
+from src.database.bundles import AccountBundle
 from src.telegram.client_pool import ClientPool
 
 logger = logging.getLogger(__name__)
 
 
 class AccountService:
-    def __init__(self, db: Database, pool: ClientPool | None = None):
-        self._db = db
+    def __init__(self, accounts: AccountBundle | Database, pool: ClientPool | None = None):
+        if isinstance(accounts, Database):
+            accounts = AccountBundle.from_database(accounts)
+        self._accounts = accounts
         self._pool = pool
 
     async def list(self):
-        return await self._db.get_accounts()
+        return await self._accounts.list_accounts()
 
     async def toggle(self, account_id: int) -> None:
-        accounts = await self._db.get_accounts()
+        accounts = await self._accounts.list_accounts()
         for acc in accounts:
             if acc.id == account_id:
-                await self._db.set_account_active(account_id, not acc.is_active)
+                await self._accounts.set_active(account_id, not acc.is_active)
                 if self._pool:
                     if not acc.is_active:
                         try:
@@ -33,9 +36,9 @@ class AccountService:
 
     async def delete(self, account_id: int) -> None:
         if self._pool:
-            accounts = await self._db.get_accounts()
+            accounts = await self._accounts.list_accounts()
             for acc in accounts:
                 if acc.id == account_id:
                     await self._pool.remove_client(acc.phone)
                     break
-        await self._db.delete_account(account_id)
+        await self._accounts.delete_account(account_id)

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.database import Database
+from src.database.bundles import ChannelBundle
 from src.models import Channel
 from src.telegram.client_pool import ClientPool
 
@@ -11,18 +12,25 @@ if TYPE_CHECKING:
 
 
 class ChannelService:
-    def __init__(self, db: Database, pool: ClientPool, queue: CollectionQueue):
-        self._db = db
+    def __init__(
+        self,
+        channels: ChannelBundle | Database,
+        pool: ClientPool,
+        queue: CollectionQueue | None,
+    ):
+        if isinstance(channels, Database):
+            channels = ChannelBundle.from_database(channels)
+        self._channels = channels
         self._pool = pool
         self._queue = queue
 
     async def list_for_page(
         self, include_filtered: bool = True
     ) -> tuple[list[Channel], dict]:
-        channels = await self._db.get_channels_with_counts(
+        channels = await self._channels.list_channels_with_counts(
             include_filtered=include_filtered
         )
-        latest_stats = await self._db.get_latest_stats_for_all()
+        latest_stats = await self._channels.get_latest_stats_for_all()
         return channels, latest_stats
 
     async def add_by_identifier(self, identifier: str) -> bool:
@@ -36,11 +44,11 @@ class ChannelService:
             channel_type=info.get("channel_type"),
             is_active=not info.get("deactivate", False),
         )
-        await self._db.add_channel(channel)
+        await self._channels.add_channel(channel)
         return True
 
     async def get_dialogs_with_added_flags(self) -> list[dict]:
-        existing = await self._db.get_channels()
+        existing = await self._channels.list_channels()
         existing_ids = {ch.channel_id for ch in existing}
         dialogs = await self._pool.get_dialogs()
         for dialog in dialogs:
@@ -54,7 +62,7 @@ class ChannelService:
             if cid not in dialogs_map:
                 continue
             dialog = dialogs_map[cid]
-            await self._db.add_channel(
+            await self._channels.add_channel(
                 Channel(
                     channel_id=dialog["channel_id"],
                     title=dialog["title"],
@@ -66,29 +74,29 @@ class ChannelService:
 
     async def get_my_dialogs(self, phone: str) -> list[dict]:
         """Get all dialogs for a specific account, enriched with already_added flag."""
-        existing_ids = {ch.channel_id for ch in await self._db.get_channels()}
+        existing_ids = {ch.channel_id for ch in await self._channels.list_channels()}
         dialogs = await self._pool.get_dialogs_for_phone(phone, include_dm=True)
         for d in dialogs:
             d["already_added"] = d["channel_id"] in existing_ids
         return dialogs
 
     async def toggle(self, pk: int) -> None:
-        channel = await self._db.get_channel_by_pk(pk)
+        channel = await self._channels.get_by_pk(pk)
         if not channel:
             return
-        await self._db.set_channel_active(pk, not channel.is_active)
+        await self._channels.set_active(pk, not channel.is_active)
 
     async def delete(self, pk: int) -> None:
-        channel = await self._db.get_channel_by_pk(pk)
+        channel = await self._channels.get_by_pk(pk)
         if channel is not None:
-            tasks = await self._db.get_active_collection_tasks_for_channel(channel.channel_id)
+            tasks = await self._channels.get_active_collection_tasks_for_channel(channel.channel_id)
             for task in tasks:
-                if task.id is not None:
+                if task.id is not None and self._queue is not None:
                     await self._queue.cancel_task(
                         task.id,
                         note="Канал удалён пользователем.",
                     )
-        await self._db.delete_channel(pk)
+        await self._channels.delete_channel(pk)
 
     async def leave_dialogs(
         self, phone: str, dialogs: list[tuple[int, str]]
@@ -96,4 +104,4 @@ class ChannelService:
         return await self._pool.leave_channels(phone, dialogs)
 
     async def get_by_pk(self, pk: int) -> Channel | None:
-        return await self._db.get_channel_by_pk(pk)
+        return await self._channels.get_by_pk(pk)

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from src.database import Database
+from src.database.bundles import ChannelBundle
 from src.models import Channel
 
 if TYPE_CHECKING:
@@ -21,13 +22,20 @@ class BulkEnqueueResult:
 
 
 class CollectionService:
-    def __init__(self, db: Database, collector: Collector, queue: CollectionQueue):
-        self._db = db
+    def __init__(
+        self,
+        channels: ChannelBundle | Database,
+        collector: Collector,
+        queue: CollectionQueue,
+    ):
+        if isinstance(channels, Database):
+            channels = ChannelBundle.from_database(channels)
+        self._channels = channels
         self._collector = collector
         self._queue = queue
 
     async def enqueue_channel_by_pk(self, pk: int, force: bool = False) -> EnqueueResult:
-        channel = await self._db.get_channel_by_pk(pk)
+        channel = await self._channels.get_by_pk(pk)
         if not channel:
             return "not_found"
         if channel.is_filtered and not force:
@@ -36,8 +44,8 @@ class CollectionService:
         return "queued"
 
     async def enqueue_all_channels(self) -> BulkEnqueueResult:
-        channels = await self._db.get_channels(active_only=True, include_filtered=False)
-        busy_channel_ids = await self._db.get_channel_ids_with_active_tasks()
+        channels = await self._channels.list_channels(active_only=True, include_filtered=False)
+        busy_channel_ids = await self._channels.get_channel_ids_with_active_tasks()
         queued_count = 0
         skipped_existing_count = 0
 

--- a/src/services/keyword_service.py
+++ b/src/services/keyword_service.py
@@ -1,25 +1,28 @@
 from __future__ import annotations
 
 from src.database import Database
+from src.database.bundles import CollectionBundle
 from src.models import Keyword
 
 
 class KeywordService:
-    def __init__(self, db: Database):
-        self._db = db
+    def __init__(self, collection: CollectionBundle | Database):
+        if isinstance(collection, Database):
+            collection = CollectionBundle.from_database(collection)
+        self._collection = collection
 
     async def add(self, pattern: str, is_regex: bool) -> int:
-        return await self._db.add_keyword(Keyword(pattern=pattern, is_regex=is_regex))
+        return await self._collection.add_keyword(Keyword(pattern=pattern, is_regex=is_regex))
 
     async def list(self):
-        return await self._db.get_keywords()
+        return await self._collection.list_keywords()
 
     async def toggle(self, keyword_id: int) -> None:
-        keywords = await self._db.get_keywords()
+        keywords = await self._collection.list_keywords()
         for kw in keywords:
             if kw.id == keyword_id:
-                await self._db.set_keyword_active(keyword_id, not kw.is_active)
+                await self._collection.set_keyword_active(keyword_id, not kw.is_active)
                 return
 
     async def delete(self, keyword_id: int) -> None:
-        await self._db.delete_keyword(keyword_id)
+        await self._collection.delete_keyword(keyword_id)

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 
 from src.database import Database
+from src.database.bundles import NotificationBundle
 from src.models import NotificationBot
 from src.services.notification_target_service import NotificationTargetService
 from src.telegram import botfather
@@ -17,12 +18,14 @@ _DEFAULT_BOT_USERNAME_PREFIX = "leadhunter_"
 class NotificationService:
     def __init__(
         self,
-        db: Database,
+        notifications: NotificationBundle | Database,
         target_service: NotificationTargetService,
         bot_name_prefix: str = _DEFAULT_BOT_NAME_PREFIX,
         bot_username_prefix: str = _DEFAULT_BOT_USERNAME_PREFIX,
     ):
-        self._db = db
+        if isinstance(notifications, Database):
+            notifications = NotificationBundle.from_database(notifications)
+        self._notifications = notifications
         self._target_service = target_service
         self._bot_name_prefix = bot_name_prefix
         self._bot_username_prefix = bot_username_prefix
@@ -66,7 +69,7 @@ class NotificationService:
             bot_username=bot_username,
             bot_token=token,
         )
-        await self._db.save_notification_bot(bot)
+        await self._notifications.save_bot(bot)
         logger.info("Notification bot @%s set up for user %s", bot_username, tg_user_id)
         return bot
 
@@ -74,18 +77,18 @@ class NotificationService:
         """Return bot info for the selected notification account, or None if not set up."""
         async with self._target_service.use_client() as (client, _phone):
             me = await asyncio.wait_for(client.get_me(), timeout=15.0)
-        return await self._db.get_notification_bot(me.id)
+        return await self._notifications.get_bot(me.id)
 
     async def teardown_bot(self) -> None:
         """Delete the notification bot via BotFather and remove it from DB."""
         async with self._target_service.use_client() as (client, _phone):
             me = await asyncio.wait_for(client.get_me(), timeout=15.0)
             tg_user_id: int = me.id
-            bot = await self._db.get_notification_bot(tg_user_id)
+            bot = await self._notifications.get_bot(tg_user_id)
             if bot is None:
                 raise RuntimeError("No notification bot found for this user")
 
             await botfather.delete_bot(client, bot.bot_username)
 
-        await self._db.delete_notification_bot(tg_user_id)
+        await self._notifications.delete_bot(tg_user_id)
         logger.info("Notification bot deleted for user %s", tg_user_id)

--- a/src/services/notification_target_service.py
+++ b/src/services/notification_target_service.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from src.database import Database
+from src.database.bundles import NotificationBundle
 from src.models import Account
 from src.telegram.client_pool import ClientPool
 
@@ -21,19 +22,21 @@ class NotificationTargetStatus:
 
 
 class NotificationTargetService:
-    def __init__(self, db: Database, pool: ClientPool):
-        self._db = db
+    def __init__(self, notifications: NotificationBundle | Database, pool: ClientPool):
+        if isinstance(notifications, Database):
+            notifications = NotificationBundle.from_database(notifications)
+        self._notifications = notifications
         self._pool = pool
 
     async def get_configured_phone(self) -> str | None:
-        raw = (await self._db.get_setting(SETTING_KEY) or "").strip()
+        raw = (await self._notifications.get_setting(SETTING_KEY) or "").strip()
         return raw or None
 
     async def set_configured_phone(self, phone: str | None) -> None:
-        await self._db.set_setting(SETTING_KEY, phone or "")
+        await self._notifications.set_setting(SETTING_KEY, phone or "")
 
     async def describe_target(self) -> NotificationTargetStatus:
-        accounts = await self._db.get_accounts()
+        accounts = await self._notifications.list_accounts()
         configured_phone = await self.get_configured_phone()
 
         if configured_phone:

--- a/src/services/stats_task_dispatcher.py
+++ b/src/services/stats_task_dispatcher.py
@@ -17,24 +17,29 @@ logger = logging.getLogger(__name__)
 
 
 class _DatabaseChannelsAdapter:
-    _ATTR_MAP = {
+    _RENAMES = {
         "get_by_channel_id": "get_channel_by_channel_id",
-        "get_collection_task": "get_collection_task",
-        "update_collection_task": "update_collection_task",
-        "update_collection_task_progress": "update_collection_task_progress",
-        "requeue_running_stats_tasks_on_startup": "requeue_running_stats_tasks_on_startup",
-        "claim_next_due_stats_task": "claim_next_due_stats_task",
-        "create_stats_continuation_task": "create_stats_continuation_task",
+    }
+    _ALLOWED = {
+        "get_collection_task",
+        "update_collection_task",
+        "update_collection_task_progress",
+        "requeue_running_stats_tasks_on_startup",
+        "claim_next_due_stats_task",
+        "create_stats_continuation_task",
     }
 
     def __init__(self, db: Database):
         self._db = db
 
     def __getattr__(self, name: str):
-        target = self._ATTR_MAP.get(name)
-        if target is None:
+        if name in self._RENAMES:
+            return getattr(self._db, self._RENAMES[name])
+        if name in self._ALLOWED:
+            return getattr(self._db, name)
+        if name not in self._RENAMES and name not in self._ALLOWED:
             raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
-        return getattr(self._db, target)
+        raise AssertionError("unreachable")
 
 
 class StatsTaskDispatcher:

--- a/src/services/stats_task_dispatcher.py
+++ b/src/services/stats_task_dispatcher.py
@@ -17,20 +17,23 @@ logger = logging.getLogger(__name__)
 
 
 class _DatabaseChannelsAdapter:
+    _ATTR_MAP = {
+        "get_by_channel_id": "get_channel_by_channel_id",
+        "get_collection_task": "get_collection_task",
+        "update_collection_task": "update_collection_task",
+        "update_collection_task_progress": "update_collection_task_progress",
+        "requeue_running_stats_tasks_on_startup": "requeue_running_stats_tasks_on_startup",
+        "claim_next_due_stats_task": "claim_next_due_stats_task",
+        "create_stats_continuation_task": "create_stats_continuation_task",
+    }
+
     def __init__(self, db: Database):
         self._db = db
 
     def __getattr__(self, name: str):
-        mapping = {
-            "get_by_channel_id": "get_channel_by_channel_id",
-            "get_collection_task": "get_collection_task",
-            "update_collection_task": "update_collection_task",
-            "update_collection_task_progress": "update_collection_task_progress",
-            "requeue_running_stats_tasks_on_startup": "requeue_running_stats_tasks_on_startup",
-            "claim_next_due_stats_task": "claim_next_due_stats_task",
-            "create_stats_continuation_task": "create_stats_continuation_task",
-        }
-        target = mapping.get(name, name)
+        target = self._ATTR_MAP.get(name)
+        if target is None:
+            raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
         return getattr(self._db, target)
 
 

--- a/src/services/stats_task_dispatcher.py
+++ b/src/services/stats_task_dispatcher.py
@@ -3,13 +3,35 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any
 
 from src.database import Database
-from src.models import CollectionTask
+from src.database.bundles import ChannelBundle
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    StatsAllTaskPayload,
+)
 from src.telegram.collector import Collector
 
 logger = logging.getLogger(__name__)
+
+
+class _DatabaseChannelsAdapter:
+    def __init__(self, db: Database):
+        self._db = db
+
+    def __getattr__(self, name: str):
+        mapping = {
+            "get_by_channel_id": "get_channel_by_channel_id",
+            "get_collection_task": "get_collection_task",
+            "update_collection_task": "update_collection_task",
+            "update_collection_task_progress": "update_collection_task_progress",
+            "requeue_running_stats_tasks_on_startup": "requeue_running_stats_tasks_on_startup",
+            "claim_next_due_stats_task": "claim_next_due_stats_task",
+            "create_stats_continuation_task": "create_stats_continuation_task",
+        }
+        target = mapping.get(name, name)
+        return getattr(self._db, target)
 
 
 class StatsTaskDispatcher:
@@ -18,14 +40,16 @@ class StatsTaskDispatcher:
     def __init__(
         self,
         collector: Collector,
-        db: Database,
+        channels: ChannelBundle | Database,
         *,
         default_batch_size: int = 20,
         poll_interval_sec: float = 1.0,
         channel_timeout_sec: float = 120.0,
     ):
         self._collector = collector
-        self._db = db
+        if isinstance(channels, Database):
+            channels = _DatabaseChannelsAdapter(channels)
+        self._channels = channels
         self._default_batch_size = default_batch_size
         self._poll_interval_sec = poll_interval_sec
         self._channel_timeout_sec = channel_timeout_sec
@@ -36,7 +60,7 @@ class StatsTaskDispatcher:
         if self._task and not self._task.done():
             return
         self._stop_event.clear()
-        recovered = await self._db.requeue_running_stats_tasks_on_startup(
+        recovered = await self._channels.requeue_running_stats_tasks_on_startup(
             datetime.now(timezone.utc)
         )
         if recovered:
@@ -61,7 +85,7 @@ class StatsTaskDispatcher:
                     await asyncio.sleep(self._poll_interval_sec)
                     continue
 
-                task = await self._db.claim_next_due_stats_task(datetime.now(timezone.utc))
+                task = await self._channels.claim_next_due_stats_task(datetime.now(timezone.utc))
                 if task is None:
                     await asyncio.sleep(self._poll_interval_sec)
                     continue
@@ -73,11 +97,11 @@ class StatsTaskDispatcher:
                 logger.exception("Stats dispatcher loop failure")
                 if task and task.id is not None:
                     try:
-                        fresh = await self._db.get_collection_task(task.id)
-                        if fresh and fresh.status == "running":
-                            await self._db.update_collection_task(
+                        fresh = await self._channels.get_collection_task(task.id)
+                        if fresh and fresh.status == CollectionTaskStatus.RUNNING:
+                            await self._channels.update_collection_task(
                                 task.id,
-                                "failed",
+                                CollectionTaskStatus.FAILED,
                                 messages_collected=fresh.messages_collected,
                                 error="Stats task failed with unexpected dispatcher error",
                             )
@@ -89,33 +113,20 @@ class StatsTaskDispatcher:
         if task.id is None:
             return
 
-        payload = task.payload or {}
-        if payload.get("task_kind") != "stats_all":
-            await self._db.update_collection_task(
-                task.id, "failed", error="Unsupported stats task payload"
+        payload = task.payload
+        if not isinstance(payload, StatsAllTaskPayload):
+            await self._channels.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Unsupported stats task payload",
             )
             return
 
-        raw_ids = payload.get("channel_ids")
-        if not isinstance(raw_ids, list):
-            await self._db.update_collection_task(
-                task.id, "failed", error="Missing channel snapshot for stats task"
-            )
-            return
-
-        channel_ids: list[int] = []
-        for value in raw_ids:
-            try:
-                channel_ids.append(int(value))
-            except (TypeError, ValueError):
-                continue
-
-        next_index = self._to_int(payload.get("next_index"), 0)
-        batch_size = max(1, self._to_int(payload.get("batch_size"), self._default_batch_size))
-        channels_ok = self._to_int(
-            payload.get("channels_ok"), task.messages_collected or 0
-        )
-        channels_err = self._to_int(payload.get("channels_err"), 0)
+        channel_ids = payload.channel_ids
+        next_index = payload.next_index
+        batch_size = max(1, payload.batch_size or self._default_batch_size)
+        channels_ok = payload.channels_ok or (task.messages_collected or 0)
+        channels_err = payload.channels_err
 
         logger.info(
             "Running stats task #%s: next_index=%d batch_size=%d total=%d",
@@ -126,8 +137,10 @@ class StatsTaskDispatcher:
         )
 
         if next_index >= len(channel_ids):
-            await self._db.update_collection_task(
-                task.id, "completed", messages_collected=channels_ok
+            await self._channels.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=channels_ok,
             )
             return
 
@@ -143,7 +156,7 @@ class StatsTaskDispatcher:
                 len(channel_ids),
                 channel_id,
             )
-            channel = await self._db.get_channel_by_channel_id(channel_id)
+            channel = await self._channels.get_by_channel_id(channel_id)
             if channel is None:
                 logger.warning(
                     "Stats task #%s: channel_id=%s not found, skipping",
@@ -190,14 +203,14 @@ class StatsTaskDispatcher:
                             channels_ok=channels_ok,
                             channels_err=channels_err,
                         )
-                        continuation_id = await self._db.create_stats_continuation_task(
+                        continuation_id = await self._channels.create_stats_continuation_task(
                             payload=continuation_payload,
                             run_after=availability.next_available_at_utc,
                             parent_task_id=task.id,
                         )
-                        await self._db.update_collection_task(
+                        await self._channels.update_collection_task(
                             task.id,
-                            "failed",
+                            CollectionTaskStatus.FAILED,
                             messages_collected=channels_ok,
                             error=(
                                 "Deferred to task "
@@ -212,9 +225,9 @@ class StatsTaskDispatcher:
                         "Stats task #%s failed: no active connected Telegram accounts",
                         task.id,
                     )
-                    await self._db.update_collection_task(
+                    await self._channels.update_collection_task(
                         task.id,
-                        "failed",
+                        CollectionTaskStatus.FAILED,
                         messages_collected=channels_ok,
                         error="No active connected Telegram accounts",
                     )
@@ -222,7 +235,7 @@ class StatsTaskDispatcher:
 
                 channels_ok += 1
                 cursor += 1
-                await self._db.update_collection_task_progress(task.id, channels_ok)
+                await self._channels.update_collection_task_progress(task.id, channels_ok)
                 logger.info(
                     "Stats task #%s: channel_id=%s done (ok=%d, err=%d)",
                     task.id,
@@ -242,7 +255,7 @@ class StatsTaskDispatcher:
                 channels_ok=channels_ok,
                 channels_err=channels_err,
             )
-            await self._db.create_stats_continuation_task(
+            await self._channels.create_stats_continuation_task(
                 payload=continuation_payload,
                 run_after=datetime.now(timezone.utc),
                 parent_task_id=task.id,
@@ -253,14 +266,18 @@ class StatsTaskDispatcher:
                 cursor,
                 len(channel_ids),
             )
-            await self._db.update_collection_task(
-                task.id, "completed", messages_collected=channels_ok
+            await self._channels.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=channels_ok,
             )
             return
 
         logger.info("Stats task #%s finished: processed all %d channels", task.id, len(channel_ids))
-        await self._db.update_collection_task(
-            task.id, "completed", messages_collected=channels_ok
+        await self._channels.update_collection_task(
+            task.id,
+            CollectionTaskStatus.COMPLETED,
+            messages_collected=channels_ok,
         )
 
     @staticmethod
@@ -271,19 +288,11 @@ class StatsTaskDispatcher:
         batch_size: int,
         channels_ok: int,
         channels_err: int,
-    ) -> dict[str, Any]:
-        return {
-            "task_kind": "stats_all",
-            "channel_ids": channel_ids,
-            "next_index": next_index,
-            "batch_size": batch_size,
-            "channels_ok": channels_ok,
-            "channels_err": channels_err,
-        }
-
-    @staticmethod
-    def _to_int(value: Any, fallback: int) -> int:
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return fallback
+    ) -> StatsAllTaskPayload:
+        return StatsAllTaskPayload(
+            channel_ids=channel_ids,
+            next_index=next_index,
+            batch_size=batch_size,
+            channels_ok=channels_ok,
+            channels_err=channels_err,
+        )

--- a/src/services/stats_task_dispatcher.py
+++ b/src/services/stats_task_dispatcher.py
@@ -37,9 +37,7 @@ class _DatabaseChannelsAdapter:
             return getattr(self._db, self._RENAMES[name])
         if name in self._ALLOWED:
             return getattr(self._db, name)
-        if name not in self._RENAMES and name not in self._ALLOWED:
-            raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
-        raise AssertionError("unreachable")
+        raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
 
 
 class StatsTaskDispatcher:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -27,7 +27,6 @@ from telethon.tl.types import (
 
 from src.config import SchedulerConfig
 from src.database import Database
-from src.database.bundles import CollectionBundle
 from src.filters.criteria import (
     LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD,
     LOW_SUBSCRIBER_RATIO_THRESHOLD,
@@ -64,7 +63,7 @@ class Collector:
     def __init__(
         self,
         pool: ClientPool,
-        db: Database | CollectionBundle,
+        db: Database,
         config: SchedulerConfig,
         notifier: Notifier | None = None,
     ):

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -27,6 +27,7 @@ from telethon.tl.types import (
 
 from src.config import SchedulerConfig
 from src.database import Database
+from src.database.bundles import CollectionBundle
 from src.filters.criteria import (
     LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD,
     LOW_SUBSCRIBER_RATIO_THRESHOLD,
@@ -63,7 +64,7 @@ class Collector:
     def __init__(
         self,
         pool: ClientPool,
-        db: Database,
+        db: Database | CollectionBundle,
         config: SchedulerConfig,
         notifier: Notifier | None = None,
     ):

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -12,7 +12,6 @@ from starlette.responses import Response
 
 from src.config import AppConfig, load_config
 from src.web.assembly import (
-    TEMPLATES_DIR,
     build_log_buffer,
     configure_app,
     register_builtin_endpoints,
@@ -20,6 +19,7 @@ from src.web.assembly import (
 )
 from src.web.bootstrap import build_container_with_templates, start_container, stop_container
 from src.web.csrf import OriginCSRFMiddleware, is_secure_request
+from src.web.paths import TEMPLATES_DIR
 from src.web.session import (
     COOKIE_MAX_AGE,
     COOKIE_NAME,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -10,8 +10,13 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from src.config import AppConfig, load_config
-from src.web.assembly import build_log_buffer, configure_app, register_builtin_endpoints, register_routes
-from src.web.bootstrap import build_container, stop_container, start_container
+from src.web.assembly import (
+    build_log_buffer,
+    configure_app,
+    register_builtin_endpoints,
+    register_routes,
+)
+from src.web.bootstrap import build_container, start_container, stop_container
 from src.web.csrf import OriginCSRFMiddleware, is_secure_request
 from src.web.session import (
     COOKIE_MAX_AGE,

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -18,7 +18,7 @@ from src.web.assembly import (
     register_builtin_endpoints,
     register_routes,
 )
-from src.web.bootstrap import build_container, start_container, stop_container
+from src.web.bootstrap import build_container_with_templates, start_container, stop_container
 from src.web.csrf import OriginCSRFMiddleware, is_secure_request
 from src.web.session import (
     COOKIE_MAX_AGE,
@@ -82,7 +82,11 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    container = await build_container(app.state.config, log_buffer=app.state.log_buffer)
+    container = await build_container_with_templates(
+        app.state.config,
+        log_buffer=app.state.log_buffer,
+        templates=app.state.templates,
+    )
     configure_app(app, container)
     logger.info("Application started")
     try:

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -6,11 +6,13 @@ import secrets
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from src.config import AppConfig, load_config
 from src.web.assembly import (
+    TEMPLATES_DIR,
     build_log_buffer,
     configure_app,
     register_builtin_endpoints,
@@ -99,6 +101,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app = FastAPI(title="TG Post Search", lifespan=lifespan)
     app.state.config = config
     app.state.log_buffer = build_log_buffer()
+    app.state.templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
     configure_app(app, None)
 
     if config.web.password:

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1,32 +1,17 @@
 from __future__ import annotations
 
-import asyncio
 import base64
 import logging
 import secrets
 from contextlib import asynccontextmanager
-from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
+from fastapi import FastAPI
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig, load_config, resolve_session_encryption_secret
-from src.database import Database
-from src.scheduler.manager import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.services.notification_target_service import NotificationTargetService
-from src.services.stats_task_dispatcher import StatsTaskDispatcher
-from src.settings_utils import parse_int_setting
-from src.telegram.auth import TelegramAuth
-from src.telegram.client_pool import ClientPool
-from src.telegram.collector import Collector
-from src.telegram.notifier import Notifier
+from src.config import AppConfig, load_config
+from src.web.assembly import build_log_buffer, configure_app, register_builtin_endpoints, register_routes
+from src.web.bootstrap import build_container, stop_container, start_container
 from src.web.csrf import OriginCSRFMiddleware, is_secure_request
 from src.web.session import (
     COOKIE_MAX_AGE,
@@ -49,27 +34,26 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
         if request.url.path in ("/health", "/logout"):
             return await call_next(request)
 
-        # 1. Check session cookie
-        cookie = request.cookies.get(COOKIE_NAME)
-        if cookie:
-            secret = getattr(request.app.state, "session_secret", None)
-            if secret:
-                cookie_user = verify_session_token(cookie, secret)
-                if cookie_user and cookie_user == self._USERNAME:
-                    return await call_next(request)
+        container = getattr(request.app.state, "container", None)
+        secret = getattr(container, "session_secret", None) or getattr(
+            request.app.state, "session_secret", None
+        )
 
-        # 2. Fallback to Basic Auth — only password is checked
+        cookie = request.cookies.get(COOKIE_NAME)
+        if cookie and secret:
+            cookie_user = verify_session_token(cookie, secret)
+            if cookie_user and cookie_user == self._USERNAME:
+                return await call_next(request)
+
         auth = request.headers.get("Authorization", "")
         if auth.startswith("Basic "):
             try:
                 decoded = base64.b64decode(auth[6:]).decode()
             except Exception:
                 decoded = ""
-            # Accept any username (or empty), only match password
             _, _, pwd = decoded.partition(":")
             if secrets.compare_digest(pwd, self.password):
                 response = await call_next(request)
-                secret = getattr(request.app.state, "session_secret", None)
                 if secret:
                     token = create_session_token(self._USERNAME, secret)
                     response.set_cookie(
@@ -88,130 +72,18 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
             headers={"WWW-Authenticate": "Basic realm='TG Post Search'"},
         )
 
-WEB_DIR = Path(__file__).parent
-TEMPLATES_DIR = WEB_DIR / "templates"
-STATIC_DIR = WEB_DIR / "static"
-
-
-async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
-    for task in list(tasks):
-        task.cancel()
-    if tasks:
-        await asyncio.gather(*tasks, return_exceptions=True)
-    tasks.clear()
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    config: AppConfig = app.state.config
-
-    # Database
-    db = Database(
-        config.database.path,
-        session_encryption_secret=resolve_session_encryption_secret(config),
-    )
-    await db.initialize()
-    recovered = await db.fail_running_collection_tasks_on_startup()
-    if recovered:
-        logger.warning("Marked %d interrupted collection tasks as failed on startup", recovered)
-    app.state.db = db
-
-    # Session secret key
-    session_secret = await db.get_setting("session_secret_key")
-    if not session_secret:
-        session_secret = secrets.token_hex(32)
-        await db.set_setting("session_secret_key", session_secret)
-    app.state.session_secret = session_secret
-
-    # Telegram auth — try config, then DB settings
-    api_id = config.telegram.api_id
-    api_hash = config.telegram.api_hash
-    if api_id == 0 or not api_hash:
-        stored_id = await db.get_setting("tg_api_id")
-        stored_hash = await db.get_setting("tg_api_hash")
-        if stored_id and stored_hash:
-            api_id = parse_int_setting(
-                stored_id,
-                setting_name="tg_api_id",
-                default=0,
-                logger=logger,
-            )
-            api_hash = stored_hash
-
-    auth = TelegramAuth(api_id, api_hash)
-    app.state.auth = auth
-
-    # Client pool
-    pool = ClientPool(auth, db, config.scheduler.max_flood_wait_sec)
-    if auth.is_configured:
-        await pool.initialize()
-    app.state.pool = pool
-
-    # Notification account selection + notifier
-    notification_target_service = NotificationTargetService(db, pool)
-    app.state.notification_target_service = notification_target_service
-
-    notifier = Notifier(notification_target_service, config.notifications.admin_chat_id)
-    app.state.notifier = notifier
-
-    # Collector
-    collector = Collector(pool, db, config.scheduler, notifier)
-    app.state.collector = collector
-
-    # Collection queue
-    collection_queue = CollectionQueue(collector, db)
-    requeued = await collection_queue.requeue_startup_tasks()
-    if requeued:
-        logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
-    app.state.collection_queue = collection_queue
-
-    # Deferred stats dispatcher
-    stats_dispatcher = StatsTaskDispatcher(collector, db, default_batch_size=20)
-    await stats_dispatcher.start()
-    app.state.stats_dispatcher = stats_dispatcher
-
-    # Search engines
-    search_engine = SearchEngine(db, pool)
-    app.state.search_engine = search_engine
-
-    ai_search = AISearchEngine(config.llm, db)
-    ai_search.initialize()
-    app.state.ai_search = ai_search
-
-    # Scheduler
-    scheduler = SchedulerManager(
-        collector, config.scheduler, search_engine=search_engine, db=db,
-    )
-    app.state.scheduler = scheduler
-
-    # Background task tracking
-    bg_tasks: set[asyncio.Task] = set()
-    app.state.bg_tasks = bg_tasks
-
-    app.state.shutting_down = False
-
+    container = await build_container(app.state.config, log_buffer=app.state.log_buffer)
+    configure_app(app, container)
     logger.info("Application started")
     try:
+        await start_container(container)
         yield
     finally:
-        app.state.shutting_down = True
         logger.info("Shutting down...")
-        for name, coro in [
-            ("stats_dispatcher", stats_dispatcher.stop()),
-            ("scheduler", scheduler.stop()),
-            ("collector", collector.cancel()),
-            ("collection_queue", collection_queue.shutdown()),
-            ("bg_tasks", _cancel_bg_tasks(bg_tasks)),
-            ("pool", pool.disconnect_all()),
-            ("auth", auth.cleanup()),
-            ("db", db.close()),
-        ]:
-            try:
-                await asyncio.wait_for(coro, timeout=5.0)
-            except asyncio.TimeoutError:
-                logger.warning("Shutdown of %s timed out", name)
-            except Exception:
-                logger.warning("Error shutting down %s", name, exc_info=True)
+        await stop_container(container)
         logger.info("Application shut down")
 
 
@@ -221,84 +93,13 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
 
     app = FastAPI(title="TG Post Search", lifespan=lifespan)
     app.state.config = config
-
-    from src.web.log_handler import LogBuffer
-    log_buffer = LogBuffer(maxlen=500)
-    log_buffer.setFormatter(logging.Formatter("%(message)s"))
-    logging.getLogger().addHandler(log_buffer)
-    app.state.log_buffer = log_buffer
+    app.state.log_buffer = build_log_buffer()
+    configure_app(app, None)
 
     if config.web.password:
-        app.add_middleware(
-            BasicAuthMiddleware,
-            password=config.web.password,
-        )
+        app.add_middleware(BasicAuthMiddleware, password=config.web.password)
     app.add_middleware(OriginCSRFMiddleware)
 
-    # Static files
-    if STATIC_DIR.exists():
-        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
-
-    # Templates
-    app.state.templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
-
-    # Health check
-    @app.get("/health")
-    async def health_check(request: Request):
-        db_ok = False
-        try:
-            await request.app.state.db.execute("SELECT 1")
-            db_ok = True
-        except Exception:
-            pass
-        accounts_connected = len(request.app.state.pool.clients)
-        status = "healthy" if db_ok else "degraded"
-        return JSONResponse(
-            {"status": status, "db": db_ok, "accounts_connected": accounts_connected}
-        )
-
-    # Logout
-    @app.get("/logout")
-    async def logout():
-        html = (
-            "<!DOCTYPE html><html lang='ru'><head><meta charset='UTF-8'>"
-            "<title>Выход</title>"
-            "<link rel='stylesheet' "
-            "href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css'>"
-            "</head><body><main class='container' style='text-align:center;margin-top:20vh'>"
-            "<h2>Вы вышли из системы</h2>"
-            "<p><a href='/'>Войти снова</a></p>"
-            "</main></body></html>"
-        )
-        response = Response(content=html, status_code=401, media_type="text/html")
-        response.delete_cookie(COOKIE_NAME)
-        return response
-
-    # Register routes
-    from src.web.routes.auth import router as auth_router
-    from src.web.routes.channel_collection import router as channel_collection_router
-    from src.web.routes.channels import router as channels_router
-    from src.web.routes.dashboard import router as dashboard_router
-    from src.web.routes.debug import router as debug_router
-    from src.web.routes.filter import router as filter_router
-    from src.web.routes.import_channels import router as import_router
-    from src.web.routes.keywords import router as keywords_router
-    from src.web.routes.my_telegram import router as my_telegram_router
-    from src.web.routes.scheduler import router as scheduler_router
-    from src.web.routes.search import router as search_router
-    from src.web.routes.settings import router as settings_router
-
-    app.include_router(search_router)
-    app.include_router(dashboard_router, prefix="/dashboard")
-    app.include_router(auth_router, prefix="/auth")
-    app.include_router(channels_router, prefix="/channels")
-    app.include_router(filter_router, prefix="/channels")
-    app.include_router(keywords_router, prefix="/keywords")
-    app.include_router(channel_collection_router, prefix="/channels")
-    app.include_router(import_router, prefix="/channels")
-    app.include_router(scheduler_router, prefix="/scheduler")
-    app.include_router(settings_router, prefix="/settings")
-    app.include_router(my_telegram_router, prefix="/my-telegram")
-    app.include_router(debug_router, prefix="/debug")
-
+    register_builtin_endpoints(app)
+    register_routes(app)
     return app

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -4,9 +4,9 @@ import logging
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.templating import Jinja2Templates
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from starlette.responses import Response
 
 from src.web.container import AppContainer
@@ -21,6 +21,16 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
     if container is not None:
         app.state.container = container
         app.state.templates = container.templates
+        # Expose frequently accessed attributes for backward compat with
+        # code that reads app.state.<attr> directly (routes, tests).
+        app.state.db = container.db
+        app.state.auth = container.auth
+        app.state.pool = container.pool
+        app.state.collector = container.collector
+        app.state.search_engine = container.search_engine
+        app.state.ai_search = container.ai_search
+        app.state.scheduler = container.scheduler
+        app.state.session_secret = container.session_secret
     elif not hasattr(app.state, "templates"):
         app.state.templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
     if STATIC_DIR.exists():

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+from starlette.responses import Response
+
+from src.web.container import AppContainer
+from src.web.session import COOKIE_NAME
+
+WEB_DIR = Path(__file__).parent
+STATIC_DIR = WEB_DIR / "static"
+TEMPLATES_DIR = WEB_DIR / "templates"
+
+
+def configure_app(app: FastAPI, container: AppContainer | None) -> None:
+    if container is not None:
+        app.state.container = container
+        app.state.templates = container.templates
+    elif not hasattr(app.state, "templates"):
+        app.state.templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    if STATIC_DIR.exists():
+        mount_names = {route.name for route in app.routes}
+        if "static" not in mount_names:
+            app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+def register_builtin_endpoints(app: FastAPI) -> None:
+    @app.get("/health")
+    async def health_check(request: Request):
+        container = getattr(request.app.state, "container", None)
+        if container is None:
+            from src.web import deps
+
+            container = deps.get_container(request)
+        db_ok = False
+        try:
+            await container.db.execute("SELECT 1")
+            db_ok = True
+        except Exception:
+            pass
+        accounts_connected = len(container.pool.clients)
+        status = "healthy" if db_ok else "degraded"
+        return JSONResponse(
+            {"status": status, "db": db_ok, "accounts_connected": accounts_connected}
+        )
+
+    @app.get("/logout")
+    async def logout():
+        html = (
+            "<!DOCTYPE html><html lang='ru'><head><meta charset='UTF-8'>"
+            "<title>Выход</title>"
+            "<link rel='stylesheet' "
+            "href='https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css'>"
+            "</head><body><main class='container' style='text-align:center;margin-top:20vh'>"
+            "<h2>Вы вышли из системы</h2>"
+            "<p><a href='/'>Войти снова</a></p>"
+            "</main></body></html>"
+        )
+        response = Response(content=html, status_code=401, media_type="text/html")
+        response.delete_cookie(COOKIE_NAME)
+        return response
+
+
+def register_routes(app: FastAPI) -> None:
+    from src.web.routes.auth import router as auth_router
+    from src.web.routes.channel_collection import router as channel_collection_router
+    from src.web.routes.channels import router as channels_router
+    from src.web.routes.dashboard import router as dashboard_router
+    from src.web.routes.debug import router as debug_router
+    from src.web.routes.filter import router as filter_router
+    from src.web.routes.import_channels import router as import_router
+    from src.web.routes.keywords import router as keywords_router
+    from src.web.routes.my_telegram import router as my_telegram_router
+    from src.web.routes.scheduler import router as scheduler_router
+    from src.web.routes.search import router as search_router
+    from src.web.routes.settings import router as settings_router
+
+    app.include_router(search_router)
+    app.include_router(dashboard_router, prefix="/dashboard")
+    app.include_router(auth_router, prefix="/auth")
+    app.include_router(channels_router, prefix="/channels")
+    app.include_router(filter_router, prefix="/channels")
+    app.include_router(keywords_router, prefix="/keywords")
+    app.include_router(channel_collection_router, prefix="/channels")
+    app.include_router(import_router, prefix="/channels")
+    app.include_router(scheduler_router, prefix="/scheduler")
+    app.include_router(settings_router, prefix="/settings")
+    app.include_router(my_telegram_router, prefix="/my-telegram")
+    app.include_router(debug_router, prefix="/debug")
+
+
+def build_log_buffer() -> logging.Handler:
+    from src.web.log_handler import LogBuffer
+
+    log_buffer = LogBuffer(maxlen=500)
+    log_buffer.setFormatter(logging.Formatter("%(message)s"))
+    logging.getLogger().addHandler(log_buffer)
+    return log_buffer

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -10,11 +8,8 @@ from fastapi.templating import Jinja2Templates
 from starlette.responses import Response
 
 from src.web.container import AppContainer
+from src.web.paths import STATIC_DIR, TEMPLATES_DIR
 from src.web.session import COOKIE_NAME
-
-WEB_DIR = Path(__file__).parent
-STATIC_DIR = WEB_DIR / "static"
-TEMPLATES_DIR = WEB_DIR / "templates"
 
 
 def configure_app(app: FastAPI, container: AppContainer | None) -> None:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -96,7 +96,7 @@ async def build_container(config: AppConfig, *, log_buffer: LogBuffer) -> AppCon
     pool = ClientPool(auth, db, config.scheduler.max_flood_wait_sec)
     notification_target_service = NotificationTargetService(notification_bundle, pool)
     notifier = Notifier(notification_target_service, config.notifications.admin_chat_id)
-    collector = Collector(pool, collection_bundle, config.scheduler, notifier)
+    collector = Collector(pool, db, config.scheduler, notifier)
     collection_queue = CollectionQueue(collector, channel_bundle)
     stats_dispatcher = StatsTaskDispatcher(collector, channel_bundle, default_batch_size=20)
     search_engine = SearchEngine(search_bundle, pool)

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from pathlib import Path
+
+from fastapi.templating import Jinja2Templates
+
+from src.collection_queue import CollectionQueue
+from src.config import AppConfig, resolve_session_encryption_secret
+from src.database import Database
+from src.database.bundles import (
+    AccountBundle,
+    ChannelBundle,
+    CollectionBundle,
+    NotificationBundle,
+    SchedulerBundle,
+    SearchBundle,
+)
+from src.scheduler.manager import SchedulerManager
+from src.search.ai_search import AISearchEngine
+from src.search.engine import SearchEngine
+from src.services.notification_target_service import NotificationTargetService
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.settings_utils import parse_int_setting
+from src.telegram.auth import TelegramAuth
+from src.telegram.client_pool import ClientPool
+from src.telegram.collector import Collector
+from src.telegram.notifier import Notifier
+from src.web.container import AppContainer
+from src.web.log_handler import LogBuffer
+
+logger = logging.getLogger(__name__)
+
+WEB_DIR = Path(__file__).parent
+TEMPLATES_DIR = WEB_DIR / "templates"
+
+
+async def load_telegram_credentials(db: Database, config: AppConfig) -> tuple[int, str]:
+    api_id = config.telegram.api_id
+    api_hash = config.telegram.api_hash
+    if api_id == 0 or not api_hash:
+        stored_id = await db.get_setting("tg_api_id")
+        stored_hash = await db.get_setting("tg_api_hash")
+        if stored_id and stored_hash:
+            api_id = parse_int_setting(
+                stored_id,
+                setting_name="tg_api_id",
+                default=0,
+                logger=logger,
+            )
+            api_hash = stored_hash
+    return api_id, api_hash
+
+
+async def build_container(config: AppConfig, *, log_buffer: LogBuffer) -> AppContainer:
+    db = Database(
+        config.database.path,
+        session_encryption_secret=resolve_session_encryption_secret(config),
+    )
+    await db.initialize()
+
+    repos = db.repos
+    account_bundle = AccountBundle(repos.accounts)
+    channel_bundle = ChannelBundle(repos.channels, repos.channel_stats, repos.tasks)
+    collection_bundle = CollectionBundle(
+        repos.channels,
+        repos.messages,
+        repos.filters,
+        repos.settings,
+        repos.keywords,
+        repos.tasks,
+        repos.channel_stats,
+    )
+    notification_bundle = NotificationBundle(
+        repos.accounts,
+        repos.settings,
+        repos.notification_bots,
+    )
+    search_bundle = SearchBundle(repos.messages, repos.search_log, repos.channels)
+    scheduler_bundle = SchedulerBundle(
+        repos.settings,
+        repos.keywords,
+        repos.tasks,
+        repos.search_log,
+    )
+
+    session_secret = await db.get_setting("session_secret_key")
+    if not session_secret:
+        session_secret = secrets.token_hex(32)
+        await db.set_setting("session_secret_key", session_secret)
+
+    api_id, api_hash = await load_telegram_credentials(db, config)
+    auth = TelegramAuth(api_id, api_hash)
+    pool = ClientPool(auth, db, config.scheduler.max_flood_wait_sec)
+    notification_target_service = NotificationTargetService(notification_bundle, pool)
+    notifier = Notifier(notification_target_service, config.notifications.admin_chat_id)
+    collector = Collector(pool, collection_bundle, config.scheduler, notifier)
+    collection_queue = CollectionQueue(collector, channel_bundle)
+    stats_dispatcher = StatsTaskDispatcher(collector, channel_bundle, default_batch_size=20)
+    search_engine = SearchEngine(search_bundle, pool)
+    ai_search = AISearchEngine(config.llm, search_bundle)
+    scheduler = SchedulerManager(
+        collector,
+        config.scheduler,
+        scheduler_bundle=scheduler_bundle,
+        search_engine=search_engine,
+    )
+
+    return AppContainer(
+        config=config,
+        db=db,
+        repos=repos,
+        account_bundle=account_bundle,
+        channel_bundle=channel_bundle,
+        collection_bundle=collection_bundle,
+        notification_bundle=notification_bundle,
+        search_bundle=search_bundle,
+        scheduler_bundle=scheduler_bundle,
+        auth=auth,
+        pool=pool,
+        notification_target_service=notification_target_service,
+        notifier=notifier,
+        collector=collector,
+        collection_queue=collection_queue,
+        stats_dispatcher=stats_dispatcher,
+        search_engine=search_engine,
+        ai_search=ai_search,
+        scheduler=scheduler,
+        templates=Jinja2Templates(directory=str(TEMPLATES_DIR)),
+        log_buffer=log_buffer,
+        session_secret=session_secret,
+        bg_tasks=set(),
+        shutting_down=False,
+    )
+
+
+async def start_container(container: AppContainer) -> None:
+    recovered = await container.channel_bundle.fail_running_collection_tasks_on_startup()
+    if recovered:
+        logger.warning("Marked %d interrupted collection tasks as failed on startup", recovered)
+
+    if container.auth.is_configured:
+        await container.pool.initialize()
+
+    requeued = await container.collection_queue.requeue_startup_tasks()
+    if requeued:
+        logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
+
+    await container.stats_dispatcher.start()
+    container.ai_search.initialize()
+
+
+async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
+    for task in list(tasks):
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    tasks.clear()
+
+
+async def stop_container(container: AppContainer) -> None:
+    container.shutting_down = True
+    for name, coro in [
+        ("stats_dispatcher", container.stats_dispatcher.stop()),
+        ("scheduler", container.scheduler.stop()),
+        ("collector", container.collector.cancel()),
+        ("collection_queue", container.collection_queue.shutdown()),
+        ("bg_tasks", _cancel_bg_tasks(container.bg_tasks)),
+        ("pool", container.pool.disconnect_all()),
+        ("auth", container.auth.cleanup()),
+        ("db", container.db.close()),
+    ]:
+        try:
+            await asyncio.wait_for(coro, timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning("Shutdown of %s timed out", name)
+        except Exception:
+            logger.warning("Error shutting down %s", name, exc_info=True)

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -55,6 +55,15 @@ async def load_telegram_credentials(db: Database, config: AppConfig) -> tuple[in
 
 
 async def build_container(config: AppConfig, *, log_buffer: LogBuffer) -> AppContainer:
+    return await build_container_with_templates(config, log_buffer=log_buffer, templates=None)
+
+
+async def build_container_with_templates(
+    config: AppConfig,
+    *,
+    log_buffer: LogBuffer,
+    templates: Jinja2Templates | None,
+) -> AppContainer:
     db = Database(
         config.database.path,
         session_encryption_secret=resolve_session_encryption_secret(config),
@@ -128,7 +137,7 @@ async def build_container(config: AppConfig, *, log_buffer: LogBuffer) -> AppCon
         search_engine=search_engine,
         ai_search=ai_search,
         scheduler=scheduler,
-        templates=Jinja2Templates(directory=str(TEMPLATES_DIR)),
+        templates=templates or Jinja2Templates(directory=str(TEMPLATES_DIR)),
         log_buffer=log_buffer,
         session_secret=session_secret,
         bg_tasks=set(),
@@ -144,11 +153,13 @@ async def start_container(container: AppContainer) -> None:
     if container.auth.is_configured:
         await container.pool.initialize()
 
-    requeued = await container.collection_queue.requeue_startup_tasks()
-    if requeued:
-        logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
+    if container.collection_queue is not None:
+        requeued = await container.collection_queue.requeue_startup_tasks()
+        if requeued:
+            logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
 
-    await container.stats_dispatcher.start()
+    if container.stats_dispatcher is not None:
+        await container.stats_dispatcher.start()
     container.ai_search.initialize()
 
 
@@ -162,16 +173,20 @@ async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
 
 async def stop_container(container: AppContainer) -> None:
     container.shutting_down = True
-    for name, coro in [
-        ("stats_dispatcher", container.stats_dispatcher.stop()),
+    shutdown_coroutines = []
+    if container.stats_dispatcher is not None:
+        shutdown_coroutines.append(("stats_dispatcher", container.stats_dispatcher.stop()))
+    if container.collection_queue is not None:
+        shutdown_coroutines.append(("collection_queue", container.collection_queue.shutdown()))
+    shutdown_coroutines.extend([
         ("scheduler", container.scheduler.stop()),
         ("collector", container.collector.cancel()),
-        ("collection_queue", container.collection_queue.shutdown()),
         ("bg_tasks", _cancel_bg_tasks(container.bg_tasks)),
         ("pool", container.pool.disconnect_all()),
         ("auth", container.auth.cleanup()),
         ("db", container.db.close()),
-    ]:
+    ])
+    for name, coro in shutdown_coroutines:
         try:
             await asyncio.wait_for(coro, timeout=5.0)
         except asyncio.TimeoutError:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
-from pathlib import Path
 
 from fastapi.templating import Jinja2Templates
 
@@ -30,11 +29,9 @@ from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
+from src.web.paths import TEMPLATES_DIR
 
 logger = logging.getLogger(__name__)
-
-WEB_DIR = Path(__file__).parent
-TEMPLATES_DIR = WEB_DIR / "templates"
 
 
 async def load_telegram_credentials(db: Database, config: AppConfig) -> tuple[int, str]:

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from fastapi.templating import Jinja2Templates
+
+from src.collection_queue import CollectionQueue
+from src.config import AppConfig
+from src.database import Database
+from src.database.bundles import (
+    AccountBundle,
+    ChannelBundle,
+    CollectionBundle,
+    DatabaseRepositories,
+    NotificationBundle,
+    SchedulerBundle,
+    SearchBundle,
+)
+from src.scheduler.manager import SchedulerManager
+from src.search.ai_search import AISearchEngine
+from src.search.engine import SearchEngine
+from src.services.notification_target_service import NotificationTargetService
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.telegram.auth import TelegramAuth
+from src.telegram.client_pool import ClientPool
+from src.telegram.collector import Collector
+from src.telegram.notifier import Notifier
+from src.web.log_handler import LogBuffer
+
+
+@dataclass(slots=True)
+class AppContainer:
+    config: AppConfig
+    db: Database
+    repos: DatabaseRepositories
+    account_bundle: AccountBundle
+    channel_bundle: ChannelBundle
+    collection_bundle: CollectionBundle
+    notification_bundle: NotificationBundle
+    search_bundle: SearchBundle
+    scheduler_bundle: SchedulerBundle
+    auth: TelegramAuth
+    pool: ClientPool
+    notification_target_service: NotificationTargetService
+    notifier: Notifier
+    collector: Collector
+    collection_queue: CollectionQueue
+    stats_dispatcher: StatsTaskDispatcher
+    search_engine: SearchEngine
+    ai_search: AISearchEngine
+    scheduler: SchedulerManager
+    templates: Jinja2Templates
+    log_buffer: LogBuffer
+    session_secret: str
+    bg_tasks: set[asyncio.Task]
+    shutting_down: bool = False

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -43,15 +43,15 @@ class AppContainer:
     auth: TelegramAuth
     pool: ClientPool
     notification_target_service: NotificationTargetService
-    notifier: Notifier
+    notifier: Notifier | None
     collector: Collector
-    collection_queue: CollectionQueue
-    stats_dispatcher: StatsTaskDispatcher
+    collection_queue: CollectionQueue | None
+    stats_dispatcher: StatsTaskDispatcher | None
     search_engine: SearchEngine
     ai_search: AISearchEngine
     scheduler: SchedulerManager
     templates: Jinja2Templates
-    log_buffer: LogBuffer
+    log_buffer: LogBuffer | None
     session_secret: str
     bg_tasks: set[asyncio.Task]
     shutting_down: bool = False

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -77,6 +77,9 @@ def get_container(request: Request) -> AppContainer:
             notification_bundle,
             _require_app_state_attr(request, "pool"),
         )
+    templates = getattr(request.app.state, "templates", None)
+    if templates is None:
+        templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
     container = AppContainer(
         config=_require_app_state_attr(request, "config"),
         db=db,
@@ -97,11 +100,7 @@ def get_container(request: Request) -> AppContainer:
         search_engine=_require_app_state_attr(request, "search_engine"),
         ai_search=_require_app_state_attr(request, "ai_search"),
         scheduler=_require_app_state_attr(request, "scheduler"),
-        templates=getattr(
-            request.app.state,
-            "templates",
-            Jinja2Templates(directory=str(TEMPLATES_DIR)),
-        ),
+        templates=templates,
         log_buffer=getattr(request.app.state, "log_buffer", None),
         session_secret=_require_app_state_attr(request, "session_secret"),
         bg_tasks=getattr(request.app.state, "bg_tasks", set()),

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -32,9 +32,9 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
-from src.web.bootstrap import TEMPLATES_DIR
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
+from src.web.paths import TEMPLATES_DIR
 
 T = TypeVar("T")
 _MISSING = object()

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -47,12 +47,19 @@ def _request_cached(request: Request, key: str, factory: Callable[[], T]) -> T:
     return value
 
 
+def _require_app_state_attr(request: Request, name: str):
+    value = getattr(request.app.state, name, None)
+    if value is None:
+        raise RuntimeError(f"Application state is missing required attribute: {name}")
+    return value
+
+
 def get_container(request: Request) -> AppContainer:
     container = getattr(request.app.state, "container", None)
     if container is not None:
         return container
 
-    db = request.app.state.db
+    db = _require_app_state_attr(request, "db")
     repos = db.repos
     account_bundle = AccountBundle.from_database(db)
     channel_bundle = ChannelBundle.from_database(db)
@@ -61,7 +68,7 @@ def get_container(request: Request) -> AppContainer:
     search_bundle = SearchBundle.from_database(db)
     scheduler_bundle = SchedulerBundle.from_database(db)
     return AppContainer(
-        config=request.app.state.config,
+        config=_require_app_state_attr(request, "config"),
         db=db,
         repos=repos,
         account_bundle=account_bundle,
@@ -70,27 +77,27 @@ def get_container(request: Request) -> AppContainer:
         notification_bundle=notification_bundle,
         search_bundle=search_bundle,
         scheduler_bundle=scheduler_bundle,
-        auth=request.app.state.auth,
-        pool=request.app.state.pool,
+        auth=_require_app_state_attr(request, "auth"),
+        pool=_require_app_state_attr(request, "pool"),
         notification_target_service=getattr(
             request.app.state,
             "notification_target_service",
-            NotificationTargetService(notification_bundle, request.app.state.pool),
+            NotificationTargetService(notification_bundle, _require_app_state_attr(request, "pool")),
         ),
         notifier=getattr(request.app.state, "notifier", None),
-        collector=request.app.state.collector,
+        collector=_require_app_state_attr(request, "collector"),
         collection_queue=getattr(request.app.state, "collection_queue", None),
         stats_dispatcher=getattr(request.app.state, "stats_dispatcher", None),
-        search_engine=request.app.state.search_engine,
-        ai_search=request.app.state.ai_search,
-        scheduler=request.app.state.scheduler,
+        search_engine=_require_app_state_attr(request, "search_engine"),
+        ai_search=_require_app_state_attr(request, "ai_search"),
+        scheduler=_require_app_state_attr(request, "scheduler"),
         templates=getattr(
             request.app.state,
             "templates",
             Jinja2Templates(directory=str(TEMPLATES_DIR)),
         ),
         log_buffer=getattr(request.app.state, "log_buffer", None),
-        session_secret=getattr(request.app.state, "session_secret", ""),
+        session_secret=_require_app_state_attr(request, "session_secret"),
         bg_tasks=getattr(request.app.state, "bg_tasks", set()),
         shutting_down=getattr(request.app.state, "shutting_down", False),
     )

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -71,6 +71,12 @@ def get_container(request: Request) -> AppContainer:
     notification_bundle = NotificationBundle.from_database(db)
     search_bundle = SearchBundle.from_database(db)
     scheduler_bundle = SchedulerBundle.from_database(db)
+    notification_target_service = getattr(request.app.state, "notification_target_service", None)
+    if notification_target_service is None:
+        notification_target_service = NotificationTargetService(
+            notification_bundle,
+            _require_app_state_attr(request, "pool"),
+        )
     container = AppContainer(
         config=_require_app_state_attr(request, "config"),
         db=db,
@@ -83,11 +89,7 @@ def get_container(request: Request) -> AppContainer:
         scheduler_bundle=scheduler_bundle,
         auth=_require_app_state_attr(request, "auth"),
         pool=_require_app_state_attr(request, "pool"),
-        notification_target_service=getattr(
-            request.app.state,
-            "notification_target_service",
-            NotificationTargetService(notification_bundle, _require_app_state_attr(request, "pool")),
-        ),
+        notification_target_service=notification_target_service,
         notifier=getattr(request.app.state, "notifier", None),
         collector=_require_app_state_attr(request, "collector"),
         collection_queue=getattr(request.app.state, "collection_queue", None),

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -37,11 +37,12 @@ from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
 
 T = TypeVar("T")
+_MISSING = object()
 
 
 def _request_cached(request: Request, key: str, factory: Callable[[], T]) -> T:
-    value = getattr(request.state, key, None)
-    if value is None:
+    value = getattr(request.state, key, _MISSING)
+    if value is _MISSING:
         value = factory()
         setattr(request.state, key, value)
     return value
@@ -58,6 +59,9 @@ def get_container(request: Request) -> AppContainer:
     container = getattr(request.app.state, "container", None)
     if container is not None:
         return container
+    cached = getattr(request.state, "_container", None)
+    if cached is not None:
+        return cached
 
     db = _require_app_state_attr(request, "db")
     repos = db.repos
@@ -67,7 +71,7 @@ def get_container(request: Request) -> AppContainer:
     notification_bundle = NotificationBundle.from_database(db)
     search_bundle = SearchBundle.from_database(db)
     scheduler_bundle = SchedulerBundle.from_database(db)
-    return AppContainer(
+    container = AppContainer(
         config=_require_app_state_attr(request, "config"),
         db=db,
         repos=repos,
@@ -101,6 +105,8 @@ def get_container(request: Request) -> AppContainer:
         bg_tasks=getattr(request.app.state, "bg_tasks", set()),
         shutting_down=getattr(request.app.state, "shutting_down", False),
     )
+    request.state._container = container
+    return container
 
 
 def get_db(request: Request) -> Database:

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -8,6 +8,14 @@ from fastapi.templating import Jinja2Templates
 
 from src.collection_queue import CollectionQueue
 from src.database import Database
+from src.database.bundles import (
+    AccountBundle,
+    ChannelBundle,
+    CollectionBundle,
+    NotificationBundle,
+    SchedulerBundle,
+    SearchBundle,
+)
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -15,13 +23,18 @@ from src.services.account_service import AccountService
 from src.services.channel_service import ChannelService
 from src.services.collection_service import CollectionService
 from src.services.keyword_service import KeywordService
+from src.services.notification_service import NotificationService
 from src.services.notification_target_service import NotificationTargetService
 from src.services.scheduler_service import SchedulerService
 from src.services.search_service import SearchService
+from src.services.stats_task_dispatcher import StatsTaskDispatcher
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
+from src.telegram.notifier import Notifier
+from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
+from src.web.bootstrap import TEMPLATES_DIR
 
 T = TypeVar("T")
 
@@ -34,71 +47,156 @@ def _request_cached(request: Request, key: str, factory: Callable[[], T]) -> T:
     return value
 
 
+def get_container(request: Request) -> AppContainer:
+    container = getattr(request.app.state, "container", None)
+    if container is not None:
+        return container
+
+    db = request.app.state.db
+    repos = db.repos
+    account_bundle = AccountBundle.from_database(db)
+    channel_bundle = ChannelBundle.from_database(db)
+    collection_bundle = CollectionBundle.from_database(db)
+    notification_bundle = NotificationBundle.from_database(db)
+    search_bundle = SearchBundle.from_database(db)
+    scheduler_bundle = SchedulerBundle.from_database(db)
+    return AppContainer(
+        config=request.app.state.config,
+        db=db,
+        repos=repos,
+        account_bundle=account_bundle,
+        channel_bundle=channel_bundle,
+        collection_bundle=collection_bundle,
+        notification_bundle=notification_bundle,
+        search_bundle=search_bundle,
+        scheduler_bundle=scheduler_bundle,
+        auth=request.app.state.auth,
+        pool=request.app.state.pool,
+        notification_target_service=getattr(
+            request.app.state,
+            "notification_target_service",
+            NotificationTargetService(notification_bundle, request.app.state.pool),
+        ),
+        notifier=getattr(request.app.state, "notifier", None),
+        collector=request.app.state.collector,
+        collection_queue=getattr(request.app.state, "collection_queue", None),
+        stats_dispatcher=getattr(request.app.state, "stats_dispatcher", None),
+        search_engine=request.app.state.search_engine,
+        ai_search=request.app.state.ai_search,
+        scheduler=request.app.state.scheduler,
+        templates=getattr(
+            request.app.state,
+            "templates",
+            Jinja2Templates(directory=str(TEMPLATES_DIR)),
+        ),
+        log_buffer=getattr(request.app.state, "log_buffer", None),
+        session_secret=getattr(request.app.state, "session_secret", ""),
+        bg_tasks=getattr(request.app.state, "bg_tasks", set()),
+        shutting_down=getattr(request.app.state, "shutting_down", False),
+    )
+
+
 def get_db(request: Request) -> Database:
-    return request.app.state.db
+    return get_container(request).db
+
+
+def get_account_bundle(request: Request) -> AccountBundle:
+    return get_container(request).account_bundle
+
+
+def get_channel_bundle(request: Request) -> ChannelBundle:
+    return get_container(request).channel_bundle
+
+
+def get_collection_bundle(request: Request) -> CollectionBundle:
+    return get_container(request).collection_bundle
+
+
+def get_notification_bundle(request: Request) -> NotificationBundle:
+    return get_container(request).notification_bundle
+
+
+def get_search_bundle(request: Request) -> SearchBundle:
+    return get_container(request).search_bundle
+
+
+def get_scheduler_bundle(request: Request) -> SchedulerBundle:
+    return get_container(request).scheduler_bundle
 
 
 def get_pool(request: Request) -> ClientPool:
-    return request.app.state.pool
+    return get_container(request).pool
 
 
 def get_collector(request: Request) -> Collector:
-    return request.app.state.collector
+    return get_container(request).collector
 
 
 def get_queue(request: Request) -> CollectionQueue:
-    queue = getattr(request.app.state, "collection_queue", None)
-    if queue is None:
-        queue = CollectionQueue(get_collector(request), get_db(request))
-        request.app.state.collection_queue = queue
-    return queue
+    return get_container(request).collection_queue
+
+
+def get_stats_dispatcher(request: Request) -> StatsTaskDispatcher:
+    return get_container(request).stats_dispatcher
 
 
 def get_scheduler(request: Request) -> SchedulerManager:
-    return request.app.state.scheduler
+    return get_container(request).scheduler
 
 
 def get_search_engine(request: Request) -> SearchEngine:
-    return request.app.state.search_engine
+    return get_container(request).search_engine
 
 
 def get_ai_search(request: Request) -> AISearchEngine:
-    return request.app.state.ai_search
+    return get_container(request).ai_search
 
 
 def get_auth(request: Request) -> TelegramAuth:
-    return request.app.state.auth
+    return get_container(request).auth
 
 
 def get_templates(request: Request) -> Jinja2Templates:
-    return request.app.state.templates
+    return get_container(request).templates
 
 
 def get_notification_target_service(request: Request) -> NotificationTargetService:
-    service = getattr(request.app.state, "notification_target_service", None)
-    if service is None:
-        service = NotificationTargetService(get_db(request), get_pool(request))
-        request.app.state.notification_target_service = service
-    return service
+    return get_container(request).notification_target_service
+
+
+def get_notifier(request: Request) -> Notifier:
+    return get_container(request).notifier
+
+
+def get_log_buffer(request: Request) -> LogBuffer:
+    return get_container(request).log_buffer
+
+
+def is_shutting_down(request: Request) -> bool:
+    return get_container(request).shutting_down
 
 
 def channel_service(request: Request) -> ChannelService:
     return _request_cached(
         request,
         "_channel_service",
-        lambda: ChannelService(get_db(request), get_pool(request), get_queue(request)),
+        lambda: ChannelService(get_channel_bundle(request), get_pool(request), get_queue(request)),
     )
 
 
 def keyword_service(request: Request) -> KeywordService:
-    return _request_cached(request, "_keyword_service", lambda: KeywordService(get_db(request)))
+    return _request_cached(
+        request,
+        "_keyword_service",
+        lambda: KeywordService(get_collection_bundle(request)),
+    )
 
 
 def account_service(request: Request) -> AccountService:
     return _request_cached(
         request,
         "_account_service",
-        lambda: AccountService(get_db(request), get_pool(request)),
+        lambda: AccountService(get_account_bundle(request), get_pool(request)),
     )
 
 
@@ -106,7 +204,11 @@ def collection_service(request: Request) -> CollectionService:
     return _request_cached(
         request,
         "_collection_service",
-        lambda: CollectionService(get_db(request), get_collector(request), get_queue(request)),
+        lambda: CollectionService(
+            get_channel_bundle(request),
+            get_collector(request),
+            get_queue(request),
+        ),
     )
 
 
@@ -118,11 +220,20 @@ def search_service(request: Request) -> SearchService:
     )
 
 
+def notification_service(request: Request) -> NotificationService:
+    return _request_cached(
+        request,
+        "_notification_service",
+        lambda: NotificationService(
+            get_notification_bundle(request),
+            get_notification_target_service(request),
+            get_container(request).config.notifications.bot_name_prefix,
+            get_container(request).config.notifications.bot_username_prefix,
+        ),
+    )
+
+
 def scheduler_service(request: Request) -> SchedulerService:
     return _request_cached(
         request, "_scheduler_service", lambda: SchedulerService(get_scheduler(request))
     )
-
-
-def get_log_buffer(request: Request) -> LogBuffer:
-    return request.app.state.log_buffer

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -32,9 +32,9 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
+from src.web.bootstrap import TEMPLATES_DIR
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
-from src.web.bootstrap import TEMPLATES_DIR
 
 T = TypeVar("T")
 
@@ -164,11 +164,11 @@ def get_notification_target_service(request: Request) -> NotificationTargetServi
     return get_container(request).notification_target_service
 
 
-def get_notifier(request: Request) -> Notifier:
+def get_notifier(request: Request) -> Notifier | None:
     return get_container(request).notifier
 
 
-def get_log_buffer(request: Request) -> LogBuffer:
+def get_log_buffer(request: Request) -> LogBuffer | None:
     return get_container(request).log_buffer
 
 

--- a/src/web/paths.py
+++ b/src/web/paths.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WEB_DIR = Path(__file__).parent
+STATIC_DIR = WEB_DIR / "static"
+TEMPLATES_DIR = WEB_DIR / "templates"

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from starlette.background import BackgroundTask
 
+from src.models import CollectionTaskStatus, StatsAllTaskPayload
 from src.services.collection_service import BulkEnqueueResult
 from src.web import deps
 
@@ -135,18 +136,12 @@ async def collect_all_stats(request: Request):
         ch for ch in channels if ch.channel_id in latest_stats
     ]
     ordered_channels = channels_without_stats + channels_with_stats
-    payload = {
-        "task_kind": "stats_all",
-        "channel_ids": [ch.channel_id for ch in ordered_channels],
-        "next_index": 0,
-        "batch_size": 20,
-        "channels_ok": 0,
-        "channels_err": 0,
-    }
-    await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=payload,
+    payload = StatsAllTaskPayload(
+        channel_ids=[ch.channel_id for ch in ordered_channels],
+        batch_size=20,
+    )
+    await db.create_stats_task(
+        payload,
     )
 
     msg = "stats_collection_queued" if collector.is_running else "stats_collection_started"
@@ -167,17 +162,23 @@ async def collect_stats(request: Request, pk: int):
     task_id = await db.create_collection_task(
         channel.channel_id, channel.title, channel_username=channel.username
     )
-    await db.update_collection_task(task_id, "running")
+    await db.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
 
     async def _run_channel_stats():
         try:
             result = await collector.collect_channel_stats(channel)
             await db.update_collection_task(
-                task_id, "completed", messages_collected=1 if result else 0
+                task_id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=1 if result else 0,
             )
         except Exception as exc:
             logger.exception("collect_channel_stats failed")
-            await db.update_collection_task(task_id, "failed", error=str(exc))
+            await db.update_collection_task(
+                task_id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc),
+            )
 
     task = BackgroundTask(_run_channel_stats)
     return RedirectResponse(

--- a/src/web/routes/debug.py
+++ b/src/web/routes/debug.py
@@ -10,7 +10,8 @@ router = APIRouter()
 
 @router.get("/", response_class=HTMLResponse)
 async def debug_page(request: Request):
-    records = deps.get_log_buffer(request).get_records()
+    log_buffer = deps.get_log_buffer(request)
+    records = log_buffer.get_records() if log_buffer is not None else []
     return deps.get_templates(request).TemplateResponse(
         request, "debug.html", {"records": records}
     )
@@ -18,7 +19,8 @@ async def debug_page(request: Request):
 
 @router.get("/logs", response_class=HTMLResponse)
 async def debug_logs_partial(request: Request):
-    records = deps.get_log_buffer(request).get_records()
+    log_buffer = deps.get_log_buffer(request)
+    records = log_buffer.get_records() if log_buffer is not None else []
     return deps.get_templates(request).TemplateResponse(
         request, "_debug_logs.html", {"records": records}
     )

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -166,18 +166,6 @@ async def save_credentials(request: Request):
     return RedirectResponse(url="/settings?msg=credentials_saved", status_code=303)
 
 
-@router.post("/{account_id}/toggle")
-async def toggle_account(request: Request, account_id: int):
-    await deps.account_service(request).toggle(account_id)
-    return RedirectResponse(url="/settings?msg=account_toggled", status_code=303)
-
-
-@router.post("/{account_id}/delete")
-async def delete_account(request: Request, account_id: int):
-    await deps.account_service(request).delete(account_id)
-    return RedirectResponse(url="/settings?msg=account_deleted", status_code=303)
-
-
 @router.post("/notifications/setup")
 async def setup_notification_bot(request: Request):
     try:
@@ -237,3 +225,15 @@ async def delete_notification_bot(request: Request):
     if _wants_json(request):
         return JSONResponse({"deleted": True})
     return RedirectResponse(url="/settings?msg=notification_bot_deleted", status_code=303)
+
+
+@router.post("/{account_id}/toggle")
+async def toggle_account(request: Request, account_id: int):
+    await deps.account_service(request).toggle(account_id)
+    return RedirectResponse(url="/settings?msg=account_toggled", status_code=303)
+
+
+@router.post("/{account_id}/delete")
+async def delete_account(request: Request, account_id: int):
+    await deps.account_service(request).delete(account_id)
+    return RedirectResponse(url="/settings?msg=account_deleted", status_code=303)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 
@@ -31,17 +33,71 @@ class AsyncIterMessages:
             raise StopAsyncIteration
 
 
+class FakeTelethonClient:
+    """Controllable Telethon-like client for collector tests."""
+
+    def __init__(
+        self,
+        *,
+        entity_resolver=None,
+        dialogs=None,
+        iter_messages_factory=None,
+    ):
+        self._entity_resolver = entity_resolver or (lambda arg: SimpleNamespace())
+        self._dialogs = [] if dialogs is None else dialogs
+        self._iter_messages_factory = iter_messages_factory or (lambda *a, **kw: AsyncIterEmpty())
+        self.get_entity = AsyncMock(side_effect=self._get_entity)
+        self.get_dialogs = AsyncMock(side_effect=self._get_dialogs)
+        self.iter_messages = MagicMock(side_effect=self._iter_messages)
+
+    async def _get_entity(self, arg):
+        result = self._entity_resolver(arg)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def _get_dialogs(self):
+        if isinstance(self._dialogs, Exception):
+            raise self._dialogs
+        return self._dialogs
+
+    def _iter_messages(self, *args, **kwargs):
+        return self._iter_messages_factory(*args, **kwargs)
+
+
+class FakeClientPool(MagicMock):
+    """Pool double with controllable async methods and dialog cache state."""
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.clients = kwargs.pop("clients", {})
+        self.release_client = kwargs.pop("release_client", AsyncMock())
+        self.report_flood = kwargs.pop("report_flood", AsyncMock())
+        self.get_client_by_phone = kwargs.pop("get_client_by_phone", AsyncMock(return_value=None))
+        self.get_available_client = kwargs.pop("get_available_client", AsyncMock(return_value=None))
+        self.get_stats_availability = kwargs.pop("get_stats_availability", AsyncMock())
+        self._dialogs_fetched: set[str] = set()
+        self.is_dialogs_fetched = lambda phone: phone in self._dialogs_fetched
+        self.mark_dialogs_fetched = lambda phone: self._dialogs_fetched.add(phone)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def make_mock_message(msg_id, text=None, media=None, sender_id=None, *, date=None):
+    return SimpleNamespace(
+        id=msg_id,
+        text=text,
+        media=media,
+        sender_id=sender_id,
+        sender=None,
+        date=date or datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def make_stats_availability(state: str, *, next_available_at_utc=None):
+    return SimpleNamespace(state=state, next_available_at_utc=next_available_at_utc)
+
+
 def make_mock_pool(**kwargs) -> MagicMock:
     """Create a MagicMock pool with async methods properly mocked."""
-    pool = MagicMock()
-    pool.clients = {}
-    pool.release_client = AsyncMock()
-    pool.report_flood = AsyncMock()
-    pool.get_client_by_phone = AsyncMock(return_value=None)
-    # Simulate the per-phone dialogs-fetched tracking used by _collect_channel
-    _dialogs_fetched: set[str] = set()
-    pool.is_dialogs_fetched = lambda phone: phone in _dialogs_fetched
-    pool.mark_dialogs_fetched = lambda phone: _dialogs_fetched.add(phone)
-    for key, value in kwargs.items():
-        setattr(pool, key, value)
-    return pool
+    return FakeClientPool(**kwargs)

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -1,0 +1,560 @@
+"""Integration tests for Bundle layer — every public method exercised against real SQLite."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.database.bundles import (
+    AccountBundle,
+    ChannelBundle,
+    CollectionBundle,
+    NotificationBundle,
+    SchedulerBundle,
+    SearchBundle,
+)
+from src.models import (
+    Account,
+    Channel,
+    ChannelStats,
+    CollectionTaskStatus,
+    Keyword,
+    Message,
+    NotificationBot,
+    StatsAllTaskPayload,
+)
+
+NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _account(phone: str = "+70001112233", session: str = "sess") -> Account:
+    return Account(phone=phone, session_string=session)
+
+
+def _channel(channel_id: int = 100, title: str = "Test") -> Channel:
+    return Channel(channel_id=channel_id, title=title)
+
+
+def _message(channel_id: int = 100, message_id: int = 1, text: str = "hello") -> Message:
+    return Message(
+        channel_id=channel_id,
+        message_id=message_id,
+        text=text,
+        date=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AccountBundle
+# ---------------------------------------------------------------------------
+
+
+class TestAccountBundle:
+    async def test_from_database(self, db):
+        bundle = AccountBundle.from_database(db)
+        assert bundle.accounts is not None
+
+    async def test_add_account(self, db):
+        b = AccountBundle.from_database(db)
+        pk = await b.add_account(_account())
+        assert isinstance(pk, int) and pk > 0
+
+    async def test_list_accounts(self, db):
+        b = AccountBundle.from_database(db)
+        await b.add_account(_account())
+        accs = await b.list_accounts()
+        assert len(accs) >= 1
+        assert accs[0].phone == "+70001112233"
+
+    async def test_set_active(self, db):
+        b = AccountBundle.from_database(db)
+        pk = await b.add_account(_account())
+        await b.set_active(pk, False)
+        accs = await b.list_accounts()
+        found = next(a for a in accs if a.id == pk)
+        assert found.is_active is False
+
+    async def test_delete_account(self, db):
+        b = AccountBundle.from_database(db)
+        pk = await b.add_account(_account())
+        await b.delete_account(pk)
+        accs = await b.list_accounts()
+        assert all(a.id != pk for a in accs)
+
+    async def test_update_flood(self, db):
+        b = AccountBundle.from_database(db)
+        await b.add_account(_account())
+        until = NOW + timedelta(hours=1)
+        await b.update_flood("+70001112233", until)
+        accs = await b.list_accounts()
+        assert accs[0].flood_wait_until is not None
+
+    async def test_update_premium(self, db):
+        b = AccountBundle.from_database(db)
+        await b.add_account(_account())
+        await b.update_premium("+70001112233", True)
+        accs = await b.list_accounts()
+        assert accs[0].is_premium is True
+
+
+# ---------------------------------------------------------------------------
+# ChannelBundle
+# ---------------------------------------------------------------------------
+
+
+class TestChannelBundle:
+    async def test_from_database(self, db):
+        b = ChannelBundle.from_database(db)
+        assert b.channels is not None
+
+    async def test_add_channel(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel())
+        assert isinstance(pk, int) and pk > 0
+
+    async def test_list_channels(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel())
+        chs = await b.list_channels()
+        assert len(chs) >= 1
+
+    async def test_list_channels_with_counts(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel())
+        chs = await b.list_channels_with_counts()
+        assert len(chs) >= 1
+
+    async def test_get_by_pk(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel())
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.channel_id == 100
+
+    async def test_get_by_channel_id(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=200))
+        ch = await b.get_by_channel_id(200)
+        assert ch is not None and ch.channel_id == 200
+
+    async def test_set_active(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel())
+        await b.set_active(pk, False)
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.is_active is False
+
+    async def test_set_type(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=300))
+        await b.set_type(300, "supergroup")
+        ch = await b.get_by_channel_id(300)
+        assert ch is not None and ch.channel_type == "supergroup"
+
+    async def test_update_last_id(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=400))
+        await b.update_last_id(400, 999)
+        ch = await b.get_by_channel_id(400)
+        assert ch is not None and ch.last_collected_id == 999
+
+    async def test_update_meta(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=500))
+        await b.update_meta(500, username="newuser", title="NewTitle")
+        ch = await b.get_by_channel_id(500)
+        assert ch is not None
+        assert ch.username == "newuser"
+        assert ch.title == "NewTitle"
+
+    async def test_set_filtered_bulk(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel(channel_id=600))
+        count = await b.set_filtered_bulk([(600, "low_uniqueness")])
+        assert count == 1
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.is_filtered is True
+
+    async def test_reset_all_filters(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel(channel_id=601))
+        await b.set_filtered_bulk([(pk, "spam")])
+        count = await b.reset_all_filters()
+        assert count >= 1
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.is_filtered is False
+
+    async def test_delete_channel(self, db):
+        b = ChannelBundle.from_database(db)
+        pk = await b.add_channel(_channel(channel_id=700))
+        await b.delete_channel(pk)
+        ch = await b.get_by_pk(pk)
+        assert ch is None
+
+    async def test_save_and_get_stats(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=800))
+        stats = ChannelStats(channel_id=800, subscriber_count=1000, avg_views=50.0)
+        sid = await b.save_stats(stats)
+        assert sid > 0
+        rows = await b.get_stats(800)
+        assert len(rows) == 1 and rows[0].subscriber_count == 1000
+
+    async def test_get_latest_stats_for_all(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=801))
+        await b.save_stats(ChannelStats(channel_id=801, subscriber_count=500))
+        result = await b.get_latest_stats_for_all()
+        assert 801 in result
+
+    async def test_create_and_get_collection_task(self, db):
+        b = ChannelBundle.from_database(db)
+        tid = await b.create_collection_task(900, "ch900")
+        task = await b.get_collection_task(tid)
+        assert task is not None and task.channel_id == 900
+
+    async def test_update_collection_task(self, db):
+        b = ChannelBundle.from_database(db)
+        tid = await b.create_collection_task(901, "ch901")
+        await b.update_collection_task(tid, CollectionTaskStatus.RUNNING)
+        task = await b.get_collection_task(tid)
+        assert task is not None and task.status == CollectionTaskStatus.RUNNING
+
+    async def test_update_collection_task_progress(self, db):
+        b = ChannelBundle.from_database(db)
+        tid = await b.create_collection_task(902, "ch902")
+        await b.update_collection_task(tid, CollectionTaskStatus.RUNNING)
+        await b.update_collection_task_progress(tid, 42)
+        task = await b.get_collection_task(tid)
+        assert task is not None and task.messages_collected == 42
+
+    async def test_get_collection_tasks(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.create_collection_task(903, "ch903")
+        tasks = await b.get_collection_tasks()
+        assert len(tasks) >= 1
+
+    async def test_get_active_collection_tasks_for_channel(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.create_collection_task(904, "ch904")
+        tasks = await b.get_active_collection_tasks_for_channel(904)
+        assert len(tasks) >= 1
+
+    async def test_get_channel_ids_with_active_tasks(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.create_collection_task(905, "ch905")
+        ids = await b.get_channel_ids_with_active_tasks()
+        assert 905 in ids
+
+    async def test_cancel_collection_task(self, db):
+        b = ChannelBundle.from_database(db)
+        tid = await b.create_collection_task(906, "ch906")
+        ok = await b.cancel_collection_task(tid, note="test cancel")
+        assert ok is True
+        task = await b.get_collection_task(tid)
+        assert task is not None and task.status == CollectionTaskStatus.CANCELLED
+
+    async def test_get_pending_channel_tasks(self, db):
+        b = ChannelBundle.from_database(db)
+        await b.create_collection_task(907, "ch907")
+        pending = await b.get_pending_channel_tasks()
+        assert any(t.channel_id == 907 for t in pending)
+
+    async def test_fail_running_on_startup(self, db):
+        b = ChannelBundle.from_database(db)
+        tid = await b.create_collection_task(908, "ch908")
+        await b.update_collection_task(tid, CollectionTaskStatus.RUNNING)
+        count = await b.fail_running_collection_tasks_on_startup()
+        assert count >= 1
+        task = await b.get_collection_task(tid)
+        assert task is not None and task.status == CollectionTaskStatus.FAILED
+
+    async def test_stats_task_lifecycle(self, db):
+        b = ChannelBundle.from_database(db)
+        payload = StatsAllTaskPayload(channel_ids=[1, 2, 3])
+        tid = await b.create_stats_task(payload)
+        assert tid > 0
+
+        active = await b.get_active_stats_task()
+        assert active is not None
+
+        claimed = await b.claim_next_due_stats_task(NOW)
+        assert claimed is not None and claimed.id == tid
+
+        cont_id = await b.create_stats_continuation_task(
+            payload=payload,
+            run_after=NOW + timedelta(minutes=5),
+            parent_task_id=tid,
+        )
+        assert cont_id > tid
+
+        count = await b.requeue_running_stats_tasks_on_startup(NOW)
+        assert count >= 0
+
+
+# ---------------------------------------------------------------------------
+# CollectionBundle
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionBundle:
+    async def test_from_database(self, db):
+        b = CollectionBundle.from_database(db)
+        assert b.channels is not None
+
+    async def test_execute(self, db):
+        b = CollectionBundle.from_database(db)
+        cur = await b.execute("SELECT 1")
+        row = await cur.fetchone()
+        assert row[0] == 1
+
+    async def test_list_channels_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1001))
+        chs = await b.list_channels()
+        assert len(chs) >= 1
+        chs2 = await b.get_channels()
+        assert len(chs2) == len(chs)
+
+    async def test_get_by_pk_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        pk = await b.channels.add_channel(_channel(channel_id=1002))
+        ch1 = await b.get_by_pk(pk)
+        ch2 = await b.get_channel_by_pk(pk)
+        assert ch1 is not None and ch2 is not None
+        assert ch1.channel_id == ch2.channel_id == 1002
+
+    async def test_get_by_channel_id_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1003))
+        ch1 = await b.get_by_channel_id(1003)
+        ch2 = await b.get_channel_by_channel_id(1003)
+        assert ch1 is not None and ch2 is not None
+
+    async def test_update_last_id_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1004))
+        await b.update_last_id(1004, 555)
+        await b.update_channel_last_id(1004, 556)
+        ch = await b.get_by_channel_id(1004)
+        assert ch is not None and ch.last_collected_id == 556
+
+    async def test_update_meta_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1005))
+        await b.update_meta(1005, username="u1", title="t1")
+        ch = await b.get_by_channel_id(1005)
+        assert ch is not None and ch.username == "u1"
+        await b.update_channel_meta(1005, username="u2", title="t2")
+        ch = await b.get_by_channel_id(1005)
+        assert ch is not None and ch.username == "u2"
+
+    async def test_set_active_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        pk = await b.channels.add_channel(_channel(channel_id=1006))
+        await b.set_active(pk, False)
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.is_active is False
+        await b.set_channel_active(pk, True)
+        ch = await b.get_by_pk(pk)
+        assert ch is not None and ch.is_active is True
+
+    async def test_set_type_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1007))
+        await b.set_type(1007, "channel")
+        ch = await b.get_by_channel_id(1007)
+        assert ch is not None and ch.channel_type == "channel"
+        await b.set_channel_type(1007, "supergroup")
+        ch = await b.get_by_channel_id(1007)
+        assert ch is not None and ch.channel_type == "supergroup"
+
+    async def test_set_filtered_bulk_and_alias(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1008))
+        count = await b.set_filtered_bulk([(1008, "spam")])
+        assert count == 1
+        count2 = await b.set_channels_filtered_bulk([(1008, "spam2")])
+        assert count2 >= 0
+
+    async def test_reset_all_filters(self, db):
+        b = CollectionBundle.from_database(db)
+        pk = await b.channels.add_channel(_channel(channel_id=1009))
+        await b.set_filtered_bulk([(pk, "spam")])
+        count = await b.reset_all_filters()
+        assert count >= 1
+
+    async def test_insert_message(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1010))
+        ok = await b.insert_message(_message(channel_id=1010, message_id=1))
+        assert ok is True
+
+    async def test_insert_messages_batch(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1011))
+        msgs = [_message(channel_id=1011, message_id=i) for i in range(1, 4)]
+        count = await b.insert_messages_batch(msgs)
+        assert count == 3
+
+    async def test_search_messages(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1012))
+        await b.insert_message(_message(channel_id=1012, message_id=1, text="findme"))
+        results, total = await b.search_messages(query="findme")
+        assert total >= 1
+
+    async def test_delete_messages_for_channel(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1013))
+        await b.insert_message(_message(channel_id=1013, message_id=1))
+        count = await b.delete_messages_for_channel(1013)
+        assert count == 1
+
+    async def test_get_message_stats(self, db):
+        b = CollectionBundle.from_database(db)
+        stats = await b.get_message_stats()
+        assert isinstance(stats, dict)
+
+    async def test_count_matching_prefixes_in_other_channels(self, db):
+        b = CollectionBundle.from_database(db)
+        count = await b.count_matching_prefixes_in_other_channels(999, ["test"])
+        assert isinstance(count, int)
+
+    async def test_settings_get_set(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.set_setting("mykey", "myval")
+        val = await b.get_setting("mykey")
+        assert val == "myval"
+
+    async def test_keywords_crud(self, db):
+        b = CollectionBundle.from_database(db)
+        kid = await b.add_keyword(Keyword(pattern="test"))
+        assert kid > 0
+        kws = await b.list_keywords()
+        assert any(k.id == kid for k in kws)
+        kws2 = await b.get_keywords()
+        assert len(kws2) == len(kws)
+        await b.set_keyword_active(kid, False)
+        await b.delete_keyword(kid)
+        kws3 = await b.list_keywords()
+        assert all(k.id != kid for k in kws3)
+
+    async def test_channel_stats(self, db):
+        b = CollectionBundle.from_database(db)
+        await b.channels.add_channel(_channel(channel_id=1014))
+        sid = await b.save_channel_stats(ChannelStats(channel_id=1014, subscriber_count=99))
+        assert sid > 0
+        rows = await b.get_channel_stats(1014)
+        assert len(rows) == 1
+
+    async def test_create_collection_task(self, db):
+        b = CollectionBundle.from_database(db)
+        tid = await b.create_collection_task(1015, "ch1015")
+        assert tid > 0
+
+    async def test_filter_repo_property(self, db):
+        b = CollectionBundle.from_database(db)
+        assert b.filter_repo is not None
+
+
+# ---------------------------------------------------------------------------
+# SearchBundle
+# ---------------------------------------------------------------------------
+
+
+class TestSearchBundle:
+    async def test_from_database(self, db):
+        b = SearchBundle.from_database(db)
+        assert b.messages is not None
+
+    async def test_search_messages(self, db):
+        b = SearchBundle.from_database(db)
+        results, total = await b.search_messages(query="nope")
+        assert total == 0
+
+    async def test_add_channel_and_insert(self, db):
+        b = SearchBundle.from_database(db)
+        pk = await b.add_channel(_channel(channel_id=2001))
+        assert pk > 0
+        count = await b.insert_messages_batch([_message(channel_id=2001, message_id=1)])
+        assert count == 1
+
+    async def test_search_after_insert(self, db):
+        b = SearchBundle.from_database(db)
+        await b.add_channel(_channel(channel_id=2002))
+        await b.insert_messages_batch([_message(channel_id=2002, message_id=1, text="searchterm")])
+        results, total = await b.search_messages(query="searchterm")
+        assert total >= 1
+
+    async def test_log_and_get_searches(self, db):
+        b = SearchBundle.from_database(db)
+        await b.log_search("+70001112233", "test query", 5)
+        recent = await b.get_recent_searches()
+        assert len(recent) >= 1
+
+
+# ---------------------------------------------------------------------------
+# SchedulerBundle
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerBundle:
+    async def test_from_database(self, db):
+        b = SchedulerBundle.from_database(db)
+        assert b.settings is not None
+
+    async def test_settings(self, db):
+        b = SchedulerBundle.from_database(db)
+        await b.set_setting("skey", "sval")
+        val = await b.get_setting("skey")
+        assert val == "sval"
+
+    async def test_list_keywords(self, db):
+        b = SchedulerBundle.from_database(db)
+        kws = await b.list_keywords()
+        assert isinstance(kws, list)
+
+    async def test_get_collection_tasks(self, db):
+        b = SchedulerBundle.from_database(db)
+        tasks = await b.get_collection_tasks()
+        assert isinstance(tasks, list)
+
+    async def test_get_recent_searches(self, db):
+        b = SchedulerBundle.from_database(db)
+        recent = await b.get_recent_searches()
+        assert isinstance(recent, list)
+
+
+# ---------------------------------------------------------------------------
+# NotificationBundle
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationBundle:
+    async def test_from_database(self, db):
+        b = NotificationBundle.from_database(db)
+        assert b.accounts is not None
+
+    async def test_list_accounts(self, db):
+        b = NotificationBundle.from_database(db)
+        accs = await b.list_accounts()
+        assert isinstance(accs, list)
+
+    async def test_settings(self, db):
+        b = NotificationBundle.from_database(db)
+        await b.set_setting("nkey", "nval")
+        val = await b.get_setting("nkey")
+        assert val == "nval"
+
+    async def test_bot_lifecycle(self, db):
+        b = NotificationBundle.from_database(db)
+        bot = NotificationBot(
+            tg_user_id=123,
+            bot_username="testbot",
+            bot_token="123:ABC",
+        )
+        bid = await b.save_bot(bot)
+        assert bid > 0
+        got = await b.get_bot(123)
+        assert got is not None and got.bot_username == "testbot"
+        await b.delete_bot(123)
+        gone = await b.get_bot(123)
+        assert gone is None

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -299,80 +299,58 @@ class TestCollectionBundle:
         b = CollectionBundle.from_database(db)
         assert b.channels is not None
 
-    async def test_execute(self, db):
-        b = CollectionBundle.from_database(db)
-        cur = await b.execute("SELECT 1")
-        row = await cur.fetchone()
-        assert row[0] == 1
-
-    async def test_list_channels_and_alias(self, db):
+    async def test_list_channels(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1001))
         chs = await b.list_channels()
         assert len(chs) >= 1
-        chs2 = await b.get_channels()
-        assert len(chs2) == len(chs)
 
-    async def test_get_by_pk_and_alias(self, db):
+    async def test_get_by_pk(self, db):
         b = CollectionBundle.from_database(db)
         pk = await b.channels.add_channel(_channel(channel_id=1002))
-        ch1 = await b.get_by_pk(pk)
-        ch2 = await b.get_channel_by_pk(pk)
-        assert ch1 is not None and ch2 is not None
-        assert ch1.channel_id == ch2.channel_id == 1002
+        ch = await b.get_by_pk(pk)
+        assert ch is not None
+        assert ch.channel_id == 1002
 
-    async def test_get_by_channel_id_and_alias(self, db):
+    async def test_get_by_channel_id(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1003))
-        ch1 = await b.get_by_channel_id(1003)
-        ch2 = await b.get_channel_by_channel_id(1003)
-        assert ch1 is not None and ch2 is not None
+        ch = await b.get_by_channel_id(1003)
+        assert ch is not None
 
-    async def test_update_last_id_and_alias(self, db):
+    async def test_update_last_id(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1004))
-        await b.update_last_id(1004, 555)
-        await b.update_channel_last_id(1004, 556)
+        await b.update_last_id(1004, 556)
         ch = await b.get_by_channel_id(1004)
         assert ch is not None and ch.last_collected_id == 556
 
-    async def test_update_meta_and_alias(self, db):
+    async def test_update_meta(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1005))
-        await b.update_meta(1005, username="u1", title="t1")
-        ch = await b.get_by_channel_id(1005)
-        assert ch is not None and ch.username == "u1"
-        await b.update_channel_meta(1005, username="u2", title="t2")
+        await b.update_meta(1005, username="u2", title="t2")
         ch = await b.get_by_channel_id(1005)
         assert ch is not None and ch.username == "u2"
 
-    async def test_set_active_and_alias(self, db):
+    async def test_set_active(self, db):
         b = CollectionBundle.from_database(db)
         pk = await b.channels.add_channel(_channel(channel_id=1006))
-        await b.set_active(pk, False)
-        ch = await b.get_by_pk(pk)
-        assert ch is not None and ch.is_active is False
-        await b.set_channel_active(pk, True)
+        await b.set_active(pk, True)
         ch = await b.get_by_pk(pk)
         assert ch is not None and ch.is_active is True
 
-    async def test_set_type_and_alias(self, db):
+    async def test_set_type(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1007))
-        await b.set_type(1007, "channel")
-        ch = await b.get_by_channel_id(1007)
-        assert ch is not None and ch.channel_type == "channel"
-        await b.set_channel_type(1007, "supergroup")
+        await b.set_type(1007, "supergroup")
         ch = await b.get_by_channel_id(1007)
         assert ch is not None and ch.channel_type == "supergroup"
 
-    async def test_set_filtered_bulk_and_alias(self, db):
+    async def test_set_filtered_bulk(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1008))
         count = await b.set_filtered_bulk([(1008, "spam")])
         assert count == 1
-        count2 = await b.set_channels_filtered_bulk([(1008, "spam2")])
-        assert count2 >= 0
 
     async def test_reset_all_filters(self, db):
         b = CollectionBundle.from_database(db)
@@ -430,8 +408,6 @@ class TestCollectionBundle:
         assert kid > 0
         kws = await b.list_keywords()
         assert any(k.id == kid for k in kws)
-        kws2 = await b.get_keywords()
-        assert len(kws2) == len(kws)
         await b.set_keyword_active(kid, False)
         await b.delete_keyword(kid)
         kws3 = await b.list_keywords()
@@ -440,7 +416,9 @@ class TestCollectionBundle:
     async def test_channel_stats(self, db):
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1014))
-        sid = await b.save_channel_stats(ChannelStats(channel_id=1014, subscriber_count=99))
+        sid = await b.channel_stats.save_channel_stats(
+            ChannelStats(channel_id=1014, subscriber_count=99)
+        )
         assert sid > 0
         rows = await b.get_channel_stats(1014)
         assert len(rows) == 1
@@ -449,11 +427,6 @@ class TestCollectionBundle:
         b = CollectionBundle.from_database(db)
         tid = await b.create_collection_task(1015, "ch1015")
         assert tid > 0
-
-    async def test_filter_repo_property(self, db):
-        b = CollectionBundle.from_database(db)
-        assert b.filter_repo is not None
-
 
 # ---------------------------------------------------------------------------
 # SearchBundle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -297,26 +297,26 @@ class TestCLIScheduler:
 
 
 # ---------------------------------------------------------------------------
-# test (smoke_test command)
+# test command
 # ---------------------------------------------------------------------------
 
 
 class TestCLITest:
     def test_read(self, cli_env, capsys):
-        from src.cli.commands.smoke_test import run
+        from src.cli.commands.test import run
         run(_ns(command="test", test_action="read"))
         out = capsys.readouterr().out
         assert "PASS" in out
         assert "db_init" in out
 
     def test_write(self, cli_env, capsys):
-        from src.cli.commands.smoke_test import run
+        from src.cli.commands.test import run
         run(_ns(command="test", test_action="write"))
         out = capsys.readouterr().out
         assert "Write Tests" in out
 
     def test_all(self, cli_env_with_pool, capsys):
-        from src.cli.commands.smoke_test import run
+        from src.cli.commands.test import run
         run(_ns(command="test", test_action="all"))
         out = capsys.readouterr().out
         assert "Read Tests" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,337 @@
+"""CLI smoke tests — every command exercised via run(args) with mocked runtime."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.config import AppConfig
+from src.database import Database
+from src.models import Account, Channel, Keyword, Message
+
+NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def cli_db(tmp_path):
+    """Sync fixture: real SQLite for CLI tests."""
+    db_path = str(tmp_path / "cli_test.db")
+    database = Database(db_path)
+    asyncio.run(database.initialize())
+    yield database
+    asyncio.run(database.close())
+
+
+@pytest.fixture
+def cli_env(cli_db):
+    """Patch runtime.init_db to return real db without loading config.yaml."""
+    config = AppConfig()
+
+    async def fake_init_db(config_path: str):
+        return config, cli_db
+
+    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+        yield cli_db
+
+
+@pytest.fixture
+def cli_env_with_pool(cli_env):
+    """Additionally patch runtime.init_pool to return a pool with no clients."""
+    fake_pool = AsyncMock()
+    fake_pool.clients = {}
+    fake_pool.disconnect_all = AsyncMock()
+
+    async def fake_init_pool(config, db):
+        from src.telegram.auth import TelegramAuth
+        return TelegramAuth(0, ""), fake_pool
+
+    with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+        yield cli_env
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build Namespace with defaults."""
+    defaults = {"config": "config.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _add_account(db: Database, phone: str = "+70001112233") -> int:
+    return asyncio.run(
+        db.add_account(Account(phone=phone, session_string="sess"))
+    )
+
+
+def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
+    return asyncio.run(
+        db.add_channel(Channel(channel_id=channel_id, title=title))
+    )
+
+
+def _add_keyword(db: Database, pattern: str = "test", is_regex: bool = False) -> int:
+    return asyncio.run(
+        db.add_keyword(Keyword(pattern=pattern, is_regex=is_regex))
+    )
+
+
+def _add_message(db: Database, channel_id: int = 100, message_id: int = 1, text: str = "hello"):
+    asyncio.run(
+        db.insert_message(
+            Message(channel_id=channel_id, message_id=message_id, text=text, date=NOW)
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# account
+# ---------------------------------------------------------------------------
+
+
+class TestCLIAccount:
+    def test_list_empty(self, cli_env, capsys):
+        from src.cli.commands.account import run
+        run(_ns(account_action="list"))
+        assert "No accounts found" in capsys.readouterr().out
+
+    def test_list_with_data(self, cli_env, capsys):
+        _add_account(cli_env)
+        from src.cli.commands.account import run
+        run(_ns(account_action="list"))
+        assert "+70001112233" in capsys.readouterr().out
+
+    def test_toggle(self, cli_env, capsys):
+        pk = _add_account(cli_env)
+        from src.cli.commands.account import run
+        run(_ns(account_action="toggle", id=pk))
+        assert "active=False" in capsys.readouterr().out
+
+    def test_toggle_not_found(self, cli_env, capsys):
+        from src.cli.commands.account import run
+        run(_ns(account_action="toggle", id=999))
+        assert "not found" in capsys.readouterr().out
+
+    def test_delete(self, cli_env, capsys):
+        pk = _add_account(cli_env)
+        from src.cli.commands.account import run
+        run(_ns(account_action="delete", id=pk))
+        assert "Deleted" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# keyword
+# ---------------------------------------------------------------------------
+
+
+class TestCLIKeyword:
+    def test_list_empty(self, cli_env, capsys):
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="list"))
+        assert "No keywords found" in capsys.readouterr().out
+
+    def test_add(self, cli_env, capsys):
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="add", pattern="urgent", regex=False))
+        assert "Added keyword" in capsys.readouterr().out
+
+    def test_add_regex(self, cli_env, capsys):
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="add", pattern="test.*", regex=True))
+        assert "(regex)" in capsys.readouterr().out
+
+    def test_list_with_data(self, cli_env, capsys):
+        _add_keyword(cli_env, "findme")
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="list"))
+        assert "findme" in capsys.readouterr().out
+
+    def test_toggle(self, cli_env, capsys):
+        kid = _add_keyword(cli_env)
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="toggle", id=kid))
+        assert "active=" in capsys.readouterr().out
+
+    def test_delete(self, cli_env, capsys):
+        kid = _add_keyword(cli_env)
+        from src.cli.commands.keyword import run
+        run(_ns(keyword_action="delete", id=kid))
+        assert "Deleted" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# channel (DB-only)
+# ---------------------------------------------------------------------------
+
+
+class TestCLIChannelDB:
+    def test_list_empty(self, cli_env, capsys):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="list"))
+        assert "No channels found" in capsys.readouterr().out
+
+    def test_list_with_data(self, cli_env, capsys):
+        _add_channel(cli_env, title="MyChan")
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="list"))
+        assert "MyChan" in capsys.readouterr().out
+
+    def test_delete(self, cli_env, capsys):
+        pk = _add_channel(cli_env, channel_id=200, title="DelCh")
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="delete", identifier=str(pk)))
+        assert "Deleted" in capsys.readouterr().out
+
+    def test_toggle(self, cli_env, capsys):
+        pk = _add_channel(cli_env, channel_id=201, title="TogCh")
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="toggle", identifier=str(pk)))
+        assert "active=" in capsys.readouterr().out
+
+    def test_toggle_not_found(self, cli_env, capsys):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="toggle", identifier="99999"))
+        assert "not found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# channel (pool-requiring)
+# ---------------------------------------------------------------------------
+
+
+class TestCLIChannelPool:
+    def test_add_no_clients(self, cli_env_with_pool, capsys, caplog):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="add", identifier="@testchan"))
+        assert "No connected accounts" in caplog.text
+
+    def test_collect_not_found(self, cli_env_with_pool, capsys, caplog):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="collect", identifier="99999"))
+        # Pool has no clients → logs error
+        assert "No connected accounts" in caplog.text
+
+    def test_stats_no_args(self, cli_env_with_pool, capsys, caplog):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="stats", identifier=None, all=False))
+        # Pool has no clients → logs error
+        assert "No connected accounts" in caplog.text
+
+    def test_import_no_identifiers(self, cli_env_with_pool, capsys):
+        from src.cli.commands.channel import run
+        run(_ns(channel_action="import", source=""))
+        assert "No identifiers found" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# filter
+# ---------------------------------------------------------------------------
+
+
+class TestCLIFilter:
+    def test_analyze_empty(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+        run(_ns(filter_action="analyze"))
+        assert "No channels found" in capsys.readouterr().out
+
+    def test_apply_empty(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+        run(_ns(filter_action="apply"))
+        assert "Applied filters: 0" in capsys.readouterr().out
+
+    def test_reset(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+        run(_ns(filter_action="reset"))
+        assert "All channel filters have been reset" in capsys.readouterr().out
+
+    def test_precheck(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+        run(_ns(filter_action="precheck"))
+        assert "Pre-filter applied" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+class TestCLISearch:
+    def test_local_empty(self, cli_env, capsys):
+        from src.cli.commands.search import run
+        run(_ns(query="nonexistent", limit=20, mode="local", channel_id=None))
+        assert "Found 0 results" in capsys.readouterr().out
+
+    def test_local_with_data(self, cli_env, capsys):
+        _add_channel(cli_env, channel_id=300, title="SearchCh")
+        _add_message(cli_env, channel_id=300, message_id=1, text="important message")
+        from src.cli.commands.search import run
+        run(_ns(query="important", limit=20, mode="local", channel_id=None))
+        out = capsys.readouterr().out
+        assert "Found" in out
+        assert "important" in out
+
+
+# ---------------------------------------------------------------------------
+# collect
+# ---------------------------------------------------------------------------
+
+
+class TestCLICollect:
+    def test_no_clients(self, cli_env_with_pool, capsys, caplog):
+        from src.cli.commands.collect import run
+        run(_ns(channel_id=None))
+        assert "No connected accounts" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# scheduler
+# ---------------------------------------------------------------------------
+
+
+class TestCLIScheduler:
+    def test_no_clients(self, cli_env_with_pool, capsys, caplog):
+        from src.cli.commands.scheduler import run
+        run(_ns(scheduler_action="trigger"))
+        assert "No connected accounts" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# test (smoke_test command)
+# ---------------------------------------------------------------------------
+
+
+class TestCLITest:
+    def test_read(self, cli_env, capsys):
+        from src.cli.commands.smoke_test import run
+        run(_ns(command="test", test_action="read"))
+        out = capsys.readouterr().out
+        assert "PASS" in out
+        assert "db_init" in out
+
+    def test_write(self, cli_env, capsys):
+        from src.cli.commands.smoke_test import run
+        run(_ns(command="test", test_action="write"))
+        out = capsys.readouterr().out
+        assert "Write Tests" in out
+
+    def test_all(self, cli_env_with_pool, capsys):
+        from src.cli.commands.smoke_test import run
+        run(_ns(command="test", test_action="all"))
+        out = capsys.readouterr().out
+        assert "Read Tests" in out
+        assert "Write Tests" in out
+        assert "Telegram Live Tests" in out
+
+    def test_parser_namespace(self):
+        from src.cli.parser import build_parser
+        parser = build_parser()
+        args = parser.parse_args(["test", "read"])
+        assert args.command == "test"
+        assert args.test_action == "read"
+
+        args = parser.parse_args(["test", "all"])
+        assert args.test_action == "all"
+
+        args = parser.parse_args(["test", "telegram"])
+        assert args.test_action == "telegram"

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon.errors import FloodWaitError, UsernameNotOccupiedError
 from telethon.tl.types import PeerChannel
 
 from src.config import SchedulerConfig
@@ -11,6 +12,7 @@ from src.models import Channel, ChannelStats, Message
 from src.telegram.collector import Collector
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
+from tests.helpers import FakeTelethonClient, make_mock_message
 from tests.helpers import make_mock_pool
 
 
@@ -192,6 +194,36 @@ async def test_collect_channel_falls_back_to_username_on_cache_miss(db):
 
 
 @pytest.mark.asyncio
+async def test_collect_channel_marks_username_changed_when_numeric_fallback_succeeds(db):
+    ch = Channel(channel_id=1970788983, title="Old Title", username="old_name")
+    channel_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(channel_id)
+    assert stored is not None
+
+    fallback_entity = SimpleNamespace(username="new_name", title="New Title")
+    client = FakeTelethonClient(
+        entity_resolver=lambda arg: (
+            UsernameNotOccupiedError(request=None)
+            if arg == "old_name"
+            else fallback_entity
+        ),
+    )
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(client, "+7000")))
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+
+    count = await collector._collect_channel(stored)
+
+    assert count == 0
+    updated = await db.get_channel_by_channel_id(stored.channel_id)
+    assert updated is not None
+    assert updated.username == "new_name"
+    assert updated.title == "New Title"
+    assert updated.is_filtered is True
+    assert "username_changed" in updated.filter_flags
+
+
+@pytest.mark.asyncio
 async def test_collect_channel_no_username_no_cache_reports_error(db):
     """Channel with no username and empty cache -> error logged, 0 messages."""
     ch = Channel(channel_id=1970788983, title="Private Group")
@@ -234,14 +266,7 @@ async def test_collect_all_dialogs_timeout(db):
 
 def _make_mock_message(msg_id, text=None, media=None, sender_id=None):
     """Helper to create a mock Telethon message."""
-    return SimpleNamespace(
-        id=msg_id,
-        text=text,
-        media=media,
-        sender_id=sender_id,
-        sender=None,
-        date=datetime(2025, 1, 1, tzinfo=timezone.utc),
-    )
+    return make_mock_message(msg_id, text=text, media=media, sender_id=sender_id)
 
 
 @pytest.mark.asyncio
@@ -503,6 +528,45 @@ async def test_incremental_collection_sends_keyword_notifications(db):
 
     assert count == 1
     notifier.notify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_collect_channel_retries_after_short_flood_wait(db):
+    ch = Channel(channel_id=-100171, title="Retry", username="retry", last_collected_id=5)
+    ch_id = await db.add_channel(ch)
+    await db.update_channel_last_id(ch.channel_id, 5)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    client = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(client, "+7000")))
+    collector = Collector(
+        pool,
+        db,
+        SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
+    )
+
+    call_index = {"idx": 0}
+
+    def _iter_messages_factory(*_args, **_kwargs):
+        idx = call_index["idx"]
+        call_index["idx"] += 1
+        if idx == 0:
+            async def _generator():
+                yield _make_mock_message(6, text="msg 6")
+                raise FloodWaitError(request=None, capture=3)
+            return _generator()
+        return _AsyncIterMessages([_make_mock_message(7, text="msg 7")])
+
+    client.iter_messages = MagicMock(side_effect=_iter_messages_factory)
+    count = await collector._collect_channel(stored)
+
+    assert count == 2
+    updated = await db.get_channel_by_channel_id(stored.channel_id)
+    assert updated is not None
+    assert updated.last_collected_id == 7
+    pool.report_flood.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -12,8 +12,7 @@ from src.models import Channel, ChannelStats, Message
 from src.telegram.collector import Collector
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
-from tests.helpers import FakeTelethonClient, make_mock_message
-from tests.helpers import make_mock_pool
+from tests.helpers import FakeTelethonClient, make_mock_message, make_mock_pool
 
 
 @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,7 +7,15 @@ import pytest
 from cryptography.fernet import Fernet
 
 from src.database import Database
-from src.models import Account, Channel, Keyword, Message
+from src.models import (
+    Account,
+    Channel,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    Keyword,
+    Message,
+    StatsAllTaskPayload,
+)
 
 
 def _encrypt_v1(secret: str, plaintext: str) -> str:
@@ -856,65 +864,115 @@ async def test_migrate_adds_is_premium_column(tmp_path):
 @pytest.mark.asyncio
 async def test_stats_task_claim_and_continuation(db):
     now = datetime.now(timezone.utc)
-    payload = {
-        "task_kind": "stats_all",
-        "channel_ids": [-1001, -1002],
-        "next_index": 0,
-        "batch_size": 20,
-        "channels_ok": 0,
-        "channels_err": 0,
-    }
-    tid = await db.create_collection_task(
-        0,
-        "Обновление статистики",
+    payload = StatsAllTaskPayload(channel_ids=[-1001, -1002])
+    tid = await db.create_stats_task(
+        payload,
         run_after=now,
-        payload=payload,
     )
 
     claimed = await db.claim_next_due_stats_task(now)
     assert claimed is not None
     assert claimed.id == tid
-    assert claimed.status == "running"
-    assert claimed.payload is not None
-    assert claimed.payload["task_kind"] == "stats_all"
+    assert claimed.task_type == CollectionTaskType.STATS_ALL
+    assert claimed.status == CollectionTaskStatus.RUNNING
+    assert isinstance(claimed.payload, StatsAllTaskPayload)
+    assert claimed.payload.task_kind == CollectionTaskType.STATS_ALL.value
 
     continuation_id = await db.create_stats_continuation_task(
-        payload={**payload, "next_index": 1},
+        payload=StatsAllTaskPayload(channel_ids=[-1001, -1002], next_index=1),
         run_after=now,
         parent_task_id=tid,
     )
     continuation = await db.get_collection_task(continuation_id)
     assert continuation is not None
     assert continuation.parent_task_id == tid
-    assert continuation.status == "pending"
-    assert continuation.payload is not None
-    assert continuation.payload["next_index"] == 1
+    assert continuation.status == CollectionTaskStatus.PENDING
+    assert isinstance(continuation.payload, StatsAllTaskPayload)
+    assert continuation.payload.next_index == 1
 
 
 @pytest.mark.asyncio
 async def test_requeue_running_stats_tasks_on_startup(db):
-    payload = {
-        "task_kind": "stats_all",
-        "channel_ids": [],
-        "next_index": 0,
-        "batch_size": 20,
-        "channels_ok": 0,
-        "channels_err": 0,
-    }
-    tid = await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=payload,
-    )
-    await db.update_collection_task(tid, "running")
+    tid = await db.create_stats_task(StatsAllTaskPayload(channel_ids=[]))
+    await db.update_collection_task(tid, CollectionTaskStatus.RUNNING)
 
     requeued = await db.requeue_running_stats_tasks_on_startup(datetime.now(timezone.utc))
     assert requeued == 1
 
     task = await db.get_collection_task(tid)
     assert task is not None
-    assert task.status == "pending"
+    assert task.status == CollectionTaskStatus.PENDING
     assert task.run_after is not None
+
+
+@pytest.mark.asyncio
+async def test_stats_payload_round_trip_serialization(db):
+    payload = StatsAllTaskPayload(channel_ids=[-1001], next_index=3, channels_ok=2, channels_err=1)
+    task_id = await db.create_stats_task(payload)
+
+    task = await db.get_collection_task(task_id)
+    assert task is not None
+    assert task.task_type == CollectionTaskType.STATS_ALL
+    assert isinstance(task.payload, StatsAllTaskPayload)
+    assert task.payload.model_dump() == payload.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_cancel_collection_task_preserves_typed_status(db):
+    task_id = await db.create_collection_task(-100123, "Channel")
+    cancelled = await db.cancel_collection_task(task_id, note="cancelled in test")
+
+    task = await db.get_collection_task(task_id)
+    assert cancelled is True
+    assert task is not None
+    assert task.task_type == CollectionTaskType.CHANNEL_COLLECT
+    assert task.status == CollectionTaskStatus.CANCELLED
+    assert task.note == "cancelled in test"
+
+
+@pytest.mark.asyncio
+async def test_migration_backfills_collection_task_type(tmp_path):
+    db_path = tmp_path / "legacy_tasks.db"
+    conn = await aiosqlite.connect(db_path)
+    conn.row_factory = aiosqlite.Row
+    await conn.executescript(
+        """
+        CREATE TABLE collection_tasks (
+            id INTEGER PRIMARY KEY,
+            channel_id INTEGER NOT NULL,
+            channel_title TEXT,
+            status TEXT DEFAULT 'pending',
+            messages_collected INTEGER DEFAULT 0,
+            error TEXT,
+            run_after TEXT,
+            payload TEXT,
+            parent_task_id INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            started_at TEXT,
+            completed_at TEXT
+        );
+        INSERT INTO collection_tasks (id, channel_id, channel_title, status, payload)
+        VALUES
+            (1, 0, 'Stats', 'pending', '{"task_kind":"stats_all","channel_ids":[],"next_index":0,"batch_size":20,"channels_ok":0,"channels_err":0}'),
+            (2, -1001, 'Channel', 'pending', NULL);
+        """
+    )
+    await conn.commit()
+    await conn.close()
+
+    database = Database(str(db_path))
+    await database.initialize()
+
+    stats_task = await database.get_collection_task(1)
+    channel_task = await database.get_collection_task(2)
+    assert stats_task is not None
+    assert channel_task is not None
+    assert stats_task.task_type == CollectionTaskType.STATS_ALL
+    assert stats_task.channel_id is None
+    assert channel_task.task_type == CollectionTaskType.CHANNEL_COLLECT
+    assert channel_task.channel_id == -1001
+
+    await database.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_stats_task_dispatcher.py
+++ b/tests/test_stats_task_dispatcher.py
@@ -1,34 +1,29 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from src.models import Channel
+from src.models import (
+    Channel,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    StatsAllTaskPayload,
+)
 from src.services.stats_task_dispatcher import StatsTaskDispatcher
 
 
-def _stats_payload(channel_ids: list[int], *, next_index: int = 0) -> dict:
-    return {
-        "task_kind": "stats_all",
-        "channel_ids": channel_ids,
-        "next_index": next_index,
-        "batch_size": 20,
-        "channels_ok": 0,
-        "channels_err": 0,
-    }
+def _stats_payload(channel_ids: list[int], *, next_index: int = 0) -> StatsAllTaskPayload:
+    return StatsAllTaskPayload(channel_ids=channel_ids, next_index=next_index)
 
 
 @pytest.mark.asyncio
 async def test_dispatcher_requeues_running_on_start(db):
-    tid = await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=_stats_payload([]),
-    )
-    await db.update_collection_task(tid, "running")
+    tid = await db.create_stats_task(_stats_payload([]))
+    await db.update_collection_task(tid, CollectionTaskStatus.RUNNING)
 
     collector = SimpleNamespace(is_running=True)
     dispatcher = StatsTaskDispatcher(collector, db, poll_interval_sec=0.01)
@@ -37,7 +32,7 @@ async def test_dispatcher_requeues_running_on_start(db):
 
     task = await db.get_collection_task(tid)
     assert task is not None
-    assert task.status == "pending"
+    assert task.status == CollectionTaskStatus.PENDING
     assert task.run_after is not None
 
 
@@ -48,11 +43,7 @@ async def test_dispatcher_creates_batch_continuation(db):
     channels = await db.get_channels(active_only=True, include_filtered=False)
     channel_ids = [ch.channel_id for ch in channels]
 
-    root_id = await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=_stats_payload(channel_ids),
-    )
+    root_id = await db.create_stats_task(_stats_payload(channel_ids))
     root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
     assert root_task is not None
 
@@ -70,24 +61,21 @@ async def test_dispatcher_creates_batch_continuation(db):
 
     root = await db.get_collection_task(root_id)
     assert root is not None
-    assert root.status == "completed"
+    assert root.status == CollectionTaskStatus.COMPLETED
     assert root.messages_collected == 20
 
     active = await db.get_active_stats_task()
     assert active is not None
     assert active.parent_task_id == root_id
-    assert active.payload is not None
-    assert active.payload["next_index"] == 20
+    assert active.task_type == CollectionTaskType.STATS_ALL
+    assert isinstance(active.payload, StatsAllTaskPayload)
+    assert active.payload.next_index == 20
 
 
 @pytest.mark.asyncio
 async def test_dispatcher_defers_when_all_clients_flooded(db):
     await db.add_channel(Channel(channel_id=-100123, title="Ch"))
-    root_id = await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=_stats_payload([-100123]),
-    )
+    root_id = await db.create_stats_task(_stats_payload([-100123]))
     root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
     assert root_task is not None
 
@@ -107,7 +95,7 @@ async def test_dispatcher_defers_when_all_clients_flooded(db):
 
     root = await db.get_collection_task(root_id)
     assert root is not None
-    assert root.status == "failed"
+    assert root.status == CollectionTaskStatus.FAILED
     assert root.error is not None
     assert "Deferred to task #" in root.error
 
@@ -115,18 +103,14 @@ async def test_dispatcher_defers_when_all_clients_flooded(db):
     assert continuation is not None
     assert continuation.parent_task_id == root_id
     assert continuation.run_after is not None
-    assert continuation.payload is not None
-    assert continuation.payload["next_index"] == 0
+    assert isinstance(continuation.payload, StatsAllTaskPayload)
+    assert continuation.payload.next_index == 0
 
 
 @pytest.mark.asyncio
 async def test_dispatcher_fails_without_connected_clients(db):
     await db.add_channel(Channel(channel_id=-100555, title="Ch"))
-    root_id = await db.create_collection_task(
-        0,
-        "Обновление статистики",
-        payload=_stats_payload([-100555]),
-    )
+    root_id = await db.create_stats_task(_stats_payload([-100555]))
     root_task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
     assert root_task is not None
 
@@ -142,8 +126,110 @@ async def test_dispatcher_fails_without_connected_clients(db):
 
     root = await db.get_collection_task(root_id)
     assert root is not None
-    assert root.status == "failed"
+    assert root.status == CollectionTaskStatus.FAILED
     assert root.error == "No active connected Telegram accounts"
 
     active = await db.get_active_stats_task()
     assert active is None
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_marks_invalid_payload_failed(db):
+    task_id = await db.create_stats_task(_stats_payload([-1001]))
+    await db.execute(
+        "UPDATE collection_tasks SET payload = ? WHERE id = ?",
+        ('{"task_kind":"broken"}', task_id),
+    )
+    assert db.db is not None
+    await db.db.commit()
+    task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert task is not None
+
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(),
+        get_stats_availability=AsyncMock(),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(task)
+
+    updated = await db.get_collection_task(task_id)
+    assert updated is not None
+    assert updated.status == CollectionTaskStatus.FAILED
+    assert updated.error == "Unsupported stats task payload"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_completes_when_cursor_already_at_end(db):
+    task_id = await db.create_stats_task(_stats_payload([-1001], next_index=1))
+    task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert task is not None
+
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(),
+        get_stats_availability=AsyncMock(),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(task)
+
+    updated = await db.get_collection_task(task_id)
+    assert updated is not None
+    assert updated.status == CollectionTaskStatus.COMPLETED
+    assert updated.messages_collected == 0
+    assert await db.get_active_stats_task() is None
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skips_missing_channel_and_completes_batch(db):
+    task_id = await db.create_stats_task(_stats_payload([-100999]))
+    task = await db.claim_next_due_stats_task(datetime.now(timezone.utc))
+    assert task is not None
+
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+        collect_channel_stats=AsyncMock(),
+        get_stats_availability=AsyncMock(),
+    )
+    dispatcher = StatsTaskDispatcher(collector, db)
+    await dispatcher._run_stats_task(task)
+
+    updated = await db.get_collection_task(task_id)
+    assert updated is not None
+    assert updated.status == CollectionTaskStatus.COMPLETED
+    assert updated.messages_collected == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_loop_marks_unexpected_failure(db):
+    task_id = await db.create_stats_task(_stats_payload([]))
+    await db.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+
+    collector = SimpleNamespace(
+        is_running=False,
+        delay_between_channels_sec=0,
+    )
+    dispatcher = StatsTaskDispatcher(collector, db, poll_interval_sec=0.01)
+
+    async def _broken(_task):
+        raise RuntimeError("boom")
+
+    dispatcher._run_stats_task = _broken  # type: ignore[method-assign]
+    claimed = AsyncMock(side_effect=[await db.get_collection_task(task_id), None])
+    db.claim_next_due_stats_task = claimed  # type: ignore[method-assign]
+
+    run_task = asyncio.create_task(dispatcher._run_loop())
+    await asyncio.sleep(0.03)
+    await dispatcher.stop()
+    if not run_task.done():
+        run_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+
+    updated = await db.get_collection_task(task_id)
+    assert updated is not None
+    assert updated.status == CollectionTaskStatus.FAILED
+    assert updated.error == "Stats task failed with unexpected dispatcher error"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,6 +1,8 @@
 import base64
 import re
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -8,7 +10,7 @@ from httpx import ASGITransport, AsyncClient
 from src.collection_queue import CollectionQueue
 from src.config import AppConfig
 from src.database import Database
-from src.models import Account
+from src.models import Account, CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -918,7 +920,7 @@ async def test_delete_channel_cancels_pending_collection_tasks(client):
 
     task = await db.get_collection_task(task_id)
     assert task is not None
-    assert task.status == "cancelled"
+    assert task.status == CollectionTaskStatus.CANCELLED
     assert task.note == "Канал удалён пользователем."
 
 
@@ -932,10 +934,11 @@ async def test_stats_all_creates_pending_task(client):
 
     tasks = await db.get_collection_tasks()
     assert len(tasks) == 1
-    assert tasks[0].channel_id == 0
-    assert tasks[0].status == "pending"
-    assert tasks[0].payload is not None
-    assert tasks[0].payload["task_kind"] == "stats_all"
+    assert tasks[0].task_type == CollectionTaskType.STATS_ALL
+    assert tasks[0].channel_id is None
+    assert tasks[0].status == CollectionTaskStatus.PENDING
+    assert isinstance(tasks[0].payload, StatsAllTaskPayload)
+    assert tasks[0].payload.task_kind == CollectionTaskType.STATS_ALL.value
 
 
 @pytest.mark.asyncio
@@ -953,21 +956,13 @@ async def test_stats_all_queued_when_collector_running(client):
 
     tasks = await db.get_collection_tasks()
     assert len(tasks) == 1
-    assert tasks[0].status == "pending"
+    assert tasks[0].status == CollectionTaskStatus.PENDING
 
 
 @pytest.mark.asyncio
 async def test_stats_all_blocks_duplicate_active_task(client):
     db = client._transport.app.state.db
-    payload = {
-        "task_kind": "stats_all",
-        "channel_ids": [],
-        "next_index": 0,
-        "batch_size": 20,
-        "channels_ok": 0,
-        "channels_err": 0,
-    }
-    await db.create_collection_task(0, "Обновление статистики", payload=payload)
+    await db.create_stats_task(StatsAllTaskPayload(channel_ids=[]))
 
     resp = await client.post("/channels/stats/all", follow_redirects=False)
     assert resp.status_code == 303
@@ -993,8 +988,8 @@ async def test_stats_all_prioritizes_channels_without_stats(client):
 
     tasks = await db.get_collection_tasks()
     payload = tasks[0].payload
-    assert payload is not None
-    channel_ids = payload["channel_ids"]
+    assert isinstance(payload, StatsAllTaskPayload)
+    channel_ids = payload.channel_ids
     assert channel_ids.index(-100901) > channel_ids.index(-100902)
     assert channel_ids.index(-100901) > channel_ids.index(-100903)
 
@@ -1200,9 +1195,9 @@ async def test_get_channel_ids_with_active_tasks_returns_distinct_non_stats_ids(
     db = client._transport.app.state.db
     await db.create_collection_task(-100801, "One")
     task_id = await db.create_collection_task(-100802, "Two")
-    await db.update_collection_task(task_id, "running")
+    await db.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
     await db.create_collection_task(-100801, "One duplicate")
-    await db.create_collection_task(0, "Stats task")
+    await db.create_stats_task(StatsAllTaskPayload(channel_ids=[]))
 
     active_ids = await db.get_channel_ids_with_active_tasks()
 
@@ -1284,3 +1279,173 @@ async def test_save_scheduler_clamps_to_max(client):
     assert "msg=scheduler_saved" in resp.headers["location"]
     db = client._transport.app.state.db
     assert await db.get_setting("collect_interval_minutes") == "1440"
+
+
+@pytest.mark.asyncio
+async def test_save_filters_valid(client):
+    from src.models import Channel, ChannelStats
+
+    db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100501, title="Small"))
+    await db.save_channel_stats(ChannelStats(channel_id=-100501, subscriber_count=3))
+
+    resp = await client.post(
+        "/settings/save-filters",
+        data={"min_subscribers_filter": "10"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    assert "msg=filters_saved" in resp.headers["location"]
+    assert await db.get_setting("min_subscribers_filter") == "10"
+    channel = await db.get_channel_by_channel_id(-100501)
+    assert channel is not None
+    assert channel.is_filtered is True
+
+
+@pytest.mark.asyncio
+async def test_save_filters_invalid_value(client):
+    resp = await client.post(
+        "/settings/save-filters",
+        data={"min_subscribers_filter": "bad"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=invalid_value" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_save_credentials_valid_and_masked_path(client):
+    db = client._transport.app.state.db
+    auth = client._transport.app.state.auth
+
+    resp = await client.post(
+        "/settings/save-credentials",
+        data={"api_id": "54321", "api_hash": "hash-1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=credentials_saved" in resp.headers["location"]
+    assert await db.get_setting("tg_api_id") == "54321"
+    assert await db.get_setting("tg_api_hash") == "hash-1"
+    assert auth._api_id == 54321
+    assert auth._api_hash == "hash-1"
+
+    resp = await client.post(
+        "/settings/save-credentials",
+        data={"api_id": "••••••••", "api_hash": "hash-2"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "msg=credentials_saved" in resp.headers["location"]
+    assert await db.get_setting("tg_api_id") == "54321"
+    assert await db.get_setting("tg_api_hash") == "hash-2"
+    assert auth._api_id == 54321
+    assert auth._api_hash == "hash-2"
+
+
+@pytest.mark.asyncio
+async def test_notification_setup_and_delete_json(client, monkeypatch):
+    from types import SimpleNamespace
+
+    from src.models import Account
+
+    db = client._transport.app.state.db
+    pool = client._transport.app.state.pool
+    await db.add_account(Account(phone="+79990000003", session_string="session", is_primary=True))
+    await db.set_setting("notification_account_phone", "+79990000003")
+    pool.clients["+79990000003"] = object()
+
+    fake_client = SimpleNamespace(
+        get_me=AsyncMock(return_value=SimpleNamespace(id=42, username="owner")),
+        send_message=AsyncMock(),
+        get_entity=AsyncMock(return_value=SimpleNamespace(id=777)),
+    )
+    pool.get_client_by_phone = AsyncMock(return_value=(fake_client, "+79990000003"))
+    pool.release_client = AsyncMock()
+
+    async def _create_bot(_client, _name, _username):
+        return "token-123"
+
+    async def _delete_bot(_client, _username):
+        return None
+
+    monkeypatch.setattr("src.services.notification_service.botfather.create_bot", _create_bot)
+    monkeypatch.setattr("src.services.notification_service.botfather.delete_bot", _delete_bot)
+
+    resp = await client.post(
+        "/settings/notifications/setup",
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bot_username"] == "leadhunter_owner_bot"
+
+    status_resp = await client.get(
+        "/settings/notifications/status",
+        headers={"Accept": "application/json"},
+    )
+    assert status_resp.status_code == 200
+    assert status_resp.json()["configured"] is True
+
+    delete_resp = await client.post(
+        "/settings/notifications/delete",
+        headers={"Accept": "application/json"},
+    )
+    assert delete_resp.status_code == 200
+    assert delete_resp.json() == {"deleted": True}
+
+
+@pytest.mark.asyncio
+async def test_notification_setup_returns_conflict_when_account_unavailable(client):
+    from src.models import Account
+
+    db = client._transport.app.state.db
+    await db.add_account(Account(phone="+79990000004", session_string="session", is_primary=True))
+    await db.set_setting("notification_account_phone", "+79990000004")
+
+    resp = await client.post(
+        "/settings/notifications/setup",
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 409
+    assert "не подключён" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_collect_stats_route_marks_task_completed(client):
+    from src.models import ChannelStats
+
+    db = client._transport.app.state.db
+    await client.post("/channels/add", data={"identifier": "@teststats"})
+    channel = next(ch for ch in await db.get_channels() if ch.username == "teststats")
+
+    client._transport.app.state.collector.collect_channel_stats = AsyncMock(
+        return_value=ChannelStats(channel_id=channel.channel_id, subscriber_count=10)
+    )
+
+    resp = await client.post(f"/channels/{channel.id}/stats", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=stats_collection_started" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    assert tasks[0].status == CollectionTaskStatus.COMPLETED
+    assert tasks[0].messages_collected == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_stats_route_marks_task_failed(client):
+    db = client._transport.app.state.db
+    await client.post("/channels/add", data={"identifier": "@teststatsfail"})
+    channel = next(ch for ch in await db.get_channels() if ch.username == "teststatsfail")
+
+    client._transport.app.state.collector.collect_channel_stats = AsyncMock(
+        side_effect=RuntimeError("stats broken")
+    )
+
+    resp = await client.post(f"/channels/{channel.id}/stats", follow_redirects=False)
+    assert resp.status_code == 303
+
+    tasks = await db.get_collection_tasks()
+    assert tasks[0].status == CollectionTaskStatus.FAILED
+    assert tasks[0].error == "stats broken"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1346,7 +1346,6 @@ async def test_save_credentials_valid_and_masked_path(client):
 
 @pytest.mark.asyncio
 async def test_notification_setup_and_delete_json(client, monkeypatch):
-    from types import SimpleNamespace
 
     from src.models import Account
 


### PR DESCRIPTION
## Summary
- introduce app container/bootstrap assembly and repo bundles with backward-compatible service wiring
- keep legacy compatibility for routes/tests while moving app dependencies behind container accessors
- replace the old smoke-test command with  subcommands and simplify live Telegram checks to a single-channel 10-post probe
- fix write-test channel toggle, premium client handling, and CLI/module naming consistency

## Verification
- python3 -m pytest tests/test_web.py tests/test_collector.py tests/test_database.py tests/test_stats_task_dispatcher.py tests/test_cli.py tests/test_bundles.py
- 271 passed
