### PR TITLE
fix: duplicate identifiers cause incorrect error reporting in bulk import

### DIFF
--- a/src/web/routes/import_channels.py
+++ b/src/web/routes/import_channels.py
@@ -54,7 +54,7 @@ async def import_channels(
     failed = 0
 
     no_client = False
-    for ident in identifiers:
+    for i, ident in enumerate(identifiers):
         try:
             info = await pool.resolve_channel(ident.strip())
         except RuntimeError as exc:
@@ -64,7 +64,7 @@ async def import_channels(
                     ident,
                 )
                 no_client = True
-                for remaining in identifiers[identifiers.index(ident):]:
+                for remaining in identifiers[i:]:
                     details.append({
                         "identifier": remaining,
                         "status": "failed",


### PR DESCRIPTION
## Summary
- Fix bug where `list.index()` returns the first occurrence of a duplicate identifier, causing the `no_client` error handler to jump back and create duplicate error entries
- Replace with `enumerate` index for correct slicing of remaining identifiers

## Test plan
- [x] All 846 existing tests pass (735 parallel + 111 serial)
- [x] ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)