### PR TITLE
feat: add CLI generate, runs, and run-show commands (#118)

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -5,6 +5,7 @@ import asyncio
 
 from src.cli import runtime
 from src.search.engine import SearchEngine
+from src.services.content_generation_service import ContentGenerationService
 from src.services.generation_service import GenerationService
 from src.services.pipeline_service import (
     PipelineService,
@@ -69,10 +70,10 @@ def run(args: argparse.Namespace) -> None:
                 print(f"image_model={pipeline.image_model or '—'}")
                 print("sources:")
                 for title in detail["source_titles"]:
-                    print(f"  - {title}")
+                    print(f" - {title}")
                 print("targets:")
                 for target in detail["targets"]:
-                    print(f"  - {target.phone}:{target.dialog_id} ({target.title or '—'})")
+                    print(f" - {target.phone}:{target.dialog_id} ({target.title or '—'})")
 
             elif args.pipeline_action == "add":
                 try:
@@ -149,22 +150,18 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Deleted pipeline id={args.id}")
 
             elif args.pipeline_action == "run":
-                # Run a pipeline generation (preview only by default)
                 pipeline = await svc.get(args.id)
                 if pipeline is None:
                     print(f"Pipeline id={args.id} not found")
                     return
-                # Build search engine and generation service
                 engine = SearchEngine(db)
 
-                # Resolve provider callable via AgentProviderService (falls back to default stub)
                 from src.services.provider_service import AgentProviderService
 
                 provider_service = AgentProviderService(db)
                 provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
                 gen_svc = GenerationService(engine, provider_callable=provider_callable)
-                # Create generation run record
                 run_id = await db.repos.generation_runs.create_run(
                     pipeline.id, pipeline.prompt_template
                 )
@@ -197,6 +194,69 @@ def run(args: argparse.Namespace) -> None:
                 except Exception as exc:
                     await db.repos.generation_runs.set_status(run_id, "failed")
                     print(f"Generation failed: {exc}")
+
+            elif args.pipeline_action == "generate":
+                pipeline = await svc.get(args.id)
+                if pipeline is None:
+                    print(f"Pipeline id={args.id} not found")
+                    return
+                engine = SearchEngine(db)
+                gen_svc = ContentGenerationService(db, engine)
+                try:
+                    run = await gen_svc.generate(
+                        pipeline=pipeline,
+                        model=args.model,
+                        max_tokens=args.max_tokens,
+                        temperature=args.temperature,
+                    )
+                    print(f"Created generation run id={run.id}")
+                    if args.preview and run.generated_text:
+                        print("--- DRAFT PREVIEW ---")
+                        print(run.generated_text)
+                except NotImplementedError as exc:
+                    print(f"Error: {exc}")
+                except Exception as exc:
+                    print(f"Generation failed: {exc}")
+
+            elif args.pipeline_action == "runs":
+                pipeline = await svc.get(args.id)
+                if pipeline is None:
+                    print(f"Pipeline id={args.id} not found")
+                    return
+                runs = await db.repos.generation_runs.list_by_pipeline(
+                    args.id, limit=args.limit
+                )
+                if args.status:
+                    runs = [r for r in runs if r.status == args.status]
+                if not runs:
+                    print("No generation runs found.")
+                    return
+                print(f"{'ID':<8} {'Status':<12} {'ModStatus':<12} {'Created':<20}")
+                print("-" * 56)
+                for r in runs:
+                    created = r.created_at.isoformat() if r.created_at else "—"
+                    print(f"{r.id:<8} {r.status:<12} {r.moderation_status:<12} {created:<20}")
+
+            elif args.pipeline_action == "run-show":
+                run = await db.repos.generation_runs.get(args.run_id)
+                if run is None:
+                    print(f"Run id={args.run_id} not found")
+                    return
+                print(f"id={run.id}")
+                print(f"pipeline_id={run.pipeline_id}")
+                print(f"status={run.status}")
+                print(f"moderation_status={run.moderation_status}")
+                print(f"created_at={run.created_at}")
+                if run.generated_text:
+                    print("--- GENERATED TEXT ---")
+                    print(run.generated_text[:500])
+                    if len(run.generated_text) > 500:
+                        print(f"... ({len(run.generated_text) - 500} more chars)")
+                if run.image_url:
+                    print(f"image_url={run.image_url}")
+                if run.published_at:
+                    print(f"published_at={run.published_at}")
+
         finally:
             await db.close()
 

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -193,7 +193,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pipeline_add.add_argument(
         "--generation-backend",
-        choices=["chain", "agent"],
+        choices=["chain", "agent", "deep_agents"],
         default="chain",
         help="Generation backend",
     )
@@ -225,7 +225,7 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_edit.add_argument("--llm-model", default=None, help="Optional LLM model")
     pipeline_edit.add_argument("--image-model", default=None, help="Optional image model")
     pipeline_edit.add_argument("--publish-mode", choices=["auto", "moderated"], default=None)
-    pipeline_edit.add_argument("--generation-backend", choices=["chain", "agent"], default=None)
+    pipeline_edit.add_argument("--generation-backend", choices=["chain", "agent", "deep_agents"], default=None)
     pipeline_edit.add_argument(
         "--interval",
         type=int,
@@ -274,6 +274,31 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_run.add_argument(
         "--temperature", type=float, default=0.0, help="Sampling temperature for generation"
     )
+
+    pipeline_generate = pipeline_sub.add_parser(
+        "generate", help="Generate content for a pipeline (uses ContentGenerationService)"
+    )
+    pipeline_generate.add_argument("id", type=int, help="Pipeline id")
+    pipeline_generate.add_argument(
+        "--max-tokens", type=int, default=512, help="Max tokens for LLM generation"
+    )
+    pipeline_generate.add_argument(
+        "--temperature", type=float, default=0.7, help="Sampling temperature for generation"
+    )
+    pipeline_generate.add_argument(
+        "--model", default=None, help="Override LLM model"
+    )
+    pipeline_generate.add_argument(
+        "--preview", action="store_true", default=False, help="Print generated text to stdout"
+    )
+
+    pipeline_runs = pipeline_sub.add_parser("runs", help="List generation runs for a pipeline")
+    pipeline_runs.add_argument("id", type=int, help="Pipeline id")
+    pipeline_runs.add_argument("--limit", type=int, default=20, help="Max runs to show")
+    pipeline_runs.add_argument("--status", default=None, help="Filter by status")
+
+    pipeline_run_show = pipeline_sub.add_parser("run-show", help="Show generation run details")
+    pipeline_run_show.add_argument("run_id", type=int, help="Run id")
 
     acc_parser = sub.add_parser("account", help="Account management")
     acc_sub = acc_parser.add_subparsers(dest="account_action")

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.database import Database
+from src.models import ContentPipeline, GenerationRun, PipelineGenerationBackend
+from src.services.generation_service import GenerationService
+from src.search.engine import SearchEngine
+
+logger = logging.getLogger(__name__)
+
+
+class ContentGenerationService:
+    """Orchestrates content generation from pipeline configuration.
+    
+    This service coordinates:
+    - Creating generation_runs records
+    - Invoking GenerationService (RAG) or AgentManager (deep agents)
+    - Handling image generation stub
+    - Updating generation_runs with results
+    - Setting initial moderation_status
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        search_engine: SearchEngine,
+        agent_manager: Any | None = None,
+        image_service: Any | None = None,
+    ) -> None:
+        self._db = db
+        self._search = search_engine
+        self._agent_manager = agent_manager
+        self._image_service = image_service
+
+    async def generate(
+        self,
+        pipeline: ContentPipeline,
+        model: str | None = None,
+        max_tokens: int = 512,
+        temperature: float = 0.7,
+    ) -> GenerationRun:
+        """Generate content for a pipeline and return the generation run.
+        
+        Steps:
+        1. Create generation_runs record (status='running')
+        2. Retrieve context messages from pipeline sources
+        3. Render prompt template with source messages
+        4. Call backend (GenerationService RAG or AgentManager)
+        5. Handle image generation if image_model is set (stub: NotImplementedError)
+        6. Save result with moderation_status='pending'
+        7. Return the GenerationRun
+        """
+        run_id = await self._db.repos.generation_runs.create_run(
+            pipeline_id=pipeline.id,
+            prompt=pipeline.prompt_template,
+        )
+        try:
+            await self._db.repos.generation_runs.set_status(run_id, "running")
+        except Exception:
+            await self._db.repos.generation_runs.set_status(run_id, "failed")
+            raise
+
+        try:
+            result = await self._run_generation(
+                pipeline=pipeline,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            generated_text = result.get("generated_text", "")
+            metadata: dict[str, Any] = {"citations": result.get("citations", [])}
+            
+            if pipeline.image_model:
+                image_url = await self._generate_image(pipeline, generated_text)
+                if image_url:
+                    await self._db.repos.generation_runs._db.execute(
+                        "UPDATE generation_runs SET image_url = ? WHERE id = ?",
+                        (image_url, run_id),
+                    )
+                    await self._db.repos.generation_runs._db.commit()
+            
+            await self._db.repos.generation_runs.save_result(run_id, generated_text, metadata)
+            run = await self._db.repos.generation_runs.get(run_id)
+            if run is None:
+                raise RuntimeError(f"Generation run {run_id} not found after save")
+            return run
+        except Exception:
+            logger.exception(
+                "Content generation failed for pipeline_id=%s run_id=%s",
+                pipeline.id,
+                run_id,
+            )
+            await self._db.repos.generation_runs.set_status(run_id, "failed")
+            raise
+
+    async def _run_generation(
+        self,
+        pipeline: ContentPipeline,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        """Execute the generation backend."""
+        if pipeline.generation_backend == PipelineGenerationBackend.DEEP_AGENTS:
+            return await self._run_deep_agents(pipeline, model, max_tokens, temperature)
+        
+        return await self._run_rag(pipeline, model, max_tokens, temperature)
+
+    async def _run_rag(
+        self,
+        pipeline: ContentPipeline,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        """Run RAG-based generation using GenerationService."""
+        from src.services.provider_service import AgentProviderService
+        
+        provider_service = AgentProviderService(self._db)
+        provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+        
+        gen = GenerationService(self._search, provider_callable=provider_callable)
+        
+        query = pipeline.prompt_template or pipeline.name or ""
+        
+        return await gen.generate(
+            query=query,
+            prompt_template=pipeline.prompt_template,
+            model=(model or pipeline.llm_model),
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+    async def _run_deep_agents(
+        self,
+        pipeline: ContentPipeline,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        """Run generation using AgentManager deep agents backend."""
+        if self._agent_manager is None:
+            raise RuntimeError("AgentManager not configured for deep_agents generation")
+        
+        import asyncio
+        import json
+        
+        prompt = pipeline.prompt_template or pipeline.name or ""
+        
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
+        full_text = ""
+        
+        async def collect():
+            nonlocal full_text
+            async for chunk in self._agent_manager.chat_stream(
+                thread_id=0,
+                message=prompt,
+                model=model,
+            ):
+                if chunk.startswith("data: "):
+                    try:
+                        data = json.loads(chunk[6:].strip())
+                        if "text" in data:
+                            full_text = data["text"]
+                        elif "full_text" in data:
+                            full_text = data["full_text"]
+                    except json.JSONDecodeError:
+                        pass
+        
+        await collect()
+        
+        return {
+            "generated_text": full_text,
+            "citations": [],
+        }
+
+    async def _generate_image(self, pipeline: ContentPipeline, text: str) -> str | None:
+        """Generate image for the content. Stub that raises NotImplementedError."""
+        if self._image_service is None:
+            raise NotImplementedError("Image generation is not yet implemented")
+        
+        return await self._image_service.generate(pipeline.image_model, text)


### PR DESCRIPTION
## Summary
- Add `pipeline generate` subcommand using `ContentGenerationService`
- Add `pipeline runs` subcommand to list generation runs for a pipeline
- Add `pipeline run-show` subcommand to display generation run details
- Update `--generation-backend` choices to include `deep_agents`
- Add `ContentGenerationService` from PR #115

## Files changed
- `src/cli/parser.py` — added `generate`, `runs`, `run-show` subcommands; updated backend choices
- `src/cli/commands/pipeline.py` — handlers for new subcommands
- `src/services/content_generation_service.py` — copied from PR #115

## Why
CLI parity with web routes for content generation. Users can now:
- Generate content via `pipeline generate <id> [--preview]`
- List runs via `pipeline runs <id>`
- View run details via `pipeline run-show <run_id>`

## Verification
```bash
# Test parser
python -m src.cli.parser

# Run generation
python -m src.main pipeline generate 1 --preview

# List runs
python -m src.main pipeline runs 1

# Show run
python -m src.main pipeline run-show 123
```

## Notes
- This PR is #4 of the 10-PR plan
- Depends on PR #117 (merged) for `moderation_status` column and `DEEP_AGENTS` enum
- Includes `ContentGenerationService` from PR #115