### PR TITLE
Enforce explicit photo target selection

### DIFF
--- a/.codex-staging/feature-dev/README.md
+++ b/.codex-staging/feature-dev/README.md
@@ -1,0 +1,15 @@
+# feature-dev
+
+Codex skill adapted from the Claude `feature-dev` plugin.
+
+It provides a structured workflow for feature delivery:
+
+1. Discovery
+2. Codebase exploration
+3. Clarifying questions
+4. Architecture design
+5. Implementation
+6. Quality review
+7. Summary
+
+Primary entrypoint: [`SKILL.md`](./SKILL.md)

--- a/.codex-staging/feature-dev/SKILL.md
+++ b/.codex-staging/feature-dev/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: feature-dev
+description: Structured feature development workflow with codebase exploration, architecture tradeoffs, implementation gating, and review
+version: 1.0.0
+metadata:
+  source: claude-plugins-official/feature-dev
+---
+
+# Feature Dev Skill
+
+Use this skill when the user wants to build a new feature and would benefit from a deliberate workflow instead of immediate implementation.
+
+## Goal
+
+Drive feature work through seven phases:
+
+1. Discovery
+2. Codebase exploration
+3. Clarifying questions
+4. Architecture design
+5. Implementation
+6. Quality review
+7. Summary
+
+## Operating Rules
+
+- Do not jump straight into code for ambiguous feature work.
+- Read the codebase before proposing implementation details.
+- Ask clarifying questions after exploration and before architecture selection.
+- Present concrete tradeoffs, not abstract options.
+- Do not start implementation until the user approves an approach.
+- After implementation, run a review pass focused on bugs, regressions, and convention mismatches.
+
+## Workflow
+
+### 1. Discovery
+
+- Restate the feature request in concrete terms.
+- If the request is underspecified, ask what problem is being solved, required behavior, constraints, and non-goals.
+- Create a task plan that tracks all seven phases.
+
+### 2. Codebase Exploration
+
+Investigate the codebase from multiple angles. Parallelize local reads and searches when possible.
+
+Cover at least these perspectives:
+- Similar or adjacent features
+- Relevant architecture layers and extension points
+- Existing tests, conventions, and user flows
+
+For each perspective, produce:
+- Key files with path references
+- Relevant control flow and abstractions
+- Constraints that affect implementation
+
+After exploration, read the most important files and summarize patterns that the new feature should follow.
+
+### 3. Clarifying Questions
+
+Before designing the solution, identify ambiguities such as:
+- Edge cases
+- Error handling
+- Scope boundaries
+- Integration points
+- Backward compatibility
+- Performance or security requirements
+
+Ask the user a concise grouped list of questions and wait for answers. If the user delegates the choice, give a recommendation and get explicit confirmation.
+
+### 4. Architecture Design
+
+Develop 2-3 implementation approaches with distinct tradeoffs:
+- Minimal changes
+- Clean architecture
+- Pragmatic balance
+
+For each approach, include:
+- Files to change or create
+- Main abstractions
+- Benefits
+- Costs and risks
+
+Recommend one approach and explain why it fits this codebase and request. Ask the user which approach to use.
+
+### 5. Implementation
+
+Do not begin until the user explicitly approves an approach.
+
+When implementing:
+- Follow existing project patterns
+- Keep changes scoped to the agreed design
+- Update the task plan as work progresses
+- Add tests when the codebase supports them
+
+### 6. Quality Review
+
+Review the resulting changes from three lenses:
+- Simplicity, DRY, and maintainability
+- Bugs, correctness, and regressions
+- Project conventions and abstraction fit
+
+Report the highest-signal findings first. If issues exist, ask whether to fix now, defer, or proceed as-is.
+
+### 7. Summary
+
+Close with:
+- What was built
+- Key decisions
+- Main files changed
+- Remaining risks or next steps
+
+## Specialist Lenses
+
+Use these role prompts internally when useful:
+
+- [code-explorer](references/code-explorer.md): trace feature flows and architecture
+- [code-architect](references/code-architect.md): produce decisive implementation blueprints
+- [code-reviewer](references/code-reviewer.md): review for real bugs and convention drift
+
+You do not need separate agents to use this skill. Reuse the lenses as structured thinking modes during exploration, design, and review.

--- a/.codex-staging/feature-dev/references/code-architect.md
+++ b/.codex-staging/feature-dev/references/code-architect.md
@@ -1,0 +1,17 @@
+# Code Architect Lens
+
+Use this lens to design a concrete implementation that fits the codebase.
+
+## Focus
+
+- Reuse established patterns
+- Pick a clear architecture rather than staying vague
+- Map files to create or modify
+- Call out interfaces, data flow, and sequencing
+
+## Output
+
+- Recommended approach
+- Tradeoffs
+- File-by-file implementation map
+- Build sequence and critical details

--- a/.codex-staging/feature-dev/references/code-explorer.md
+++ b/.codex-staging/feature-dev/references/code-explorer.md
@@ -1,0 +1,17 @@
+# Code Explorer Lens
+
+Use this lens to understand how an existing feature works before changing it.
+
+## Focus
+
+- Find entry points
+- Trace execution flow end to end
+- Identify important abstractions and dependencies
+- Surface existing patterns worth reusing
+
+## Output
+
+- Key files to read
+- Step-by-step flow
+- Data transformations
+- Notable constraints, risks, or technical debt

--- a/.codex-staging/feature-dev/references/code-reviewer.md
+++ b/.codex-staging/feature-dev/references/code-reviewer.md
@@ -1,0 +1,17 @@
+# Code Reviewer Lens
+
+Use this lens after implementation to review only meaningful issues.
+
+## Focus
+
+- Functional correctness
+- Regression risk
+- Convention mismatches
+- Simplicity and maintainability
+
+## Output
+
+- High-signal findings only
+- Concrete file references
+- Specific fix guidance
+- Residual risks if no issues are found

--- a/src/web/routes/import_channels.py
+++ b/src/web/routes/import_channels.py
@@ -74,7 +74,7 @@ async def import_channels(
                 break
             logger.warning("Failed to resolve '%s': %s", ident, exc)
             info = None
-        except Exception as exc:
+        except Exception:
             logger.exception("Unexpected error resolving %r during bulk import", ident)
             info = None
 

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -80,7 +80,13 @@ async def _validate_target(
         return None, "photo_target_invalid"
 
     dialogs = await deps.channel_service(request).get_my_dialogs(phone)
-    if not any(int(dialog["channel_id"]) == dialog_id for dialog in dialogs):
+    dialog = next(
+        (item for item in dialogs if int(item["channel_id"]) == dialog_id),
+        None,
+    )
+    if dialog is None:
+        return None, "photo_target_invalid"
+    if str(dialog.get("channel_type", "")).strip() == "bot":
         return None, "photo_target_invalid"
     target = _parse_target(
         {
@@ -293,17 +299,19 @@ async def photo_send(
     caption: str = Form(""),
     photos: list[UploadFile] = File(...),
 ):
-    target, target_error = await _validate_target(
-        request,
-        phone=phone,
-        target_dialog_id=target_dialog_id,
-        target_title=target_title,
-        target_type=target_type,
-    )
-    if target_error:
-        return _redirect(phone, target_error, error=True)
-    saved = await _persist_uploads(photos, f"manual_{uuid.uuid4().hex}")
+    target = None
+    saved: list[str] = []
     try:
+        target, target_error = await _validate_target(
+            request,
+            phone=phone,
+            target_dialog_id=target_dialog_id,
+            target_title=target_title,
+            target_type=target_type,
+        )
+        if target_error:
+            return _redirect(phone, target_error, error=True)
+        saved = await _persist_uploads(photos, f"manual_{uuid.uuid4().hex}")
         await deps.get_photo_task_service(request).send_now(
             phone=phone,
             target=target,
@@ -317,8 +325,8 @@ async def photo_send(
             "target_type=%r send_mode=%s files=%d",
             phone,
             target_dialog_id,
-            target.title,
-            target.target_type,
+            getattr(target, "title", None),
+            getattr(target, "target_type", None),
             send_mode,
             len(saved),
         )
@@ -338,17 +346,19 @@ async def photo_schedule(
     schedule_at: str = Form(...),
     photos: list[UploadFile] = File(...),
 ):
-    target, target_error = await _validate_target(
-        request,
-        phone=phone,
-        target_dialog_id=target_dialog_id,
-        target_title=target_title,
-        target_type=target_type,
-    )
-    if target_error:
-        return _redirect(phone, target_error, error=True)
-    saved = await _persist_uploads(photos, f"scheduled_{uuid.uuid4().hex}")
+    target = None
+    saved: list[str] = []
     try:
+        target, target_error = await _validate_target(
+            request,
+            phone=phone,
+            target_dialog_id=target_dialog_id,
+            target_title=target_title,
+            target_type=target_type,
+        )
+        if target_error:
+            return _redirect(phone, target_error, error=True)
+        saved = await _persist_uploads(photos, f"scheduled_{uuid.uuid4().hex}")
         parsed_schedule_at = _parse_schedule_at(schedule_at)
         await deps.get_photo_task_service(request).schedule_send(
             phone=phone,
@@ -364,8 +374,8 @@ async def photo_schedule(
             "target_type=%r send_mode=%s files=%d schedule_at=%r",
             phone,
             target_dialog_id,
-            target.title,
-            target.target_type,
+            getattr(target, "title", None),
+            getattr(target, "target_type", None),
             send_mode,
             len(saved),
             schedule_at,
@@ -384,16 +394,17 @@ async def photo_batch(
     caption: str = Form(""),
     manifest_text: str = Form(""),
 ):
-    target, target_error = await _validate_target(
-        request,
-        phone=phone,
-        target_dialog_id=target_dialog_id,
-        target_title=target_title,
-        target_type=target_type,
-    )
-    if target_error:
-        return _redirect(phone, target_error, error=True)
+    target = None
     try:
+        target, target_error = await _validate_target(
+            request,
+            phone=phone,
+            target_dialog_id=target_dialog_id,
+            target_title=target_title,
+            target_type=target_type,
+        )
+        if target_error:
+            return _redirect(phone, target_error, error=True)
         manifest = json.loads(manifest_text)
         await deps.get_photo_task_service(request).create_batch(
             phone=phone,
@@ -408,8 +419,8 @@ async def photo_batch(
             "target_type=%r manifest_entries=%s",
             phone,
             target_dialog_id,
-            target.title,
-            target.target_type,
+            getattr(target, "title", None),
+            getattr(target, "target_type", None),
             manifest_size,
         )
         return _redirect(phone, "photo_batch_failed", error=True)
@@ -428,16 +439,17 @@ async def photo_auto_create(
     caption: str = Form(""),
     interval_minutes: int = Form(...),
 ):
-    target, target_error = await _validate_target(
-        request,
-        phone=phone,
-        target_dialog_id=target_dialog_id,
-        target_title=target_title,
-        target_type=target_type,
-    )
-    if target_error:
-        return _redirect(phone, target_error, error=True)
+    target = None
     try:
+        target, target_error = await _validate_target(
+            request,
+            phone=phone,
+            target_dialog_id=target_dialog_id,
+            target_title=target_title,
+            target_type=target_type,
+        )
+        if target_error:
+            return _redirect(phone, target_error, error=True)
         await deps.get_photo_auto_upload_service(request).create_job(
             PhotoAutoUploadJob(
                 phone=phone,
@@ -457,8 +469,8 @@ async def photo_auto_create(
             "target_type=%r folder_path=%r send_mode=%s interval_minutes=%s",
             phone,
             target_dialog_id,
-            target.title,
-            target.target_type,
+            getattr(target, "title", None),
+            getattr(target, "target_type", None),
             folder_path,
             send_mode,
             interval_minutes,

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -63,6 +63,38 @@ def _parse_target(form, dialogs: list[dict]) -> PhotoTarget:
     return PhotoTarget(dialog_id=dialog_id, title=title, target_type=target_type)
 
 
+async def _validate_target(
+    request: Request,
+    *,
+    phone: str,
+    target_dialog_id: str,
+    target_title: str = "",
+    target_type: str = "",
+) -> tuple[PhotoTarget | None, str | None]:
+    raw_id = target_dialog_id.strip()
+    if not raw_id:
+        return None, "photo_target_required"
+    try:
+        dialog_id = int(raw_id)
+    except ValueError:
+        return None, "photo_target_invalid"
+
+    dialogs = await deps.channel_service(request).get_my_dialogs(phone)
+    if not any(int(dialog["channel_id"]) == dialog_id for dialog in dialogs):
+        return None, "photo_target_invalid"
+    target = _parse_target(
+        {
+            "target_dialog_id": str(dialog_id),
+            "target_title": target_title,
+            "target_type": target_type,
+        },
+        dialogs,
+    )
+    if target.title is None or target.target_type is None:
+        return None, "photo_target_invalid"
+    return target, None
+
+
 def _parse_schedule_at(value: str) -> datetime:
     dt = datetime.fromisoformat(value)
     if dt.tzinfo is None:
@@ -158,6 +190,22 @@ def _build_feedback(
             "highlight_kind": "",
         }
 
+    if error == "photo_target_required":
+        return {
+            "variant": "error",
+            "title": "Цель не выбрана",
+            "body": "Сначала выберите канал, чат или личный диалог.",
+            "highlight_kind": "",
+        }
+
+    if error == "photo_target_invalid":
+        return {
+            "variant": "error",
+            "title": "Цель недоступна",
+            "body": "Выбранная цель недоступна. Выберите её заново.",
+            "highlight_kind": "",
+        }
+
     if error == "photo_schedule_failed":
         return {
             "variant": "error",
@@ -238,18 +286,22 @@ async def photo_loader_refresh(request: Request, phone: str = Form(...)):
 async def photo_send(
     request: Request,
     phone: str = Form(...),
-    target_dialog_id: int = Form(...),
+    target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
     photos: list[UploadFile] = File(...),
 ):
-    target = PhotoTarget(
-        dialog_id=target_dialog_id,
-        title=target_title or None,
-        target_type=target_type or None,
+    target, target_error = await _validate_target(
+        request,
+        phone=phone,
+        target_dialog_id=target_dialog_id,
+        target_title=target_title,
+        target_type=target_type,
     )
+    if target_error:
+        return _redirect(phone, target_error, error=True)
     saved = await _persist_uploads(photos, f"manual_{uuid.uuid4().hex}")
     try:
         await deps.get_photo_task_service(request).send_now(
@@ -278,7 +330,7 @@ async def photo_send(
 async def photo_schedule(
     request: Request,
     phone: str = Form(...),
-    target_dialog_id: int = Form(...),
+    target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     send_mode: str = Form(PhotoSendMode.SEPARATE.value),
@@ -286,11 +338,15 @@ async def photo_schedule(
     schedule_at: str = Form(...),
     photos: list[UploadFile] = File(...),
 ):
-    target = PhotoTarget(
-        dialog_id=target_dialog_id,
-        title=target_title or None,
-        target_type=target_type or None,
+    target, target_error = await _validate_target(
+        request,
+        phone=phone,
+        target_dialog_id=target_dialog_id,
+        target_title=target_title,
+        target_type=target_type,
     )
+    if target_error:
+        return _redirect(phone, target_error, error=True)
     saved = await _persist_uploads(photos, f"scheduled_{uuid.uuid4().hex}")
     try:
         parsed_schedule_at = _parse_schedule_at(schedule_at)
@@ -322,17 +378,21 @@ async def photo_schedule(
 async def photo_batch(
     request: Request,
     phone: str = Form(...),
-    target_dialog_id: int = Form(...),
+    target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     caption: str = Form(""),
     manifest_text: str = Form(""),
 ):
-    target = PhotoTarget(
-        dialog_id=target_dialog_id,
-        title=target_title or None,
-        target_type=target_type or None,
+    target, target_error = await _validate_target(
+        request,
+        phone=phone,
+        target_dialog_id=target_dialog_id,
+        target_title=target_title,
+        target_type=target_type,
     )
+    if target_error:
+        return _redirect(phone, target_error, error=True)
     try:
         manifest = json.loads(manifest_text)
         await deps.get_photo_task_service(request).create_batch(
@@ -360,7 +420,7 @@ async def photo_batch(
 async def photo_auto_create(
     request: Request,
     phone: str = Form(...),
-    target_dialog_id: int = Form(...),
+    target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     folder_path: str = Form(...),
@@ -368,13 +428,22 @@ async def photo_auto_create(
     caption: str = Form(""),
     interval_minutes: int = Form(...),
 ):
+    target, target_error = await _validate_target(
+        request,
+        phone=phone,
+        target_dialog_id=target_dialog_id,
+        target_title=target_title,
+        target_type=target_type,
+    )
+    if target_error:
+        return _redirect(phone, target_error, error=True)
     try:
         await deps.get_photo_auto_upload_service(request).create_job(
             PhotoAutoUploadJob(
                 phone=phone,
-                target_dialog_id=target_dialog_id,
-                target_title=target_title or None,
-                target_type=target_type or None,
+                target_dialog_id=target.dialog_id,
+                target_title=target.title,
+                target_type=target.target_type,
                 folder_path=folder_path,
                 send_mode=PhotoSendMode(send_mode),
                 caption=caption or None,
@@ -388,8 +457,8 @@ async def photo_auto_create(
             "target_type=%r folder_path=%r send_mode=%s interval_minutes=%s",
             phone,
             target_dialog_id,
-            target_title or None,
-            target_type or None,
+            target.title,
+            target.target_type,
             folder_path,
             send_mode,
             interval_minutes,

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -117,6 +117,8 @@
         notification_action_failed: "Не удалось выполнить действие с notification bot.",
         notification_test_failed: "Не удалось отправить тестовое уведомление.",
         photo_send_failed: "Не удалось отправить фото.",
+        photo_target_required: "Сначала выберите канал, чат или личный диалог.",
+        photo_target_invalid: "Выбранная цель недоступна. Выберите её заново.",
         photo_schedule_failed: "Не удалось создать отложенную отправку фото.",
         photo_batch_failed: "Не удалось создать batch photo tasks.",
         photo_auto_failed: "Не удалось создать или изменить auto job.",

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -511,13 +511,12 @@
         }));
     }
 
-    function clearSelection() {
+    function resetSelectionUI() {
         options.forEach(function(option) {
             option.classList.remove("active");
         });
         updateForms(null);
         updateSummary(null);
-        saveTarget(null);
     }
 
     function setActiveOption(button) {
@@ -591,7 +590,7 @@
 
     searchInput.addEventListener("input", applyFilters);
 
-    clearSelection();
+    resetSelectionUI();
     if (!restoreTarget()) {
         updateForms(null);
         updateSummary(null);

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% block title %}Photo Loader — TG Agent{% endblock %}
 {% set selectable_dialogs = dialogs | rejectattr("channel_type", "equalto", "bot") | list %}
-{% set initial_target = selectable_dialogs[0] if selectable_dialogs else none %}
-{% set target_available = initial_target is not none %}
+{% set target_available = selectable_dialogs | length > 0 %}
 {% macro target_group(dialog) -%}
     {%- if dialog.channel_type in ["channel", "monoforum", "scam", "fake", "restricted"] -%}channel
     {%- elif dialog.channel_type in ["supergroup", "group", "gigagroup", "forum"] -%}group
@@ -17,10 +16,10 @@
     {%- else -%}Прочее
     {%- endif -%}
 {%- endmacro %}
-{% macro render_target_hidden_inputs(initial_target) -%}
-<input type="hidden" name="target_dialog_id" value="{{ initial_target.channel_id if initial_target else '' }}" data-target-field="id">
-<input type="hidden" name="target_title" value="{{ initial_target.title if initial_target else '' }}" data-target-field="title">
-<input type="hidden" name="target_type" value="{{ initial_target.channel_type if initial_target else '' }}" data-target-field="type">
+{% macro render_target_hidden_inputs() -%}
+<input type="hidden" name="target_dialog_id" value="" data-target-field="id">
+<input type="hidden" name="target_title" value="" data-target-field="title">
+<input type="hidden" name="target_type" value="" data-target-field="type">
 {%- endmacro %}
 {% block content %}
 <h1>Photo Loader</h1>
@@ -74,12 +73,10 @@
                         <p class="text-muted mb-0">Один выбор цели используется во всех формах ниже.</p>
                     </div>
                     <div class="photo-target-summary" data-target-summary>
-                        {% if target_available %}
-                        <strong>{{ initial_target.title }}</strong>
-                        <span class="badge text-bg-light">{{ target_group_label(target_group(initial_target)) }}</span>
-                        <span class="text-muted small">{{ initial_target.channel_type }}</span>
-                        {% else %}
+                        {% if not target_available %}
                         <span class="text-muted">Нет доступных каналов, чатов или личных диалогов для отправки.</span>
+                        {% else %}
+                        <span class="text-muted">Цель не выбрана.</span>
                         {% endif %}
                     </div>
                 </div>
@@ -88,7 +85,8 @@
                 <div id="photo-target-picker"
                      class="mt-4"
                      data-target-picker
-                     data-initial-target-id="{{ initial_target.channel_id }}">
+                     data-target-phone="{{ selected_phone }}">
+                    <p class="text-muted small mb-3">Сначала выберите канал, чат или личный диалог. Выбор сохранится на текущую браузерную сессию.</p>
                     <div class="row g-3">
                         <div class="col-lg-5">
                             <label class="form-label" for="target-search">Поиск</label>
@@ -108,7 +106,7 @@
                                 {% for dialog in selectable_dialogs %}
                                 {% set group = target_group(dialog) %}
                                 <button type="button"
-                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-start{% if initial_target and dialog.channel_id == initial_target.channel_id %} active{% endif %}"
+                                        class="list-group-item list-group-item-action d-flex justify-content-between align-items-start"
                                         data-target-option
                                         data-target-id="{{ dialog.channel_id }}"
                                         data-target-title="{{ dialog.title }}"
@@ -142,11 +140,11 @@
                 <h2 class="h5">Обычная загрузка</h2>
                 <form method="post" action="/my-telegram/photos/send" enctype="multipart/form-data" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
-                    {{ render_target_hidden_inputs(initial_target) }}
+                    {{ render_target_hidden_inputs() }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
                         <div class="form-control bg-body-tertiary" data-target-display>
-                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                            {% if target_available %}Цель не выбрана{% else %}Цель недоступна{% endif %}
                         </div>
                     </div>
                     <div class="col-md-6">
@@ -165,7 +163,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-primary" type="submit" data-photo-submit-button data-busy-label="Отправка..." {% if not target_available %}disabled{% endif %}>Отправить</button>
+                        <button class="btn btn-primary" type="submit" data-photo-submit-button data-busy-label="Отправка..." disabled>Отправить</button>
                         <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
@@ -179,11 +177,11 @@
                 <h2 class="h5">Отложенная загрузка</h2>
                 <form method="post" action="/my-telegram/photos/schedule" enctype="multipart/form-data" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
-                    {{ render_target_hidden_inputs(initial_target) }}
+                    {{ render_target_hidden_inputs() }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
                         <div class="form-control bg-body-tertiary" data-target-display>
-                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                            {% if target_available %}Цель не выбрана{% else %}Цель недоступна{% endif %}
                         </div>
                     </div>
                     <div class="col-md-6">
@@ -206,7 +204,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-primary" type="submit" data-photo-submit-button data-busy-label="Создаём отложку..." {% if not target_available %}disabled{% endif %}>Поставить в отложку</button>
+                        <button class="btn btn-outline-primary" type="submit" data-photo-submit-button data-busy-label="Создаём отложку..." disabled>Поставить в отложку</button>
                         <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
@@ -221,11 +219,11 @@
                 <p class="text-muted small">JSON-массив объектов вида <code>{"at":"2026-03-11T18:30","files":["/abs/1.jpg"],"mode":"album"}</code></p>
                 <form method="post" action="/my-telegram/photos/batch" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
-                    {{ render_target_hidden_inputs(initial_target) }}
+                    {{ render_target_hidden_inputs() }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
                         <div class="form-control bg-body-tertiary" data-target-display>
-                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                            {% if target_available %}Цель не выбрана{% else %}Цель недоступна{% endif %}
                         </div>
                     </div>
                     <div class="col-12">
@@ -239,7 +237,7 @@
 ]</textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-secondary" type="submit" data-photo-submit-button data-busy-label="Создаём batch..." {% if not target_available %}disabled{% endif %}>Создать batch</button>
+                        <button class="btn btn-outline-secondary" type="submit" data-photo-submit-button data-busy-label="Создаём batch..." disabled>Создать batch</button>
                         <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
@@ -253,11 +251,11 @@
                 <h2 class="h5">Автозагрузка из папки</h2>
                 <form method="post" action="/my-telegram/photos/auto" class="row g-3" data-photo-target-form data-photo-submit-form>
                     <input type="hidden" name="phone" value="{{ selected_phone }}">
-                    {{ render_target_hidden_inputs(initial_target) }}
+                    {{ render_target_hidden_inputs() }}
                     <div class="col-12">
                         <label class="form-label">Канал / чат</label>
                         <div class="form-control bg-body-tertiary" data-target-display>
-                            {% if target_available %}{{ initial_target.title }}{% else %}Цель недоступна{% endif %}
+                            {% if target_available %}Цель не выбрана{% else %}Цель недоступна{% endif %}
                         </div>
                     </div>
                     <div class="col-md-7">
@@ -280,7 +278,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-dark" type="submit" data-photo-submit-button data-busy-label="Создаём авто-джоб..." {% if not target_available %}disabled{% endif %}>Создать авто-джоб</button>
+                        <button class="btn btn-outline-dark" type="submit" data-photo-submit-button data-busy-label="Создаём авто-джоб..." disabled>Создать авто-джоб</button>
                         <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
@@ -452,6 +450,9 @@
     var summary = document.querySelector("[data-target-summary]");
     var forms = Array.from(document.querySelectorAll("[data-photo-target-form]"));
     var activeFilter = "all";
+    var selectedPhone = picker.dataset.targetPhone || "";
+    var storageKey = selectedPhone ? "photo_loader_target:" + selectedPhone : "";
+    var emptyDisplayText = "Цель не выбрана";
 
     function updateForms(target) {
         forms.forEach(function(form) {
@@ -459,16 +460,25 @@
             var titleField = form.querySelector('[data-target-field="title"]');
             var typeField = form.querySelector('[data-target-field="type"]');
             var display = form.querySelector("[data-target-display]");
-            if (idField) idField.value = target.id;
-            if (titleField) titleField.value = target.title;
-            if (typeField) typeField.value = target.type;
-            if (display) display.textContent = target.title;
+            var submitButton = form.querySelector("[data-photo-submit-button]");
+            if (idField) idField.value = target ? target.id : "";
+            if (titleField) titleField.value = target ? target.title : "";
+            if (typeField) typeField.value = target ? target.type : "";
+            if (display) display.textContent = target ? target.title : emptyDisplayText;
+            if (submitButton) submitButton.disabled = !target;
         });
     }
 
     function updateSummary(target) {
         if (!summary) return;
         summary.replaceChildren();
+        if (!target) {
+            var empty = document.createElement("span");
+            empty.className = "text-muted";
+            empty.textContent = emptyDisplayText + ".";
+            summary.append(empty);
+            return;
+        }
 
         var title = document.createElement("strong");
         title.textContent = target.title;
@@ -488,6 +498,28 @@
         summary.append(title, spacerAfterTitle, badge, spacerAfterBadge, type);
     }
 
+    function saveTarget(target) {
+        if (!storageKey) return;
+        if (!target) {
+            sessionStorage.removeItem(storageKey);
+            return;
+        }
+        sessionStorage.setItem(storageKey, JSON.stringify({
+            id: target.id,
+            title: target.title,
+            type: target.type
+        }));
+    }
+
+    function clearSelection() {
+        options.forEach(function(option) {
+            option.classList.remove("active");
+        });
+        updateForms(null);
+        updateSummary(null);
+        saveTarget(null);
+    }
+
     function setActiveOption(button) {
         options.forEach(function(option) {
             option.classList.toggle("active", option === button);
@@ -500,6 +532,32 @@
         };
         updateForms(target);
         updateSummary(target);
+        saveTarget(target);
+    }
+
+    function findOptionById(id) {
+        return options.find(function(option) {
+            return option.dataset.targetId === String(id);
+        }) || null;
+    }
+
+    function restoreTarget() {
+        if (!storageKey) return false;
+        var raw = sessionStorage.getItem(storageKey);
+        if (!raw) return false;
+        try {
+            var saved = JSON.parse(raw);
+            var option = findOptionById(saved.id);
+            if (!option) {
+                sessionStorage.removeItem(storageKey);
+                return false;
+            }
+            setActiveOption(option);
+            return true;
+        } catch (_error) {
+            sessionStorage.removeItem(storageKey);
+            return false;
+        }
     }
 
     function applyFilters() {
@@ -533,11 +591,10 @@
 
     searchInput.addEventListener("input", applyFilters);
 
-    var initial = options.find(function(option) {
-        return option.dataset.targetId === picker.dataset.initialTargetId;
-    }) || options[0];
-    if (initial) {
-        setActiveOption(initial);
+    clearSelection();
+    if (!restoreTarget()) {
+        updateForms(null);
+        updateSummary(null);
     }
     applyFilters();
 })();

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -291,6 +291,15 @@ async def test_photo_loader_page_renders(tmp_path):
         assert resp.text.count('data-photo-submit-form') >= 4
         assert resp.text.count('data-photo-submit-button') >= 4
         assert resp.text.count('data-photo-submit-status') >= 4
+        assert "Цель не выбрана" in resp.text
+        assert "Выбор сохранится на текущую браузерную сессию." in resp.text
+        assert 'data-target-phone="+7000"' in resp.text
+        assert 'data-initial-target-id=' not in resp.text
+        assert 'name="target_title" value="Target Channel"' not in resp.text
+        assert 'name="target_type" value="channel"' not in resp.text
+        assert "sessionStorage.setItem(storageKey" in resp.text
+        assert "sessionStorage.getItem(storageKey)" in resp.text
+        assert "photo_loader_target:" in resp.text
         assert "Запрос отправлен, ожидаем ответ сервера..." in resp.text
         assert "Target Channel" in resp.text
         assert "Target Group" in resp.text
@@ -503,9 +512,11 @@ async def test_photo_loader_page_without_phone_selects_first_account(tmp_path):
         assert "Photo Loader" in resp.text
         assert 'option value="+7000" selected' in resp.text
         assert "Target +7000" in resp.text
-        assert 'data-initial-target-id="-1001"' in resp.text
-        assert 'name="target_title" value="Target +7000"' in resp.text
-        assert 'name="target_type" value="channel"' in resp.text
+        assert 'data-target-phone="+7000"' in resp.text
+        assert 'data-initial-target-id=' not in resp.text
+        assert 'name="target_title" value="Target +7000"' not in resp.text
+        assert 'name="target_type" value="channel"' not in resp.text
+        assert "Цель не выбрана" in resp.text
 
     assert seen_phones == ["+7000"]
     await db.close()
@@ -773,6 +784,76 @@ async def test_photo_schedule_logs_exception(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
+async def test_photo_schedule_requires_target_selection(tmp_path):
+    app, db = await _build_photo_loader_app(tmp_path)
+    app.state.photo_task_service = SimpleNamespace(
+        schedule_send=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/schedule",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "",
+                "target_title": "",
+                "target_type": "",
+                "send_mode": "separate",
+                "caption": "caption",
+                "schedule_at": "2026-03-11T18:30:00+00:00",
+            },
+            files={"photos": ("one.jpg", b"x", "image/jpeg")},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_required" in resp.headers["location"]
+    app.state.photo_task_service.schedule_send.assert_not_awaited()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_schedule_rejects_unknown_target(tmp_path):
+    app, db = await _build_photo_loader_app(tmp_path)
+    app.state.photo_task_service = SimpleNamespace(
+        schedule_send=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/schedule",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "9999",
+                "target_title": "Ghost",
+                "target_type": "channel",
+                "send_mode": "separate",
+                "caption": "caption",
+                "schedule_at": "2026-03-11T18:30:00+00:00",
+            },
+            files={"photos": ("one.jpg", b"x", "image/jpeg")},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_invalid" in resp.headers["location"]
+    app.state.photo_task_service.schedule_send.assert_not_awaited()
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_photo_send_logs_exception(tmp_path, caplog):
     app, db = await _build_photo_loader_app(tmp_path)
     app.state.photo_task_service = SimpleNamespace(
@@ -804,6 +885,40 @@ async def test_photo_send_logs_exception(tmp_path, caplog):
     assert resp.status_code == 303
     assert "error=photo_send_failed" in resp.headers["location"]
     assert "Photo send failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_send_requires_target_selection(tmp_path):
+    app, db = await _build_photo_loader_app(tmp_path)
+    app.state.photo_task_service = SimpleNamespace(
+        send_now=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/send",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "",
+                "target_title": "",
+                "target_type": "",
+                "send_mode": "separate",
+                "caption": "caption",
+            },
+            files={"photos": ("one.jpg", b"x", "image/jpeg")},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_required" in resp.headers["location"]
+    app.state.photo_task_service.send_now.assert_not_awaited()
     await db.close()
 
 
@@ -842,6 +957,39 @@ async def test_photo_batch_logs_exception(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
+async def test_photo_batch_rejects_unknown_target(tmp_path):
+    app, db = await _build_photo_loader_app(tmp_path)
+    app.state.photo_task_service = SimpleNamespace(
+        create_batch=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/batch",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "9999",
+                "target_title": "Ghost",
+                "target_type": "channel",
+                "caption": "caption",
+                "manifest_text": '[{"files":["/tmp/a.jpg"],"at":"2026-03-11T18:30:00+00:00"}]',
+            },
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_invalid" in resp.headers["location"]
+    app.state.photo_task_service.create_batch.assert_not_awaited()
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_photo_auto_logs_exception(tmp_path, caplog):
     app, db = await _build_photo_loader_app(tmp_path)
     app.state.photo_auto_upload_service = SimpleNamespace(
@@ -874,6 +1022,41 @@ async def test_photo_auto_logs_exception(tmp_path, caplog):
     assert resp.status_code == 303
     assert "error=photo_auto_failed" in resp.headers["location"]
     assert "Photo auto job creation failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_auto_requires_target_selection(tmp_path):
+    app, db = await _build_photo_loader_app(tmp_path)
+    app.state.photo_auto_upload_service = SimpleNamespace(
+        create_job=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/auto",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "",
+                "target_title": "",
+                "target_type": "",
+                "folder_path": "/tmp/photos",
+                "send_mode": "separate",
+                "caption": "caption",
+                "interval_minutes": "30",
+            },
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_required" in resp.headers["location"]
+    app.state.photo_auto_upload_service.create_job.assert_not_awaited()
     await db.close()
 
 

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -31,7 +31,7 @@ from src.telegram.collector import Collector
 from src.web.app import create_app
 
 
-async def _build_photo_loader_app(tmp_path):
+async def _build_photo_loader_app(tmp_path, dialogs=None, dialogs_error=None):
     config = AppConfig()
     config.database.path = str(tmp_path / "test.db")
     config.telegram.api_id = 12345
@@ -46,7 +46,9 @@ async def _build_photo_loader_app(tmp_path):
     mock_client = MagicMock()
 
     async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
-        return [{"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}]
+        if dialogs_error is not None:
+            raise dialogs_error
+        return dialogs or [{"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}]
 
     async def _get_client_by_phone(self, phone):
         return mock_client, phone
@@ -300,6 +302,8 @@ async def test_photo_loader_page_renders(tmp_path):
         assert "sessionStorage.setItem(storageKey" in resp.text
         assert "sessionStorage.getItem(storageKey)" in resp.text
         assert "photo_loader_target:" in resp.text
+        assert "resetSelectionUI();" in resp.text
+        assert "clearSelection();" not in resp.text
         assert "Запрос отправлен, ожидаем ответ сервера..." in resp.text
         assert "Target Channel" in resp.text
         assert "Target Group" in resp.text
@@ -784,6 +788,43 @@ async def test_photo_schedule_logs_exception(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
+async def test_photo_schedule_redirects_when_target_validation_raises(tmp_path, caplog):
+    app, db = await _build_photo_loader_app(tmp_path, dialogs_error=RuntimeError("dialogs boom"))
+    app.state.photo_task_service = SimpleNamespace(
+        schedule_send=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        with caplog.at_level(logging.ERROR, logger="src.web.routes.photo_loader"):
+            resp = await client.post(
+                "/my-telegram/photos/schedule",
+                data={
+                    "phone": "+7000",
+                    "target_dialog_id": "-1001",
+                    "target_title": "Target Channel",
+                    "target_type": "channel",
+                    "send_mode": "separate",
+                    "caption": "caption",
+                    "schedule_at": "2026-03-11T18:30:00+00:00",
+                },
+                files={"photos": ("one.jpg", b"x", "image/jpeg")},
+                follow_redirects=False,
+            )
+
+    assert resp.status_code == 303
+    assert "error=photo_schedule_failed" in resp.headers["location"]
+    app.state.photo_task_service.schedule_send.assert_not_awaited()
+    assert "Photo schedule failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_photo_schedule_requires_target_selection(tmp_path):
     app, db = await _build_photo_loader_app(tmp_path)
     app.state.photo_task_service = SimpleNamespace(
@@ -889,6 +930,42 @@ async def test_photo_send_logs_exception(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
+async def test_photo_send_redirects_when_target_validation_raises(tmp_path, caplog):
+    app, db = await _build_photo_loader_app(tmp_path, dialogs_error=RuntimeError("dialogs boom"))
+    app.state.photo_task_service = SimpleNamespace(
+        send_now=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        with caplog.at_level(logging.ERROR, logger="src.web.routes.photo_loader"):
+            resp = await client.post(
+                "/my-telegram/photos/send",
+                data={
+                    "phone": "+7000",
+                    "target_dialog_id": "-1001",
+                    "target_title": "Target Channel",
+                    "target_type": "channel",
+                    "send_mode": "separate",
+                    "caption": "caption",
+                },
+                files={"photos": ("one.jpg", b"x", "image/jpeg")},
+                follow_redirects=False,
+            )
+
+    assert resp.status_code == 303
+    assert "error=photo_send_failed" in resp.headers["location"]
+    app.state.photo_task_service.send_now.assert_not_awaited()
+    assert "Photo send failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_photo_send_requires_target_selection(tmp_path):
     app, db = await _build_photo_loader_app(tmp_path)
     app.state.photo_task_service = SimpleNamespace(
@@ -957,6 +1034,41 @@ async def test_photo_batch_logs_exception(tmp_path, caplog):
 
 
 @pytest.mark.asyncio
+async def test_photo_batch_redirects_when_target_validation_raises(tmp_path, caplog):
+    app, db = await _build_photo_loader_app(tmp_path, dialogs_error=RuntimeError("dialogs boom"))
+    app.state.photo_task_service = SimpleNamespace(
+        create_batch=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        with caplog.at_level(logging.ERROR, logger="src.web.routes.photo_loader"):
+            resp = await client.post(
+                "/my-telegram/photos/batch",
+                data={
+                    "phone": "+7000",
+                    "target_dialog_id": "-1001",
+                    "target_title": "Target Channel",
+                    "target_type": "channel",
+                    "caption": "caption",
+                    "manifest_text": '[{"files":["/tmp/a.jpg"],"at":"2026-03-11T18:30:00+00:00"}]',
+                },
+                follow_redirects=False,
+            )
+
+    assert resp.status_code == 303
+    assert "error=photo_batch_failed" in resp.headers["location"]
+    app.state.photo_task_service.create_batch.assert_not_awaited()
+    assert "Photo batch creation failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_photo_batch_rejects_unknown_target(tmp_path):
     app, db = await _build_photo_loader_app(tmp_path)
     app.state.photo_task_service = SimpleNamespace(
@@ -986,6 +1098,46 @@ async def test_photo_batch_rejects_unknown_target(tmp_path):
     assert resp.status_code == 303
     assert "error=photo_target_invalid" in resp.headers["location"]
     app.state.photo_task_service.create_batch.assert_not_awaited()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_send_rejects_bot_target(tmp_path):
+    app, db = await _build_photo_loader_app(
+        tmp_path,
+        dialogs=[
+            {"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"},
+            {"channel_id": 99, "title": "Target Bot", "channel_type": "bot"},
+        ],
+    )
+    app.state.photo_task_service = SimpleNamespace(
+        send_now=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        resp = await client.post(
+            "/my-telegram/photos/send",
+            data={
+                "phone": "+7000",
+                "target_dialog_id": "99",
+                "target_title": "Target Bot",
+                "target_type": "bot",
+                "send_mode": "separate",
+                "caption": "caption",
+            },
+            files={"photos": ("one.jpg", b"x", "image/jpeg")},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=photo_target_invalid" in resp.headers["location"]
+    app.state.photo_task_service.send_now.assert_not_awaited()
     await db.close()
 
 
@@ -1021,6 +1173,43 @@ async def test_photo_auto_logs_exception(tmp_path, caplog):
 
     assert resp.status_code == 303
     assert "error=photo_auto_failed" in resp.headers["location"]
+    assert "Photo auto job creation failed" in caplog.text
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_photo_auto_redirects_when_target_validation_raises(tmp_path, caplog):
+    app, db = await _build_photo_loader_app(tmp_path, dialogs_error=RuntimeError("dialogs boom"))
+    app.state.photo_auto_upload_service = SimpleNamespace(
+        create_job=AsyncMock(),
+    )
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as client:
+        with caplog.at_level(logging.ERROR, logger="src.web.routes.photo_loader"):
+            resp = await client.post(
+                "/my-telegram/photos/auto",
+                data={
+                    "phone": "+7000",
+                    "target_dialog_id": "-1001",
+                    "target_title": "Target Channel",
+                    "target_type": "channel",
+                    "folder_path": "/tmp/photos",
+                    "send_mode": "separate",
+                    "caption": "caption",
+                    "interval_minutes": "30",
+                },
+                follow_redirects=False,
+            )
+
+    assert resp.status_code == 303
+    assert "error=photo_auto_failed" in resp.headers["location"]
+    app.state.photo_auto_upload_service.create_job.assert_not_awaited()
     assert "Photo auto job creation failed" in caplog.text
     await db.close()
 

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -48,7 +48,9 @@ async def _build_photo_loader_app(tmp_path, dialogs=None, dialogs_error=None):
     async def _get_dialogs_for_phone(self, phone, include_dm=False, mode="full", refresh=False):
         if dialogs_error is not None:
             raise dialogs_error
-        return dialogs or [{"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}]
+        return dialogs or [
+            {"channel_id": -1001, "title": "Target Channel", "channel_type": "channel"}
+        ]
 
     async def _get_client_by_phone(self, phone):
         return mock_client, phone


### PR DESCRIPTION
Summary
- require each Photo Loader form to validate a selected target instead of auto-prefilling the first dialog
- persist the last explicit target per phone in sessionStorage so the picker, summary, and hidden fields restore it across reloads
- add server-side validation helper and error feedback for missing or invalid targets, keeping the existing resolve_dialog_entity fix intact

Testing
- Not run (not requested)