### PR TITLE
db: extend generation_runs for moderation and publishing (#117)

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -290,6 +290,23 @@ async def run_migrations(db: aiosqlite.Connection, *, vec_available: bool = Fals
         CREATE INDEX IF NOT EXISTS idx_generation_runs_pipeline_status
         ON generation_runs(pipeline_id, status)
         """)
+    # Ensure new columns for moderation and publishing exist (PR #117)
+    cur = await db.execute("PRAGMA table_info(generation_runs)")
+    gr_columns = {row["name"] for row in await cur.fetchall()}
+    if "image_url" not in gr_columns:
+        await db.execute("ALTER TABLE generation_runs ADD COLUMN image_url TEXT")
+        await db.commit()
+    if "moderation_status" not in gr_columns:
+        await db.execute(
+            "ALTER TABLE generation_runs ADD COLUMN moderation_status TEXT DEFAULT 'pending'"
+        )
+        await db.commit()
+    if "published_at" not in gr_columns:
+        await db.execute("ALTER TABLE generation_runs ADD COLUMN published_at TEXT")
+        await db.commit()
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_generation_runs_moderation ON generation_runs(moderation_status, pipeline_id)"
+    )
     await db.execute("""
         CREATE TABLE IF NOT EXISTS pipeline_sources (
             id INTEGER PRIMARY KEY,

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -42,6 +42,58 @@ class GenerationRunsRepository:
         )
         await self._db.commit()
 
+    async def set_moderation_status(self, run_id: int, status: str) -> None:
+        await self._db.execute(
+            "UPDATE generation_runs SET moderation_status = ?, updated_at = datetime('now') WHERE id = ?",
+            (status, run_id),
+        )
+        await self._db.commit()
+
+    async def set_published_at(self, run_id: int) -> None:
+        await self._db.execute(
+            ("UPDATE generation_runs SET published_at = datetime('now'), "
+             "moderation_status = 'published', updated_at = datetime('now') WHERE id = ?"),
+            (run_id,),
+        )
+        await self._db.commit()
+
+    async def list_pending_moderation(self, pipeline_id: int | None = None, limit: int = 50, offset: int = 0) -> list[GenerationRun]:
+        if pipeline_id is None:
+            cur = await self._db.execute(
+                "SELECT * FROM generation_runs WHERE moderation_status = 'pending' ORDER BY id DESC LIMIT ? OFFSET ?",
+                (limit, offset),
+            )
+        else:
+            cur = await self._db.execute(
+                "SELECT * FROM generation_runs WHERE moderation_status = 'pending' AND pipeline_id = ? ORDER BY id DESC LIMIT ? OFFSET ?",
+                (pipeline_id, limit, offset),
+            )
+        rows = await cur.fetchall()
+        results: list[GenerationRun] = []
+        for row in rows:
+            metadata = None
+            if row["metadata"]:
+                try:
+                    metadata = json.loads(row["metadata"])
+                except Exception:
+                    metadata = None
+            results.append(
+                GenerationRun(
+                    id=row["id"],
+                    pipeline_id=row["pipeline_id"],
+                    status=row["status"],
+                    prompt=row["prompt"],
+                    generated_text=row["generated_text"],
+                    metadata=metadata,
+                    image_url=row.get("image_url"),
+                    moderation_status=row.get("moderation_status") or "pending",
+                    published_at=_dt(row.get("published_at")),
+                    created_at=_dt(row["created_at"]),
+                    updated_at=_dt(row["updated_at"]),
+                )
+            )
+        return results
+
     async def reset_running_on_startup(self) -> int:
         """Reset generation_runs stuck in 'running' state to 'failed' on server startup."""
         cur = await self._db.execute(

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -16,6 +16,31 @@ class GenerationRunsRepository:
     def __init__(self, db: aiosqlite.Connection):
         self._db = db
 
+    @staticmethod
+    def _to_generation_run(row: aiosqlite.Row) -> GenerationRun:
+        metadata = None
+        if row["metadata"]:
+            try:
+                metadata = json.loads(row["metadata"])
+            except Exception:
+                metadata = None
+        return GenerationRun(
+            id=row["id"],
+            pipeline_id=row["pipeline_id"],
+            status=row["status"],
+            prompt=row["prompt"],
+            generated_text=row["generated_text"],
+            metadata=metadata,
+            image_url=row["image_url"] if "image_url" in row.keys() else None,
+            moderation_status=(
+                row["moderation_status"] if "moderation_status" in row.keys() else "pending"
+            )
+            or "pending",
+            published_at=_dt(row["published_at"] if "published_at" in row.keys() else None),
+            created_at=_dt(row["created_at"]),
+            updated_at=_dt(row["updated_at"]),
+        )
+
     async def create_run(self, pipeline_id: int | None, prompt: str) -> int:
         cur = await self._db.execute(
             ("INSERT INTO generation_runs (pipeline_id, status, prompt, created_at) "
@@ -57,7 +82,12 @@ class GenerationRunsRepository:
         )
         await self._db.commit()
 
-    async def list_pending_moderation(self, pipeline_id: int | None = None, limit: int = 50, offset: int = 0) -> list[GenerationRun]:
+    async def list_pending_moderation(
+        self,
+        pipeline_id: int | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[GenerationRun]:
         if pipeline_id is None:
             cur = await self._db.execute(
                 "SELECT * FROM generation_runs WHERE moderation_status = 'pending' ORDER BY id DESC LIMIT ? OFFSET ?",
@@ -65,34 +95,13 @@ class GenerationRunsRepository:
             )
         else:
             cur = await self._db.execute(
-                "SELECT * FROM generation_runs WHERE moderation_status = 'pending' AND pipeline_id = ? ORDER BY id DESC LIMIT ? OFFSET ?",
+                "SELECT * FROM generation_runs "
+                "WHERE moderation_status = 'pending' "
+                "AND pipeline_id = ? ORDER BY id DESC LIMIT ? OFFSET ?",
                 (pipeline_id, limit, offset),
             )
         rows = await cur.fetchall()
-        results: list[GenerationRun] = []
-        for row in rows:
-            metadata = None
-            if row["metadata"]:
-                try:
-                    metadata = json.loads(row["metadata"])
-                except Exception:
-                    metadata = None
-            results.append(
-                GenerationRun(
-                    id=row["id"],
-                    pipeline_id=row["pipeline_id"],
-                    status=row["status"],
-                    prompt=row["prompt"],
-                    generated_text=row["generated_text"],
-                    metadata=metadata,
-                    image_url=row.get("image_url"),
-                    moderation_status=row.get("moderation_status") or "pending",
-                    published_at=_dt(row.get("published_at")),
-                    created_at=_dt(row["created_at"]),
-                    updated_at=_dt(row["updated_at"]),
-                )
-            )
-        return results
+        return [self._to_generation_run(row) for row in rows]
 
     async def reset_running_on_startup(self) -> int:
         """Reset generation_runs stuck in 'running' state to 'failed' on server startup."""
@@ -107,22 +116,7 @@ class GenerationRunsRepository:
         row = await cur.fetchone()
         if not row:
             return None
-        metadata = None
-        if row["metadata"]:
-            try:
-                metadata = json.loads(row["metadata"])
-            except Exception:
-                metadata = None
-        return GenerationRun(
-            id=row["id"],
-            pipeline_id=row["pipeline_id"],
-            status=row["status"],
-            prompt=row["prompt"],
-            generated_text=row["generated_text"],
-            metadata=metadata,
-            created_at=_dt(row["created_at"]),
-            updated_at=_dt(row["updated_at"]),
-        )
+        return self._to_generation_run(row)
 
     async def list_by_pipeline(
         self, pipeline_id: int, limit: int = 20, offset: int = 0
@@ -132,24 +126,4 @@ class GenerationRunsRepository:
             (pipeline_id, limit, offset),
         )
         rows = await cur.fetchall()
-        results: list[GenerationRun] = []
-        for row in rows:
-            metadata = None
-            if row["metadata"]:
-                try:
-                    metadata = json.loads(row["metadata"])
-                except Exception:
-                    metadata = None
-            results.append(
-                GenerationRun(
-                    id=row["id"],
-                    pipeline_id=row["pipeline_id"],
-                    status=row["status"],
-                    prompt=row["prompt"],
-                    generated_text=row["generated_text"],
-                    metadata=metadata,
-                    created_at=_dt(row["created_at"]),
-                    updated_at=_dt(row["updated_at"]),
-                )
-            )
-        return results
+        return [self._to_generation_run(row) for row in rows]

--- a/src/models.py
+++ b/src/models.py
@@ -130,6 +130,7 @@ class PipelinePublishMode(StrEnum):
 class PipelineGenerationBackend(StrEnum):
     CHAIN = "chain"
     AGENT = "agent"
+    DEEP_AGENTS = "deep_agents"
 
 
 class ContentPipeline(BaseModel):
@@ -231,6 +232,9 @@ class GenerationRun(BaseModel):
     prompt: str | None = None
     generated_text: str | None = None
     metadata: dict | None = None
+    image_url: str | None = None
+    moderation_status: str = "pending"
+    published_at: datetime | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -22,3 +22,36 @@ async def test_generation_runs_repo(db):
 
     rows = await repo.list_by_pipeline(42)
     assert any(r.id == run_id for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_generation_runs_repo_hydrates_moderation_fields(db):
+    repo = db.repos.generation_runs
+    run_id = await repo.create_run(42, "prompt-template")
+
+    await repo.set_status(run_id, "completed")
+    await repo.set_moderation_status(run_id, "approved")
+    await repo.set_published_at(run_id)
+
+    run = await repo.get(run_id)
+    assert run is not None
+    assert run.moderation_status == "published"
+    assert run.published_at is not None
+
+    rows = await repo.list_by_pipeline(42)
+    assert rows[0].moderation_status == "published"
+    assert rows[0].published_at is not None
+
+
+@pytest.mark.asyncio
+async def test_list_pending_moderation_returns_runs(db):
+    repo = db.repos.generation_runs
+    pending_id = await repo.create_run(42, "pending-prompt")
+    approved_id = await repo.create_run(42, "approved-prompt")
+
+    await repo.set_moderation_status(approved_id, "approved")
+
+    pending = await repo.list_pending_moderation(42)
+
+    assert [run.id for run in pending] == [pending_id]
+    assert pending[0].moderation_status == "pending"


### PR DESCRIPTION
## Summary
- Add moderation & publish columns to `generation_runs` (`image_url`, `moderation_status`, `published_at`)
- Add `DEEP_AGENTS` backend enum value and fields to `GenerationRun` model
- Add repository helpers: `set_moderation_status`, `set_published_at`, `list_pending_moderation`

## Why
Prepare DB + model + minimal API for moderated generation and publishing flows. Migration is non-destructive and only adds missing columns.

## Files changed
- `src/database/migrations.py`
- `src/models.py`
- `src/database/repositories/generation_runs.py`

## Verification steps
1. Start the app to run migrations: `python -m src.main serve`
2. Confirm columns exist: `sqlite3 path/to/database.db "PRAGMA table_info(generation_runs);"`
3. Run tests: `pytest tests/test_generation_runs_repo.py -q` or full suite: `pytest -q`

## Notes
- This PR is the first of a 10-PR plan to implement generation → moderation → publish flows (see project plan).
- Image generation is not implemented yet; it's a later PR.