### PR TITLE
feat: collect message reactions from Telegram channels

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -17,6 +17,9 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     if "topic_id" not in msg_columns:
         await db.execute("ALTER TABLE messages ADD COLUMN topic_id INTEGER")
         await db.commit()
+    if "reactions_json" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN reactions_json TEXT")
+        await db.commit()
 
     cur = await db.execute("PRAGMA table_info(accounts)")
     acc_columns = {row["name"] for row in await cur.fetchall()}

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -46,8 +46,8 @@ class MessagesRepository:
             cur = await self._db.execute(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
-                    text, media_type, topic_id, date)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    text, media_type, topic_id, reactions_json, date)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     msg.channel_id,
                     msg.message_id,
@@ -56,6 +56,7 @@ class MessagesRepository:
                     msg.text,
                     msg.media_type,
                     msg.topic_id,
+                    msg.reactions_json,
                     msg.date.isoformat(),
                 ),
             )
@@ -81,6 +82,7 @@ class MessagesRepository:
                 m.text,
                 m.media_type,
                 m.topic_id,
+                m.reactions_json,
                 m.date.isoformat(),
             )
             for m in messages
@@ -89,8 +91,8 @@ class MessagesRepository:
             cur = await self._db.executemany(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
-                    text, media_type, topic_id, date)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    text, media_type, topic_id, reactions_json, date)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 data,
             )
             await self._db.commit()
@@ -217,6 +219,7 @@ class MessagesRepository:
                 text=r["text"],
                 media_type=r["media_type"],
                 topic_id=r["topic_id"],
+                reactions_json=r["reactions_json"],
                 date=datetime.fromisoformat(r["date"]),
                 collected_at=(
                     datetime.fromisoformat(r["collected_at"]) if r["collected_at"] else None

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS messages (
     text TEXT,
     media_type TEXT,
     topic_id INTEGER,
+    reactions_json TEXT,
     date TEXT NOT NULL,
     collected_at TEXT DEFAULT (datetime('now')),
     UNIQUE(channel_id, message_id)

--- a/src/models.py
+++ b/src/models.py
@@ -50,6 +50,7 @@ class Message(BaseModel):
     text: str | None = None
     media_type: str | None = None
     topic_id: int | None = None
+    reactions_json: str | None = None
     date: datetime
     collected_at: datetime | None = None
     channel_title: str | None = None

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
@@ -490,6 +491,7 @@ class Collector:
                         text=msg.text,
                         media_type=self._get_media_type(msg),
                         topic_id=topic_id,
+                        reactions_json=self._extract_reactions(msg),
                         date=msg.date.replace(tzinfo=timezone.utc)
                         if msg.date and msg.date.tzinfo is None
                         else msg.date,
@@ -823,6 +825,32 @@ class Collector:
                 return stats
             finally:
                 self._stats_all_running = False
+
+    @staticmethod
+    def _extract_reactions(msg) -> str | None:
+        """Extract reactions from a Telethon message as JSON string."""
+        reactions = getattr(msg, "reactions", None)
+        if not reactions:
+            return None
+        results = getattr(reactions, "results", None)
+        if not results:
+            return None
+        items = []
+        for r in results:
+            reaction = getattr(r, "reaction", None)
+            if reaction is None:
+                continue
+            emoticon = getattr(reaction, "emoticon", None)
+            if emoticon:
+                emoji = emoticon
+            else:
+                document_id = getattr(reaction, "document_id", None)
+                if document_id is not None:
+                    emoji = f"custom:{document_id}"
+                else:
+                    continue
+            items.append({"emoji": emoji, "count": getattr(r, "count", 0)})
+        return json.dumps(items, ensure_ascii=False) if items else None
 
     @staticmethod
     def _get_sender_name(msg) -> str | None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -279,7 +279,25 @@ class FakeClientPool(MagicMock):
         return ClientPool._classify_entity(entity)
 
 
-def make_mock_message(msg_id, text=None, media=None, sender_id=None, *, date=None):
+def make_mock_reactions(items: list[tuple[str, int]]) -> SimpleNamespace:
+    """Create a mock MessageReactions object.
+
+    Args:
+        items: list of (emoji_or_custom_id, count) tuples.
+            Plain strings are treated as emoticons;
+            integers are treated as custom emoji document_ids.
+    """
+    results = []
+    for emoji, count in items:
+        if isinstance(emoji, int):
+            reaction = SimpleNamespace(emoticon=None, document_id=emoji)
+        else:
+            reaction = SimpleNamespace(emoticon=emoji)
+        results.append(SimpleNamespace(reaction=reaction, count=count))
+    return SimpleNamespace(results=results)
+
+
+def make_mock_message(msg_id, text=None, media=None, sender_id=None, *, date=None, reactions=None):
     return SimpleNamespace(
         id=msg_id,
         text=text,
@@ -287,6 +305,7 @@ def make_mock_message(msg_id, text=None, media=None, sender_id=None, *, date=Non
         sender_id=sender_id,
         sender=None,
         date=date or datetime(2025, 1, 1, tzinfo=timezone.utc),
+        reactions=reactions,
     )
 
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -12,7 +12,12 @@ from src.models import Channel, ChannelStats, Message
 from src.telegram.collector import Collector
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
-from tests.helpers import FakeTelethonClient, make_mock_message, make_mock_pool
+from tests.helpers import (
+    FakeTelethonClient,
+    make_mock_message,
+    make_mock_pool,
+    make_mock_reactions,
+)
 
 
 @pytest.mark.asyncio
@@ -328,6 +333,56 @@ async def test_get_media_type_poll():
 
     msg = SimpleNamespace(media=MessageMediaPoll(poll=None, results=None))
     assert Collector._get_media_type(msg) == "poll"
+
+
+# --- _extract_reactions tests ---
+
+
+@pytest.mark.asyncio
+async def test_extract_reactions_none():
+    """No reactions attr → None."""
+    msg = SimpleNamespace(reactions=None)
+    assert Collector._extract_reactions(msg) is None
+
+
+@pytest.mark.asyncio
+async def test_extract_reactions_empty_results():
+    """reactions exists but results is empty → None."""
+    msg = SimpleNamespace(reactions=SimpleNamespace(results=[]))
+    assert Collector._extract_reactions(msg) is None
+
+
+@pytest.mark.asyncio
+async def test_extract_reactions_single_emoji():
+    import json
+
+    msg = SimpleNamespace(reactions=make_mock_reactions([("👍", 5)]))
+    result = Collector._extract_reactions(msg)
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed == [{"emoji": "👍", "count": 5}]
+
+
+@pytest.mark.asyncio
+async def test_extract_reactions_multiple():
+    import json
+
+    msg = SimpleNamespace(reactions=make_mock_reactions([("👍", 5), ("❤️", 3)]))
+    result = Collector._extract_reactions(msg)
+    parsed = json.loads(result)
+    assert len(parsed) == 2
+    assert parsed[0] == {"emoji": "👍", "count": 5}
+    assert parsed[1] == {"emoji": "❤️", "count": 3}
+
+
+@pytest.mark.asyncio
+async def test_extract_reactions_custom_emoji():
+    import json
+
+    msg = SimpleNamespace(reactions=make_mock_reactions([(12345678, 2)]))
+    result = Collector._extract_reactions(msg)
+    parsed = json.loads(result)
+    assert parsed == [{"emoji": "custom:12345678", "count": 2}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1065,3 +1065,108 @@ async def test_update_channel_meta(db):
     # Other fields must remain untouched
     assert stored.is_active is True
     assert stored.is_filtered is False
+
+
+@pytest.mark.aiosqlite_serial
+@pytest.mark.asyncio
+async def test_migrate_adds_reactions_json_column(tmp_path):
+    """Migration adds reactions_json column to existing DB without it."""
+    db_path = str(tmp_path / "migrate_reactions.db")
+
+    conn = await aiosqlite.connect(db_path)
+    try:
+        await conn.executescript("""
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY,
+                channel_id INTEGER NOT NULL,
+                message_id INTEGER NOT NULL,
+                sender_id INTEGER,
+                sender_name TEXT,
+                text TEXT,
+                media_type TEXT,
+                topic_id INTEGER,
+                date TEXT NOT NULL,
+                collected_at TEXT DEFAULT (datetime('now')),
+                UNIQUE(channel_id, message_id)
+            );
+            CREATE TABLE IF NOT EXISTS accounts (
+                id INTEGER PRIMARY KEY,
+                phone TEXT UNIQUE NOT NULL,
+                session_string TEXT NOT NULL,
+                is_primary INTEGER DEFAULT 0,
+                is_active INTEGER DEFAULT 1,
+                flood_wait_until TEXT,
+                created_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS channels (
+                id INTEGER PRIMARY KEY,
+                channel_id INTEGER UNIQUE NOT NULL,
+                title TEXT,
+                username TEXT,
+                is_active INTEGER DEFAULT 1,
+                last_collected_id INTEGER DEFAULT 0,
+                added_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+        """)
+        await conn.commit()
+    finally:
+        await conn.close()
+
+    database = Database(db_path)
+    await database.initialize()
+
+    cur = await database.execute("PRAGMA table_info(messages)")
+    columns = {row["name"] for row in await cur.fetchall()}
+    assert "reactions_json" in columns
+
+    msg = Message(
+        channel_id=-100123,
+        message_id=1,
+        text="test",
+        reactions_json='[{"emoji": "👍", "count": 5}]',
+        date=datetime.now(timezone.utc),
+    )
+    await database.insert_message(msg)
+    messages, total = await database.search_messages()
+    assert total == 1
+    assert messages[0].reactions_json == '[{"emoji": "👍", "count": 5}]'
+
+    await database.close()
+
+
+@pytest.mark.asyncio
+async def test_reactions_json_roundtrip(db):
+    """reactions_json is persisted and retrieved via search_messages."""
+    await db.add_channel(Channel(channel_id=-100999, title="ReactTest"))
+    msg = Message(
+        channel_id=-100999,
+        message_id=42,
+        text="hello",
+        reactions_json='[{"emoji": "❤️", "count": 3}]',
+        date=datetime.now(timezone.utc),
+    )
+    await db.insert_message(msg)
+
+    messages, total = await db.search_messages(channel_id=-100999)
+    assert total == 1
+    assert messages[0].reactions_json == '[{"emoji": "❤️", "count": 3}]'
+
+
+@pytest.mark.asyncio
+async def test_reactions_json_null_when_absent(db):
+    """reactions_json is None when message has no reactions."""
+    await db.add_channel(Channel(channel_id=-100998, title="NoReact"))
+    msg = Message(
+        channel_id=-100998,
+        message_id=1,
+        text="no reactions",
+        date=datetime.now(timezone.utc),
+    )
+    await db.insert_message(msg)
+
+    messages, _ = await db.search_messages(channel_id=-100998)
+    assert messages[0].reactions_json is None


### PR DESCRIPTION
## Summary
- Add `reactions_json` field to Message model, DB schema, and migration
- Add `Collector._extract_reactions()` to parse Telethon `MessageReactions` into JSON (`[{"emoji": "👍", "count": 5}, ...]`)
- Support custom emoji reactions as `custom:{document_id}`
- No extra API calls — reactions come with `iter_messages()` responses

## Test plan
- [x] `ruff check` passes
- [x] 5 unit tests for `_extract_reactions`: None, empty, single emoji, multiple, custom emoji
- [x] All 787 parallel + 127 serial tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)