### PR TITLE
fix: atomic task creation to prevent duplicate collection tasks

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -21,16 +21,24 @@ class CollectionQueue:
         self._worker: asyncio.Task | None = None
         self._current_task_id: int | None = None
 
-    async def enqueue(self, channel: Channel, force: bool = False, full: bool = True) -> int:
+    async def enqueue(
+        self, channel: Channel, force: bool = False, full: bool = True
+    ) -> int | None:
+        """Enqueue a channel for collection, atomically skipping duplicates.
+
+        Returns the new task ID, or ``None`` if an active task already exists.
+        """
         payload = {}
         if force:
             payload["force"] = True
         if not full:
             payload["full"] = False
-        task_id = await self._channels.create_collection_task(
+        task_id = await self._channels.create_collection_task_if_not_active(
             channel.channel_id, channel.title, channel_username=channel.username,
             payload=payload or None,
         )
+        if task_id is None:
+            return None
         await self._queue.put((task_id, channel, force, full))
         self._ensure_worker()
         return task_id

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -175,6 +175,25 @@ class ChannelBundle:
             parent_task_id=parent_task_id,
         )
 
+    async def create_collection_task_if_not_active(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        channel_username: str | None = None,
+        run_after: datetime | None = None,
+        payload: dict | None = None,
+        parent_task_id: int | None = None,
+    ) -> int | None:
+        return await self.tasks.create_collection_task_if_not_active(
+            channel_id,
+            channel_title,
+            channel_username=channel_username,
+            run_after=run_after,
+            payload=payload,
+            parent_task_id=parent_task_id,
+        )
+
     async def update_collection_task(
         self,
         task_id: int,

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -148,7 +148,7 @@ class CollectionTasksRepository:
             ),
         )
         await self._db.commit()
-        if (cur.rowcount or 0) > 0:
+        if cur.rowcount == 1:
             return cur.lastrowid or 0
         return None
 

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -106,6 +106,52 @@ class CollectionTasksRepository:
         await self._db.commit()
         return cur.lastrowid or 0
 
+    async def create_collection_task_if_not_active(
+        self,
+        channel_id: int,
+        channel_title: str | None,
+        *,
+        channel_username: str | None = None,
+        run_after: datetime | None = None,
+        payload: dict[str, Any] | None = None,
+        parent_task_id: int | None = None,
+    ) -> int | None:
+        """Atomically create a collection task only if no active task exists.
+
+        Returns the new task ID, or ``None`` if an active task already exists.
+        """
+        run_after_iso = (
+            run_after.astimezone(timezone.utc).isoformat() if run_after else None
+        )
+        payload_json = self._serialize_payload(payload)
+        cur = await self._db.execute(
+            "INSERT INTO collection_tasks "
+            "(channel_id, channel_title, channel_username, task_type,"
+            " run_after, payload, parent_task_id) "
+            "SELECT ?, ?, ?, ?, ?, ?, ? "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM collection_tasks "
+            "  WHERE channel_id = ? AND task_type = ? AND status IN (?, ?)"
+            ")",
+            (
+                channel_id,
+                channel_title,
+                channel_username,
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                run_after_iso,
+                payload_json,
+                parent_task_id,
+                channel_id,
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                CollectionTaskStatus.PENDING.value,
+                CollectionTaskStatus.RUNNING.value,
+            ),
+        )
+        await self._db.commit()
+        if (cur.rowcount or 0) > 0:
+            return cur.lastrowid or 0
+        return None
+
     async def create_stats_task(
         self,
         payload: StatsAllTaskPayload,

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -36,20 +36,26 @@ class CollectionService:
 
     async def _enqueue_channel(
         self, channel: Channel, force: bool = False, full: bool = True
-    ) -> None:
+    ) -> bool:
+        """Enqueue a channel for collection, atomically skipping duplicates.
+
+        Returns ``True`` if a new task was created, ``False`` if skipped.
+        """
         if self._queue is not None:
-            await self._queue.enqueue(channel, force=force, full=full)
+            task_id = await self._queue.enqueue(channel, force=force, full=full)
+            return task_id is not None
         else:
             payload = {}
             if force:
                 payload["force"] = True
             if not full:
                 payload["full"] = False
-            await self._channels.create_collection_task(
+            task_id = await self._channels.create_collection_task_if_not_active(
                 channel.channel_id, channel.title,
                 channel_username=channel.username,
                 payload=payload or None,
             )
+            return task_id is not None
 
     async def enqueue_channel_by_pk(self, pk: int, force: bool = False) -> EnqueueResult:
         channel = await self._channels.get_by_pk(pk)
@@ -62,18 +68,17 @@ class CollectionService:
 
     async def enqueue_all_channels(self) -> BulkEnqueueResult:
         channels = await self._channels.list_channels(active_only=True, include_filtered=False)
-        busy_channel_ids = await self._channels.get_channel_ids_with_active_tasks()
         queued_count = 0
         skipped_existing_count = 0
 
         for channel in channels:
-            if channel.channel_id in busy_channel_ids:
+            # Atomic INSERT … WHERE NOT EXISTS prevents duplicate tasks
+            # even under concurrent calls (scheduler + web UI).
+            created = await self._enqueue_channel(channel, force=True, full=False)
+            if created:
+                queued_count += 1
+            else:
                 skipped_existing_count += 1
-                continue
-            # Bulk collection should continue from last_collected_id when the
-            # channel already has history, instead of reloading the full archive.
-            await self._enqueue_channel(channel, force=True, full=False)
-            queued_count += 1
 
         return BulkEnqueueResult(
             queued_count=queued_count,

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from src.collection_queue import CollectionQueue
     from src.telegram.collector import Collector
 
-EnqueueResult = Literal["not_found", "filtered", "queued"]
+EnqueueResult = Literal["not_found", "filtered", "queued", "already_active"]
 
 
 @dataclass(slots=True)
@@ -63,8 +63,8 @@ class CollectionService:
             return "not_found"
         if channel.is_filtered and not force:
             return "filtered"
-        await self._enqueue_channel(channel, force=force)
-        return "queued"
+        created = await self._enqueue_channel(channel, force=force)
+        return "queued" if created else "already_active"
 
     async def enqueue_all_channels(self) -> BulkEnqueueResult:
         channels = await self._channels.list_channels(active_only=True, include_filtered=False)

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -102,6 +102,17 @@ async def collect_channel(request: Request, pk: int):
     if is_htmx:
         if enqueue_status == "not_found":
             return HTMLResponse(f'<span id="collect-btn-{pk}">❓</span>')
+        if enqueue_status == "already_active":
+            btn = (
+                '<button class="btn btn-outline-secondary btn-sm emoji-btn"'
+                ' disabled title="Уже в очереди">⏳</button>'
+            )
+            fragment = (
+                f'<span id="collect-btn-{pk}">{btn}</span>'
+                f'<span id="collect-btn-m-{pk}" hx-swap-oob="true">'
+                f'{btn}</span>'
+            )
+            return HTMLResponse(fragment)
         collector = deps.get_collector(request)
         label = "В очереди" if collector.is_running else "Запущен"
         filtered_badge = ' <small title="Канал отфильтрован">⚡</small>' if is_filtered else ""
@@ -119,6 +130,8 @@ async def collect_channel(request: Request, pk: int):
 
     if enqueue_status == "not_found":
         return RedirectResponse(url="/channels?msg=channel_not_found", status_code=303)
+    if enqueue_status == "already_active":
+        return RedirectResponse(url="/channels?msg=collect_already_active", status_code=303)
     collector = deps.get_collector(request)
     msg = "collect_queued" if collector.is_running else "collect_started"
     return RedirectResponse(url=f"/channels?msg={msg}", status_code=303)


### PR DESCRIPTION
## Summary
- Add `create_collection_task_if_not_active()` to `CollectionTasksRepository` using atomic `INSERT...SELECT...WHERE NOT EXISTS` to prevent duplicate tasks at the DB level
- Update `CollectionQueue.enqueue()` and `CollectionService._enqueue_channel()` to use the new atomic method, returning whether a task was actually created
- Remove the racy `get_channel_ids_with_active_tasks()` pre-check from `enqueue_all_channels()` — each channel insert is now individually atomic

## Test plan
- [x] `ruff check` passes
- [x] All 783 parallel tests pass
- [x] All 129 serial tests pass
- [x] Existing tests for `enqueue_all_channels` and `CollectionQueue.enqueue` continue to pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)