### PR TITLE
fix: narrow _stats_lock scope to prevent starvation

### DIFF
--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -782,40 +782,40 @@ class Collector:
                 await self._pool.release_client(phone)
 
     async def collect_all_stats(self) -> dict:
-        async with self._stats_lock:
-            self._stats_running = True
-            try:
-                channels = await self._db.get_channels(
-                    active_only=True, include_filtered=False
-                )
-                stats = {"channels": 0, "errors": 0}
-                for idx, channel in enumerate(channels):
-                    while True:
-                        try:
+        self._stats_running = True
+        try:
+            channels = await self._db.get_channels(
+                active_only=True, include_filtered=False
+            )
+            stats = {"channels": 0, "errors": 0}
+            for idx, channel in enumerate(channels):
+                while True:
+                    try:
+                        async with self._stats_lock:
                             await self._collect_channel_stats(channel)
-                            stats["channels"] += 1
-                            break
-                        except AllStatsClientsFloodedError as e:
-                            logger.warning(
-                                "All clients are flood-waited for stats. "
-                                "Waiting %ds until %s",
-                                e.retry_after_sec,
-                                e.next_available_at.isoformat(),
-                            )
-                            await asyncio.sleep(e.retry_after_sec)
-                        except NoActiveStatsClientsError:
-                            logger.error("No active connected clients for stats collection")
-                            stats["errors"] += len(channels) - idx
-                            return stats
-                        except Exception as e:
-                            logger.error("Stats error for %s: %s", channel.channel_id, e)
-                            stats["errors"] += 1
-                            break
-                    if idx < len(channels) - 1:
-                        await asyncio.sleep(self._config.delay_between_channels_sec)
-                return stats
-            finally:
-                self._stats_running = False
+                        stats["channels"] += 1
+                        break
+                    except AllStatsClientsFloodedError as e:
+                        logger.warning(
+                            "All clients are flood-waited for stats. "
+                            "Waiting %ds until %s",
+                            e.retry_after_sec,
+                            e.next_available_at.isoformat(),
+                        )
+                        await asyncio.sleep(e.retry_after_sec)
+                    except NoActiveStatsClientsError:
+                        logger.error("No active connected clients for stats collection")
+                        stats["errors"] += len(channels) - idx
+                        return stats
+                    except Exception as e:
+                        logger.error("Stats error for %s: %s", channel.channel_id, e)
+                        stats["errors"] += 1
+                        break
+                if idx < len(channels) - 1:
+                    await asyncio.sleep(self._config.delay_between_channels_sec)
+            return stats
+        finally:
+            self._stats_running = False
 
     @staticmethod
     def _get_sender_name(msg) -> str | None:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -72,17 +72,19 @@ class Collector:
         self._notifier = notifier
         self._running = False
         self._stats_running = False
+        self._stats_all_running = False
         self._cancel_event = asyncio.Event()
         self._lock = asyncio.Lock()
         self._stats_lock = asyncio.Lock()
+        self._stats_all_lock = asyncio.Lock()
 
     @property
     def is_running(self) -> bool:
-        return self._running or self._stats_running
+        return self._running or self._stats_running or self._stats_all_running
 
     @property
     def is_stats_running(self) -> bool:
-        return self._stats_running
+        return self._stats_running or self._stats_all_running
 
     @property
     def delay_between_channels_sec(self) -> int:
@@ -782,40 +784,45 @@ class Collector:
                 await self._pool.release_client(phone)
 
     async def collect_all_stats(self) -> dict:
-        self._stats_running = True
-        try:
-            channels = await self._db.get_channels(
-                active_only=True, include_filtered=False
-            )
-            stats = {"channels": 0, "errors": 0}
-            for idx, channel in enumerate(channels):
-                while True:
-                    try:
-                        async with self._stats_lock:
-                            await self._collect_channel_stats(channel)
-                        stats["channels"] += 1
-                        break
-                    except AllStatsClientsFloodedError as e:
-                        logger.warning(
-                            "All clients are flood-waited for stats. "
-                            "Waiting %ds until %s",
-                            e.retry_after_sec,
-                            e.next_available_at.isoformat(),
-                        )
-                        await asyncio.sleep(e.retry_after_sec)
-                    except NoActiveStatsClientsError:
-                        logger.error("No active connected clients for stats collection")
-                        stats["errors"] += len(channels) - idx
-                        return stats
-                    except Exception as e:
-                        logger.error("Stats error for %s: %s", channel.channel_id, e)
-                        stats["errors"] += 1
-                        break
-                if idx < len(channels) - 1:
-                    await asyncio.sleep(self._config.delay_between_channels_sec)
-            return stats
-        finally:
-            self._stats_running = False
+        async with self._stats_all_lock:
+            self._stats_all_running = True
+            try:
+                channels = await self._db.get_channels(
+                    active_only=True, include_filtered=False
+                )
+                stats = {"channels": 0, "errors": 0}
+                for idx, channel in enumerate(channels):
+                    while True:
+                        try:
+                            async with self._stats_lock:
+                                await self._collect_channel_stats(channel)
+                            stats["channels"] += 1
+                            break
+                        except AllStatsClientsFloodedError as e:
+                            logger.warning(
+                                "All clients are flood-waited for stats. "
+                                "Waiting %ds until %s",
+                                e.retry_after_sec,
+                                e.next_available_at.isoformat(),
+                            )
+                            await asyncio.sleep(e.retry_after_sec)
+                        except NoActiveStatsClientsError:
+                            logger.error(
+                                "No active connected clients for stats collection"
+                            )
+                            stats["errors"] += len(channels) - idx
+                            return stats
+                        except Exception as e:
+                            logger.error(
+                                "Stats error for %s: %s", channel.channel_id, e
+                            )
+                            stats["errors"] += 1
+                            break
+                    if idx < len(channels) - 1:
+                        await asyncio.sleep(self._config.delay_between_channels_sec)
+                return stats
+            finally:
+                self._stats_all_running = False
 
     @staticmethod
     def _get_sender_name(msg) -> str | None:


### PR DESCRIPTION
## Summary
- **Bug**: `collect_all_stats()` held `_stats_lock` for its entire duration, including `asyncio.sleep()` during flood waits that can last hours. This blocked `collect_channel_stats()` callers (used by `UnifiedDispatcher._handle_stats_all`) from ever acquiring the lock.
- **Fix**: Move `_stats_lock` to only wrap individual `_collect_channel_stats()` calls. Inter-channel delays and flood-wait sleeps now happen outside the lock, allowing other callers to interleave.
- The `_stats_running` flag is set/cleared via `try/finally` outside the lock, preserving status reporting.

## Test plan
- [x] `ruff check` passes
- [x] All 783 parallel tests pass
- [x] All 129 serial tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)