### PR TITLE
Добавить ручной кеш диалогов

### DIFF
--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -8,6 +8,7 @@ from src.database.repositories.accounts import AccountsRepository
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.database.repositories.dialog_cache import DialogCacheRepository
 from src.database.repositories.filters import FilterRepository
 from src.database.repositories.messages import MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
@@ -50,6 +51,7 @@ class DatabaseRepositories:
     notification_bots: NotificationBotsRepository
     search_queries: SearchQueriesRepository
     photo_loader: PhotoLoaderRepository
+    dialog_cache: DialogCacheRepository
 
 
 @dataclass(frozen=True)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -12,6 +12,7 @@ from src.database.repositories.accounts import AccountsRepository
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.database.repositories.dialog_cache import DialogCacheRepository
 from src.database.repositories.filters import FilterRepository
 from src.database.repositories.messages import MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
@@ -55,6 +56,7 @@ class Database:
         self._notification_bots: NotificationBotsRepository | None = None
         self._search_queries: SearchQueriesRepository | None = None
         self._photo_loader: PhotoLoaderRepository | None = None
+        self._dialog_cache: DialogCacheRepository | None = None
         self._repos: DatabaseRepositories | None = None
 
     async def _has_encrypted_sessions(self) -> bool:
@@ -99,6 +101,7 @@ class Database:
         self._notification_bots = NotificationBotsRepository(self._db)
         self._search_queries = SearchQueriesRepository(self._db)
         self._photo_loader = PhotoLoaderRepository(self._db)
+        self._dialog_cache = DialogCacheRepository(self._db)
         self._repos = DatabaseRepositories(
             accounts=self._accounts,
             channels=self._channels,
@@ -111,6 +114,7 @@ class Database:
             notification_bots=self._notification_bots,
             search_queries=self._search_queries,
             photo_loader=self._photo_loader,
+            dialog_cache=self._dialog_cache,
         )
 
         await self._accounts.migrate_sessions()
@@ -155,6 +159,7 @@ class Database:
                 self._notification_bots,
                 self._search_queries,
                 self._photo_loader,
+                self._dialog_cache,
             )
         ):
             raise RuntimeError("Database.initialize() has not been called")

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -347,6 +347,28 @@ async def run_migrations(db: aiosqlite.Connection) -> None:
         )
         """
     )
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dialog_cache (
+            id INTEGER PRIMARY KEY,
+            phone TEXT NOT NULL,
+            dialog_id INTEGER NOT NULL,
+            title TEXT,
+            username TEXT,
+            channel_type TEXT NOT NULL,
+            deactivate INTEGER NOT NULL DEFAULT 0,
+            is_own INTEGER NOT NULL DEFAULT 0,
+            cached_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(phone, dialog_id)
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_dialog_cache_phone
+        ON dialog_cache(phone)
+        """
+    )
     await db.commit()
 
     cur = await db.execute("SELECT value FROM settings WHERE key = 'fts5_initialized'")

--- a/src/database/repositories/dialog_cache.py
+++ b/src/database/repositories/dialog_cache.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import aiosqlite
+
+
+def _dt(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+class DialogCacheRepository:
+    def __init__(self, db: aiosqlite.Connection):
+        self._db = db
+
+    async def list_dialogs(self, phone: str) -> list[dict]:
+        cur = await self._db.execute(
+            """
+            SELECT dialog_id, title, username, channel_type, deactivate, is_own
+            FROM dialog_cache
+            WHERE phone = ?
+            ORDER BY id ASC
+            """,
+            (phone,),
+        )
+        rows = await cur.fetchall()
+        return [
+            {
+                "channel_id": row["dialog_id"],
+                "title": row["title"],
+                "username": row["username"],
+                "channel_type": row["channel_type"],
+                "deactivate": bool(row["deactivate"]),
+                "is_own": bool(row["is_own"]),
+            }
+            for row in rows
+        ]
+
+    async def replace_dialogs(self, phone: str, dialogs: list[dict]) -> None:
+        await self._db.execute("BEGIN IMMEDIATE")
+        try:
+            await self._db.execute("DELETE FROM dialog_cache WHERE phone = ?", (phone,))
+            if dialogs:
+                cached_at = datetime.now().isoformat()
+                await self._db.executemany(
+                    """
+                    INSERT INTO dialog_cache (
+                        phone, dialog_id, title, username, channel_type,
+                        deactivate, is_own, cached_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        (
+                            phone,
+                            int(dialog["channel_id"]),
+                            dialog.get("title"),
+                            dialog.get("username"),
+                            dialog.get("channel_type"),
+                            1 if dialog.get("deactivate") else 0,
+                            1 if dialog.get("is_own") else 0,
+                            cached_at,
+                        )
+                        for dialog in dialogs
+                    ],
+                )
+            await self._db.commit()
+        except Exception:
+            await self._db.rollback()
+            raise
+
+    async def clear_dialogs(self, phone: str) -> None:
+        await self._db.execute("DELETE FROM dialog_cache WHERE phone = ?", (phone,))
+        await self._db.commit()
+
+    async def has_dialogs(self, phone: str) -> bool:
+        cur = await self._db.execute(
+            "SELECT 1 FROM dialog_cache WHERE phone = ? LIMIT 1",
+            (phone,),
+        )
+        return bool(await cur.fetchone())
+
+    async def get_cached_at(self, phone: str) -> datetime | None:
+        cur = await self._db.execute(
+            "SELECT MAX(cached_at) AS cached_at FROM dialog_cache WHERE phone = ?",
+            (phone,),
+        )
+        row = await cur.fetchone()
+        if not row:
+            return None
+        return _dt(row["cached_at"])

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -196,4 +196,20 @@ CREATE TABLE IF NOT EXISTS photo_auto_upload_files (
     UNIQUE(job_id, file_path),
     FOREIGN KEY (job_id) REFERENCES photo_auto_upload_jobs(id)
 );
+
+CREATE TABLE IF NOT EXISTS dialog_cache (
+    id INTEGER PRIMARY KEY,
+    phone TEXT NOT NULL,
+    dialog_id INTEGER NOT NULL,
+    title TEXT,
+    username TEXT,
+    channel_type TEXT NOT NULL,
+    deactivate INTEGER NOT NULL DEFAULT 0,
+    is_own INTEGER NOT NULL DEFAULT 0,
+    cached_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(phone, dialog_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dialog_cache_phone
+    ON dialog_cache(phone);
 """

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -76,12 +76,17 @@ class ChannelService:
                 )
             )
 
-    async def get_my_dialogs(self, phone: str) -> list[dict]:
+    async def get_my_dialogs(self, phone: str, refresh: bool = False) -> list[dict]:
         """Get all dialogs for a specific account, enriched with already_added flag."""
         started_at = time.perf_counter()
         existing_ids = {ch.channel_id for ch in await self._channels.list_channels()}
         db_elapsed_ms = int((time.perf_counter() - started_at) * 1000)
-        dialogs = await self._pool.get_dialogs_for_phone(phone, include_dm=True, mode="full")
+        dialogs = await self._pool.get_dialogs_for_phone(
+            phone,
+            include_dm=True,
+            mode="full",
+            refresh=refresh,
+        )
         enrich_started_at = time.perf_counter()
         for d in dialogs:
             d["already_added"] = d["channel_id"] in existing_ids

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -32,6 +32,7 @@ class DialogFetchStats:
 
 @dataclass
 class DialogCacheEntry:
+    fetched_at_monotonic: float
     dialogs: list[dict]
 
 
@@ -54,6 +55,7 @@ class ClientPool:
         self._in_use: set[str] = set()
         self._dialogs_fetched: set[str] = set()
         self._dialogs_cache: dict[tuple[str, str], DialogCacheEntry] = {}
+        self._dialogs_cache_ttl_sec = 60.0
 
     def is_dialogs_fetched(self, phone: str) -> bool:
         """Return True if get_dialogs() was already called for this phone in this process."""
@@ -73,11 +75,19 @@ class ClientPool:
 
     def _get_cached_dialogs(self, phone: str, mode: str) -> list[dict] | None:
         entry = self._dialogs_cache.get((phone, mode))
-        if entry is None:
-            if mode != "channels_only":
-                return None
+        if entry is not None:
+            age = time.monotonic() - entry.fetched_at_monotonic
+            if age <= self._dialogs_cache_ttl_sec:
+                return [dict(dialog) for dialog in entry.dialogs]
+            self._dialogs_cache.pop((phone, mode), None)
+
+        if mode == "channels_only":
             full_entry = self._dialogs_cache.get((phone, "full"))
             if full_entry is not None:
+                age = time.monotonic() - full_entry.fetched_at_monotonic
+                if age > self._dialogs_cache_ttl_sec:
+                    self._dialogs_cache.pop((phone, "full"), None)
+                    return None
                 filtered = [
                     dict(dialog)
                     for dialog in full_entry.dialogs
@@ -86,10 +96,11 @@ class ClientPool:
                 self._store_cached_dialogs(phone, mode, filtered)
                 return filtered
             return None
-        return [dict(dialog) for dialog in entry.dialogs]
+        return None
 
     def _store_cached_dialogs(self, phone: str, mode: str, dialogs: list[dict]) -> None:
         self._dialogs_cache[(phone, mode)] = DialogCacheEntry(
+            fetched_at_monotonic=time.monotonic(),
             dialogs=[dict(dialog) for dialog in dialogs],
         )
 

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -32,7 +32,6 @@ class DialogFetchStats:
 
 @dataclass
 class DialogCacheEntry:
-    fetched_at_monotonic: float
     dialogs: list[dict]
 
 
@@ -55,7 +54,6 @@ class ClientPool:
         self._in_use: set[str] = set()
         self._dialogs_fetched: set[str] = set()
         self._dialogs_cache: dict[tuple[str, str], DialogCacheEntry] = {}
-        self._dialogs_cache_ttl_sec = 60.0
 
     def is_dialogs_fetched(self, phone: str) -> bool:
         """Return True if get_dialogs() was already called for this phone in this process."""
@@ -80,26 +78,18 @@ class ClientPool:
                 return None
             full_entry = self._dialogs_cache.get((phone, "full"))
             if full_entry is not None:
-                age = time.monotonic() - full_entry.fetched_at_monotonic
-                if age <= self._dialogs_cache_ttl_sec:
-                    filtered = [
-                        dict(dialog)
-                        for dialog in full_entry.dialogs
-                        if dialog.get("channel_type") not in ("dm", "bot")
-                    ]
-                    self._store_cached_dialogs(phone, mode, filtered)
-                    return filtered
-                self._dialogs_cache.pop((phone, "full"), None)
-            return None
-        age = time.monotonic() - entry.fetched_at_monotonic
-        if age > self._dialogs_cache_ttl_sec:
-            self._dialogs_cache.pop((phone, mode), None)
+                filtered = [
+                    dict(dialog)
+                    for dialog in full_entry.dialogs
+                    if dialog.get("channel_type") not in ("dm", "bot")
+                ]
+                self._store_cached_dialogs(phone, mode, filtered)
+                return filtered
             return None
         return [dict(dialog) for dialog in entry.dialogs]
 
     def _store_cached_dialogs(self, phone: str, mode: str, dialogs: list[dict]) -> None:
         self._dialogs_cache[(phone, mode)] = DialogCacheEntry(
-            fetched_at_monotonic=time.monotonic(),
             dialogs=[dict(dialog) for dialog in dialogs],
         )
 
@@ -398,18 +388,32 @@ class ClientPool:
         phone: str,
         include_dm: bool = False,
         mode: str = "channels_only",
+        refresh: bool = False,
     ) -> list[dict]:
         """Get all dialogs for a specific connected account."""
         cache_mode = "full" if include_dm or mode == "full" else "channels_only"
-        cached = self._get_cached_dialogs(phone, cache_mode)
-        if cached is not None:
+        if refresh:
             logger.info(
-                "get_dialogs_for_phone: cache hit for %s mode=%s count=%d",
+                "get_dialogs_for_phone: manual refresh for %s mode=%s",
                 phone,
                 cache_mode,
-                len(cached),
             )
-            return cached
+            self.invalidate_dialogs_cache(phone)
+        else:
+            cached = self._get_cached_dialogs(phone, cache_mode)
+            if cached is not None:
+                logger.info(
+                    "get_dialogs_for_phone: cache hit for %s mode=%s count=%d",
+                    phone,
+                    cache_mode,
+                    len(cached),
+                )
+                return cached
+            logger.info(
+                "get_dialogs_for_phone: cache miss for %s mode=%s",
+                phone,
+                cache_mode,
+            )
 
         result = await self.get_client_by_phone(phone)
         if not result:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -73,6 +73,22 @@ class ClientPool:
         for key in keys:
             del self._dialogs_cache[key]
 
+    async def _get_db_cached_dialogs(self, phone: str, mode: str) -> list[dict] | None:
+        full_dialogs = await self._db.repos.dialog_cache.list_dialogs(phone)
+        if not full_dialogs:
+            return None
+        if mode == "channels_only":
+            filtered = [
+                dict(dialog)
+                for dialog in full_dialogs
+                if dialog.get("channel_type") not in ("dm", "bot")
+            ]
+            self._store_cached_dialogs(phone, mode, filtered)
+            self._store_cached_dialogs(phone, "full", full_dialogs)
+            return filtered
+        self._store_cached_dialogs(phone, "full", full_dialogs)
+        return [dict(dialog) for dialog in full_dialogs]
+
     def _get_cached_dialogs(self, phone: str, mode: str) -> list[dict] | None:
         entry = self._dialogs_cache.get((phone, mode))
         if entry is not None:
@@ -409,7 +425,6 @@ class ClientPool:
                 phone,
                 cache_mode,
             )
-            self.invalidate_dialogs_cache(phone)
         else:
             cached = self._get_cached_dialogs(phone, cache_mode)
             if cached is not None:
@@ -420,8 +435,17 @@ class ClientPool:
                     len(cached),
                 )
                 return cached
+            db_cached = await self._get_db_cached_dialogs(phone, cache_mode)
+            if db_cached is not None:
+                logger.info(
+                    "get_dialogs_for_phone: db cache hit for %s mode=%s count=%d",
+                    phone,
+                    cache_mode,
+                    len(db_cached),
+                )
+                return db_cached
             logger.info(
-                "get_dialogs_for_phone: cache miss for %s mode=%s",
+                "get_dialogs_for_phone: cache miss for %s mode=%s source=telegram",
                 phone,
                 cache_mode,
             )
@@ -498,8 +522,11 @@ class ClientPool:
                 stats.partial,
                 len(items),
             )
-            if items and not stats.partial:
+            if not stats.partial:
+                self.invalidate_dialogs_cache(phone)
                 self._store_cached_dialogs(phone, cache_mode, items)
+                if cache_mode == "full":
+                    await self._db.repos.dialog_cache.replace_dialogs(phone, items)
             return items
         finally:
             await self.release_client(phone)
@@ -539,6 +566,7 @@ class ClientPool:
         finally:
             await self.release_client(phone)
         self.invalidate_dialogs_cache(phone)
+        await self._db.repos.dialog_cache.clear_dialogs(phone)
         return outcomes
 
     async def get_forum_topics(self, channel_id: int) -> list[dict]:

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -25,8 +25,12 @@ async def my_telegram_page(
     accounts = sorted(pool.clients.keys())
     selected_phone = phone if phone in pool.clients else None
     dialogs = []
+    dialogs_cached_at = None
     if selected_phone:
         dialogs = await deps.channel_service(request).get_my_dialogs(selected_phone)
+        dialogs_cached_at = await deps.get_db(request).repos.dialog_cache.get_cached_at(
+            selected_phone
+        )
     elapsed_ms = int((time.perf_counter() - started_at) * 1000)
     logger.info(
         "my_telegram_page: phone=%s accounts=%d dialogs=%d duration_ms=%d",
@@ -40,6 +44,7 @@ async def my_telegram_page(
             "accounts": accounts,
             "selected_phone": selected_phone,
             "dialogs": dialogs,
+            "dialogs_cached_at": dialogs_cached_at,
             "left": left,
             "failed": failed,
         }

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -4,7 +4,7 @@ import logging
 import time
 from urllib.parse import quote
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.web import deps
@@ -43,6 +43,15 @@ async def my_telegram_page(
             "left": left,
             "failed": failed,
         }
+    )
+
+
+@router.post("/refresh")
+async def refresh_dialogs(request: Request, phone: str = Form(...)):
+    await deps.channel_service(request).get_my_dialogs(phone, refresh=True)
+    return RedirectResponse(
+        url=f"/my-telegram/?phone={quote(phone, safe='')}",
+        status_code=303,
     )
 
 

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -93,6 +93,15 @@ async def photo_loader_page(request: Request, phone: str | None = None):
     )
 
 
+@router.post("/refresh")
+async def photo_loader_refresh(request: Request, phone: str = Form(...)):
+    await deps.channel_service(request).get_my_dialogs(phone, refresh=True)
+    return RedirectResponse(
+        url=f"/my-telegram/photos?phone={quote(phone, safe='')}",
+        status_code=303,
+    )
+
+
 @router.post("/send")
 async def photo_send(
     request: Request,
@@ -100,7 +109,7 @@ async def photo_send(
     target_dialog_id: int = Form(...),
     target_title: str = Form(""),
     target_type: str = Form(""),
-    send_mode: str = Form(PhotoSendMode.ALBUM.value),
+    send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
     photos: list[UploadFile] = File(...),
 ):
@@ -130,7 +139,7 @@ async def photo_schedule(
     target_dialog_id: int = Form(...),
     target_title: str = Form(""),
     target_type: str = Form(""),
-    send_mode: str = Form(PhotoSendMode.ALBUM.value),
+    send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
     schedule_at: str = Form(...),
     photos: list[UploadFile] = File(...),
@@ -191,7 +200,7 @@ async def photo_auto_create(
     target_title: str = Form(""),
     target_type: str = Form(""),
     folder_path: str = Form(...),
-    send_mode: str = Form(PhotoSendMode.ALBUM.value),
+    send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
     interval_minutes: int = Form(...),
 ):

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -191,8 +191,12 @@ async def photo_loader_page(request: Request, phone: str | None = None):
     msg = request.query_params.get("msg")
     error = request.query_params.get("error")
     dialogs = []
+    dialogs_cached_at = None
     if selected_phone:
         dialogs = await deps.channel_service(request).get_my_dialogs(selected_phone)
+        dialogs_cached_at = await deps.get_db(request).repos.dialog_cache.get_cached_at(
+            selected_phone
+        )
     batches = await deps.get_photo_task_service(request).list_batches(limit=20)
     items = await deps.get_photo_task_service(request).list_items(limit=20)
     auto_jobs = await deps.get_photo_auto_upload_service(request).list_jobs()
@@ -210,6 +214,7 @@ async def photo_loader_page(request: Request, phone: str | None = None):
             "accounts": accounts,
             "selected_phone": selected_phone,
             "dialogs": dialogs,
+            "dialogs_cached_at": dialogs_cached_at,
             "batches": batches,
             "items": items,
             "auto_jobs": auto_jobs,

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -68,17 +68,141 @@ def _parse_schedule_at(value: str) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+def _target_label(target_title: str | None, target_dialog_id: int | None) -> str | None:
+    if target_title:
+        return target_title
+    if target_dialog_id is not None:
+        return str(target_dialog_id)
+    return None
+
+
+def _build_feedback(
+    msg: str | None,
+    error: str | None,
+    *,
+    batches,
+    items,
+    auto_jobs,
+) -> dict | None:
+    if msg == "photo_sent":
+        item = items[0] if items else None
+        target = _target_label(
+            getattr(item, "target_title", None),
+            getattr(item, "target_dialog_id", None),
+        )
+        body = "Фото успешно отправлены."
+        if target:
+            body = f"Фото успешно отправлены в {target}."
+        return {
+            "variant": "success",
+            "title": "Отправка завершена",
+            "body": body + " Свежий результат показан в списке photo items ниже.",
+            "highlight_kind": "item",
+        }
+
+    if msg == "photo_scheduled":
+        item = items[0] if items else None
+        target = _target_label(
+            getattr(item, "target_title", None),
+            getattr(item, "target_dialog_id", None),
+        )
+        body = "Отложенная отправка создана."
+        if target:
+            body = f"Отложенная отправка создана для {target}."
+        return {
+            "variant": "success",
+            "title": "Отложка создана",
+            "body": body + " Свежий item подсвечен ниже.",
+            "highlight_kind": "item",
+        }
+
+    if msg == "photo_batch_created":
+        batch = batches[0] if batches else None
+        target = _target_label(
+            getattr(batch, "target_title", None),
+            getattr(batch, "target_dialog_id", None),
+        )
+        body = "Batch photo tasks создан."
+        if target:
+            body = f"Batch photo tasks создан для {target}."
+        return {
+            "variant": "success",
+            "title": "Batch создан",
+            "body": body + " Свежий batch подсвечен ниже.",
+            "highlight_kind": "batch",
+        }
+
+    if msg == "photo_auto_created":
+        job = auto_jobs[0] if auto_jobs else None
+        target = _target_label(
+            getattr(job, "target_title", None),
+            getattr(job, "target_dialog_id", None),
+        )
+        body = "Авто-джоб создан."
+        if target:
+            body = f"Авто-джоб создан для {target}."
+        return {
+            "variant": "success",
+            "title": "Авто-загрузка настроена",
+            "body": body + " Свежий auto job подсвечен ниже.",
+            "highlight_kind": "auto",
+        }
+
+    if error == "photo_send_failed":
+        return {
+            "variant": "error",
+            "title": "Отправка не выполнена",
+            "body": "Не удалось отправить фото. Проверьте аккаунт, диалог и логи сервера.",
+            "highlight_kind": "",
+        }
+
+    if error == "photo_schedule_failed":
+        return {
+            "variant": "error",
+            "title": "Отложка не создана",
+            "body": "Не удалось создать отложенную отправку. Проверьте дату, аккаунт и логи.",
+            "highlight_kind": "",
+        }
+
+    if error == "photo_batch_failed":
+        return {
+            "variant": "error",
+            "title": "Batch не создан",
+            "body": "Не удалось создать batch photo tasks. Проверьте manifest и логи сервера.",
+            "highlight_kind": "",
+        }
+
+    if error == "photo_auto_failed":
+        return {
+            "variant": "error",
+            "title": "Авто-загрузка не создана",
+            "body": "Не удалось создать auto job. Проверьте папку, аккаунт и логи сервера.",
+            "highlight_kind": "",
+        }
+
+    return None
+
+
 @router.get("", response_class=HTMLResponse)
 async def photo_loader_page(request: Request, phone: str | None = None):
     pool = deps.get_pool(request)
     accounts = sorted(pool.clients.keys())
     selected_phone = phone if phone in pool.clients else (accounts[0] if accounts else None)
+    msg = request.query_params.get("msg")
+    error = request.query_params.get("error")
     dialogs = []
     if selected_phone:
         dialogs = await deps.channel_service(request).get_my_dialogs(selected_phone)
     batches = await deps.get_photo_task_service(request).list_batches(limit=20)
     items = await deps.get_photo_task_service(request).list_items(limit=20)
     auto_jobs = await deps.get_photo_auto_upload_service(request).list_jobs()
+    photo_feedback = _build_feedback(
+        msg,
+        error,
+        batches=batches,
+        items=items,
+        auto_jobs=auto_jobs,
+    )
     return deps.get_templates(request).TemplateResponse(
         request,
         "photo_loader.html",
@@ -89,6 +213,7 @@ async def photo_loader_page(request: Request, phone: str | None = None):
             "batches": batches,
             "items": items,
             "auto_jobs": auto_jobs,
+            "photo_feedback": photo_feedback,
         },
     )
 

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -158,6 +158,40 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
     text-align: left;
 }
 
+.photo-feedback-panel {
+    border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+    box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+}
+
+.photo-submit-status {
+    min-height: 1.25rem;
+    margin-top: 0.65rem;
+    color: var(--bs-secondary-color);
+    font-size: 0.85rem;
+}
+
+[data-photo-submit-button].is-busy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    opacity: 1;
+}
+
+.photo-result-highlight {
+    animation: photo-result-pulse 2.4s ease;
+    outline: 2px solid rgba(13, 110, 253, 0.3);
+    outline-offset: -2px;
+}
+
+@keyframes photo-result-pulse {
+    0% {
+        background-color: rgba(13, 110, 253, 0.18);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
 /* ── Responsive: Tablet (<768px) ── */
 @media (max-width: 767.98px) {
     .channels-table,

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -145,6 +145,19 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
     margin-top: 0.4rem;
 }
 
+.photo-target-summary {
+    min-height: 2.5rem;
+}
+
+.photo-target-list {
+    max-height: 20rem;
+    overflow-y: auto;
+}
+
+.photo-target-list .list-group-item {
+    text-align: left;
+}
+
 /* ── Responsive: Tablet (<768px) ── */
 @media (max-width: 767.98px) {
     .channels-table,

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -36,6 +36,11 @@
             <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
             <button class="btn btn-outline-secondary btn-sm" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
         </form>
+        {% if selected_phone %}
+        <small class="text-muted d-block mt-2">
+            Показан сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at.strftime("%Y-%m-%d %H:%M") }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
+        </small>
+        {% endif %}
     </div>
     {% endif %}
 </div>

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -2,28 +2,47 @@
 {% block title %}Мой Телеграм — TG Agent{% endblock %}
 {% block content %}
 <h1>Мой Телеграм</h1>
-<p><a class="btn btn-outline-primary btn-sm" href="/my-telegram/photos{% if selected_phone %}?phone={{ selected_phone|urlencode }}{% endif %}">Открыть Photo Loader</a></p>
+
+<div class="d-flex flex-column flex-md-row align-items-md-start gap-3 mb-4">
+    {% if accounts %}
+    <div class="d-flex flex-column gap-1">
+        <a class="btn btn-outline-primary btn-sm align-self-start" href="/my-telegram/photos{% if selected_phone %}?phone={{ selected_phone|urlencode }}{% endif %}">Открыть Photo Loader</a>
+        <small class="text-muted">Если аккаунт не выбран, откроется первый доступный профиль.</small>
+    </div>
+    {% else %}
+    <div class="d-flex flex-column gap-1">
+        <span class="btn btn-outline-secondary btn-sm disabled" aria-disabled="true">Открыть Photo Loader</span>
+        <small class="text-muted">Сначала добавьте Telegram-аккаунт в настройках.</small>
+    </div>
+    {% endif %}
+
+    {% if accounts %}
+    <div class="mb-0" style="max-width:400px">
+        <label class="form-label">Аккаунт</label>
+        <select name="phone" class="form-select"
+                hx-get="/my-telegram/"
+                hx-include="this"
+                hx-target="body"
+                hx-push-url="true"
+                hx-trigger="change"
+                hx-indicator="#dialogs-loading">
+            <option value="" {% if not selected_phone %}selected{% endif %}>Выберите аккаунт</option>
+            {% for acc in accounts %}
+            <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
+            {% endfor %}
+        </select>
+        <span id="dialogs-loading" class="htmx-indicator d-inline-block mt-2">&#9203; Загрузка диалогов…</span>
+        <form method="post" action="/my-telegram/refresh" class="mt-2">
+            <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
+            <button class="btn btn-outline-secondary btn-sm" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
+        </form>
+    </div>
+    {% endif %}
+</div>
 
 {% if not accounts %}
 <p>Нет подключённых аккаунтов. Добавьте аккаунт в <a href="/settings">Настройках</a>.</p>
 {% else %}
-
-<div class="mb-4" style="max-width:400px">
-    <label class="form-label">Аккаунт</label>
-    <select name="phone" class="form-select"
-            hx-get="/my-telegram/"
-            hx-include="this"
-            hx-target="body"
-            hx-push-url="true"
-            hx-trigger="change"
-            hx-indicator="#dialogs-loading">
-        <option value="" {% if not selected_phone %}selected{% endif %}>Выберите аккаунт</option>
-        {% for acc in accounts %}
-        <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
-        {% endfor %}
-    </select>
-</div>
-<span id="dialogs-loading" class="htmx-indicator">&#9203; Загрузка диалогов…</span>
 
 {% if left or failed %}
 <p class="mb-3">

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -373,9 +373,24 @@
 
     function updateSummary(target) {
         if (!summary) return;
-        summary.innerHTML = "<strong>" + target.title + "</strong> " +
-            '<span class="badge text-bg-light">' + target.groupLabel + "</span> " +
-            '<span class="text-muted small">' + target.type + "</span>";
+        summary.replaceChildren();
+
+        var title = document.createElement("strong");
+        title.textContent = target.title;
+
+        var spacerAfterTitle = document.createTextNode(" ");
+
+        var badge = document.createElement("span");
+        badge.className = "badge text-bg-light";
+        badge.textContent = target.groupLabel;
+
+        var spacerAfterBadge = document.createTextNode(" ");
+
+        var type = document.createElement("span");
+        type.className = "text-muted small";
+        type.textContent = target.type;
+
+        summary.append(title, spacerAfterTitle, badge, spacerAfterBadge, type);
     }
 
     function setActiveOption(button) {

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -1,5 +1,27 @@
 {% extends "base.html" %}
 {% block title %}Photo Loader — TG Agent{% endblock %}
+{% set selectable_dialogs = dialogs | rejectattr("channel_type", "equalto", "bot") | list %}
+{% set initial_target = selectable_dialogs[0] if selectable_dialogs else none %}
+{% set target_available = initial_target is not none %}
+{% macro target_group(dialog) -%}
+    {%- if dialog.channel_type in ["channel", "monoforum", "scam", "fake", "restricted"] -%}channel
+    {%- elif dialog.channel_type in ["supergroup", "group", "gigagroup", "forum"] -%}group
+    {%- elif dialog.channel_type == "dm" -%}dm
+    {%- else -%}other
+    {%- endif -%}
+{%- endmacro %}
+{% macro target_group_label(group) -%}
+    {%- if group == "channel" -%}Каналы
+    {%- elif group == "group" -%}Группы и чаты
+    {%- elif group == "dm" -%}Личные диалоги
+    {%- else -%}Прочее
+    {%- endif -%}
+{%- endmacro %}
+{% macro render_target_hidden_inputs(initial_target) -%}
+<input type="hidden" name="target_dialog_id" value="{{ initial_target.channel_id if initial_target else '' }}" data-target-field="id">
+<input type="hidden" name="target_title" value="{{ initial_target.title if initial_target else '' }}" data-target-field="title">
+<input type="hidden" name="target_type" value="{{ initial_target.channel_type if initial_target else '' }}" data-target-field="type">
+{%- endmacro %}
 {% block content %}
 <h1>Photo Loader</h1>
 
@@ -8,41 +30,111 @@
 {% else %}
 <div class="row g-4">
     <div class="col-12">
-        <form method="get" action="/my-telegram/photos" class="row g-2 align-items-end">
-            <div class="col-md-4">
-                <label class="form-label">Аккаунт</label>
-                <select name="phone" class="form-select" onchange="this.form.submit()">
-                    {% for acc in accounts %}
-                    <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+        <div class="row g-2 align-items-end">
+        <form method="get" action="/my-telegram/photos" class="col-md-4">
+            <label class="form-label">Аккаунт</label>
+            <select name="phone" class="form-select" onchange="this.form.submit()">
+                {% for acc in accounts %}
+                <option value="{{ acc }}" {% if acc == selected_phone %}selected{% endif %}>{{ acc }}</option>
+                {% endfor %}
+            </select>
         </form>
+        <form method="post" action="/my-telegram/photos/refresh" class="col-md-auto">
+            <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
+            <button class="btn btn-outline-secondary" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
+        </form>
+        </div>
+    </div>
+
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 align-items-lg-start">
+                    <div>
+                        <h2 class="h5 mb-1">Цель отправки</h2>
+                        <p class="text-muted mb-0">Один выбор цели используется во всех формах ниже.</p>
+                    </div>
+                    <div class="photo-target-summary" data-target-summary>
+                        {% if target_available %}
+                        <strong>{{ initial_target.title }}</strong>
+                        <span class="badge text-bg-light">{{ target_group_label(target_group(initial_target)) }}</span>
+                        <span class="text-muted small">{{ initial_target.channel_type }}</span>
+                        {% else %}
+                        <span class="text-muted">Нет доступных каналов, чатов или личных диалогов для отправки.</span>
+                        {% endif %}
+                    </div>
+                </div>
+
+                {% if target_available %}
+                <div id="photo-target-picker"
+                     class="mt-4"
+                     data-target-picker
+                     data-initial-target-id="{{ initial_target.channel_id }}">
+                    <div class="row g-3">
+                        <div class="col-lg-5">
+                            <label class="form-label" for="target-search">Поиск</label>
+                            <input id="target-search" type="search" class="form-control" placeholder="Название канала, чата или контакта" data-target-search>
+                        </div>
+                        <div class="col-lg-7">
+                            <label class="form-label d-block">Тип</label>
+                            <div class="btn-group flex-wrap" role="group" aria-label="Фильтр по типу">
+                                <button type="button" class="btn btn-outline-secondary active" data-target-filter="all">Все</button>
+                                <button type="button" class="btn btn-outline-secondary" data-target-filter="channel">Каналы</button>
+                                <button type="button" class="btn btn-outline-secondary" data-target-filter="group">Группы и чаты</button>
+                                <button type="button" class="btn btn-outline-secondary" data-target-filter="dm">Личные диалоги</button>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="list-group photo-target-list" data-target-list>
+                                {% for dialog in selectable_dialogs %}
+                                {% set group = target_group(dialog) %}
+                                <button type="button"
+                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-start{% if initial_target and dialog.channel_id == initial_target.channel_id %} active{% endif %}"
+                                        data-target-option
+                                        data-target-id="{{ dialog.channel_id }}"
+                                        data-target-title="{{ dialog.title }}"
+                                        data-target-type="{{ dialog.channel_type }}"
+                                        data-target-group="{{ group }}"
+                                        data-target-search-text="{{ (dialog.title ~ ' ' ~ dialog.channel_type)|lower }}">
+                                    <span class="me-3 text-start">
+                                        <strong class="d-block">{{ dialog.title }}</strong>
+                                        <span class="text-muted small">{{ dialog.channel_type }}</span>
+                                    </span>
+                                    <span class="badge rounded-pill text-bg-light">{{ target_group_label(group) }}</span>
+                                </button>
+                                {% endfor %}
+                            </div>
+                            <p class="text-muted small mt-2 mb-0 d-none" data-target-empty>Ничего не найдено.</p>
+                        </div>
+                    </div>
+                </div>
+                {% else %}
+                <div class="alert alert-secondary mt-4 mb-0" role="alert">
+                    Для выбранного аккаунта нет доступных целей отправки. Проверьте список диалогов в разделе <a href="/my-telegram">Мой Телеграм</a>.
+                </div>
+                {% endif %}
+            </div>
+        </div>
     </div>
 
     <div class="col-lg-6">
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Обычная загрузка</h2>
-                <form method="post" action="/my-telegram/photos/send" enctype="multipart/form-data" class="row g-3">
+                <form method="post" action="/my-telegram/photos/send" enctype="multipart/form-data" class="row g-3" data-photo-target-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
+                    {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
-                        <select name="target_dialog_id" class="form-select" required>
-                            {% for dialog in dialogs %}
-                            {% if dialog.channel_type != "bot" %}
-                            <option value="{{ dialog.channel_id }}" data-title="{{ dialog.title }}" data-type="{{ dialog.channel_type }}">
-                                {{ dialog.title }} ({{ dialog.channel_type }})
-                            </option>
-                            {% endif %}
-                            {% endfor %}
-                        </select>
+                        <div class="form-control bg-body-tertiary" data-target-display>
+                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                        </div>
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">Режим</label>
                         <select name="send_mode" class="form-select">
+                            <option value="separate" selected>Отдельные посты</option>
                             <option value="album">Альбом</option>
-                            <option value="separate">Отдельные посты</option>
                         </select>
                     </div>
                     <div class="col-12">
@@ -54,7 +146,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-primary" type="submit">Отправить</button>
+                        <button class="btn btn-primary" type="submit" {% if not target_available %}disabled{% endif %}>Отправить</button>
                     </div>
                 </form>
             </div>
@@ -65,23 +157,20 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Отложенная загрузка</h2>
-                <form method="post" action="/my-telegram/photos/schedule" enctype="multipart/form-data" class="row g-3">
+                <form method="post" action="/my-telegram/photos/schedule" enctype="multipart/form-data" class="row g-3" data-photo-target-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
+                    {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
-                        <select name="target_dialog_id" class="form-select" required>
-                            {% for dialog in dialogs %}
-                            {% if dialog.channel_type != "bot" %}
-                            <option value="{{ dialog.channel_id }}">{{ dialog.title }} ({{ dialog.channel_type }})</option>
-                            {% endif %}
-                            {% endfor %}
-                        </select>
+                        <div class="form-control bg-body-tertiary" data-target-display>
+                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                        </div>
                     </div>
                     <div class="col-md-6">
                         <label class="form-label">Режим</label>
                         <select name="send_mode" class="form-select">
+                            <option value="separate" selected>Отдельные посты</option>
                             <option value="album">Альбом</option>
-                            <option value="separate">Отдельные посты</option>
                         </select>
                     </div>
                     <div class="col-md-6">
@@ -97,7 +186,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-primary" type="submit">Поставить в отложку</button>
+                        <button class="btn btn-outline-primary" type="submit" {% if not target_available %}disabled{% endif %}>Поставить в отложку</button>
                     </div>
                 </form>
             </div>
@@ -109,17 +198,14 @@
             <div class="card-body">
                 <h2 class="h5">Batch delayed</h2>
                 <p class="text-muted small">JSON-массив объектов вида <code>{"at":"2026-03-11T18:30","files":["/abs/1.jpg"],"mode":"album"}</code></p>
-                <form method="post" action="/my-telegram/photos/batch" class="row g-3">
+                <form method="post" action="/my-telegram/photos/batch" class="row g-3" data-photo-target-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
+                    {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
-                        <select name="target_dialog_id" class="form-select" required>
-                            {% for dialog in dialogs %}
-                            {% if dialog.channel_type != "bot" %}
-                            <option value="{{ dialog.channel_id }}">{{ dialog.title }} ({{ dialog.channel_type }})</option>
-                            {% endif %}
-                            {% endfor %}
-                        </select>
+                        <div class="form-control bg-body-tertiary" data-target-display>
+                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                        </div>
                     </div>
                     <div class="col-12">
                         <label class="form-label">Общая подпись</label>
@@ -132,7 +218,7 @@
 ]</textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-secondary" type="submit">Создать batch</button>
+                        <button class="btn btn-outline-secondary" type="submit" {% if not target_available %}disabled{% endif %}>Создать batch</button>
                     </div>
                 </form>
             </div>
@@ -143,17 +229,14 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Автозагрузка из папки</h2>
-                <form method="post" action="/my-telegram/photos/auto" class="row g-3">
+                <form method="post" action="/my-telegram/photos/auto" class="row g-3" data-photo-target-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
+                    {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
-                        <select name="target_dialog_id" class="form-select" required>
-                            {% for dialog in dialogs %}
-                            {% if dialog.channel_type != "bot" %}
-                            <option value="{{ dialog.channel_id }}">{{ dialog.title }} ({{ dialog.channel_type }})</option>
-                            {% endif %}
-                            {% endfor %}
-                        </select>
+                        <div class="form-control bg-body-tertiary" data-target-display>
+                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                        </div>
                     </div>
                     <div class="col-md-7">
                         <label class="form-label">Папка</label>
@@ -166,8 +249,8 @@
                     <div class="col-md-6">
                         <label class="form-label">Режим</label>
                         <select name="send_mode" class="form-select">
+                            <option value="separate" selected>Отдельные посты</option>
                             <option value="album">Альбом</option>
-                            <option value="separate">Отдельные посты</option>
                         </select>
                     </div>
                     <div class="col-12">
@@ -175,7 +258,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-dark" type="submit">Создать авто-джоб</button>
+                        <button class="btn btn-outline-dark" type="submit" {% if not target_available %}disabled{% endif %}>Создать авто-джоб</button>
                     </div>
                 </form>
             </div>
@@ -261,5 +344,93 @@
         </div>
     </div>
 </div>
+
+<script>
+(function() {
+    var picker = document.querySelector("[data-target-picker]");
+    if (!picker) return;
+
+    var searchInput = picker.querySelector("[data-target-search]");
+    var options = Array.from(picker.querySelectorAll("[data-target-option]"));
+    var filterButtons = Array.from(picker.querySelectorAll("[data-target-filter]"));
+    var emptyState = picker.querySelector("[data-target-empty]");
+    var summary = document.querySelector("[data-target-summary]");
+    var forms = Array.from(document.querySelectorAll("[data-photo-target-form]"));
+    var activeFilter = "all";
+
+    function updateForms(target) {
+        forms.forEach(function(form) {
+            var idField = form.querySelector('[data-target-field="id"]');
+            var titleField = form.querySelector('[data-target-field="title"]');
+            var typeField = form.querySelector('[data-target-field="type"]');
+            var display = form.querySelector("[data-target-display]");
+            if (idField) idField.value = target.id;
+            if (titleField) titleField.value = target.title;
+            if (typeField) typeField.value = target.type;
+            if (display) display.textContent = target.title;
+        });
+    }
+
+    function updateSummary(target) {
+        if (!summary) return;
+        summary.innerHTML = "<strong>" + target.title + "</strong> " +
+            '<span class="badge text-bg-light">' + target.groupLabel + "</span> " +
+            '<span class="text-muted small">' + target.type + "</span>";
+    }
+
+    function setActiveOption(button) {
+        options.forEach(function(option) {
+            option.classList.toggle("active", option === button);
+        });
+        var target = {
+            id: button.dataset.targetId,
+            title: button.dataset.targetTitle,
+            type: button.dataset.targetType,
+            groupLabel: button.querySelector(".badge").textContent
+        };
+        updateForms(target);
+        updateSummary(target);
+    }
+
+    function applyFilters() {
+        var query = (searchInput.value || "").trim().toLowerCase();
+        var visibleCount = 0;
+        options.forEach(function(option) {
+            var matchesType = activeFilter === "all" || option.dataset.targetGroup === activeFilter;
+            var matchesText = !query || option.dataset.targetSearchText.indexOf(query) !== -1;
+            var visible = matchesType && matchesText;
+            option.classList.toggle("d-none", !visible);
+            if (visible) visibleCount += 1;
+        });
+        emptyState.classList.toggle("d-none", visibleCount !== 0);
+    }
+
+    options.forEach(function(option) {
+        option.addEventListener("click", function() {
+            setActiveOption(option);
+        });
+    });
+
+    filterButtons.forEach(function(button) {
+        button.addEventListener("click", function() {
+            activeFilter = button.dataset.targetFilter;
+            filterButtons.forEach(function(item) {
+                item.classList.toggle("active", item === button);
+            });
+            applyFilters();
+        });
+    });
+
+    searchInput.addEventListener("input", applyFilters);
+
+    var initial = options.find(function(option) {
+        return option.dataset.targetId === picker.dataset.initialTargetId;
+    }) || options[0];
+    if (initial) {
+        setActiveOption(initial);
+    }
+    applyFilters();
+})();
+</script>
 {% endif %}
 {% endblock %}

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -29,6 +29,20 @@
 <p>Нет подключённых аккаунтов. Добавьте аккаунт в <a href="/settings">Настройках</a>.</p>
 {% else %}
 <div class="row g-4">
+    {% if photo_feedback %}
+    <div class="col-12">
+        <div class="alert {% if photo_feedback.variant == 'success' %}alert-success{% else %}alert-danger{% endif %} photo-feedback-panel mb-0"
+             role="alert"
+             data-photo-feedback
+             data-highlight-kind="{{ photo_feedback.highlight_kind }}">
+            <div class="d-flex flex-column gap-1">
+                <strong data-photo-feedback-title>{{ photo_feedback.title }}</strong>
+                <span data-photo-feedback-body>{{ photo_feedback.body }}</span>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="col-12">
         <div class="row g-2 align-items-end">
         <form method="get" action="/my-telegram/photos" class="col-md-4">
@@ -121,7 +135,7 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Обычная загрузка</h2>
-                <form method="post" action="/my-telegram/photos/send" enctype="multipart/form-data" class="row g-3" data-photo-target-form>
+                <form method="post" action="/my-telegram/photos/send" enctype="multipart/form-data" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
                     {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
@@ -146,7 +160,8 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-primary" type="submit" {% if not target_available %}disabled{% endif %}>Отправить</button>
+                        <button class="btn btn-primary" type="submit" data-photo-submit-button data-busy-label="Отправка..." {% if not target_available %}disabled{% endif %}>Отправить</button>
+                        <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
             </div>
@@ -157,7 +172,7 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Отложенная загрузка</h2>
-                <form method="post" action="/my-telegram/photos/schedule" enctype="multipart/form-data" class="row g-3" data-photo-target-form>
+                <form method="post" action="/my-telegram/photos/schedule" enctype="multipart/form-data" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
                     {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
@@ -186,7 +201,8 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-primary" type="submit" {% if not target_available %}disabled{% endif %}>Поставить в отложку</button>
+                        <button class="btn btn-outline-primary" type="submit" data-photo-submit-button data-busy-label="Создаём отложку..." {% if not target_available %}disabled{% endif %}>Поставить в отложку</button>
+                        <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
             </div>
@@ -198,7 +214,7 @@
             <div class="card-body">
                 <h2 class="h5">Batch delayed</h2>
                 <p class="text-muted small">JSON-массив объектов вида <code>{"at":"2026-03-11T18:30","files":["/abs/1.jpg"],"mode":"album"}</code></p>
-                <form method="post" action="/my-telegram/photos/batch" class="row g-3" data-photo-target-form>
+                <form method="post" action="/my-telegram/photos/batch" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
                     {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
@@ -218,7 +234,8 @@
 ]</textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-secondary" type="submit" {% if not target_available %}disabled{% endif %}>Создать batch</button>
+                        <button class="btn btn-outline-secondary" type="submit" data-photo-submit-button data-busy-label="Создаём batch..." {% if not target_available %}disabled{% endif %}>Создать batch</button>
+                        <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
             </div>
@@ -229,7 +246,7 @@
         <div class="card">
             <div class="card-body">
                 <h2 class="h5">Автозагрузка из папки</h2>
-                <form method="post" action="/my-telegram/photos/auto" class="row g-3" data-photo-target-form>
+                <form method="post" action="/my-telegram/photos/auto" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
                     {{ render_target_hidden_inputs(initial_target) }}
                     <div class="col-12">
@@ -258,7 +275,8 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-dark" type="submit" {% if not target_available %}disabled{% endif %}>Создать авто-джоб</button>
+                        <button class="btn btn-outline-dark" type="submit" data-photo-submit-button data-busy-label="Создаём авто-джоб..." {% if not target_available %}disabled{% endif %}>Создать авто-джоб</button>
+                        <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
             </div>
@@ -275,6 +293,35 @@
     <div class="col-12">
         <div class="card">
             <div class="card-body">
+                <h2 class="h5">Последние batches</h2>
+                {% if batches %}
+                <div class="table-responsive">
+                    <table class="table table-sm">
+                        <thead><tr><th>ID</th><th>Target</th><th>Режим</th><th>Статус</th><th>Создан</th></tr></thead>
+                        <tbody>
+                        {% for batch in batches %}
+                        <tr data-photo-result-row="batch"
+                            data-photo-result-target="{{ batch.target_title or batch.target_dialog_id }}">
+                            <td>{{ batch.id }}</td>
+                            <td>{{ batch.target_title or batch.target_dialog_id }}</td>
+                            <td>{{ batch.send_mode }}</td>
+                            <td>{{ batch.status }}</td>
+                            <td>{{ batch.created_at or "—" }}</td>
+                        </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% else %}
+                <p class="mb-0 text-muted">Batch tasks пока нет.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
                 <h2 class="h5">Auto Jobs</h2>
                 {% if auto_jobs %}
                 <div class="table-responsive">
@@ -282,7 +329,8 @@
                         <thead><tr><th>ID</th><th>Папка</th><th>Интервал</th><th>Статус</th><th>Последний запуск</th><th></th></tr></thead>
                         <tbody>
                         {% for job in auto_jobs %}
-                        <tr>
+                        <tr data-photo-result-row="auto"
+                            data-photo-result-target="{{ job.target_title or job.target_dialog_id }}">
                             <td>{{ job.id }}</td>
                             <td class="font-monospace">{{ job.folder_path }}</td>
                             <td>{{ job.interval_minutes }} мин.</td>
@@ -320,7 +368,8 @@
                         <thead><tr><th>ID</th><th>Target</th><th>Файлы</th><th>Время</th><th>Статус</th><th></th></tr></thead>
                         <tbody>
                         {% for item in items %}
-                        <tr>
+                        <tr data-photo-result-row="item"
+                            data-photo-result-target="{{ item.target_title or item.target_dialog_id }}">
                             <td>{{ item.id }}</td>
                             <td>{{ item.target_title or item.target_dialog_id }}</td>
                             <td>{{ item.file_paths|length }}</td>
@@ -347,6 +396,47 @@
 
 <script>
 (function() {
+    var submitForms = Array.from(document.querySelectorAll("[data-photo-submit-form]"));
+    var feedback = document.querySelector("[data-photo-feedback]");
+
+    submitForms.forEach(function(form) {
+        form.addEventListener("submit", function(event) {
+            if (form.dataset.submitting === "true") {
+                event.preventDefault();
+                return;
+            }
+
+            var submitter = event.submitter || form.querySelector("[data-photo-submit-button]");
+            if (!submitter) return;
+
+            form.dataset.submitting = "true";
+            submitter.disabled = true;
+            submitter.classList.add("is-busy");
+            submitter.innerHTML =
+                '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>' +
+                "<span>" + (submitter.dataset.busyLabel || "Выполняется...") + "</span>";
+
+            var status = form.querySelector("[data-photo-submit-status]");
+            if (status) {
+                status.textContent = "Запрос отправлен, ожидаем ответ сервера...";
+                status.classList.remove("d-none");
+            }
+        });
+    });
+
+    if (feedback) {
+        var highlightKind = feedback.dataset.highlightKind;
+        if (highlightKind) {
+            var row = document.querySelector('[data-photo-result-row="' + highlightKind + '"]');
+            if (row) {
+                row.classList.add("photo-result-highlight");
+                row.setAttribute("tabindex", "-1");
+                row.focus({preventScroll: true});
+                row.scrollIntoView({behavior: "smooth", block: "center"});
+            }
+        }
+    }
+
     var picker = document.querySelector("[data-target-picker]");
     if (!picker) return;
 

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -57,6 +57,11 @@
             <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
             <button class="btn btn-outline-secondary" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
         </form>
+        <div class="col-12">
+            <small class="text-muted">
+                Используется сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at.strftime("%Y-%m-%d %H:%M") }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
+            </small>
+        </div>
         </div>
     </div>
 

--- a/tests/test_client_pool_extended.py
+++ b/tests/test_client_pool_extended.py
@@ -16,6 +16,9 @@ def mock_db():
     db.update_account_flood = AsyncMock()
     db.update_account_premium = AsyncMock()
     db.get_channel_by_channel_id = AsyncMock()
+    db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    db.repos.dialog_cache.clear_dialogs = AsyncMock()
     return db
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,7 +59,13 @@ async def app_with_db(tmp_path):
     async def _get_dialogs(self):
         return []
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
+    async def _get_dialogs_for_phone(
+        self,
+        phone,
+        include_dm=False,
+        mode="channels_only",
+        refresh=False,
+    ):
         return []
 
     pool = type(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,7 +59,7 @@ async def app_with_db(tmp_path):
     async def _get_dialogs(self):
         return []
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only"):
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
         return []
 
     pool = type(

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -20,14 +20,50 @@ from src.web.app import create_app
 
 _FAKE_DIALOGS = [
     {"channel_id": -100111, "title": "My Channel", "username": "mychan",
-     "channel_type": "channel", "deactivate": False},
+     "channel_type": "channel", "deactivate": False, "is_own": False},
     {"channel_id": -100222, "title": "My Group", "username": None,
-     "channel_type": "supergroup", "deactivate": False},
+     "channel_type": "supergroup", "deactivate": False, "is_own": False},
     {"channel_id": 999, "title": "Some User", "username": "someuser",
-     "channel_type": "dm", "deactivate": False},
+     "channel_type": "dm", "deactivate": False, "is_own": False},
     {"channel_id": 888, "title": "My Bot", "username": "mybot",
-     "channel_type": "bot", "deactivate": False},
+     "channel_type": "bot", "deactivate": False, "is_own": False},
 ]
+
+
+def _bind_dialog_cache_methods(pool):
+    from src.telegram.client_pool import ClientPool
+
+    pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
+    pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
+    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
+    pool._get_db_cached_dialogs = ClientPool._get_db_cached_dialogs.__get__(pool, ClientPool)
+    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+
+
+def _make_channel_dialog(
+    channel_id: int,
+    title: str = "Cached Channel",
+    username: str = "cachedchan",
+):
+    channel_entity = MagicMock()
+    channel_entity.id = channel_id
+    channel_entity.username = username
+    channel_entity.creator = False
+
+    dialog = MagicMock()
+    dialog.entity = channel_entity
+    dialog.title = title
+    dialog.is_channel = True
+    dialog.is_group = False
+    return dialog
+
+
+def _strip_extra_dialog_fields(dialogs: list[dict]) -> list[dict]:
+    return [
+        {key: value for key, value in dialog.items() if key != "already_added"}
+        for dialog in dialogs
+    ]
 
 
 @pytest.fixture
@@ -127,6 +163,7 @@ async def test_my_telegram_page_shows_dialogs(client):
     assert "tab-bots" in resp.text
     assert 'action="/my-telegram/refresh"' in resp.text
     assert "Обновить диалоги" in resp.text
+    assert "Показан сохранённый список диалогов" in resp.text
 
 
 @pytest.mark.asyncio
@@ -173,6 +210,9 @@ async def test_leave_channels_success():
 
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.clear_dialogs = AsyncMock()
+    pool.invalidate_dialogs_cache = MagicMock()
 
     dialogs = [(-100111, "channel"), (999, "dm")]
     with patch("src.telegram.client_pool.asyncio.sleep", AsyncMock()):
@@ -184,6 +224,8 @@ async def test_leave_channels_success():
     assert received_peers[0].channel_id == 100111
     assert isinstance(received_peers[1], PeerUser)
     assert received_peers[1].user_id == 999
+    pool.invalidate_dialogs_cache.assert_called_once_with("+1234567890")
+    pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
 @pytest.mark.asyncio
@@ -210,6 +252,9 @@ async def test_leave_channels_partial_failure():
 
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.clear_dialogs = AsyncMock()
+    pool.invalidate_dialogs_cache = MagicMock()
 
     dialogs = [(-100111, "channel"), (-100222, "supergroup")]
     with patch("src.telegram.client_pool.asyncio.sleep", AsyncMock()):
@@ -217,6 +262,7 @@ async def test_leave_channels_partial_failure():
 
     assert result[-100111] is False
     assert result[-100222] is True
+    pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
 @pytest.mark.asyncio
@@ -243,6 +289,9 @@ async def test_leave_channels_flood_breaks_loop():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool.report_flood = AsyncMock()
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.clear_dialogs = AsyncMock()
+    pool.invalidate_dialogs_cache = MagicMock()
 
     dialogs = [(-100111, "channel"), (-100222, "supergroup")]
     with patch("src.telegram.client_pool.asyncio.sleep", AsyncMock()):
@@ -251,6 +300,7 @@ async def test_leave_channels_flood_breaks_loop():
     assert result[-100111] is False
     assert result[-100222] is False
     pool.report_flood.assert_awaited_once_with("+1234567890", 60)
+    pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
 @pytest.mark.asyncio
@@ -408,10 +458,10 @@ async def test_get_my_dialogs_bot_type():
 
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
-    pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
-    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
-    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    pool._db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    _bind_dialog_cache_methods(pool)
 
     # Call the real method
     result = await ClientPool.get_dialogs_for_phone(
@@ -461,10 +511,10 @@ async def test_get_dialogs_for_phone_partial_on_timeout():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
-    pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
-    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
-    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    pool._db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    _bind_dialog_cache_methods(pool)
 
     # Patch wait_for to use a tiny timeout so we don't wait 60 s in tests
     original_wait_for = asyncio.wait_for
@@ -583,17 +633,7 @@ async def test_get_dialogs_for_phone_uses_manual_cache():
 
     pool = MagicMock(spec=ClientPool)
     mock_client = MagicMock()
-
-    channel_entity = MagicMock()
-    channel_entity.id = -100123
-    channel_entity.username = "cachedchan"
-    channel_entity.creator = False
-
-    dialog = MagicMock()
-    dialog.entity = channel_entity
-    dialog.title = "Cached Channel"
-    dialog.is_channel = True
-    dialog.is_group = False
+    dialog = _make_channel_dialog(-100123)
 
     async def _fake_iter_dialogs():
         yield dialog
@@ -602,11 +642,10 @@ async def test_get_dialogs_for_phone_uses_manual_cache():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
-    pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
-    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
-    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
-    pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    pool._db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    _bind_dialog_cache_methods(pool)
 
     result1 = await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
     result2 = await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
@@ -621,17 +660,7 @@ async def test_get_dialogs_for_phone_refresh_bypasses_cache():
 
     pool = MagicMock(spec=ClientPool)
     mock_client = MagicMock()
-
-    channel_entity = MagicMock()
-    channel_entity.id = -100123
-    channel_entity.username = "cachedchan"
-    channel_entity.creator = False
-
-    dialog = MagicMock()
-    dialog.entity = channel_entity
-    dialog.title = "Cached Channel"
-    dialog.is_channel = True
-    dialog.is_group = False
+    dialog = _make_channel_dialog(-100123)
 
     async def _fake_iter_dialogs():
         yield dialog
@@ -640,11 +669,10 @@ async def test_get_dialogs_for_phone_refresh_bypasses_cache():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
-    pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
-    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
-    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
-    pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    pool._db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    _bind_dialog_cache_methods(pool)
 
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890", refresh=True)
@@ -658,17 +686,7 @@ async def test_get_dialogs_for_phone_refetches_after_ttl_expiry():
 
     pool = MagicMock(spec=ClientPool)
     mock_client = MagicMock()
-
-    channel_entity = MagicMock()
-    channel_entity.id = -100123
-    channel_entity.username = "cachedchan"
-    channel_entity.creator = False
-
-    dialog = MagicMock()
-    dialog.entity = channel_entity
-    dialog.title = "Cached Channel"
-    dialog.is_channel = True
-    dialog.is_group = False
+    dialog = _make_channel_dialog(-100123)
 
     async def _fake_iter_dialogs():
         yield dialog
@@ -677,12 +695,138 @@ async def test_get_dialogs_for_phone_refetches_after_ttl_expiry():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
-    pool._dialogs_cache = {}
+    pool._db = MagicMock()
+    pool._db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    pool._db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    _bind_dialog_cache_methods(pool)
     pool._dialogs_cache_ttl_sec = -1.0
-    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
-    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
 
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
 
     assert mock_client.iter_dialogs.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_uses_db_cache_across_pool_instances(db):
+    from src.telegram.client_pool import ClientPool
+
+    await db.repos.dialog_cache.replace_dialogs("+1234567890", list(_FAKE_DIALOGS))
+
+    pool = MagicMock(spec=ClientPool)
+    pool._db = db
+    pool.get_client_by_phone = AsyncMock()
+    pool.release_client = AsyncMock()
+    _bind_dialog_cache_methods(pool)
+
+    dialogs = await ClientPool.get_dialogs_for_phone(
+        pool,
+        "+1234567890",
+        include_dm=True,
+        mode="full",
+    )
+
+    assert _strip_extra_dialog_fields(dialogs) == _strip_extra_dialog_fields(_FAKE_DIALOGS)
+    pool.get_client_by_phone.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_refresh_replaces_db_cache(db):
+    from src.telegram.client_pool import ClientPool
+
+    await db.repos.dialog_cache.replace_dialogs(
+        "+1234567890",
+        [dict(_FAKE_DIALOGS[0], title="Stale Title")],
+    )
+
+    pool = MagicMock(spec=ClientPool)
+    mock_client = MagicMock()
+    dialog = _make_channel_dialog(-100111, title="Fresh Title", username="freshchan")
+
+    async def _fake_iter_dialogs():
+        yield dialog
+
+    mock_client.iter_dialogs.return_value = _fake_iter_dialogs()
+    pool._db = db
+    pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
+    pool.release_client = AsyncMock()
+    pool._classify_entity = MagicMock(return_value=("channel", False))
+    _bind_dialog_cache_methods(pool)
+
+    dialogs = await ClientPool.get_dialogs_for_phone(
+        pool,
+        "+1234567890",
+        include_dm=True,
+        mode="full",
+        refresh=True,
+    )
+
+    assert dialogs[0]["title"] == "Fresh Title"
+    cached = await db.repos.dialog_cache.list_dialogs("+1234567890")
+    assert cached[0]["title"] == "Fresh Title"
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_failed_refresh_keeps_existing_db_cache(db):
+    from src.telegram.client_pool import ClientPool
+
+    await db.repos.dialog_cache.replace_dialogs("+1234567890", list(_FAKE_DIALOGS))
+
+    pool = MagicMock(spec=ClientPool)
+    pool._db = db
+    pool.get_client_by_phone = AsyncMock(return_value=None)
+    pool.release_client = AsyncMock()
+    _bind_dialog_cache_methods(pool)
+
+    dialogs = await ClientPool.get_dialogs_for_phone(
+        pool,
+        "+1234567890",
+        include_dm=True,
+        mode="full",
+        refresh=True,
+    )
+
+    assert dialogs == []
+    cached = await db.repos.dialog_cache.list_dialogs("+1234567890")
+    assert _strip_extra_dialog_fields(cached) == _strip_extra_dialog_fields(_FAKE_DIALOGS)
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_partial_timeout_keeps_existing_db_cache(db):
+    from src.telegram.client_pool import ClientPool
+
+    await db.repos.dialog_cache.replace_dialogs("+1234567890", list(_FAKE_DIALOGS))
+
+    pool = MagicMock(spec=ClientPool)
+
+    mock_client = MagicMock()
+    partial_dialog = _make_channel_dialog(-100999, title="Partial Channel", username="partial")
+
+    async def _iter():
+        yield partial_dialog
+        await asyncio.sleep(120)
+
+    mock_client.iter_dialogs.return_value = _iter()
+    pool._db = db
+    pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
+    pool.release_client = AsyncMock()
+    pool._classify_entity = MagicMock(return_value=("channel", False))
+    _bind_dialog_cache_methods(pool)
+
+    original_wait_for = asyncio.wait_for
+
+    async def fast_wait_for(coro, timeout):
+        return await original_wait_for(coro, timeout=min(timeout, 0.05))
+
+    with patch("src.telegram.client_pool.asyncio.wait_for", fast_wait_for):
+        result = await ClientPool.get_dialogs_for_phone(
+            pool,
+            "+1234567890",
+            include_dm=True,
+            mode="full",
+            refresh=True,
+        )
+
+    assert result[0]["title"] == "Partial Channel"
+    cached = await db.repos.dialog_cache.list_dialogs("+1234567890")
+    assert _strip_extra_dialog_fields(cached) == _strip_extra_dialog_fields(_FAKE_DIALOGS)

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -43,7 +43,13 @@ async def client(tmp_path):
     await db.initialize()
     app.state.db = db
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
+    async def _get_dialogs_for_phone(
+        self,
+        phone,
+        include_dm=False,
+        mode="channels_only",
+        refresh=False,
+    ):
         return _FAKE_DIALOGS
 
     async def _get_dialogs(self):

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -409,6 +409,7 @@ async def test_get_my_dialogs_bot_type():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
 
@@ -461,6 +462,7 @@ async def test_get_dialogs_for_phone_partial_on_timeout():
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
     pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
 
@@ -601,6 +603,7 @@ async def test_get_dialogs_for_phone_uses_manual_cache():
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
     pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
     pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
@@ -638,11 +641,48 @@ async def test_get_dialogs_for_phone_refresh_bypasses_cache():
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
     pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
     pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
 
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
     await ClientPool.get_dialogs_for_phone(pool, "+1234567890", refresh=True)
+
+    assert mock_client.iter_dialogs.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_refetches_after_ttl_expiry():
+    from src.telegram.client_pool import ClientPool
+
+    pool = MagicMock(spec=ClientPool)
+    mock_client = MagicMock()
+
+    channel_entity = MagicMock()
+    channel_entity.id = -100123
+    channel_entity.username = "cachedchan"
+    channel_entity.creator = False
+
+    dialog = MagicMock()
+    dialog.entity = channel_entity
+    dialog.title = "Cached Channel"
+    dialog.is_channel = True
+    dialog.is_group = False
+
+    async def _fake_iter_dialogs():
+        yield dialog
+
+    mock_client.iter_dialogs.side_effect = [_fake_iter_dialogs(), _fake_iter_dialogs()]
+    pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
+    pool.release_client = AsyncMock()
+    pool._classify_entity = MagicMock(return_value=("channel", False))
+    pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = -1.0
+    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
+    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+
+    await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
+    await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
 
     assert mock_client.iter_dialogs.call_count == 2

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -43,7 +43,7 @@ async def client(tmp_path):
     await db.initialize()
     app.state.db = db
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only"):
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
         return _FAKE_DIALOGS
 
     async def _get_dialogs(self):
@@ -100,6 +100,8 @@ async def test_my_telegram_page_renders(client):
     resp = await client.get("/my-telegram/")
     assert resp.status_code == 200
     assert "Мой Телеграм" in resp.text
+    assert 'href="/my-telegram/photos"' in resp.text
+    assert "Если аккаунт не выбран, откроется первый доступный профиль." in resp.text
     assert "Выберите аккаунт" in resp.text
     assert "загрузить список диалогов" in resp.text
 
@@ -117,6 +119,8 @@ async def test_my_telegram_page_shows_dialogs(client):
     assert "tab-groups" in resp.text
     assert "tab-dms" in resp.text
     assert "tab-bots" in resp.text
+    assert 'action="/my-telegram/refresh"' in resp.text
+    assert "Обновить диалоги" in resp.text
 
 
 @pytest.mark.asyncio
@@ -255,6 +259,65 @@ async def test_leave_dialogs_post(client):
 
 
 @pytest.mark.asyncio
+async def test_refresh_dialogs_post_warms_cache(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    pool = MagicMock()
+    pool.clients = {"+1234567890": MagicMock()}
+    pool.get_users_info = AsyncMock(return_value=[])
+    pool.get_dialogs = AsyncMock(return_value=[])
+    pool.get_dialogs_for_phone = AsyncMock(return_value=list(_FAKE_DIALOGS))
+    pool.leave_channels = AsyncMock(return_value={})
+    app.state.pool = pool
+
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+    collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.collector = collector
+    app.state.collection_queue = CollectionQueue(collector, db)
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(collector, config.scheduler)
+    app.state.session_secret = "test_secret_key"
+
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as c:
+        resp = await c.post("/my-telegram/refresh", data={"phone": "+1234567890"})
+
+    assert resp.status_code == 200
+    assert "My Channel" in resp.text
+    assert pool.get_dialogs_for_phone.await_count == 2
+    first_call = pool.get_dialogs_for_phone.await_args_list[0]
+    second_call = pool.get_dialogs_for_phone.await_args_list[1]
+    assert first_call.args == ("+1234567890",)
+    assert first_call.kwargs == {"include_dm": True, "mode": "full", "refresh": True}
+    assert second_call.args == ("+1234567890",)
+    assert second_call.kwargs == {"include_dm": True, "mode": "full", "refresh": False}
+
+    await app.state.collection_queue.shutdown()
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_leave_dialogs_flash_message(client):
     """GET with left/failed params shows flash banner."""
     resp = await client.get("/my-telegram/?phone=%2B1234567890&left=2&failed=1")
@@ -287,12 +350,30 @@ async def test_get_my_dialogs_enriches_already_added(db):
         "+1234567890",
         include_dm=True,
         mode="full",
+        refresh=False,
     )
     by_id = {d["channel_id"]: d for d in dialogs}
     assert by_id[-100111]["already_added"] is True
     assert by_id[-100222]["already_added"] is False
     assert by_id[999]["already_added"] is False
     assert by_id[888]["already_added"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_my_dialogs_passes_refresh_flag(db):
+    pool = MagicMock()
+    pool.get_dialogs_for_phone = AsyncMock(return_value=list(_FAKE_DIALOGS))
+    queue = MagicMock()
+
+    service = ChannelService(db, pool, queue)
+    await service.get_my_dialogs("+1234567890", refresh=True)
+
+    pool.get_dialogs_for_phone.assert_awaited_once_with(
+        "+1234567890",
+        include_dm=True,
+        mode="full",
+        refresh=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -322,7 +403,6 @@ async def test_get_my_dialogs_bot_type():
     pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
     pool.release_client = AsyncMock()
     pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
 
@@ -375,7 +455,6 @@ async def test_get_dialogs_for_phone_partial_on_timeout():
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
     pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
 
@@ -439,6 +518,7 @@ async def test_my_telegram_page_without_phone_does_not_fetch_dialogs(tmp_path):
 
     assert resp.status_code == 200
     assert "Выберите аккаунт" in resp.text
+    assert 'href="/my-telegram/photos"' in resp.text
     pool.get_dialogs_for_phone.assert_not_awaited()
 
     await app.state.collection_queue.shutdown()
@@ -446,7 +526,51 @@ async def test_my_telegram_page_without_phone_does_not_fetch_dialogs(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_get_dialogs_for_phone_uses_ttl_cache():
+async def test_my_telegram_page_without_accounts_shows_disabled_photo_loader(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+    app.state.pool = type("Pool", (), {"clients": {}})()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+    collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.collector = collector
+    app.state.collection_queue = CollectionQueue(collector, db)
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(collector, config.scheduler)
+    app.state.session_secret = "test_secret_key"
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as c:
+        resp = await c.get("/my-telegram/")
+
+    assert resp.status_code == 200
+    assert "Сначала добавьте Telegram-аккаунт в настройках." in resp.text
+    assert 'href="/my-telegram/photos"' not in resp.text
+    assert 'aria-disabled="true"' in resp.text
+
+    await app.state.collection_queue.shutdown()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_uses_manual_cache():
     from src.telegram.client_pool import ClientPool
 
     pool = MagicMock(spec=ClientPool)
@@ -471,12 +595,48 @@ async def test_get_dialogs_for_phone_uses_ttl_cache():
     pool.release_client = AsyncMock()
     pool._classify_entity = MagicMock(return_value=("channel", False))
     pool._dialogs_cache = {}
-    pool._dialogs_cache_ttl_sec = 60.0
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+    pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
 
     result1 = await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
     result2 = await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
 
     assert result1 == result2
     assert mock_client.iter_dialogs.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_dialogs_for_phone_refresh_bypasses_cache():
+    from src.telegram.client_pool import ClientPool
+
+    pool = MagicMock(spec=ClientPool)
+    mock_client = MagicMock()
+
+    channel_entity = MagicMock()
+    channel_entity.id = -100123
+    channel_entity.username = "cachedchan"
+    channel_entity.creator = False
+
+    dialog = MagicMock()
+    dialog.entity = channel_entity
+    dialog.title = "Cached Channel"
+    dialog.is_channel = True
+    dialog.is_group = False
+
+    async def _fake_iter_dialogs():
+        yield dialog
+
+    mock_client.iter_dialogs.side_effect = [_fake_iter_dialogs(), _fake_iter_dialogs()]
+    pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+1234567890"))
+    pool.release_client = AsyncMock()
+    pool._classify_entity = MagicMock(return_value=("channel", False))
+    pool._dialogs_cache = {}
+    pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
+    pool._store_cached_dialogs = ClientPool._store_cached_dialogs.__get__(pool, ClientPool)
+    pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
+
+    await ClientPool.get_dialogs_for_phone(pool, "+1234567890")
+    await ClientPool.get_dialogs_for_phone(pool, "+1234567890", refresh=True)
+
+    assert mock_client.iter_dialogs.call_count == 2

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -232,6 +232,7 @@ async def test_photo_loader_page_renders(tmp_path):
         assert "Автозагрузка из папки" in resp.text
         assert 'action="/my-telegram/photos/refresh"' in resp.text
         assert "Обновить диалоги" in resp.text
+        assert "Используется сохранённый список диалогов" in resp.text
         assert resp.text.count('option value="separate" selected') >= 3
         assert 'data-target-picker' in resp.text
         assert 'data-target-search' in resp.text

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -14,7 +14,14 @@ from src.cli.parser import build_parser
 from src.config import AppConfig
 from src.database import Database
 from src.database.bundles import PhotoLoaderBundle
-from src.models import Account, PhotoAutoUploadJob, PhotoBatchStatus, PhotoSendMode
+from src.models import (
+    Account,
+    PhotoAutoUploadJob,
+    PhotoBatch,
+    PhotoBatchItem,
+    PhotoBatchStatus,
+    PhotoSendMode,
+)
 from src.scheduler.manager import SchedulerManager
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
@@ -233,12 +240,156 @@ async def test_photo_loader_page_renders(tmp_path):
         assert 'data-target-filter="dm"' in resp.text
         assert resp.text.count('name="target_dialog_id"') == 4
         assert 'select name="target_dialog_id"' not in resp.text
+        assert resp.text.count('data-photo-submit-form') >= 4
+        assert resp.text.count('data-photo-submit-button') >= 4
+        assert resp.text.count('data-photo-submit-status') >= 4
+        assert "Запрос отправлен, ожидаем ответ сервера..." in resp.text
         assert "Target Channel" in resp.text
         assert "Target Group" in resp.text
         assert "Target DM" in resp.text
         assert "Target Bot" not in resp.text
         assert "summary.innerHTML" not in resp.text
         assert "summary.replaceChildren()" in resp.text
+        assert "Последние batches" in resp.text
+        assert 'role="alert"\n             data-photo-feedback' not in resp.text
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected_title", "expected_text", "highlight_kind"),
+    [
+        (
+            "msg=photo_sent",
+            "Отправка завершена",
+            "Фото успешно отправлены в Target Channel.",
+            "item",
+        ),
+        (
+            "msg=photo_scheduled",
+            "Отложка создана",
+            "Отложенная отправка создана для Target Channel.",
+            "item",
+        ),
+        (
+            "msg=photo_batch_created",
+            "Batch создан",
+            "Batch photo tasks создан для Target Channel.",
+            "batch",
+        ),
+        (
+            "msg=photo_auto_created",
+            "Авто-загрузка настроена",
+            "Авто-джоб создан для Target Channel.",
+            "auto",
+        ),
+        ("error=photo_send_failed", "Отправка не выполнена", "Не удалось отправить фото.", ""),
+    ],
+)
+async def test_photo_loader_page_feedback_panel_and_highlight_hooks(
+    tmp_path,
+    query,
+    expected_title,
+    expected_text,
+    highlight_kind,
+):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    mock_client = MagicMock()
+
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
+        return [{"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}]
+
+    async def _get_client_by_phone(self, phone):
+        return mock_client, phone
+
+    async def _release_client(self, phone):
+        return None
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {"+7000": mock_client},
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
+            "get_client_by_phone": _get_client_by_phone,
+            "release_client": _release_client,
+        },
+    )()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "hash")
+    app.state.collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.search_engine = MagicMock()
+    app.state.ai_search = MagicMock()
+    app.state.scheduler = SchedulerManager(app.state.collector, config.scheduler)
+    app.state.session_secret = "secret"
+    await db.add_account(Account(phone="+7000", session_string="s"))
+
+    bundle = PhotoLoaderBundle.from_database(db)
+    batch_id = await bundle.create_batch(
+        PhotoBatch(
+            phone="+7000",
+            target_dialog_id=-1001,
+            target_title="Target Channel",
+            target_type="channel",
+            send_mode=PhotoSendMode.SEPARATE,
+            status=PhotoBatchStatus.COMPLETED,
+        )
+    )
+    await bundle.create_item(
+        PhotoBatchItem(
+            batch_id=batch_id,
+            phone="+7000",
+            target_dialog_id=-1001,
+            target_title="Target Channel",
+            target_type="channel",
+            file_paths=["/tmp/a.jpg"],
+            send_mode=PhotoSendMode.SEPARATE,
+            status=PhotoBatchStatus.COMPLETED,
+        )
+    )
+    await bundle.create_auto_job(
+        PhotoAutoUploadJob(
+            phone="+7000",
+            target_dialog_id=-1001,
+            target_title="Target Channel",
+            target_type="channel",
+            folder_path="/tmp/photos",
+            send_mode=PhotoSendMode.SEPARATE,
+            interval_minutes=60,
+            is_active=True,
+        )
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.get(f"/my-telegram/photos?phone=%2B7000&{query}")
+
+    assert resp.status_code == 200
+    assert expected_title in resp.text
+    assert expected_text in resp.text
+    assert 'data-photo-feedback' in resp.text
+    assert f'data-highlight-kind="{highlight_kind}"' in resp.text
+    assert 'data-photo-result-row="item"' in resp.text
+    assert 'data-photo-result-row="batch"' in resp.text
+    assert 'data-photo-result-row="auto"' in resp.text
 
     await db.close()
 

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -237,6 +237,8 @@ async def test_photo_loader_page_renders(tmp_path):
         assert "Target Group" in resp.text
         assert "Target DM" in resp.text
         assert "Target Bot" not in resp.text
+        assert "summary.innerHTML" not in resp.text
+        assert "summary.replaceChildren()" in resp.text
 
     await db.close()
 

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -177,8 +177,13 @@ async def test_photo_loader_page_renders(tmp_path):
     mock_client = MagicMock()
     mock_client.send_file = AsyncMock(return_value=SimpleNamespace(id=1))
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full"):
-        return [{"channel_id": -1001, "title": "Target", "channel_type": "channel"}]
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
+        return [
+            {"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"},
+            {"channel_id": -1002, "title": "Target Group", "channel_type": "supergroup"},
+            {"channel_id": 42, "title": "Target DM", "channel_type": "dm"},
+            {"channel_id": 99, "title": "Target Bot", "channel_type": "bot"},
+        ]
 
     async def _get_client_by_phone(self, phone):
         return mock_client, phone
@@ -218,7 +223,253 @@ async def test_photo_loader_page_renders(tmp_path):
         assert resp.status_code == 200
         assert "Photo Loader" in resp.text
         assert "Автозагрузка из папки" in resp.text
+        assert 'action="/my-telegram/photos/refresh"' in resp.text
+        assert "Обновить диалоги" in resp.text
+        assert resp.text.count('option value="separate" selected') >= 3
+        assert 'data-target-picker' in resp.text
+        assert 'data-target-search' in resp.text
+        assert 'data-target-filter="channel"' in resp.text
+        assert 'data-target-filter="group"' in resp.text
+        assert 'data-target-filter="dm"' in resp.text
+        assert resp.text.count('name="target_dialog_id"') == 4
+        assert 'select name="target_dialog_id"' not in resp.text
+        assert "Target Channel" in resp.text
+        assert "Target Group" in resp.text
+        assert "Target DM" in resp.text
+        assert "Target Bot" not in resp.text
 
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_loader_page_without_phone_selects_first_account(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    mock_client_a = MagicMock()
+    mock_client_b = MagicMock()
+    seen_phones: list[str] = []
+
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
+        seen_phones.append(phone)
+        return [{"channel_id": -1001, "title": f"Target {phone}", "channel_type": "channel"}]
+
+    async def _get_client_by_phone(self, phone):
+        return mock_client_a, phone
+
+    async def _release_client(self, phone):
+        return None
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {"+7999": mock_client_b, "+7000": mock_client_a},
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
+            "get_client_by_phone": _get_client_by_phone,
+            "release_client": _release_client,
+        },
+    )()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "hash")
+    app.state.collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.search_engine = MagicMock()
+    app.state.ai_search = MagicMock()
+    app.state.scheduler = SchedulerManager(app.state.collector, config.scheduler)
+    app.state.session_secret = "secret"
+    await db.add_account(Account(phone="+7000", session_string="a"))
+    await db.add_account(Account(phone="+7999", session_string="b"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.get("/my-telegram/photos")
+        assert resp.status_code == 200
+        assert "Photo Loader" in resp.text
+        assert 'option value="+7000" selected' in resp.text
+        assert "Target +7000" in resp.text
+        assert 'data-initial-target-id="-1001"' in resp.text
+        assert 'name="target_title" value="Target +7000"' in resp.text
+        assert 'name="target_type" value="channel"' in resp.text
+
+    assert seen_phones == ["+7000"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_loader_page_without_selectable_targets_disables_forms(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    mock_client = MagicMock()
+
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
+        return [{"channel_id": 77, "title": "Only Bot", "channel_type": "bot"}]
+
+    async def _get_client_by_phone(self, phone):
+        return mock_client, phone
+
+    async def _release_client(self, phone):
+        return None
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {"+7000": mock_client},
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
+            "get_client_by_phone": _get_client_by_phone,
+            "release_client": _release_client,
+        },
+    )()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "hash")
+    app.state.collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.search_engine = MagicMock()
+    app.state.ai_search = MagicMock()
+    app.state.scheduler = SchedulerManager(app.state.collector, config.scheduler)
+    app.state.session_secret = "secret"
+    await db.add_account(Account(phone="+7000", session_string="s"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.get("/my-telegram/photos?phone=%2B7000")
+        assert resp.status_code == 200
+        assert "нет доступных целей отправки" in resp.text.lower()
+        assert 'id="photo-target-picker"' not in resp.text
+        assert resp.text.count("disabled") >= 4
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_loader_page_without_accounts_renders_empty_state(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+    app.state.pool = type("Pool", (), {"clients": {}})()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "hash")
+    app.state.collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.search_engine = MagicMock()
+    app.state.ai_search = MagicMock()
+    app.state.scheduler = SchedulerManager(app.state.collector, config.scheduler)
+    app.state.session_secret = "secret"
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.get("/my-telegram/photos")
+        assert resp.status_code == 200
+        assert "Нет подключённых аккаунтов." in resp.text
+        assert "Добавьте аккаунт" in resp.text
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_loader_refresh_warms_dialog_cache(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    mock_client = MagicMock()
+
+    seen_refresh_values: list[bool] = []
+
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
+        seen_refresh_values.append(refresh)
+        return [{"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}]
+
+    async def _get_client_by_phone(self, phone):
+        return mock_client, phone
+
+    async def _release_client(self, phone):
+        return None
+
+    app.state.pool = type(
+        "Pool",
+        (),
+        {
+            "clients": {"+7000": mock_client},
+            "get_dialogs_for_phone": _get_dialogs_for_phone,
+            "get_client_by_phone": _get_client_by_phone,
+            "release_client": _release_client,
+        },
+    )()
+    from src.telegram.auth import TelegramAuth
+
+    app.state.auth = TelegramAuth(12345, "hash")
+    app.state.collector = Collector(app.state.pool, db, config.scheduler)
+    app.state.search_engine = MagicMock()
+    app.state.ai_search = MagicMock()
+    app.state.scheduler = SchedulerManager(app.state.collector, config.scheduler)
+    app.state.session_secret = "secret"
+    await db.add_account(Account(phone="+7000", session_string="s"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post("/my-telegram/photos/refresh", data={"phone": "+7000"})
+        assert resp.status_code == 200
+        assert "Photo Loader" in resp.text
+        assert "Target Channel" in resp.text
+
+    assert seen_refresh_values == [True, False]
     await db.close()
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -58,7 +58,13 @@ async def client(tmp_path):
             },
         ]
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
+    async def _get_dialogs_for_phone(
+        self,
+        phone,
+        include_dm=False,
+        mode="channels_only",
+        refresh=False,
+    ):
         return []
 
     app.state.pool = type(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -58,7 +58,7 @@ async def client(tmp_path):
             },
         ]
 
-    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only"):
+    async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="channels_only", refresh=False):
         return []
 
     app.state.pool = type(


### PR DESCRIPTION
Re-submits the reverted dialog-cache changes from #34 after the follow-up fixes:\n- fix CI/lint issues\n- avoid unsafe summary HTML in photo loader\n- restore bounded dialog cache TTL while keeping manual refresh\n\nOpened after reverting #34 in #35 so the changes can be reviewed again cleanly.