### PR TITLE
Unify button styles and add loading feedback

### DIFF
--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 _COLLECT_ALL_FORM = (
     '<form method="post" action="/channels/collect-all" class="d-inline"'
     ' hx-post="/channels/collect-all" hx-target="#collect-all-btn" hx-swap="outerHTML">'
-    '<button type="submit" class="btn btn-outline-primary btn-sm">Собрать все каналы</button>'
+    '<button type="submit" class="btn btn-secondary btn-sm">Собрать все каналы</button>'
     '</form>'
 )
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -184,6 +184,7 @@
     });
     // Unified busy-button handler: add data-busy to any <form> for auto spinner
     document.addEventListener('submit', function(e) {
+        if (e.defaultPrevented) return;
         var form = e.target;
         if (!form.hasAttribute('data-busy')) return;
         var btn = e.submitter || form.querySelector('button[type="submit"]');

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -182,6 +182,16 @@
             a.classList.add("active");
         }
     });
+    // Unified busy-button handler: add data-busy to any <form> for auto spinner
+    document.addEventListener('submit', function(e) {
+        var form = e.target;
+        if (!form.hasAttribute('data-busy')) return;
+        var btn = e.submitter || form.querySelector('button[type="submit"]');
+        if (!btn || btn.disabled) return;
+        btn.disabled = true;
+        var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
+    });
 })();
 </script>
 </body>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -6,7 +6,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Добавить канал</div>
     <div class="card-body">
-        <form method="post" action="/channels/add">
+        <form method="post" action="/channels/add" data-busy>
             <div class="mb-3">
                 <label class="form-label">Username или ссылка</label>
                 <input type="text" class="form-control" name="identifier" required placeholder="Введите username или ссылку">
@@ -23,16 +23,16 @@
 
 {% if channels or show_all %}
 <div class="d-flex gap-2 align-items-center flex-wrap mb-3">
-    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-secondary' }}">Активные</a>
-    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-secondary' }}">Все каналы</a>
+    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-primary' }}">Активные</a>
+    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-primary' }}">Все каналы</a>
     <span class="flex-fill"></span>
-    <form method="post" action="/channels/filter/analyze" class="d-inline">
+    <form method="post" action="/channels/filter/analyze" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Обновить фильтры</button>
     </form>
-    <form method="post" action="/channels/filter/reset" class="d-inline">
+    <form method="post" action="/channels/filter/reset" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-secondary btn-sm">Сброс фильтров</button>
     </form>
-    <form method="post" action="/channels/stats/all" class="d-inline">
+    <form method="post" action="/channels/stats/all" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Обновить статистику</button>
     </form>
     <span id="collect-all-btn">
@@ -40,7 +40,7 @@
               hx-post="/channels/collect-all"
               hx-target="#collect-all-btn"
               hx-swap="outerHTML">
-            <button type="submit" class="btn btn-outline-primary btn-sm">Собрать все каналы</button>
+            <button type="submit" class="btn btn-secondary btn-sm">Собрать все каналы</button>
         </form>
     </span>
 </div>

--- a/src/web/templates/import_channels.html
+++ b/src/web/templates/import_channels.html
@@ -6,7 +6,7 @@
 
 <div class="card mb-4">
     <div class="card-body">
-        <form method="post" action="/channels/import" enctype="multipart/form-data">
+        <form method="post" action="/channels/import" enctype="multipart/form-data" data-busy>
             <div class="mb-3">
                 <label class="form-label">Файл (любой формат)</label>
                 <input type="file" class="form-control" name="file">
@@ -16,18 +16,11 @@
                 <textarea class="form-control" name="text_input" rows="6" placeholder="@channel1&#10;t.me/channel2&#10;-1001234567890&#10;https://t.me/+invite_hash"></textarea>
                 <div class="form-text">Загрузите файл любого формата — парсер автоматически найдёт все Telegram-идентификаторы (<code>@username</code>, <code>t.me/...</code>, числовой ID).</div>
             </div>
-            <button type="submit" class="btn btn-primary" id="import-btn">Импортировать</button>
+            <button type="submit" class="btn btn-primary" id="import-btn" data-busy-label="Импорт выполняется...">Импортировать</button>
         </form>
     </div>
 </div>
 
-<script>
-document.querySelector('form[action$="/import"]').addEventListener('submit', function() {
-    var btn = document.getElementById('import-btn');
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Импорт выполняется…';
-    btn.disabled = true;
-});
-</script>
 
 {% if results is not none %}
 <div class="card">

--- a/src/web/templates/login.html
+++ b/src/web/templates/login.html
@@ -33,7 +33,7 @@
     <div class="card-header fw-semibold">Шаг 1: API Credentials</div>
     <div class="card-body">
         <p>API credentials не настроены. Введите <code>api_id</code> и <code>api_hash</code> с <a href="https://my.telegram.org/apps" target="_blank">my.telegram.org/apps</a>.</p>
-        <form method="post" action="/auth/save-credentials">
+        <form method="post" action="/auth/save-credentials" data-busy>
             <div class="mb-3">
                 <label for="api_id" class="form-label">API ID</label>
                 <input type="number" class="form-control" id="api_id" name="api_id" placeholder="12345678" required>
@@ -50,7 +50,7 @@
 {% elif step == 'phone' or not step %}
 <div class="card mb-4">
     <div class="card-body">
-        <form method="post" action="/auth/send-code">
+        <form method="post" action="/auth/send-code" data-busy>
             <div class="mb-3">
                 <label for="phone" class="form-label">Номер телефона</label>
                 <input type="tel" class="form-control" id="phone" name="phone" placeholder="+1234567890" value="{{ phone or '' }}" required>
@@ -63,7 +63,7 @@
 {% elif step == 'code' %}
 <div class="card mb-4">
     <div class="card-body">
-        <form method="post" action="/auth/verify-code">
+        <form method="post" action="/auth/verify-code" data-busy>
             <input type="hidden" name="phone" value="{{ phone }}">
             <input type="hidden" name="phone_code_hash" value="{{ phone_code_hash }}">
             <input type="hidden" name="code_type" value="{{ code_type or '' }}">
@@ -81,7 +81,7 @@
             <button type="submit" class="btn btn-primary">Подтвердить</button>
         </form>
         {% if next_type %}
-        <form method="post" action="/auth/resend-code" class="mt-3">
+        <form method="post" action="/auth/resend-code" class="mt-3" data-busy>
             <input type="hidden" name="phone" value="{{ phone }}">
             <input type="hidden" name="phone_code_hash" value="{{ phone_code_hash }}">
             <button type="submit" id="resend-btn" class="btn btn-outline-secondary">
@@ -89,7 +89,7 @@
             </button>
         </form>
         {% endif %}
-        <form method="post" action="/auth/send-code" class="mt-2">
+        <form method="post" action="/auth/send-code" class="mt-2" data-busy>
             <input type="hidden" name="phone" value="{{ phone }}">
             <button type="submit" class="btn btn-outline-secondary">Отправить код повторно</button>
         </form>
@@ -123,7 +123,7 @@
 {% elif step == '2fa' %}
 <div class="card mb-4">
     <div class="card-body">
-        <form method="post" action="/auth/verify-code">
+        <form method="post" action="/auth/verify-code" data-busy>
             <input type="hidden" name="phone" value="{{ phone }}">
             <input type="hidden" name="code" value="{{ code }}">
             <input type="hidden" name="phone_code_hash" value="{{ phone_code_hash }}">

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -32,7 +32,7 @@
             {% endfor %}
         </select>
         <span id="dialogs-loading" class="htmx-indicator d-inline-block mt-2">&#9203; Загрузка диалогов…</span>
-        <form method="post" action="/my-telegram/refresh" class="mt-2">
+        <form method="post" action="/my-telegram/refresh" class="mt-2" data-busy>
             <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
             <button class="btn btn-outline-secondary btn-sm" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
         </form>
@@ -64,7 +64,7 @@
 
 <p class="text-muted">Всего диалогов: <strong>{{ dialogs|length }}</strong></p>
 
-<form method="post" action="/my-telegram/leave" id="leave-form">
+<form method="post" action="/my-telegram/leave" id="leave-form" data-busy>
 <input type="hidden" name="phone" value="{{ selected_phone }}">
 
 <div id="leave-bar" class="d-none gap-3 align-items-center mb-3">

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -52,7 +52,7 @@
                 {% endfor %}
             </select>
         </form>
-        <form method="post" action="/my-telegram/photos/refresh" class="col-md-auto">
+        <form method="post" action="/my-telegram/photos/refresh" class="col-md-auto" data-busy>
             <input type="hidden" name="phone" value="{{ selected_phone or '' }}">
             <button class="btn btn-outline-secondary" type="submit" {% if not selected_phone %}disabled{% endif %}>Обновить диалоги</button>
         </form>
@@ -278,7 +278,7 @@
                         <textarea name="caption" class="form-control" rows="2"></textarea>
                     </div>
                     <div class="col-12">
-                        <button class="btn btn-outline-dark" type="submit" data-photo-submit-button data-busy-label="Создаём авто-джоб..." disabled>Создать авто-джоб</button>
+                        <button class="btn btn-outline-secondary" type="submit" data-photo-submit-button data-busy-label="Создаём авто-джоб..." disabled>Создать авто-джоб</button>
                         <div class="photo-submit-status d-none" data-photo-submit-status aria-live="polite"></div>
                     </div>
                 </form>
@@ -287,7 +287,7 @@
     </div>
 
     <div class="col-12">
-        <form method="post" action="/my-telegram/photos/run-due">
+        <form method="post" action="/my-telegram/photos/run-due" data-busy>
             <input type="hidden" name="phone" value="{{ selected_phone }}">
             <button class="btn btn-sm btn-secondary" type="submit">Запустить due photo tasks сейчас</button>
         </form>
@@ -340,11 +340,11 @@
                             <td>{{ "active" if job.is_active else "paused" }}</td>
                             <td>{{ job.last_run_at or "—" }}</td>
                             <td class="d-flex gap-2">
-                                <form method="post" action="/my-telegram/photos/auto/{{ job.id }}/toggle">
+                                <form method="post" action="/my-telegram/photos/auto/{{ job.id }}/toggle" data-busy>
                                     <input type="hidden" name="phone" value="{{ selected_phone }}">
-                                    <button class="btn btn-sm btn-outline-primary" type="submit">Toggle</button>
+                                    <button class="btn btn-sm btn-outline-secondary" type="submit">Toggle</button>
                                 </form>
-                                <form method="post" action="/my-telegram/photos/auto/{{ job.id }}/delete">
+                                <form method="post" action="/my-telegram/photos/auto/{{ job.id }}/delete" data-busy>
                                     <input type="hidden" name="phone" value="{{ selected_phone }}">
                                     <button class="btn btn-sm btn-outline-danger" type="submit">Delete</button>
                                 </form>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -31,11 +31,11 @@
                     Включает фоновый планировщик: сбор каждые {{ interval_minutes }} мин., поиск каждые {{ search_interval_minutes }} мин.
                 </small>
                 {% if not is_running %}
-                <form method="post" action="/scheduler/start">
+                <form method="post" action="/scheduler/start" data-busy>
                     <button type="submit" class="btn btn-primary w-100">&#9654; Запустить планировщик</button>
                 </form>
                 {% else %}
-                <form method="post" action="/scheduler/stop">
+                <form method="post" action="/scheduler/stop" data-busy>
                     <button type="submit" class="btn btn-secondary w-100">&#9724; Остановить планировщик</button>
                 </form>
                 {% endif %}
@@ -49,7 +49,7 @@
                 <small class="text-muted d-block mb-3">
                     Добавляет задачи в очередь для каждого активного канала. То же, что на странице <a href="/channels">каналов</a>.
                 </small>
-                <form method="post" action="/scheduler/trigger">
+                <form method="post" action="/scheduler/trigger" data-busy>
                     <button type="submit" class="btn btn-secondary w-100">
                         &#9654; Собрать все каналы
                     </button>
@@ -76,10 +76,10 @@
         <p>Результат: запросов — {{ last_search_stats.queries }}, найдено — {{ last_search_stats.results }}, ошибок — {{ last_search_stats.errors }}</p>
         {% endif %}
         <div class="d-flex flex-wrap gap-2">
-            <form method="post" action="/scheduler/trigger-search">
+            <form method="post" action="/scheduler/trigger-search" data-busy>
                 <button type="submit" class="btn btn-secondary">&#9654; Запустить поиск по запросам</button>
             </form>
-            <form method="post" action="/scheduler/test-notification">
+            <form method="post" action="/scheduler/test-notification" data-busy>
                 <button type="submit" class="btn btn-outline-secondary"
                         {% if not bot_configured %}disabled title="Подключите бот в Настройках → Уведомления"{% endif %}>
                     Протестировать уведомления
@@ -282,14 +282,6 @@
 {% endif %}
 
 <script>
-document.querySelectorAll('form[action$="/trigger"], form[action$="/start"], form[action$="/stop"]').forEach(function(form) {
-    form.addEventListener('submit', function() {
-        var btn = form.querySelector('button[type="submit"]');
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> ' + btn.textContent.trim();
-        btn.disabled = true;
-    });
-});
-
 {% if has_active_tasks %}
 setTimeout(function() {
     window.location.reload();

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1>Поиск по постам</h1>
 
-<form method="get" action="/search">
+<form method="get" action="/search" data-busy>
     <div class="mb-3">
         <label for="q" class="form-label">Запрос</label>
         <input type="text" class="form-control" id="q" name="q" value="{{ q }}" placeholder="Введите поисковый запрос" autofocus>

--- a/src/web/templates/search_queries.html
+++ b/src/web/templates/search_queries.html
@@ -9,7 +9,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Добавить запрос</div>
     <div class="card-body">
-        <form method="post" action="/search-queries/add">
+        <form method="post" action="/search-queries/add" data-busy>
             <div class="row g-3 mb-3">
                 <div class="col-12 col-md-8">
                     <label class="form-label">Запрос <span class="hint" data-tooltip="Текст для поиска в собранных сообщениях. Поддерживает обычный текст, regex и FTS5-синтаксис">?</span></label>
@@ -89,22 +89,22 @@
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">&#128269;</a>
                 {% endif %}
                 <button type="button" class="btn btn-outline-secondary btn-sm emoji-btn" title="Редактировать" onclick="toggleEdit({{ sq.id }})">&#9999;&#65039;</button>
-                <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline">
+                <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Запустить сейчас">&#9654;&#65039;</button>
                 </form>
-                <form method="post" action="/search-queries/{{ sq.id }}/toggle" class="d-inline">
+                <form method="post" action="/search-queries/{{ sq.id }}/toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="{{ 'Отключить' if sq.is_active else 'Включить' }}">
                         {{ "⏏️" if sq.is_active else "🔄" }}
                     </button>
                 </form>
-                <form method="post" action="/search-queries/{{ sq.id }}/delete" class="d-inline" onsubmit="return confirm('Удалить этот запрос и всю его статистику?')">
+                <form method="post" action="/search-queries/{{ sq.id }}/delete" class="d-inline" onsubmit="return confirm('Удалить этот запрос и всю его статистику?')" data-busy>
                     <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Удалить">&#128465;&#65039;</button>
                 </form>
             </td>
         </tr>
         <tr id="edit-{{ sq.id }}" class="d-none">
             <td colspan="7">
-                <form method="post" action="/search-queries/{{ sq.id }}/edit">
+                <form method="post" action="/search-queries/{{ sq.id }}/edit" data-busy>
                     <div class="row g-3 mb-3">
                         <div class="col-12 col-md-8">
                             <label class="form-label">Запрос <span class="hint" data-tooltip="Текст для поиска в собранных сообщениях. Поддерживает обычный текст, regex и FTS5-синтаксис">?</span></label>
@@ -211,15 +211,15 @@
                 <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">&#128269;</a>
                 {% endif %}
-                <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline">
+                <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Запустить сейчас">&#9654;&#65039;</button>
                 </form>
-                <form method="post" action="/search-queries/{{ sq.id }}/toggle" class="d-inline">
+                <form method="post" action="/search-queries/{{ sq.id }}/toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="{{ 'Отключить' if sq.is_active else 'Включить' }}">
                         {{ "⏏️" if sq.is_active else "🔄" }}
                     </button>
                 </form>
-                <form method="post" action="/search-queries/{{ sq.id }}/delete" class="d-inline" onsubmit="return confirm('Удалить этот запрос и всю его статистику?')">
+                <form method="post" action="/search-queries/{{ sq.id }}/delete" class="d-inline" onsubmit="return confirm('Удалить этот запрос и всю его статистику?')" data-busy>
                     <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Удалить">&#128465;&#65039;</button>
                 </form>
             </div>

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -113,7 +113,7 @@
             </ol>
         </details>
 
-        <form method="post" action="/settings/save-credentials" class="mt-3">
+        <form method="post" action="/settings/save-credentials" class="mt-3" data-busy>
             <div class="row g-3 mb-3">
                 <div class="col-12 col-md-6">
                     <label for="api_id" class="form-label">API ID</label>
@@ -139,7 +139,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Планировщик</div>
     <div class="card-body">
-        <form method="post" action="/settings/save-scheduler">
+        <form method="post" action="/settings/save-scheduler" data-busy>
             <div class="mb-3">
                 <label for="collect_interval_minutes" class="form-label">Интервал сбора сообщений (минуты)</label>
                 <input type="number" class="form-control" id="collect_interval_minutes" name="collect_interval_minutes"
@@ -154,7 +154,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Режим разработчика</div>
     <div class="card-body">
-        <form method="post" action="/settings/save-agent">
+        <form method="post" action="/settings/save-agent" data-busy>
             <input type="hidden" name="agent_form_scope" value="dev_mode">
             <div class="form-check form-switch mb-3">
                 <input class="form-check-input" type="checkbox" id="agent_dev_mode_enabled"
@@ -184,7 +184,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">AI Agent</div>
     <div class="card-body">
-        <form method="post" action="/settings/save-agent">
+        <form method="post" action="/settings/save-agent" data-busy>
             <input type="hidden" name="agent_form_scope" value="backend_override">
             <div class="mb-3">
                 <label for="agent_backend_override" class="form-label">Backend override</label>
@@ -222,7 +222,7 @@
                         {% if not agent_provider_writes_enabled %}disabled{% endif %}>
                     Обновить модели у всех
                 </button>
-                <button type="button" class="btn btn-outline-primary btn-sm"
+                <button type="button" class="btn btn-outline-secondary btn-sm"
                         id="bulk-test-agent-providers-btn"
                         onclick="bulkTestAgentProviders()"
                         {% if not agent_provider_writes_enabled %}disabled{% endif %}>
@@ -238,7 +238,7 @@
         </div>
         {% endif %}
 
-        <form method="post" action="/settings/agent-providers/add" class="row g-2 align-items-end mb-4">
+        <form method="post" action="/settings/agent-providers/add" class="row g-2 align-items-end mb-4" data-busy>
             <div class="col-12 col-md-6">
                 <label for="deepagents_provider_add" class="form-label">Добавить провайдера</label>
                 <select id="deepagents_provider_add" name="provider" class="form-select" {% if not agent_provider_writes_enabled %}disabled{% endif %}>
@@ -254,7 +254,7 @@
         </form>
 
         {% if agent_provider_views %}
-        <form method="post" action="/settings/agent-providers/save">
+        <form method="post" action="/settings/agent-providers/save" data-busy>
             {% for item in agent_provider_views %}
             <div class="border rounded p-3 mb-3" data-provider-card="{{ item.provider }}">
                 <input type="hidden" name="provider_present__{{ item.provider }}" value="1">
@@ -388,7 +388,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Фильтры каналов</div>
     <div class="card-body">
-        <form method="post" action="/settings/save-filters">
+        <form method="post" action="/settings/save-filters" data-busy>
             <div class="mb-3">
                 <label for="min_subscribers_filter" class="form-label">Минимальное количество подписчиков</label>
                 <input type="number" class="form-control" id="min_subscribers_filter" name="min_subscribers_filter"
@@ -404,7 +404,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Уведомления</div>
     <div class="card-body">
-        <form method="post" action="/settings/save-notification-account" class="mb-3">
+        <form method="post" action="/settings/save-notification-account" class="mb-3" data-busy>
             <div class="mb-3">
                 <label for="notification_account_phone" class="form-label">Аккаунт для уведомлений</label>
                 <select id="notification_account_phone" name="notification_account_phone" class="form-select" class="w-auto">
@@ -434,19 +434,19 @@
             Notification bot: <code>@{{ notification_bot.bot_username }}</code>
             {% if notification_bot.bot_id %}(ID {{ notification_bot.bot_id }}){% endif %}
         </p>
-        <form method="post" action="/settings/notifications/delete" class="d-inline">
+        <form method="post" action="/settings/notifications/delete" class="d-inline" data-busy>
             <button type="submit" class="btn btn-outline-danger">Удалить notification bot</button>
         </form>
         {% if notification_target.state == "available" %}
-        <form method="post" action="/settings/notifications/test" class="d-inline">
-            <button type="submit" class="btn btn-outline-primary">Тест</button>
+        <form method="post" action="/settings/notifications/test" class="d-inline" data-busy>
+            <button type="submit" class="btn btn-outline-secondary">Тест</button>
         </form>
         {% endif %}
         {% elif notification_bot_error %}
         <p><small class="text-muted">{{ notification_bot_error }}</small></p>
         {% else %}
         <p>Для выбранного аккаунта notification bot ещё не настроен.</p>
-        <form method="post" action="/settings/notifications/setup" class="d-inline">
+        <form method="post" action="/settings/notifications/setup" class="d-inline" data-busy>
             <button type="submit" class="btn btn-outline-primary">Создать notification bot</button>
         </form>
         {% endif %}

--- a/src/web/templates/web_login.html
+++ b/src/web/templates/web_login.html
@@ -42,6 +42,7 @@
     </div>
 <script>
 document.addEventListener('submit', function(e) {
+    if (e.defaultPrevented) return;
     var form = e.target;
     if (!form.hasAttribute('data-busy')) return;
     var btn = e.submitter || form.querySelector('button[type="submit"]');

--- a/src/web/templates/web_login.html
+++ b/src/web/templates/web_login.html
@@ -21,7 +21,7 @@
                 <div class="alert alert-danger" role="alert">{{ error }}</div>
                 {% endif %}
 
-                <form method="post" action="/login">
+                <form method="post" action="/login" data-busy>
                     <input type="hidden" name="next" value="{{ next }}">
                     <div class="mb-3">
                         <label for="password" class="form-label">Пароль</label>
@@ -40,5 +40,16 @@
             </div>
         </div>
     </div>
+<script>
+document.addEventListener('submit', function(e) {
+    var form = e.target;
+    if (!form.hasAttribute('data-busy')) return;
+    var btn = e.submitter || form.querySelector('button[type="submit"]');
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
+});
+</script>
 </body>
 </html>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2338,7 +2338,7 @@ async def test_channels_page_collect_all_button_matches_htmx_fragment(client):
         'hx-post="/channels/collect-all"',
         'hx-target="#collect-all-btn"',
         'hx-swap="outerHTML"',
-        "btn-outline-primary",
+        "btn-secondary",
         "Собрать все каналы",
     ):
         assert expected in template_fragment


### PR DESCRIPTION
## Summary
- Add shared `data-busy` form handler in `base.html` — any `<form data-busy>` automatically shows a spinner and disables the submit button on submit
- Standardize button colors across all pages: trigger actions → `btn-secondary`, test/diagnostic → `btn-outline-secondary`, filter tabs → `btn-outline-primary`
- Replace per-page inline spinner scripts (scheduler.html, import_channels.html) with the shared utility
- Add loading feedback to ~40 forms that previously had no visual response on click

## Test plan
- [x] `ruff check` passes
- [x] All 135 web tests pass
- [ ] Manual browser check: scheduler, channels, settings, import, search, search_queries, login pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)