### PR TITLE
ci: opt into Node.js 24 for Claude action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true for the claude-review workflow job to opt into Node.js 24 and avoid action runtime deprecation issues. This is a minimal, reversible change to reduce transient CI failures.