### PR TITLE
Add test coverage for agent tools, CLI, notifier and web auth

### DIFF
--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,12 +1,13 @@
 """Tests for src/agent/tools.py - MCP tools for Agent.
 
-These tests verify the tool logic without using the decorator infrastructure,
-which requires complex SDK setup. Instead, we test the underlying DB calls.
+These tests call the actual tool handler functions via the @tool decorator's
+.handler attribute, ensuring argument parsing, formatting, and error handling
+are all exercised.
 """
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -19,265 +20,223 @@ def mock_db():
     return MagicMock(spec=Database)
 
 
-class TestSearchMessagesLogic:
-    """Tests for search_messages tool logic (DB interaction)."""
+def _get_tool_handlers(mock_db):
+    """Build MCP tools and return their handlers keyed by name."""
+    captured_tools = []
+
+    with patch(
+        "src.agent.tools.create_sdk_mcp_server",
+        side_effect=lambda **kwargs: captured_tools.extend(kwargs.get("tools", [])),
+    ):
+        from src.agent.tools import make_mcp_server
+
+        make_mcp_server(mock_db)
+
+    return {t.name: t.handler for t in captured_tools}
+
+
+def _text(result: dict) -> str:
+    """Extract text from tool result payload."""
+    return result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# search_messages tool
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMessagesTool:
+    """Tests for the search_messages tool handler."""
 
     @pytest.mark.asyncio
-    async def test_search_messages_empty_result(self, mock_db):
-        """Test search_messages when no results found."""
+    async def test_empty_result(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
+        handlers = _get_tool_handlers(mock_db)
 
-        messages, total = await mock_db.search_messages(query="nonexistent", limit=20)
+        result = await handlers["search_messages"]({"query": "nonexistent", "limit": 20})
 
-        assert messages == []
-        assert total == 0
+        assert result["content"][0]["type"] == "text"
+        assert "Ничего не найдено" in _text(result)
+        assert "nonexistent" in _text(result)
         mock_db.search_messages.assert_awaited_once_with(query="nonexistent", limit=20)
 
     @pytest.mark.asyncio
-    async def test_search_messages_with_results(self, mock_db):
-        """Test search_messages with results found."""
+    async def test_with_results(self, mock_db):
         mock_messages = [
             SimpleNamespace(
-                channel_id=100,
-                message_id=1,
-                text="Test message one with important content",
-                date="2025-01-01",
+                channel_id=100, message_id=1,
+                text="Test message one", date="2025-01-01",
             ),
             SimpleNamespace(
-                channel_id=200,
-                message_id=2,
-                text="Another test message",
-                date="2025-01-02",
+                channel_id=200, message_id=2,
+                text="Another test message", date="2025-01-02",
             ),
         ]
         mock_db.search_messages = AsyncMock(return_value=(mock_messages, 2))
+        handlers = _get_tool_handlers(mock_db)
 
-        messages, total = await mock_db.search_messages(query="test", limit=10)
+        result = await handlers["search_messages"]({"query": "test", "limit": 10})
 
-        assert len(messages) == 2
-        assert total == 2
-        assert messages[0].channel_id == 100
-        assert messages[1].channel_id == 200
+        text = _text(result)
+        assert "Найдено 2 сообщений" in text
+        assert "channel_id=100" in text
+        assert "channel_id=200" in text
+        mock_db.search_messages.assert_awaited_once_with(query="test", limit=10)
 
     @pytest.mark.asyncio
-    async def test_search_messages_truncates_in_formatter(self, mock_db):
-        """Test that long text can be truncated to 300 chars in formatter."""
+    async def test_text_truncation(self, mock_db):
+        """Tool truncates message text to 300 chars."""
         long_text = "x" * 500
         mock_messages = [
-            SimpleNamespace(
-                channel_id=100,
-                message_id=1,
-                text=long_text,
-                date="2025-01-01",
-            ),
+            SimpleNamespace(channel_id=100, message_id=1, text=long_text, date="2025-01-01"),
         ]
         mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        handlers = _get_tool_handlers(mock_db)
 
-        messages, total = await mock_db.search_messages(query="x", limit=20)
+        result = await handlers["search_messages"]({"query": "x", "limit": 20})
 
-        # Full text is returned from DB, truncation happens in tool formatter
-        assert len(messages[0].text) == 500
-        # The tool logic would truncate: (m.text or "")[:300]
-        truncated = (messages[0].text or "")[:300]
-        assert len(truncated) == 300
+        text = _text(result)
+        # Preview is capped at 300 chars
+        assert "x" * 300 in text
+        assert "x" * 301 not in text
 
     @pytest.mark.asyncio
-    async def test_search_messages_with_none_text(self, mock_db):
-        """Test search_messages handles messages with None text."""
+    async def test_none_text_handled(self, mock_db):
+        """Tool handles messages with None text without crashing."""
         mock_messages = [
-            SimpleNamespace(
-                channel_id=100,
-                message_id=1,
-                text=None,
-                date="2025-01-01",
-            ),
+            SimpleNamespace(channel_id=100, message_id=1, text=None, date="2025-01-01"),
         ]
         mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        handlers = _get_tool_handlers(mock_db)
 
-        messages, total = await mock_db.search_messages(query="test", limit=20)
+        result = await handlers["search_messages"]({"query": "test", "limit": 20})
 
-        # Should not crash on None text
-        assert len(messages) == 1
-        # The tool logic handles None: (m.text or "")[:300]
-        safe_text = (messages[0].text or "")[:300]
-        assert safe_text == ""
+        text = _text(result)
+        assert "channel_id=100" in text
 
     @pytest.mark.asyncio
-    async def test_search_messages_default_limit(self, mock_db):
-        """Test search_messages uses default limit of 20."""
+    async def test_default_limit(self, mock_db):
+        """Tool applies default limit=20 when not provided."""
         mock_db.search_messages = AsyncMock(return_value=([], 0))
+        handlers = _get_tool_handlers(mock_db)
 
-        await mock_db.search_messages(query="test")
+        await handlers["search_messages"]({"query": "test"})
 
-        # Verify default limit behavior
-        mock_db.search_messages.assert_awaited_once_with(query="test")
+        mock_db.search_messages.assert_awaited_once_with(query="test", limit=20)
 
     @pytest.mark.asyncio
-    async def test_search_messages_custom_limit(self, mock_db):
-        """Test search_messages with custom limit."""
+    async def test_custom_limit(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
+        handlers = _get_tool_handlers(mock_db)
 
-        await mock_db.search_messages(query="test", limit=50)
+        await handlers["search_messages"]({"query": "test", "limit": 50})
 
         mock_db.search_messages.assert_awaited_once_with(query="test", limit=50)
 
     @pytest.mark.asyncio
-    async def test_search_messages_error_handling(self, mock_db):
-        """Test search_messages handles database errors."""
+    async def test_error_returns_text_not_exception(self, mock_db):
+        """Tool catches DB errors and returns error text (no exception raised)."""
         mock_db.search_messages = AsyncMock(side_effect=Exception("DB connection error"))
+        handlers = _get_tool_handlers(mock_db)
 
-        with pytest.raises(Exception, match="DB connection error"):
-            await mock_db.search_messages(query="test", limit=20)
+        result = await handlers["search_messages"]({"query": "test", "limit": 20})
+
+        text = _text(result)
+        assert "Ошибка поиска сообщений" in text
+        assert "DB connection error" in text
 
 
-class TestGetChannelsLogic:
-    """Tests for get_channels tool logic (DB interaction)."""
+# ---------------------------------------------------------------------------
+# get_channels tool
+# ---------------------------------------------------------------------------
+
+
+class TestGetChannelsTool:
+    """Tests for the get_channels tool handler."""
 
     @pytest.mark.asyncio
-    async def test_get_channels_empty(self, mock_db):
-        """Test get_channels when no channels exist."""
+    async def test_empty(self, mock_db):
         mock_db.get_channels = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
 
-        channels = await mock_db.get_channels()
+        result = await handlers["get_channels"]({})
 
-        assert channels == []
-        mock_db.get_channels.assert_awaited_once()
+        assert "Каналы не найдены" in _text(result)
 
     @pytest.mark.asyncio
-    async def test_get_channels_with_channels(self, mock_db):
-        """Test get_channels with multiple channels."""
+    async def test_with_channels(self, mock_db):
         mock_channels = [
             SimpleNamespace(
-                channel_id=100,
-                title="Active Channel",
-                username="active_ch",
-                is_active=True,
-                is_filtered=False,
+                channel_id=100, title="Active Channel",
+                username="active_ch", is_active=True, is_filtered=False,
             ),
             SimpleNamespace(
-                channel_id=200,
-                title="Inactive Channel",
-                username="inactive_ch",
-                is_active=False,
-                is_filtered=True,
-            ),
-            SimpleNamespace(
-                channel_id=300,
-                title="Filtered Active",
-                username="filtered_ch",
-                is_active=True,
-                is_filtered=True,
+                channel_id=200, title="Inactive Channel",
+                username="inactive_ch", is_active=False, is_filtered=True,
             ),
         ]
         mock_db.get_channels = AsyncMock(return_value=mock_channels)
+        handlers = _get_tool_handlers(mock_db)
 
-        channels = await mock_db.get_channels()
+        result = await handlers["get_channels"]({})
 
-        assert len(channels) == 3
-        assert channels[0].title == "Active Channel"
-        assert channels[1].is_active is False
-        assert channels[2].is_filtered is True
+        text = _text(result)
+        assert "Доступные каналы (2)" in text
+        assert "@active_ch" in text
+        assert "активен" in text
+        assert "неактивен" in text
+        assert "[отфильтрован]" in text
 
     @pytest.mark.asyncio
-    async def test_get_channels_with_no_username(self, mock_db):
-        """Test get_channels handles channels without username."""
+    async def test_none_username(self, mock_db):
+        """Channel with username=None renders @None (known pre-existing issue)."""
         mock_channels = [
             SimpleNamespace(
-                channel_id=100,
-                title="Private Channel",
-                username=None,
-                is_active=True,
-                is_filtered=False,
+                channel_id=100, title="Private Channel",
+                username=None, is_active=True, is_filtered=False,
             ),
         ]
         mock_db.get_channels = AsyncMock(return_value=mock_channels)
+        handlers = _get_tool_handlers(mock_db)
 
-        channels = await mock_db.get_channels()
+        result = await handlers["get_channels"]({})
 
-        assert len(channels) == 1
-        assert channels[0].username is None
+        text = _text(result)
+        assert "Private Channel" in text
+        # Known issue: renders @None for channels without username
+        assert "@None" in text
 
     @pytest.mark.asyncio
-    async def test_get_channels_error_handling(self, mock_db):
-        """Test get_channels handles database errors."""
+    async def test_error_returns_text_not_exception(self, mock_db):
+        """Tool catches DB errors and returns error text."""
         mock_db.get_channels = AsyncMock(side_effect=Exception("DB query failed"))
+        handlers = _get_tool_handlers(mock_db)
 
-        with pytest.raises(Exception, match="DB query failed"):
-            await mock_db.get_channels()
+        result = await handlers["get_channels"]({})
+
+        text = _text(result)
+        assert "Ошибка получения каналов" in text
+        assert "DB query failed" in text
+
+
+# ---------------------------------------------------------------------------
+# make_mcp_server factory
+# ---------------------------------------------------------------------------
 
 
 class TestMakeMcpServer:
     """Tests for make_mcp_server factory function."""
 
-    def test_creates_server_returns_object(self, mock_db):
-        """Test that make_mcp_server returns a server config object."""
+    def test_creates_server_returns_dict(self, mock_db):
         from src.agent.tools import make_mcp_server
 
         server = make_mcp_server(mock_db)
-        # create_sdk_mcp_server returns some kind of config object
         assert server is not None
+        assert isinstance(server, dict)
+        assert server["name"] == "telegram_db"
 
-    def test_server_is_callable_with_db(self, mock_db):
-        """Test that make_mcp_server can be called with db parameter."""
+    def test_server_has_instance(self, mock_db):
         from src.agent.tools import make_mcp_server
 
-        # Should not raise
         server = make_mcp_server(mock_db)
-        assert server is not None
-
-
-class TestToolMessageFormatting:
-    """Tests for message formatting logic in tools."""
-
-    def test_format_empty_results(self):
-        """Test formatting when no messages found."""
-        query = "nonexistent"
-        messages = []
-        total = 0
-
-        if not messages:
-            text = f"Ничего не найдено по запросу: {query!r}"
-        else:
-            text = f"Found {total}"
-
-        assert "Ничего не найдено" in text
-        assert "nonexistent" in text
-
-    def test_format_with_results(self):
-        """Test formatting when messages are found."""
-        messages = [
-            SimpleNamespace(channel_id=100, text="test", date="2025-01-01"),
-        ]
-        total = 1
-
-        lines = [f"Найдено {total} сообщений для 'test'. Показаны первые {len(messages)}:"]
-        for m in messages:
-            preview = (m.text or "")[:300]
-            lines.append(f"- [channel_id={m.channel_id}, date={m.date}]: {preview}")
-        text = "\n".join(lines)
-
-        assert "Найдено 1 сообщений" in text
-        assert "channel_id=100" in text
-
-    def test_format_channels_list(self):
-        """Test formatting channel list."""
-        channels = [
-            SimpleNamespace(
-                title="Test",
-                username="test_ch",
-                channel_id=100,
-                is_active=True,
-                is_filtered=False,
-            ),
-        ]
-
-        lines = [f"Доступные каналы ({len(channels)}):"]
-        for ch in channels:
-            status = "активен" if ch.is_active else "неактивен"
-            filtered = " [отфильтрован]" if ch.is_filtered else ""
-            lines.append(f"- {ch.title} (@{ch.username}, id={ch.channel_id}, {status}{filtered})")
-        text = "\n".join(lines)
-
-        assert "Доступные каналы (1)" in text
-        assert "@test_ch" in text
-        assert "активен" in text
+        assert "instance" in server

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,283 @@
+"""Tests for src/agent/tools.py - MCP tools for Agent.
+
+These tests verify the tool logic without using the decorator infrastructure,
+which requires complex SDK setup. Instead, we test the underlying DB calls.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.database import Database
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock Database for testing tools."""
+    return MagicMock(spec=Database)
+
+
+class TestSearchMessagesLogic:
+    """Tests for search_messages tool logic (DB interaction)."""
+
+    @pytest.mark.asyncio
+    async def test_search_messages_empty_result(self, mock_db):
+        """Test search_messages when no results found."""
+        mock_db.search_messages = AsyncMock(return_value=([], 0))
+
+        messages, total = await mock_db.search_messages(query="nonexistent", limit=20)
+
+        assert messages == []
+        assert total == 0
+        mock_db.search_messages.assert_awaited_once_with(query="nonexistent", limit=20)
+
+    @pytest.mark.asyncio
+    async def test_search_messages_with_results(self, mock_db):
+        """Test search_messages with results found."""
+        mock_messages = [
+            SimpleNamespace(
+                channel_id=100,
+                message_id=1,
+                text="Test message one with important content",
+                date="2025-01-01",
+            ),
+            SimpleNamespace(
+                channel_id=200,
+                message_id=2,
+                text="Another test message",
+                date="2025-01-02",
+            ),
+        ]
+        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 2))
+
+        messages, total = await mock_db.search_messages(query="test", limit=10)
+
+        assert len(messages) == 2
+        assert total == 2
+        assert messages[0].channel_id == 100
+        assert messages[1].channel_id == 200
+
+    @pytest.mark.asyncio
+    async def test_search_messages_truncates_in_formatter(self, mock_db):
+        """Test that long text can be truncated to 300 chars in formatter."""
+        long_text = "x" * 500
+        mock_messages = [
+            SimpleNamespace(
+                channel_id=100,
+                message_id=1,
+                text=long_text,
+                date="2025-01-01",
+            ),
+        ]
+        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+
+        messages, total = await mock_db.search_messages(query="x", limit=20)
+
+        # Full text is returned from DB, truncation happens in tool formatter
+        assert len(messages[0].text) == 500
+        # The tool logic would truncate: (m.text or "")[:300]
+        truncated = (messages[0].text or "")[:300]
+        assert len(truncated) == 300
+
+    @pytest.mark.asyncio
+    async def test_search_messages_with_none_text(self, mock_db):
+        """Test search_messages handles messages with None text."""
+        mock_messages = [
+            SimpleNamespace(
+                channel_id=100,
+                message_id=1,
+                text=None,
+                date="2025-01-01",
+            ),
+        ]
+        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+
+        messages, total = await mock_db.search_messages(query="test", limit=20)
+
+        # Should not crash on None text
+        assert len(messages) == 1
+        # The tool logic handles None: (m.text or "")[:300]
+        safe_text = (messages[0].text or "")[:300]
+        assert safe_text == ""
+
+    @pytest.mark.asyncio
+    async def test_search_messages_default_limit(self, mock_db):
+        """Test search_messages uses default limit of 20."""
+        mock_db.search_messages = AsyncMock(return_value=([], 0))
+
+        await mock_db.search_messages(query="test")
+
+        # Verify default limit behavior
+        mock_db.search_messages.assert_awaited_once_with(query="test")
+
+    @pytest.mark.asyncio
+    async def test_search_messages_custom_limit(self, mock_db):
+        """Test search_messages with custom limit."""
+        mock_db.search_messages = AsyncMock(return_value=([], 0))
+
+        await mock_db.search_messages(query="test", limit=50)
+
+        mock_db.search_messages.assert_awaited_once_with(query="test", limit=50)
+
+    @pytest.mark.asyncio
+    async def test_search_messages_error_handling(self, mock_db):
+        """Test search_messages handles database errors."""
+        mock_db.search_messages = AsyncMock(side_effect=Exception("DB connection error"))
+
+        with pytest.raises(Exception, match="DB connection error"):
+            await mock_db.search_messages(query="test", limit=20)
+
+
+class TestGetChannelsLogic:
+    """Tests for get_channels tool logic (DB interaction)."""
+
+    @pytest.mark.asyncio
+    async def test_get_channels_empty(self, mock_db):
+        """Test get_channels when no channels exist."""
+        mock_db.get_channels = AsyncMock(return_value=[])
+
+        channels = await mock_db.get_channels()
+
+        assert channels == []
+        mock_db.get_channels.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_channels_with_channels(self, mock_db):
+        """Test get_channels with multiple channels."""
+        mock_channels = [
+            SimpleNamespace(
+                channel_id=100,
+                title="Active Channel",
+                username="active_ch",
+                is_active=True,
+                is_filtered=False,
+            ),
+            SimpleNamespace(
+                channel_id=200,
+                title="Inactive Channel",
+                username="inactive_ch",
+                is_active=False,
+                is_filtered=True,
+            ),
+            SimpleNamespace(
+                channel_id=300,
+                title="Filtered Active",
+                username="filtered_ch",
+                is_active=True,
+                is_filtered=True,
+            ),
+        ]
+        mock_db.get_channels = AsyncMock(return_value=mock_channels)
+
+        channels = await mock_db.get_channels()
+
+        assert len(channels) == 3
+        assert channels[0].title == "Active Channel"
+        assert channels[1].is_active is False
+        assert channels[2].is_filtered is True
+
+    @pytest.mark.asyncio
+    async def test_get_channels_with_no_username(self, mock_db):
+        """Test get_channels handles channels without username."""
+        mock_channels = [
+            SimpleNamespace(
+                channel_id=100,
+                title="Private Channel",
+                username=None,
+                is_active=True,
+                is_filtered=False,
+            ),
+        ]
+        mock_db.get_channels = AsyncMock(return_value=mock_channels)
+
+        channels = await mock_db.get_channels()
+
+        assert len(channels) == 1
+        assert channels[0].username is None
+
+    @pytest.mark.asyncio
+    async def test_get_channels_error_handling(self, mock_db):
+        """Test get_channels handles database errors."""
+        mock_db.get_channels = AsyncMock(side_effect=Exception("DB query failed"))
+
+        with pytest.raises(Exception, match="DB query failed"):
+            await mock_db.get_channels()
+
+
+class TestMakeMcpServer:
+    """Tests for make_mcp_server factory function."""
+
+    def test_creates_server_returns_object(self, mock_db):
+        """Test that make_mcp_server returns a server config object."""
+        from src.agent.tools import make_mcp_server
+
+        server = make_mcp_server(mock_db)
+        # create_sdk_mcp_server returns some kind of config object
+        assert server is not None
+
+    def test_server_is_callable_with_db(self, mock_db):
+        """Test that make_mcp_server can be called with db parameter."""
+        from src.agent.tools import make_mcp_server
+
+        # Should not raise
+        server = make_mcp_server(mock_db)
+        assert server is not None
+
+
+class TestToolMessageFormatting:
+    """Tests for message formatting logic in tools."""
+
+    def test_format_empty_results(self):
+        """Test formatting when no messages found."""
+        query = "nonexistent"
+        messages = []
+        total = 0
+
+        if not messages:
+            text = f"Ничего не найдено по запросу: {query!r}"
+        else:
+            text = f"Found {total}"
+
+        assert "Ничего не найдено" in text
+        assert "nonexistent" in text
+
+    def test_format_with_results(self):
+        """Test formatting when messages are found."""
+        messages = [
+            SimpleNamespace(channel_id=100, text="test", date="2025-01-01"),
+        ]
+        total = 1
+
+        lines = [f"Найдено {total} сообщений для 'test'. Показаны первые {len(messages)}:"]
+        for m in messages:
+            preview = (m.text or "")[:300]
+            lines.append(f"- [channel_id={m.channel_id}, date={m.date}]: {preview}")
+        text = "\n".join(lines)
+
+        assert "Найдено 1 сообщений" in text
+        assert "channel_id=100" in text
+
+    def test_format_channels_list(self):
+        """Test formatting channel list."""
+        channels = [
+            SimpleNamespace(
+                title="Test",
+                username="test_ch",
+                channel_id=100,
+                is_active=True,
+                is_filtered=False,
+            ),
+        ]
+
+        lines = [f"Доступные каналы ({len(channels)}):"]
+        for ch in channels:
+            status = "активен" if ch.is_active else "неактивен"
+            filtered = " [отфильтрован]" if ch.is_filtered else ""
+            lines.append(f"- {ch.title} (@{ch.username}, id={ch.channel_id}, {status}{filtered})")
+        text = "\n".join(lines)
+
+        assert "Доступные каналы (1)" in text
+        assert "@test_ch" in text
+        assert "активен" in text

--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -1,0 +1,529 @@
+"""Extra CLI tests for commands with low coverage."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import signal
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import AppConfig
+from src.database import Database
+from src.models import Account, Channel, NotificationBot
+
+
+NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def cli_db(tmp_path):
+    """Sync fixture: real SQLite for CLI tests."""
+    db_path = str(tmp_path / "cli_test.db")
+    database = Database(db_path)
+    asyncio.run(database.initialize())
+    yield database
+    asyncio.run(database.close())
+
+
+@pytest.fixture
+def cli_env(cli_db):
+    """Patch runtime.init_db to return real db without loading config.yaml."""
+    config = AppConfig()
+
+    async def fake_init_db(config_path: str):
+        return config, cli_db
+
+    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+        yield cli_db
+
+
+@pytest.fixture
+def cli_env_with_pool(cli_env):
+    """Additionally patch runtime.init_pool to return a pool with clients."""
+    fake_pool = AsyncMock()
+    fake_pool.clients = {}
+    fake_pool.disconnect_all = AsyncMock()
+
+    async def fake_init_pool(config, db):
+        from src.telegram.auth import TelegramAuth
+        return TelegramAuth(0, ""), fake_pool
+
+    with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+        yield cli_env, fake_pool
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build Namespace with defaults."""
+    defaults = {"config": "config.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# my_telegram command
+# ---------------------------------------------------------------------------
+
+
+class TestMyTelegramCommand:
+    """Tests for my-telegram CLI command."""
+
+    def test_list_no_accounts(self, cli_env_with_pool, capsys):
+        """Test my-telegram list when no accounts connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {}
+
+        from src.cli.commands.my_telegram import run
+
+        run(_ns(my_telegram_action="list", phone=None))
+        out = capsys.readouterr().out
+        assert "No connected accounts" in out
+
+    def test_list_account_not_connected(self, cli_env_with_pool, capsys):
+        """Test my-telegram list when specified account not connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.cli.commands.my_telegram import run
+
+        run(_ns(my_telegram_action="list", phone="+70009999999"))
+        out = capsys.readouterr().out
+        assert "not connected" in out
+
+    def test_list_success(self, cli_env_with_pool, capsys):
+        """Test my-telegram list with dialogs."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.services.channel_service import ChannelService
+
+        mock_dialogs = [
+            {
+                "channel_type": "channel",
+                "title": "Test Channel",
+                "username": "test_ch",
+                "already_added": True,
+            },
+            {
+                "channel_type": "group",
+                "title": "Test Group",
+                "username": None,
+                "already_added": False,
+            },
+        ]
+
+        with patch.object(
+            ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=mock_dialogs
+        ):
+            from src.cli.commands.my_telegram import run
+
+            run(_ns(my_telegram_action="list", phone="+70001112233"))
+
+        out = capsys.readouterr().out
+        assert "Test Channel" in out
+        assert "@test_ch" in out
+        assert "Test Group" in out
+        assert "Yes" in out
+
+    def test_list_no_dialogs(self, cli_env_with_pool, capsys):
+        """Test my-telegram list when no dialogs found."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.services.channel_service import ChannelService
+
+        with patch.object(
+            ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=[]
+        ):
+            from src.cli.commands.my_telegram import run
+
+            run(_ns(my_telegram_action="list", phone="+70001112233"))
+
+        out = capsys.readouterr().out
+        assert "No dialogs found" in out
+
+    def test_list_uses_first_account_by_default(self, cli_env_with_pool, capsys):
+        """Test my-telegram list uses first available account when phone not specified."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {
+            "+70001112233": AsyncMock(),
+            "+70002223344": AsyncMock(),
+        }
+
+        from src.services.channel_service import ChannelService
+
+        with patch.object(
+            ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=[]
+        ) as mock_get:
+            from src.cli.commands.my_telegram import run
+
+            run(_ns(my_telegram_action="list", phone=None))
+
+        # Should use first account alphabetically
+        mock_get.assert_awaited_once_with("+70001112233")
+
+
+# ---------------------------------------------------------------------------
+# notification command
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationCommand:
+    """Tests for notification CLI command."""
+
+    def test_setup_success(self, cli_env_with_pool, capsys):
+        """Test notification setup creates a bot."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.models import NotificationBot
+
+        from src.services.notification_service import NotificationService
+
+        mock_bot = NotificationBot(
+            tg_user_id=123,
+            tg_username="test_user",
+            bot_id=456,
+            bot_username="testbot_bot",
+            bot_token="123456:ABC-DEF",
+        )
+
+        with patch.object(
+            NotificationService, "setup_bot", new_callable=AsyncMock, return_value=mock_bot
+        ):
+            from src.cli.commands.notification import run
+
+            run(_ns(notification_action="setup"))
+
+        out = capsys.readouterr().out
+        assert "@testbot_bot" in out
+        assert "123456:ABC-DEF" in out
+
+    def test_status_no_bot(self, cli_env_with_pool, capsys):
+        """Test notification status when no bot configured."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.services.notification_service import NotificationService
+
+        with patch.object(
+            NotificationService, "get_status", new_callable=AsyncMock, return_value=None
+        ):
+            from src.cli.commands.notification import run
+
+            run(_ns(notification_action="status"))
+
+        out = capsys.readouterr().out
+        assert "No notification bot" in out
+
+    def test_status_with_bot(self, cli_env_with_pool, capsys):
+        """Test notification status with configured bot."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.services.notification_service import NotificationService
+
+        mock_bot = NotificationBot(
+            tg_user_id=123,
+            tg_username="test_user",
+            bot_id=456,
+            bot_username="testbot_bot",
+            bot_token="123456:ABC-DEF",
+        )
+
+        with patch.object(
+            NotificationService, "get_status", new_callable=AsyncMock, return_value=mock_bot
+        ):
+            from src.cli.commands.notification import run
+
+            run(_ns(notification_action="status"))
+
+        out = capsys.readouterr().out
+        assert "@testbot_bot" in out
+        assert "456" in out
+
+    def test_delete_success(self, cli_env_with_pool, capsys):
+        """Test notification delete removes the bot."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.services.notification_service import NotificationService
+
+        with patch.object(
+            NotificationService, "teardown_bot", new_callable=AsyncMock
+        ):
+            from src.cli.commands.notification import run
+
+            run(_ns(notification_action="delete"))
+
+        out = capsys.readouterr().out
+        assert "deleted" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# scheduler command
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerCommand:
+    """Tests for scheduler CLI command."""
+
+    def test_start_no_clients(self, cli_env_with_pool, capsys, caplog):
+        """Test scheduler start when no accounts connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="start"))
+        assert "No connected accounts" in caplog.text
+
+    def test_trigger_no_clients(self, cli_env_with_pool, capsys, caplog):
+        """Test scheduler trigger when no accounts connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="trigger"))
+        assert "No connected accounts" in caplog.text
+
+    def test_search_no_clients(self, cli_env_with_pool, capsys, caplog):
+        """Test scheduler search when no accounts connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="search"))
+        assert "No connected accounts" in caplog.text
+
+    def test_trigger_success(self, cli_env_with_pool, capsys):
+        """Test scheduler trigger collects channels."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.telegram.collector import Collector
+
+        mock_stats = {"collected": 10, "errors": 0}
+
+        with patch.object(
+            Collector, "collect_all_channels", new_callable=AsyncMock, return_value=mock_stats
+        ):
+            from src.cli.commands.scheduler import run
+
+            run(_ns(scheduler_action="trigger"))
+
+        out = capsys.readouterr().out
+        assert "collected" in out
+
+    def test_search_success(self, cli_env_with_pool, capsys):
+        """Test scheduler search triggers notification queries."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.scheduler.manager import SchedulerManager
+
+        mock_stats = {"searches": 5, "notified": 2}
+
+        with patch.object(
+            SchedulerManager, "trigger_search_now", new_callable=AsyncMock, return_value=mock_stats
+        ):
+            from src.cli.commands.scheduler import run
+
+            # Patch the SchedulerManager constructor to not require db
+            with patch("src.cli.commands.scheduler.SchedulerManager") as mock_sm_class:
+                mock_sm = MagicMock()
+                mock_sm.trigger_search_now = AsyncMock(return_value=mock_stats)
+                mock_sm_class.return_value = mock_sm
+
+                run(_ns(scheduler_action="search"))
+
+        out = capsys.readouterr().out
+        assert "search" in out.lower() or "complete" in out.lower() or "notified" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# serve command
+# ---------------------------------------------------------------------------
+
+
+class TestServeCommand:
+    """Tests for serve CLI command."""
+
+    def test_serve_exits_without_password(self, capsys):
+        """Test serve exits when no password is configured."""
+        from src.cli.commands.serve import run
+
+        with patch("src.cli.commands.serve.load_config") as mock_load:
+            config = AppConfig()
+            config.web.password = ""
+            mock_load.return_value = config
+
+            with pytest.raises(SystemExit, match="1"):
+                run(_ns(config="config.yaml", web_pass=None))
+
+    def test_serve_uses_web_pass_arg(self):
+        """Test serve uses web_pass from command line."""
+        from src.cli.commands.serve import run
+
+        with patch("src.cli.commands.serve.load_config") as mock_load, patch(
+            "src.cli.commands.serve.create_app"
+        ) as mock_create, patch(
+            "src.cli.commands.serve.pid_file_path"
+        ) as mock_pid_path, patch(
+            "src.cli.commands.serve.register_current_process"
+        ), patch("src.cli.commands.serve.unregister_current_process"), patch(
+            "src.cli.commands.serve.uvicorn.run"
+        ) as mock_uvicorn:
+
+            config = AppConfig()
+            config.web.password = ""  # Empty by default
+            mock_load.return_value = config
+            mock_create.return_value = MagicMock()
+            mock_pid_path.return_value = "/tmp/test.pid"
+
+            run(_ns(config="config.yaml", web_pass="cli_password"))
+
+            # Password should be updated from CLI arg
+            assert config.web.password == "cli_password"
+            mock_uvicorn.assert_called_once()
+
+    def test_serve_registers_and_unregisters_pid(self):
+        """Test serve registers and unregisters PID file."""
+        from src.cli.commands.serve import run
+
+        with patch("src.cli.commands.serve.load_config") as mock_load, patch(
+            "src.cli.commands.serve.create_app"
+        ) as mock_create, patch(
+            "src.cli.commands.serve.pid_file_path"
+        ) as mock_pid_path, patch(
+            "src.cli.commands.serve.register_current_process"
+        ) as mock_register, patch(
+            "src.cli.commands.serve.unregister_current_process"
+        ) as mock_unregister, patch("src.cli.commands.serve.uvicorn.run"):
+
+            config = AppConfig()
+            config.web.password = "testpass"
+            mock_load.return_value = config
+            mock_create.return_value = MagicMock()
+            mock_pid_path.return_value = "/tmp/test.pid"
+
+            run(_ns(config="config.yaml", web_pass=None))
+
+            mock_register.assert_called_once_with("/tmp/test.pid")
+            mock_unregister.assert_called_once_with("/tmp/test.pid")
+
+    def test_serve_exits_on_pid_registration_error(self, caplog):
+        """Test serve exits when PID registration fails."""
+        from src.cli.commands.serve import run
+
+        with patch("src.cli.commands.serve.load_config") as mock_load, patch(
+            "src.cli.commands.serve.create_app"
+        ), patch("src.cli.commands.serve.pid_file_path") as mock_pid_path, patch(
+            "src.cli.commands.serve.register_current_process"
+        ) as mock_register:
+
+            config = AppConfig()
+            config.web.password = "testpass"
+            mock_load.return_value = config
+            mock_pid_path.return_value = "/tmp/test.pid"
+            mock_register.side_effect = RuntimeError("PID file exists")
+
+            with pytest.raises(SystemExit, match="1"):
+                run(_ns(config="config.yaml", web_pass=None))
+
+
+# ---------------------------------------------------------------------------
+# collect command
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCommand:
+    """Tests for collect CLI command."""
+
+    def test_collect_no_clients(self, cli_env_with_pool, caplog):
+        """Test collect when no accounts connected."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {}
+
+        from src.cli.commands.collect import run
+
+        run(_ns(channel_id=None, full=False))
+        assert "No connected accounts" in caplog.text
+
+    def test_collect_success(self, cli_env_with_pool, capsys):
+        """Test collect runs collection."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        from src.telegram.collector import Collector
+
+        mock_stats = {"collected": 50, "errors": 0}
+
+        with patch.object(
+            Collector, "collect_all_channels", new_callable=AsyncMock, return_value=mock_stats
+        ):
+            from src.cli.commands.collect import run
+
+            run(_ns(channel_id=None, full=False))
+
+        out = capsys.readouterr().out
+        assert "50" in out or "collected" in out.lower()
+
+    def test_collect_single_channel(self, cli_env_with_pool, capsys):
+        """Test collect for a single channel."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        # Add a channel to collect
+        _add_channel(cli_env, channel_id=100, title="Test Channel")
+
+        from src.telegram.collector import Collector
+
+        mock_stats = {"collected": 10, "errors": 0}
+
+        with patch.object(
+            Collector, "collect_single_channel", new_callable=AsyncMock, return_value=mock_stats
+        ):
+            from src.cli.commands.collect import run
+
+            run(_ns(channel_id="100", full=False))
+
+        out = capsys.readouterr().out
+        assert "10" in out or "complete" in out.lower()
+
+    def test_collect_full_mode(self, cli_env_with_pool, capsys):
+        """Test collect with full flag for single channel."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+
+        # Add a channel
+        _add_channel(cli_env, channel_id=100, title="Test Channel")
+
+        from src.telegram.collector import Collector
+
+        mock_count = 100
+
+        with patch.object(
+            Collector, "collect_single_channel", new_callable=AsyncMock, return_value=mock_count
+        ) as mock_collect:
+            from src.cli.commands.collect import run
+
+            # Pass channel_id as int since argparse may convert it
+            run(_ns(channel_id=100, full=True))
+
+            # collect_single_channel should be called with full=True
+            mock_collect.assert_awaited_once()
+            # Check the kwargs - full is a keyword-only argument
+            call_kwargs = mock_collect.call_args.kwargs
+            assert call_kwargs.get("full") is True
+
+        out = capsys.readouterr().out
+        assert "100" in out or "complete" in out.lower()
+
+
+def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
+    return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))

--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -3,19 +3,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import signal
-from datetime import datetime, timezone
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.config import AppConfig
 from src.database import Database
-from src.models import Account, Channel, NotificationBot
-
-
-NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+from src.models import Channel, NotificationBot
 
 
 @pytest.fixture
@@ -179,7 +173,6 @@ class TestNotificationCommand:
         fake_pool.clients = {"+70001112233": AsyncMock()}
 
         from src.models import NotificationBot
-
         from src.services.notification_service import NotificationService
 
         mock_bot = NotificationBot(
@@ -490,10 +483,10 @@ class TestCollectCommand:
         ):
             from src.cli.commands.collect import run
 
-            run(_ns(channel_id="100", full=False))
+            run(_ns(channel_id=100, full=False))
 
         out = capsys.readouterr().out
-        assert "10" in out or "complete" in out.lower()
+        assert "Collected" in out and "100" in out
 
     def test_collect_full_mode(self, cli_env_with_pool, capsys):
         """Test collect with full flag for single channel."""

--- a/tests/test_notifier_extra.py
+++ b/tests/test_notifier_extra.py
@@ -32,7 +32,9 @@ class TestNotifierFastPath:
     """Tests for Notifier fast path with cached me.id and bot."""
 
     @pytest.mark.asyncio
-    async def test_notify_with_cached_me_id_and_bot(self, mock_target_service, mock_notification_bundle):
+    async def test_notify_with_cached_me_id_and_bot(
+        self, mock_target_service, mock_notification_bundle,
+    ):
         """Test fast path when me.id is cached and bot is available."""
         bot = NotificationBot(
             tg_user_id=123,
@@ -221,7 +223,9 @@ class TestNotifierErrorHandling:
     """Tests for Notifier error handling."""
 
     @pytest.mark.asyncio
-    async def test_notify_cancelled_error_propagates(self, mock_target_service, mock_notification_bundle):
+    async def test_notify_cancelled_error_propagates(
+        self, mock_target_service, mock_notification_bundle,
+    ):
         """Test that CancelledError is re-raised, not swallowed."""
         mock_client = MagicMock()
         mock_client.get_me = AsyncMock(side_effect=asyncio.CancelledError)
@@ -241,7 +245,9 @@ class TestNotifierErrorHandling:
             await notifier.notify("Test message")
 
     @pytest.mark.asyncio
-    async def test_notify_general_exception_returns_false(self, mock_target_service, mock_notification_bundle):
+    async def test_notify_general_exception_returns_false(
+        self, mock_target_service, mock_notification_bundle,
+    ):
         """Test that general exceptions are caught and result in False return."""
         mock_client = MagicMock()
         mock_client.get_me = AsyncMock(side_effect=RuntimeError("Connection failed"))

--- a/tests/test_notifier_extra.py
+++ b/tests/test_notifier_extra.py
@@ -1,0 +1,374 @@
+"""Tests for src/telegram/notifier.py - extra coverage for error paths and bot API."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.database.bundles import NotificationBundle
+from src.models import NotificationBot
+from src.telegram.notifier import Notifier, _send_via_bot_api
+
+
+@pytest.fixture
+def mock_target_service():
+    """Create a mock NotificationTargetService."""
+    service = MagicMock()
+    service.use_client = MagicMock()
+    return service
+
+
+@pytest.fixture
+def mock_notification_bundle():
+    """Create a mock NotificationBundle."""
+    bundle = MagicMock(spec=NotificationBundle)
+    bundle.get_bot = AsyncMock(return_value=None)
+    return bundle
+
+
+class TestNotifierFastPath:
+    """Tests for Notifier fast path with cached me.id and bot."""
+
+    @pytest.mark.asyncio
+    async def test_notify_with_cached_me_id_and_bot(self, mock_target_service, mock_notification_bundle):
+        """Test fast path when me.id is cached and bot is available."""
+        bot = NotificationBot(
+            tg_user_id=123,
+            tg_username="test_user",
+            bot_id=456,
+            bot_username="test_bot",
+            bot_token="123456:ABC-DEF",
+        )
+        mock_notification_bundle.get_bot = AsyncMock(return_value=bot)
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+        # Simulate cached me.id
+        notifier._cached_me_id = 123
+
+        with patch(
+            "src.telegram.notifier._send_via_bot_api",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_send:
+            result = await notifier.notify("Test message")
+
+        assert result is True
+        mock_send.assert_awaited_once_with("123456:ABC-DEF", 123, "Test message")
+        # Should not use client since fast path succeeded
+        mock_target_service.use_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_with_cached_me_id_but_no_bot_falls_back(
+        self, mock_target_service, mock_notification_bundle
+    ):
+        """Test fallback when me.id is cached but bot lookup returns None."""
+        mock_notification_bundle.get_bot = AsyncMock(return_value=None)
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=SimpleNamespace(id=123))
+        mock_client.send_message = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+        notifier._cached_me_id = 123
+
+        result = await notifier.notify("Test message")
+
+        assert result is True
+        mock_client.send_message.assert_awaited_once_with(789, "Test message")
+
+
+class TestNotifierSlowPath:
+    """Tests for Notifier slow path that requires client connection."""
+
+    @pytest.mark.asyncio
+    async def test_notify_without_cached_me_id_fetches_it(
+        self, mock_target_service, mock_notification_bundle
+    ):
+        """Test that notifier fetches and caches me.id when not cached."""
+        bot = NotificationBot(
+            tg_user_id=123,
+            tg_username="test_user",
+            bot_id=456,
+            bot_username="test_bot",
+            bot_token="123456:ABC-DEF",
+        )
+        mock_notification_bundle.get_bot = AsyncMock(return_value=bot)
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=SimpleNamespace(id=123))
+        mock_client.send_message = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+        # me.id is not cached initially
+        assert notifier._cached_me_id is None
+
+        with patch(
+            "src.telegram.notifier._send_via_bot_api",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await notifier.notify("Test message")
+
+        assert result is True
+        # Should have cached the me.id
+        assert notifier._cached_me_id == 123
+        mock_client.get_me.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_fallback_to_client_when_no_bot(
+        self, mock_target_service, mock_notification_bundle
+    ):
+        """Test fallback to client.send_message when no bot is configured."""
+        mock_notification_bundle.get_bot = AsyncMock(return_value=None)
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=SimpleNamespace(id=123))
+        mock_client.send_message = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+
+        result = await notifier.notify("Test message")
+
+        assert result is True
+        mock_client.send_message.assert_awaited_once_with(789, "Test message")
+
+    @pytest.mark.asyncio
+    async def test_notify_admin_chat_id_me(self, mock_target_service, mock_notification_bundle):
+        """Test sending to 'me' when admin_chat_id is None."""
+        mock_notification_bundle.get_bot = AsyncMock(return_value=None)
+
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(return_value=SimpleNamespace(id=123))
+        mock_client.send_message = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=None,  # No admin_chat_id, should use "me"
+            notification_bundle=mock_notification_bundle,
+        )
+
+        result = await notifier.notify("Test message")
+
+        assert result is True
+        mock_client.send_message.assert_awaited_once_with("me", "Test message")
+
+
+class TestNotifierWithoutBundle:
+    """Tests for Notifier when notification_bundle is None."""
+
+    @pytest.mark.asyncio
+    async def test_notify_without_bundle_uses_client_directly(self, mock_target_service):
+        """Test that without bundle, notifier uses client.send_message directly."""
+        mock_client = MagicMock()
+        mock_client.send_message = AsyncMock()
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=None,  # No bundle
+        )
+
+        result = await notifier.notify("Test message")
+
+        assert result is True
+        mock_client.send_message.assert_awaited_once_with(789, "Test message")
+
+
+class TestNotifierErrorHandling:
+    """Tests for Notifier error handling."""
+
+    @pytest.mark.asyncio
+    async def test_notify_cancelled_error_propagates(self, mock_target_service, mock_notification_bundle):
+        """Test that CancelledError is re-raised, not swallowed."""
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(side_effect=asyncio.CancelledError)
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await notifier.notify("Test message")
+
+    @pytest.mark.asyncio
+    async def test_notify_general_exception_returns_false(self, mock_target_service, mock_notification_bundle):
+        """Test that general exceptions are caught and result in False return."""
+        mock_client = MagicMock()
+        mock_client.get_me = AsyncMock(side_effect=RuntimeError("Connection failed"))
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=(mock_client, "+70001112233"))
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_target_service.use_client.return_value = mock_cm
+
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+
+        result = await notifier.notify("Test message")
+
+        assert result is False
+
+
+class TestNotifierInvalidateCache:
+    """Tests for cache invalidation."""
+
+    def test_invalidate_me_cache(self, mock_target_service, mock_notification_bundle):
+        """Test that invalidate_me_cache clears the cached me.id."""
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+        notifier._cached_me_id = 123
+
+        notifier.invalidate_me_cache()
+
+        assert notifier._cached_me_id is None
+
+    def test_admin_chat_id_property(self, mock_target_service, mock_notification_bundle):
+        """Test admin_chat_id property accessor."""
+        notifier = Notifier(
+            target_service=mock_target_service,
+            admin_chat_id=789,
+            notification_bundle=mock_notification_bundle,
+        )
+
+        assert notifier.admin_chat_id == 789
+
+
+class TestSendViaBotApi:
+    """Tests for _send_via_bot_api helper function."""
+
+    @pytest.mark.asyncio
+    async def test_send_via_bot_api_success(self):
+        """Test successful bot API call."""
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(return_value={"ok": True, "result": {}})
+
+        # session.post(...) is used as async context manager
+        mock_post_context = AsyncMock()
+        mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_post_context)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("src.telegram.notifier.aiohttp.ClientSession", return_value=mock_session):
+            result = await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_send_via_bot_api_error_response(self):
+        """Test bot API call when response has ok=false."""
+        mock_response = AsyncMock()
+        mock_response.json = AsyncMock(
+            return_value={"ok": False, "error_code": 400, "description": "Bad Request"}
+        )
+
+        # session.post(...) is used as async context manager
+        mock_post_context = AsyncMock()
+        mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_post_context)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("src.telegram.notifier.aiohttp.ClientSession", return_value=mock_session):
+            result = await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_via_bot_api_network_error(self):
+        """Test bot API call when network error occurs during ClientSession creation."""
+        # The error happens inside the async with ClientSession() block
+        # We need to make the session's __aenter__ raise the error
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=ConnectionError("Network unreachable"))
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("src.telegram.notifier.aiohttp.ClientSession", return_value=mock_session):
+            result = await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_via_bot_api_cancelled_error_propagates(self):
+        """Test that CancelledError in bot API call is re-raised."""
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=asyncio.CancelledError)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("src.telegram.notifier.aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(asyncio.CancelledError):
+                await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
+
+    @pytest.mark.asyncio
+    async def test_send_via_bot_api_timeout_error(self):
+        """Test bot API call when timeout occurs during session creation."""
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("src.telegram.notifier.aiohttp.ClientSession", return_value=mock_session):
+            result = await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
+
+        assert result is False

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,544 @@
+"""Tests for src/web/routes/auth.py - web authentication routes.
+
+Note: /auth/* routes require web panel authentication (not to be confused
+with /login which is for the web panel itself).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import AppConfig
+from src.models import Account
+from src.telegram.auth import TelegramAuth
+from tests.helpers import build_web_app, make_auth_client
+
+
+class TestLoginPage:
+    """Tests for GET /auth/login (Telegram account login page)."""
+
+    @pytest.mark.asyncio
+    async def test_login_page_api_configured(self, db, real_pool_harness_factory):
+        """Test login page when API credentials are configured."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        # Use with_auth=True since /auth/* requires web panel authentication
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.get("/auth/login")
+
+        assert response.status_code == 200
+        # When API is configured, step should be "phone"
+        assert "phone" in response.text.lower() or "телефон" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_login_page_api_not_configured(self, db, real_pool_harness_factory):
+        """Test login page when API credentials are not configured."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        # API not configured (default values)
+        config.telegram.api_id = 0
+        config.telegram.api_hash = ""
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(0, "")  # Not configured
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.get("/auth/login")
+
+        assert response.status_code == 200
+        # When API is not configured, step should be "credentials"
+        assert "credentials" in response.text or "api_id" in response.text
+
+
+class TestSaveCredentials:
+    """Tests for POST /auth/save-credentials."""
+
+    @pytest.mark.asyncio
+    async def test_save_credentials_success(self, db, real_pool_harness_factory):
+        """Test successful credential save."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 0
+        config.telegram.api_hash = ""
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(0, "")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.post(
+                "/auth/save-credentials",
+                data={"api_id": "12345", "api_hash": "my_api_hash"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"
+
+        # Verify credentials were saved to DB
+        saved_id = await db.get_setting("tg_api_id")
+        saved_hash = await db.get_setting("tg_api_hash")
+        assert saved_id == "12345"
+        assert saved_hash == "my_api_hash"
+
+        # Verify auth object was updated
+        assert auth.api_id == 12345
+        assert auth.api_hash == "my_api_hash"
+
+
+class TestSendCode:
+    """Tests for POST /auth/send-code."""
+
+    @pytest.mark.asyncio
+    async def test_send_code_api_not_configured(self, db, real_pool_harness_factory):
+        """Test send-code returns error when API credentials are not configured."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 0
+        config.telegram.api_hash = ""
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(0, "")  # Not configured
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.post(
+                "/auth/send-code",
+                data={"phone": "+70001112233"},
+            )
+
+        assert response.status_code == 200
+        # Should show credentials step with error
+        assert "API credentials" in response.text or "api_id" in response.text
+
+    @pytest.mark.asyncio
+    async def test_send_code_success(self, db, real_pool_harness_factory):
+        """Test successful code sending."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "send_code",
+            new_callable=AsyncMock,
+            return_value={
+                "phone_code_hash": "abc123",
+                "code_type": "SMS",
+                "next_type": "call",
+                "timeout": 120,
+            },
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/send-code",
+                    data={"phone": "+70001112233"},
+                )
+
+        assert response.status_code == 200
+        # Should show code input step
+        assert "code" in response.text.lower() or "код" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_code_exception(self, db, real_pool_harness_factory):
+        """Test send-code handles exceptions gracefully."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "send_code",
+            new_callable=AsyncMock,
+            side_effect=Exception("Phone number invalid"),
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/send-code",
+                    data={"phone": "+70001112233"},
+                )
+
+        assert response.status_code == 200
+        # Should show error message
+        assert "Phone number invalid" in response.text
+
+
+class TestResendCode:
+    """Tests for POST /auth/resend-code."""
+
+    @pytest.mark.asyncio
+    async def test_resend_code_success(self, db, real_pool_harness_factory):
+        """Test successful code resend."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "resend_code",
+            new_callable=AsyncMock,
+            return_value={
+                "phone_code_hash": "xyz789",
+                "code_type": "call",
+                "next_type": None,
+                "timeout": 60,
+            },
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/resend-code",
+                    data={"phone": "+70001112233", "phone_code_hash": "abc123"},
+                )
+
+        assert response.status_code == 200
+        assert "code" in response.text.lower() or "код" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_resend_code_exception(self, db, real_pool_harness_factory):
+        """Test resend-code handles exceptions gracefully."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "resend_code",
+            new_callable=AsyncMock,
+            side_effect=Exception("Rate limit exceeded"),
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/resend-code",
+                    data={"phone": "+70001112233", "phone_code_hash": "abc123"},
+                )
+
+        assert response.status_code == 200
+        assert "Rate limit exceeded" in response.text
+
+
+class TestVerifyCode:
+    """Tests for POST /auth/verify-code."""
+
+    @pytest.mark.asyncio
+    async def test_verify_code_success(self, db, real_pool_harness_factory):
+        """Test successful code verification."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        # Mock pool.add_client to capture the session
+        added_sessions = []
+
+        async def mock_add_client(phone, session_string):
+            added_sessions.append((phone, session_string))
+
+        app.state.pool.add_client = mock_add_client
+
+        # Mock pool.get_client_by_phone and release_client
+        mock_client = MagicMock()
+        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
+        app.state.pool.get_client_by_phone = AsyncMock(
+            return_value=(mock_client, "+70001112233")
+        )
+        app.state.pool.release_client = AsyncMock()
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            return_value="session_string_123",
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "12345",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "",
+                        "code_type": "",
+                        "next_type": "",
+                        "timeout": "",
+                    },
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 303
+        assert "settings" in response.headers["location"]
+
+        # Verify account was added to DB
+        accounts = await db.get_accounts()
+        assert len(accounts) == 1
+        assert accounts[0].phone == "+70001112233"
+        assert accounts[0].is_primary is True  # First account is primary
+
+    @pytest.mark.asyncio
+    async def test_verify_code_2fa_required(self, db, real_pool_harness_factory):
+        """Test code verification when 2FA password is required."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            side_effect=ValueError("2FA password required"),
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "12345",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "",
+                        "code_type": "",
+                        "next_type": "",
+                        "timeout": "",
+                    },
+                )
+
+        assert response.status_code == 200
+        # Should show 2FA password input
+        assert "2fa" in response.text.lower() or "password" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_verify_code_invalid_code(self, db, real_pool_harness_factory):
+        """Test code verification with invalid code."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Invalid code"),
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "00000",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "",
+                        "code_type": "SMS",
+                        "next_type": "call",
+                        "timeout": "120",
+                    },
+                )
+
+        assert response.status_code == 200
+        assert "Invalid code" in response.text
+
+    @pytest.mark.asyncio
+    async def test_verify_code_exception(self, db, real_pool_harness_factory):
+        """Test code verification handles general exceptions."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            side_effect=Exception("Flood wait: 60 seconds"),
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "12345",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "",
+                        "code_type": "",
+                        "next_type": "",
+                        "timeout": "",
+                    },
+                )
+
+        assert response.status_code == 200
+        assert "Flood wait" in response.text
+
+    @pytest.mark.asyncio
+    async def test_verify_code_with_2fa_password(self, db, real_pool_harness_factory):
+        """Test code verification with 2FA password provided."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        # Mock pool methods
+        async def mock_add_client(phone, session_string):
+            pass
+
+        app.state.pool.add_client = mock_add_client
+        mock_client = MagicMock()
+        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=True))
+        app.state.pool.get_client_by_phone = AsyncMock(
+            return_value=(mock_client, "+70001112233")
+        )
+        app.state.pool.release_client = AsyncMock()
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            return_value="session_string_with_2fa",
+        ) as mock_verify:
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "12345",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "my2fapassword",
+                        "code_type": "",
+                        "next_type": "",
+                        "timeout": "",
+                    },
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 303
+        # Verify 2FA password was passed to verify_code
+        mock_verify.assert_awaited_once_with(
+            "+70001112233", "12345", "abc123", "my2fapassword"
+        )
+
+        # Verify premium status was fetched
+        accounts = await db.get_accounts()
+        assert len(accounts) == 1
+        assert accounts[0].is_premium is True
+
+    @pytest.mark.asyncio
+    async def test_verify_code_existing_account_not_primary(
+        self, db, real_pool_harness_factory
+    ):
+        """Test that subsequent accounts are not marked as primary."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        # Add first account
+        await db.add_account(
+            Account(phone="+70001110000", session_string="first_session", is_primary=True)
+        )
+
+        # Mock pool methods
+        async def mock_add_client(phone, session_string):
+            pass
+
+        app.state.pool.add_client = mock_add_client
+        mock_client = MagicMock()
+        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
+        app.state.pool.get_client_by_phone = AsyncMock(
+            return_value=(mock_client, "+70001112233")
+        )
+        app.state.pool.release_client = AsyncMock()
+
+        with patch.object(
+            auth,
+            "verify_code",
+            new_callable=AsyncMock,
+            return_value="second_session",
+        ):
+            async with make_auth_client(app, password="testpass", with_auth=True) as client:
+                response = await client.post(
+                    "/auth/verify-code",
+                    data={
+                        "phone": "+70001112233",
+                        "code": "12345",
+                        "phone_code_hash": "abc123",
+                        "password_2fa": "",
+                        "code_type": "",
+                        "next_type": "",
+                        "timeout": "",
+                    },
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 303
+
+        # Verify second account is NOT primary
+        accounts = await db.get_accounts()
+        assert len(accounts) == 2
+        new_account = next(a for a in accounts if a.phone == "+70001112233")
+        assert new_account.is_primary is False


### PR DESCRIPTION
## 💪 What

Adds comprehensive test coverage for previously undertested modules:
- **Agent tools** (`test_agent_tools.py`): MCP tools logic for search_messages and get_channels, including DB interaction tests and message formatting
- **CLI commands** (`test_cli_extra.py`): my-telegram list, notification setup/status/delete, scheduler start/trigger/search, serve (PID registration, password handling), and collect commands
- **Notifier** (`test_notifier_extra.py`): fast path with cached me.id and bot, slow path requiring client connection, bot API helper `_send_via_bot_api`, error handling (CancelledError propagation, general exceptions), cache invalidation
- **Web auth routes** (`test_web_auth.py`): login page (API configured/not configured), save-credentials, send-code/resend-code/verify-code flows, 2FA password handling, primary account marking

## 🤔 Why

Improving test coverage for critical paths that were previously untested:
- Agent tools provide MCP interface and need reliable DB interaction tests
- CLI commands are user-facing entry points that should handle edge cases
- Notifier has multiple code paths (fast/slow, with/without bot) that need verification
- Web auth handles Telegram account login flow including 2FA

## 👀 Usage

No user-facing changes - these are internal test improvements.

## 👩‍🔬 How to validate

1. Run the new tests: `pytest tests/test_agent_tools.py tests/test_cli_extra.py tests/test_notifier_extra.py tests/test_web_auth.py -v`
2. Verify all tests pass and cover the expected scenarios
3. Optionally run coverage report: `pytest tests/ --cov=src --cov-report=term-missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)