### PR TITLE
refactor: unified task dispatcher and enqueue-based scheduler

### DIFF
--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -5,6 +5,10 @@ import asyncio
 import logging
 
 from src.cli import runtime
+from src.collection_queue import CollectionQueue
+from src.database.bundles import ChannelBundle
+from src.services.collection_service import CollectionService
+from src.services.task_enqueuer import TaskEnqueuer
 from src.telegram.collector import Collector
 
 
@@ -33,8 +37,18 @@ def run(args: argparse.Namespace) -> None:
                 count = await collector.collect_single_channel(channel, full=True)
                 print(f"Collected {count} messages from channel {args.channel_id}")
             else:
-                stats = await collector.collect_all_channels()
-                print(f"Collection complete: {stats}")
+                channel_bundle = ChannelBundle.from_database(db)
+                collection_queue = CollectionQueue(collector, channel_bundle)
+                collection_service = CollectionService(
+                    channel_bundle, collector, collection_queue
+                )
+                task_enqueuer = TaskEnqueuer(db, channel_bundle, collection_service)
+                result = await task_enqueuer.enqueue_all_channels()
+                print(
+                    f"Enqueued {result.queued_count} channels "
+                    f"(skipped {result.skipped_existing_count}, "
+                    f"total {result.total_candidates})"
+                )
         finally:
             await pool.disconnect_all()
             await db.close()

--- a/src/cli/commands/scheduler.py
+++ b/src/cli/commands/scheduler.py
@@ -36,6 +36,7 @@ def run(args: argparse.Namespace) -> None:
                     config.scheduler,
                     task_enqueuer=task_enqueuer,
                     search_engine=search_engine,
+                    db=db,
                 )
                 await manager.start()
                 print(

--- a/src/cli/commands/scheduler.py
+++ b/src/cli/commands/scheduler.py
@@ -5,8 +5,12 @@ import asyncio
 import logging
 
 from src.cli import runtime
+from src.collection_queue import CollectionQueue
+from src.database.bundles import ChannelBundle
 from src.scheduler.manager import SchedulerManager
 from src.search.engine import SearchEngine
+from src.services.collection_service import CollectionService
+from src.services.task_enqueuer import TaskEnqueuer
 from src.telegram.collector import Collector
 
 
@@ -22,10 +26,16 @@ def run(args: argparse.Namespace) -> None:
 
             collector = Collector(pool, db, config.scheduler)
             search_engine = SearchEngine(db, pool)
+            channel_bundle = ChannelBundle.from_database(db)
+            collection_queue = CollectionQueue(collector, channel_bundle)
+            collection_service = CollectionService(channel_bundle, collector, collection_queue)
+            task_enqueuer = TaskEnqueuer(db, channel_bundle, collection_service)
 
             if args.scheduler_action == "start":
                 manager = SchedulerManager(
-                    collector, config.scheduler, search_engine=search_engine, db=db
+                    config.scheduler,
+                    task_enqueuer=task_enqueuer,
+                    search_engine=search_engine,
                 )
                 await manager.start()
                 print(
@@ -39,14 +49,18 @@ def run(args: argparse.Namespace) -> None:
                     await manager.stop()
                     print("\nScheduler stopped.")
             elif args.scheduler_action == "trigger":
-                stats = await collector.collect_all_channels()
-                print(f"Collection complete: {stats}")
-            elif args.scheduler_action == "search":
-                manager = SchedulerManager(
-                    collector, config.scheduler, search_engine=search_engine, db=db
+                result = await collection_service.enqueue_all_channels()
+                print(
+                    f"Enqueued {result.queued_count} channels "
+                    f"(skipped {result.skipped_existing_count}, "
+                    f"total {result.total_candidates})"
                 )
-                stats = await manager.trigger_search_now()
-                print(f"Notification query search complete: {stats}")
+            elif args.scheduler_action == "search":
+                task_id = await task_enqueuer.enqueue_notification_search()
+                if task_id:
+                    print(f"Enqueued notification search task #{task_id}")
+                else:
+                    print("Notification search task already active")
         finally:
             await pool.disconnect_all()
             await db.close()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -10,6 +10,7 @@ from src.models import (
     CollectionTask,
     CollectionTaskStatus,
     CollectionTaskType,
+    SqStatsTaskPayload,
     StatsAllTaskPayload,
 )
 
@@ -21,7 +22,7 @@ class CollectionTasksRepository:
     @staticmethod
     def _deserialize_payload(
         raw: str | None,
-    ) -> dict[str, Any] | StatsAllTaskPayload | None:
+    ) -> dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None:
         if not raw:
             return None
         try:
@@ -30,15 +31,20 @@ class CollectionTasksRepository:
             return None
         if not isinstance(parsed, dict):
             return None
-        if parsed.get("task_kind") == CollectionTaskType.STATS_ALL.value:
+        task_kind = parsed.get("task_kind")
+        if task_kind == CollectionTaskType.STATS_ALL.value:
             return StatsAllTaskPayload.model_validate(parsed)
+        if task_kind == CollectionTaskType.SQ_STATS.value:
+            return SqStatsTaskPayload.model_validate(parsed)
         return parsed
 
     @staticmethod
-    def _serialize_payload(payload: dict[str, Any] | StatsAllTaskPayload | None) -> str | None:
+    def _serialize_payload(
+        payload: dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None,
+    ) -> str | None:
         if payload is None:
             return None
-        if isinstance(payload, StatsAllTaskPayload):
+        if isinstance(payload, (StatsAllTaskPayload, SqStatsTaskPayload)):
             return payload.model_dump_json()
         return json.dumps(payload)
 
@@ -375,6 +381,121 @@ class CollectionTasksRepository:
         )
         await self._db.commit()
         return cur.rowcount or 0
+
+    async def create_generic_task(
+        self,
+        task_type: CollectionTaskType | str,
+        *,
+        title: str = "",
+        payload: dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None = None,
+        run_after: datetime | None = None,
+        parent_task_id: int | None = None,
+    ) -> int:
+        tt = task_type
+        task_type_value = tt.value if isinstance(tt, CollectionTaskType) else tt
+        run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
+        cur = await self._db.execute(
+            "INSERT INTO collection_tasks "
+            "(channel_id, channel_title, channel_username, task_type,"
+            " run_after, payload, parent_task_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                None,
+                title or task_type_value,
+                None,
+                task_type_value,
+                run_after_iso,
+                self._serialize_payload(payload),
+                parent_task_id,
+            ),
+        )
+        await self._db.commit()
+        return cur.lastrowid or 0
+
+    async def claim_next_due_generic_task(
+        self, now: datetime, handled_types: list[str]
+    ) -> CollectionTask | None:
+        if not handled_types:
+            return None
+        now_iso = now.astimezone(timezone.utc).isoformat()
+        placeholders = ", ".join("?" for _ in handled_types)
+        try:
+            await self._db.execute("BEGIN IMMEDIATE")
+            cur = await self._db.execute(
+                f"SELECT id FROM collection_tasks "
+                f"WHERE task_type IN ({placeholders}) "
+                "AND status = ? "
+                "AND (run_after IS NULL OR run_after <= ?) "
+                "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
+                (*handled_types, CollectionTaskStatus.PENDING.value, now_iso),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                await self._db.commit()
+                return None
+            selected_id = row["id"]
+            updated = await self._db.execute(
+                "UPDATE collection_tasks "
+                "SET status = 'running', started_at = ?, completed_at = NULL "
+                "WHERE id = ? AND status = ?",
+                (now_iso, selected_id, CollectionTaskStatus.PENDING.value),
+            )
+            if (updated.rowcount or 0) == 0:
+                await self._db.commit()
+                return None
+            cur = await self._db.execute(
+                "SELECT * FROM collection_tasks WHERE id = ?",
+                (selected_id,),
+            )
+            claimed = await cur.fetchone()
+            await self._db.commit()
+            if claimed is None:
+                return None
+            return self._to_task(claimed)
+        except Exception:
+            await self._db.rollback()
+            raise
+
+    async def requeue_running_generic_tasks_on_startup(
+        self, now: datetime, handled_types: list[str]
+    ) -> int:
+        if not handled_types:
+            return 0
+        now_iso = now.astimezone(timezone.utc).isoformat()
+        placeholders = ", ".join("?" for _ in handled_types)
+        cur = await self._db.execute(
+            f"UPDATE collection_tasks "
+            "SET status = 'pending', started_at = NULL, run_after = COALESCE(run_after, ?) "
+            f"WHERE task_type IN ({placeholders}) AND status = ?",
+            (now_iso, *handled_types, CollectionTaskStatus.RUNNING.value),
+        )
+        await self._db.commit()
+        return cur.rowcount or 0
+
+    async def has_active_task(
+        self,
+        task_type: CollectionTaskType | str,
+        *,
+        payload_filter_key: str | None = None,
+        payload_filter_value: str | int | None = None,
+    ) -> bool:
+        tt = task_type
+        task_type_value = tt.value if isinstance(tt, CollectionTaskType) else tt
+        sql = (
+            "SELECT COUNT(*) as cnt FROM collection_tasks "
+            "WHERE task_type = ? AND status IN (?, ?)"
+        )
+        params: list[Any] = [
+            task_type_value,
+            CollectionTaskStatus.PENDING.value,
+            CollectionTaskStatus.RUNNING.value,
+        ]
+        if payload_filter_key is not None and payload_filter_value is not None:
+            sql += f" AND json_extract(payload, '$.{payload_filter_key}') = ?"
+            params.append(payload_filter_value)
+        cur = await self._db.execute(sql, tuple(params))
+        row = await cur.fetchone()
+        return (row["cnt"] if row else 0) > 0
 
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
         now = datetime.now(tz=timezone.utc).isoformat()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -14,6 +14,8 @@ from src.models import (
     StatsAllTaskPayload,
 )
 
+_ALLOWED_PAYLOAD_KEYS = frozenset({"sq_id"})
+
 
 class CollectionTasksRepository:
     def __init__(self, db: aiosqlite.Connection):
@@ -144,6 +146,7 @@ class CollectionTasksRepository:
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
+        payload: dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None = None,
     ) -> None:
         status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -165,6 +168,9 @@ class CollectionTasksRepository:
         if note is not None:
             sets.append("note = ?")
             params.append(note)
+        if payload is not None:
+            sets.append("payload = ?")
+            params.append(self._serialize_payload(payload))
         params.append(task_id)
         await self._db.execute(
             f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
@@ -491,6 +497,8 @@ class CollectionTasksRepository:
             CollectionTaskStatus.RUNNING.value,
         ]
         if payload_filter_key is not None and payload_filter_value is not None:
+            if payload_filter_key not in _ALLOWED_PAYLOAD_KEYS:
+                raise ValueError(f"Invalid payload filter key: {payload_filter_key!r}")
             sql += f" AND json_extract(payload, '$.{payload_filter_key}') = ?"
             params.append(payload_filter_value)
         cur = await self._db.execute(sql, tuple(params))

--- a/src/models.py
+++ b/src/models.py
@@ -67,6 +67,10 @@ class CollectionTaskStatus(StrEnum):
 class CollectionTaskType(StrEnum):
     CHANNEL_COLLECT = "channel_collect"
     STATS_ALL = "stats_all"
+    NOTIFICATION_SEARCH = "notification_search"
+    SQ_STATS = "sq_stats"
+    PHOTO_DUE = "photo_due"
+    PHOTO_AUTO = "photo_auto"
 
 
 class StatsAllTaskPayload(BaseModel):
@@ -76,6 +80,11 @@ class StatsAllTaskPayload(BaseModel):
     batch_size: int = 20
     channels_ok: int = 0
     channels_err: int = 0
+
+
+class SqStatsTaskPayload(BaseModel):
+    task_kind: str = CollectionTaskType.SQ_STATS.value
+    sq_id: int
 
 
 class CollectionTask(BaseModel):
@@ -89,7 +98,7 @@ class CollectionTask(BaseModel):
     error: str | None = None
     note: str | None = None
     run_after: datetime | None = None
-    payload: dict[str, Any] | StatsAllTaskPayload | None = None
+    payload: dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None = None
     parent_task_id: int | None = None
     created_at: datetime | None = None
     started_at: datetime | None = None

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -12,12 +12,9 @@ from src.config import SchedulerConfig
 from src.database import Database
 from src.database.bundles import SchedulerBundle, SearchQueryBundle
 from src.settings_utils import parse_int_setting
-from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
-    from src.search.engine import SearchEngine
-    from src.services.photo_auto_upload_service import PhotoAutoUploadService
-    from src.services.photo_task_service import PhotoTaskService
+    from src.services.task_enqueuer import TaskEnqueuer
 
 logger = logging.getLogger(__name__)
 
@@ -36,39 +33,64 @@ class _LegacySchedulerBundle:
 class SchedulerManager:
     def __init__(
         self,
-        collector: Collector,
-        config: SchedulerConfig,
+        *args,
+        config: SchedulerConfig | None = None,
         scheduler_bundle: SchedulerBundle | Database | None = None,
-        search_engine: SearchEngine | None = None,
         search_query_bundle: SearchQueryBundle | None = None,
-        photo_task_service: PhotoTaskService | None = None,
-        photo_auto_upload_service: PhotoAutoUploadService | None = None,
+        task_enqueuer: TaskEnqueuer | None = None,
+        collector=None,
+        search_engine=None,
+        photo_task_service=None,
+        photo_auto_upload_service=None,
+        db=None,
     ):
-        self._collector = collector
+        # Support legacy: SchedulerManager(collector, config, bundle)
+        # and new: SchedulerManager(config, ...) or all-keyword
+        if args:
+            if isinstance(args[0], SchedulerConfig):
+                config = args[0]
+            else:
+                collector = args[0]
+                if len(args) >= 2:
+                    config = args[1]
+                if len(args) >= 3 and scheduler_bundle is None:
+                    scheduler_bundle = args[2]
+
+        if config is None:
+            config = SchedulerConfig()
         self._config = config
+        self._task_enqueuer = task_enqueuer
+
         if scheduler_bundle is None:
-            scheduler_bundle = getattr(collector, "_db", None)
+            if db is not None:
+                scheduler_bundle = db
+            elif collector is not None:
+                scheduler_bundle = getattr(collector, "_db", None)
         if isinstance(scheduler_bundle, Database):
             scheduler_bundle = SchedulerBundle.from_database(scheduler_bundle)
         elif not isinstance(scheduler_bundle, SchedulerBundle):
-            scheduler_bundle = _LegacySchedulerBundle(scheduler_bundle)
+            if scheduler_bundle is not None:
+                scheduler_bundle = _LegacySchedulerBundle(scheduler_bundle)
         self._scheduler_bundle = scheduler_bundle
-        self._search_engine = search_engine
         self._sq_bundle = search_query_bundle
-        self._photo_task_service = photo_task_service
-        self._photo_auto_upload_service = photo_auto_upload_service
         self._scheduler: AsyncIOScheduler | None = None
         self._job_id = "collect_all"
         self._search_job_id = "notification_search"
         self._photo_due_job_id = "photo_due"
         self._photo_auto_job_id = "photo_auto"
+        self._current_interval_minutes: int = config.collect_interval_minutes
+
+        # Legacy attributes for backward compat
+        self._collector = collector
+        self._search_engine = search_engine
+        self._photo_task_service = photo_task_service
+        self._photo_auto_upload_service = photo_auto_upload_service
         self._last_run: datetime | None = None
         self._last_stats: dict | None = None
         self._last_search_run: datetime | None = None
         self._last_search_stats: dict | None = None
         self._bg_task: asyncio.Task | None = None
         self._search_bg_task: asyncio.Task | None = None
-        self._current_interval_minutes: int = config.collect_interval_minutes
 
     @property
     def is_running(self) -> bool:
@@ -76,7 +98,17 @@ class SchedulerManager:
 
     @property
     def is_collecting(self) -> bool:
-        return self._collector.is_running
+        if self._collector:
+            return self._collector.is_running
+        return False
+
+    @property
+    def interval_minutes(self) -> int:
+        return self._current_interval_minutes
+
+    @property
+    def search_interval_minutes(self) -> int:
+        return self._config.search_interval_minutes
 
     @property
     def last_run(self) -> datetime | None:
@@ -94,30 +126,22 @@ class SchedulerManager:
     def last_search_stats(self) -> dict | None:
         return self._last_search_stats
 
-    @property
-    def interval_minutes(self) -> int:
-        # Before start() is called, reflects config default (not yet loaded from DB).
-        return self._current_interval_minutes
-
-    @property
-    def search_interval_minutes(self) -> int:
-        return self._config.search_interval_minutes
-
     async def start(self) -> None:
         if self._scheduler is not None and self._scheduler.running:
             logger.warning("Scheduler already running")
             return
 
         if self._scheduler is not None:
-            # Clean up a previously created but no-longer-running scheduler
-            # to avoid orphaning it when we create a new one below.
             try:
                 self._scheduler.shutdown(wait=False)
             except Exception:
                 pass
 
         self._scheduler = AsyncIOScheduler()
-        saved_interval = await self._scheduler_bundle.get_setting("collect_interval_minutes")
+        if self._scheduler_bundle:
+            saved_interval = await self._scheduler_bundle.get_setting("collect_interval_minutes")
+        else:
+            saved_interval = None
         collect_interval = parse_int_setting(
             saved_interval,
             setting_name="collect_interval_minutes",
@@ -132,7 +156,9 @@ class SchedulerManager:
             replace_existing=True,
         )
 
-        if self._search_engine:
+        # Notification search job
+        has_search = self._task_enqueuer is not None or self._search_engine is not None
+        if has_search:
             self._scheduler.add_job(
                 self._run_keyword_search,
                 IntervalTrigger(minutes=self._config.search_interval_minutes),
@@ -146,14 +172,20 @@ class SchedulerManager:
 
         if self._sq_bundle:
             await self.sync_search_query_jobs()
-        if self._photo_task_service:
+
+        # Photo jobs
+        has_photo_due = self._task_enqueuer is not None or self._photo_task_service is not None
+        has_photo_auto = (
+            self._task_enqueuer is not None or self._photo_auto_upload_service is not None
+        )
+        if has_photo_due:
             self._scheduler.add_job(
                 self._run_photo_due,
                 IntervalTrigger(minutes=1),
                 id=self._photo_due_job_id,
                 replace_existing=True,
             )
-        if self._photo_auto_upload_service:
+        if has_photo_auto:
             self._scheduler.add_job(
                 self._run_photo_auto,
                 IntervalTrigger(minutes=1),
@@ -162,10 +194,7 @@ class SchedulerManager:
             )
 
         self._scheduler.start()
-        logger.info(
-            "Scheduler started: collecting every %d minutes",
-            collect_interval,
-        )
+        logger.info("Scheduler started: collecting every %d minutes", collect_interval)
 
     async def stop(self) -> None:
         for task in (self._bg_task, self._search_bg_task):
@@ -185,96 +214,100 @@ class SchedulerManager:
         logger.info("Scheduler stopped")
 
     def update_interval(self, minutes: int) -> None:
-        """Reschedule the collection job with a new interval."""
         self._current_interval_minutes = minutes
         if self._scheduler and self._scheduler.running:
             self._scheduler.reschedule_job(self._job_id, trigger=IntervalTrigger(minutes=minutes))
             logger.info("Collection interval updated to %d minutes", minutes)
-        else:
-            logger.debug(
-                "Scheduler not running; interval %d minutes will apply on next start", minutes
-            )
 
     async def trigger_now(self) -> dict:
-        """Trigger immediate collection run."""
         return await self._run_collection()
 
     async def trigger_background(self) -> None:
-        """Fire-and-forget collection run."""
-        if self._collector.is_running or (self._bg_task and not self._bg_task.done()):
+        """Fire-and-forget collection run (legacy compat)."""
+        if self._collector and self._collector.is_running:
+            return
+        if self._bg_task and not self._bg_task.done():
             return
         self._bg_task = asyncio.create_task(self._run_collection())
 
     async def trigger_search_now(self) -> dict:
-        """Trigger immediate notification query search."""
         return await self._run_keyword_search()
 
     async def trigger_search_background(self) -> None:
-        """Fire-and-forget notification query search run."""
+        """Fire-and-forget notification search run (legacy compat)."""
         if self._search_bg_task and not self._search_bg_task.done():
             return
         self._search_bg_task = asyncio.create_task(self._run_keyword_search())
 
-    async def trigger_photo_due_now(self) -> dict:
-        return await self._run_photo_due()
-
-    async def trigger_photo_auto_now(self) -> dict:
-        return await self._run_photo_auto()
-
     async def _run_collection(self) -> dict:
+        """Enqueue all channels for collection."""
         logger.info("Starting scheduled collection")
-        try:
-            stats = await self._collector.collect_all_channels()
-        except Exception:
-            logger.exception("Collection failed with unhandled error")
-            return {"channels": 0, "messages": 0, "errors": 1}
-        self._last_run = datetime.now(timezone.utc)
-        self._last_stats = stats
-        return stats
+        if self._task_enqueuer:
+            try:
+                result = await self._task_enqueuer.enqueue_all_channels()
+                stats = {
+                    "channels": result.queued_count,
+                    "skipped": result.skipped_existing_count,
+                    "total": result.total_candidates,
+                }
+                self._last_run = datetime.now(timezone.utc)
+                self._last_stats = stats
+                logger.info("Scheduled collection enqueued: %s", stats)
+                return stats
+            except Exception:
+                logger.exception("Collection enqueue failed")
+                return {"channels": 0, "messages": 0, "errors": 1}
+        # Legacy fallback
+        if self._collector:
+            try:
+                stats = await self._collector.collect_all_channels()
+                self._last_run = datetime.now(timezone.utc)
+                self._last_stats = stats
+                return stats
+            except Exception:
+                logger.exception("Collection failed")
+                return {"channels": 0, "messages": 0, "errors": 1}
+        return {"channels": 0, "messages": 0, "errors": 0}
 
     async def _run_keyword_search(self) -> dict:
-        """Search Telegram API by notification queries (premium global search).
+        """Enqueue a notification search task."""
+        if self._task_enqueuer:
+            try:
+                task_id = await self._task_enqueuer.enqueue_notification_search()
+                if task_id:
+                    logger.info("Enqueued notification search task #%d", task_id)
+                return {"enqueued": bool(task_id)}
+            except Exception:
+                logger.exception("Notification search enqueue failed")
+                return {"queries": 0, "results": 0, "errors": 1}
+        # Legacy fallback
+        if self._search_engine and self._scheduler_bundle:
+            stats = await self._run_keyword_search_legacy()
+            self._last_search_run = datetime.now(timezone.utc)
+            self._last_search_stats = stats
+            return stats
+        return {"queries": 0, "results": 0, "errors": 0}
 
-        This complements the local text/regex matching in Collector._check_notification_queries
-        which runs at collection time. This method uses SearchEngine.search_telegram (Telegram's
-        premium global search API) to discover messages across channels not yet collected.
-        """
-        if not self._search_engine:
-            return {"queries": 0, "results": 0, "errors": 0}
-
-        logger.info("Starting scheduled notification query search")
+    async def _run_keyword_search_legacy(self) -> dict:
         queries = await self._scheduler_bundle.list_notification_queries(active_only=True)
         total_results = 0
         searched = 0
         errors = 0
-
         for sq in queries:
-            query = sq.query
             try:
-                quota = await self._search_engine.check_search_quota(query)
+                quota = await self._search_engine.check_search_quota(sq.query)
                 if quota and quota.get("remains") == 0 and not quota.get("query_is_free"):
-                    logger.info("Search quota exhausted, stopping notification search")
                     break
-
-                result = await self._search_engine.search_telegram(query, limit=50)
+                result = await self._search_engine.search_telegram(sq.query, limit=50)
                 if result.error:
-                    logger.warning("Search for '%s' returned error: %s", query, result.error)
                     errors += 1
                 else:
                     total_results += result.total
                     searched += 1
-                    logger.info(
-                        "Query '%s': found %d messages", query, result.total
-                    )
             except Exception:
-                logger.exception("Error searching query '%s'", query)
+                logger.exception("Error searching query '%s'", sq.query)
                 errors += 1
-
-        stats = {"queries": searched, "results": total_results, "errors": errors}
-        self._last_search_run = datetime.now(timezone.utc)
-        self._last_search_stats = stats
-        logger.info("Notification query search complete: %s", stats)
-        return stats
+        return {"queries": searched, "results": total_results, "errors": errors}
 
     async def sync_search_query_jobs(self) -> None:
         if not self._sq_bundle or not self._scheduler:
@@ -302,13 +335,22 @@ class SchedulerManager:
         logger.info("Synced %d search query jobs", len(active_queries))
 
     async def _run_search_query(self, sq_id: int) -> None:
+        """Enqueue SQ_STATS task for a search query."""
+        if self._task_enqueuer:
+            try:
+                await self._task_enqueuer.enqueue_sq_stats(sq_id)
+            except Exception:
+                logger.exception("Error enqueuing SQ_STATS for sq_id=%d", sq_id)
+            return
+        # Legacy fallback
         if not self._sq_bundle:
             return
         sq = await self._sq_bundle.get_by_id(sq_id)
         if not sq:
-            logger.warning("Search query id=%d not found, skipping", sq_id)
             return
         try:
+            from datetime import date
+
             today = date.today().isoformat()
             daily = await self._sq_bundle.get_fts_daily_stats_for_query(sq, days=1)
             today_count = 0
@@ -317,20 +359,31 @@ class SchedulerManager:
                     today_count = d.count
                     break
             await self._sq_bundle.record_stat(sq_id, today_count)
-            logger.info(
-                "Search query '%s' (id=%d): %d matches today", sq.query, sq_id, today_count
-            )
         except Exception:
             logger.exception("Error running search query id=%d", sq_id)
 
     async def _run_photo_due(self) -> dict:
-        if not self._photo_task_service:
-            return {"processed": 0}
-        processed = await self._photo_task_service.run_due()
-        return {"processed": processed}
+        if self._task_enqueuer:
+            try:
+                await self._task_enqueuer.enqueue_photo_due()
+            except Exception:
+                logger.exception("Error enqueuing photo_due")
+            return {"enqueued": True}
+        # Legacy fallback
+        if self._photo_task_service:
+            processed = await self._photo_task_service.run_due()
+            return {"processed": processed}
+        return {"processed": 0}
 
     async def _run_photo_auto(self) -> dict:
-        if not self._photo_auto_upload_service:
-            return {"jobs": 0}
-        jobs = await self._photo_auto_upload_service.run_due()
-        return {"jobs": jobs}
+        if self._task_enqueuer:
+            try:
+                await self._task_enqueuer.enqueue_photo_auto()
+            except Exception:
+                logger.exception("Error enqueuing photo_auto")
+            return {"enqueued": True}
+        # Legacy fallback
+        if self._photo_auto_upload_service:
+            jobs = await self._photo_auto_upload_service.run_due()
+            return {"jobs": jobs}
+        return {"jobs": 0}

--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+import re
+
+from src.models import Message, SearchQuery
+from src.telegram.notifier import Notifier
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationMatcher:
+    """Match messages against notification queries and send batched notifications."""
+
+    def __init__(self, notifier: Notifier):
+        self._notifier = notifier
+
+    async def match_and_notify(
+        self,
+        messages: list[Message],
+        queries: list[SearchQuery],
+    ) -> dict[int, int]:
+        """Match messages against queries and notify. Returns {sq_id: match_count}."""
+        if not messages or not queries:
+            return {}
+
+        # Collect matches per query: {sq_id: (query_name, count, first_preview)}
+        matches: dict[int, tuple[str, int, str]] = {}
+        for msg in messages:
+            if not msg.text:
+                continue
+            for sq in queries:
+                if sq.max_length is not None and len(msg.text) >= sq.max_length:
+                    continue
+                if any(p.lower() in msg.text.lower() for p in sq.exclude_patterns_list):
+                    continue
+
+                matched = False
+                if sq.is_regex:
+                    try:
+                        matched = bool(re.search(sq.query, msg.text, re.IGNORECASE))
+                    except re.error:
+                        pass
+                elif sq.is_fts:
+                    matched = _fts_query_matches(sq.query, msg.text)
+                else:
+                    matched = sq.query.lower() in msg.text.lower()
+
+                if matched:
+                    key = sq.id or id(sq)
+                    if key in matches:
+                        name, count, preview = matches[key]
+                        matches[key] = (name, count + 1, preview)
+                    else:
+                        matches[key] = (sq.query, 1, msg.text[:200])
+
+        result: dict[int, int] = {}
+        for sq_id, (name, count, preview) in matches.items():
+            result[sq_id] = count
+            if count == 1:
+                await self._notifier.notify(
+                    f"Query '{name}' matched in channel:\n{preview}"
+                )
+            else:
+                await self._notifier.notify(
+                    f"Query '{name}' matched {count} times. First:\n{preview}"
+                )
+
+        return result
+
+
+def _fts_query_matches(fts_query: str, text: str) -> bool:
+    """Approximate FTS5 boolean query matching against plain text."""
+    text_lower = text.lower()
+    parts = re.split(r"\bAND\b", fts_query, flags=re.IGNORECASE)
+    for part in parts:
+        part = part.strip().strip("()")
+        alternatives = re.split(r"\bOR\b", part, flags=re.IGNORECASE)
+        if not any(alt.strip().strip('"').lower() in text_lower for alt in alternatives):
+            return False
+    return True

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -14,10 +14,7 @@ class SchedulerService:
         await self._manager.stop()
 
     async def trigger_collection(self) -> None:
-        await self._manager.trigger_background()
+        await self._manager.trigger_now()
 
     async def trigger_search(self) -> None:
-        await self._manager.trigger_search_background()
-
-    async def trigger_search_now(self) -> dict:
-        return await self._manager.trigger_search_now()
+        await self._manager.trigger_search_now()

--- a/src/services/task_enqueuer.py
+++ b/src/services/task_enqueuer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.database import Database
+from src.database.bundles import ChannelBundle
+from src.models import CollectionTaskType, SqStatsTaskPayload
+
+if TYPE_CHECKING:
+    from src.services.collection_service import CollectionService
+
+logger = logging.getLogger(__name__)
+
+
+class TaskEnqueuer:
+    """Thin service for creating tasks in DB with deduplication."""
+
+    def __init__(
+        self,
+        db: Database,
+        channels: ChannelBundle,
+        collection_service: CollectionService,
+    ):
+        self._db = db
+        self._channels = channels
+        self._collection_service = collection_service
+
+    async def enqueue_all_channels(self):
+        """Delegate to CollectionService for channel collection tasks."""
+        return await self._collection_service.enqueue_all_channels()
+
+    async def enqueue_notification_search(self) -> int | None:
+        """Create a NOTIFICATION_SEARCH task if none is already pending/running."""
+        has = await self._db.repos.tasks.has_active_task(
+            CollectionTaskType.NOTIFICATION_SEARCH
+        )
+        if has:
+            logger.debug("NOTIFICATION_SEARCH task already active, skipping")
+            return None
+        task_id = await self._db.repos.tasks.create_generic_task(
+            CollectionTaskType.NOTIFICATION_SEARCH,
+            title="Поиск по запросам",
+        )
+        logger.info("Enqueued NOTIFICATION_SEARCH task #%d", task_id)
+        return task_id
+
+    async def enqueue_sq_stats(self, sq_id: int) -> int | None:
+        """Create a SQ_STATS task for a specific search query, with dedup."""
+        has = await self._db.repos.tasks.has_active_task(
+            CollectionTaskType.SQ_STATS,
+            payload_filter_key="sq_id",
+            payload_filter_value=sq_id,
+        )
+        if has:
+            logger.debug("SQ_STATS task for sq_id=%d already active, skipping", sq_id)
+            return None
+        task_id = await self._db.repos.tasks.create_generic_task(
+            CollectionTaskType.SQ_STATS,
+            title=f"Статистика запроса #{sq_id}",
+            payload=SqStatsTaskPayload(sq_id=sq_id),
+        )
+        logger.info("Enqueued SQ_STATS task #%d for sq_id=%d", task_id, sq_id)
+        return task_id
+
+    async def enqueue_photo_due(self) -> int | None:
+        """Create a PHOTO_DUE task if none is already pending/running."""
+        has = await self._db.repos.tasks.has_active_task(CollectionTaskType.PHOTO_DUE)
+        if has:
+            return None
+        task_id = await self._db.repos.tasks.create_generic_task(
+            CollectionTaskType.PHOTO_DUE,
+            title="Отправка фото",
+        )
+        return task_id
+
+    async def enqueue_photo_auto(self) -> int | None:
+        """Create a PHOTO_AUTO task if none is already pending/running."""
+        has = await self._db.repos.tasks.has_active_task(CollectionTaskType.PHOTO_AUTO)
+        if has:
+            return None
+        task_id = await self._db.repos.tasks.create_generic_task(
+            CollectionTaskType.PHOTO_AUTO,
+            title="Автозагрузка фото",
+        )
+        return task_id

--- a/src/services/task_enqueuer.py
+++ b/src/services/task_enqueuer.py
@@ -23,7 +23,6 @@ class TaskEnqueuer:
         collection_service: CollectionService,
     ):
         self._db = db
-        self._channels = channels
         self._collection_service = collection_service
 
     async def enqueue_all_channels(self):

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -145,6 +145,7 @@ class UnifiedDispatcher:
                             await self._channels.update_collection_task(
                                 task.id,
                                 CollectionTaskStatus.FAILED,
+                                messages_collected=fresh.messages_collected,
                                 error="Task failed with unexpected dispatcher error",
                             )
                     except Exception:
@@ -192,6 +193,13 @@ class UnifiedDispatcher:
             task.id, next_index, batch_size, len(channel_ids),
         )
 
+        if self._collector.is_running:
+            logger.info("Collector is running, deferring STATS_ALL task #%s", task.id)
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.PENDING,
+            )
+            return
+
         if next_index >= len(channel_ids):
             await self._channels.update_collection_task(
                 task.id, CollectionTaskStatus.COMPLETED, messages_collected=channels_ok,
@@ -203,8 +211,22 @@ class UnifiedDispatcher:
 
         while cursor < batch_end:
             if self._collector.is_running:
-                await asyncio.sleep(self._poll_interval_sec)
-                continue
+                logger.info(
+                    "Collector started mid-batch, suspending STATS_ALL task #%s at index %d",
+                    task.id, cursor,
+                )
+                suspended_payload = StatsAllTaskPayload(
+                    channel_ids=channel_ids,
+                    next_index=cursor,
+                    batch_size=batch_size,
+                    channels_ok=channels_ok,
+                    channels_err=channels_err,
+                )
+                await self._channels.update_collection_task(
+                    task.id, CollectionTaskStatus.PENDING,
+                    payload=suspended_payload,
+                )
+                return
 
             channel_id = channel_ids[cursor]
             channel = await self._channels.get_by_channel_id(channel_id)

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, timezone
+from typing import TYPE_CHECKING
+
+from src.database import Database
+from src.database.bundles import ChannelBundle, SearchQueryBundle
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    SqStatsTaskPayload,
+    StatsAllTaskPayload,
+)
+from src.telegram.collector import Collector
+
+if TYPE_CHECKING:
+    from src.search.engine import SearchEngine
+    from src.services.notification_matcher import NotificationMatcher
+    from src.services.photo_auto_upload_service import PhotoAutoUploadService
+    from src.services.photo_task_service import PhotoTaskService
+
+logger = logging.getLogger(__name__)
+
+HANDLED_TYPES = [
+    CollectionTaskType.STATS_ALL.value,
+    CollectionTaskType.NOTIFICATION_SEARCH.value,
+    CollectionTaskType.SQ_STATS.value,
+    CollectionTaskType.PHOTO_DUE.value,
+    CollectionTaskType.PHOTO_AUTO.value,
+]
+
+
+class _DatabaseAdapter:
+    """Adapts Database to the interface expected by UnifiedDispatcher."""
+
+    def __init__(self, db: Database):
+        self._db = db
+        self._tasks = db.repos.tasks
+
+    async def get_by_channel_id(self, channel_id: int):
+        return await self._db.get_channel_by_channel_id(channel_id)
+
+    async def get_collection_task(self, task_id: int):
+        return await self._tasks.get_collection_task(task_id)
+
+    async def update_collection_task(self, task_id, status, **kw):
+        return await self._tasks.update_collection_task(task_id, status, **kw)
+
+    async def update_collection_task_progress(self, task_id, messages_collected):
+        return await self._tasks.update_collection_task_progress(task_id, messages_collected)
+
+    async def claim_next_due_generic_task(self, now, handled_types):
+        return await self._tasks.claim_next_due_generic_task(now, handled_types)
+
+    async def requeue_running_generic_tasks_on_startup(self, now, handled_types):
+        return await self._tasks.requeue_running_generic_tasks_on_startup(now, handled_types)
+
+    async def create_stats_continuation_task(self, *, payload, run_after, parent_task_id):
+        return await self._tasks.create_stats_continuation_task(
+            payload=payload, run_after=run_after, parent_task_id=parent_task_id,
+        )
+
+    async def get_notification_queries(self, active_only: bool = True):
+        return await self._db.get_notification_queries(active_only=active_only)
+
+
+class UnifiedDispatcher:
+    """Polls DB for non-CHANNEL_COLLECT tasks and dispatches them to handlers."""
+
+    def __init__(
+        self,
+        collector: Collector,
+        channels: ChannelBundle | Database,
+        *,
+        search_engine: SearchEngine | None = None,
+        notification_matcher: NotificationMatcher | None = None,
+        sq_bundle: SearchQueryBundle | None = None,
+        photo_task_service: PhotoTaskService | None = None,
+        photo_auto_upload_service: PhotoAutoUploadService | None = None,
+        default_batch_size: int = 20,
+        poll_interval_sec: float = 1.0,
+        channel_timeout_sec: float = 120.0,
+    ):
+        self._collector = collector
+        if isinstance(channels, Database):
+            channels_adapter = _DatabaseAdapter(channels)
+        else:
+            channels_adapter = channels
+        self._channels = channels_adapter
+        self._search_engine = search_engine
+        self._notification_matcher = notification_matcher
+        self._sq_bundle = sq_bundle
+        self._photo_task_service = photo_task_service
+        self._photo_auto_upload_service = photo_auto_upload_service
+        self._default_batch_size = default_batch_size
+        self._poll_interval_sec = poll_interval_sec
+        self._channel_timeout_sec = channel_timeout_sec
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task and not self._task.done():
+            return
+        self._stop_event.clear()
+        recovered = await self._channels.requeue_running_generic_tasks_on_startup(
+            datetime.now(timezone.utc), HANDLED_TYPES
+        )
+        if recovered:
+            logger.warning("Recovered %d interrupted generic tasks on startup", recovered)
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+
+    async def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            task: CollectionTask | None = None
+            try:
+                task = await self._channels.claim_next_due_generic_task(
+                    datetime.now(timezone.utc), HANDLED_TYPES
+                )
+                if task is None:
+                    await asyncio.sleep(self._poll_interval_sec)
+                    continue
+
+                await self._dispatch(task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Unified dispatcher loop failure")
+                if task and task.id is not None:
+                    try:
+                        fresh = await self._channels.get_collection_task(task.id)
+                        if fresh and fresh.status == CollectionTaskStatus.RUNNING:
+                            await self._channels.update_collection_task(
+                                task.id,
+                                CollectionTaskStatus.FAILED,
+                                error="Task failed with unexpected dispatcher error",
+                            )
+                    except Exception:
+                        logger.exception("Failed to mark broken task as failed")
+                await asyncio.sleep(self._poll_interval_sec)
+
+    async def _dispatch(self, task: CollectionTask) -> None:
+        handler = {
+            CollectionTaskType.STATS_ALL: self._handle_stats_all,
+            CollectionTaskType.NOTIFICATION_SEARCH: self._handle_notification_search,
+            CollectionTaskType.SQ_STATS: self._handle_sq_stats,
+            CollectionTaskType.PHOTO_DUE: self._handle_photo_due,
+            CollectionTaskType.PHOTO_AUTO: self._handle_photo_auto,
+        }.get(task.task_type)
+        if handler is None:
+            await self._channels.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=f"Unknown task type: {task.task_type}",
+            )
+            return
+        await handler(task)
+
+    # -- STATS_ALL (ported from StatsTaskDispatcher) --
+
+    async def _handle_stats_all(self, task: CollectionTask) -> None:
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, StatsAllTaskPayload):
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Unsupported stats task payload"
+            )
+            return
+
+        channel_ids = payload.channel_ids
+        next_index = payload.next_index
+        batch_size = max(1, payload.batch_size or self._default_batch_size)
+        channels_ok = payload.channels_ok or (task.messages_collected or 0)
+        channels_err = payload.channels_err
+
+        logger.info(
+            "Running stats task #%s: next_index=%d batch_size=%d total=%d",
+            task.id, next_index, batch_size, len(channel_ids),
+        )
+
+        if next_index >= len(channel_ids):
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED, messages_collected=channels_ok,
+            )
+            return
+
+        batch_end = min(next_index + batch_size, len(channel_ids))
+        cursor = next_index
+
+        while cursor < batch_end:
+            if self._collector.is_running:
+                await asyncio.sleep(self._poll_interval_sec)
+                continue
+
+            channel_id = channel_ids[cursor]
+            channel = await self._channels.get_by_channel_id(channel_id)
+            if channel is None:
+                channels_err += 1
+                cursor += 1
+                continue
+
+            try:
+                result = await asyncio.wait_for(
+                    self._collector.collect_channel_stats(channel),
+                    timeout=self._channel_timeout_sec,
+                )
+            except asyncio.TimeoutError:
+                channels_err += 1
+                cursor += 1
+            except Exception as exc:
+                logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
+                channels_err += 1
+                cursor += 1
+            else:
+                if result is None:
+                    availability = await self._collector.get_stats_availability()
+                    if (
+                        availability.state == "all_flooded"
+                        and availability.next_available_at_utc is not None
+                    ):
+                        continuation_payload = StatsAllTaskPayload(
+                            channel_ids=channel_ids, next_index=cursor,
+                            batch_size=batch_size, channels_ok=channels_ok,
+                            channels_err=channels_err,
+                        )
+                        continuation_id = await self._channels.create_stats_continuation_task(
+                            payload=continuation_payload,
+                            run_after=availability.next_available_at_utc,
+                            parent_task_id=task.id,
+                        )
+                        await self._channels.update_collection_task(
+                            task.id, CollectionTaskStatus.FAILED,
+                            messages_collected=channels_ok,
+                            error=(
+                                f"Deferred to task #{continuation_id} until "
+                                f"{availability.next_available_at_utc.isoformat()} "
+                                "(all clients flood-waited)"
+                            ),
+                        )
+                        return
+
+                    await self._channels.update_collection_task(
+                        task.id, CollectionTaskStatus.FAILED,
+                        messages_collected=channels_ok,
+                        error="No active connected Telegram accounts",
+                    )
+                    return
+
+                channels_ok += 1
+                cursor += 1
+                await self._channels.update_collection_task_progress(task.id, channels_ok)
+
+            if cursor < batch_end:
+                await asyncio.sleep(self._collector.delay_between_channels_sec)
+
+        if cursor < len(channel_ids):
+            continuation_payload = StatsAllTaskPayload(
+                channel_ids=channel_ids, next_index=cursor,
+                batch_size=batch_size, channels_ok=channels_ok,
+                channels_err=channels_err,
+            )
+            await self._channels.create_stats_continuation_task(
+                payload=continuation_payload,
+                run_after=datetime.now(timezone.utc),
+                parent_task_id=task.id,
+            )
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED, messages_collected=channels_ok,
+            )
+            return
+
+        await self._channels.update_collection_task(
+            task.id, CollectionTaskStatus.COMPLETED, messages_collected=channels_ok,
+        )
+
+    # -- NOTIFICATION_SEARCH --
+
+    async def _handle_notification_search(self, task: CollectionTask) -> None:
+        if not self._search_engine:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                note="No search engine configured",
+            )
+            return
+
+        queries = await self._channels.get_notification_queries(active_only=True)
+        total_results = 0
+        searched = 0
+        errors = 0
+
+        for sq in queries:
+            try:
+                quota = await self._search_engine.check_search_quota(sq.query)
+                if quota and quota.get("remains") == 0 and not quota.get("query_is_free"):
+                    logger.info("Search quota exhausted, stopping notification search")
+                    break
+
+                result = await self._search_engine.search_telegram(sq.query, limit=50)
+                if result.error:
+                    errors += 1
+                else:
+                    total_results += result.total
+                    searched += 1
+
+                    # Send notifications for found messages
+                    if self._notification_matcher and result.messages:
+                        await self._notification_matcher.match_and_notify(result.messages, [sq])
+            except Exception:
+                logger.exception("Error searching query '%s'", sq.query)
+                errors += 1
+
+        await self._channels.update_collection_task(
+            task.id, CollectionTaskStatus.COMPLETED,
+            messages_collected=total_results,
+            note=f"queries={searched}, errors={errors}",
+        )
+
+    # -- SQ_STATS --
+
+    async def _handle_sq_stats(self, task: CollectionTask) -> None:
+        if not self._sq_bundle:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                note="No search query bundle configured",
+            )
+            return
+
+        payload = task.payload
+        if not isinstance(payload, SqStatsTaskPayload):
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Invalid SQ_STATS payload",
+            )
+            return
+
+        sq = await self._sq_bundle.get_by_id(payload.sq_id)
+        if not sq:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                note=f"Search query id={payload.sq_id} not found",
+            )
+            return
+
+        try:
+            today = date.today().isoformat()
+            daily = await self._sq_bundle.get_fts_daily_stats_for_query(sq, days=1)
+            today_count = 0
+            for d in daily:
+                if d.day == today:
+                    today_count = d.count
+                    break
+            await self._sq_bundle.record_stat(payload.sq_id, today_count)
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                messages_collected=today_count,
+                note=f"sq={sq.query}",
+            )
+        except Exception as exc:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )
+
+    # -- PHOTO_DUE --
+
+    async def _handle_photo_due(self, task: CollectionTask) -> None:
+        if not self._photo_task_service:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED, note="No photo service",
+            )
+            return
+        try:
+            processed = await self._photo_task_service.run_due()
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                messages_collected=processed,
+            )
+        except Exception as exc:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error=str(exc)[:500],
+            )
+
+    # -- PHOTO_AUTO --
+
+    async def _handle_photo_auto(self, task: CollectionTask) -> None:
+        if not self._photo_auto_upload_service:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED, note="No photo auto service",
+            )
+            return
+        try:
+            jobs = await self._photo_auto_upload_service.run_due()
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.COMPLETED,
+                messages_collected=jobs,
+            )
+        except Exception as exc:
+            await self._channels.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error=str(exc)[:500],
+            )

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -35,6 +35,7 @@ from src.filters.criteria import (
     PRECHECK_CROSS_DUPE_SAMPLE,
 )
 from src.models import Channel, ChannelStats, Message
+from src.services.notification_matcher import NotificationMatcher
 from src.settings_utils import parse_int_setting
 from src.telegram.backends import adapt_transport_session
 from src.telegram.client_pool import ClientPool
@@ -71,6 +72,7 @@ class Collector:
         self._db = db
         self._config = config
         self._notifier = notifier
+        self._notification_matcher = NotificationMatcher(notifier) if notifier else None
         self._running = False
         self._stats_running = False
         self._cancel_event = asyncio.Event()
@@ -677,17 +679,14 @@ class Collector:
 
     async def _check_notification_queries(self, messages: list[Message]) -> None:
         """Check messages against active notification queries and send batched notifications."""
-        if not self._notifier:
+        if not self._notification_matcher:
             return
 
         queries = await self._db.get_notification_queries(active_only=True)
         if not queries:
             return
 
-        from src.services.notification_matcher import NotificationMatcher
-
-        matcher = NotificationMatcher(self._notifier)
-        await matcher.match_and_notify(messages, queries)
+        await self._notification_matcher.match_and_notify(messages, queries)
 
     async def _channel_still_exists(self, channel_id: int) -> bool:
         return await self._db.get_channel_by_channel_id(channel_id) is not None

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -676,11 +676,7 @@ class Collector:
         return True
 
     async def _check_notification_queries(self, messages: list[Message]) -> None:
-        """Check messages against active notification queries and send batched notifications.
-
-        Sends one notification per query per collection run with a count and
-        a preview of the first matching message to avoid flooding.
-        """
+        """Check messages against active notification queries and send batched notifications."""
         if not self._notifier:
             return
 
@@ -688,46 +684,10 @@ class Collector:
         if not queries:
             return
 
-        # Collect matches per query: {sq_id: (sq, count, first_preview)}
-        matches: dict[int, tuple[str, int, str]] = {}
-        for msg in messages:
-            if not msg.text:
-                continue
-            for sq in queries:
-                # Apply exclude_patterns and max_length filters first
-                if sq.max_length is not None and len(msg.text) >= sq.max_length:
-                    continue
-                if any(p.lower() in msg.text.lower() for p in sq.exclude_patterns_list):
-                    continue
+        from src.services.notification_matcher import NotificationMatcher
 
-                matched = False
-                if sq.is_regex:
-                    try:
-                        matched = bool(re.search(sq.query, msg.text, re.IGNORECASE))
-                    except re.error:
-                        pass
-                elif sq.is_fts:
-                    matched = self._fts_query_matches(sq.query, msg.text)
-                else:
-                    matched = sq.query.lower() in msg.text.lower()
-
-                if matched:
-                    key = sq.id or id(sq)
-                    if key in matches:
-                        name, count, preview = matches[key]
-                        matches[key] = (name, count + 1, preview)
-                    else:
-                        matches[key] = (sq.query, 1, msg.text[:200])
-
-        for _sq_id, (name, count, preview) in matches.items():
-            if count == 1:
-                await self._notifier.notify(
-                    f"Query '{name}' matched in channel:\n{preview}"
-                )
-            else:
-                await self._notifier.notify(
-                    f"Query '{name}' matched {count} times. First:\n{preview}"
-                )
+        matcher = NotificationMatcher(self._notifier)
+        await matcher.match_and_notify(messages, queries)
 
     async def _channel_still_exists(self, channel_id: int) -> bool:
         return await self._db.get_channel_by_channel_id(channel_id) is not None

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -23,11 +23,13 @@ from src.database.bundles import (
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
+from src.services.notification_matcher import NotificationMatcher
 from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTaskService
-from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.services.task_enqueuer import TaskEnqueuer
+from src.services.unified_dispatcher import UnifiedDispatcher
 from src.settings_utils import parse_int_setting
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
@@ -122,19 +124,30 @@ async def build_container_with_templates(
     )
     collector = Collector(pool, db, config.scheduler, notifier)
     collection_queue = CollectionQueue(collector, channel_bundle)
-    stats_dispatcher = StatsTaskDispatcher(collector, channel_bundle, default_batch_size=20)
     search_engine = SearchEngine(search_bundle, pool)
     ai_search = AISearchEngine(config.llm, search_bundle)
     agent_manager = AgentManager(db, config)
     search_query_bundle = SearchQueryBundle(repos.search_queries, repos.messages)
-    scheduler = SchedulerManager(
+
+    from src.services.collection_service import CollectionService
+
+    collection_service = CollectionService(channel_bundle, collector, collection_queue)
+    task_enqueuer = TaskEnqueuer(db, channel_bundle, collection_service)
+    notification_matcher = NotificationMatcher(notifier)
+    unified_dispatcher = UnifiedDispatcher(
         collector,
-        config.scheduler,
-        scheduler_bundle=scheduler_bundle,
+        db,
         search_engine=search_engine,
-        search_query_bundle=search_query_bundle,
+        notification_matcher=notification_matcher,
+        sq_bundle=search_query_bundle,
         photo_task_service=photo_task_service,
         photo_auto_upload_service=photo_auto_upload_service,
+    )
+    scheduler = SchedulerManager(
+        config.scheduler,
+        scheduler_bundle=scheduler_bundle,
+        search_query_bundle=search_query_bundle,
+        task_enqueuer=task_enqueuer,
     )
 
     _templates = configure_template_globals(
@@ -163,7 +176,8 @@ async def build_container_with_templates(
         photo_auto_upload_service=photo_auto_upload_service,
         collector=collector,
         collection_queue=collection_queue,
-        stats_dispatcher=stats_dispatcher,
+        task_enqueuer=task_enqueuer,
+        unified_dispatcher=unified_dispatcher,
         search_engine=search_engine,
         ai_search=ai_search,
         scheduler=scheduler,
@@ -192,8 +206,8 @@ async def start_container(container: AppContainer) -> None:
         if requeued:
             logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
 
-    if container.stats_dispatcher is not None:
-        await container.stats_dispatcher.start()
+    if container.unified_dispatcher is not None:
+        await container.unified_dispatcher.start()
     container.ai_search.initialize()
     if container.agent_manager is not None:
         await container.agent_manager.refresh_settings_cache(preflight=True)
@@ -211,8 +225,8 @@ async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
 async def stop_container(container: AppContainer) -> None:
     container.shutting_down = True
     shutdown_coroutines = []
-    if container.stats_dispatcher is not None:
-        shutdown_coroutines.append(("stats_dispatcher", container.stats_dispatcher.stop()))
+    if container.unified_dispatcher is not None:
+        shutdown_coroutines.append(("unified_dispatcher", container.unified_dispatcher.stop()))
     if container.collection_queue is not None:
         shutdown_coroutines.append(("collection_queue", container.collection_queue.shutdown()))
     if container.agent_manager is not None:

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -27,7 +27,8 @@ from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTaskService
-from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.services.task_enqueuer import TaskEnqueuer
+from src.services.unified_dispatcher import UnifiedDispatcher
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
@@ -57,7 +58,8 @@ class AppContainer:
     photo_auto_upload_service: PhotoAutoUploadService
     collector: Collector
     collection_queue: CollectionQueue | None
-    stats_dispatcher: StatsTaskDispatcher | None
+    task_enqueuer: TaskEnqueuer | None
+    unified_dispatcher: UnifiedDispatcher | None
     search_engine: SearchEngine
     ai_search: AISearchEngine
     scheduler: SchedulerManager

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -33,7 +33,8 @@ from src.services.photo_task_service import PhotoTaskService
 from src.services.scheduler_service import SchedulerService
 from src.services.search_query_service import SearchQueryService
 from src.services.search_service import SearchService
-from src.services.stats_task_dispatcher import StatsTaskDispatcher
+from src.services.task_enqueuer import TaskEnqueuer
+from src.services.unified_dispatcher import UnifiedDispatcher
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
@@ -121,7 +122,8 @@ def get_container(request: Request) -> AppContainer:
         photo_auto_upload_service=photo_auto_upload_service,
         collector=_require_app_state_attr(request, "collector"),
         collection_queue=getattr(request.app.state, "collection_queue", None),
-        stats_dispatcher=getattr(request.app.state, "stats_dispatcher", None),
+        task_enqueuer=getattr(request.app.state, "task_enqueuer", None),
+        unified_dispatcher=getattr(request.app.state, "unified_dispatcher", None),
         search_engine=_require_app_state_attr(request, "search_engine"),
         ai_search=_require_app_state_attr(request, "ai_search"),
         scheduler=_require_app_state_attr(request, "scheduler"),
@@ -184,8 +186,12 @@ def get_queue(request: Request) -> CollectionQueue:
     return get_container(request).collection_queue
 
 
-def get_stats_dispatcher(request: Request) -> StatsTaskDispatcher:
-    return get_container(request).stats_dispatcher
+def get_unified_dispatcher(request: Request) -> UnifiedDispatcher:
+    return get_container(request).unified_dispatcher
+
+
+def get_task_enqueuer(request: Request) -> TaskEnqueuer:
+    return get_container(request).task_enqueuer
 
 
 def get_scheduler(request: Request) -> SchedulerManager:

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -26,13 +26,12 @@ async def scheduler_page(
     limit: int = Query(50),
 ):
     sched = deps.get_scheduler(request)
-    collector = deps.get_collector(request)
     db = deps.get_db(request)
     msg = request.query_params.get("msg")
 
     # Validation
     page = max(1, page)
-    limit = max(10, min(limit, 100))  # 10-100 задач
+    limit = max(10, min(limit, 100))
     status_filter = status if status in VALID_STATUS_FILTERS else "all"
 
     # Get tasks with filter and pagination
@@ -50,12 +49,11 @@ async def scheduler_page(
             limit=limit, offset=offset, status_filter=status_filter
         )
 
-    # Get counts for all tabs (cheap count-only queries)
+    # Get counts for all tabs
     all_count = await db.count_collection_tasks()
     active_count = await db.count_collection_tasks("active")
     completed_count = all_count - active_count
 
-    # Check if there are any active tasks (for auto-refresh)
     has_active_tasks = active_count > 0
 
     search_log = await db.get_recent_searches()
@@ -72,13 +70,8 @@ async def scheduler_page(
         "scheduler.html",
         {
             "is_running": sched.is_running,
-            "last_run": sched.last_run,
-            "last_stats": sched.last_stats,
             "interval_minutes": sched.interval_minutes,
             "search_interval_minutes": sched.search_interval_minutes,
-            "last_search_run": sched.last_search_run,
-            "last_search_stats": sched.last_search_stats,
-            "collecting_now": collector.is_running,
             "msg": msg,
             "tasks": tasks,
             "has_active_tasks": has_active_tasks,

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -3,86 +3,46 @@
 {% block content %}
 <h1>Планировщик</h1>
 
-<div class="card mb-4">
-    <div class="card-header fw-semibold">
-        Статус планировщика
-        <span class="hint" data-tooltip="Планировщик автоматически собирает сообщения и запускает поиск по расписанию">?</span>
-    </div>
-    <div class="card-body">
-        <small class="text-muted d-block mb-2">Автоматический сбор сообщений из всех каналов и поиск по ключевым словам.</small>
-        <p>Планировщик: <strong>{{ "Запущен" if is_running else "Остановлен" }}</strong></p>
-        <p>Интервал сбора: <strong>{{ interval_minutes }}</strong> мин.</p>
-        <p>Сбор данных: <strong>{{ "Идёт" if collecting_now else "Ожидание" }}</strong></p>
-        {% if last_run %}
-        <p>Последний запуск: <strong>{{ last_run.strftime('%Y-%m-%d %H:%M:%S UTC') }}</strong></p>
-        {% endif %}
-        {% if last_stats %}
-        <p>Результат: каналов — {{ last_stats.channels }}, сообщений — {{ last_stats.messages }}, ошибок — {{ last_stats.errors }}</p>
-        {% endif %}
-    </div>
-</div>
-
-<div class="row g-3 mb-4">
-    <div class="col-12 col-md-6">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-title">Автоматический режим</h6>
-                <small class="text-muted d-block mb-3">
-                    Включает фоновый планировщик: сбор каждые {{ interval_minutes }} мин., поиск каждые {{ search_interval_minutes }} мин.
-                </small>
-                {% if not is_running %}
-                <form method="post" action="/scheduler/start" data-busy>
-                    <button type="submit" class="btn btn-primary w-100">&#9654; Запустить планировщик</button>
-                </form>
-                {% else %}
-                <form method="post" action="/scheduler/stop" data-busy>
-                    <button type="submit" class="btn btn-secondary w-100">&#9724; Остановить планировщик</button>
-                </form>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-    <div class="col-12 col-md-6">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-title">Ручной сбор</h6>
-                <small class="text-muted d-block mb-3">
-                    Добавляет задачи в очередь для каждого активного канала. То же, что на странице <a href="/channels">каналов</a>.
-                </small>
-                <form method="post" action="/scheduler/trigger" data-busy>
-                    <button type="submit" class="btn btn-secondary w-100">
-                        &#9654; Собрать все каналы
-                    </button>
-                </form>
-            </div>
-        </div>
-    </div>
-</div>
+{% macro task_type_label(t) %}
+    {% if t.task_type.value == 'channel_collect' %}Сбор канала
+    {% elif t.task_type.value == 'stats_all' %}Статистика
+    {% elif t.task_type.value == 'notification_search' %}Поиск
+    {% elif t.task_type.value == 'sq_stats' %}Статистика запроса
+    {% elif t.task_type.value == 'photo_due' %}Фото
+    {% elif t.task_type.value == 'photo_auto' %}Автофото
+    {% else %}{{ t.task_type.value }}
+    {% endif %}
+{% endmacro %}
 
 <div class="card mb-4">
     <div class="card-header fw-semibold">
-        Поиск по запросам
-        <span class="hint" data-tooltip="Ищет совпадения по ключевым словам, настроенным на странице «Запросы»">?</span>
+        Планировщик
+        <span class="hint" data-tooltip="Планировщик автоматически ставит задачи в очередь: сбор, поиск, статистику">?</span>
     </div>
     <div class="card-body">
-        <small class="text-muted d-block mb-2">
-            Запускает поиск по всем активным <a href="/search-queries">поисковым запросам</a>. При совпадении отправляет уведомления.
-        </small>
-        <p>Интервал поиска: <strong>{{ search_interval_minutes }}</strong> мин.</p>
-        {% if last_search_run %}
-        <p>Последний поиск: <strong>{{ last_search_run.strftime('%Y-%m-%d %H:%M:%S UTC') }}</strong></p>
-        {% endif %}
-        {% if last_search_stats %}
-        <p>Результат: запросов — {{ last_search_stats.queries }}, найдено — {{ last_search_stats.results }}, ошибок — {{ last_search_stats.errors }}</p>
-        {% endif %}
+        <small class="text-muted d-block mb-2">Автоматическое создание задач: сбор каждые {{ interval_minutes }} мин., поиск каждые {{ search_interval_minutes }} мин.</small>
+        <p>Статус: <strong>{{ "Запущен" if is_running else "Остановлен" }}</strong></p>
+
         <div class="d-flex flex-wrap gap-2">
+            {% if not is_running %}
+            <form method="post" action="/scheduler/start" data-busy>
+                <button type="submit" class="btn btn-primary">&#9654; Запустить</button>
+            </form>
+            {% else %}
+            <form method="post" action="/scheduler/stop" data-busy>
+                <button type="submit" class="btn btn-secondary">&#9724; Остановить</button>
+            </form>
+            {% endif %}
+            <form method="post" action="/scheduler/trigger" data-busy>
+                <button type="submit" class="btn btn-outline-primary">&#9654; Собрать все каналы</button>
+            </form>
             <form method="post" action="/scheduler/trigger-search" data-busy>
-                <button type="submit" class="btn btn-secondary">&#9654; Запустить поиск по запросам</button>
+                <button type="submit" class="btn btn-outline-primary">&#9654; Запустить поиск</button>
             </form>
             <form method="post" action="/scheduler/test-notification" data-busy>
                 <button type="submit" class="btn btn-outline-secondary"
                         {% if not bot_configured %}disabled title="Подключите бот в Настройках → Уведомления"{% endif %}>
-                    Протестировать уведомления
+                    Тест уведомлений
                 </button>
             </form>
         </div>
@@ -139,9 +99,9 @@
 
 {% if all_count > 0 %}
 <div class="card mb-4">
-    <div class="card-header fw-semibold">Задачи сбора</div>
+    <div class="card-header fw-semibold">Задачи</div>
     <div class="card-body p-0">
-        <p class="px-3 pt-3"><small class="text-muted">Все задачи сбора: автоматические (от планировщика), ручные (кнопка выше) и одиночные (со страницы каналов).</small></p>
+        <p class="px-3 pt-3"><small class="text-muted">Все задачи: сбор каналов, поиск, статистика, фото.</small></p>
 
         <!-- Filter tabs -->
         <div class="px-3 pb-2">
@@ -164,9 +124,10 @@
         <table class="table table-striped table-sm mb-0">
             <thead>
                 <tr>
-                    <th>Канал</th>
+                    <th>Тип</th>
+                    <th>Канал / Описание</th>
                     <th>Статус</th>
-                    <th>Сообщений</th>
+                    <th>Результат</th>
                     <th>Создана</th>
                     <th>Завершена</th>
                     <th>Действие</th>
@@ -175,12 +136,12 @@
             <tbody>
                 {% for t in tasks %}
                 <tr>
+                    <td><span class="badge text-bg-info">{{ task_type_label(t) }}</span></td>
                     <td>
-                        {{ t.channel_title or t.channel_id }}
-                        <br><small class="text-muted">
-                            {%- if t.channel_username %}@{{ t.channel_username }} &middot; {% endif -%}
-                            {% if t.channel_id != 0 %}id: {{ t.channel_id }}{% endif %}
-                        </small>
+                        {{ t.channel_title or t.channel_id or '—' }}
+                        {% if t.channel_username %}
+                        <br><small class="text-muted">@{{ t.channel_username }}</small>
+                        {% endif %}
                     </td>
                     <td>
                         {% if t.status == 'running' %}
@@ -227,7 +188,8 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-start mb-1">
                         <div>
-                            <strong>{{ t.channel_title or t.channel_id }}</strong>
+                            <span class="badge text-bg-info me-1">{{ task_type_label(t) }}</span>
+                            <strong>{{ t.channel_title or t.channel_id or '—' }}</strong>
                             {% if t.channel_username %}<br><small class="text-muted">@{{ t.channel_username }}</small>{% endif %}
                         </div>
                         <span>

--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -294,48 +294,28 @@ class TestSchedulerCommand:
         assert "No connected accounts" in caplog.text
 
     def test_trigger_success(self, cli_env_with_pool, capsys):
-        """Test scheduler trigger collects channels."""
+        """Test scheduler trigger enqueues channels."""
         cli_env, fake_pool = cli_env_with_pool
         fake_pool.clients = {"+70001112233": AsyncMock()}
 
-        from src.telegram.collector import Collector
+        from src.cli.commands.scheduler import run
 
-        mock_stats = {"collected": 10, "errors": 0}
-
-        with patch.object(
-            Collector, "collect_all_channels", new_callable=AsyncMock, return_value=mock_stats
-        ):
-            from src.cli.commands.scheduler import run
-
-            run(_ns(scheduler_action="trigger"))
+        run(_ns(scheduler_action="trigger"))
 
         out = capsys.readouterr().out
-        assert "collected" in out
+        assert "enqueued" in out.lower()
 
     def test_search_success(self, cli_env_with_pool, capsys):
-        """Test scheduler search triggers notification queries."""
+        """Test scheduler search enqueues notification search task."""
         cli_env, fake_pool = cli_env_with_pool
         fake_pool.clients = {"+70001112233": AsyncMock()}
 
-        from src.scheduler.manager import SchedulerManager
+        from src.cli.commands.scheduler import run
 
-        mock_stats = {"searches": 5, "notified": 2}
-
-        with patch.object(
-            SchedulerManager, "trigger_search_now", new_callable=AsyncMock, return_value=mock_stats
-        ):
-            from src.cli.commands.scheduler import run
-
-            # Patch the SchedulerManager constructor to not require db
-            with patch("src.cli.commands.scheduler.SchedulerManager") as mock_sm_class:
-                mock_sm = MagicMock()
-                mock_sm.trigger_search_now = AsyncMock(return_value=mock_stats)
-                mock_sm_class.return_value = mock_sm
-
-                run(_ns(scheduler_action="search"))
+        run(_ns(scheduler_action="search"))
 
         out = capsys.readouterr().out
-        assert "search" in out.lower() or "complete" in out.lower() or "notified" in out.lower()
+        assert "enqueued" in out.lower() or "search" in out.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -448,23 +428,16 @@ class TestCollectCommand:
         assert "No connected accounts" in caplog.text
 
     def test_collect_success(self, cli_env_with_pool, capsys):
-        """Test collect runs collection."""
+        """Test collect enqueues channels."""
         cli_env, fake_pool = cli_env_with_pool
         fake_pool.clients = {"+70001112233": AsyncMock()}
 
-        from src.telegram.collector import Collector
+        from src.cli.commands.collect import run
 
-        mock_stats = {"collected": 50, "errors": 0}
-
-        with patch.object(
-            Collector, "collect_all_channels", new_callable=AsyncMock, return_value=mock_stats
-        ):
-            from src.cli.commands.collect import run
-
-            run(_ns(channel_id=None, full=False))
+        run(_ns(channel_id=None, full=False))
 
         out = capsys.readouterr().out
-        assert "50" in out or "collected" in out.lower()
+        assert "enqueued" in out.lower()
 
     def test_collect_single_channel(self, cli_env_with_pool, capsys):
         """Test collect for a single channel."""

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -6,6 +6,7 @@ import pytest
 from telethon.errors import FloodWaitError
 
 from src.models import Channel, ChannelStats, Message, SearchQuery
+from src.services.notification_matcher import NotificationMatcher
 from src.telegram.collector import AllStatsClientsFloodedError, Collector, NoActiveStatsClientsError
 
 
@@ -121,14 +122,16 @@ async def test_flush_batch_persistence_error(collector, mock_pool, mock_db):
 
 @pytest.mark.asyncio
 async def test_notification_queries_logic(collector, mock_db):
-    collector._notifier = AsyncMock()
+    notifier = AsyncMock()
+    collector._notifier = notifier
+    collector._notification_matcher = NotificationMatcher(notifier)
     sq = SearchQuery(id=1, query="test", is_regex=False, is_fts=False)
     mock_db.get_notification_queries.return_value = [sq]
 
     # Need messages with actual text
     msgs = [Message(channel_id=1, message_id=1, text="This is a test message", date=datetime.now())]
     await collector._check_notification_queries(msgs)
-    collector._notifier.notify.assert_called_once()
+    notifier.notify.assert_called_once()
 
 @pytest.mark.asyncio
 async def test_fts_query_matches_logic(collector):


### PR DESCRIPTION
## Summary
- **UnifiedDispatcher** replaces `StatsTaskDispatcher` — polls DB for all non-CHANNEL_COLLECT task types (STATS_ALL, NOTIFICATION_SEARCH, SQ_STATS, PHOTO_DUE, PHOTO_AUTO)
- **TaskEnqueuer** — thin deduplication service for creating tasks in DB; SchedulerManager now only enqueues, never executes directly
- **NotificationMatcher** — extracted from Collector for reuse in Premium search notifications
- Simplified scheduler UI: single control block, unified task table with "Тип" column

## Test plan
- [x] `ruff check src/ tests/ conftest.py` — all checks passed
- [x] `pytest tests/ -m "not aiosqlite_serial" -n auto` — 788 passed
- [x] `pytest tests/ -m aiosqlite_serial` — 129 passed
- [ ] Manual: start server, enable scheduler, verify tasks appear with correct types
- [ ] Manual: CLI `python -m src.main scheduler trigger` creates tasks in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)