### PR TITLE
Unify SearchQuery SQL building into single _build_sq_parts method

### DIFF
--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -203,7 +203,11 @@ class MessagesRepository:
             )
 
         rows = await cur.fetchall()
-        messages = [
+        return self._rows_to_messages(rows), total
+
+    @staticmethod
+    def _rows_to_messages(rows) -> list[Message]:
+        return [
             Message(
                 id=r["id"],
                 channel_id=r["channel_id"],
@@ -222,7 +226,6 @@ class MessagesRepository:
             )
             for r in rows
         ]
-        return messages, total
 
     @staticmethod
     def _build_fts_match(query: str, is_fts: bool) -> str:
@@ -245,39 +248,69 @@ class MessagesRepository:
             params.append(f"%{stripped}%")
         return conditions, params
 
+    def _build_sq_parts(self, sq: SearchQuery) -> tuple[str, list[str], list]:
+        """Build FTS match and WHERE conditions from a SearchQuery.
+
+        Single source of truth for SearchQuery → SQL. All *_for_query methods
+        must use this instead of calling _build_fts_match/_build_extra_conditions
+        directly.
+
+        Returns (fts_query, extra_conditions, extra_params).
+        """
+        fts_query = self._build_fts_match(sq.query, sq.is_fts)
+        extra_conds, extra_params = self._build_extra_conditions(sq)
+        return fts_query, extra_conds, extra_params
+
     def _require_fts(self) -> None:
         if not self._fts_available:
             raise RuntimeError(
                 "FTS5 full-text search is unavailable (index build failed at startup)."
             )
 
+    _FTS_JOIN = (
+        " INNER JOIN (SELECT rowid FROM messages_fts"
+        " WHERE messages_fts MATCH ?) AS fts ON m.id = fts.rowid"
+    )
+    _CHANNEL_JOIN = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
+    _BASE_FILTER = "(c.is_filtered IS NULL OR c.is_filtered = 0)"
+
     async def search_messages_for_query(
         self, sq: SearchQuery, limit: int = 1,
     ) -> tuple[list[Message], int]:
-        """Quick message lookup for test notifications.
+        """Search messages using all SearchQuery parameters."""
+        self._require_fts()
+        fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
+        where_parts = [self._BASE_FILTER, *extra_conds]
+        where_clause = " AND ".join(where_parts)
 
-        Note: is_regex and exclude_patterns are not supported here;
-        this is a connectivity check, not a full notification simulation.
-        """
-        return await self.search_messages(
-            query=sq.query,
-            limit=limit,
-            is_fts=sq.is_fts,
-            max_length=sq.max_length,
+        count_cur = await self._db.execute(
+            f"SELECT COUNT(*) AS cnt FROM messages m"
+            f"{self._FTS_JOIN}{self._CHANNEL_JOIN}"
+            f" WHERE {where_clause}",
+            (fts_query, *extra_params),
         )
+        row = await count_cur.fetchone()
+        total = row["cnt"] if row else 0
+
+        cur = await self._db.execute(
+            f"SELECT m.*, c.title as channel_title, c.username as channel_username"
+            f" FROM messages m{self._FTS_JOIN}{self._CHANNEL_JOIN}"
+            f" WHERE {where_clause}"
+            f" ORDER BY m.date DESC LIMIT ?",
+            (fts_query, *extra_params, limit),
+        )
+        rows = await cur.fetchall()
+        messages = self._rows_to_messages(rows)
+        return messages, total
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:
         self._require_fts()
-        fts_query = self._build_fts_match(sq.query, sq.is_fts)
-        extra_conds, extra_params = self._build_extra_conditions(sq)
-        where_parts = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
-        where_parts.extend(extra_conds)
+        fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
+        where_parts = [self._BASE_FILTER, *extra_conds]
         where_clause = " AND ".join(where_parts)
         cur = await self._db.execute(
             f"SELECT COUNT(*) AS cnt FROM messages m"
-            f" INNER JOIN (SELECT rowid FROM messages_fts"
-            f" WHERE messages_fts MATCH ?) AS fts ON m.id = fts.rowid"
-            f" LEFT JOIN channels c ON m.channel_id = c.channel_id"
+            f"{self._FTS_JOIN}{self._CHANNEL_JOIN}"
             f" WHERE {where_clause}",
             (fts_query, *extra_params),
         )
@@ -290,21 +323,17 @@ class MessagesRepository:
         self._require_fts()
         from src.models import SearchQueryDailyStat
 
-        fts_query = self._build_fts_match(sq.query, sq.is_fts)
-        extra_conds, extra_params = self._build_extra_conditions(sq)
+        fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
         where_parts = [
-            "(c.is_filtered IS NULL OR c.is_filtered = 0)",
+            self._BASE_FILTER,
             "m.date >= datetime('now', ?)",
+            *extra_conds,
         ]
-        where_parts.extend(extra_conds)
         where_clause = " AND ".join(where_parts)
         cur = await self._db.execute(
             f"""
             SELECT date(m.date) AS day, COUNT(*) AS count
-            FROM messages m
-            INNER JOIN (SELECT rowid FROM messages_fts
-                        WHERE messages_fts MATCH ?) AS fts ON m.id = fts.rowid
-            LEFT JOIN channels c ON m.channel_id = c.channel_id
+            FROM messages m{self._FTS_JOIN}{self._CHANNEL_JOIN}
             WHERE {where_clause}
             GROUP BY date(m.date)
             ORDER BY day

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -137,10 +137,10 @@ async def test_notification(request: Request):
 
     db = deps.get_db(request)
     queries = await db.repos.search_queries.get_all(active_only=True)
-    if not queries:
+    q = next((q for q in queries if not q.is_regex), None)
+    if not q:
         text = "🔔 Тест уведомлений: нет поисковых запросов"
     else:
-        q = queries[0]
         messages, _ = await db.search_messages_for_query(q, limit=1)
         if messages:
             msg = messages[0]

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -136,7 +136,7 @@ async def test_notification(request: Request):
         return RedirectResponse(url="/scheduler?error=bot_not_configured", status_code=303)
 
     db = deps.get_db(request)
-    queries = await db.get_notification_queries(active_only=True)
+    queries = await db.repos.search_queries.get_all(active_only=True)
     if not queries:
         text = "🔔 Тест уведомлений: нет поисковых запросов"
     else:


### PR DESCRIPTION
## 💪 What

- Extracts `_build_sq_parts(sq)` as the single source of truth for converting `SearchQuery` → FTS match expression + WHERE conditions in `MessagesRepository`
- Rewrites `search_messages_for_query` to build SQL directly via `_build_sq_parts` instead of delegating to `search_messages()` — now properly handles `exclude_patterns`
- Simplifies `count_fts_matches_for_query` and `get_fts_daily_stats_for_query` to use `_build_sq_parts` and shared SQL constants (`_FTS_JOIN`, `_CHANNEL_JOIN`, `_BASE_FILTER`)
- Extracts `_rows_to_messages()` static method to avoid duplicating row→Message mapping
- Fixes test-notification to query all active search queries (`get_all`) instead of only `notify_on_collect` ones

## 🤔 Why

- Three functions built SQL from `SearchQuery` independently — adding a new field meant editing 3 places
- `search_messages_for_query` skipped `exclude_patterns` entirely, producing different results than the Search Queries page
- `get_notification_queries` filtered out queries without `notify_on_collect=True`, making the test notification button useless when the user's only query had `notify_on_collect=False`

## 👩‍🔬 How to validate

1. Create a search query on `/search-queries` with FTS syntax (e.g. `word1* AND word2*`) and `is_fts=True`, leave `notify_on_collect` unchecked
2. Click "Протестировать уведомления" on `/scheduler` — should find messages and send a real preview with a t.me link
3. Verify the Search Queries page (`/search-queries`) still shows correct match counts
4. Run the query manually on the Search page (`/search`) with FTS checkbox — results should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)