### PR TITLE
fix: skip avatar download in CLI account info command

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -14,7 +14,7 @@ def run(args: argparse.Namespace) -> None:
         try:
             if args.account_action == "info":
                 _, pool = await runtime.init_pool(config, db)
-                users = await pool.get_users_info()
+                users = await pool.get_users_info(include_avatar=False)
                 phone_filter = getattr(args, "phone", None)
                 if phone_filter:
                     users = [u for u in users if u.phone == phone_filter]

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -467,12 +467,16 @@ class ClientPool:
         return lease
 
 
-    async def get_users_info(self) -> list[TelegramUserInfo]:
+    async def get_users_info(self, include_avatar: bool = True) -> list[TelegramUserInfo]:
         """Get info about all connected Telegram accounts.
 
         Direct sessions (self.clients) are borrowed refs with disconnect_on_close=False —
         they must NOT be released here; the pool owns their lifetime.
         Only the fallback lease (when no direct session is available) requires explicit release.
+
+        Args:
+            include_avatar: If True (default), download and encode profile photos as base64.
+                           Set to False for CLI usage to skip unnecessary 15s I/O per account.
         """
         accounts = await self._db.get_accounts(active_only=True)
         primary_phones = {a.phone for a in accounts if a.is_primary}
@@ -491,18 +495,19 @@ class ClientPool:
 
                 me = await asyncio.wait_for(session.fetch_me(), timeout=15.0)
                 avatar_base64 = None
-                try:
-                    buf = io.BytesIO()
-                    downloaded = await asyncio.wait_for(
-                        session.fetch_profile_photo("me", file=buf),
-                        timeout=15.0,
-                    )
-                    if downloaded:
-                        buf.seek(0)
-                        encoded = base64.b64encode(buf.read()).decode()
-                        avatar_base64 = f"data:image/jpeg;base64,{encoded}"
-                except Exception:
-                    logger.debug("Failed to download avatar for %s", phone)
+                if include_avatar:
+                    try:
+                        buf = io.BytesIO()
+                        downloaded = await asyncio.wait_for(
+                            session.fetch_profile_photo("me", file=buf),
+                            timeout=15.0,
+                        )
+                        if downloaded:
+                            buf.seek(0)
+                            encoded = base64.b64encode(buf.read()).decode()
+                            avatar_base64 = f"data:image/jpeg;base64,{encoded}"
+                    except Exception:
+                        logger.debug("Failed to download avatar for %s", phone)
 
                 result.append(TelegramUserInfo(
                     phone=phone,


### PR DESCRIPTION
Optimizes the `account info` CLI command by skipping unnecessary profile photo downloads.

The `get_users_info()` method was downloading and base64-encoding profile photos for every account, even though the CLI command never uses avatar data (it's only for the web interface).

With N accounts and a 15s timeout per download, this caused ~15s * N of unnecessary Telegram I/O per call.

Changes:
- Add `include_avatar: bool = True` parameter to `ClientPool.get_users_info()`
- Skip avatar download when `include_avatar=False`
- Update CLI `account info` to pass `include_avatar=False`
- Web API continues to use full avatars (default behavior)