### PR TITLE
refactor: remove NOTIFICATION_SEARCH, unify notifications

### DIFF
--- a/src/cli/commands/scheduler.py
+++ b/src/cli/commands/scheduler.py
@@ -53,15 +53,6 @@ def run(args: argparse.Namespace) -> None:
                     f"total {result.total_candidates}). "
                     f"Run 'serve' to execute tasks."
                 )
-            elif args.scheduler_action == "search":
-                task_id = await task_enqueuer.enqueue_notification_search()
-                if task_id:
-                    print(
-                        f"Enqueued notification search task #{task_id}. "
-                        f"Run 'serve' to execute tasks."
-                    )
-                else:
-                    print("Notification search task already active")
         finally:
             await pool.disconnect_all()
             await db.close()

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -135,7 +135,6 @@ def build_parser() -> argparse.ArgumentParser:
     sched_sub = sched_parser.add_subparsers(dest="scheduler_action")
     sched_sub.add_parser("start", help="Start scheduler (foreground)")
     sched_sub.add_parser("trigger", help="Trigger one-shot collection")
-    sched_sub.add_parser("search", help="Run notification query search now")
 
     my_tg_parser = sub.add_parser("my-telegram", help="View account dialogs")
     my_tg_sub = my_tg_parser.add_subparsers(dest="my_telegram_action")

--- a/src/config.py
+++ b/src/config.py
@@ -24,7 +24,6 @@ class WebConfig(BaseModel):
 
 class SchedulerConfig(BaseModel):
     collect_interval_minutes: int = 60
-    search_interval_minutes: int = 60
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1
     max_flood_wait_sec: int = 300

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -128,6 +128,16 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     )
     await db.commit()
 
+    # Remove legacy notification_search tasks (path removed in favour of notify_on_collect)
+    await db.execute(
+        """
+        UPDATE collection_tasks
+        SET status = 'failed', error = 'removed: NOTIFICATION_SEARCH path deleted'
+        WHERE task_type = 'notification_search' AND status IN ('pending', 'running')
+        """
+    )
+    await db.commit()
+
     await db.execute("UPDATE channels SET channel_type='supergroup' WHERE channel_type='group'")
     await db.execute("UPDATE channels SET channel_type='group' WHERE channel_type='chat'")
     await db.commit()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -17,6 +17,13 @@ from src.models import (
 _ALLOWED_PAYLOAD_FILTER_KEYS = frozenset({"sq_id"})
 
 
+def _safe_task_type(raw: str) -> CollectionTaskType:
+    try:
+        return CollectionTaskType(raw)
+    except ValueError:
+        return CollectionTaskType.CHANNEL_COLLECT
+
+
 class CollectionTasksRepository:
     def __init__(self, db: aiosqlite.Connection):
         self._db = db
@@ -57,7 +64,7 @@ class CollectionTasksRepository:
             channel_id=row["channel_id"],
             channel_title=row["channel_title"],
             channel_username=row["channel_username"],
-            task_type=CollectionTaskType(row["task_type"]),
+            task_type=_safe_task_type(row["task_type"]),
             status=CollectionTaskStatus(row["status"]),
             messages_collected=row["messages_collected"],
             error=row["error"],

--- a/src/models.py
+++ b/src/models.py
@@ -67,7 +67,6 @@ class CollectionTaskStatus(StrEnum):
 class CollectionTaskType(StrEnum):
     CHANNEL_COLLECT = "channel_collect"
     STATS_ALL = "stats_all"
-    NOTIFICATION_SEARCH = "notification_search"
     SQ_STATS = "sq_stats"
     PHOTO_DUE = "photo_due"
     PHOTO_AUTO = "photo_auto"

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -34,12 +34,10 @@ class SchedulerManager:
         self._sq_bundle = search_query_bundle
         self._scheduler: AsyncIOScheduler | None = None
         self._job_id = "collect_all"
-        self._search_job_id = "notification_search"
         self._photo_due_job_id = "photo_due"
         self._photo_auto_job_id = "photo_auto"
         self._current_interval_minutes: int = config.collect_interval_minutes
         self._bg_task: asyncio.Task | None = None
-        self._search_bg_task: asyncio.Task | None = None
 
     @property
     def is_running(self) -> bool:
@@ -48,10 +46,6 @@ class SchedulerManager:
     @property
     def interval_minutes(self) -> int:
         return self._current_interval_minutes
-
-    @property
-    def search_interval_minutes(self) -> int:
-        return self._config.search_interval_minutes
 
     async def start(self) -> None:
         if self._scheduler is not None and self._scheduler.running:
@@ -83,18 +77,6 @@ class SchedulerManager:
             replace_existing=True,
         )
 
-        if self._task_enqueuer is not None:
-            self._scheduler.add_job(
-                self._run_keyword_search,
-                IntervalTrigger(minutes=self._config.search_interval_minutes),
-                id=self._search_job_id,
-                replace_existing=True,
-            )
-            logger.info(
-                "Notification search job added: every %d minutes",
-                self._config.search_interval_minutes,
-            )
-
         if self._sq_bundle:
             await self.sync_search_query_jobs()
 
@@ -116,15 +98,13 @@ class SchedulerManager:
         logger.info("Scheduler started: collecting every %d minutes", collect_interval)
 
     async def stop(self) -> None:
-        for task in (self._bg_task, self._search_bg_task):
-            if task and not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        if self._bg_task and not self._bg_task.done():
+            self._bg_task.cancel()
+            try:
+                await self._bg_task
+            except asyncio.CancelledError:
+                pass
         self._bg_task = None
-        self._search_bg_task = None
 
         if self._scheduler is None or not self._scheduler.running:
             return
@@ -147,15 +127,6 @@ class SchedulerManager:
             return
         self._bg_task = asyncio.create_task(self._run_collection())
 
-    async def trigger_search_now(self) -> dict:
-        return await self._run_keyword_search()
-
-    async def trigger_search_background(self) -> None:
-        """Fire-and-forget notification search run."""
-        if self._search_bg_task and not self._search_bg_task.done():
-            return
-        self._search_bg_task = asyncio.create_task(self._run_keyword_search())
-
     async def _run_collection(self) -> dict:
         """Enqueue all channels for collection."""
         logger.info("Starting scheduled collection")
@@ -174,19 +145,6 @@ class SchedulerManager:
         except Exception:
             logger.exception("Collection enqueue failed")
             return {"enqueued": 0, "skipped": 0, "total": 0, "errors": 1}
-
-    async def _run_keyword_search(self) -> dict:
-        """Enqueue a notification search task."""
-        if not self._task_enqueuer:
-            return {"enqueued": False, "errors": 0}
-        try:
-            task_id = await self._task_enqueuer.enqueue_notification_search()
-            if task_id:
-                logger.info("Enqueued notification search task #%d", task_id)
-            return {"enqueued": bool(task_id), "errors": 0}
-        except Exception:
-            logger.exception("Notification search enqueue failed")
-            return {"enqueued": False, "errors": 1}
 
     async def sync_search_query_jobs(self) -> None:
         if not self._sq_bundle or not self._scheduler:

--- a/src/services/task_enqueuer.py
+++ b/src/services/task_enqueuer.py
@@ -27,21 +27,6 @@ class TaskEnqueuer:
         """Delegate to CollectionService for channel collection tasks."""
         return await self._collection_service.enqueue_all_channels()
 
-    async def enqueue_notification_search(self) -> int | None:
-        """Create a NOTIFICATION_SEARCH task if none is already pending/running."""
-        has = await self._db.repos.tasks.has_active_task(
-            CollectionTaskType.NOTIFICATION_SEARCH
-        )
-        if has:
-            logger.debug("NOTIFICATION_SEARCH task already active, skipping")
-            return None
-        task_id = await self._db.repos.tasks.create_generic_task(
-            CollectionTaskType.NOTIFICATION_SEARCH,
-            title="Поиск по запросам",
-        )
-        logger.info("Enqueued NOTIFICATION_SEARCH task #%d", task_id)
-        return task_id
-
     async def enqueue_sq_stats(self, sq_id: int) -> int | None:
         """Create a SQ_STATS task for a specific search query, with dedup."""
         has = await self._db.repos.tasks.has_active_task(

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine
 from datetime import date, datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from src.database.bundles import ChannelBundle, SearchQueryBundle
 from src.database.repositories.collection_tasks import CollectionTasksRepository
@@ -12,15 +11,12 @@ from src.models import (
     CollectionTask,
     CollectionTaskStatus,
     CollectionTaskType,
-    SearchQuery,
     SqStatsTaskPayload,
     StatsAllTaskPayload,
 )
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
-    from src.search.engine import SearchEngine
-    from src.services.notification_matcher import NotificationMatcher
     from src.services.photo_auto_upload_service import PhotoAutoUploadService
     from src.services.photo_task_service import PhotoTaskService
 
@@ -28,13 +24,10 @@ logger = logging.getLogger(__name__)
 
 HANDLED_TYPES = [
     CollectionTaskType.STATS_ALL.value,
-    CollectionTaskType.NOTIFICATION_SEARCH.value,
     CollectionTaskType.SQ_STATS.value,
     CollectionTaskType.PHOTO_DUE.value,
     CollectionTaskType.PHOTO_AUTO.value,
 ]
-
-NotificationQueryFn = Callable[..., Coroutine[Any, Any, list[SearchQuery]]]
 
 
 class UnifiedDispatcher:
@@ -46,9 +39,6 @@ class UnifiedDispatcher:
         channel_bundle: ChannelBundle,
         tasks_repo: CollectionTasksRepository,
         *,
-        notification_query_fn: NotificationQueryFn | None = None,
-        search_engine: SearchEngine | None = None,
-        notification_matcher: NotificationMatcher | None = None,
         sq_bundle: SearchQueryBundle | None = None,
         photo_task_service: PhotoTaskService | None = None,
         photo_auto_upload_service: PhotoAutoUploadService | None = None,
@@ -59,9 +49,6 @@ class UnifiedDispatcher:
         self._collector = collector
         self._channel_bundle = channel_bundle
         self._tasks = tasks_repo
-        self._notification_query_fn = notification_query_fn
-        self._search_engine = search_engine
-        self._notification_matcher = notification_matcher
         self._sq_bundle = sq_bundle
         self._photo_task_service = photo_task_service
         self._photo_auto_upload_service = photo_auto_upload_service
@@ -124,7 +111,6 @@ class UnifiedDispatcher:
     async def _dispatch(self, task: CollectionTask) -> None:
         handler = {
             CollectionTaskType.STATS_ALL: self._handle_stats_all,
-            CollectionTaskType.NOTIFICATION_SEARCH: self._handle_notification_search,
             CollectionTaskType.SQ_STATS: self._handle_sq_stats,
             CollectionTaskType.PHOTO_DUE: self._handle_photo_due,
             CollectionTaskType.PHOTO_AUTO: self._handle_photo_auto,
@@ -267,57 +253,6 @@ class UnifiedDispatcher:
 
         await self._tasks.update_collection_task(
             task.id, CollectionTaskStatus.COMPLETED, messages_collected=channels_ok,
-        )
-
-    # ── NOTIFICATION_SEARCH ──
-
-    async def _handle_notification_search(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        if not self._search_engine:
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.COMPLETED,
-                note="No search engine configured",
-            )
-            return
-
-        if not self._notification_query_fn:
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.COMPLETED,
-                note="No notification query source",
-            )
-            return
-
-        queries = await self._notification_query_fn(active_only=True)
-        total_results = 0
-        searched = 0
-        errors = 0
-
-        for sq in queries:
-            try:
-                quota = await self._search_engine.check_search_quota(sq.query)
-                if quota and quota.get("remains") == 0 and not quota.get("query_is_free"):
-                    logger.info("Search quota exhausted, stopping notification search")
-                    break
-
-                result = await self._search_engine.search_telegram(sq.query, limit=50)
-                if result.error:
-                    errors += 1
-                else:
-                    total_results += result.total
-                    searched += 1
-
-                    if self._notification_matcher and result.messages:
-                        await self._notification_matcher.match_and_notify(result.messages, [sq])
-            except Exception:
-                logger.exception("Error searching query '%s'", sq.query)
-                errors += 1
-
-        await self._tasks.update_collection_task(
-            task.id, CollectionTaskStatus.COMPLETED,
-            messages_collected=total_results,
-            note=f"queries={searched}, errors={errors}",
         )
 
     # ── SQ_STATS ──

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -23,7 +23,6 @@ from src.database.bundles import (
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
-from src.services.notification_matcher import NotificationMatcher
 from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
@@ -133,14 +132,10 @@ async def build_container_with_templates(
 
     collection_service = CollectionService(channel_bundle, collector, collection_queue)
     task_enqueuer = TaskEnqueuer(db, collection_service)
-    notification_matcher = NotificationMatcher(notifier)
     unified_dispatcher = UnifiedDispatcher(
         collector,
         channel_bundle,
         repos.tasks,
-        notification_query_fn=repos.search_queries.get_notification_queries,
-        search_engine=search_engine,
-        notification_matcher=notification_matcher,
         sq_bundle=search_query_bundle,
         photo_task_service=photo_task_service,
         photo_auto_upload_service=photo_auto_upload_service,

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -71,7 +71,6 @@ async def scheduler_page(
         {
             "is_running": sched.is_running,
             "interval_minutes": sched.interval_minutes,
-            "search_interval_minutes": sched.search_interval_minutes,
             "msg": msg,
             "tasks": tasks,
             "has_active_tasks": has_active_tasks,
@@ -154,9 +153,3 @@ async def test_notification(request: Request):
     return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
 
 
-@router.post("/trigger-search")
-async def trigger_search(request: Request):
-    if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-    await deps.scheduler_service(request).trigger_search_background()
-    return RedirectResponse(url="/scheduler?msg=search_triggered", status_code=303)

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -6,7 +6,6 @@
 {% macro task_type_label(t) %}
     {% if t.task_type.value == 'channel_collect' %}Сбор канала
     {% elif t.task_type.value == 'stats_all' %}Статистика
-    {% elif t.task_type.value == 'notification_search' %}Поиск
     {% elif t.task_type.value == 'sq_stats' %}Статистика запроса
     {% elif t.task_type.value == 'photo_due' %}Фото
     {% elif t.task_type.value == 'photo_auto' %}Автофото
@@ -20,7 +19,7 @@
         <span class="hint" data-tooltip="Планировщик автоматически ставит задачи в очередь: сбор, поиск, статистику">?</span>
     </div>
     <div class="card-body">
-        <small class="text-muted d-block mb-2">Автоматическое создание задач: сбор каждые {{ interval_minutes }} мин., поиск каждые {{ search_interval_minutes }} мин.</small>
+        <small class="text-muted d-block mb-2">Автоматическое создание задач: сбор каждые {{ interval_minutes }} мин.</small>
         <p>Статус: <strong>{{ "Запущен" if is_running else "Остановлен" }}</strong></p>
 
         <div class="d-flex flex-wrap gap-2">
@@ -35,9 +34,6 @@
             {% endif %}
             <form method="post" action="/scheduler/trigger" data-busy>
                 <button type="submit" class="btn btn-outline-primary">&#9654; Собрать все каналы</button>
-            </form>
-            <form method="post" action="/scheduler/trigger-search" data-busy>
-                <button type="submit" class="btn btn-outline-primary">&#9654; Запустить поиск</button>
             </form>
             <form method="post" action="/scheduler/test-notification" data-busy>
                 <button type="submit" class="btn btn-outline-secondary"

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -16,7 +16,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">
         Планировщик
-        <span class="hint" data-tooltip="Планировщик автоматически ставит задачи в очередь: сбор, поиск, статистику">?</span>
+        <span class="hint" data-tooltip="Планировщик автоматически ставит задачи в очередь: сбор, статистику">?</span>
     </div>
     <div class="card-body">
         <small class="text-muted d-block mb-2">Автоматическое создание задач: сбор каждые {{ interval_minutes }} мин.</small>
@@ -97,7 +97,7 @@
 <div class="card mb-4">
     <div class="card-header fw-semibold">Задачи</div>
     <div class="card-body p-0">
-        <p class="px-3 pt-3"><small class="text-muted">Все задачи: сбор каналов, поиск, статистика, фото.</small></p>
+        <p class="px-3 pt-3"><small class="text-muted">Все задачи: сбор каналов, статистика, фото.</small></p>
 
         <!-- Filter tabs -->
         <div class="px-3 pb-2">

--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -283,16 +283,6 @@ class TestSchedulerCommand:
         run(_ns(scheduler_action="trigger"))
         assert "No connected accounts" in caplog.text
 
-    def test_search_no_clients(self, cli_env_with_pool, capsys, caplog):
-        """Test scheduler search when no accounts connected."""
-        cli_env, fake_pool = cli_env_with_pool
-        fake_pool.clients = {}
-
-        from src.cli.commands.scheduler import run
-
-        run(_ns(scheduler_action="search"))
-        assert "No connected accounts" in caplog.text
-
     def test_trigger_success(self, cli_env_with_pool, capsys):
         """Test scheduler trigger enqueues channels."""
         cli_env, fake_pool = cli_env_with_pool
@@ -305,17 +295,6 @@ class TestSchedulerCommand:
         out = capsys.readouterr().out
         assert "enqueued" in out.lower()
 
-    def test_search_success(self, cli_env_with_pool, capsys):
-        """Test scheduler search enqueues notification search task."""
-        cli_env, fake_pool = cli_env_with_pool
-        fake_pool.clients = {"+70001112233": AsyncMock()}
-
-        from src.cli.commands.scheduler import run
-
-        run(_ns(scheduler_action="search"))
-
-        out = capsys.readouterr().out
-        assert "enqueued" in out.lower() or "search" in out.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduler_manager.py
+++ b/tests/test_scheduler_manager.py
@@ -32,7 +32,6 @@ def mock_task_enqueuer():
     result.skipped_existing_count = 1
     result.total_candidates = 4
     enqueuer.enqueue_all_channels = AsyncMock(return_value=result)
-    enqueuer.enqueue_notification_search = AsyncMock(return_value=42)
     enqueuer.enqueue_sq_stats = AsyncMock()
     enqueuer.enqueue_photo_due = AsyncMock()
     enqueuer.enqueue_photo_auto = AsyncMock()
@@ -41,9 +40,7 @@ def mock_task_enqueuer():
 
 @pytest.fixture
 def scheduler_config():
-    return SchedulerConfig(
-        collect_interval_minutes=60, search_interval_minutes=30,
-    )
+    return SchedulerConfig(collect_interval_minutes=60)
 
 
 @pytest.mark.asyncio
@@ -138,26 +135,6 @@ async def test_run_collection_failure(
     )
     res = await mgr._run_collection()
     assert res["errors"] == 1
-
-
-@pytest.mark.asyncio
-async def test_run_keyword_search_no_enqueuer(scheduler_config, mock_bundle):
-    mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
-    res = await mgr._run_keyword_search()
-    assert res["enqueued"] is False
-
-
-@pytest.mark.asyncio
-async def test_run_keyword_search_with_enqueuer(
-    scheduler_config, mock_bundle, mock_task_enqueuer,
-):
-    mgr = SchedulerManager(
-        scheduler_config, scheduler_bundle=mock_bundle,
-        task_enqueuer=mock_task_enqueuer,
-    )
-    res = await mgr._run_keyword_search()
-    assert res["enqueued"] is True
-    mock_task_enqueuer.enqueue_notification_search.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Removed the `NOTIFICATION_SEARCH` path entirely — notifications now fire **only** during channel message collection (`notify_on_collect`)
- Eliminated duplicate notification risk: the old periodic Telegram Global Search path had no per-message dedup and could re-notify the same messages across scheduler cycles
- Cleaned up 12 files: enum, config, scheduler, dispatcher, CLI, web routes, templates, and tests (−203 lines)

## Test plan
- [x] `ruff check` passes
- [x] All 781 parallel tests pass
- [x] All 127 serial tests pass
- [ ] Verify `notify_on_collect` still works end-to-end on a running instance
- [ ] Confirm scheduler page renders without errors (no missing template vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)