### PR TITLE
feat: global exception handler for 500 error debugging

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -5,10 +5,10 @@ import logging
 import secrets
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import RedirectResponse, Response
+from starlette.responses import HTMLResponse, RedirectResponse, Response
 
 from src.config import AppConfig, load_config
 from src.web.assembly import (
@@ -110,6 +110,26 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     if config.web.password:
         app.add_middleware(BasicAuthMiddleware, password=config.web.password)
     app.add_middleware(OriginCSRFMiddleware)
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+
+        if request.headers.get("HX-Request") == "true":
+            return HTMLResponse(
+                '<div class="alert alert-danger">Internal error — check /debug/</div>',
+                status_code=500,
+            )
+
+        try:
+            return app.state.templates.TemplateResponse(
+                request,
+                "error.html",
+                {"status_code": 500, "detail": str(exc)},
+                status_code=500,
+            )
+        except Exception:
+            return HTMLResponse("Internal Server Error", status_code=500)
 
     register_builtin_endpoints(app)
     register_routes(app)

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -125,7 +125,10 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
             return app.state.templates.TemplateResponse(
                 request,
                 "error.html",
-                {"status_code": 500, "detail": str(exc)},
+                {
+                    "status_code": 500,
+                    "detail": "An unexpected error occurred. See /debug/ for details.",
+                },
                 status_code=500,
             )
         except Exception:

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -117,7 +117,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
 
         if request.headers.get("HX-Request") == "true":
             return HTMLResponse(
-                '<div class="alert alert-danger">Internal error — check /debug/</div>',
+                '<div class="alert alert-danger">Внутренняя ошибка — см. /debug/</div>',
                 status_code=500,
             )
 

--- a/src/web/templates/error.html
+++ b/src/web/templates/error.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Ошибка {{ status_code }}{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card border-danger">
+                <div class="card-body text-center py-5">
+                    <h1 class="display-1 text-danger mb-3">{{ status_code }}</h1>
+                    <h4 class="mb-3">Ошибка сервера</h4>
+                    <p class="text-muted mb-4">{{ detail }}</p>
+                    <a href="/debug/" class="btn btn-outline-secondary">Подробности в /debug/</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2970,7 +2970,7 @@ async def test_unhandled_exception_returns_error_page(error_client):
     resp = await error_client.get("/test-500")
     assert resp.status_code == 500
     assert "Ошибка сервера" in resp.text
-    assert "kaboom" in resp.text
+    assert "kaboom" not in resp.text  # exception detail must not leak
     assert "/debug/" in resp.text
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2940,3 +2940,57 @@ async def test_test_notification_notify_fails(client, monkeypatch):
     resp = await client.post("/scheduler/test-notification")
     assert resp.status_code == 200
     assert "Не удалось отправить уведомление" in resp.text
+
+
+# --- Global error handler ---
+
+
+@pytest.fixture
+async def error_client(client):
+    """Client with raise_app_exceptions=False so exception handler is tested."""
+    app = client._transport.app
+
+    @app.get("/test-500")
+    async def _blow_up():
+        raise RuntimeError("kaboom")
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": f"Basic {auth_header}"},
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_returns_error_page(error_client):
+    """Unhandled exception in a route returns 500 with error template."""
+    resp = await error_client.get("/test-500")
+    assert resp.status_code == 500
+    assert "Ошибка сервера" in resp.text
+    assert "kaboom" in resp.text
+    assert "/debug/" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_htmx_returns_fragment(error_client):
+    """HTMX request to a broken route returns an alert fragment, not full page."""
+    resp = await error_client.get("/test-500", headers={"HX-Request": "true"})
+    assert resp.status_code == 500
+    assert "alert-danger" in resp.text
+    assert "/debug/" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_unhandled_exception_logged_to_logbuffer(error_client):
+    """Exception traceback is captured by logger (and thus by LogBuffer)."""
+    app = error_client._transport.app
+    log_buffer = app.state.log_buffer
+
+    initial_count = len(log_buffer.get_records())
+    await error_client.get("/test-500")
+
+    new_records = log_buffer.get_records()[initial_count:]
+    assert any("kaboom" in r["message"] for r in new_records)


### PR DESCRIPTION
## Summary
- Add `@app.exception_handler(Exception)` in `create_app()` to catch unhandled exceptions
- Return proper error page (`error.html`) for regular requests, alert fragment for HTMX requests
- Traceback logged via `logger.exception()` → `LogBuffer` → visible on `/debug/`

## Test plan
- [x] 3 new tests: error page rendering, HTMX fragment, LogBuffer capture
- [x] All 138 existing `test_web.py` tests pass
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)