### PR TITLE
Add CLI stop and restart commands for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Supports `${ENV_VAR}` substitution. Empty env vars are dropped (defaults apply).
 ```bash
 # Web server
 python -m src.main [--config CONFIG] serve [--web-pass PASS]
+python -m src.main [--config CONFIG] stop
+python -m src.main [--config CONFIG] restart [--web-pass PASS]
 
 # One-shot collection
 python -m src.main [--config CONFIG] collect [--channel-id ID]

--- a/README.ru.md
+++ b/README.ru.md
@@ -93,6 +93,8 @@ docker-compose up -d
 ```bash
 # Веб-сервер
 python -m src.main [--config CONFIG] serve [--web-pass PASS]
+python -m src.main [--config CONFIG] stop
+python -m src.main [--config CONFIG] restart [--web-pass PASS]
 
 # Разовый сбор
 python -m src.main [--config CONFIG] collect [--channel-id ID]

--- a/src/cli/commands/serve.py
+++ b/src/cli/commands/serve.py
@@ -6,6 +6,7 @@ import sys
 
 import uvicorn
 
+from src.cli.process_control import pid_file_path, register_current_process, unregister_current_process
 from src.config import load_config
 from src.web.app import create_app
 
@@ -18,4 +19,14 @@ def run(args: argparse.Namespace) -> None:
         logging.error("WEB_PASS must be set for web panel authentication")
         sys.exit(1)
     app = create_app(config)
-    uvicorn.run(app, host=config.web.host, port=config.web.port)
+    pid_path = pid_file_path(config)
+    try:
+        register_current_process(pid_path)
+    except RuntimeError as exc:
+        logging.error(str(exc))
+        sys.exit(1)
+
+    try:
+        uvicorn.run(app, host=config.web.host, port=config.web.port)
+    finally:
+        unregister_current_process(pid_path)

--- a/src/cli/commands/serve.py
+++ b/src/cli/commands/serve.py
@@ -6,7 +6,11 @@ import sys
 
 import uvicorn
 
-from src.cli.process_control import pid_file_path, register_current_process, unregister_current_process
+from src.cli.process_control import (
+    pid_file_path,
+    register_current_process,
+    unregister_current_process,
+)
 from src.config import load_config
 from src.web.app import create_app
 

--- a/src/cli/commands/server_control.py
+++ b/src/cli/commands/server_control.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+from src.cli.commands import serve
+from src.cli.process_control import ProcessControlError, pid_file_path, stop_server
+from src.config import load_config
+
+
+def run_stop(args: argparse.Namespace) -> None:
+    config = load_config(args.config)
+    try:
+        stopped, message = stop_server(pid_file_path(config))
+    except ProcessControlError as exc:
+        print(str(exc))
+        sys.exit(1)
+    print(message)
+    if not stopped and not message.startswith("Removed stale PID file") and "not running" not in message:
+        sys.exit(1)
+
+
+def run_restart(args: argparse.Namespace) -> None:
+    config = load_config(args.config)
+    try:
+        stopped, message = stop_server(pid_file_path(config))
+    except ProcessControlError as exc:
+        print(str(exc))
+        sys.exit(1)
+    print(message)
+    if not stopped and not message.startswith("Removed stale PID file") and "not running" not in message:
+        sys.exit(1)
+    serve.run(args)

--- a/src/cli/commands/server_control.py
+++ b/src/cli/commands/server_control.py
@@ -16,7 +16,12 @@ def run_stop(args: argparse.Namespace) -> None:
         print(str(exc))
         sys.exit(1)
     print(message)
-    if not stopped and not message.startswith("Removed stale PID file") and "not running" not in message:
+    can_continue = (
+        stopped
+        or message.startswith("Removed stale PID file")
+        or "not running" in message
+    )
+    if not can_continue:
         sys.exit(1)
 
 
@@ -28,6 +33,11 @@ def run_restart(args: argparse.Namespace) -> None:
         print(str(exc))
         sys.exit(1)
     print(message)
-    if not stopped and not message.startswith("Removed stale PID file") and "not running" not in message:
+    can_continue = (
+        stopped
+        or message.startswith("Removed stale PID file")
+        or "not running" in message
+    )
+    if not can_continue:
         sys.exit(1)
     serve.run(args)

--- a/src/cli/commands/server_control.py
+++ b/src/cli/commands/server_control.py
@@ -4,40 +4,35 @@ import argparse
 import sys
 
 from src.cli.commands import serve
-from src.cli.process_control import ProcessControlError, pid_file_path, stop_server
+from src.cli.process_control import (
+    ProcessControlError,
+    StopResult,
+    pid_file_path,
+    stop_server,
+)
 from src.config import load_config
 
 
 def run_stop(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     try:
-        stopped, message = stop_server(pid_file_path(config))
+        outcome = stop_server(pid_file_path(config))
     except ProcessControlError as exc:
         print(str(exc))
         sys.exit(1)
-    print(message)
-    can_continue = (
-        stopped
-        or message.startswith("Removed stale PID file")
-        or "not running" in message
-    )
-    if not can_continue:
+    print(outcome.message)
+    if outcome.result in (StopResult.UNMANAGED, StopResult.TIMEOUT):
         sys.exit(1)
 
 
 def run_restart(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     try:
-        stopped, message = stop_server(pid_file_path(config))
+        outcome = stop_server(pid_file_path(config))
     except ProcessControlError as exc:
         print(str(exc))
         sys.exit(1)
-    print(message)
-    can_continue = (
-        stopped
-        or message.startswith("Removed stale PID file")
-        or "not running" in message
-    )
-    if not can_continue:
+    print(outcome.message)
+    if outcome.result in (StopResult.UNMANAGED, StopResult.TIMEOUT):
         sys.exit(1)
     serve.run(args)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -12,8 +12,8 @@ from src.cli.commands import (
     scheduler,
     search,
     search_query,
-    server_control,
     serve,
+    server_control,
 )
 from src.cli.commands import agent as agent_cmd
 from src.cli.commands import filter as filter_cmd

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -12,6 +12,7 @@ from src.cli.commands import (
     scheduler,
     search,
     search_query,
+    server_control,
     serve,
 )
 from src.cli.commands import agent as agent_cmd
@@ -33,6 +34,8 @@ def main() -> None:
 
     commands = {
         "serve": serve.run,
+        "stop": server_control.run_stop,
+        "restart": server_control.run_restart,
         "collect": collect.run,
         "search": search.run,
         "channel": channel.run,

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -11,6 +11,11 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser = sub.add_parser("serve", help="Start web server")
     serve_parser.add_argument("--web-pass", help="Web panel password (overrides config)")
 
+    sub.add_parser("stop", help="Stop web server started by this app")
+
+    restart_parser = sub.add_parser("restart", help="Restart web server")
+    restart_parser.add_argument("--web-pass", help="Web panel password (overrides config)")
+
     collect_parser = sub.add_parser("collect", help="Run one-shot collection")
     collect_parser.add_argument(
         "--channel-id", type=int, default=None,

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -124,9 +124,12 @@ def register_current_process(path: Path) -> None:
 
 
 def unregister_current_process(path: Path) -> None:
-    pid = read_pid(path)
-    if pid == os.getpid():
-        remove_pid_file(path)
+    try:
+        pid = read_pid(path)
+        if pid == os.getpid():
+            remove_pid_file(path)
+    except Exception:
+        pass
 
 
 def stop_server(

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -129,7 +129,11 @@ def unregister_current_process(path: Path) -> None:
         remove_pid_file(path)
 
 
-def stop_server(path: Path, timeout_sec: float = 10.0) -> StopOutcome:
+def stop_server(
+    path: Path,
+    timeout_sec: float = 10.0,
+    kill_timeout_sec: float = 1.0,
+) -> StopOutcome:
     pid = read_pid(path)
     if pid is None:
         return StopOutcome(
@@ -178,7 +182,14 @@ def stop_server(path: Path, timeout_sec: float = 10.0) -> StopOutcome:
             f"Server stopped (PID {pid}).",
         )
 
-    kill_deadline = time.monotonic() + 1.0
+    if not is_process_alive(pid):
+        remove_pid_file(path)
+        return StopOutcome(
+            StopResult.STOPPED,
+            f"Server stopped after force kill (PID {pid}).",
+        )
+
+    kill_deadline = time.monotonic() + kill_timeout_sec
     while time.monotonic() < kill_deadline:
         if not is_process_alive(pid):
             remove_pid_file(path)

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from src.config import AppConfig
+
+
+class ProcessControlError(RuntimeError):
+    """Raised when server process control cannot proceed safely."""
+
+
+def pid_file_path(config: AppConfig) -> Path:
+    db_path = Path(config.database.path)
+    return db_path.with_suffix(".pid")
+
+
+def is_process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def read_pid(path: Path) -> int | None:
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+
+    if not raw:
+        return None
+
+    try:
+        return int(raw)
+    except ValueError:
+        raise ProcessControlError(f"Invalid PID file contents: {path}")
+
+
+def _process_command(pid: int) -> str:
+    if sys.platform.startswith("linux"):
+        cmdline_path = Path("/proc") / str(pid) / "cmdline"
+        try:
+            raw = cmdline_path.read_bytes()
+        except FileNotFoundError:
+            return ""
+        return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return ""
+
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def is_expected_server_process(pid: int) -> bool:
+    if pid <= 0 or not is_process_alive(pid):
+        return False
+
+    command = _process_command(pid)
+    if not command:
+        return False
+
+    return "src.main" in command and "serve" in command
+
+
+def remove_pid_file(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def ensure_server_not_running(path: Path) -> None:
+    pid = read_pid(path)
+    if pid is None:
+        return
+
+    if is_expected_server_process(pid):
+        raise ProcessControlError(f"Server already running with PID {pid}")
+
+    remove_pid_file(path)
+
+
+def register_current_process(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_server_not_running(path)
+    path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+
+
+def unregister_current_process(path: Path) -> None:
+    pid = read_pid(path)
+    if pid == os.getpid():
+        remove_pid_file(path)
+
+
+def stop_server(path: Path, timeout_sec: float = 10.0) -> tuple[bool, str]:
+    pid = read_pid(path)
+    if pid is None:
+        return False, f"Server is not running (no PID file: {path})."
+
+    if not is_process_alive(pid):
+        remove_pid_file(path)
+        return False, f"Removed stale PID file: {path}."
+
+    if not is_expected_server_process(pid):
+        return False, f"PID {pid} is not a managed src.main serve process."
+
+    os.kill(pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if not is_process_alive(pid):
+            remove_pid_file(path)
+            return True, f"Server stopped (PID {pid})."
+        time.sleep(0.1)
+
+    return False, f"Timed out waiting for server PID {pid} to stop."

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -5,6 +5,8 @@ import signal
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 from src.config import AppConfig
@@ -12,6 +14,20 @@ from src.config import AppConfig
 
 class ProcessControlError(RuntimeError):
     """Raised when server process control cannot proceed safely."""
+
+
+class StopResult(Enum):
+    STOPPED = "stopped"
+    NOT_RUNNING = "not_running"
+    STALE_PID = "stale_pid"
+    UNMANAGED = "unmanaged"
+    TIMEOUT = "timeout"
+
+
+@dataclass(frozen=True)
+class StopOutcome:
+    result: StopResult
+    message: str
 
 
 def pid_file_path(config: AppConfig) -> Path:
@@ -76,7 +92,11 @@ def is_expected_server_process(pid: int) -> bool:
     if not command:
         return False
 
-    return "src.main" in command and "serve" in command
+    tokens = command.split()
+    for index, token in enumerate(tokens[:-2]):
+        if token == "-m" and tokens[index + 1] == "src.main" and tokens[index + 2] == "serve":
+            return True
+    return False
 
 
 def remove_pid_file(path: Path) -> None:
@@ -109,25 +129,66 @@ def unregister_current_process(path: Path) -> None:
         remove_pid_file(path)
 
 
-def stop_server(path: Path, timeout_sec: float = 10.0) -> tuple[bool, str]:
+def stop_server(path: Path, timeout_sec: float = 10.0) -> StopOutcome:
     pid = read_pid(path)
     if pid is None:
-        return False, f"Server is not running (no PID file: {path})."
+        return StopOutcome(
+            StopResult.NOT_RUNNING,
+            f"Server is not running (no PID file: {path}).",
+        )
 
     if not is_process_alive(pid):
         remove_pid_file(path)
-        return False, f"Removed stale PID file: {path}."
+        return StopOutcome(
+            StopResult.STALE_PID,
+            f"Removed stale PID file: {path}.",
+        )
 
     if not is_expected_server_process(pid):
-        return False, f"PID {pid} is not a managed src.main serve process."
+        return StopOutcome(
+            StopResult.UNMANAGED,
+            f"PID {pid} is not a managed src.main serve process.",
+        )
 
-    os.kill(pid, signal.SIGTERM)
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        remove_pid_file(path)
+        return StopOutcome(
+            StopResult.STALE_PID,
+            f"Removed stale PID file: {path}.",
+        )
 
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
         if not is_process_alive(pid):
             remove_pid_file(path)
-            return True, f"Server stopped (PID {pid})."
+            return StopOutcome(
+                StopResult.STOPPED,
+                f"Server stopped (PID {pid}).",
+            )
         time.sleep(0.1)
 
-    return False, f"Timed out waiting for server PID {pid} to stop."
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        remove_pid_file(path)
+        return StopOutcome(
+            StopResult.STOPPED,
+            f"Server stopped (PID {pid}).",
+        )
+
+    kill_deadline = time.monotonic() + 1.0
+    while time.monotonic() < kill_deadline:
+        if not is_process_alive(pid):
+            remove_pid_file(path)
+            return StopOutcome(
+                StopResult.STOPPED,
+                f"Server stopped after force kill (PID {pid}).",
+            )
+        time.sleep(0.05)
+
+    return StopOutcome(
+        StopResult.TIMEOUT,
+        f"Timed out waiting for server PID {pid} to stop.",
+    )

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -165,6 +165,10 @@ def stop_server(
             StopResult.STALE_PID,
             f"Removed stale PID file: {path}.",
         )
+    except PermissionError as exc:
+        raise ProcessControlError(
+            f"Permission denied sending signal to PID {pid}"
+        ) from exc
 
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
@@ -184,6 +188,10 @@ def stop_server(
             StopResult.STOPPED,
             f"Server stopped (PID {pid}).",
         )
+    except PermissionError as exc:
+        raise ProcessControlError(
+            f"Permission denied sending signal to PID {pid}"
+        ) from exc
 
     if not is_process_alive(pid):
         remove_pid_file(path)

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -357,7 +357,6 @@ class ClientPool:
                             "deactivate": deactivate,
                             "is_own": bool(
                                 getattr(entity, "creator", False)
-                                or getattr(entity, "admin_rights", None)
                             ),
                         })
                     elif include_dm:
@@ -508,6 +507,9 @@ class ClientPool:
                             "username": getattr(entity, "username", None),
                             "channel_type": channel_type,
                             "deactivate": deactivate,
+                            "is_own": bool(
+                                getattr(entity, "creator", False)
+                            ),
                         })
                 return result
 

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -52,13 +52,13 @@
 
 <ul class="nav nav-tabs nav-fill mb-3" role="tablist">
     <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="tab-dms" data-bs-toggle="tab" data-bs-target="#pane-dms" type="button" role="tab">ДМ ({{ dms|length }})</button>
+        <button class="nav-link active" id="tab-channels" data-bs-toggle="tab" data-bs-target="#pane-channels" type="button" role="tab">Каналы ({{ channels|length }})</button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-own" data-bs-toggle="tab" data-bs-target="#pane-own" type="button" role="tab">Мои ({{ own|length }})</button>
+        <button class="nav-link" id="tab-own" data-bs-toggle="tab" data-bs-target="#pane-own" type="button" role="tab">Созданные ({{ own|length }})</button>
     </li>
     <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-channels" data-bs-toggle="tab" data-bs-target="#pane-channels" type="button" role="tab">Каналы ({{ channels|length }})</button>
+        <button class="nav-link" id="tab-dms" data-bs-toggle="tab" data-bs-target="#pane-dms" type="button" role="tab">ДМ ({{ dms|length }})</button>
     </li>
     <li class="nav-item" role="presentation">
         <button class="nav-link" id="tab-groups" data-bs-toggle="tab" data-bs-target="#pane-groups" type="button" role="tab">Группы ({{ groups|length }})</button>
@@ -110,7 +110,7 @@
     {% else %}<p>Нет своих каналов/групп.</p>{% endif %}
     </div>
 
-    <div class="tab-pane fade" id="pane-channels" role="tabpanel">
+    <div class="tab-pane fade show active" id="pane-channels" role="tabpanel">
     {% if channels %}
     <!-- Desktop -->
     <div class="table-responsive d-none d-md-block">
@@ -192,7 +192,7 @@
     {% else %}<p>Нет групп.</p>{% endif %}
     </div>
 
-    <div class="tab-pane fade show active" id="pane-dms" role="tabpanel">
+    <div class="tab-pane fade" id="pane-dms" role="tabpanel">
     {% if dms %}
     <!-- Desktop -->
     <div class="table-responsive d-none d-md-block">

--- a/tests/test_ai_search.py
+++ b/tests/test_ai_search.py
@@ -1,10 +1,13 @@
-import asyncio
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from src.search.ai_search import AISearchEngine
-from src.config import LLMConfig
-from src.models import SearchResult, Message
+import sys
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import LLMConfig
+from src.models import Message
+from src.search.ai_search import AISearchEngine
+
 
 @pytest.fixture
 def llm_config():
@@ -22,7 +25,7 @@ async def test_ai_search_disabled(mock_search_bundle):
     engine = AISearchEngine(config, mock_search_bundle)
     engine.initialize()
     assert engine._agent is None
-    
+
     res = await engine.search("test")
     assert "AI search is not available" in res.ai_summary
 
@@ -31,26 +34,19 @@ async def test_ai_search_initialization_success(llm_config, mock_search_bundle):
     with patch("deepagents.create_deep_agent") as mock_create:
         mock_agent = MagicMock()
         mock_create.return_value = mock_agent
-        
+
         engine = AISearchEngine(llm_config, mock_search_bundle)
         engine.initialize()
-        
+
         assert engine._agent == mock_agent
         mock_create.assert_called_once()
 
 @pytest.mark.asyncio
 async def test_ai_search_initialization_import_error(llm_config, mock_search_bundle):
-    # Mock __import__ to raise ImportError specifically for deepagents
-    real_import = __import__
-    def mock_import(name, *args, **kwargs):
-        if name == "deepagents":
-            raise ImportError("not found")
-        return real_import(name, *args, **kwargs)
-        
-    with patch("builtins.__import__", side_effect=mock_import):
-         engine = AISearchEngine(llm_config, mock_search_bundle)
-         engine.initialize()
-         assert engine._agent is None
+    with patch.dict(sys.modules, {"deepagents": None}):
+        engine = AISearchEngine(llm_config, mock_search_bundle)
+        engine.initialize()
+        assert engine._agent is None
 
 @pytest.mark.asyncio
 async def test_ai_search_initialization_general_error(llm_config, mock_search_bundle):
@@ -63,15 +59,15 @@ async def test_ai_search_initialization_general_error(llm_config, mock_search_bu
 async def test_ai_search_run_success(llm_config, mock_search_bundle):
     mock_agent = MagicMock()
     mock_agent.run.return_value = "AI Summary Result"
-    
+
     mock_search_bundle.search_messages.return_value = ([
         Message(channel_id=1, message_id=1, text="hello", date=datetime.now())
     ], 1)
-    
+
     with patch("deepagents.create_deep_agent", return_value=mock_agent):
         engine = AISearchEngine(llm_config, mock_search_bundle)
         engine.initialize()
-        
+
         res = await engine.search("hello")
         assert res.ai_summary == "AI Summary Result"
         assert res.total == 1
@@ -80,11 +76,11 @@ async def test_ai_search_run_success(llm_config, mock_search_bundle):
 async def test_ai_search_run_error(llm_config, mock_search_bundle):
     mock_agent = MagicMock()
     mock_agent.run.side_effect = Exception("AI Fail")
-    
+
     with patch("deepagents.create_deep_agent", return_value=mock_agent):
         engine = AISearchEngine(llm_config, mock_search_bundle)
         engine.initialize()
-        
+
         res = await engine.search("hello")
         assert "AI search error: AI Fail" in res.ai_summary
 
@@ -94,16 +90,16 @@ async def test_search_posts_tool_logic(llm_config, mock_search_bundle):
     mock_search_bundle.search_messages.return_value = ([
         Message(channel_id=1, message_id=1, text="content", date=datetime.now())
     ], 1)
-    
+
     with patch("deepagents.create_deep_agent") as mock_create:
         engine = AISearchEngine(llm_config, mock_search_bundle)
         engine.initialize()
-        
+
         # Extract the tool function from mock_create call
         args, kwargs = mock_create.call_args
         tools = kwargs['tools']
         search_tool = tools[0]
-        
+
         # Test tool without running loop (simulating thread pool behavior)
         result = search_tool("query")
         assert "Found 1 results" in result
@@ -112,11 +108,11 @@ async def test_search_posts_tool_logic(llm_config, mock_search_bundle):
 @pytest.mark.asyncio
 async def test_search_posts_tool_no_results(llm_config, mock_search_bundle):
     mock_search_bundle.search_messages.return_value = ([], 0)
-    
+
     with patch("deepagents.create_deep_agent") as mock_create:
         engine = AISearchEngine(llm_config, mock_search_bundle)
         engine.initialize()
         search_tool = mock_create.call_args[1]['tools'][0]
-        
+
         result = search_tool("nothing")
         assert "No results found" in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,10 +348,14 @@ class TestCLIScheduler:
 class TestCLIServerControl:
     def test_stop_command(self, capsys):
         from src.cli.commands.server_control import run_stop
+        from src.cli.process_control import StopOutcome, StopResult
 
         with patch(
             "src.cli.commands.server_control.stop_server",
-            return_value=(True, "Server stopped (PID 123)."),
+            return_value=StopOutcome(
+                StopResult.STOPPED,
+                "Server stopped (PID 123).",
+            ),
         ):
             run_stop(_ns(command="stop"))
 
@@ -360,10 +364,14 @@ class TestCLIServerControl:
 
     def test_stop_command_not_running_is_not_error(self, capsys):
         from src.cli.commands.server_control import run_stop
+        from src.cli.process_control import StopOutcome, StopResult
 
         with patch(
             "src.cli.commands.server_control.stop_server",
-            return_value=(False, "Server is not running (no PID file: data/tg_search.pid)."),
+            return_value=StopOutcome(
+                StopResult.NOT_RUNNING,
+                "Server is not running (no PID file: data/tg_search.pid).",
+            ),
         ):
             run_stop(_ns(command="stop"))
 
@@ -372,20 +380,28 @@ class TestCLIServerControl:
 
     def test_stop_command_exits_for_unmanaged_process(self):
         from src.cli.commands.server_control import run_stop
+        from src.cli.process_control import StopOutcome, StopResult
 
         with patch(
             "src.cli.commands.server_control.stop_server",
-            return_value=(False, "PID 321 is not a managed src.main serve process."),
+            return_value=StopOutcome(
+                StopResult.UNMANAGED,
+                "PID 321 is not a managed src.main serve process.",
+            ),
         ):
             with pytest.raises(SystemExit, match="1"):
                 run_stop(_ns(command="stop"))
 
     def test_restart_command_starts_serve_after_stop(self, capsys):
         from src.cli.commands.server_control import run_restart
+        from src.cli.process_control import StopOutcome, StopResult
 
         with patch(
             "src.cli.commands.server_control.stop_server",
-            return_value=(True, "Server stopped (PID 123)."),
+            return_value=StopOutcome(
+                StopResult.STOPPED,
+                "Server stopped (PID 123).",
+            ),
         ):
             with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
                 args = _ns(command="restart", web_pass="secret")
@@ -397,10 +413,14 @@ class TestCLIServerControl:
 
     def test_restart_command_starts_serve_when_not_running(self, capsys):
         from src.cli.commands.server_control import run_restart
+        from src.cli.process_control import StopOutcome, StopResult
 
         with patch(
             "src.cli.commands.server_control.stop_server",
-            return_value=(False, "Server is not running (no PID file: data/tg_search.pid)."),
+            return_value=StopOutcome(
+                StopResult.NOT_RUNNING,
+                "Server is not running (no PID file: data/tg_search.pid).",
+            ),
         ):
             with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
                 args = _ns(command="restart", web_pass=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,6 +341,86 @@ class TestCLIScheduler:
 
 
 # ---------------------------------------------------------------------------
+# server control
+# ---------------------------------------------------------------------------
+
+
+class TestCLIServerControl:
+    def test_stop_command(self, capsys):
+        from src.cli.commands.server_control import run_stop
+
+        with patch("src.cli.commands.server_control.stop_server", return_value=(True, "Server stopped (PID 123).")):
+            run_stop(_ns(command="stop"))
+
+        out = capsys.readouterr().out
+        assert "Server stopped" in out
+
+    def test_stop_command_not_running_is_not_error(self, capsys):
+        from src.cli.commands.server_control import run_stop
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=(False, "Server is not running (no PID file: data/tg_search.pid)."),
+        ):
+            run_stop(_ns(command="stop"))
+
+        out = capsys.readouterr().out
+        assert "not running" in out
+
+    def test_stop_command_exits_for_unmanaged_process(self):
+        from src.cli.commands.server_control import run_stop
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=(False, "PID 321 is not a managed src.main serve process."),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_stop(_ns(command="stop"))
+
+    def test_restart_command_starts_serve_after_stop(self, capsys):
+        from src.cli.commands.server_control import run_restart
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=(True, "Server stopped (PID 123)."),
+        ):
+            with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
+                args = _ns(command="restart", web_pass="secret")
+                run_restart(args)
+
+        out = capsys.readouterr().out
+        assert "Server stopped" in out
+        mock_serve_run.assert_called_once_with(args)
+
+    def test_restart_command_starts_serve_when_not_running(self, capsys):
+        from src.cli.commands.server_control import run_restart
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=(False, "Server is not running (no PID file: data/tg_search.pid)."),
+        ):
+            with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
+                args = _ns(command="restart", web_pass=None)
+                run_restart(args)
+
+        out = capsys.readouterr().out
+        assert "not running" in out
+        mock_serve_run.assert_called_once_with(args)
+
+    def test_parser_stop_and_restart(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+
+        args = parser.parse_args(["stop"])
+        assert args.command == "stop"
+
+        args = parser.parse_args(["restart", "--web-pass", "secret"])
+        assert args.command == "restart"
+        assert args.web_pass == "secret"
+
+
+# ---------------------------------------------------------------------------
 # test command
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -349,7 +349,10 @@ class TestCLIServerControl:
     def test_stop_command(self, capsys):
         from src.cli.commands.server_control import run_stop
 
-        with patch("src.cli.commands.server_control.stop_server", return_value=(True, "Server stopped (PID 123).")):
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=(True, "Server stopped (PID 123)."),
+        ):
             run_stop(_ns(command="stop"))
 
         out = capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -392,6 +392,20 @@ class TestCLIServerControl:
             with pytest.raises(SystemExit, match="1"):
                 run_stop(_ns(command="stop"))
 
+    def test_stop_command_exits_for_timeout(self):
+        from src.cli.commands.server_control import run_stop
+        from src.cli.process_control import StopOutcome, StopResult
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=StopOutcome(
+                StopResult.TIMEOUT,
+                "Timed out waiting for server PID 321 to stop.",
+            ),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_stop(_ns(command="stop"))
+
     def test_restart_command_starts_serve_after_stop(self, capsys):
         from src.cli.commands.server_control import run_restart
         from src.cli.process_control import StopOutcome, StopResult
@@ -429,6 +443,42 @@ class TestCLIServerControl:
         out = capsys.readouterr().out
         assert "not running" in out
         mock_serve_run.assert_called_once_with(args)
+
+    def test_restart_command_exits_for_timeout(self):
+        from src.cli.commands.server_control import run_restart
+        from src.cli.process_control import StopOutcome, StopResult
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            return_value=StopOutcome(
+                StopResult.TIMEOUT,
+                "Timed out waiting for server PID 321 to stop.",
+            ),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_restart(_ns(command="restart", web_pass=None))
+
+    def test_stop_command_exits_for_process_control_error(self):
+        from src.cli.commands.server_control import run_stop
+        from src.cli.process_control import ProcessControlError
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            side_effect=ProcessControlError("broken pid file"),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_stop(_ns(command="stop"))
+
+    def test_restart_command_exits_for_process_control_error(self):
+        from src.cli.commands.server_control import run_restart
+        from src.cli.process_control import ProcessControlError
+
+        with patch(
+            "src.cli.commands.server_control.stop_server",
+            side_effect=ProcessControlError("broken pid file"),
+        ):
+            with pytest.raises(SystemExit, match="1"):
+                run_restart(_ns(command="restart", web_pass=None))
 
     def test_parser_stop_and_restart(self):
         from src.cli.parser import build_parser

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -3,18 +3,32 @@ from __future__ import annotations
 import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
-import pydantic.root_model  # Workaround for pydantic/mcp issue
 
+# Pre-import pydantic.root_model to prevent lazy-import conflict
+# between pydantic v2 and mcp SDK when both are installed.
+import pydantic.root_model  # noqa: F401
 import pytest
 
 from src.config import AppConfig
 from src.database import Database
-from src.models import Channel, CollectionTaskStatus, ChannelStats
+from src.models import Channel, ChannelStats, CollectionTaskStatus
+
 
 def _ns(**kwargs) -> argparse.Namespace:
     defaults = {"config": "config.yaml"}
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
+
+
+def _chan(channel_id, title, username="", ch_type="channel", deactivate=False):
+    return {
+        "channel_id": channel_id,
+        "title": title,
+        "username": username,
+        "channel_type": ch_type,
+        "deactivate": deactivate,
+    }
+
 
 @pytest.fixture
 def cli_db(tmp_path):
@@ -31,7 +45,10 @@ def cli_env(cli_db):
         # Patch close to do nothing so we can reuse the connection in tests
         cli_db.close = AsyncMock()
         return config, cli_db
-    with patch("src.cli.commands.channel.runtime.init_db", side_effect=fake_init_db):
+    with patch(
+        "src.cli.commands.channel.runtime.init_db",
+        side_effect=fake_init_db,
+    ):
         yield cli_db
 
 @pytest.fixture
@@ -40,33 +57,34 @@ def cli_env_with_mock_pool(cli_env):
     mock_pool.clients = {"+70001112233": MagicMock()}
     mock_pool.disconnect_all = AsyncMock()
     mock_pool.release_client = AsyncMock()
-    
+
     mock_client = AsyncMock()
     mock_client.get_dialogs = AsyncMock()
-    mock_pool.get_available_client = AsyncMock(return_value=(mock_client, "+70001112233"))
+    mock_pool.get_available_client = AsyncMock(
+        return_value=(mock_client, "+70001112233"),
+    )
 
     async def fake_init_pool(config, db):
         from src.telegram.auth import TelegramAuth
         return TelegramAuth(0, ""), mock_pool
 
-    with patch("src.cli.commands.channel.runtime.init_pool", side_effect=fake_init_pool):
+    with patch(
+        "src.cli.commands.channel.runtime.init_pool",
+        side_effect=fake_init_pool,
+    ):
         yield cli_env, mock_pool
 
 class TestCLIChannelExtended:
     def test_add_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        pool.resolve_channel.return_value = {
-            "channel_id": 12345,
-            "title": "New Channel",
-            "username": "new_chan",
-            "channel_type": "channel",
-            "deactivate": False
-        }
+        pool.resolve_channel.return_value = _chan(
+            12345, "New Channel", "new_chan",
+        )
         from src.cli.commands.channel import run
         run(_ns(channel_action="add", identifier="@new_chan"))
         out = capsys.readouterr().out
         assert "Added channel: New Channel (12345)" in out
-        
+
         # Verify it was added to DB
         ch = asyncio.run(db.get_channel_by_channel_id(12345))
         assert ch is not None
@@ -74,18 +92,14 @@ class TestCLIChannelExtended:
 
     def test_add_deactivated(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        pool.resolve_channel.return_value = {
-            "channel_id": 67890,
-            "title": "Scam Channel",
-            "username": "scam_chan",
-            "channel_type": "scam",
-            "deactivate": True
-        }
+        pool.resolve_channel.return_value = _chan(
+            67890, "Scam Channel", "scam_chan", "scam", True,
+        )
         from src.cli.commands.channel import run
         run(_ns(channel_action="add", identifier="@scam_chan"))
         out = capsys.readouterr().out
         assert "WARN: deactivated, type=scam" in out
-        
+
         ch = asyncio.run(db.get_channel_by_channel_id(67890))
         assert ch is not None
         assert ch.is_active is False
@@ -93,8 +107,8 @@ class TestCLIChannelExtended:
     def test_import_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
         pool.resolve_channel.side_effect = [
-            {"channel_id": 1, "title": "Ch1", "username": "u1", "channel_type": "channel", "deactivate": False},
-            {"channel_id": 2, "title": "Ch2", "username": "u2", "channel_type": "channel", "deactivate": False}
+            _chan(1, "Ch1", "u1"),
+            _chan(2, "Ch2", "u2"),
         ]
         from src.cli.commands.channel import run
         run(_ns(channel_action="import", source="u1, u2"))
@@ -107,11 +121,11 @@ class TestCLIChannelExtended:
         db, pool = cli_env_with_mock_pool
         # Add one existing channel
         asyncio.run(db.add_channel(Channel(channel_id=1, title="Ch1")))
-        
+
         pool.resolve_channel.side_effect = [
-            {"channel_id": 1, "title": "Ch1", "username": "u1", "channel_type": "channel", "deactivate": False},
-            None, # Failed to resolve
-            {"channel_id": 3, "title": "Ch3", "username": "u3", "channel_type": "channel", "deactivate": False}
+            _chan(1, "Ch1", "u1"),
+            None,  # Failed to resolve
+            _chan(3, "Ch3", "u3"),
         ]
         from src.cli.commands.channel import run
         run(_ns(channel_action="import", source="u1, u2, u3"))
@@ -122,53 +136,70 @@ class TestCLIChannelExtended:
 
     def test_stats_single_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        ch_id = asyncio.run(db.add_channel(Channel(channel_id=100, title="StatsChan")))
-        
+        ch_id = asyncio.run(db.add_channel(
+            Channel(channel_id=100, title="StatsChan"),
+        ))
+
         mock_stats = ChannelStats(
             channel_id=100, subscriber_count=500,
             avg_views=10.5, avg_reactions=2.0, avg_forwards=1.0
         )
-        
-        with patch("src.cli.commands.channel.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_channel_stats = AsyncMock(return_value=mock_stats)
-            
+
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_channel_stats = AsyncMock(
+                return_value=mock_stats,
+            )
+
             from src.cli.commands.channel import run
-            run(_ns(channel_action="stats", identifier=str(ch_id), all=False))
-            
+            run(_ns(
+                channel_action="stats",
+                identifier=str(ch_id), all=False,
+            ))
+
         out = capsys.readouterr().out
         assert "Subscribers: 500" in out
         assert "Avg views: 10.5" in out
 
     def test_stats_all_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        with patch("src.cli.commands.channel.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_all_stats = AsyncMock(return_value={"channels": 5, "errors": 0})
-            
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_all_stats = AsyncMock(
+                return_value={"channels": 5, "errors": 0},
+            )
+
             from src.cli.commands.channel import run
             run(_ns(channel_action="stats", identifier=None, all=True))
-            
+
         out = capsys.readouterr().out
         assert "Stats collected: {'channels': 5, 'errors': 0}" in out
 
     def test_refresh_types_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        asyncio.run(db.add_channel(Channel(channel_id=101, title="T1", username="u1", is_active=True)))
-        asyncio.run(db.add_channel(Channel(channel_id=102, title="T2", username="u2", is_active=True)))
-        
+        asyncio.run(db.add_channel(Channel(
+            channel_id=101, title="T1", username="u1", is_active=True,
+        )))
+        asyncio.run(db.add_channel(Channel(
+            channel_id=102, title="T2", username="u2", is_active=True,
+        )))
+
         pool.resolve_channel.side_effect = [
-            {"channel_id": 101, "title": "T1", "username": "u1", "channel_type": "supergroup", "deactivate": False},
-            {"channel_id": 102, "title": "T2", "username": "u2", "channel_type": "scam", "deactivate": True}
+            _chan(101, "T1", "u1", "supergroup"),
+            _chan(102, "T2", "u2", "scam", True),
         ]
-        
+
         from src.cli.commands.channel import run
         run(_ns(channel_action="refresh-types"))
-        
+
         out = capsys.readouterr().out
         assert "OK: T1 → supergroup" in out
         assert "DEACTIVATED (scam): T2" in out
-        
+
         ch1 = asyncio.run(db.get_channel_by_channel_id(101))
         assert ch1.channel_type == "supergroup"
         ch2 = asyncio.run(db.get_channel_by_channel_id(102))
@@ -194,10 +225,10 @@ class TestCLIChannelExtended:
         db, pool = cli_env_with_mock_pool
         import_file = tmp_path / "channels.txt"
         import_file.write_text("@chan1\n@chan2")
-        
+
         pool.resolve_channel.side_effect = [
-            {"channel_id": 10, "title": "C1", "username": "chan1", "channel_type": "channel", "deactivate": False},
-            {"channel_id": 20, "title": "C2", "username": "chan2", "channel_type": "channel", "deactivate": False}
+            _chan(10, "C1", "chan1"),
+            _chan(20, "C2", "chan2"),
         ]
         from src.cli.commands.channel import run
         run(_ns(channel_action="import", source=str(import_file)))
@@ -214,18 +245,27 @@ class TestCLIChannelExtended:
 
     def test_stats_no_client_available(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        ch_id = asyncio.run(db.add_channel(Channel(channel_id=100, title="StatsChan")))
-        with patch("src.cli.commands.channel.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_channel_stats = AsyncMock(return_value=None)
+        ch_id = asyncio.run(db.add_channel(
+            Channel(channel_id=100, title="StatsChan"),
+        ))
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_channel_stats = AsyncMock(return_value=None)
             from src.cli.commands.channel import run
-            run(_ns(channel_action="stats", identifier=str(ch_id), all=False))
+            run(_ns(
+                channel_action="stats",
+                identifier=str(ch_id), all=False,
+            ))
         out = capsys.readouterr().out
         assert "No client available" in out
 
     def test_refresh_types_resolve_exception(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        asyncio.run(db.add_channel(Channel(channel_id=101, title="T1", is_active=True)))
+        asyncio.run(db.add_channel(
+            Channel(channel_id=101, title="T1", is_active=True),
+        ))
         pool.resolve_channel.side_effect = Exception("resolve error")
         from src.cli.commands.channel import run
         run(_ns(channel_action="refresh-types"))
@@ -234,8 +274,10 @@ class TestCLIChannelExtended:
 
     def test_refresh_types_not_found(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        asyncio.run(db.add_channel(Channel(channel_id=101, title="T1", is_active=True)))
-        pool.resolve_channel.return_value = False # Simulation of not found
+        asyncio.run(db.add_channel(
+            Channel(channel_id=101, title="T1", is_active=True),
+        ))
+        pool.resolve_channel.return_value = False  # Simulation of not found
         from src.cli.commands.channel import run
         run(_ns(channel_action="refresh-types"))
         out = capsys.readouterr().out
@@ -243,18 +285,22 @@ class TestCLIChannelExtended:
 
     def test_collect_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        ch_id = asyncio.run(db.add_channel(Channel(channel_id=103, title="CollectMe")))
-        
-        with patch("src.cli.commands.channel.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_single_channel = AsyncMock(return_value=42)
-            
+        ch_id = asyncio.run(db.add_channel(
+            Channel(channel_id=103, title="CollectMe"),
+        ))
+
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_single_channel = AsyncMock(return_value=42)
+
             from src.cli.commands.channel import run
             run(_ns(channel_action="collect", identifier=str(ch_id)))
-            
+
         out = capsys.readouterr().out
         assert "Collected 42 messages" in out
-        
+
         # Verify task status
         tasks = asyncio.run(db.get_collection_tasks(limit=1))
         assert tasks[0].status == CollectionTaskStatus.COMPLETED
@@ -262,10 +308,9 @@ class TestCLIChannelExtended:
 
     def test_import_deactivated(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        pool.resolve_channel.return_value = {
-            "channel_id": 99, "title": "Deactivated", "username": "u99", 
-            "channel_type": "scam", "deactivate": True
-        }
+        pool.resolve_channel.return_value = _chan(
+            99, "Deactivated", "u99", "scam", True,
+        )
         from src.cli.commands.channel import run
         run(_ns(channel_action="import", source="u99"))
         out = capsys.readouterr().out
@@ -280,7 +325,9 @@ class TestCLIChannelExtended:
     def test_stats_not_found(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
         from src.cli.commands.channel import run
-        run(_ns(channel_action="stats", identifier="999", all=False))
+        run(_ns(
+            channel_action="stats", identifier="999", all=False,
+        ))
         out = capsys.readouterr().out
         assert "not found" in out
 
@@ -295,9 +342,11 @@ class TestCLIChannelExtended:
         db, pool = cli_env_with_mock_pool
         async def _test():
             mock_client, _ = await pool.get_available_client()
-            mock_client.get_dialogs.side_effect = Exception("prefetch failed")
+            mock_client.get_dialogs.side_effect = Exception(
+                "prefetch failed",
+            )
         asyncio.run(_test())
-        
+
         from src.cli.commands.channel import run
         run(_ns(channel_action="refresh-types"))
         # Should continue even if prefetch fails
@@ -305,11 +354,12 @@ class TestCLIChannelExtended:
 
     def test_refresh_types_with_null_type(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        asyncio.run(db.add_channel(Channel(channel_id=105, title="NullType", channel_type=None)))
-        pool.resolve_channel.return_value = {
-            "channel_id": 105, "title": "NullType", "username": "u105", 
-            "channel_type": "channel", "deactivate": False
-        }
+        asyncio.run(db.add_channel(Channel(
+            channel_id=105, title="NullType", channel_type=None,
+        )))
+        pool.resolve_channel.return_value = _chan(
+            105, "NullType", "u105",
+        )
         from src.cli.commands.channel import run
         run(_ns(channel_action="refresh-types"))
         out = capsys.readouterr().out
@@ -317,13 +367,22 @@ class TestCLIChannelExtended:
 
     def test_collect_error(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
-        ch_id = asyncio.run(db.add_channel(Channel(channel_id=103, title="CollectMe")))
-        with patch("src.cli.commands.channel.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_single_channel = AsyncMock(side_effect=Exception("collect fail"))
+        ch_id = asyncio.run(db.add_channel(
+            Channel(channel_id=103, title="CollectMe"),
+        ))
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_single_channel = AsyncMock(
+                side_effect=Exception("collect fail"),
+            )
             from src.cli.commands.channel import run
             with pytest.raises(Exception, match="collect fail"):
-                run(_ns(channel_action="collect", identifier=str(ch_id)))
+                run(_ns(
+                    channel_action="collect",
+                    identifier=str(ch_id),
+                ))
         tasks = asyncio.run(db.get_collection_tasks(limit=1))
         assert tasks[0].status == CollectionTaskStatus.FAILED
         assert "collect fail" in tasks[0].error
@@ -331,10 +390,16 @@ class TestCLIChannelExtended:
 class TestCLITestExtended:
     def test_read_checks_with_errors(self, cli_env, capsys):
         # Mock db methods to raise exceptions
-        cli_env.get_stats = AsyncMock(side_effect=Exception("stats fail"))
-        cli_env.get_accounts = AsyncMock(side_effect=Exception("acc fail"))
-        cli_env.get_channels_with_counts = AsyncMock(side_effect=Exception("chan fail"))
-        
+        cli_env.get_stats = AsyncMock(
+            side_effect=Exception("stats fail"),
+        )
+        cli_env.get_accounts = AsyncMock(
+            side_effect=Exception("acc fail"),
+        )
+        cli_env.get_channels_with_counts = AsyncMock(
+            side_effect=Exception("chan fail"),
+        )
+
         from src.cli.commands.test import run
         with pytest.raises(SystemExit):
             run(_ns(command="test", test_action="read"))
@@ -346,70 +411,129 @@ class TestCLITestExtended:
     def test_write_checks_with_empty_db(self, cli_env, capsys):
         # Empty DB (no accounts, no channels)
         from src.cli.commands.test import run
-        # Patch init_db in test module as well
-        with patch("src.cli.commands.test.runtime.init_db", side_effect=AsyncMock(return_value=(AppConfig(), cli_env))):
+        init_db_mock = AsyncMock(
+            return_value=(AppConfig(), cli_env),
+        )
+        with patch(
+            "src.cli.commands.test.runtime.init_db",
+            side_effect=init_db_mock,
+        ):
             run(_ns(command="test", test_action="write"))
         out = capsys.readouterr().out
-        # In current test setup, it might not skip if we don't ensure the DB copy is also empty.
+        # In current test setup, it might not skip if we don't
+        # ensure the DB copy is also empty.
         # But we'll at least cover the code paths.
         assert "write_db_copy" in out
 
-    def test_telegram_live_checks_no_accounts(self, cli_env_with_mock_pool, capsys):
+    def test_telegram_live_checks_no_accounts(
+        self, cli_env_with_mock_pool, capsys,
+    ):
         db, pool = cli_env_with_mock_pool
-        pool.clients = {} # No accounts
-        
+        pool.clients = {}  # No accounts
+
         from src.cli.commands.test import run
-        with patch("src.cli.commands.test.runtime.init_db", side_effect=AsyncMock(return_value=(AppConfig(), db))):
-            with patch("src.cli.commands.test.runtime.init_pool", side_effect=AsyncMock(return_value=(None, pool))):
+        init_db = AsyncMock(return_value=(AppConfig(), db))
+        init_pool = AsyncMock(return_value=(None, pool))
+        with patch(
+            "src.cli.commands.test.runtime.init_db",
+            side_effect=init_db,
+        ):
+            with patch(
+                "src.cli.commands.test.runtime.init_pool",
+                side_effect=init_pool,
+            ):
                 run(_ns(command="test", test_action="telegram"))
         out = capsys.readouterr().out
         assert "tg_pool_init" in out
 
-    def test_telegram_live_checks_full_mock(self, cli_env_with_mock_pool, capsys):
+    def test_telegram_live_checks_full_mock(
+        self, cli_env_with_mock_pool, capsys,
+    ):
         db, pool = cli_env_with_mock_pool
         # Add channel to avoid skips
-        asyncio.run(db.add_channel(Channel(channel_id=1, title="Ch1", username="u1", is_active=True)))
-        
+        asyncio.run(db.add_channel(Channel(
+            channel_id=1, title="Ch1", username="u1",
+            is_active=True,
+        )))
+
         # Mock various Telegram calls
         pool.get_users_info.return_value = [MagicMock(phone="+7999")]
         pool.get_dialogs.return_value = [{"id": 1, "title": "D1"}]
-        pool.resolve_channel.return_value = {"channel_id": 1, "title": "Ch1"}
-        
+        pool.resolve_channel.return_value = {
+            "channel_id": 1, "title": "Ch1",
+        }
+
         mock_client, _ = asyncio.run(pool.get_available_client())
         mock_client.get_entity.return_value = MagicMock(id=1)
-        
+
         # Mock iter_messages
         async def mock_iter(*args, **kwargs):
             m = MagicMock()
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            # Use real datetime and strings to satisfy Pydantic/models
             from datetime import datetime
             m.date = datetime.now()
             m.media = None
-            # Ensure Collector static methods return strings
-            with patch("src.telegram.collector.Collector._get_sender_name", return_value="Test Sender"):
-                with patch("src.telegram.collector.Collector._get_media_type", return_value="text"):
-                    yield m
+            sender_patch = patch(
+                "src.telegram.collector.Collector._get_sender_name",
+                return_value="Test Sender",
+            )
+            media_patch = patch(
+                "src.telegram.collector.Collector._get_media_type",
+                return_value="text",
+            )
+            with sender_patch, media_patch:
+                yield m
         mock_client.iter_messages = mock_iter
-        
-        with patch("src.telegram.collector.Collector") as MockCollector:
-            collector_instance = MockCollector.return_value
-            collector_instance.collect_channel_stats = AsyncMock(return_value=MagicMock(subscriber_count=100))
-            
-            with patch("src.search.engine.SearchEngine") as MockEngine:
-                engine_instance = MockEngine.return_value
-                engine_instance.search_my_chats = AsyncMock(return_value=MagicMock(total=5))
-                engine_instance.search_in_channel = AsyncMock(return_value=MagicMock(total=3))
-                engine_instance.search_telegram = AsyncMock(return_value=MagicMock(total=0, error="Premium needed"))
-                engine_instance.check_search_quota = AsyncMock(return_value={"left": 10})
-                
+
+        with patch(
+            "src.telegram.collector.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_channel_stats = AsyncMock(
+                return_value=MagicMock(subscriber_count=100),
+            )
+
+            with patch(
+                "src.search.engine.SearchEngine",
+            ) as mock_engine:
+                ei = mock_engine.return_value
+                ei.search_my_chats = AsyncMock(
+                    return_value=MagicMock(total=5),
+                )
+                ei.search_in_channel = AsyncMock(
+                    return_value=MagicMock(total=3),
+                )
+                ei.search_telegram = AsyncMock(
+                    return_value=MagicMock(
+                        total=0, error="Premium needed",
+                    ),
+                )
+                ei.check_search_quota = AsyncMock(
+                    return_value={"left": 10},
+                )
+
                 from src.cli.commands.test import run
-                with patch("src.cli.commands.test.runtime.init_db", side_effect=AsyncMock(return_value=(AppConfig(), db))):
-                    with patch("src.cli.commands.test.runtime.init_pool", side_effect=AsyncMock(return_value=(None, pool))):
-                        run(_ns(command="test", test_action="telegram"))
-        
+                init_db = AsyncMock(
+                    return_value=(AppConfig(), db),
+                )
+                init_pool = AsyncMock(
+                    return_value=(None, pool),
+                )
+                with patch(
+                    "src.cli.commands.test.runtime.init_db",
+                    side_effect=init_db,
+                ):
+                    with patch(
+                        "src.cli.commands.test.runtime.init_pool",
+                        side_effect=init_pool,
+                    ):
+                        run(_ns(
+                            command="test",
+                            test_action="telegram",
+                        ))
+
         out = capsys.readouterr().out
         assert "tg_users_info" in out
         assert "tg_get_dialogs" in out

--- a/tests/test_client_pool_extended.py
+++ b/tests/test_client_pool_extended.py
@@ -1,11 +1,13 @@
 import asyncio
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, timedelta, timezone
-from src.telegram.client_pool import ClientPool, StatsClientAvailability
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telethon.errors import FloodWaitError, UsernameInvalidError
+
 from src.models import Account, Channel
-from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
-from telethon.tl.types import Channel as TelethonChannel, PeerChannel, PeerUser
+from src.telegram.client_pool import ClientPool
+
 
 @pytest.fixture
 def mock_db():
@@ -24,16 +26,19 @@ def mock_auth():
 
 @pytest.mark.asyncio
 async def test_client_pool_initialize_success(mock_db, mock_auth):
-    acc = Account(phone="+7999", session_string="sess", is_active=True, is_primary=True, is_premium=False)
+    acc = Account(
+        phone="+7999", session_string="sess",
+        is_active=True, is_primary=True, is_premium=False,
+    )
     mock_db.get_accounts.return_value = [acc]
-    
+
     mock_client = AsyncMock()
     mock_client.get_me.return_value = MagicMock(premium=True)
     mock_auth.create_client_from_session.return_value = mock_client
-    
+
     pool = ClientPool(mock_auth, mock_db)
     await pool.initialize()
-    
+
     assert "+7999" in pool.clients
     mock_db.update_account_premium.assert_called_once_with("+7999", True)
 
@@ -42,19 +47,19 @@ async def test_get_available_client_rotation(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, session_string="s1")
     acc2 = Account(phone="+7002", is_active=True, session_string="s2")
     mock_db.get_accounts.return_value = [acc1, acc2]
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": MagicMock(), "+7002": MagicMock()}
-    
+
     # First client
     res1 = await pool.get_available_client()
     assert res1[1] == "+7001"
     assert "+7001" in pool._in_use
-    
+
     # Second client
     res2 = await pool.get_available_client()
     assert res2[1] == "+7002"
-    
+
     # Fallback when all in use
     res3 = await pool.get_available_client()
     assert res3 is not None # Should return one of them even if in use
@@ -65,10 +70,10 @@ async def test_get_available_client_flood_waited(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, session_string="s1", flood_wait_until=future)
     acc2 = Account(phone="+7002", is_active=True, session_string="s2")
     mock_db.get_accounts.return_value = [acc1, acc2]
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": MagicMock(), "+7002": MagicMock()}
-    
+
     res = await pool.get_available_client()
     assert res[1] == "+7002"
 
@@ -77,10 +82,10 @@ async def test_get_premium_client_unavailable(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, is_premium=False, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
     pool = ClientPool(mock_auth, mock_db)
-    
+
     res = await pool.get_premium_client()
     assert res is None
-    
+
     reason = await pool.get_premium_unavailability_reason()
     assert "Нет аккаунтов с Telegram Premium" in reason
 
@@ -89,10 +94,10 @@ async def test_get_stats_availability_all_flooded(mock_db, mock_auth):
     future = datetime.now(timezone.utc) + timedelta(seconds=100)
     acc = Account(phone="+7001", is_active=True, session_string="s1", flood_wait_until=future)
     mock_db.get_accounts.return_value = [acc]
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": MagicMock()}
-    
+
     stats = await pool.get_stats_availability()
     assert stats.state == "all_flooded"
     assert stats.retry_after_sec >= 99
@@ -102,15 +107,15 @@ async def test_resolve_channel_flood_rotation(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, session_string="s1")
     acc2 = Account(phone="+7002", is_active=True, session_string="s2")
     mock_db.get_accounts.return_value = [acc1, acc2]
-    
+
     c1 = AsyncMock()
     c1.get_entity.side_effect = FloodWaitError(10)
     c2 = AsyncMock()
     c2.get_entity.return_value = MagicMock(id=123, title="Title", broadcast=True)
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": c1, "+7002": c2}
-    
+
     # We mock get_available_client to force rotation
     with patch.object(pool, "get_available_client", side_effect=[(c1, "+7001"), (c2, "+7002")]):
         res = await pool.resolve_channel("@test")
@@ -124,15 +129,15 @@ async def test_resolve_channel_errors(mock_db, mock_auth):
     client = AsyncMock()
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": client}
-    
+
     # Timeout
     client.get_entity.side_effect = asyncio.TimeoutError()
     assert await pool.resolve_channel("@t") is None
-    
+
     # Username errors
     client.get_entity.side_effect = UsernameInvalidError("inv")
     assert await pool.resolve_channel("@t") is None
-    
+
     # No client
     mock_db.get_accounts.return_value = []
     with pytest.raises(RuntimeError, match="no_client"):
@@ -145,10 +150,10 @@ async def test_get_users_info_with_avatar(mock_db, mock_auth):
     client = AsyncMock()
     client.get_me.return_value = MagicMock(first_name="F", last_name="L", username="u")
     client.download_profile_photo.return_value = True
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": client}
-    
+
     with patch("io.BytesIO", return_value=MagicMock(read=lambda: b"imgdata")):
         info = await pool.get_users_info()
         assert len(info) == 1
@@ -161,10 +166,10 @@ async def test_leave_channels_flood(mock_db, mock_auth):
     mock_db.get_accounts.return_value = [acc]
     client = AsyncMock()
     client.delete_dialog.side_effect = FloodWaitError(5)
-    
+
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": client}
-    
+
     res = await pool.leave_channels("+7001", [(123, "channel"), (456, "channel")])
     assert res[123] is False
     assert res[456] is False
@@ -177,13 +182,13 @@ async def test_get_forum_topics_cache_hit_and_miss(mock_db, mock_auth):
     client = AsyncMock()
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": client}
-    
+
     # Cache hit
     client.get_entity.return_value = MagicMock(id=1)
     client.return_value = MagicMock(topics=[MagicMock(id=10, title="T1")])
     topics = await pool.get_forum_topics(1)
     assert topics[0]["title"] == "T1"
-    
+
     # Cache miss (ValueError) then resolve by username
     client.get_entity.side_effect = [ValueError(), MagicMock(id=1)]
     mock_db.get_channel_by_channel_id.return_value = Channel(channel_id=1, username="u1")
@@ -195,15 +200,15 @@ async def test_get_dialogs_timeout(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
     client = AsyncMock()
-    
+
     async def slow_iter():
         await asyncio.sleep(0.1)
         yield MagicMock()
-        
+
     client.iter_dialogs = slow_iter
     pool = ClientPool(mock_auth, mock_db)
     pool.clients = {"+7001": client}
-    
+
     with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
         res = await pool.get_dialogs()
         assert res == []

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -1,11 +1,13 @@
 import asyncio
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime, timezone
-from src.telegram.collector import Collector, AllStatsClientsFloodedError, NoActiveStatsClientsError
-from src.models import Channel, Message, ChannelStats, SearchQuery
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from telethon.errors import FloodWaitError
-from telethon.tl.types import PeerChannel
+
+from src.models import Channel, ChannelStats, Message, SearchQuery
+from src.telegram.collector import AllStatsClientsFloodedError, Collector, NoActiveStatsClientsError
+
 
 @pytest.fixture
 def mock_pool():
@@ -47,10 +49,10 @@ def collector(mock_pool, mock_db):
 async def test_collect_channel_flood_wait_retry(collector, mock_pool, mock_db):
     channel = Channel(id=1, channel_id=123, title="Ch", last_collected_id=10)
     mock_db.get_channel_by_pk.return_value = channel
-    
+
     client = AsyncMock()
     mock_pool.get_available_client.return_value = (client, "+7999")
-    
+
     # First call to iter_messages raises FloodWait, second succeeds
     async def mock_iter(*args, **kwargs):
         if not hasattr(mock_iter, "called"):
@@ -60,13 +62,13 @@ async def test_collect_channel_flood_wait_retry(collector, mock_pool, mock_db):
         m.sender.first_name = "First"
         m.sender.last_name = "Last"
         yield m
-        
+
     client.iter_messages = mock_iter
     client.get_entity.return_value = MagicMock(id=123)
-    
+
     # Mock flush batch to return True
     mock_db.execute.return_value.fetchall.return_value = [{"message_id": 11}]
-    
+
     res = await collector.collect_single_channel(channel)
     assert res == 1
     mock_pool.report_flood.assert_called_once()
@@ -76,10 +78,10 @@ async def test_collect_channel_pre_filter_min_subs(collector, mock_pool, mock_db
     channel = Channel(channel_id=123, title="Ch")
     mock_db.get_setting.return_value = "100" # min_subscribers_filter
     mock_db.get_channel_stats.return_value = [ChannelStats(channel_id=123, subscriber_count=50)]
-    
+
     # Ensure client is available for internal calls before pre-filter
     mock_pool.get_available_client.return_value = (AsyncMock(), "+7999")
-    
+
     res = await collector.collect_single_channel(channel)
     assert res == 0
     mock_db.set_channels_filtered_bulk.assert_called_with([(123, "low_subscriber_manual")])
@@ -90,9 +92,9 @@ async def test_collect_channel_pre_filter_ratio(collector, mock_pool, mock_db):
     mock_db.get_channel_stats.return_value = [ChannelStats(channel_id=123, subscriber_count=10)]
     # Mock message count query
     mock_db.execute.return_value.fetchone.return_value = [100] # 10 subs / 100 msgs = 0.1 ratio
-    
+
     mock_pool.get_available_client.return_value = (AsyncMock(), "+7999")
-    
+
     res = await collector.collect_single_channel(channel)
     assert res == 0
     mock_db.set_channels_filtered_bulk.assert_called_with([(123, "low_subscriber_ratio")])
@@ -103,17 +105,17 @@ async def test_flush_batch_persistence_error(collector, mock_pool, mock_db):
     client = AsyncMock()
     mock_pool.get_available_client.return_value = (client, "+7999")
     client.get_entity.return_value = MagicMock(id=123)
-    
+
     async def mock_iter(*args, **kwargs):
         m = MagicMock(id=11, text="msg", date=datetime.now(timezone.utc))
         m.sender.first_name = "First"
         m.sender.last_name = "Last"
         yield m
     client.iter_messages = mock_iter
-    
+
     # Mock execute to return empty list (persistence failed)
     mock_db.execute.return_value.fetchall.return_value = []
-    
+
     res = await collector._collect_channel(channel)
     assert res == 0 # persisted_max_msg_id not updated, stop_due_to_persistence_error = True
 
@@ -122,7 +124,7 @@ async def test_notification_queries_logic(collector, mock_db):
     collector._notifier = AsyncMock()
     sq = SearchQuery(id=1, query="test", is_regex=False, is_fts=False)
     mock_db.get_notification_queries.return_value = [sq]
-    
+
     # Need messages with actual text
     msgs = [Message(channel_id=1, message_id=1, text="This is a test message", date=datetime.now())]
     await collector._check_notification_queries(msgs)
@@ -138,12 +140,12 @@ async def test_fts_query_matches_logic(collector):
 async def test_collect_channel_stats_flooded_error(collector, mock_pool):
     channel = Channel(channel_id=123)
     mock_pool.get_available_client.return_value = None
-    
+
     from src.telegram.client_pool import StatsClientAvailability
     mock_pool.get_stats_availability = AsyncMock(return_value=StatsClientAvailability(
         state="all_flooded", retry_after_sec=10, next_available_at_utc=datetime.now()
     ))
-    
+
     with pytest.raises(AllStatsClientsFloodedError):
         await collector._collect_channel_stats(channel)
 
@@ -160,7 +162,7 @@ async def test_collect_channel_entity_timeout(collector, mock_pool):
     client = AsyncMock()
     mock_pool.get_available_client.return_value = (client, "+7999")
     client.get_entity.side_effect = asyncio.TimeoutError()
-    
+
     res = await collector._collect_channel(channel)
     assert res == 0
 
@@ -169,10 +171,13 @@ async def test_collect_channel_username_changed(collector, mock_pool, mock_db):
     channel = Channel(channel_id=123, username="old_user")
     client = AsyncMock()
     mock_pool.get_available_client.return_value = (client, "+7999")
-    
+
     # Fails by username, succeeds by numeric ID
-    client.get_entity.side_effect = [ValueError(), MagicMock(id=123, username="new_user", title="New")]
-    
+    client.get_entity.side_effect = [
+        ValueError(),
+        MagicMock(id=123, username="new_user", title="New"),
+    ]
+
     res = await collector._collect_channel(channel)
     assert res == 0
     mock_db.update_channel_meta.assert_called_once()

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -111,7 +111,7 @@ def test_stop_server_timeout(tmp_path):
     with patch("src.cli.process_control.is_process_alive", return_value=True):
         with patch("src.cli.process_control.is_expected_server_process", return_value=True):
             with patch("src.cli.process_control.os.kill"):
-                outcome = stop_server(path, timeout_sec=0.0)
+                outcome = stop_server(path, timeout_sec=0.0, kill_timeout_sec=0.0)
 
     assert outcome.result is StopResult.TIMEOUT
     assert "Timed out" in outcome.message
@@ -122,7 +122,7 @@ def test_stop_server_force_kill_removes_pid(tmp_path):
     path = tmp_path / "app.pid"
     path.write_text("123\n", encoding="utf-8")
 
-    alive_states = iter([True, True, False])
+    alive_states = iter([True, False])
 
     with patch(
         "src.cli.process_control.is_process_alive",
@@ -130,7 +130,7 @@ def test_stop_server_force_kill_removes_pid(tmp_path):
     ):
         with patch("src.cli.process_control.is_expected_server_process", return_value=True):
             with patch("src.cli.process_control.os.kill") as mock_kill:
-                outcome = stop_server(path, timeout_sec=0.0)
+                outcome = stop_server(path, timeout_sec=0.0, kill_timeout_sec=0.0)
 
     assert outcome.result is StopResult.STOPPED
     assert "force kill" in outcome.message

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.cli.process_control import (
     ProcessControlError,
+    StopResult,
     ensure_server_not_running,
     pid_file_path,
     register_current_process,
@@ -53,9 +54,9 @@ def test_ensure_server_not_running_cleans_stale_pid(tmp_path):
 
 
 def test_stop_server_without_pid_file(tmp_path):
-    stopped, message = stop_server(tmp_path / "missing.pid")
-    assert stopped is False
-    assert "not running" in message
+    outcome = stop_server(tmp_path / "missing.pid")
+    assert outcome.result is StopResult.NOT_RUNNING
+    assert "not running" in outcome.message
 
 
 def test_stop_server_cleans_stale_pid(tmp_path):
@@ -63,10 +64,10 @@ def test_stop_server_cleans_stale_pid(tmp_path):
     path.write_text("123\n", encoding="utf-8")
 
     with patch("src.cli.process_control.is_process_alive", return_value=False):
-        stopped, message = stop_server(path)
+        outcome = stop_server(path)
 
-    assert stopped is False
-    assert "stale PID file" in message
+    assert outcome.result is StopResult.STALE_PID
+    assert "stale PID file" in outcome.message
     assert not path.exists()
 
 
@@ -76,10 +77,10 @@ def test_stop_server_rejects_unmanaged_pid(tmp_path):
 
     with patch("src.cli.process_control.is_process_alive", return_value=True):
         with patch("src.cli.process_control.is_expected_server_process", return_value=False):
-            stopped, message = stop_server(path)
+            outcome = stop_server(path)
 
-    assert stopped is False
-    assert "not a managed" in message
+    assert outcome.result is StopResult.UNMANAGED
+    assert "not a managed" in outcome.message
     assert path.exists()
 
 
@@ -95,9 +96,60 @@ def test_stop_server_stops_process_and_removes_pid(tmp_path):
     ):
         with patch("src.cli.process_control.is_expected_server_process", return_value=True):
             with patch("src.cli.process_control.os.kill") as mock_kill:
-                stopped, message = stop_server(path, timeout_sec=0.5)
+                outcome = stop_server(path, timeout_sec=0.5)
 
-    assert stopped is True
-    assert "Server stopped" in message
+    assert outcome.result is StopResult.STOPPED
+    assert "Server stopped" in outcome.message
     mock_kill.assert_called_once()
+    assert not path.exists()
+
+
+def test_stop_server_timeout(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_process_alive", return_value=True):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill"):
+                outcome = stop_server(path, timeout_sec=0.0)
+
+    assert outcome.result is StopResult.TIMEOUT
+    assert "Timed out" in outcome.message
+    assert path.exists()
+
+
+def test_stop_server_force_kill_removes_pid(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    alive_states = iter([True, True, False])
+
+    with patch(
+        "src.cli.process_control.is_process_alive",
+        side_effect=lambda pid: next(alive_states),
+    ):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill") as mock_kill:
+                outcome = stop_server(path, timeout_sec=0.0)
+
+    assert outcome.result is StopResult.STOPPED
+    assert "force kill" in outcome.message
+    assert mock_kill.call_count == 2
+    assert not path.exists()
+
+
+def test_stop_server_handles_pid_disappearing_before_sigterm(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    def raise_lookup(pid, sig):
+        raise ProcessLookupError
+
+    with patch("src.cli.process_control.is_process_alive", return_value=True):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill", side_effect=raise_lookup):
+                outcome = stop_server(path)
+
+    assert outcome.result is StopResult.STALE_PID
+    assert "stale PID file" in outcome.message
     assert not path.exists()

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -153,3 +153,30 @@ def test_stop_server_handles_pid_disappearing_before_sigterm(tmp_path):
     assert outcome.result is StopResult.STALE_PID
     assert "stale PID file" in outcome.message
     assert not path.exists()
+
+
+def test_stop_server_permission_denied_on_sigterm(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_process_alive", return_value=True):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill", side_effect=PermissionError):
+                with pytest.raises(ProcessControlError, match="Permission denied"):
+                    stop_server(path)
+
+
+def test_stop_server_permission_denied_on_sigkill(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    def kill_side_effect(pid, sig):
+        if sig == 15:
+            return None
+        raise PermissionError
+
+    with patch("src.cli.process_control.is_process_alive", return_value=True):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill", side_effect=kill_side_effect):
+                with pytest.raises(ProcessControlError, match="Permission denied"):
+                    stop_server(path, timeout_sec=0.0, kill_timeout_sec=0.0)

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -89,7 +89,10 @@ def test_stop_server_stops_process_and_removes_pid(tmp_path):
 
     alive_states = iter([True, False])
 
-    with patch("src.cli.process_control.is_process_alive", side_effect=lambda pid: next(alive_states)):
+    with patch(
+        "src.cli.process_control.is_process_alive",
+        side_effect=lambda pid: next(alive_states),
+    ):
         with patch("src.cli.process_control.is_expected_server_process", return_value=True):
             with patch("src.cli.process_control.os.kill") as mock_kill:
                 stopped, message = stop_server(path, timeout_sec=0.5)

--- a/tests/test_process_control.py
+++ b/tests/test_process_control.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.cli.process_control import (
+    ProcessControlError,
+    ensure_server_not_running,
+    pid_file_path,
+    register_current_process,
+    stop_server,
+    unregister_current_process,
+)
+from src.config import AppConfig
+
+
+def test_pid_file_path_uses_database_path_suffix():
+    config = AppConfig()
+    config.database.path = "data/custom.db"
+    assert pid_file_path(config) == Path("data/custom.pid")
+
+
+def test_register_and_unregister_current_process(tmp_path):
+    path = tmp_path / "app.pid"
+
+    register_current_process(path)
+    assert path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    unregister_current_process(path)
+    assert not path.exists()
+
+
+def test_ensure_server_not_running_raises_for_live_server(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+        with pytest.raises(ProcessControlError, match="Server already running"):
+            ensure_server_not_running(path)
+
+
+def test_ensure_server_not_running_cleans_stale_pid(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_expected_server_process", return_value=False):
+        ensure_server_not_running(path)
+
+    assert not path.exists()
+
+
+def test_stop_server_without_pid_file(tmp_path):
+    stopped, message = stop_server(tmp_path / "missing.pid")
+    assert stopped is False
+    assert "not running" in message
+
+
+def test_stop_server_cleans_stale_pid(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_process_alive", return_value=False):
+        stopped, message = stop_server(path)
+
+    assert stopped is False
+    assert "stale PID file" in message
+    assert not path.exists()
+
+
+def test_stop_server_rejects_unmanaged_pid(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    with patch("src.cli.process_control.is_process_alive", return_value=True):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=False):
+            stopped, message = stop_server(path)
+
+    assert stopped is False
+    assert "not a managed" in message
+    assert path.exists()
+
+
+def test_stop_server_stops_process_and_removes_pid(tmp_path):
+    path = tmp_path / "app.pid"
+    path.write_text("123\n", encoding="utf-8")
+
+    alive_states = iter([True, False])
+
+    with patch("src.cli.process_control.is_process_alive", side_effect=lambda pid: next(alive_states)):
+        with patch("src.cli.process_control.is_expected_server_process", return_value=True):
+            with patch("src.cli.process_control.os.kill") as mock_kill:
+                stopped, message = stop_server(path, timeout_sec=0.5)
+
+    assert stopped is True
+    assert "Server stopped" in message
+    mock_kill.assert_called_once()
+    assert not path.exists()

--- a/tests/test_scheduler_manager.py
+++ b/tests/test_scheduler_manager.py
@@ -1,10 +1,12 @@
-import asyncio
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime, timezone
-from src.scheduler.manager import SchedulerManager
+
 from src.config import SchedulerConfig
 from src.models import SearchQuery, SearchResult
+from src.scheduler.manager import SchedulerManager
+
 
 @pytest.fixture
 def mock_collector():
@@ -39,28 +41,36 @@ def mock_search_engine():
 
 @pytest.fixture
 def scheduler_config():
-    return SchedulerConfig(collect_interval_minutes=60, search_interval_minutes=30)
+    return SchedulerConfig(
+        collect_interval_minutes=60, search_interval_minutes=30,
+    )
 
 @pytest.mark.asyncio
-async def test_scheduler_start_stop(mock_collector, scheduler_config, mock_bundle):
+async def test_scheduler_start_stop(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     await mgr.start()
     assert mgr.is_running
     assert mgr.interval_minutes == 60
-    
+
     await mgr.stop()
     assert not mgr.is_running
 
 @pytest.mark.asyncio
-async def test_scheduler_start_already_running(mock_collector, scheduler_config, mock_bundle):
+async def test_scheduler_start_already_running(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     await mgr.start()
-    await mgr.start() # Should log warning and return
+    await mgr.start()  # Should log warning and return
     assert mgr.is_running
     await mgr.stop()
 
 @pytest.mark.asyncio
-async def test_scheduler_update_interval(mock_collector, scheduler_config, mock_bundle):
+async def test_scheduler_update_interval(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     await mgr.start()
     mgr.update_interval(10)
@@ -68,15 +78,21 @@ async def test_scheduler_update_interval(mock_collector, scheduler_config, mock_
     await mgr.stop()
 
 @pytest.mark.asyncio
-async def test_scheduler_trigger_now(mock_collector, scheduler_config, mock_bundle):
-    mock_collector.collect_all_channels.return_value = {"channels": 1, "messages": 5}
+async def test_scheduler_trigger_now(
+    mock_collector, scheduler_config, mock_bundle,
+):
+    mock_collector.collect_all_channels.return_value = {
+        "channels": 1, "messages": 5,
+    }
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     res = await mgr.trigger_now()
     assert res["channels"] == 1
     assert mgr.last_run is not None
 
 @pytest.mark.asyncio
-async def test_scheduler_trigger_background(mock_collector, scheduler_config, mock_bundle):
+async def test_scheduler_trigger_background(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mock_collector.collect_all_channels.return_value = {"channels": 1}
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     await mgr.trigger_background()
@@ -85,83 +101,123 @@ async def test_scheduler_trigger_background(mock_collector, scheduler_config, mo
     assert mgr.last_stats["channels"] == 1
 
 @pytest.mark.asyncio
-async def test_run_collection_failure(mock_collector, scheduler_config, mock_bundle):
+async def test_run_collection_failure(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mock_collector.collect_all_channels.side_effect = Exception("boom")
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     res = await mgr._run_collection()
     assert res["errors"] == 1
 
 @pytest.mark.asyncio
-async def test_run_keyword_search_no_engine(mock_collector, scheduler_config, mock_bundle):
+async def test_run_keyword_search_no_engine(
+    mock_collector, scheduler_config, mock_bundle,
+):
     mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle)
     res = await mgr._run_keyword_search()
     assert res["queries"] == 0
 
 @pytest.mark.asyncio
-async def test_run_keyword_search_success(mock_collector, scheduler_config, mock_bundle, mock_search_engine):
+async def test_run_keyword_search_success(
+    mock_collector, scheduler_config, mock_bundle, mock_search_engine,
+):
     sq = MagicMock()
     sq.query = "test"
     mock_bundle.get_notification_queries = AsyncMock(return_value=[sq])
-    mock_search_engine.check_search_quota = AsyncMock(return_value={"remains": 10})
-    mock_search_engine.search_telegram.return_value = SearchResult(total=5, messages=[], query="test")
-    
-    mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle, search_engine=mock_search_engine)
+    mock_search_engine.check_search_quota = AsyncMock(
+        return_value={"remains": 10},
+    )
+    mock_search_engine.search_telegram.return_value = SearchResult(
+        total=5, messages=[], query="test",
+    )
+
+    mgr = SchedulerManager(
+        mock_collector, scheduler_config, mock_bundle,
+        search_engine=mock_search_engine,
+    )
     res = await mgr._run_keyword_search()
     assert res["queries"] == 1
     assert res["results"] == 5
     assert mgr.last_search_run is not None
 
 @pytest.mark.asyncio
-async def test_run_keyword_search_quota_exhausted(mock_collector, scheduler_config, mock_bundle, mock_search_engine):
+async def test_run_keyword_search_quota_exhausted(
+    mock_collector, scheduler_config, mock_bundle, mock_search_engine,
+):
     sq = MagicMock()
     sq.query = "test"
     mock_bundle.get_notification_queries = AsyncMock(return_value=[sq])
-    mock_search_engine.check_search_quota.return_value = {"remains": 0, "query_is_free": False}
-    
-    mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle, search_engine=mock_search_engine)
+    mock_search_engine.check_search_quota.return_value = {
+        "remains": 0, "query_is_free": False,
+    }
+
+    mgr = SchedulerManager(
+        mock_collector, scheduler_config, mock_bundle,
+        search_engine=mock_search_engine,
+    )
     res = await mgr._run_keyword_search()
-    assert res["queries"] == 0 # Stopped before search
+    assert res["queries"] == 0  # Stopped before search
 
 @pytest.mark.asyncio
-async def test_sync_search_query_jobs(mock_collector, scheduler_config, mock_bundle, mock_sq_bundle):
-    sq1 = SearchQuery(id=1, name="q1", query="q1", track_stats=True, interval_minutes=10)
+async def test_sync_search_query_jobs(
+    mock_collector, scheduler_config, mock_bundle, mock_sq_bundle,
+):
+    sq1 = SearchQuery(
+        id=1, name="q1", query="q1",
+        track_stats=True, interval_minutes=10,
+    )
     mock_sq_bundle.get_all.return_value = [sq1]
-    
-    mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle, search_query_bundle=mock_sq_bundle)
+
+    mgr = SchedulerManager(
+        mock_collector, scheduler_config, mock_bundle,
+        search_query_bundle=mock_sq_bundle,
+    )
     await mgr.start()
     await mgr.sync_search_query_jobs()
-    
+
     jobs = mgr._scheduler.get_jobs()
     assert any(j.id == "sq_1" for j in jobs)
-    
+
     # Remove job
     mock_sq_bundle.get_all.return_value = []
     await mgr.sync_search_query_jobs()
     jobs = mgr._scheduler.get_jobs()
     assert not any(j.id == "sq_1" for j in jobs)
-    
+
     await mgr.stop()
 
 @pytest.mark.asyncio
-async def test_run_search_query_logic(mock_collector, scheduler_config, mock_bundle, mock_sq_bundle):
+async def test_run_search_query_logic(
+    mock_collector, scheduler_config, mock_bundle, mock_sq_bundle,
+):
     sq = SearchQuery(id=1, name="q1", query="q1", track_stats=True)
     mock_sq_bundle.get_by_id.return_value = sq
-    
+
     class Stat:
         def __init__(self, day, count):
             self.day = day
             self.count = count
-            
-    mock_sq_bundle.get_fts_daily_stats_for_query.return_value = [Stat(datetime.now(timezone.utc).date().isoformat(), 10)]
-    
-    mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle, search_query_bundle=mock_sq_bundle)
+
+    mock_sq_bundle.get_fts_daily_stats_for_query.return_value = [
+        Stat(date.today().isoformat(), 10),
+    ]
+
+    mgr = SchedulerManager(
+        mock_collector, scheduler_config, mock_bundle,
+        search_query_bundle=mock_sq_bundle,
+    )
     await mgr._run_search_query(1)
     mock_sq_bundle.record_stat.assert_called_once_with(1, 10)
 
 @pytest.mark.asyncio
-async def test_run_search_query_not_found(mock_collector, scheduler_config, mock_bundle, mock_sq_bundle):
+async def test_run_search_query_not_found(
+    mock_collector, scheduler_config, mock_bundle, mock_sq_bundle,
+):
     mock_sq_bundle.get_by_id.return_value = None
-    mgr = SchedulerManager(mock_collector, scheduler_config, mock_bundle, search_query_bundle=mock_sq_bundle)
+    mgr = SchedulerManager(
+        mock_collector, scheduler_config, mock_bundle,
+        search_query_bundle=mock_sq_bundle,
+    )
     await mgr._run_search_query(1)
     mock_sq_bundle.record_stat.assert_not_called()
 
@@ -170,10 +226,10 @@ async def test_legacy_bundle_fallback():
     store = MagicMock()
     store.get_setting = AsyncMock(return_value="5")
     store.get_notification_queries = AsyncMock(return_value=[])
-    
+
     collector = MagicMock()
     config = SchedulerConfig(collect_interval_minutes=60)
-    
+
     mgr = SchedulerManager(collector, config, scheduler_bundle=store)
     await mgr.start()
     assert mgr.interval_minutes == 5

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,15 +1,27 @@
-import pytest
-from unittest.mock import MagicMock
 from datetime import datetime, timezone
-from src.search.transformers import TelegramMessageTransformer
+from unittest.mock import MagicMock
+
 from telethon.tl.types import (
-    MessageMediaPhoto, MessageMediaDocument, MessageMediaWebPage,
-    MessageMediaGeo, MessageMediaGeoLive, MessageMediaContact,
-    MessageMediaPoll, MessageMediaDice, MessageMediaGame,
-    Document, DocumentAttributeSticker, DocumentAttributeVideo,
-    DocumentAttributeAudio, DocumentAttributeAnimated,
-    PeerUser, PeerChannel
+    Document,
+    DocumentAttributeAnimated,
+    DocumentAttributeAudio,
+    DocumentAttributeSticker,
+    DocumentAttributeVideo,
+    MessageMediaContact,
+    MessageMediaDice,
+    MessageMediaDocument,
+    MessageMediaGame,
+    MessageMediaGeo,
+    MessageMediaGeoLive,
+    MessageMediaPhoto,
+    MessageMediaPoll,
+    MessageMediaWebPage,
+    PeerChannel,
+    PeerUser,
 )
+
+from src.search.transformers import TelegramMessageTransformer
+
 
 def test_media_type_none():
     msg = MagicMock(media=None)
@@ -56,13 +68,14 @@ def test_media_type_gif():
     assert TelegramMessageTransformer.media_type_from_message(msg) == "gif"
 
 def test_media_type_simple_types():
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaWebPage))) == "web_page"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaGeo))) == "location"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaGeoLive))) == "geo_live"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaContact))) == "contact"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaPoll))) == "poll"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaDice))) == "dice"
-    assert TelegramMessageTransformer.media_type_from_message(MagicMock(media=MagicMock(spec=MessageMediaGame))) == "game"
+    mt = TelegramMessageTransformer.media_type_from_message
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaWebPage))) == "web_page"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaGeo))) == "location"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaGeoLive))) == "geo_live"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaContact))) == "contact"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaPoll))) == "poll"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaDice))) == "dice"
+    assert mt(MagicMock(media=MagicMock(spec=MessageMediaGame))) == "game"
 
 def test_convert_telethon_message_basic():
     msg = MagicMock()
@@ -76,7 +89,7 @@ def test_convert_telethon_message_basic():
     msg.date = datetime(2025, 1, 1)
     msg.message = "hello"
     msg.media = None
-    
+
     res = TelegramMessageTransformer.convert_telethon_message(msg)
     assert res.channel_id == 456
     assert res.sender_name == "John Doe"


### PR DESCRIPTION
## Summary
- add PID-based process control for the web server started via 
- add top-level  and  CLI commands
- document the new commands and cover them with CLI/process-control tests

## Testing
- python3 -m pytest tests/test_process_control.py tests/test_cli.py -q