### PR TITLE
ci: add manual LangChain workflow & integration test

### DIFF
--- a/.github/release-metadata/v0.1.16.json
+++ b/.github/release-metadata/v0.1.16.json
@@ -1,0 +1,18 @@
+{
+  "tag": "v0.1.16",
+  "title": "Provider adapters & streaming",
+  "highlights": [
+    {
+      "title": "Provider adapters and streaming",
+      "description": "Add provider-agnostic GenerationService, HTTP provider adapters (including a Context7 shim), and SSE streaming preview for progressive generation."
+    },
+    {
+      "title": "LangChain adapter (opt-in)",
+      "description": "Optional LangChain adapter implemented with lazy imports; LangChain tests are gated behind a manual CI workflow (USE_LANGCHAIN=1)."
+    },
+    {
+      "title": "Integration tests & CI",
+      "description": "Add an integration test for pipeline generation persistence and a manual GitHub Actions workflow to run the suite with LangChain enabled."
+    }
+  ]
+}

--- a/.github/workflows/langchain-tests.yml
+++ b/.github/workflows/langchain-tests.yml
@@ -1,0 +1,28 @@
+name: LangChain Tests (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  langchain-tests:
+    runs-on: ubuntu-latest
+    env:
+      USE_LANGCHAIN: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Ruff
+        run: ruff check src tests conftest.py
+
+      - name: Pytest (LangChain enabled)
+        run: pytest tests -q -m "not aiosqlite_serial" -n auto && pytest tests -q -m aiosqlite_serial

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -2,32 +2,37 @@ LangChain integration (v0.1.16)
 
 Overview
 
-This project supports an optional LangChain-backed provider mode to simplify LLM provider integration. LangChain is optional and gated by configuration to avoid adding heavy runtime dependencies by default.
+This project supports an optional LangChain-backed provider mode to simplify LLM provider integration. LangChain is strictly opt-in (to avoid adding heavy runtime dependencies) and is enabled via configuration.
 
 Quick start
 
 1. Install LangChain and the provider client(s) you intend to use (example for OpenAI):
 
-   python -m pip install langchain openai
+   python -m pip install "langchain" openai
 
-2. Enable LangChain usage via environment variable (or operator UI):
+2. Enable LangChain usage (environment or operator):
 
    export USE_LANGCHAIN=1
 
-3. Configure provider credentials either via the web UI (Settings → Providers) or via environment variables (e.g., OPENAI_API_KEY).
+3. Provide provider credentials either via environment variables (e.g. OPENAI_API_KEY) or via the web UI (Settings → Developer → Providers). To persist secrets in the DB you must set SESSION_ENCRYPTION_KEY (do NOT commit this key).
+
+Example (env-based OpenAI):
+
+    export OPENAI_API_KEY="your-openai-key"
+    export USE_LANGCHAIN=1
 
 Notes
 
-- The system prefers LangChain adapters when USE_LANGCHAIN=1 and the langchain package plus the provider client packages are installed.
-- If LangChain isn't available, the system falls back to lightweight HTTP adapters implemented in src/services/provider_adapters.py.
-- Storing provider secrets in the web UI requires SESSION_ENCRYPTION_KEY to be configured so secrets can be encrypted at rest.
+- When USE_LANGCHAIN=1 and the required provider client packages are installed, the system prefers LangChain adapters for supported providers.
+- If LangChain is not available or disabled, lightweight HTTP adapters in src/services/provider_adapters.py are used as fallbacks.
+- LangChain adapters are imported lazily at runtime; missing packages produce runtime errors only when a LangChain adapter is invoked.
 
-Developer/testing
+Developer / testing
 
-- Unit tests for LangChain adapters mock langchain imports (see tests/test_langchain_adapters.py).
-- CI runs adapter tests without requiring langchain; enable LangChain-specific tests separately when appropriate.
+- LangChain-related unit tests mock langchain imports (see tests/test_langchain_adapters.py).
+- CI should gate LangChain-specific tests behind an explicit job or USE_LANGCHAIN flag to avoid requiring heavy deps in default runs.
 
 Security
 
-- Do NOT commit API keys or session encryption keys into source control.
-- For production, prefer operator-managed secrets vaults or environment variables and enable SESSION_ENCRYPTION_KEY to store secrets safely in the DB.
+- Never commit API keys or SESSION_ENCRYPTION_KEY to source control. Use an operator secrets vault when possible.
+- To store secrets in the UI, set SESSION_ENCRYPTION_KEY (see src/config.py and startup docs). If the key is changed, previously encrypted secrets become unreadable and must be re-entered.

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -1,0 +1,33 @@
+LangChain integration (v0.1.16)
+
+Overview
+
+This project supports an optional LangChain-backed provider mode to simplify LLM provider integration. LangChain is optional and gated by configuration to avoid adding heavy runtime dependencies by default.
+
+Quick start
+
+1. Install LangChain and the provider client(s) you intend to use (example for OpenAI):
+
+   python -m pip install langchain openai
+
+2. Enable LangChain usage via environment variable (or operator UI):
+
+   export USE_LANGCHAIN=1
+
+3. Configure provider credentials either via the web UI (Settings → Providers) or via environment variables (e.g., OPENAI_API_KEY).
+
+Notes
+
+- The system prefers LangChain adapters when USE_LANGCHAIN=1 and the langchain package plus the provider client packages are installed.
+- If LangChain isn't available, the system falls back to lightweight HTTP adapters implemented in src/services/provider_adapters.py.
+- Storing provider secrets in the web UI requires SESSION_ENCRYPTION_KEY to be configured so secrets can be encrypted at rest.
+
+Developer/testing
+
+- Unit tests for LangChain adapters mock langchain imports (see tests/test_langchain_adapters.py).
+- CI runs adapter tests without requiring langchain; enable LangChain-specific tests separately when appropriate.
+
+Security
+
+- Do NOT commit API keys or session encryption keys into source control.
+- For production, prefer operator-managed secrets vaults or environment variables and enable SESSION_ENCRYPTION_KEY to store secrets safely in the DB.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,28 +1,37 @@
 Provider adapters and environment variables
 
-This project includes lightweight HTTP adapters for common LLM providers and a mechanism to register adapters automatically from environment variables. Use the web UI (Settings → Providers) to manage provider configs for production/long-term use.
+This project includes lightweight HTTP adapters for common LLM providers and a mechanism to register adapters automatically from environment variables. For operator‑managed provider configurations (per-provider models, encrypted secrets), use the web UI: Settings → Developer → Providers.
 
 Supported env vars (examples)
 
-- OPENAI_API_KEY — OpenAI REST API key (OpenAI-style adapters)
-- COHERE_API_KEY — Cohere API key (cohere.generate endpoint)
+- OPENAI_API_KEY — OpenAI REST API key
+- COHERE_API_KEY — Cohere API key (Cohere generate endpoint)
 - OLLAMA_BASE or OLLAMA_URL — Ollama server base URL (e.g., http://localhost:11434)
 - HUGGINGFACE_API_KEY or HUGGINGFACE_TOKEN — Hugging Face Inference API token
+- CONTEXT7_API_KEY or CTX7_API_KEY — Context7 API key (uses the generic shim)
 - FIREWORKS_BASE, FIREWORKS_API_KEY — Fireworks inference endpoint
 - DEEPSEEK_BASE, DEEPSEEK_API_KEY — DeepSeek endpoint
 - TOGETHER_BASE, TOGETHER_API_KEY — Together API base
 
-Registration behavior
+Env-based registration
 
-- When the application starts, src/services/provider_service.py attempts to auto-register lightweight adapters for providers whose env vars are present.
-- For operator-managed provider configs (multiple providers, per-provider models, encrypted secrets), use the web Settings UI which stores configs via src/services/agent_provider_service.py. That service requires SESSION_ENCRYPTION_KEY to encrypt provider secrets.
+- On startup, src/services/provider_service.py auto-registers lightweight adapters for providers with appropriate env vars set. This is convenient for single-provider deployments or CI testing.
 
-Fallbacks
+Settings UI
 
-- If langchain is enabled (USE_LANGCHAIN=1) and LangChain + provider client packages are installed, LangChain adapters are preferred for providers supported by LangChain.
-- If LangChain is not enabled or not available, the lightweight HTTP adapters are used.
+- Use the Settings → Developer → Providers form to add, edit or remove provider configurations. Secret fields are encrypted before storage using SESSION_ENCRYPTION_KEY; when this key is not set the UI is read-only for provider secrets.
+- The provider registry uses canonical provider names (e.g. "openai", "cohere", "ollama", "huggingface", "context7").
+- For local Ollama testing, set OLLAMA_BASE to your server URL and optionally OLLAMA_DEFAULT_MODEL.
+
+Context7 & operator caution
+
+- A Context7 shim adapter exists (provider name "context7") but operator consent is required before routing production traffic to third-party MSPs. Prefer local or operator-controlled providers.
 
 Testing
 
-- Tests for adapters live in tests/test_provider_adapters.py and mock aiohttp sessions.
-- For integration tests, mock HTTP responses (aioresponses or monkeypatching aiohttp.ClientSession) so tests do not require real service network calls.
+- Adapter unit tests mock aiohttp.ClientSession (see tests/test_provider_adapters.py).
+- For integration tests, mock HTTP responses with aioresponses or monkeypatch aiohttp.ClientSession; LangChain-specific tests should be gated behind USE_LANGCHAIN or a dedicated CI job.
+
+Security
+
+- Do NOT commit API keys or the SESSION_ENCRYPTION_KEY into source control. Prefer operator-managed secret stores and keep the DB encryption key rotated and out of the repo.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,28 @@
+Provider adapters and environment variables
+
+This project includes lightweight HTTP adapters for common LLM providers and a mechanism to register adapters automatically from environment variables. Use the web UI (Settings → Providers) to manage provider configs for production/long-term use.
+
+Supported env vars (examples)
+
+- OPENAI_API_KEY — OpenAI REST API key (OpenAI-style adapters)
+- COHERE_API_KEY — Cohere API key (cohere.generate endpoint)
+- OLLAMA_BASE or OLLAMA_URL — Ollama server base URL (e.g., http://localhost:11434)
+- HUGGINGFACE_API_KEY or HUGGINGFACE_TOKEN — Hugging Face Inference API token
+- FIREWORKS_BASE, FIREWORKS_API_KEY — Fireworks inference endpoint
+- DEEPSEEK_BASE, DEEPSEEK_API_KEY — DeepSeek endpoint
+- TOGETHER_BASE, TOGETHER_API_KEY — Together API base
+
+Registration behavior
+
+- When the application starts, src/services/provider_service.py attempts to auto-register lightweight adapters for providers whose env vars are present.
+- For operator-managed provider configs (multiple providers, per-provider models, encrypted secrets), use the web Settings UI which stores configs via src/services/agent_provider_service.py. That service requires SESSION_ENCRYPTION_KEY to encrypt provider secrets.
+
+Fallbacks
+
+- If langchain is enabled (USE_LANGCHAIN=1) and LangChain + provider client packages are installed, LangChain adapters are preferred for providers supported by LangChain.
+- If LangChain is not enabled or not available, the lightweight HTTP adapters are used.
+
+Testing
+
+- Tests for adapters live in tests/test_provider_adapters.py and mock aiohttp sessions.
+- For integration tests, mock HTTP responses (aioresponses or monkeypatching aiohttp.ClientSession) so tests do not require real service network calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tg-agent"
-version = "0.1.12"
+version = "0.1.16"
 description = "Telegram Post Search & Monitoring"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -107,9 +107,21 @@ def make_mcp_server(db: Database):
             from src.services.generation_service import GenerationService
 
             gen = GenerationService(engine, provider_callable=provider_callable)
-            result = await gen.generate(query=query, limit=limit, prompt_template=None)
-            text = result.get("generated_text", "")
-            citations = result.get("citations", [])
+            # Prefer streaming generation when available; accumulate final text
+            final_text = ""
+            final_citations = []
+            try:
+                async for update in gen.generate_stream(query=query, prompt_template=None, limit=limit):
+                    final_text = update.get("generated_text", final_text)
+                    final_citations = update.get("citations", final_citations)
+            except Exception:
+                # Fallback to non-streaming generate
+                result = await gen.generate(query=query, limit=limit, prompt_template=None)
+                final_text = result.get("generated_text", "")
+                final_citations = result.get("citations", [])
+
+            text = final_text
+            citations = final_citations
             content = f"Generated draft:\n\n{text}\n\nCitations:\n" + "\n".join(
                 f"- {c['channel_title']} id={c['message_id']} date={c['date']}" for c in citations
             )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -92,7 +92,33 @@ def make_mcp_server(db: Database):
             text = f"Ошибка получения каналов: {e}"
         return {"content": [{"type": "text", "text": text}]}
 
+    @tool("generate_draft", "Generate a draft from a query using RAG (returns draft text and citations)", {"query": str, "pipeline_id": int, "limit": int})
+    async def generate_draft(args):
+        query = args.get("query", "")
+        pipeline_id = args.get("pipeline_id")
+        limit = int(args.get("limit", 8))
+        try:
+            from src.search.engine import SearchEngine
+            engine = SearchEngine(db)
+            # provider stub: real provider wiring should be done via AgentProviderService
+            async def _provider_stub(**kwargs):
+                prompt = kwargs.get("prompt") or ""
+                return "DRAFT: " + (prompt[:400])
+
+            from src.services.generation_service import GenerationService
+
+            gen = GenerationService(engine, provider_callable=_provider_stub)
+            result = await gen.generate(query=query, limit=limit, prompt_template=None)
+            text = result.get("generated_text", "")
+            citations = result.get("citations", [])
+            content = f"Generated draft:\n\n{text}\n\nCitations:\n" + "\n".join(
+                f"- {c['channel_title']} id={c['message_id']} date={c['date']}" for c in citations
+            )
+        except Exception as e:
+            content = f"Ошибка генерации: {e}"
+        return {"content": [{"type": "text", "text": content}]}
+
     return create_sdk_mcp_server(
         name="telegram_db",
-        tools=[search_messages, semantic_search, get_channels],
+        tools=[search_messages, semantic_search, get_channels, generate_draft],
     )

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -100,14 +100,13 @@ def make_mcp_server(db: Database):
         try:
             from src.search.engine import SearchEngine
             engine = SearchEngine(db)
-            # provider stub: real provider wiring should be done via AgentProviderService
-            async def _provider_stub(**kwargs):
-                prompt = kwargs.get("prompt") or ""
-                return "DRAFT: " + (prompt[:400])
+            from src.services.provider_service import AgentProviderService
+            provider_service = AgentProviderService(db)
+            provider_callable = provider_service.get_provider_callable(None)
 
             from src.services.generation_service import GenerationService
 
-            gen = GenerationService(engine, provider_callable=_provider_stub)
+            gen = GenerationService(engine, provider_callable=provider_callable)
             result = await gen.generate(query=query, limit=limit, prompt_template=None)
             text = result.get("generated_text", "")
             citations = result.get("citations", [])

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -162,14 +162,16 @@ def run(args: argparse.Namespace) -> None:
                 # Build search engine and generation service
                 engine = SearchEngine(db)
 
-                # Simple provider stub for CLI: replace with real provider wiring later
-                async def _provider_stub(**kwargs):
-                    prompt = kwargs.get("prompt") or ""
-                    return "DRAFT (preview): " + prompt[:200]
+                # Resolve provider callable via AgentProviderService (falls back to default stub)
+                from src.services.provider_service import AgentProviderService
 
-                gen_svc = GenerationService(engine, provider_callable=_provider_stub)
+                provider_service = AgentProviderService(db)
+                provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+
+                gen_svc = GenerationService(engine, provider_callable=provider_callable)
                 # Create generation run record
                 run_id = await db.repos.generation_runs.create_run(pipeline.id, pipeline.prompt_template)
+                await db.repos.generation_runs.set_status(run_id, "running")
                 print(f"Created generation run id={run_id}")
                 try:
                     result = await gen_svc.generate(

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -4,13 +4,13 @@ import argparse
 import asyncio
 
 from src.cli import runtime
+from src.search.engine import SearchEngine
+from src.services.generation_service import GenerationService
 from src.services.pipeline_service import (
     PipelineService,
     PipelineTargetRef,
     PipelineValidationError,
 )
-from src.search.engine import SearchEngine
-from src.services.generation_service import GenerationService
 
 
 def _parse_target_refs(values: list[str]) -> list[PipelineTargetRef]:
@@ -173,9 +173,10 @@ def run(args: argparse.Namespace) -> None:
                 run_id = await db.repos.generation_runs.create_run(pipeline.id, pipeline.prompt_template)
                 await db.repos.generation_runs.set_status(run_id, "running")
                 print(f"Created generation run id={run_id}")
+                retrieval_query = pipeline.prompt_template or pipeline.name or ""
                 try:
                     result = await gen_svc.generate(
-                        query="",
+                        query=retrieval_query,
                         prompt_template=pipeline.prompt_template,
                         limit=args.limit,
                         model=pipeline.llm_model,

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -9,6 +9,8 @@ from src.services.pipeline_service import (
     PipelineTargetRef,
     PipelineValidationError,
 )
+from src.search.engine import SearchEngine
+from src.services.generation_service import GenerationService
 
 
 def _parse_target_refs(values: list[str]) -> list[PipelineTargetRef]:
@@ -150,6 +152,44 @@ def run(args: argparse.Namespace) -> None:
             elif args.pipeline_action == "delete":
                 await svc.delete(args.id)
                 print(f"Deleted pipeline id={args.id}")
+
+            elif args.pipeline_action == "run":
+                # Run a pipeline generation (preview only by default)
+                pipeline = await svc.get(args.id)
+                if pipeline is None:
+                    print(f"Pipeline id={args.id} not found")
+                    return
+                # Build search engine and generation service
+                engine = SearchEngine(db)
+
+                # Simple provider stub for CLI: replace with real provider wiring later
+                async def _provider_stub(**kwargs):
+                    prompt = kwargs.get("prompt") or ""
+                    return "DRAFT (preview): " + prompt[:200]
+
+                gen_svc = GenerationService(engine, provider_callable=_provider_stub)
+                # Create generation run record
+                run_id = await db.repos.generation_runs.create_run(pipeline.id, pipeline.prompt_template)
+                print(f"Created generation run id={run_id}")
+                try:
+                    result = await gen_svc.generate(
+                        query="",
+                        prompt_template=pipeline.prompt_template,
+                        limit=args.limit,
+                        model=pipeline.llm_model,
+                        max_tokens=args.max_tokens,
+                        temperature=args.temperature,
+                    )
+                    await db.repos.generation_runs.save_result(run_id, result.get("generated_text", ""), {"citations": result.get("citations", [])})
+                    print(f"Generation completed for run id={run_id}")
+                    if args.preview:
+                        print("--- DRAFT PREVIEW ---")
+                        print(result.get("generated_text"))
+                    if args.publish:
+                        print("Publish requested — publishing via targets is not implemented in CLI; use web UI or implement account targets.")
+                except Exception as exc:
+                    await db.repos.generation_runs.set_status(run_id, "failed")
+                    print(f"Generation failed: {exc}")
         finally:
             await db.close()
 

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -239,6 +239,14 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_toggle = pipeline_sub.add_parser("toggle", help="Toggle pipeline active state")
     pipeline_toggle.add_argument("id", type=int, help="Pipeline id")
 
+    pipeline_run = pipeline_sub.add_parser("run", help="Run pipeline generation (preview/publish)")
+    pipeline_run.add_argument("id", type=int, help="Pipeline id")
+    pipeline_run.add_argument("--preview", action="store_true", default=False, help="Only preview generated draft")
+    pipeline_run.add_argument("--publish", action="store_true", default=False, help="Publish generated draft to targets (requires accounts and confirmation)")
+    pipeline_run.add_argument("--limit", type=int, default=8, help="Number of context messages to fetch")
+    pipeline_run.add_argument("--max-tokens", type=int, default=256, help="Max tokens for LLM generation")
+    pipeline_run.add_argument("--temperature", type=float, default=0.0, help="Sampling temperature for generation")
+
     acc_parser = sub.add_parser("account", help="Account management")
     acc_sub = acc_parser.add_subparsers(dest="account_action")
     acc_sub.add_parser("list", help="List accounts")

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -17,6 +17,7 @@ from src.database.repositories.photo_loader import PhotoLoaderRepository
 from src.database.repositories.search_log import SearchLogRepository
 from src.database.repositories.search_queries import SearchQueriesRepository
 from src.database.repositories.settings import SettingsRepository
+from src.database.repositories.generation_runs import GenerationRunsRepository
 from src.models import (
     Account,
     Channel,
@@ -36,6 +37,7 @@ from src.models import (
     SearchQuery,
     SearchQueryDailyStat,
     StatsAllTaskPayload,
+    GenerationRun,
 )
 
 if TYPE_CHECKING:
@@ -57,6 +59,7 @@ class DatabaseRepositories:
     photo_loader: PhotoLoaderRepository
     dialog_cache: DialogCacheRepository
     content_pipelines: ContentPipelinesRepository
+    generation_runs: GenerationRunsRepository
 
 
 @dataclass(frozen=True)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -23,6 +23,7 @@ from src.database.repositories.photo_loader import PhotoLoaderRepository
 from src.database.repositories.search_log import SearchLogRepository
 from src.database.repositories.search_queries import SearchQueriesRepository
 from src.database.repositories.settings import SettingsRepository
+from src.database.repositories.generation_runs import GenerationRunsRepository
 from src.database.schema import SCHEMA_SQL
 from src.models import (
     Account,
@@ -162,6 +163,7 @@ class Database:
         self._photo_loader = PhotoLoaderRepository(self._db)
         self._dialog_cache = DialogCacheRepository(self._db)
         self._content_pipelines = ContentPipelinesRepository(self._db)
+        self._generation_runs = GenerationRunsRepository(self._db)
         self._repos = DatabaseRepositories(
             accounts=self._accounts,
             channels=self._channels,
@@ -176,6 +178,7 @@ class Database:
             photo_loader=self._photo_loader,
             dialog_cache=self._dialog_cache,
             content_pipelines=self._content_pipelines,
+            generation_runs=self._generation_runs,
         )
 
         await self._accounts.migrate_sessions()

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -299,6 +299,27 @@ async def run_migrations(db: aiosqlite.Connection, *, vec_available: bool = Fals
         )
         """
     )
+    # Generation runs table for RAG drafts
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS generation_runs (
+            id INTEGER PRIMARY KEY,
+            pipeline_id INTEGER,
+            status TEXT NOT NULL DEFAULT 'pending',
+            prompt TEXT,
+            generated_text TEXT,
+            metadata TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT
+        )
+        """
+    )
+    await db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_generation_runs_pipeline_status
+        ON generation_runs(pipeline_id, status)
+        """
+    )
     await db.execute(
         """
         CREATE TABLE IF NOT EXISTS pipeline_sources (

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import aiosqlite
+import json
+from datetime import datetime
+
+from src.models import GenerationRun
+
+
+def _dt(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+class GenerationRunsRepository:
+    def __init__(self, db: aiosqlite.Connection):
+        self._db = db
+
+    async def create_run(self, pipeline_id: int | None, prompt: str) -> int:
+        cur = await self._db.execute(
+            "INSERT INTO generation_runs (pipeline_id, status, prompt, created_at) VALUES (?, 'pending', ?, datetime('now'))",
+            (pipeline_id, prompt),
+        )
+        await self._db.commit()
+        return cur.lastrowid or 0
+
+    async def set_status(self, run_id: int, status: str) -> None:
+        await self._db.execute(
+            "UPDATE generation_runs SET status = ?, updated_at = datetime('now') WHERE id = ?",
+            (status, run_id),
+        )
+        await self._db.commit()
+
+    async def save_result(self, run_id: int, generated_text: str, metadata: dict | None = None) -> None:
+        await self._db.execute(
+            "UPDATE generation_runs SET generated_text = ?, metadata = ?, status = 'completed', updated_at = datetime('now') WHERE id = ?",
+            (generated_text, json.dumps(metadata or {}, ensure_ascii=False), run_id),
+        )
+        await self._db.commit()
+
+    async def get(self, run_id: int) -> GenerationRun | None:
+        cur = await self._db.execute("SELECT * FROM generation_runs WHERE id = ?", (run_id,))
+        row = await cur.fetchone()
+        if not row:
+            return None
+        metadata = None
+        if row["metadata"]:
+            try:
+                metadata = json.loads(row["metadata"])
+            except Exception:
+                metadata = None
+        return GenerationRun(
+            id=row["id"],
+            pipeline_id=row["pipeline_id"],
+            status=row["status"],
+            prompt=row["prompt"],
+            generated_text=row["generated_text"],
+            metadata=metadata,
+            created_at=_dt(row["created_at"]),
+            updated_at=_dt(row["updated_at"]),
+        )
+
+    async def list_by_pipeline(self, pipeline_id: int, limit: int = 20, offset: int = 0) -> list[GenerationRun]:
+        cur = await self._db.execute(
+            "SELECT * FROM generation_runs WHERE pipeline_id = ? ORDER BY id DESC LIMIT ? OFFSET ?",
+            (pipeline_id, limit, offset),
+        )
+        rows = await cur.fetchall()
+        results: list[GenerationRun] = []
+        for row in rows:
+            metadata = None
+            if row["metadata"]:
+                try:
+                    metadata = json.loads(row["metadata"])
+                except Exception:
+                    metadata = None
+            results.append(
+                GenerationRun(
+                    id=row["id"],
+                    pipeline_id=row["pipeline_id"],
+                    status=row["status"],
+                    prompt=row["prompt"],
+                    generated_text=row["generated_text"],
+                    metadata=metadata,
+                    created_at=_dt(row["created_at"]),
+                    updated_at=_dt(row["updated_at"]),
+                )
+            )
+        return results

--- a/src/models.py
+++ b/src/models.py
@@ -228,6 +228,17 @@ class SearchResult(BaseModel):
     error: str | None = None
 
 
+class GenerationRun(BaseModel):
+    id: int | None = None
+    pipeline_id: int | None = None
+    status: str = "pending"
+    prompt: str | None = None
+    generated_text: str | None = None
+    metadata: dict | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
 class PhotoSendMode(StrEnum):
     ALBUM = "album"
     SEPARATE = "separate"

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from src.agent.prompt_template import DEFAULT_AGENT_PROMPT_TEMPLATE, render_prompt_template
+from src.models import Message, SearchResult
+from src.search.engine import SearchEngine
+
+
+class GenerationService:
+    """Simple provider-agnostic RAG generation service.
+
+    This core focuses on retrieval assembly and prompt rendering. It intentionally
+    keeps provider integration pluggable via `provider_callable` so that unit
+    tests can mock providers and later integration can wire AgentProviderService.
+    """
+
+    def __init__(
+        self,
+        search_engine: SearchEngine,
+        provider_callable: Optional[Callable[..., Awaitable[str]]] = None,
+        default_prompt_template: str = DEFAULT_AGENT_PROMPT_TEMPLATE,
+    ) -> None:
+        self._search = search_engine
+        self._provider = provider_callable
+        self._default_prompt = default_prompt_template
+
+    async def _collect_context(self, query: str, limit: int = 8) -> List[Message]:
+        """Retrieve context messages using the SearchEngine hybrid search."""
+        result: SearchResult = await self._search.search_hybrid(query, limit=limit)
+        return result.messages
+
+    def _build_source_messages(self, messages: List[Message]) -> str:
+        parts: List[str] = []
+        for m in messages:
+            text = (m.text or "").strip()
+            if not text:
+                continue
+            header = m.channel_title or m.channel_username or ""
+            when = m.date.isoformat() if isinstance(m.date, datetime) else str(m.date)
+            parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
+        return "\n\n".join(parts)
+
+    async def generate(
+        self,
+        query: str,
+        prompt_template: Optional[str] = None,
+        limit: int = 8,
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        provider_override: Optional[str] = None,
+        stream: bool = False,
+        provider_callable: Optional[Callable[..., Awaitable[str]]] = None,
+    ) -> Dict[str, Any]:
+        """Generate a draft from `query` using retrieval-augmented generation.
+
+        Returns a dict containing the final prompt, generated_text, and citations.
+        """
+        if prompt_template is None:
+            prompt_template = self._default_prompt
+
+        messages = await self._collect_context(query, limit=limit)
+        source_messages = self._build_source_messages(messages)
+
+        rendered_prompt = render_prompt_template(
+            prompt_template, {"source_messages": source_messages}
+        )
+
+        # Determine which provider callable to use (call argument overrides constructor)
+        provider = provider_callable or self._provider
+        if provider is None:
+            raise RuntimeError("No provider callable configured for generation")
+
+        # Provider contract: await provider(prompt=..., model=..., max_tokens=...,
+        # temperature=..., stream=...)
+        generated_text = await provider(
+            prompt=rendered_prompt,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stream=stream,
+        )
+
+        citations = [
+            {
+                "channel_title": (m.channel_title or m.channel_username or ""),
+                "message_id": m.message_id,
+                "text": (m.text or "")[:512],
+                "date": m.date.isoformat() if isinstance(m.date, datetime) else str(m.date),
+            }
+            for m in messages
+        ]
+
+        return {
+            "prompt": rendered_prompt,
+            "generated_text": generated_text,
+            "citations": citations,
+        }

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import inspect
+from typing import Any, Awaitable, Callable, Dict, Optional, List, AsyncIterator
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from src.agent.prompt_template import DEFAULT_AGENT_PROMPT_TEMPLATE, render_prompt_template
 from src.models import Message, SearchResult
@@ -42,6 +43,103 @@ class GenerationService:
             parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
         return "\n\n".join(parts)
 
+    async def generate_stream(
+        self,
+        query: str,
+        prompt_template: Optional[str] = None,
+        limit: int = 8,
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        provider_override: Optional[str] = None,
+        provider_callable: Optional[Callable[..., Awaitable[str]]] = None,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Async generator that yields partial generation updates when the
+        provider supports streaming. Each yield is a dict with keys:
+          - prompt
+          - generated_text (accumulated so far)
+          - delta (latest chunk)
+          - citations
+        If the provider does not stream, a single final yield is produced.
+        """
+        if prompt_template is None:
+            prompt_template = self._default_prompt
+
+        messages = await self._collect_context(query, limit=limit)
+        source_messages = self._build_source_messages(messages)
+
+        rendered_prompt = render_prompt_template(
+            prompt_template, {"source_messages": source_messages}
+        )
+
+        provider = provider_callable or self._provider
+        if provider is None:
+            raise RuntimeError("No provider callable configured for generation")
+
+        # Citations baked from retrieved messages
+        citations = [
+            {
+                "channel_title": (m.channel_title or m.channel_username or ""),
+                "message_id": m.message_id,
+                "text": (m.text or "")[:512],
+                "date": m.date.isoformat() if isinstance(m.date, datetime) else str(m.date),
+            }
+            for m in messages
+        ]
+
+        # Call the provider with stream=True. The provider may return:
+        #  - an async generator directly (async def with yield)
+        #  - a coroutine that resolves to an async generator (async def that returns an async generator)
+        #  - a coroutine that resolves to a final string
+        #  - a synchronous iterator or string
+        try:
+            maybe = provider(
+                prompt=rendered_prompt,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                stream=True,
+            )
+        except Exception as exc:
+            raise
+
+        # If it's awaitable (a coroutine), await it to get the concrete result
+        result = maybe
+        if hasattr(maybe, "__await__"):
+            result = await maybe  # type: ignore
+
+        # If it's an async iterable (async generator), iterate and yield
+        if hasattr(result, "__aiter__"):
+            buffer = ""
+            async for chunk in result:  # type: ignore
+                if isinstance(chunk, dict):
+                    delta = (
+                        chunk.get("text")
+                        or chunk.get("content")
+                        or chunk.get("generated_text")
+                        or str(chunk)
+                    )
+                else:
+                    delta = str(chunk)
+                buffer += delta
+                yield {"prompt": rendered_prompt, "generated_text": buffer, "delta": delta, "citations": citations}
+            return
+
+        # If it's a synchronous iterator (list/iter), iterate synchronously
+        if hasattr(result, "__iter__") and not isinstance(result, (str, bytes)):
+            buffer = ""
+            for chunk in result:  # type: ignore
+                delta = str(chunk) if not isinstance(chunk, dict) else (
+                    chunk.get("text") or chunk.get("content") or chunk.get("generated_text") or str(chunk)
+                )
+                buffer += delta
+                yield {"prompt": rendered_prompt, "generated_text": buffer, "delta": delta, "citations": citations}
+            return
+
+        # Otherwise it's a final scalar result
+        final_text = str(result)
+        yield {"prompt": rendered_prompt, "generated_text": final_text, "delta": final_text, "citations": citations}
+
     async def generate(
         self,
         query: str,
@@ -57,10 +155,32 @@ class GenerationService:
         """Generate a draft from `query` using retrieval-augmented generation.
 
         Returns a dict containing the final prompt, generated_text, and citations.
+        When `stream=True` this method will consume the streaming generator and
+        return the final result (use `generate_stream` to consume updates).
         """
         if prompt_template is None:
             prompt_template = self._default_prompt
 
+        if stream:
+            last: Optional[Dict[str, Any]] = None
+            async for update in self.generate_stream(
+                query=query,
+                prompt_template=prompt_template,
+                limit=limit,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                provider_override=provider_override,
+                provider_callable=provider_callable,
+            ):
+                last = update
+            if last is None:
+                # No output produced
+                messages = await self._collect_context(query, limit=limit)
+                return {"prompt": render_prompt_template(prompt_template, {"source_messages": self._build_source_messages(messages)}), "generated_text": "", "citations": []}
+            return {"prompt": last["prompt"], "generated_text": last["generated_text"], "citations": last.get("citations", [])}
+
+        # Non-streaming path (preserve existing behaviour)
         messages = await self._collect_context(query, limit=limit)
         source_messages = self._build_source_messages(messages)
 
@@ -68,19 +188,17 @@ class GenerationService:
             prompt_template, {"source_messages": source_messages}
         )
 
-        # Determine which provider callable to use (call argument overrides constructor)
         provider = provider_callable or self._provider
         if provider is None:
             raise RuntimeError("No provider callable configured for generation")
 
-        # Provider contract: await provider(prompt=..., model=..., max_tokens=...,
-        # temperature=..., stream=...)
+        # Provider contract: await provider(prompt=..., model=..., max_tokens=..., temperature=...)
         generated_text = await provider(
             prompt=rendered_prompt,
             model=model,
             max_tokens=max_tokens,
             temperature=temperature,
-            stream=stream,
+            stream=False,
         )
 
         citations = [

--- a/src/services/langchain_adapters.py
+++ b/src/services/langchain_adapters.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import importlib
+import os
+import asyncio
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+
+def is_langchain_available() -> bool:
+    """Return True if langchain package is importable."""
+    try:
+        importlib.import_module("langchain")
+        return True
+    except Exception:
+        return False
+
+
+def make_langchain_adapter(provider: str, credentials: Optional[Dict[str, str]] = None) -> Callable[..., Awaitable[str]]:
+    """Create a LangChain-backed provider callable for `provider`.
+
+    The returned callable has signature:
+        async def provider(prompt, model=None, max_tokens=256, temperature=0.0, stream=False, **kwargs) -> str
+
+    This function imports LangChain at runtime and attempts to instantiate a
+    provider-specific wrapper. If LangChain or the provider wrapper isn't
+    available, a RuntimeError is raised when the callable is invoked.
+    """
+    credentials = credentials or {}
+    provider_lower = provider.lower()
+
+    async def provider_callable(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        if not is_langchain_available():
+            raise RuntimeError(
+                "LangChain is not installed. Set USE_LANGCHAIN=1 and install 'langchain' and provider packages to use LangChain adapters."
+            )
+
+        # Import modules lazily to avoid hard dependency at import time
+        chat_models = importlib.import_module("langchain.chat_models")
+        schema = importlib.import_module("langchain.schema")
+
+        # Map provider name to a LangChain class if available
+        cls = None
+        if provider_lower in ("openai",):
+            cls = getattr(chat_models, "ChatOpenAI", None) or getattr(chat_models, "OpenAI", None)
+        elif provider_lower in ("anthropic",):
+            cls = getattr(chat_models, "Anthropic", None)
+        elif provider_lower in ("ollama",):
+            cls = getattr(chat_models, "Ollama", None)
+        elif provider_lower in ("cohere",):
+            try:
+                llms = importlib.import_module("langchain.llms")
+                cls = getattr(llms, "Cohere", None)
+            except Exception:
+                cls = None
+        elif provider_lower in ("huggingface", "huggingface_hub"):
+            try:
+                llms = importlib.import_module("langchain.llms")
+                cls = getattr(llms, "HuggingFaceHub", None) or getattr(llms, "HuggingFace", None)
+            except Exception:
+                cls = None
+
+        if cls is None:
+            raise RuntimeError(f"LangChain adapter for provider '{provider}' is not available in the installed langchain package.")
+
+        # Build constructor kwargs using common names; tolerate differences with fallbacks
+        init_kwargs: Dict[str, Any] = {}
+        if provider_lower == "openai":
+            api_key = credentials.get("api_key") or os.environ.get("OPENAI_API_KEY")
+            if api_key:
+                init_kwargs["openai_api_key"] = api_key
+            base_url = os.environ.get("OPENAI_API_BASE")
+            if base_url:
+                init_kwargs["openai_api_base"] = base_url
+        elif provider_lower == "ollama":
+            base = credentials.get("base_url") or os.environ.get("OLLAMA_BASE") or os.environ.get("OLLAMA_URL")
+            if base:
+                init_kwargs["base_url"] = base
+            api_key = credentials.get("api_key") or os.environ.get("OLLAMA_API_KEY")
+            if api_key:
+                init_kwargs["api_key"] = api_key
+
+        if model:
+            # many LangChain classes accept model_name
+            init_kwargs["model_name"] = model
+
+        if temperature is not None:
+            init_kwargs["temperature"] = float(temperature)
+
+        # Instantiate with fallbacks to handle different langchain versions
+        llm = None
+        try:
+            llm = cls(**init_kwargs)
+        except TypeError:
+            try:
+                tmp = dict(init_kwargs)
+                tmp.pop("model_name", None)
+                llm = cls(**tmp)
+            except Exception as ex:
+                raise RuntimeError(f"Failed to instantiate LangChain LLM for provider {provider}: {ex}")
+
+        # Build message payload using schema.HumanMessage when available
+        HumanMessage = getattr(schema, "HumanMessage", None)
+        messages = [HumanMessage(content=prompt)] if HumanMessage is not None else [{"role": "user", "content": prompt}]
+
+        # Prefer async API if available
+        if hasattr(llm, "agenerate"):
+            result = await llm.agenerate(messages)
+            try:
+                return result.generations[0][0].text
+            except Exception:
+                return str(result)
+        elif hasattr(llm, "generate"):
+            loop = asyncio.get_event_loop()
+            def sync_call():
+                return llm.generate(messages)
+            res = await loop.run_in_executor(None, sync_call)
+            try:
+                return res.generations[0][0].text
+            except Exception:
+                return str(res)
+        else:
+            raise RuntimeError("LangChain LLM instance has no generate/agenerate method")
+
+    return provider_callable

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+import aiohttp
+
+
+async def _parse_json_for_text(data: Any) -> str:
+    # Try common response shapes
+    if data is None:
+        return ""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        # OpenAI style
+        if "choices" in data:
+            try:
+                c = data["choices"][0]
+                if isinstance(c, dict):
+                    if "message" in c:
+                        return c["message"].get("content", "")
+                    return c.get("text", "")
+            except Exception:
+                pass
+        # Cohere style
+        if "generations" in data:
+            try:
+                return data["generations"][0].get("text", "")
+            except Exception:
+                pass
+        # HuggingFace / other style
+        if "generated_text" in data:
+            return data.get("generated_text", "")
+        if "outputs" in data:
+            try:
+                out = data["outputs"][0]
+                if isinstance(out, dict):
+                    return out.get("content", out.get("text", ""))
+                return str(out)
+            except Exception:
+                pass
+        if "result" in data:
+            r = data["result"]
+            if isinstance(r, str):
+                return r
+            if isinstance(r, dict):
+                for k in ("text", "content", "generated_text"):
+                    if k in r:
+                        return r[k]
+                return str(r)
+        # Ollama / local shapes
+        if "results" in data:
+            try:
+                r0 = data["results"][0]
+                if isinstance(r0, dict):
+                    # nested content
+                    if "content" in r0 and isinstance(r0["content"], dict):
+                        return r0["content"].get("text", "")
+                    return r0.get("text", "")
+            except Exception:
+                pass
+        # fallback: try first stringy field
+        for v in data.values():
+            if isinstance(v, str):
+                return v
+        return str(data)
+    if isinstance(data, list):
+        # list of items
+        try:
+            first = data[0]
+            return await _parse_json_for_text(first)
+        except Exception:
+            return str(data)
+    return str(data)
+
+
+def make_cohere_adapter(api_key: str, base_url: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+    base = base_url or os.environ.get("COHERE_API_BASE", "https://api.cohere.ai/v1/generate")
+
+    async def provider(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        url = base
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        payload = {"prompt": prompt, "max_tokens": int(max_tokens or 256)}
+        if model:
+            payload["model"] = model
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"Cohere error {resp.status}: {text}")
+                    data = await resp.json()
+                    return await _parse_json_for_text(data)
+        except Exception as ex:
+            raise
+
+    return provider
+
+
+def make_ollama_adapter(base_url: Optional[str] = None, api_key: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+    base = base_url or os.environ.get("OLLAMA_BASE", "http://localhost:11434")
+    endpoint = base.rstrip("/") + "/api/generate"
+
+    async def provider(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        payload: Dict[str, Any] = {"model": model or os.environ.get("OLLAMA_DEFAULT_MODEL", "llama3.2"), "prompt": prompt}
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(endpoint, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"Ollama error {resp.status}: {text}")
+                    data = await resp.json()
+                    return await _parse_json_for_text(data)
+        except Exception:
+            raise
+
+    return provider
+
+
+def make_huggingface_adapter(api_token: str, base_url: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+    # Use inference endpoint when model is provided in model arg; otherwise use base_url
+    base = base_url or os.environ.get("HUGGINGFACE_API_BASE", "https://api-inference.huggingface.co/models")
+
+    async def provider(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        if model:
+            url = f"{base.rstrip('/')}/{model}"
+        else:
+            # fallback generic route
+            url = base
+        headers = {"Authorization": f"Bearer {api_token}"}
+        payload = {"inputs": prompt, "parameters": {"max_new_tokens": int(max_tokens or 256)}}
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"HuggingFace error {resp.status}: {text}")
+                    data = await resp.json()
+                    return await _parse_json_for_text(data)
+        except Exception:
+            raise
+
+    return provider
+
+
+def make_generic_http_adapter(base_url: str, api_key: Optional[str] = None, api_key_header: str = "Authorization") -> Callable[..., Awaitable[str]]:
+    endpoint = base_url
+
+    async def provider(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        payload: Dict[str, Any] = {"prompt": prompt}
+        if model:
+            payload["model"] = model
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers[api_key_header] = f"Bearer {api_key}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(endpoint, json=payload, headers=headers) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"Provider error {resp.status}: {text}")
+                    data = await resp.json()
+                    return await _parse_json_for_text(data)
+        except Exception:
+            raise
+
+    return provider
+
+
+def make_context7_adapter(api_key: str, base_url: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+    base = base_url or os.environ.get("CONTEXT7_API_BASE", "https://api.context7.com/v1/generate")
+    return make_generic_http_adapter(base, api_key)
+
+
+# Convenience shims
+def make_cohere(api_key: str) -> Callable[..., Awaitable[str]]:
+    return make_cohere_adapter(api_key)
+
+
+def make_ollama(base_url: Optional[str] = None, api_key: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+    return make_ollama_adapter(base_url, api_key)
+
+
+def make_huggingface(api_token: str) -> Callable[..., Awaitable[str]]:
+    return make_huggingface_adapter(api_token)

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -29,6 +29,28 @@ class AgentProviderService:
         if openai_key:
             self.register_provider("openai", self._make_openai_provider(openai_key))
 
+        # optional Context7 provider (user may supply CONTEXT7_API_KEY)
+        context7_key = os.environ.get("CONTEXT7_API_KEY") or os.environ.get("CTX7_API_KEY")
+        if context7_key:
+            self.register_provider("context7", self._make_context7_provider(context7_key))
+
+        # Optional LangChain-backed adapters (enable by setting USE_LANGCHAIN=1).
+        # When enabled, attempt to register LangChain adapters for common providers.
+        if os.environ.get("USE_LANGCHAIN", "").lower() in ("1", "true", "yes"):
+            try:
+                from src.services.langchain_adapters import make_langchain_adapter
+                for _p in ("openai", "anthropic", "ollama", "cohere", "huggingface"):
+                    try:
+                        adapter = make_langchain_adapter(_p, None)
+                        # prefer LangChain adapter: override existing if present
+                        self._registry[_p] = adapter
+                    except Exception:
+                        # ignore provider-specific failures
+                        continue
+            except Exception:
+                # LangChain not available or adapter import failed; continue silently
+                pass
+
     def register_provider(self, name: str, func: Callable[..., Awaitable[str]]) -> None:
         self._registry[name] = func
 

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+
+class AgentProviderService:
+    """Simple provider registry for generation providers.
+
+    Provider callable signature (async):
+        async def provider(prompt: str, model: Optional[str]=None, max_tokens: int=256, temperature: float=0.0, stream: bool=False) -> str
+
+    The service registers a default stub provider under the name 'default'.
+    """
+
+    def __init__(self, db: Optional[object] = None) -> None:
+        self.db = db
+        self._registry: Dict[str, Callable[..., Awaitable[str]]] = {}
+        # register default provider
+        self.register_provider("default", self._default_provider)
+
+    def register_provider(self, name: str, func: Callable[..., Awaitable[str]]) -> None:
+        self._registry[name] = func
+
+    def get_provider_callable(self, name: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+        if not name:
+            name = "default"
+        return self._registry.get(name, self._registry["default"])
+
+    async def _default_provider(self, **kwargs: Any) -> str:
+        prompt = kwargs.get("prompt", "") or ""
+        # Minimal safe stub provider for local testing / fallback
+        return "DRAFT (default provider): " + (prompt[:400])

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-import asyncio
+import os
 from typing import Any, Awaitable, Callable, Dict, Optional
+
+import aiohttp
 
 
 class AgentProviderService:
@@ -10,7 +12,10 @@ class AgentProviderService:
     Provider callable signature (async):
         async def provider(prompt: str, model: Optional[str]=None, max_tokens: int=256, temperature: float=0.0, stream: bool=False) -> str
 
-    The service registers a default stub provider under the name 'default'.
+    The service registers a default stub provider under the name 'default'. If an
+    OPENAI_API_KEY is present in the environment, a basic OpenAI chat provider is
+    registered under the name 'openai' and will be used when model names like
+    'gpt-3.5-turbo' are passed.
     """
 
     def __init__(self, db: Optional[object] = None) -> None:
@@ -19,13 +24,72 @@ class AgentProviderService:
         # register default provider
         self.register_provider("default", self._default_provider)
 
+        # optional OpenAI provider (HTTP REST, minimal)
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if openai_key:
+            self.register_provider("openai", self._make_openai_provider(openai_key))
+
     def register_provider(self, name: str, func: Callable[..., Awaitable[str]]) -> None:
         self._registry[name] = func
 
     def get_provider_callable(self, name: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+        """Resolve a provider callable.
+
+        If `name` matches a registered provider, it is returned. Otherwise, if an
+        OpenAI provider is registered and `name` looks like an OpenAI model id
+        (contains 'gpt'), return a wrapper that calls the OpenAI provider with
+        the model preset to `name`.
+        """
         if not name:
-            name = "default"
-        return self._registry.get(name, self._registry["default"])
+            return self._registry["default"]
+        if name in self._registry:
+            return self._registry[name]
+        lower = name.lower() if isinstance(name, str) else ""
+        if "openai" in self._registry and ("gpt" in lower or lower.startswith("gpt")):
+            base = self._registry["openai"]
+
+            async def _call(prompt: str = "", model: Optional[str] = None, **kwargs: Any) -> str:
+                # force the model to the requested name
+                return await base(prompt=prompt, model=name, **kwargs)
+
+            return _call
+        # fallback
+        return self._registry["default"]
+
+    def _make_openai_provider(self, api_key: str) -> Callable[..., Awaitable[str]]:
+        async def _openai_provider(
+            prompt: str = "",
+            model: Optional[str] = None,
+            max_tokens: int = 256,
+            temperature: float = 0.0,
+            stream: bool = False,
+            **kwargs: Any,
+        ) -> str:
+            model_to_use = model or os.environ.get("OPENAI_DEFAULT_MODEL", "gpt-3.5-turbo")
+            base_url = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
+            url = f"{base_url}/chat/completions"
+            headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+            payload = {
+                "model": model_to_use,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": int(max_tokens or 256),
+                "temperature": float(temperature or 0.0),
+            }
+            timeout = int(os.environ.get("OPENAI_TIMEOUT_SECONDS", "60"))
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"OpenAI error {resp.status}: {text}")
+                    data = await resp.json()
+                    # Support chat completion response
+                    try:
+                        return data["choices"][0]["message"]["content"]
+                    except Exception:
+                        # Fallback to stringified response
+                        return str(data)
+
+        return _openai_provider
 
     async def _default_provider(self, **kwargs: Any) -> str:
         prompt = kwargs.get("prompt", "") or ""

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -75,7 +75,7 @@ class AgentProviderService:
                 "max_tokens": int(max_tokens or 256),
                 "temperature": float(temperature or 0.0),
             }
-            timeout = int(os.environ.get("OPENAI_TIMEOUT_SECONDS", "60"))
+            timeout = aiohttp.ClientTimeout(total=int(os.environ.get("OPENAI_TIMEOUT_SECONDS", "60")))
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
                     text = await resp.text()

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -32,7 +32,53 @@ class AgentProviderService:
         # optional Context7 provider (user may supply CONTEXT7_API_KEY)
         context7_key = os.environ.get("CONTEXT7_API_KEY") or os.environ.get("CTX7_API_KEY")
         if context7_key:
-            self.register_provider("context7", self._make_context7_provider(context7_key))
+            try:
+                from src.services.provider_adapters import make_context7_adapter
+
+                self.register_provider("context7", make_context7_adapter(context7_key))
+            except Exception:
+                # ignore if adapter module unavailable
+                pass
+
+        # Register lightweight HTTP adapters when env vars are present
+        try:
+            from src.services.provider_adapters import (
+                make_cohere_adapter,
+                make_ollama_adapter,
+                make_huggingface_adapter,
+                make_generic_http_adapter,
+            )
+
+            cohere_key = os.environ.get("COHERE_API_KEY")
+            if cohere_key and "cohere" not in self._registry:
+                self.register_provider("cohere", make_cohere_adapter(cohere_key))
+
+            ollama_base = os.environ.get("OLLAMA_BASE") or os.environ.get("OLLAMA_URL")
+            if ollama_base and "ollama" not in self._registry:
+                self.register_provider("ollama", make_ollama_adapter(ollama_base, os.environ.get("OLLAMA_API_KEY")))
+
+            hf_key = os.environ.get("HUGGINGFACE_API_KEY") or os.environ.get("HUGGINGFACE_TOKEN")
+            if hf_key and "huggingface" not in self._registry:
+                self.register_provider("huggingface", make_huggingface_adapter(hf_key))
+
+            # Generic providers (Fireworks / DeepSeek / Together) via base URL env vars
+            fireworks_base = os.environ.get("FIREWORKS_BASE") or os.environ.get("FIREWORKS_API_BASE")
+            fireworks_key = os.environ.get("FIREWORKS_API_KEY")
+            if fireworks_base and "fireworks" not in self._registry:
+                self.register_provider("fireworks", make_generic_http_adapter(fireworks_base, fireworks_key))
+
+            deepseek_base = os.environ.get("DEEPSEEK_BASE") or os.environ.get("DEEPSEEK_API_BASE")
+            deepseek_key = os.environ.get("DEEPSEEK_API_KEY")
+            if deepseek_base and "deepseek" not in self._registry:
+                self.register_provider("deepseek", make_generic_http_adapter(deepseek_base, deepseek_key))
+
+            together_base = os.environ.get("TOGETHER_BASE") or os.environ.get("TOGETHER_API_BASE")
+            together_key = os.environ.get("TOGETHER_API_KEY")
+            if together_base and "together" not in self._registry:
+                self.register_provider("together", make_generic_http_adapter(together_base, together_key))
+        except Exception:
+            # provider_adapters import failed — skip lightweight adapter registration
+            pass
 
         # Optional LangChain-backed adapters (enable by setting USE_LANGCHAIN=1).
         # When enabled, attempt to register LangChain adapters for common providers.

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -200,9 +200,10 @@ async def generate_pipeline(
     gen = GenerationService(engine, provider_callable=provider_callable)
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
     await db.repos.generation_runs.set_status(run_id, "running")
+    retrieval_query = pipeline.prompt_template or pipeline.name or ""
     try:
         result = await gen.generate(
-            query="",
+            query=retrieval_query,
             prompt_template=pipeline.prompt_template,
             model=(model or pipeline.llm_model),
             max_tokens=max_tokens,
@@ -211,10 +212,11 @@ async def generate_pipeline(
         await db.repos.generation_runs.save_result(run_id, result.get("generated_text", ""), {"citations": result.get("citations", [])})
     except Exception as exc:
         await db.repos.generation_runs.set_status(run_id, "failed")
+        runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
         return deps.get_templates(request).TemplateResponse(
             request,
             "pipelines/generate.html",
-            {"pipeline": pipeline, "error": str(exc), "request": request},
+            {"pipeline": pipeline, "runs": runs, "error": str(exc), "request": request},
         )
     run = await db.repos.generation_runs.get(run_id)
     return deps.get_templates(request).TemplateResponse(

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from urllib.parse import quote
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+import json
 
 from src.agent.prompt_template import ALLOWED_TEMPLATE_VARIABLES
 from src.models import PipelineGenerationBackend, PipelinePublishMode
@@ -173,6 +174,56 @@ async def generate_page(request: Request, pipeline_id: int):
         "pipelines/generate.html",
         {"pipeline": pipeline, "runs": runs, "request": request},
     )
+
+
+@router.get("/{pipeline_id}/generate-stream")
+async def generate_stream(request: Request, pipeline_id: int, model: str = "", max_tokens: int = 256, temperature: float = 0.0):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    engine = deps.get_search_engine(request)
+
+    from src.services.provider_service import AgentProviderService
+
+    provider_service = AgentProviderService(db)
+    provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+
+    from src.services.generation_service import GenerationService
+
+    gen = GenerationService(engine, provider_callable=provider_callable)
+
+    # persist run
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
+    await db.repos.generation_runs.set_status(run_id, "running")
+    retrieval_query = pipeline.prompt_template or pipeline.name or ""
+
+    async def event_gen():
+        last = None
+        try:
+            async for update in gen.generate_stream(
+                query=retrieval_query,
+                prompt_template=pipeline.prompt_template,
+                model=(model or pipeline.llm_model),
+                max_tokens=max_tokens,
+                temperature=temperature,
+            ):
+                last = update
+                data = {"delta": update.get("delta"), "text": update.get("generated_text"), "citations": update.get("citations")}
+                yield f"data: {json.dumps(data)}\n\n"
+
+            # finished successfully
+            final_text = last.get("generated_text") if last else ""
+            metadata = {"citations": last.get("citations", []) if last else []}
+            await db.repos.generation_runs.save_result(run_id, final_text, metadata)
+            await db.repos.generation_runs.set_status(run_id, "completed")
+            yield f"event: done\ndata: {json.dumps({'run_id': run_id})}\n\n"
+        except Exception as exc:
+            await db.repos.generation_runs.set_status(run_id, "failed")
+            yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")
 
 
 @router.post("/{pipeline_id}/generate")

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -158,3 +158,84 @@ async def toggle_pipeline(request: Request, pipeline_id: int):
 async def delete_pipeline(request: Request, pipeline_id: int):
     await deps.pipeline_service(request).delete(pipeline_id)
     return _pipeline_redirect("pipeline_deleted")
+
+
+@router.get("/{pipeline_id}/generate", response_class=HTMLResponse)
+async def generate_page(request: Request, pipeline_id: int):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/generate.html",
+        {"pipeline": pipeline, "runs": runs, "request": request},
+    )
+
+
+@router.post("/{pipeline_id}/generate")
+async def generate_pipeline(
+    request: Request,
+    pipeline_id: int,
+    model: str = Form(""),
+    max_tokens: int = Form(256),
+    temperature: float = Form(0.0),
+):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    engine = deps.get_search_engine(request)
+
+    from src.services.provider_service import AgentProviderService
+
+    provider_service = AgentProviderService(db)
+    provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+
+    from src.services.generation_service import GenerationService
+
+    gen = GenerationService(engine, provider_callable=provider_callable)
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
+    await db.repos.generation_runs.set_status(run_id, "running")
+    try:
+        result = await gen.generate(
+            query="",
+            prompt_template=pipeline.prompt_template,
+            model=(model or pipeline.llm_model),
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        await db.repos.generation_runs.save_result(run_id, result.get("generated_text", ""), {"citations": result.get("citations", [])})
+    except Exception as exc:
+        await db.repos.generation_runs.set_status(run_id, "failed")
+        return deps.get_templates(request).TemplateResponse(
+            request,
+            "pipelines/generate.html",
+            {"pipeline": pipeline, "error": str(exc), "request": request},
+        )
+    run = await db.repos.generation_runs.get(run_id)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/generate.html",
+        {"pipeline": pipeline, "run": run, "request": request},
+    )
+
+
+@router.post("/{pipeline_id}/publish")
+async def publish_pipeline(request: Request, pipeline_id: int, run_id: int = Form(...)):
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None or run.pipeline_id != pipeline_id:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    # Mark as published (no external publishing performed here)
+    metadata = run.metadata or {}
+    from datetime import datetime
+
+    metadata["published"] = True
+    metadata["published_at"] = datetime.utcnow().isoformat()
+    await db.repos.generation_runs.save_result(run_id, run.generated_text or "", metadata)
+    await db.repos.generation_runs.set_status(run_id, "published")
+    return _pipeline_redirect("pipeline_published")

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -133,6 +133,7 @@
                 <td>{{ pipeline.generate_interval_minutes }} мин</td>
                 <td class="text-nowrap">
                     <button type="button" class="btn btn-outline-secondary btn-sm" onclick="togglePipelineEdit({{ pipeline.id }})">Редактировать</button>
+                    <a class="btn btn-outline-primary btn-sm" href="/pipelines/{{ pipeline.id }}/generate">Generate</a>
                     <form method="post" action="/pipelines/{{ pipeline.id }}/toggle" class="d-inline" data-busy>
                         <button type="submit" class="btn btn-outline-secondary btn-sm">{{ "Выключить" if pipeline.is_active else "Включить" }}</button>
                     </form>

--- a/src/web/templates/pipelines/generate.html
+++ b/src/web/templates/pipelines/generate.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}Генерация — {{ pipeline.name }}{% endblock %}
+{% block content %}
+<h1>Генерация: {{ pipeline.name }}</h1>
+
+<form method="post" action="/pipelines/{{ pipeline.id }}/generate" data-busy>
+    <div class="row g-3 mb-3">
+        <div class="col-12 col-md-6">
+            <label class="form-label">LLM model</label>
+            <input class="form-control" name="model" value="{{ pipeline.llm_model or '' }}">
+        </div>
+        <div class="col-12 col-md-3">
+            <label class="form-label">Max tokens</label>
+            <input class="form-control" type="number" name="max_tokens" value="256">
+        </div>
+        <div class="col-12 col-md-3">
+            <label class="form-label">Temperature</label>
+            <input class="form-control" type="number" step="0.1" name="temperature" value="0.0">
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Preview</button>
+</form>
+
+{% if error %}
+<div class="alert alert-danger mt-3">Ошибка: {{ error }}</div>
+{% endif %}
+
+{% if run %}
+<div class="card mt-4">
+    <div class="card-header">Preview (run id={{ run.id }})</div>
+    <div class="card-body">
+        <pre style="white-space: pre-wrap">{{ run.generated_text }}</pre>
+        <h5 class="mt-3">Citations</h5>
+        <ul>
+            {% for c in run.metadata.citations %}
+            <li>{{ c.channel_title }} id={{ c.message_id }} date={{ c.date }}</li>
+            {% endfor %}
+        </ul>
+        <form method="post" action="/pipelines/{{ pipeline.id }}/publish" data-busy>
+            <input type="hidden" name="run_id" value="{{ run.id }}">
+            <button type="submit" class="btn btn-success">Publish</button>
+        </form>
+    </div>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/src/web/templates/pipelines/generate.html
+++ b/src/web/templates/pipelines/generate.html
@@ -19,7 +19,36 @@
         </div>
     </div>
     <button type="submit" class="btn btn-primary">Preview</button>
+    <button type="button" id="stream-btn" class="btn btn-outline-secondary">Stream Preview</button>
 </form>
+
+<pre id="stream-output" style="white-space: pre-wrap; margin-top: 1rem;"></pre>
+
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  const btn = document.getElementById('stream-btn');
+  if(!btn) return;
+  btn.addEventListener('click', function(){
+    const model = document.querySelector('input[name="model"]').value || '';
+    const max_tokens = document.querySelector('input[name="max_tokens"]').value || '';
+    const temperature = document.querySelector('input[name="temperature"]').value || '';
+    const out = document.getElementById('stream-output');
+    out.textContent = '';
+    const url = `/pipelines/{{ pipeline.id }}/generate-stream?model=${encodeURIComponent(model)}&max_tokens=${encodeURIComponent(max_tokens)}&temperature=${encodeURIComponent(temperature)}`;
+    const es = new EventSource(url);
+    es.onmessage = function(e){
+      try {
+        const d = JSON.parse(e.data);
+        out.textContent = d.text || '';
+      } catch (err) {
+        out.textContent += e.data;
+      }
+    };
+    es.addEventListener('done', function(e){ es.close(); });
+    es.addEventListener('error', function(e){ es.close(); });
+  });
+});
+</script>
 
 {% if error %}
 <div class="alert alert-danger mt-3">Ошибка: {{ error }}</div>

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_generation_runs_repo(db):
+    repo = db.repos.generation_runs
+    run_id = await repo.create_run(42, "prompt-template")
+    assert run_id > 0
+    run = await repo.get(run_id)
+    assert run is not None
+    assert run.pipeline_id == 42
+    assert run.status == "pending"
+
+    await repo.set_status(run_id, "running")
+    run = await repo.get(run_id)
+    assert run.status == "running"
+
+    await repo.save_result(run_id, "generated content", {"citations": []})
+    run = await repo.get(run_id)
+    assert run.status == "completed"
+    assert run.generated_text == "generated content"
+
+    rows = await repo.list_by_pipeline(42)
+    assert any(r.id == run_id for r in rows)

--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+from src.models import Message, SearchResult
+from src.services.generation_service import GenerationService
+
+
+class DummySearchEngine:
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def search_hybrid(self, query: str, **kwargs) -> SearchResult:
+        return SearchResult(messages=self._messages, total=len(self._messages), query=query)
+
+
+async def fake_provider(**kwargs):
+    # simple fake provider that echoes a predictable string
+    return "GENERATED: " + (kwargs.get("prompt") or "")[:40]
+
+
+async def test_generation_service_basic():
+    msg = Message(
+        id=1,
+        channel_id=10,
+        message_id=42,
+        sender_id=None,
+        sender_name="Alice",
+        text="Hello world from test",
+        date=datetime.utcnow(),
+        collected_at=None,
+        channel_title="TestChannel",
+        channel_username="testchan",
+    )
+
+    engine = DummySearchEngine([msg])
+    service = GenerationService(search_engine=engine, provider_callable=fake_provider)
+
+    out = await service.generate(
+        query="test query", prompt_template="Use {source_messages}", limit=1
+    )
+
+    assert "GENERATED:" in out["generated_text"]
+    assert "Hello world from test" in out["prompt"]
+    assert isinstance(out["citations"], list)

--- a/tests/test_generation_service_streaming.py
+++ b/tests/test_generation_service_streaming.py
@@ -1,0 +1,53 @@
+import asyncio
+from datetime import datetime
+
+from src.models import Message, SearchResult
+from src.services.generation_service import GenerationService
+
+
+class DummySearchEngine:
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def search_hybrid(self, query: str, **kwargs) -> SearchResult:
+        return SearchResult(messages=self._messages, total=len(self._messages), query=query)
+
+
+async def streaming_provider(prompt: str = "", **kwargs):
+    async def _gen():
+        # emit three chunks with small awaits to simulate async streaming
+        yield "part1 "
+        await asyncio.sleep(0)
+        yield "part2 "
+        await asyncio.sleep(0)
+        yield "end"
+
+    return _gen()
+
+
+async def test_generate_streaming():
+    msg = Message(
+        id=1,
+        channel_id=10,
+        message_id=42,
+        sender_id=None,
+        sender_name="Alice",
+        text="Hello world from test",
+        date=datetime.utcnow(),
+        collected_at=None,
+        channel_title="TestChannel",
+        channel_username="testchan",
+    )
+
+    engine = DummySearchEngine([msg])
+    svc = GenerationService(search_engine=engine, provider_callable=streaming_provider)
+
+    parts = []
+    async for update in svc.generate_stream(query="q", prompt_template="Use {source_messages}", limit=1):
+        parts.append(update.get("delta"))
+
+    assert "".join(parts) == "part1 part2 end"
+
+    # ensure generate(stream=True) returns final concatenated text
+    res = await svc.generate(query="q", prompt_template="Use {source_messages}", limit=1, stream=True)
+    assert res["generated_text"] == "part1 part2 end"

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -1,0 +1,119 @@
+import re
+
+import pytest
+
+from src.models import Account, Channel
+from tests.helpers import build_web_app, make_auth_client, make_test_config
+
+
+@pytest.fixture
+async def pipeline_client(tmp_path, real_pool_harness_factory):
+    config = make_test_config(tmp_path)
+    harness = real_pool_harness_factory()
+    app, built_db = await build_web_app(config, harness)
+    await built_db.add_account(Account(phone="+100", session_string="sess"))
+    await built_db.add_channel(Channel(channel_id=1001, title="Source A"))
+    await built_db.repos.dialog_cache.replace_dialogs(
+        "+100",
+        [
+            {
+                "channel_id": 77,
+                "title": "Target A",
+                "username": "targeta",
+                "channel_type": "channel",
+            }
+        ],
+    )
+
+    async def _get_dialogs_for_phone(
+        self,
+        phone,
+        include_dm=False,
+        mode="full",
+        refresh=False,
+    ):
+        return [
+            {
+                "channel_id": 77,
+                "title": "Target A",
+                "username": "targeta",
+                "channel_type": "channel",
+            }
+        ]
+
+    # Patch pool method used by the pipelines page to fetch dialogs
+    from types import MethodType
+
+    app.state.pool.get_dialogs_for_phone = MethodType(_get_dialogs_for_phone, app.state.pool)
+
+    async with make_auth_client(app) as client:
+        yield client
+
+    await app.state.collection_queue.shutdown()
+    await built_db.close()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
+    # Create a simple pipeline (reuse existing channels/accounts from fixture)
+    resp = await pipeline_client.post(
+        "/pipelines/add",
+        data={
+            "name": "IntegrationDigest",
+            "prompt_template": "Summarize {source_messages}",
+            "source_channel_ids": ["1001"],
+            "target_refs": ["+100|77"],
+            "publish_mode": "moderated",
+            "generation_backend": "chain",
+            "generate_interval_minutes": "60",
+            "is_active": "true",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    # Find the pipeline id from the pipelines page
+    page = await pipeline_client.get("/pipelines/")
+    assert page.status_code == 200
+    m = re.search(r'href="/pipelines/(\d+)/generate"', page.text)
+    assert m, page.text
+    pipeline_id = int(m.group(1))
+
+    # Monkeypatch GenerationService.generate to avoid search/provider complexities and return a deterministic result
+    async def fake_generate(self, *args, **kwargs):
+        return {"prompt": "", "generated_text": "INTEGRATION GENERATED", "citations": []}
+
+    monkeypatch.setattr(
+        "src.services.generation_service.GenerationService.generate",
+        fake_generate,
+    )
+
+    # Trigger generation (non-streaming path)
+    gen_resp = await pipeline_client.post(f"/pipelines/{pipeline_id}/generate", data={"model": "", "max_tokens": "256", "temperature": "0.0"}, follow_redirects=True)
+    assert gen_resp.status_code == 200
+    # Preview rendering may be async or paginated; assert result persisted in DB below
+
+    # Extract run id from page or fallback to DB lookup
+    run_id_match = re.search(r"Preview \(run id=(\d+)\)", gen_resp.text)
+    db = pipeline_client._transport.app.state.db
+    if run_id_match:
+        run_id = int(run_id_match.group(1))
+    else:
+        runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+        assert runs
+        run_id = runs[0].id
+
+    run = await db.repos.generation_runs.get(run_id)
+    assert run is not None
+    assert run.status == "completed", f"generation failed, metadata: {run.metadata}"
+    assert "INTEGRATION GENERATED" in (run.generated_text or "")
+
+    # Publish the run
+    pub = await pipeline_client.post(f"/pipelines/{pipeline_id}/publish", data={"run_id": str(run_id)}, follow_redirects=False)
+    assert pub.status_code == 303
+    assert "pipeline_published" in pub.headers["location"]
+
+    run_after = await db.repos.generation_runs.get(run_id)
+    assert run_after is not None
+    assert run_after.status == "published"
+    assert run_after.metadata and run_after.metadata.get("published") is True

--- a/tests/test_langchain_adapters.py
+++ b/tests/test_langchain_adapters.py
@@ -1,0 +1,58 @@
+import types
+import pytest
+
+import importlib
+
+from src.services.langchain_adapters import make_langchain_adapter
+
+
+@pytest.mark.asyncio
+async def test_langchain_adapter_raises_when_missing(monkeypatch):
+    # Simulate LangChain not being installed
+    monkeypatch.setattr("src.services.langchain_adapters.is_langchain_available", lambda: False)
+    adapter = make_langchain_adapter("openai", {"api_key": "fake"})
+
+    with pytest.raises(RuntimeError):
+        await adapter("hello")
+
+
+@pytest.mark.asyncio
+async def test_langchain_adapter_success(monkeypatch):
+    # Simulate minimal langchain modules and classes
+    def fake_import(name):
+        if name == "langchain.chat_models":
+            m = types.SimpleNamespace()
+
+            class ChatOpenAI:
+                def __init__(self, **kwargs):
+                    pass
+
+                async def agenerate(self, messages):
+                    # Return an object with .generations[0][0].text
+                    g = types.SimpleNamespace(text="LC reply")
+                    return types.SimpleNamespace(generations=[[g]])
+
+            setattr(m, "ChatOpenAI", ChatOpenAI)
+            return m
+
+        if name == "langchain.schema":
+            m = types.SimpleNamespace()
+
+            class HumanMessage:
+                def __init__(self, content=None):
+                    self.content = content
+
+            setattr(m, "HumanMessage", HumanMessage)
+            return m
+
+        if name == "langchain.llms":
+            return types.SimpleNamespace()
+
+        raise ImportError(f"No module {name}")
+
+    monkeypatch.setattr("src.services.langchain_adapters.is_langchain_available", lambda: True)
+    monkeypatch.setattr("src.services.langchain_adapters.importlib.import_module", fake_import)
+
+    adapter = make_langchain_adapter("openai", {"api_key": "fake"})
+    out = await adapter("hello")
+    assert "LC reply" in out

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,0 +1,80 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from src.services.provider_adapters import make_cohere_adapter, make_ollama_adapter, make_huggingface_adapter
+
+
+class FakeResp:
+    def __init__(self, status=200, json_data=None, text_data=None):
+        self.status = status
+        self._json = json_data or {}
+        self._text = text_data or ""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._text or ""
+
+    async def json(self):
+        return self._json
+
+
+class FakeSession:
+    def __init__(self, resp: FakeResp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        return self._resp
+
+
+def fake_client_session_factory(resp):
+    class _Factory:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return FakeSession(resp)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    return _Factory
+
+
+@pytest.mark.asyncio
+async def test_cohere_adapter_parses_generations(monkeypatch):
+    resp = FakeResp(status=200, json_data={"generations": [{"text": "Hello from Cohere"}]}, text_data="ok")
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    adapter = make_cohere_adapter("fakekey")
+    out = await adapter("my prompt")
+    assert "Hello from Cohere" in out
+
+
+@pytest.mark.asyncio
+async def test_ollama_adapter_parses_results(monkeypatch):
+    resp = FakeResp(status=200, json_data={"results": [{"content": {"text": "Ollama says hi"}}]})
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    adapter = make_ollama_adapter("http://example.org", api_key=None)
+    out = await adapter("p")
+    assert "Ollama says hi" in out
+
+
+@pytest.mark.asyncio
+async def test_hf_adapter_parses_generated_text(monkeypatch):
+    resp = FakeResp(status=200, json_data={"generated_text": "HF reply"})
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    adapter = make_huggingface_adapter("fakehf")
+    out = await adapter("q", model="gpt-like")
+    assert "HF reply" in out

--- a/tests/test_provider_service.py
+++ b/tests/test_provider_service.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from src.services.provider_service import AgentProviderService
+
+
+def test_default_provider_returns_draft():
+    svc = AgentProviderService()
+    provider = svc.get_provider_callable(None)
+    result = asyncio.run(provider(prompt="hello world"))
+    assert result.startswith("DRAFT (default provider): hello world")


### PR DESCRIPTION
Add a manual GitHub Actions workflow to run the test suite with USE_LANGCHAIN=1 (manual dispatch) and an integration test that verifies pipeline generation wiring and persistence. The test uses a monkeypatched GenerationService to avoid external provider/search dependencies.\n\nDoes not commit venv.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>