### PR TITLE
fix: wire SearchQuery.name field to DB column

### DIFF
--- a/src/database/repositories/search_queries.py
+++ b/src/database/repositories/search_queries.py
@@ -18,7 +18,7 @@ class SearchQueriesRepository:
             "track_stats, interval_minutes, exclude_patterns, max_length) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                sq.query,
+                sq.name,
                 sq.query,
                 int(sq.is_regex),
                 int(sq.is_fts),
@@ -60,7 +60,7 @@ class SearchQueriesRepository:
             "exclude_patterns = ?, max_length = ? "
             "WHERE id = ?",
             (
-                sq.query,
+                sq.name,
                 sq.query,
                 int(sq.is_regex),
                 int(sq.is_fts),
@@ -157,6 +157,7 @@ class SearchQueriesRepository:
     def _row_to_model(row) -> SearchQuery:
         return SearchQuery(
             id=row["id"],
+            name=row["name"],
             query=row["query"],
             is_regex=bool(row["is_regex"]),
             is_fts=bool(row["is_fts"]) if row["is_fts"] is not None else False,

--- a/src/models.py
+++ b/src/models.py
@@ -118,6 +118,7 @@ class NotificationBot(BaseModel):
 
 class SearchQuery(BaseModel):
     id: int | None = None
+    name: str = ""
     query: str
     is_regex: bool = False
     is_fts: bool = False
@@ -133,6 +134,12 @@ class SearchQuery(BaseModel):
     def check_mode_exclusive(self) -> "SearchQuery":
         if self.is_regex and self.is_fts:
             raise ValueError("is_regex and is_fts are mutually exclusive")
+        return self
+
+    @model_validator(mode="after")
+    def default_name_to_query(self) -> "SearchQuery":
+        if not self.name:
+            self.name = self.query
         return self
 
     @property


### PR DESCRIPTION
## Summary
- **Fixed copy-paste bug** in `SearchQueriesRepository.add()` and `update()` where the `name` DB column was always set to `sq.query` instead of a proper `name` value
- **Added `name` field** to `SearchQuery` model with a validator that defaults it to `query` when empty, preserving backward compatibility
- **Updated `_row_to_model`** to read the `name` column back from DB rows

## Test plan
- [x] All 735 parallel tests pass
- [x] All 111 serial tests pass
- [x] Ruff lint clean
- [x] Existing tests that already pass `name=` to SearchQuery() (e.g. `test_scheduler_manager.py`) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)