### PR TITLE
feat: add pagination and filters to scheduler tasks

### DIFF
--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -200,6 +200,9 @@ class ChannelBundle:
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         return await self.tasks.get_collection_tasks(limit)
 
+    async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        return await self.tasks.count_collection_tasks(status_filter)
+
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:
@@ -620,6 +623,9 @@ class SchedulerBundle:
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         return await self.tasks.get_collection_tasks(limit)
+
+    async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        return await self.tasks.count_collection_tasks(status_filter)
 
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -200,6 +200,11 @@ class ChannelBundle:
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         return await self.tasks.get_collection_tasks(limit)
 
+    async def get_collection_tasks_paginated(
+        self, limit: int = 20, offset: int = 0, status_filter: str | None = None
+    ) -> tuple[list[CollectionTask], int]:
+        return await self.tasks.get_collection_tasks_paginated(limit, offset, status_filter)
+
     async def get_active_collection_tasks_for_channel(
         self,
         channel_id: int,
@@ -615,6 +620,11 @@ class SchedulerBundle:
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         return await self.tasks.get_collection_tasks(limit)
+
+    async def get_collection_tasks_paginated(
+        self, limit: int = 20, offset: int = 0, status_filter: str | None = None
+    ) -> tuple[list[CollectionTask], int]:
+        return await self.tasks.get_collection_tasks_paginated(limit, offset, status_filter)
 
     async def get_recent_searches(self, limit: int = 20) -> list[dict]:
         return await self.search_log.get_recent_searches(limit)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -342,6 +342,12 @@ class Database:
         self._require()
         return await self._tasks.get_collection_tasks(limit)
 
+    async def get_collection_tasks_paginated(
+        self, limit: int = 20, offset: int = 0, status_filter: str | None = None
+    ) -> tuple[list[CollectionTask], int]:
+        self._require()
+        return await self._tasks.get_collection_tasks_paginated(limit, offset, status_filter)
+
     async def get_active_collection_tasks_for_channel(
         self,
         channel_id: int,

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -342,6 +342,10 @@ class Database:
         self._require()
         return await self._tasks.get_collection_tasks(limit)
 
+    async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        self._require()
+        return await self._tasks.count_collection_tasks(status_filter)
+
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -182,6 +182,47 @@ class CollectionTasksRepository:
         rows = await cur.fetchall()
         return [self._to_task(r) for r in rows]
 
+    async def get_collection_tasks_paginated(
+        self, limit: int = 20, offset: int = 0, status_filter: str | None = None
+    ) -> tuple[list[CollectionTask], int]:
+        """Get tasks with pagination and optional status filter.
+
+        Returns: (tasks, total_count)
+        """
+        # Base query
+        query = "SELECT * FROM collection_tasks"
+        params: list[Any] = []
+
+        # Add filter if needed
+        where_clause = ""
+        if status_filter and status_filter != "all":
+            if status_filter == "active":
+                where_clause = " WHERE status IN (?, ?)"
+                params = [CollectionTaskStatus.PENDING.value, CollectionTaskStatus.RUNNING.value]
+            elif status_filter == "completed":
+                where_clause = (
+                    " WHERE status IN (?, ?, ?)"
+                )
+                params = [
+                    CollectionTaskStatus.COMPLETED.value,
+                    CollectionTaskStatus.FAILED.value,
+                    CollectionTaskStatus.CANCELLED.value,
+                ]
+
+        # Get total count
+        count_query = f"SELECT COUNT(*) as cnt FROM collection_tasks{where_clause}"
+        cur = await self._db.execute(count_query, params)
+        count_row = await cur.fetchone()
+        total = count_row["cnt"] if count_row else 0
+
+        # Get paginated results
+        query += where_clause + " ORDER BY id DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        cur = await self._db.execute(query, params)
+        rows = await cur.fetchall()
+
+        return [self._to_task(r) for r in rows], total
+
     async def get_active_collection_tasks_for_channel(
         self,
         channel_id: int,

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -182,6 +182,31 @@ class CollectionTasksRepository:
         rows = await cur.fetchall()
         return [self._to_task(r) for r in rows]
 
+    @staticmethod
+    def _status_where(status_filter: str | None) -> tuple[str, list[Any]]:
+        """Build WHERE clause for status filter. Returns (clause, params)."""
+        if status_filter == "active":
+            return " WHERE status IN (?, ?)", [
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ]
+        if status_filter == "completed":
+            return " WHERE status IN (?, ?, ?)", [
+                CollectionTaskStatus.COMPLETED.value,
+                CollectionTaskStatus.FAILED.value,
+                CollectionTaskStatus.CANCELLED.value,
+            ]
+        return "", []
+
+    async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        """Count tasks matching the given status filter."""
+        where, params = self._status_where(status_filter)
+        cur = await self._db.execute(
+            f"SELECT COUNT(*) as cnt FROM collection_tasks{where}", params
+        )
+        row = await cur.fetchone()
+        return row["cnt"] if row else 0
+
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:
@@ -189,34 +214,17 @@ class CollectionTasksRepository:
 
         Returns: (tasks, total_count)
         """
-        # Base query
-        query = "SELECT * FROM collection_tasks"
-        params: list[Any] = []
-
-        # Add filter if needed
-        where_clause = ""
-        if status_filter and status_filter != "all":
-            if status_filter == "active":
-                where_clause = " WHERE status IN (?, ?)"
-                params = [CollectionTaskStatus.PENDING.value, CollectionTaskStatus.RUNNING.value]
-            elif status_filter == "completed":
-                where_clause = (
-                    " WHERE status IN (?, ?, ?)"
-                )
-                params = [
-                    CollectionTaskStatus.COMPLETED.value,
-                    CollectionTaskStatus.FAILED.value,
-                    CollectionTaskStatus.CANCELLED.value,
-                ]
+        where, params = self._status_where(status_filter)
 
         # Get total count
-        count_query = f"SELECT COUNT(*) as cnt FROM collection_tasks{where_clause}"
-        cur = await self._db.execute(count_query, params)
+        cur = await self._db.execute(
+            f"SELECT COUNT(*) as cnt FROM collection_tasks{where}", list(params)
+        )
         count_row = await cur.fetchone()
         total = count_row["cnt"] if count_row else 0
 
         # Get paginated results
-        query += where_clause + " ORDER BY id DESC LIMIT ? OFFSET ?"
+        query = f"SELECT * FROM collection_tasks{where} ORDER BY id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         cur = await self._db.execute(query, params)
         rows = await cur.fetchall()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -183,20 +183,20 @@ class CollectionTasksRepository:
         return [self._to_task(r) for r in rows]
 
     @staticmethod
-    def _status_where(status_filter: str | None) -> tuple[str, list[Any]]:
+    def _status_where(status_filter: str | None) -> tuple[str, tuple[Any, ...]]:
         """Build WHERE clause for status filter. Returns (clause, params)."""
         if status_filter == "active":
-            return " WHERE status IN (?, ?)", [
+            return " WHERE status IN (?, ?)", (
                 CollectionTaskStatus.PENDING.value,
                 CollectionTaskStatus.RUNNING.value,
-            ]
+            )
         if status_filter == "completed":
-            return " WHERE status IN (?, ?, ?)", [
+            return " WHERE status IN (?, ?, ?)", (
                 CollectionTaskStatus.COMPLETED.value,
                 CollectionTaskStatus.FAILED.value,
                 CollectionTaskStatus.CANCELLED.value,
-            ]
-        return "", []
+            )
+        return "", ()
 
     async def count_collection_tasks(self, status_filter: str | None = None) -> int:
         """Count tasks matching the given status filter."""
@@ -214,19 +214,18 @@ class CollectionTasksRepository:
 
         Returns: (tasks, total_count)
         """
-        where, params = self._status_where(status_filter)
+        where, base_params = self._status_where(status_filter)
 
         # Get total count
         cur = await self._db.execute(
-            f"SELECT COUNT(*) as cnt FROM collection_tasks{where}", list(params)
+            f"SELECT COUNT(*) as cnt FROM collection_tasks{where}", base_params
         )
         count_row = await cur.fetchone()
         total = count_row["cnt"] if count_row else 0
 
         # Get paginated results
         query = f"SELECT * FROM collection_tasks{where} ORDER BY id DESC LIMIT ? OFFSET ?"
-        params.extend([limit, offset])
-        cur = await self._db.execute(query, params)
+        cur = await self._db.execute(query, (*base_params, limit, offset))
         rows = await cur.fetchall()
 
         return [self._to_task(r) for r in rows], total

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.web import deps
@@ -14,13 +14,40 @@ async def cancel_task(request: Request, task_id: int):
 
 
 @router.get("/", response_class=HTMLResponse)
-async def scheduler_page(request: Request):
+async def scheduler_page(
+    request: Request,
+    page: int = Query(1),
+    status: str = Query("all"),
+    limit: int = Query(50),
+):
     sched = deps.get_scheduler(request)
     collector = deps.get_collector(request)
     db = deps.get_db(request)
     msg = request.query_params.get("msg")
-    tasks = await db.get_collection_tasks()
-    has_active_tasks = any(t.status in ("pending", "running") for t in tasks)
+
+    # Validation
+    page = max(1, page)
+    limit = max(10, min(limit, 100))  # 10-100 задач
+
+    # Get tasks with filter and pagination
+    offset = (page - 1) * limit
+    tasks, total_count = await db.get_collection_tasks_paginated(
+        limit=limit, offset=offset, status_filter=status
+    )
+
+    # Calculate pagination
+    total_pages = (total_count + limit - 1) // limit if total_count > 0 else 1
+    if page > total_pages:
+        page = max(1, total_pages)
+
+    # Count active tasks (for counter)
+    _, active_count = await db.get_collection_tasks_paginated(
+        limit=10000, status_filter="active"
+    )
+
+    # Check if there are any active tasks (for auto-refresh)
+    has_active_tasks = active_count > 0
+
     search_log = await db.get_recent_searches()
     return deps.get_templates(request).TemplateResponse(
         request,
@@ -37,6 +64,12 @@ async def scheduler_page(request: Request):
             "msg": msg,
             "tasks": tasks,
             "has_active_tasks": has_active_tasks,
+            "page": page,
+            "total_pages": total_pages,
+            "total_count": total_count,
+            "active_count": active_count,
+            "status_filter": status,
+            "limit": limit,
             "search_log": search_log,
         },
     )

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -13,6 +13,9 @@ async def cancel_task(request: Request, task_id: int):
     return RedirectResponse(url="/scheduler?msg=task_cancelled", status_code=303)
 
 
+VALID_STATUS_FILTERS = {"all", "active", "completed"}
+
+
 @router.get("/", response_class=HTMLResponse)
 async def scheduler_page(
     request: Request,
@@ -28,22 +31,27 @@ async def scheduler_page(
     # Validation
     page = max(1, page)
     limit = max(10, min(limit, 100))  # 10-100 задач
+    status_filter = status if status in VALID_STATUS_FILTERS else "all"
 
     # Get tasks with filter and pagination
     offset = (page - 1) * limit
-    tasks, total_count = await db.get_collection_tasks_paginated(
-        limit=limit, offset=offset, status_filter=status
+    tasks, filtered_count = await db.get_collection_tasks_paginated(
+        limit=limit, offset=offset, status_filter=status_filter
     )
 
-    # Calculate pagination
-    total_pages = (total_count + limit - 1) // limit if total_count > 0 else 1
+    # Calculate pagination; clamp page and re-fetch if needed
+    total_pages = max(1, (filtered_count + limit - 1) // limit)
     if page > total_pages:
-        page = max(1, total_pages)
+        page = total_pages
+        offset = (page - 1) * limit
+        tasks, filtered_count = await db.get_collection_tasks_paginated(
+            limit=limit, offset=offset, status_filter=status_filter
+        )
 
-    # Count active tasks (for counter)
-    _, active_count = await db.get_collection_tasks_paginated(
-        limit=10000, status_filter="active"
-    )
+    # Get counts for all tabs (cheap count-only queries)
+    all_count = await db.count_collection_tasks()
+    active_count = await db.count_collection_tasks("active")
+    completed_count = all_count - active_count
 
     # Check if there are any active tasks (for auto-refresh)
     has_active_tasks = active_count > 0
@@ -66,9 +74,10 @@ async def scheduler_page(
             "has_active_tasks": has_active_tasks,
             "page": page,
             "total_pages": total_pages,
-            "total_count": total_count,
+            "all_count": all_count,
             "active_count": active_count,
-            "status_filter": status,
+            "completed_count": completed_count,
+            "status_filter": status_filter,
             "limit": limit,
             "search_log": search_log,
         },

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -100,11 +100,28 @@
 </div>
 {% endif %}
 
-{% if tasks %}
+{% if total_count > 0 %}
 <div class="card mb-4">
     <div class="card-header fw-semibold">Задачи сбора</div>
     <div class="card-body p-0">
         <p class="px-3 pt-3"><small class="text-muted">Здесь отображаются и ручные задачи из кнопки «Загрузить все», и одиночные загрузки каналов.</small></p>
+
+        <!-- Filter tabs -->
+        <div class="px-3 pb-2">
+            <div class="btn-group" role="tablist">
+                <a href="/scheduler?status=all&page=1" class="btn btn-sm {% if status_filter == 'all' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    Все ({{ total_count }})
+                </a>
+                <a href="/scheduler?status=active&page=1" class="btn btn-sm {% if status_filter == 'active' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    Активные ({{ active_count }})
+                </a>
+                <a href="/scheduler?status=completed&page=1" class="btn btn-sm {% if status_filter == 'completed' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    Завершенные ({{ total_count - active_count }})
+                </a>
+            </div>
+        </div>
+
+        {% if tasks %}
         <!-- Desktop -->
         <div class="table-responsive d-none d-md-block">
         <table class="table table-striped table-sm mb-0">
@@ -205,6 +222,22 @@
             </div>
             {% endfor %}
         </div>
+
+        <!-- Pagination -->
+        {% if total_pages > 1 %}
+        <nav>
+            <ul class="pagination justify-content-center mb-0">
+                {% if page > 1 %}
+                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page - 1 }}">Назад</a></li>
+                {% endif %}
+                <li class="page-item disabled"><span class="page-link">Страница {{ page }} из {{ total_pages }}</span></li>
+                {% if page < total_pages %}
+                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page + 1 }}">Далее</a></li>
+                {% endif %}
+            </ul>
+        </nav>
+        {% endif %}
+        {% endif %}
     </div>
 </div>
 {% endif %}

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -100,7 +100,7 @@
 </div>
 {% endif %}
 
-{% if total_count > 0 %}
+{% if all_count > 0 %}
 <div class="card mb-4">
     <div class="card-header fw-semibold">Задачи сбора</div>
     <div class="card-body p-0">
@@ -109,14 +109,14 @@
         <!-- Filter tabs -->
         <div class="px-3 pb-2">
             <div class="btn-group" role="tablist">
-                <a href="/scheduler?status=all&page=1" class="btn btn-sm {% if status_filter == 'all' %}btn-primary{% else %}btn-outline-primary{% endif %}">
-                    Все ({{ total_count }})
+                <a href="/scheduler?status=all&page=1&limit={{ limit }}" class="btn btn-sm {% if status_filter == 'all' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    Все ({{ all_count }})
                 </a>
-                <a href="/scheduler?status=active&page=1" class="btn btn-sm {% if status_filter == 'active' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                <a href="/scheduler?status=active&page=1&limit={{ limit }}" class="btn btn-sm {% if status_filter == 'active' %}btn-primary{% else %}btn-outline-primary{% endif %}">
                     Активные ({{ active_count }})
                 </a>
-                <a href="/scheduler?status=completed&page=1" class="btn btn-sm {% if status_filter == 'completed' %}btn-primary{% else %}btn-outline-primary{% endif %}">
-                    Завершенные ({{ total_count - active_count }})
+                <a href="/scheduler?status=completed&page=1&limit={{ limit }}" class="btn btn-sm {% if status_filter == 'completed' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    Завершенные ({{ completed_count }})
                 </a>
             </div>
         </div>
@@ -228,15 +228,17 @@
         <nav>
             <ul class="pagination justify-content-center mb-0">
                 {% if page > 1 %}
-                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page - 1 }}">Назад</a></li>
+                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page - 1 }}&limit={{ limit }}">Назад</a></li>
                 {% endif %}
                 <li class="page-item disabled"><span class="page-link">Страница {{ page }} из {{ total_pages }}</span></li>
                 {% if page < total_pages %}
-                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page + 1 }}">Далее</a></li>
+                <li class="page-item"><a class="page-link" href="/scheduler?status={{ status_filter }}&page={{ page + 1 }}&limit={{ limit }}">Далее</a></li>
                 {% endif %}
             </ul>
         </nav>
         {% endif %}
+        {% else %}
+        <p class="text-muted text-center py-3">Нет задач с выбранным фильтром.</p>
         {% endif %}
     </div>
 </div>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1112,8 +1112,8 @@ async def test_scheduler_page(client):
 async def test_scheduler_filter_active(client):
     db = client._transport.app.state.db
     await db.create_collection_task(-100901, "Active Task")
-    await db.create_collection_task(-100902, "Done Task")
-    await db.update_collection_task(2, "completed", messages_collected=10)
+    done_id = await db.create_collection_task(-100902, "Done Task")
+    await db.update_collection_task(done_id, "completed", messages_collected=10)
 
     resp = await client.get("/scheduler/?status=active")
     assert resp.status_code == 200

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1109,6 +1109,49 @@ async def test_scheduler_page(client):
 
 
 @pytest.mark.asyncio
+async def test_scheduler_filter_active(client):
+    db = client._transport.app.state.db
+    await db.create_collection_task(-100901, "Active Task")
+    await db.create_collection_task(-100902, "Done Task")
+    await db.update_collection_task(2, "completed", messages_collected=10)
+
+    resp = await client.get("/scheduler/?status=active")
+    assert resp.status_code == 200
+    assert "Active Task" in resp.text
+
+    resp = await client.get("/scheduler/?status=completed")
+    assert resp.status_code == 200
+    assert "Done Task" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_filter_invalid_status(client):
+    resp = await client.get("/scheduler/?status=bogus")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_scheduler_pagination_out_of_range(client):
+    db = client._transport.app.state.db
+    await db.create_collection_task(-100950, "Some Task")
+
+    resp = await client.get("/scheduler/?page=999")
+    assert resp.status_code == 200
+    assert "Some Task" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_limit_preserved_in_links(client):
+    db = client._transport.app.state.db
+    for i in range(15):
+        await db.create_collection_task(-100800 - i, f"Task {i}")
+
+    resp = await client.get("/scheduler/?limit=10")
+    assert resp.status_code == 200
+    assert "limit=10" in resp.text
+
+
+@pytest.mark.asyncio
 async def test_search_with_query(client):
     resp = await client.get("/search?q=test&mode=local")
     assert resp.status_code == 200


### PR DESCRIPTION
## 💪 What

- **Adds pagination** to scheduler tasks page (50 tasks per page, configurable 10-100)
- **Adds status filters** with counters: All / Active / Completed
- **Improves UX** with filter tabs and Bootstrap pagination component
- **Preserves both views**: desktop table and mobile card layouts
- **Maintains backward compatibility**: old `get_collection_tasks()` method unchanged

## 🤔 Why

When there are 50+ collection tasks, the scheduler page becomes hard to navigate:
- No indication of total task count
- No way to focus on active tasks
- Page loads slower with large lists

This change makes it easier to:
- See how many tasks are running vs completed
- Focus on active collection tasks
- Navigate through large task lists

## 👀 Usage

Navigate to `/scheduler/` and use the filter tabs to switch views:

- **Все (100)** — Shows all tasks with pagination
- **Активные (5)** — Shows only pending/running tasks
- **Завершенные (95)** — Shows completed/failed/cancelled tasks

Pagination links preserve the current filter in the URL:
\`/scheduler/?status=active&page=2\`

## 👩‍🔬 How to validate

1. Open http://localhost:8000/scheduler/
2. Verify filter tabs are displayed with counters
3. Click on "Активные" tab — page should show only active tasks and update counter
4. If >50 total tasks exist, verify pagination appears at the bottom
5. Click pagination "Далее" button — counter and filter should remain applied
6. Click "Завершенные" tab — verify it shows completed tasks only
7. Test on mobile view (F12 resize) — verify cards display correctly with pagination

## 🔗 Related links

- #43 (fix/agent-history-embedding) — Previous UI improvements to scheduler