### PR TITLE
feat: inline len<N / len>N filters in search query

### DIFF
--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -216,7 +216,7 @@ class MessagesRepository:
             params.append(sq.max_length)
         for pat in sq.exclude_patterns_list:
             conditions.append("m.text NOT LIKE ?")
-            params.append(f"%{pat}%")
+            params.append(f"%{pat.rstrip('*')}%")
         return conditions, params
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -215,8 +215,11 @@ class MessagesRepository:
             conditions.append("LENGTH(m.text) < ?")
             params.append(sq.max_length)
         for pat in sq.exclude_patterns_list:
+            stripped = pat.rstrip("*")
+            if not stripped:
+                continue
             conditions.append("m.text NOT LIKE ?")
-            params.append(f"%{pat.rstrip('*')}%")
+            params.append(f"%{stripped}%")
         return conditions, params
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -133,10 +133,10 @@ class MessagesRepository:
             params.append(normalized_date_to)
 
         if min_length is not None:
-            conditions.append("LENGTH(m.text) >= ?")
+            conditions.append("LENGTH(m.text) > ?")
             params.append(min_length)
         if max_length is not None:
-            conditions.append("LENGTH(m.text) <= ?")
+            conditions.append("LENGTH(m.text) < ?")
             params.append(max_length)
 
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
@@ -212,7 +212,7 @@ class MessagesRepository:
         conditions: list[str] = []
         params: list = []
         if sq.max_length is not None:
-            conditions.append("LENGTH(m.text) <= ?")
+            conditions.append("LENGTH(m.text) < ?")
             params.append(sq.max_length)
         for pat in sq.exclude_patterns_list:
             conditions.append("m.text NOT LIKE ?")

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -24,7 +24,7 @@ def _extract_length(q: str) -> tuple[str, int | None, int | None]:
             max_length = val
         else:
             min_length = val
-    cleaned = _LEN_RE.sub("", q).strip()
+    cleaned = re.sub(r"\s+", " ", _LEN_RE.sub("", q)).strip()
     return cleaned, min_length, max_length
 
 

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -64,10 +64,9 @@ async def _render_search_page(
         except ValueError:
             channel_id_error = f"Некорректный ID канала: {channel_id}"
 
-    if mode == "local":
-        fts_query, min_length, max_length = _extract_length(q)
-    else:
-        fts_query, min_length, max_length = q, None, None
+    fts_query, min_length, max_length = _extract_length(q)
+    if mode != "local":
+        min_length, max_length = None, None
 
     service = deps.search_service(request)
     channels = await db.get_channels()

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -11,7 +11,7 @@ from src.web.template_globals import _agent_available_for_request
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-_LEN_RE = re.compile(r"\blen\s*(<|>)\s*(\d+)")
+_LEN_RE = re.compile(r"\blen\s*(<|>)\s*(\d+)[,;]?")
 
 
 def _extract_length(q: str) -> tuple[str, int | None, int | None]:
@@ -64,7 +64,10 @@ async def _render_search_page(
         except ValueError:
             channel_id_error = f"Некорректный ID канала: {channel_id}"
 
-    fts_query, min_length, max_length = _extract_length(q)
+    if mode == "local":
+        fts_query, min_length, max_length = _extract_length(q)
+    else:
+        fts_query, min_length, max_length = q, None, None
 
     service = deps.search_service(request)
     channels = await db.get_channels()

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -9,6 +10,22 @@ from src.web.template_globals import _agent_available_for_request
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+_LEN_RE = re.compile(r"\blen\s*(<|>)\s*(\d+)")
+
+
+def _extract_length(q: str) -> tuple[str, int | None, int | None]:
+    """Extract ``len<N`` / ``len>N`` tokens from *q*, return cleaned query."""
+    min_length: int | None = None
+    max_length: int | None = None
+    for m in _LEN_RE.finditer(q):
+        op, val = m.group(1), int(m.group(2))
+        if op == "<":
+            max_length = val
+        else:
+            min_length = val
+    cleaned = _LEN_RE.sub("", q).strip()
+    return cleaned, min_length, max_length
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -26,8 +43,6 @@ async def _render_search_page(
     date_to: str = "",
     mode: str = "local",
     is_fts: bool = False,
-    msg_length_op: str = "",
-    msg_length_val: int | None = None,
     page: int = 1,
 ) -> HTMLResponse | RedirectResponse:
     # Onboarding: redirect if no accounts configured
@@ -49,8 +64,7 @@ async def _render_search_page(
         except ValueError:
             channel_id_error = f"Некорректный ID канала: {channel_id}"
 
-    min_length = msg_length_val if msg_length_op == "gt" and msg_length_val is not None else None
-    max_length = msg_length_val if msg_length_op == "lt" and msg_length_val is not None else None
+    fts_query, min_length, max_length = _extract_length(q)
 
     service = deps.search_service(request)
     channels = await db.get_channels()
@@ -62,7 +76,7 @@ async def _render_search_page(
             try:
                 result = await service.search(
                     mode=mode,
-                    query=q,
+                    query=fts_query,
                     limit=limit,
                     channel_id=channel_id_int,
                     date_from=date_from or None,
@@ -104,8 +118,6 @@ async def _render_search_page(
             "date_to": date_to,
             "mode": mode,
             "is_fts": is_fts,
-            "msg_length_op": msg_length_op,
-            "msg_length_val": msg_length_val,
             "page": page,
             "total_pages": total_pages,
             "ai_enabled": ai_enabled,
@@ -122,8 +134,6 @@ async def search_page(
     date_to: str = Query(""),
     mode: str = Query("local"),
     is_fts: bool = Query(False),
-    msg_length_op: str = Query(""),
-    msg_length_val: str = Query(""),
     page: int = Query(1),
 ):
     return await _render_search_page(
@@ -134,7 +144,5 @@ async def search_page(
         date_to=date_to,
         mode=mode,
         is_fts=is_fts,
-        msg_length_op=msg_length_op,
-        msg_length_val=int(msg_length_val) if msg_length_val else None,
         page=page,
     )

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -29,18 +29,6 @@
             <label for="date-to" class="form-label">Дата до</label>
             <input type="date" class="form-control" name="date_to" id="date-to" value="{{ date_to }}">
         </div>
-        <div class="col-12 col-sm-6 col-md-3">
-            <label class="form-label">Длина сообщения</label>
-            <div class="input-group">
-                <select name="msg_length_op" id="msg-length-op" class="form-select" style="max-width: 5rem;">
-                    <option value="">Выкл</option>
-                    <option value="gt" {{ 'selected' if msg_length_op == 'gt' else '' }}>&gt;</option>
-                    <option value="lt" {{ 'selected' if msg_length_op == 'lt' else '' }}>&lt;</option>
-                </select>
-                <input type="number" class="form-control" name="msg_length_val" id="msg-length-val"
-                       min="1" placeholder="символов" value="{{ msg_length_val or '' }}">
-            </div>
-        </div>
     </div>
 
     <div class="d-flex align-items-center gap-3 flex-wrap mb-3">
@@ -73,7 +61,7 @@
         {% endif %}
         <div class="form-check form-check-inline" id="fts-label" title="Полнотекстовый поиск FTS5 (поддерживает операторы AND, OR, NOT, фразы в кавычках)">
             <input class="form-check-input" type="checkbox" name="is_fts" value="1" id="fts-checkbox" {{ 'checked' if is_fts else '' }}>
-            <label class="form-check-label" for="fts-checkbox">FTS5 <span class="hint" data-tooltip="Полнотекстовый поиск с поддержкой операторов: OR, AND, NOT, префикс*, «точная фраза»">?</span></label>
+            <label class="form-check-label" for="fts-checkbox">FTS5 <span class="hint" data-tooltip="Полнотекстовый поиск с поддержкой операторов: OR, AND, NOT, префикс*, «точная фраза», len&lt;400, len&gt;100">?</span></label>
         </div>
         <button type="submit" class="btn btn-primary ms-auto">Найти</button>
     </div>
@@ -148,11 +136,11 @@
 <nav>
     <ul class="pagination justify-content-center">
         {% if page > 1 %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&msg_length_op={{ msg_length_op }}{% if msg_length_val %}&msg_length_val={{ msg_length_val }}{% endif %}&page={{ page - 1 }}">Назад</a></li>
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&page={{ page - 1 }}">Назад</a></li>
         {% endif %}
         <li class="page-item disabled"><span class="page-link">Страница {{ page }} из {{ total_pages }}</span></li>
         {% if page < total_pages %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&msg_length_op={{ msg_length_op }}{% if msg_length_val %}&msg_length_val={{ msg_length_val }}{% endif %}&page={{ page + 1 }}">Далее</a></li>
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&page={{ page + 1 }}">Далее</a></li>
         {% endif %}
     </ul>
 </nav>
@@ -172,8 +160,6 @@
     var dateTo = document.getElementById('date-to');
     var ftsLabel = document.getElementById('fts-label');
     var ftsCheckbox = document.getElementById('fts-checkbox');
-    var msgLengthOp = document.getElementById('msg-length-op');
-    var msgLengthVal = document.getElementById('msg-length-val');
 
     function updateState() {
         var mode = document.querySelector('input[name="mode"]:checked').value;
@@ -183,8 +169,6 @@
         dateTo.disabled = !isLocal;
         ftsLabel.style.display = isLocal ? '' : 'none';
         ftsCheckbox.disabled = !isLocal;
-        msgLengthOp.disabled = !isLocal;
-        msgLengthVal.disabled = !isLocal;
     }
 
     radios.forEach(function(r) {

--- a/src/web/templates/search_queries.html
+++ b/src/web/templates/search_queries.html
@@ -85,7 +85,7 @@
                 {% if sq.is_regex %}
                 <span class="btn btn-outline-secondary btn-sm emoji-btn opacity-50" style="cursor:default" title="Regex-запросы нельзя открыть в поиске">&#128269;</span>
                 {% else %}
-                <a href="/search?q={{ sq.query|urlencode }}{% if sq.is_fts %}&is_fts=1{% endif %}{% if sq.max_length %}&msg_length_op=lt&msg_length_val={{ sq.max_length }}{% endif %}"
+                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">&#128269;</a>
                 {% endif %}
                 <button type="button" class="btn btn-outline-secondary btn-sm emoji-btn" title="Редактировать" onclick="toggleEdit({{ sq.id }})">&#9999;&#65039;</button>
@@ -208,7 +208,7 @@
             </small>
             <div class="card-actions">
                 {% if not sq.is_regex %}
-                <a href="/search?q={{ sq.query|urlencode }}{% if sq.is_fts %}&is_fts=1{% endif %}{% if sq.max_length %}&msg_length_op=lt&msg_length_val={{ sq.max_length }}{% endif %}"
+                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">&#128269;</a>
                 {% endif %}
                 <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline">

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.models import Message
 from src.search.engine import SearchEngine
+from src.web.routes.search import _extract_length
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
 
 
@@ -399,3 +400,26 @@ async def test_search_in_channel_runtime_error_returns_search_result(
 
     assert result.total == 0
     assert "channel search failure" in result.error
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("crypto len<400", ("crypto", None, 400)),
+        ("crypto len>100 len<400", ("crypto", 100, 400)),
+        ("len>100", ("", 100, None)),
+        ("crypto", ("crypto", None, None)),
+        ("", ("", None, None)),
+        ("lenovo", ("lenovo", None, None)),
+    ],
+    ids=[
+        "max_only",
+        "range",
+        "min_only",
+        "no_len",
+        "empty",
+        "lenovo_no_match",
+    ],
+)
+def test_extract_length(query, expected):
+    assert _extract_length(query) == expected


### PR DESCRIPTION
## 💪 What

- Replaces separate UI controls (select + input) for message length filtering with inline `len<N` / `len>N` syntax parsed directly from the search query
- Removes `msg_length_op` and `msg_length_val` query parameters and template variables
- Simplifies operators to strict `<` and `>` (drops `<=` / `>=`)
- Fixes exclude pattern wildcard stripping (`rstrip('*')`) in SQL LIKE conditions
- Adds FTS5 tooltip hint showing `len<400, len>100` syntax
- Adds 6 parametrized tests for `_extract_length` (range, single bound, edge cases, "lenovo" false-positive guard)

## 🤔 Why

- Inline syntax is faster to type than switching between dropdown + input field
- Fewer query params simplify pagination URLs and reduce template complexity
- `<=` / `>=` added no practical value over `<` / `>` for message length filtering

## 👀 Usage

Type length constraints directly in the search box:

```
crypto len<400          # messages shorter than 400 chars
crypto len>100 len<400  # messages between 100 and 400 chars
len>100                 # all messages longer than 100 chars
```

## 👩‍🔬 How to validate

1. Open `/search`, type `crypto len<400` — verify results contain only short messages
2. Type `crypto len>100 len<400` — verify both bounds applied
3. Type `lenovo` — verify no length filter is triggered (word boundary check)
4. Check that the old "Длина сообщения" dropdown is gone from the UI
5. Hover FTS5 `?` hint — should show `len<400, len>100` in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)