### PR TITLE
fix: handle stale transaction in apply_filters

### DIFF
--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -168,7 +168,9 @@ class ChannelAnalyzer:
         # (isolation_level=None means autocommit, so rollback is a no-op when clean).
         try:
             await conn.execute("BEGIN")
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as e:
+            if "cannot start a transaction within a transaction" not in str(e):
+                raise
             await conn.rollback()
             await conn.execute("BEGIN")
         try:

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 
 from src.database import Database
 from src.filters.criteria import (
@@ -167,7 +168,7 @@ class ChannelAnalyzer:
         # (isolation_level=None means autocommit, so rollback is a no-op when clean).
         try:
             await conn.execute("BEGIN")
-        except Exception:
+        except sqlite3.OperationalError:
             await conn.rollback()
             await conn.execute("BEGIN")
         try:

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -163,7 +163,13 @@ class ChannelAnalyzer:
         updates = [(cid, ",".join(sorted(flags))) for cid, flags in deduped.items()]
         conn = self._database.db
         assert conn is not None
-        await conn.execute("BEGIN")
+        # Rollback any stale transaction left by a prior interrupted operation
+        # (isolation_level=None means autocommit, so rollback is a no-op when clean).
+        try:
+            await conn.execute("BEGIN")
+        except Exception:
+            await conn.rollback()
+            await conn.execute("BEGIN")
         try:
             await self._database.reset_all_channel_filters(commit=False)
             count = 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -372,6 +372,18 @@ class TestChannelAnalyzer:
         assert row["is_filtered"] == 1
         assert row["filter_flags"] == "legacy_flag"
 
+    async def test_apply_filters_recovers_from_stale_transaction(self, db, raw_db):
+        """BEGIN succeeds even if a prior operation left an uncommitted txn."""
+        await _insert_channel(raw_db, 714, title="Stale")
+        await raw_db.commit()
+        # Simulate stale transaction left by an interrupted operation
+        await db.db.execute("BEGIN")
+        analyzer = ChannelAnalyzer(db)
+        report = FilterReport(results=[], total_channels=0, filtered_count=0)
+        # Should not raise OperationalError
+        count = await analyzer.apply_filters(report)
+        assert count == 0
+
     async def test_reset_filters(self, db, raw_db):
         await _insert_channel(raw_db, 800)
         await raw_db.execute(


### PR DESCRIPTION
## Summary
- Fix `sqlite3.OperationalError: cannot start a transaction within a transaction` when clicking "Обновить статистику" (`POST /channels/filter/analyze`)
- A prior interrupted operation could leave an uncommitted transaction on the shared aiosqlite connection; now we catch the error, rollback the stale transaction, and retry `BEGIN`
- Atomicity of the reset+apply operation is preserved

## Test plan
- [x] All 33 filter tests pass (`test_filters.py`), including `test_apply_filters_is_atomic_on_error`
- [ ] Manual: click "Обновить статистику" on the channels page — no 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)