### PR TITLE
feat(agent): add AI agent with Claude SDK, SSE streaming, and MCP tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,9 @@ SESSION_ENCRYPTION_KEY=
 
 # LLM for AI search (optional)
 LLM_API_KEY=
+
+# AI Agent — Claude API key and OAuth token
+ANTHROPIC_API_KEY=
+CLAUDE_CODE_OAUTH_TOKEN=
+# AI Agent model override (optional, default: anthropic:claude-sonnet-4-6)
+AGENT_MODEL=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ dependencies = [
     "cryptography==46.0.5",
     "openpyxl>=3.1.0",
     "aiohttp>=3.9.0",
+    "claude-agent-sdk",
 ]
 
 [project.optional-dependencies]
-ai = ["deepagents==0.3.6"]
 dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import AsyncGenerator
 from contextlib import suppress
 
@@ -35,7 +36,9 @@ class AgentManager:
 
     @property
     def available(self) -> bool:
-        return True
+        return bool(
+            os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+        )
 
     def _build_prompt(self, history: list[dict], message: str) -> str:
         lines = []
@@ -50,10 +53,12 @@ class AgentManager:
         history = await self._db.get_agent_messages(thread_id)
         prompt = self._build_prompt(history[:-1], message)
 
+        model = os.environ.get("AGENT_MODEL") or None
         options = ClaudeAgentOptions(
             system_prompt=_SYSTEM_PROMPT,
             mcp_servers={"telegram_db": self._server},
             allowed_tools=_ALLOWED_TOOLS,
+            model=model,
         )
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -42,12 +42,12 @@ class AgentManager:
         )
 
     def _build_prompt(self, history: list[dict], message: str) -> str:
-        lines = []
+        parts = []
         for msg in history:
-            role_label = "User" if msg["role"] == "user" else "Assistant"
-            lines.append(f"{role_label}: {msg['content']}")
-        lines.append(f"User: {message}")
-        return "\n".join(lines)
+            tag = "user" if msg["role"] == "user" else "assistant"
+            parts.append(f"<{tag}>\n{msg['content']}\n</{tag}>")
+        parts.append(f"<user>\n{message}\n</user>")
+        return "\n".join(parts)
 
     async def chat_stream(self, thread_id: int, message: str) -> AsyncGenerator[str, None]:
         """Async generator yielding raw SSE lines: data: <json>\\n\\n"""

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncGenerator
+from contextlib import suppress
+
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, TextBlock, query
+
+from src.database import Database
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "Ты — аналитический ассистент для работы с данными из Telegram-каналов.\n"
+    "Используй search_messages для поиска сообщений и get_channels для списка каналов.\n"
+    "Основной use-case: анализ вопросов и ответов из каналов для создания учебного курса.\n"
+    "Отвечай на русском языке. Будь точным и структурированным."
+)
+
+_ALLOWED_TOOLS = ["mcp__telegram_db__search_messages", "mcp__telegram_db__get_channels"]
+
+
+class AgentManager:
+    def __init__(self, db: Database) -> None:
+        self._db = db
+        self._server = None
+
+    def initialize(self) -> None:
+        from src.agent.tools import make_mcp_server
+
+        self._server = make_mcp_server(self._db)
+        logger.info("AgentManager initialized (claude-agent-sdk)")
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    def _build_prompt(self, history: list[dict], message: str) -> str:
+        lines = []
+        for msg in history:
+            role_label = "User" if msg["role"] == "user" else "Assistant"
+            lines.append(f"{role_label}: {msg['content']}")
+        lines.append(f"User: {message}")
+        return "\n".join(lines)
+
+    async def chat_stream(self, thread_id: int, message: str) -> AsyncGenerator[str, None]:
+        """Async generator yielding raw SSE lines: data: <json>\\n\\n"""
+        history = await self._db.get_agent_messages(thread_id)
+        prompt = self._build_prompt(history[:-1], message)
+
+        options = ClaudeAgentOptions(
+            system_prompt=_SYSTEM_PROMPT,
+            mcp_servers={"telegram_db": self._server},
+            allowed_tools=_ALLOWED_TOOLS,
+        )
+
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        async def _run_query() -> None:
+            draining = False
+            try:
+                full_text = ""
+                async for msg in query(prompt=prompt, options=options):
+                    if draining:
+                        continue  # drain to StopAsyncIteration to avoid cleanup Task
+                    try:
+                        if isinstance(msg, AssistantMessage):
+                            for block in msg.content:
+                                if isinstance(block, TextBlock):
+                                    full_text += block.text
+                                    chunk_payload = json.dumps(
+                                        {"text": block.text}, ensure_ascii=False
+                                    )
+                                    await queue.put(f"data: {chunk_payload}\n\n")
+                        elif isinstance(msg, ResultMessage):
+                            done_payload = json.dumps(
+                                {"done": True, "full_text": full_text}, ensure_ascii=False
+                            )
+                            await queue.put(f"data: {done_payload}\n\n")
+                            # NO return — let the loop exhaust naturally
+                    except asyncio.CancelledError:
+                        draining = True  # switch to drain mode, keep iterating
+            except Exception as e:
+                logger.exception("Agent chat error for thread %d", thread_id)
+                err_payload = json.dumps({"error": f"Ошибка агента: {e}"}, ensure_ascii=False)
+                await queue.put(f"data: {err_payload}\n\n")
+            finally:
+                await queue.put(None)  # sentinel
+
+        task = asyncio.create_task(_run_query())
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    break
+                yield item
+        finally:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def close_all(self) -> None:
+        pass

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -27,6 +27,7 @@ class AgentManager:
     def __init__(self, db: Database) -> None:
         self._db = db
         self._server = None
+        self._active_tasks: set[asyncio.Task] = set()
 
     def initialize(self) -> None:
         from src.agent.tools import make_mcp_server
@@ -53,12 +54,14 @@ class AgentManager:
         history = await self._db.get_agent_messages(thread_id)
         prompt = self._build_prompt(history[:-1], message)
 
-        model = os.environ.get("AGENT_MODEL") or None
+        extra: dict = {}
+        if agent_model := os.environ.get("AGENT_MODEL"):
+            extra["model"] = agent_model
         options = ClaudeAgentOptions(
             system_prompt=_SYSTEM_PROMPT,
             mcp_servers={"telegram_db": self._server},
             allowed_tools=_ALLOWED_TOOLS,
-            model=model,
+            **extra,
         )
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -95,6 +98,8 @@ class AgentManager:
                 await queue.put(None)  # sentinel
 
         task = asyncio.create_task(_run_query())
+        self._active_tasks.add(task)
+        task.add_done_callback(self._active_tasks.discard)
         try:
             while True:
                 item = await queue.get()
@@ -107,4 +112,9 @@ class AgentManager:
                 await task
 
     async def close_all(self) -> None:
-        pass
+        tasks = list(self._active_tasks)
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            with suppress(asyncio.CancelledError):
+                await t

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -52,6 +52,11 @@ class AgentManager:
     async def chat_stream(self, thread_id: int, message: str) -> AsyncGenerator[str, None]:
         """Async generator yielding raw SSE lines: data: <json>\\n\\n"""
         history = await self._db.get_agent_messages(thread_id)
+        # Callers must save the user message before calling chat_stream, so history[-1]
+        # is always the user's message we're about to answer — exclude it from context.
+        assert not history or history[-1]["role"] == "user", (
+            "Expected last DB message to be the user message just saved"
+        )
         prompt = self._build_prompt(history[:-1], message)
 
         extra: dict = {}

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from claude_agent_sdk import create_sdk_mcp_server, tool
+
+from src.database import Database
+
+
+def make_mcp_server(db: Database):
+    """Create an in-process MCP server with DB-bound tools."""
+
+    @tool(
+        "search_messages",
+        "Search messages in Telegram channels by query text",
+        {"query": str, "limit": int},
+    )
+    async def search_messages(args):
+        query = args.get("query", "")
+        limit = int(args.get("limit", 20))
+        try:
+            messages, total = await db.search_messages(query=query, limit=limit)
+            if not messages:
+                text = f"Ничего не найдено по запросу: {query!r}"
+            else:
+                lines = [
+                    f"Найдено {total} сообщений для '{query}'. Показаны первые {len(messages)}:"
+                ]
+                for m in messages:
+                    preview = (m.text or "")[:300]
+                    lines.append(f"- [channel_id={m.channel_id}, date={m.date}]: {preview}")
+                text = "\n".join(lines)
+        except Exception as e:
+            text = f"Ошибка поиска сообщений: {e}"
+        return {"content": [{"type": "text", "text": text}]}
+
+    @tool("get_channels", "List all available Telegram channels in the database", {})
+    async def get_channels(args):
+        try:
+            channels = await db.get_channels()
+            if not channels:
+                text = "Каналы не найдены."
+            else:
+                lines = [f"Доступные каналы ({len(channels)}):"]
+                for ch in channels:
+                    status = "активен" if ch.is_active else "неактивен"
+                    filtered = " [отфильтрован]" if ch.is_filtered else ""
+                    lines.append(
+                        f"- {ch.title} (@{ch.username}, id={ch.channel_id}, {status}{filtered})"
+                    )
+                text = "\n".join(lines)
+        except Exception as e:
+            text = f"Ошибка получения каналов: {e}"
+        return {"content": [{"type": "text", "text": text}]}
+
+    return create_sdk_mcp_server(
+        name="telegram_db",
+        tools=[search_messages, get_channels],
+    )

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -54,7 +54,7 @@ def run(args: argparse.Namespace) -> None:
                         continue
                     if "text" in payload:
                         print(payload["text"], end="", flush=True)
-                        full_text = payload.get("text", full_text)
+                        full_text += payload.get("text", "")
                     if payload.get("done"):
                         print()
                         break

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from src.cli import runtime
+
+
+def run(args: argparse.Namespace) -> None:
+    async def _run() -> None:
+        config, db = await runtime.init_db(args.config)
+        try:
+            action = args.agent_action
+
+            if action == "threads":
+                threads = await db.get_agent_threads()
+                if not threads:
+                    print("Нет тредов.")
+                else:
+                    for t in threads:
+                        print(f"[{t['id']}] {t['title']}  ({t['created_at']})")
+
+            elif action == "thread-create":
+                title = getattr(args, "title", None) or "Новый тред"
+                tid = await db.create_agent_thread(title)
+                print(f"Создан тред #{tid}: {title}")
+
+            elif action == "thread-delete":
+                await db.delete_agent_thread(args.thread_id)
+                print(f"Тред #{args.thread_id} удалён.")
+
+            elif action == "chat":
+                from src.agent.manager import AgentManager
+
+                if args.thread_id:
+                    thread_id = args.thread_id
+                else:
+                    thread_id = await db.create_agent_thread("Новый тред")
+                    print(f"(создан тред #{thread_id})")
+
+                await db.save_agent_message(thread_id, "user", args.message)
+
+                mgr = AgentManager(db)
+                mgr.initialize()
+
+                print("Агент: ", end="", flush=True)
+                full_text = ""
+                async for chunk in mgr.chat_stream(thread_id, args.message):
+                    raw = chunk.removeprefix("data: ").strip()
+                    try:
+                        payload = json.loads(raw)
+                    except Exception:
+                        continue
+                    if "text" in payload:
+                        print(payload["text"], end="", flush=True)
+                        full_text = payload.get("text", full_text)
+                    if payload.get("done"):
+                        print()
+                        break
+                    if "error" in payload:
+                        print(f"\nОшибка: {payload['error']}")
+                        break
+
+                if full_text:
+                    await db.save_agent_message(thread_id, "assistant", full_text)
+        finally:
+            await db.close()
+
+    asyncio.run(_run())

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -14,6 +14,7 @@ from src.cli.commands import (
     search_query,
     serve,
 )
+from src.cli.commands import agent as agent_cmd
 from src.cli.commands import filter as filter_cmd
 from src.cli.commands import my_telegram as my_telegram_cmd
 from src.cli.commands import (
@@ -42,6 +43,7 @@ def main() -> None:
         "notification": notification.run,
         "my-telegram": my_telegram_cmd.run,
         "test": test_cmd.run,
+        "agent": agent_cmd.run,
     }
 
     handler = commands.get(args.command)
@@ -55,6 +57,7 @@ def main() -> None:
             "notification": "notification_action",
             "my-telegram": "my_telegram_action",
             "test": "test_action",
+            "agent": "agent_action",
         }
         if args.command in sub_attr and not getattr(args, sub_attr[args.command], None):
             parser.parse_args([args.command, "--help"])

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -143,6 +143,21 @@ def build_parser() -> argparse.ArgumentParser:
     notif_sub.add_parser("status", help="Show notification bot status")
     notif_sub.add_parser("delete", help="Delete notification bot via BotFather")
 
+    agent_parser = sub.add_parser("agent", help="Agent chat management")
+    agent_sub = agent_parser.add_subparsers(dest="agent_action")
+
+    agent_sub.add_parser("threads", help="List agent threads")
+
+    agent_create = agent_sub.add_parser("thread-create", help="Create new thread")
+    agent_create.add_argument("--title", default=None, help="Thread title")
+
+    agent_delete = agent_sub.add_parser("thread-delete", help="Delete thread")
+    agent_delete.add_argument("thread_id", type=int, help="Thread ID")
+
+    agent_chat = agent_sub.add_parser("chat", help="Send message to agent")
+    agent_chat.add_argument("message", help="Message text")
+    agent_chat.add_argument("--thread-id", type=int, default=None, dest="thread_id")
+
     test_parser = sub.add_parser("test", help="Run diagnostic tests")
     test_sub = test_parser.add_subparsers(dest="test_action")
     test_sub.add_parser("all", help="Run all test sections (read + write + telegram)")

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -16,6 +16,7 @@ class DBConnection:
         self.db.row_factory = aiosqlite.Row
         await self.db.execute("PRAGMA journal_mode=WAL")
         await self.db.execute("PRAGMA synchronous=NORMAL")
+        await self.db.execute("PRAGMA foreign_keys=ON")
         return self.db
 
     async def close(self) -> None:

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -12,7 +12,7 @@ class DBConnection:
 
     async def connect(self) -> aiosqlite.Connection:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.db = await aiosqlite.connect(self._db_path, timeout=10.0)
+        self.db = await aiosqlite.connect(self._db_path, timeout=10.0, isolation_level=None)
         self.db.row_factory = aiosqlite.Row
         await self.db.execute("PRAGMA journal_mode=WAL")
         await self.db.execute("PRAGMA synchronous=NORMAL")

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -445,6 +445,14 @@ class Database:
         rows = await cur.fetchall()
         return [dict(r) for r in rows]
 
+    async def get_agent_thread(self, thread_id: int) -> dict | None:
+        assert self._db is not None
+        cur = await self._db.execute(
+            "SELECT id, title, created_at FROM agent_threads WHERE id = ?", (thread_id,)
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
     async def rename_agent_thread(self, thread_id: int, title: str) -> None:
         assert self._db is not None
         await self._db.execute(

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -425,3 +425,52 @@ class Database:
         self._require()
         assert self._notification_bots is not None
         await self._notification_bots.delete_bot(tg_user_id)
+
+    # ── Agent chat ─────────────────────────────────────────────────────────────
+
+    async def create_agent_thread(self, title: str = "Новый тред") -> int:
+        assert self._db is not None
+        cur = await self._db.execute(
+            "INSERT INTO agent_threads (title) VALUES (?)", (title,)
+        )
+        await self._db.commit()
+        assert cur.lastrowid is not None
+        return cur.lastrowid
+
+    async def get_agent_threads(self) -> list[dict]:
+        assert self._db is not None
+        cur = await self._db.execute(
+            "SELECT id, title, created_at FROM agent_threads ORDER BY created_at DESC"
+        )
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
+    async def rename_agent_thread(self, thread_id: int, title: str) -> None:
+        assert self._db is not None
+        await self._db.execute(
+            "UPDATE agent_threads SET title = ? WHERE id = ?", (title, thread_id)
+        )
+        await self._db.commit()
+
+    async def delete_agent_thread(self, thread_id: int) -> None:
+        assert self._db is not None
+        await self._db.execute("DELETE FROM agent_threads WHERE id = ?", (thread_id,))
+        await self._db.commit()
+
+    async def get_agent_messages(self, thread_id: int) -> list[dict]:
+        assert self._db is not None
+        cur = await self._db.execute(
+            "SELECT id, thread_id, role, content, created_at"
+            " FROM agent_messages WHERE thread_id = ? ORDER BY created_at ASC",
+            (thread_id,),
+        )
+        rows = await cur.fetchall()
+        return [dict(r) for r in rows]
+
+    async def save_agent_message(self, thread_id: int, role: str, content: str) -> None:
+        assert self._db is not None
+        await self._db.execute(
+            "INSERT INTO agent_messages (thread_id, role, content) VALUES (?, ?, ?)",
+            (thread_id, role, content),
+        )
+        await self._db.commit()

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -429,6 +429,7 @@ class Database:
     # ── Agent chat ─────────────────────────────────────────────────────────────
 
     async def create_agent_thread(self, title: str = "Новый тред") -> int:
+        self._require()
         assert self._db is not None
         cur = await self._db.execute(
             "INSERT INTO agent_threads (title) VALUES (?)", (title,)
@@ -438,6 +439,7 @@ class Database:
         return cur.lastrowid
 
     async def get_agent_threads(self) -> list[dict]:
+        self._require()
         assert self._db is not None
         cur = await self._db.execute(
             "SELECT id, title, created_at FROM agent_threads ORDER BY created_at DESC"
@@ -446,6 +448,7 @@ class Database:
         return [dict(r) for r in rows]
 
     async def get_agent_thread(self, thread_id: int) -> dict | None:
+        self._require()
         assert self._db is not None
         cur = await self._db.execute(
             "SELECT id, title, created_at FROM agent_threads WHERE id = ?", (thread_id,)
@@ -454,6 +457,7 @@ class Database:
         return dict(row) if row else None
 
     async def rename_agent_thread(self, thread_id: int, title: str) -> None:
+        self._require()
         assert self._db is not None
         await self._db.execute(
             "UPDATE agent_threads SET title = ? WHERE id = ?", (title, thread_id)
@@ -461,11 +465,13 @@ class Database:
         await self._db.commit()
 
     async def delete_agent_thread(self, thread_id: int) -> None:
+        self._require()
         assert self._db is not None
         await self._db.execute("DELETE FROM agent_threads WHERE id = ?", (thread_id,))
         await self._db.commit()
 
     async def get_agent_messages(self, thread_id: int) -> list[dict]:
+        self._require()
         assert self._db is not None
         cur = await self._db.execute(
             "SELECT id, thread_id, role, content, created_at"
@@ -476,6 +482,7 @@ class Database:
         return [dict(r) for r in rows]
 
     async def save_agent_message(self, thread_id: int, role: str, content: str) -> None:
+        self._require()
         assert self._db is not None
         await self._db.execute(
             "INSERT INTO agent_messages (thread_id, role, content) VALUES (?, ?, ?)",

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -293,5 +293,4 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
         )
         """
     )
-    await db.execute("PRAGMA foreign_keys = ON")
     await db.commit()

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -271,3 +271,27 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
             logger.info("FTS5 index built for existing messages")
         except Exception as exc:
             logger.warning("FTS5 index build failed (FTS5 may be unavailable): %s", exc)
+
+    # Agent chat tables
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_threads (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            title      TEXT NOT NULL DEFAULT 'Новый тред',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_messages (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            thread_id  INTEGER NOT NULL REFERENCES agent_threads(id) ON DELETE CASCADE,
+            role       TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+            content    TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """
+    )
+    await db.execute("PRAGMA foreign_keys = ON")
+    await db.commit()

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -163,6 +163,7 @@ class ChannelAnalyzer:
         updates = [(cid, ",".join(sorted(flags))) for cid, flags in deduped.items()]
         conn = self._database.db
         assert conn is not None
+        await conn.execute("BEGIN")
         try:
             await self._database.reset_all_channel_filters(commit=False)
             count = 0

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -92,6 +92,7 @@ def register_builtin_endpoints(app: FastAPI) -> None:
 
 
 def register_routes(app: FastAPI) -> None:
+    from src.web.routes.agent import router as agent_router
     from src.web.routes.auth import router as auth_router
     from src.web.routes.channel_collection import router as channel_collection_router
     from src.web.routes.channels import router as channels_router
@@ -105,6 +106,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.search_queries import router as search_queries_router
     from src.web.routes.settings import router as settings_router
 
+    app.include_router(agent_router, prefix="/agent")
     app.include_router(search_router)
     app.include_router(dashboard_router, prefix="/dashboard")
     app.include_router(auth_router, prefix="/auth")

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import secrets
 
 from fastapi.templating import Jinja2Templates
 
+from src.agent.manager import AgentManager
 from src.collection_queue import CollectionQueue
 from src.config import AppConfig, resolve_session_encryption_secret
 from src.database import Database
@@ -110,6 +112,7 @@ async def build_container_with_templates(
     stats_dispatcher = StatsTaskDispatcher(collector, channel_bundle, default_batch_size=20)
     search_engine = SearchEngine(search_bundle, pool)
     ai_search = AISearchEngine(config.llm, search_bundle)
+    agent_manager = AgentManager(db)
     search_query_bundle = SearchQueryBundle(repos.search_queries, repos.messages)
     scheduler = SchedulerManager(
         collector,
@@ -117,6 +120,11 @@ async def build_container_with_templates(
         scheduler_bundle=scheduler_bundle,
         search_engine=search_engine,
         search_query_bundle=search_query_bundle,
+    )
+
+    _templates = templates or Jinja2Templates(directory=str(TEMPLATES_DIR))
+    _templates.env.globals["agent_available"] = bool(
+        os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
     )
 
     return AppContainer(
@@ -140,10 +148,11 @@ async def build_container_with_templates(
         search_engine=search_engine,
         ai_search=ai_search,
         scheduler=scheduler,
-        templates=templates or Jinja2Templates(directory=str(TEMPLATES_DIR)),
+        templates=_templates,
         log_buffer=log_buffer,
         session_secret=session_secret,
         bg_tasks=set(),
+        agent_manager=agent_manager,
         shutting_down=False,
     )
 
@@ -164,6 +173,8 @@ async def start_container(container: AppContainer) -> None:
     if container.stats_dispatcher is not None:
         await container.stats_dispatcher.start()
     container.ai_search.initialize()
+    if container.agent_manager is not None:
+        container.agent_manager.initialize()
 
 
 async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
@@ -181,6 +192,8 @@ async def stop_container(container: AppContainer) -> None:
         shutdown_coroutines.append(("stats_dispatcher", container.stats_dispatcher.stop()))
     if container.collection_queue is not None:
         shutdown_coroutines.append(("collection_queue", container.collection_queue.shutdown()))
+    if container.agent_manager is not None:
+        shutdown_coroutines.append(("agent_manager", container.agent_manager.close_all()))
     shutdown_coroutines.extend([
         ("scheduler", container.scheduler.stop()),
         ("collector", container.collector.cancel()),

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from fastapi.templating import Jinja2Templates
 
+from src.agent.manager import AgentManager
 from src.collection_queue import CollectionQueue
 from src.config import AppConfig
 from src.database import Database
@@ -56,4 +57,5 @@ class AppContainer:
     log_buffer: LogBuffer | None
     session_secret: str
     bg_tasks: set[asyncio.Task]
+    agent_manager: AgentManager | None = None
     shutting_down: bool = False

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
 
+from src.agent.manager import AgentManager
 from src.collection_queue import CollectionQueue
 from src.database import Database
 from src.database.bundles import (
@@ -107,6 +108,7 @@ def get_container(request: Request) -> AppContainer:
         log_buffer=getattr(request.app.state, "log_buffer", None),
         session_secret=_require_app_state_attr(request, "session_secret"),
         bg_tasks=getattr(request.app.state, "bg_tasks", set()),
+        agent_manager=getattr(request.app.state, "agent_manager", None),
         shutting_down=getattr(request.app.state, "shutting_down", False),
     )
     request.state._container = container
@@ -195,6 +197,10 @@ def get_log_buffer(request: Request) -> LogBuffer | None:
 
 def is_shutting_down(request: Request) -> bool:
     return get_container(request).shutting_down
+
+
+def get_agent_manager(request: Request) -> AgentManager | None:
+    return get_container(request).agent_manager
 
 
 def channel_service(request: Request) -> ChannelService:

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -101,23 +101,17 @@ async def chat(request: Request, thread_id: int):
         raise HTTPException(status_code=503, detail="AgentManager not initialized")
 
     async def generate():
-        full_text_parts = []
-
         async for chunk in agent_manager.chat_stream(thread_id, message):
-            yield chunk
-            # Collect full_text from done event
+            # Save before yielding so disconnect doesn't lose the message
             try:
                 data_str = chunk.removeprefix("data: ").strip()
                 data = json.loads(data_str)
                 if data.get("done") and data.get("full_text"):
-                    full_text_parts.append(data["full_text"])
+                    await db.save_agent_message(thread_id, "assistant", data["full_text"])
                 elif data.get("error"):
-                    full_text_parts.append(data["error"])
+                    await db.save_agent_message(thread_id, "assistant", data["error"])
             except Exception:
                 pass
-
-        # Save assistant response
-        if full_text_parts:
-            await db.save_agent_message(thread_id, "assistant", full_text_parts[-1])
+            yield chunk
 
     return StreamingResponse(generate(), media_type="text/event-stream")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
@@ -84,18 +85,16 @@ async def chat(request: Request, thread_id: int):
     db = deps.get_db(request)
 
     # Verify thread exists
-    threads = await db.get_agent_threads()
-    if not any(t["id"] == thread_id for t in threads):
+    thread = await db.get_agent_thread(thread_id)
+    if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
     # Save user message
     await db.save_agent_message(thread_id, "user", message)
 
     # Auto-rename thread from first message
-    for t in threads:
-        if t["id"] == thread_id and t["title"] == "Новый тред":
-            await db.rename_agent_thread(thread_id, message[:60])
-            break
+    if thread["title"] == "Новый тред":
+        await db.rename_agent_thread(thread_id, message[:60])
 
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is None:
@@ -103,27 +102,22 @@ async def chat(request: Request, thread_id: int):
 
     async def generate():
         full_text_parts = []
-        had_error = False
 
         async for chunk in agent_manager.chat_stream(thread_id, message):
             yield chunk
             # Collect full_text from done event
-            import json
-
             try:
                 data_str = chunk.removeprefix("data: ").strip()
                 data = json.loads(data_str)
                 if data.get("done") and data.get("full_text"):
                     full_text_parts.append(data["full_text"])
                 elif data.get("error"):
-                    had_error = True
                     full_text_parts.append(data["error"])
             except Exception:
                 pass
 
         # Save assistant response
         if full_text_parts:
-            role = "assistant" if not had_error else "assistant"
-            await db.save_agent_message(thread_id, role, full_text_parts[-1])
+            await db.save_agent_message(thread_id, "assistant", full_text_parts[-1])
 
     return StreamingResponse(generate(), media_type="text/event-stream")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -26,11 +26,7 @@ async def agent_page(request: Request, thread_id: int | None = None):
     active_thread = None
 
     if thread_id is not None:
-        # Validate thread exists
-        for t in threads:
-            if t["id"] == thread_id:
-                active_thread = t
-                break
+        active_thread = await db.get_agent_thread(thread_id)
         if active_thread is None and threads:
             # Redirect to first existing thread
             return RedirectResponse(url=f"/agent?thread_id={threads[0]['id']}", status_code=303)
@@ -108,10 +104,10 @@ async def chat(request: Request, thread_id: int):
                 data = json.loads(data_str)
                 if data.get("done") and data.get("full_text"):
                     await db.save_agent_message(thread_id, "assistant", data["full_text"])
-                elif data.get("error"):
-                    await db.save_agent_message(thread_id, "assistant", data["error"])
-            except Exception:
+            except json.JSONDecodeError:
                 pass
+            except Exception:
+                logger.exception("Failed to save agent message for thread %d", thread_id)
             yield chunk
 
     return StreamingResponse(generate(), media_type="text/event-stream")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from pydantic import BaseModel
+
+from src.web import deps
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class ChatRequest(BaseModel):
+    message: str
+
+
+@router.get("", response_class=HTMLResponse)
+async def agent_page(request: Request, thread_id: int | None = None):
+    db = deps.get_db(request)
+    threads = await db.get_agent_threads()
+
+    messages = []
+    active_thread = None
+
+    if thread_id is not None:
+        # Validate thread exists
+        for t in threads:
+            if t["id"] == thread_id:
+                active_thread = t
+                break
+        if active_thread is None and threads:
+            # Redirect to first existing thread
+            return RedirectResponse(url=f"/agent?thread_id={threads[0]['id']}", status_code=303)
+        if active_thread is not None:
+            messages = await db.get_agent_messages(thread_id)
+    elif threads:
+        return RedirectResponse(url=f"/agent?thread_id={threads[0]['id']}", status_code=303)
+
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "agent.html",
+        {
+            "threads": threads,
+            "active_thread": active_thread,
+            "messages": messages,
+        },
+    )
+
+
+@router.post("/threads", response_class=HTMLResponse)
+async def create_thread(request: Request):
+    db = deps.get_db(request)
+    thread_id = await db.create_agent_thread("Новый тред")
+    return RedirectResponse(url=f"/agent?thread_id={thread_id}", status_code=303)
+
+
+@router.delete("/threads/{thread_id}")
+async def delete_thread(request: Request, thread_id: int):
+    db = deps.get_db(request)
+    await db.delete_agent_thread(thread_id)
+    return {"ok": True}
+
+
+@router.post("/threads/{thread_id}/rename")
+async def rename_thread(request: Request, thread_id: int):
+    body = await request.json()
+    title = (body.get("title") or "").strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="Title cannot be empty")
+    db = deps.get_db(request)
+    await db.rename_agent_thread(thread_id, title[:100])
+    return {"ok": True}
+
+
+@router.post("/threads/{thread_id}/chat")
+async def chat(request: Request, thread_id: int):
+    body = await request.json()
+    message = (body.get("message") or "").strip()
+    if not message:
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
+
+    db = deps.get_db(request)
+
+    # Verify thread exists
+    threads = await db.get_agent_threads()
+    if not any(t["id"] == thread_id for t in threads):
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    # Save user message
+    await db.save_agent_message(thread_id, "user", message)
+
+    # Auto-rename thread from first message
+    for t in threads:
+        if t["id"] == thread_id and t["title"] == "Новый тред":
+            await db.rename_agent_thread(thread_id, message[:60])
+            break
+
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is None:
+        raise HTTPException(status_code=503, detail="AgentManager not initialized")
+
+    async def generate():
+        full_text_parts = []
+        had_error = False
+
+        async for chunk in agent_manager.chat_stream(thread_id, message):
+            yield chunk
+            # Collect full_text from done event
+            import json
+
+            try:
+                data_str = chunk.removeprefix("data: ").strip()
+                data = json.loads(data_str)
+                if data.get("done") and data.get("full_text"):
+                    full_text_parts.append(data["full_text"])
+                elif data.get("error"):
+                    had_error = True
+                    full_text_parts.append(data["error"])
+            except Exception:
+                pass
+
+        # Save assistant response
+        if full_text_parts:
+            role = "assistant" if not had_error else "assistant"
+            await db.save_agent_message(thread_id, role, full_text_parts[-1])
+
+    return StreamingResponse(generate(), media_type="text/event-stream")

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -343,14 +343,6 @@
             aiBubble.textContent = 'Ошибка соединения: ' + err.message;
         }
 
-        // Refresh page title with thread name (auto-renamed on first message)
-        try {
-            var titleResp = await fetch('/agent?thread_id=' + threadId, {
-                headers: {'Accept': 'text/html'}
-            });
-            // We don't parse the page, just update sidebar if needed
-        } catch(e) {}
-
         sending = false;
         inputEl.disabled = false;
         sendBtn.disabled = false;

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -1,0 +1,375 @@
+{% extends "base.html" %}
+{% block title %}Агент — TG Agent{% endblock %}
+
+{% block head_scripts %}
+<style>
+.agent-layout {
+    display: flex;
+    gap: 1rem;
+    height: calc(100vh - 220px);
+    min-height: 400px;
+}
+.agent-sidebar {
+    width: 240px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    overflow-y: auto;
+}
+.agent-sidebar h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.9rem;
+    color: var(--pico-muted-color);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.thread-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    border: 1px solid var(--pico-muted-border-color);
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    font-size: 0.9rem;
+    background: transparent;
+    transition: background 0.15s;
+}
+.thread-item:hover {
+    background: var(--pico-secondary-background);
+}
+.thread-item.active {
+    background: var(--pico-primary-background);
+    border-color: var(--pico-primary-border);
+    color: var(--pico-primary);
+    font-weight: 600;
+}
+.thread-item .thread-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.thread-delete-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 2px;
+    color: var(--pico-muted-color);
+    font-size: 0.8rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+.thread-delete-btn:hover { color: var(--pico-del-color, red); }
+.new-thread-btn {
+    margin-top: auto;
+    width: 100%;
+}
+
+.agent-chat {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.chat-header {
+    font-size: 1rem;
+    font-weight: 600;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    margin-bottom: 0.75rem;
+    color: var(--pico-muted-color);
+}
+.chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding-right: 0.5rem;
+}
+.message-bubble {
+    max-width: 85%;
+    padding: 0.6rem 0.9rem;
+    border-radius: 10px;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.message-user {
+    align-self: flex-end;
+    background: var(--pico-primary);
+    color: #fff;
+    border-bottom-right-radius: 3px;
+}
+.message-assistant {
+    align-self: flex-start;
+    background: var(--pico-secondary-background);
+    border: 1px solid var(--pico-muted-border-color);
+    border-bottom-left-radius: 3px;
+}
+.message-error {
+    align-self: flex-start;
+    background: #ffeaea;
+    border: 1px solid #f5a;
+    color: #c00;
+    border-radius: 10px;
+    padding: 0.6rem 0.9rem;
+    font-size: 0.9rem;
+    max-width: 85%;
+}
+.typing-indicator {
+    display: inline-block;
+    color: var(--pico-muted-color);
+    font-style: italic;
+}
+.typing-indicator::after {
+    content: "...";
+    animation: dots 1.2s steps(3, end) infinite;
+}
+@keyframes dots {
+    0%, 20% { content: "."; }
+    40% { content: ".."; }
+    60%, 100% { content: "..."; }
+}
+
+.chat-input-area {
+    display: flex;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+    margin-top: 0.75rem;
+}
+.chat-input-area textarea {
+    flex: 1;
+    resize: none;
+    min-height: 60px;
+    max-height: 140px;
+    font-size: 0.9rem;
+    margin-bottom: 0;
+}
+.chat-send-btn {
+    align-self: flex-end;
+    white-space: nowrap;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--pico-muted-color);
+    gap: 1rem;
+    text-align: center;
+}
+
+</style>
+{% endblock %}
+
+{% block content %}
+<h2>Агент</h2>
+
+
+<div class="agent-layout">
+    <!-- Sidebar: thread list -->
+    <div class="agent-sidebar">
+        <h3>Треды</h3>
+
+        {% for thread in threads %}
+        <a class="thread-item {% if active_thread and active_thread.id == thread.id %}active{% endif %}"
+           href="/agent?thread_id={{ thread.id }}"
+           data-thread-id="{{ thread.id }}">
+            <span class="thread-title" title="{{ thread.title }}">{{ thread.title }}</span>
+            <button class="thread-delete-btn"
+                    onclick="deleteThread(event, {{ thread.id }})"
+                    title="Удалить тред">✕</button>
+        </a>
+        {% else %}
+        <p style="font-size:0.8rem;color:var(--pico-muted-color)">Тредов пока нет</p>
+        {% endfor %}
+
+        <form method="post" action="/agent/threads" style="margin-top:auto">
+            <button type="submit" class="new-thread-btn outline" style="margin-top:0.5rem">+ Новый тред</button>
+        </form>
+    </div>
+
+    <!-- Main chat area -->
+    <div class="agent-chat">
+        {% if active_thread %}
+        <div class="chat-header">{{ active_thread.title }}</div>
+
+        <div class="chat-messages" id="chat-messages">
+            {% for msg in messages %}
+            <div class="message-bubble message-{{ msg.role }}">{{ msg.content }}</div>
+            {% else %}
+            <div class="empty-state">
+                <span style="font-size:2rem">🤖</span>
+                <p>Напишите первое сообщение</p>
+            </div>
+            {% endfor %}
+        </div>
+
+        <div class="chat-input-area">
+            <textarea id="chat-input"
+                      placeholder="Введите сообщение… (Enter — отправить, Shift+Enter — перенос строки)"
+                      ></textarea>
+            <button class="chat-send-btn" id="send-btn"
+                    onclick="sendMessage()">Отправить</button>
+        </div>
+        {% else %}
+        <div class="empty-state">
+            <span style="font-size:3rem">🤖</span>
+            <p>Создайте новый тред, чтобы начать диалог с агентом</p>
+            <form method="post" action="/agent/threads">
+                <button type="submit">+ Новый тред</button>
+            </form>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<script>
+(function() {
+    var threadId = {{ active_thread.id if active_thread else 'null' }};
+    var sending = false;
+
+    // Scroll to bottom on load
+    var chatMessages = document.getElementById('chat-messages');
+    if (chatMessages) {
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+    }
+
+    // Enter to send
+    var input = document.getElementById('chat-input');
+    if (input) {
+        input.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+    }
+
+    window.sendMessage = async function() {
+        if (sending || !threadId) return;
+        var inputEl = document.getElementById('chat-input');
+        var sendBtn = document.getElementById('send-btn');
+        var text = (inputEl.value || '').trim();
+        if (!text) return;
+
+        sending = true;
+        inputEl.disabled = true;
+        sendBtn.disabled = true;
+        inputEl.value = '';
+
+        var container = document.getElementById('chat-messages');
+
+        // Remove empty-state if present
+        var emptyState = container.querySelector('.empty-state');
+        if (emptyState) emptyState.remove();
+
+        // Append user bubble
+        var userBubble = document.createElement('div');
+        userBubble.className = 'message-bubble message-user';
+        userBubble.textContent = text;
+        container.appendChild(userBubble);
+        container.scrollTop = container.scrollHeight;
+
+        // Append assistant bubble with typing indicator
+        var aiBubble = document.createElement('div');
+        aiBubble.className = 'message-bubble message-assistant';
+        aiBubble.innerHTML = '<span class="typing-indicator">Думаю</span>';
+        container.appendChild(aiBubble);
+        container.scrollTop = container.scrollHeight;
+
+        try {
+            var resp = await fetch('/agent/threads/' + threadId + '/chat', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({message: text})
+            });
+
+            if (!resp.ok) {
+                throw new Error('HTTP ' + resp.status);
+            }
+
+            var reader = resp.body.getReader();
+            var decoder = new TextDecoder();
+            var buffer = '';
+            var fullText = '';
+
+            while (true) {
+                var result = await reader.read();
+                if (result.done) break;
+
+                buffer += decoder.decode(result.value, {stream: true});
+                var lines = buffer.split('\n');
+                buffer = lines.pop(); // keep incomplete line
+
+                for (var line of lines) {
+                    line = line.trim();
+                    if (!line.startsWith('data:')) continue;
+                    var jsonStr = line.slice(5).trim();
+                    try {
+                        var data = JSON.parse(jsonStr);
+                        if (data.error) {
+                            aiBubble.className = 'message-error';
+                            aiBubble.textContent = data.error;
+                            fullText = data.error;
+                        } else if (data.text !== undefined) {
+                            fullText += data.text;
+                            aiBubble.textContent = fullText;
+                            container.scrollTop = container.scrollHeight;
+                        } else if (data.done) {
+                            aiBubble.textContent = data.full_text || fullText;
+                            container.scrollTop = container.scrollHeight;
+                        }
+                    } catch(e) { /* skip bad JSON */ }
+                }
+            }
+
+            // If bubble is still showing typing indicator, show error
+            if (aiBubble.querySelector('.typing-indicator')) {
+                aiBubble.textContent = 'Нет ответа от агента.';
+            }
+
+        } catch(err) {
+            aiBubble.className = 'message-error';
+            aiBubble.textContent = 'Ошибка соединения: ' + err.message;
+        }
+
+        // Refresh page title with thread name (auto-renamed on first message)
+        try {
+            var titleResp = await fetch('/agent?thread_id=' + threadId, {
+                headers: {'Accept': 'text/html'}
+            });
+            // We don't parse the page, just update sidebar if needed
+        } catch(e) {}
+
+        sending = false;
+        inputEl.disabled = false;
+        sendBtn.disabled = false;
+        inputEl.focus();
+        container.scrollTop = container.scrollHeight;
+    };
+
+    window.deleteThread = async function(e, tid) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!confirm('Удалить тред?')) return;
+        try {
+            await fetch('/agent/threads/' + tid, {method: 'DELETE'});
+            // Redirect to agent page without thread
+            window.location.href = '/agent';
+        } catch(err) {
+            alert('Ошибка удаления: ' + err.message);
+        }
+    };
+})();
+</script>
+{% endblock %}

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -16,6 +16,7 @@
             <li><strong><span style="white-space:nowrap">TG Agent</span></strong></li>
         </ul>
         <ul>
+            {% if agent_available %}<li><a href="/agent">Чат</a></li>{% endif %}
             <li><a href="/">Поиск</a></li>
             <li><a href="/dashboard">Панель</a></li>
             <li><a href="/channels">Каналы</a></li>

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agent.manager import AgentManager
+from src.agent.tools import make_mcp_server
+
+
+@pytest.mark.asyncio
+async def test_make_mcp_server_returns_server(db):
+    server = make_mcp_server(db)
+    assert server is not None
+
+
+@pytest.mark.asyncio
+async def test_agent_manager_initialize(db):
+    mgr = AgentManager(db)
+    mgr.initialize()
+    assert mgr._server is not None
+
+
+@pytest.mark.asyncio
+async def test_agent_chat_stream_mocked(db):
+    thread_id = await db.create_agent_thread("test thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    text_block = TextBlock(text="hello")
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [text_block]
+
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    assert chunks, "должны быть SSE-строки"
+    assert all(c.startswith("data: ") for c in chunks)
+    last_chunk = chunks[-1]
+    assert "done" in last_chunk or "full_text" in last_chunk or "hello" in last_chunk

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -50,3 +50,65 @@ async def test_agent_chat_stream_mocked(db):
     assert all(c.startswith("data: ") for c in chunks)
     last_chunk = chunks[-1]
     assert "done" in last_chunk or "full_text" in last_chunk or "hello" in last_chunk
+
+
+# ── DB round-trip tests ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_agent_thread_crud(db):
+    tid = await db.create_agent_thread("My Thread")
+    assert isinstance(tid, int)
+
+    thread = await db.get_agent_thread(tid)
+    assert thread is not None
+    assert thread["title"] == "My Thread"
+
+    await db.rename_agent_thread(tid, "Renamed")
+    thread = await db.get_agent_thread(tid)
+    assert thread["title"] == "Renamed"
+
+    threads = await db.get_agent_threads()
+    assert any(t["id"] == tid for t in threads)
+
+    await db.delete_agent_thread(tid)
+    assert await db.get_agent_thread(tid) is None
+
+
+@pytest.mark.asyncio
+async def test_agent_messages_cascade_delete(db):
+    tid = await db.create_agent_thread("cascade test")
+    await db.save_agent_message(tid, "user", "hello")
+    await db.save_agent_message(tid, "assistant", "hi")
+
+    msgs = await db.get_agent_messages(tid)
+    assert len(msgs) == 2
+
+    # Deleting the thread should cascade-delete messages
+    await db.delete_agent_thread(tid)
+    msgs = await db.get_agent_messages(tid)
+    assert msgs == []
+
+
+# ── build_prompt tests ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_build_prompt_empty_history(db):
+    mgr = AgentManager(db)
+    prompt = mgr._build_prompt([], "hello")
+    assert "<user>" in prompt
+    assert "hello" in prompt
+
+
+@pytest.mark.asyncio
+async def test_build_prompt_multi_turn(db):
+    mgr = AgentManager(db)
+    history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+    prompt = mgr._build_prompt(history, "second question")
+    assert "<user>" in prompt
+    assert "<assistant>" in prompt
+    assert "first question" in prompt
+    assert "first answer" in prompt
+    assert "second question" in prompt


### PR DESCRIPTION
## Summary

- Добавлен `AgentManager` на базе `claude-agent-sdk` с SSE-стримингом через `asyncio.Queue`
- Исправлена ошибка Python 3.12 `RuntimeError: Attempted to exit cancel scope in a different task` — генератор истощается естественно без `return`, `CancelledError` перехватывается внутри цикла для drain-режима
- MCP-инструменты: `search_messages`, `get_channels` поверх SQLite
- Web UI на `/agent` с управлением тредами и чатом
- CLI-команды: `agent chat`, `agent list`, `agent delete`
- DB-миграции: таблицы `agent_threads` и `agent_messages`

## Test plan

- [ ] `pytest tests/test_agent.py -v` — все тесты зелёные
- [ ] `ruff check src/agent/` — без ошибок
- [ ] Открыть `/agent` в браузере, отправить сообщение, убедиться что стриминг работает
- [ ] Проверить отсутствие `RuntimeError: Attempted to exit cancel scope` в логах

🤖 Generated with [Claude Code](https://claude.com/claude-code)