### PR TITLE
feat: add moderation queue UI (#119)

### DIFF
--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -115,6 +115,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.debug import router as debug_router
     from src.web.routes.filter import router as filter_router
     from src.web.routes.import_channels import router as import_router
+    from src.web.routes.moderation import router as moderation_router
     from src.web.routes.my_telegram import router as my_telegram_router
     from src.web.routes.photo_loader import router as photo_loader_router
     from src.web.routes.pipelines import router as pipelines_router
@@ -125,6 +126,7 @@ def register_routes(app: FastAPI) -> None:
 
     app.include_router(agent_router, prefix="/agent")
     app.include_router(analytics_router, prefix="/analytics")
+    app.include_router(moderation_router, prefix="/moderation")
     app.include_router(search_router)
     app.include_router(dashboard_router, prefix="/dashboard")
     app.include_router(auth_router, prefix="/auth")

--- a/src/web/routes/moderation.py
+++ b/src/web/routes/moderation.py
@@ -5,6 +5,7 @@ import logging
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from src.services.publish_service import PublishService
 from src.web import deps
 
 logger = logging.getLogger(__name__)
@@ -29,10 +30,10 @@ async def moderation_queue_page(
         limit=limit,
         offset=offset,
     )
-    
+
     pipelines_svc = deps.pipeline_service(request)
     pipelines = await pipelines_svc.get_with_relations()
-    
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "moderation.html",
@@ -52,7 +53,7 @@ async def view_run(request: Request, run_id: int):
     run = await db.repos.generation_runs.get(run_id)
     if run is None:
         return _moderation_redirect("run_not_found", error=True)
-    
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "moderation/view.html",
@@ -66,7 +67,7 @@ async def approve_run(request: Request, run_id: int):
     run = await db.repos.generation_runs.get(run_id)
     if run is None:
         return _moderation_redirect("run_not_found", error=True)
-    
+
     await db.repos.generation_runs.set_moderation_status(run_id, "approved")
     return _moderation_redirect("run_approved")
 
@@ -77,7 +78,7 @@ async def reject_run(request: Request, run_id: int):
     run = await db.repos.generation_runs.get(run_id)
     if run is None:
         return _moderation_redirect("run_not_found", error=True)
-    
+
     await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
     return _moderation_redirect("run_rejected")
 
@@ -88,11 +89,23 @@ async def publish_run(request: Request, run_id: int):
     run = await db.repos.generation_runs.get(run_id)
     if run is None:
         return _moderation_redirect("run_not_found", error=True)
-    
+
+    if run.pipeline_id is None:
+        return _moderation_redirect("pipeline_invalid", error=True)
+
+    pipeline = await deps.pipeline_service(request).get(run.pipeline_id)
+    if pipeline is None:
+        return _moderation_redirect("pipeline_invalid", error=True)
+
     if run.moderation_status != "approved":
         return _moderation_redirect("run_not_approved", error=True)
-    
-    await db.repos.generation_runs.set_published_at(run_id)
+
+    publish_service = PublishService(db, deps.get_pool(request))
+    results = await publish_service.publish_run(run, pipeline)
+    if not results or not all(result.success for result in results):
+        logger.warning("Moderation publish failed for run %s: %s", run_id, results)
+        return _moderation_redirect("pipeline_run_failed", error=True)
+
     return _moderation_redirect("run_published")
 
 
@@ -103,7 +116,7 @@ async def bulk_approve(request: Request, run_ids: list[int] = Form(default=[])):
         run = await db.repos.generation_runs.get(run_id)
         if run is not None:
             await db.repos.generation_runs.set_moderation_status(run_id, "approved")
-    
+
     return _moderation_redirect("runs_approved")
 
 
@@ -114,5 +127,5 @@ async def bulk_reject(request: Request, run_ids: list[int] = Form(default=[])):
         run = await db.repos.generation_runs.get(run_id)
         if run is not None:
             await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
-    
+
     return _moderation_redirect("runs_rejected")

--- a/src/web/routes/moderation.py
+++ b/src/web/routes/moderation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from src.web import deps
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+def _moderation_redirect(code: str, *, error: bool = False) -> RedirectResponse:
+    key = "error" if error else "msg"
+    return RedirectResponse(url=f"/moderation?{key}={code}", status_code=303)
+
+
+@router.get("/", response_class=HTMLResponse)
+async def moderation_queue_page(
+    request: Request,
+    pipeline_id: int | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    db = deps.get_db(request)
+    pending_runs = await db.repos.generation_runs.list_pending_moderation(
+        pipeline_id=pipeline_id,
+        limit=limit,
+        offset=offset,
+    )
+    
+    pipelines_svc = deps.pipeline_service(request)
+    pipelines = await pipelines_svc.get_with_relations()
+    
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "moderation.html",
+        {
+            "pending_runs": pending_runs,
+            "pipelines": pipelines,
+            "selected_pipeline_id": pipeline_id,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
+
+
+@router.get("/{run_id}/view", response_class=HTMLResponse)
+async def view_run(request: Request, run_id: int):
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None:
+        return _moderation_redirect("run_not_found", error=True)
+    
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "moderation/view.html",
+        {"run": run},
+    )
+
+
+@router.post("/{run_id}/approve")
+async def approve_run(request: Request, run_id: int):
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None:
+        return _moderation_redirect("run_not_found", error=True)
+    
+    await db.repos.generation_runs.set_moderation_status(run_id, "approved")
+    return _moderation_redirect("run_approved")
+
+
+@router.post("/{run_id}/reject")
+async def reject_run(request: Request, run_id: int):
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None:
+        return _moderation_redirect("run_not_found", error=True)
+    
+    await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
+    return _moderation_redirect("run_rejected")
+
+
+@router.post("/{run_id}/publish")
+async def publish_run(request: Request, run_id: int):
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None:
+        return _moderation_redirect("run_not_found", error=True)
+    
+    if run.moderation_status != "approved":
+        return _moderation_redirect("run_not_approved", error=True)
+    
+    await db.repos.generation_runs.set_published_at(run_id)
+    return _moderation_redirect("run_published")
+
+
+@router.post("/bulk-approve")
+async def bulk_approve(request: Request, run_ids: list[int] = Form(default=[])):
+    db = deps.get_db(request)
+    for run_id in run_ids:
+        run = await db.repos.generation_runs.get(run_id)
+        if run is not None:
+            await db.repos.generation_runs.set_moderation_status(run_id, "approved")
+    
+    return _moderation_redirect("runs_approved")
+
+
+@router.post("/bulk-reject")
+async def bulk_reject(request: Request, run_ids: list[int] = Form(default=[])):
+    db = deps.get_db(request)
+    for run_id in run_ids:
+        run = await db.repos.generation_runs.get(run_id)
+        if run is not None:
+            await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
+    
+    return _moderation_redirect("runs_rejected")

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -6,14 +6,6 @@
 <div class="container-fluid">
     <h1 class="h3 mb-4">Очередь модерации</h1>
 
-    {% if request.query_params.get("msg") %}
-    <div class="alert alert-success">{{ request.query_params.get("msg") }}</div>
-    {% endif %}
-
-    {% if request.query_params.get("error") %}
-    <div class="alert alert-danger">{{ request.query_params.get("error") }}</div>
-    {% endif %}
-
     <div class="card mb-4">
         <div class="card-body">
             <form method="get" class="row g-3">
@@ -114,9 +106,12 @@
 </div>
 
 <script>
-document.getElementById('select-all').addEventListener('change', function() {
-    const checkboxes = document.querySelectorAll('.run-checkbox');
-    checkboxes.forEach(cb => cb.checked = this.checked);
-});
+const selectAll = document.getElementById('select-all');
+if (selectAll) {
+    selectAll.addEventListener('change', function() {
+        const checkboxes = document.querySelectorAll('.run-checkbox');
+        checkboxes.forEach(cb => cb.checked = this.checked);
+    });
+}
 </script>
 {% endblock %}

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -1,0 +1,122 @@
+{% extends "base.html" %}
+
+{% block title %}Очередь модерации{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="h3 mb-4">Очередь модерации</h1>
+
+    {% if request.query_params.get("msg") %}
+    <div class="alert alert-success">{{ request.query_params.get("msg") }}</div>
+    {% endif %}
+
+    {% if request.query_params.get("error") %}
+    <div class="alert alert-danger">{{ request.query_params.get("error") }}</div>
+    {% endif %}
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <form method="get" class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Пайплайн</label>
+                    <select name="pipeline_id" class="form-select">
+                        <option value="">Все пайплайны</option>
+                        {% for item in pipelines %}
+                        <option value="{{ item.pipeline.id }}" {% if selected_pipeline_id == item.pipeline.id %}selected{% endif %}>
+                            {{ item.pipeline.name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">Лимит</label>
+                    <input type="number" name="limit" value="{{ limit }}" class="form-control" min="1" max="200">
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary">Фильтр</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {% if pending_runs %}
+    <form method="post" action="/moderation/bulk-approve">
+        <div class="mb-3">
+            <button type="submit" class="btn btn-success btn-sm">Одобрить выбранные</button>
+            <button type="submit" formaction="/moderation/bulk-reject" class="btn btn-danger btn-sm">Отклонить выбранные</button>
+        </div>
+
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th><input type="checkbox" id="select-all"></th>
+                        <th>ID</th>
+                        <th>Пайплайн</th>
+                        <th>Статус</th>
+                        <th>Создан</th>
+                        <th>Превью</th>
+                        <th>Действия</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for run in pending_runs %}
+                    <tr>
+                        <td>
+                            <input type="checkbox" name="run_ids" value="{{ run.id }}" class="run-checkbox">
+                        </td>
+                        <td>{{ run.id }}</td>
+                        <td>{{ run.pipeline_id }}</td>
+                        <td>
+                            <span class="badge bg-{% if run.moderation_status == 'pending' %}secondary{% elif run.moderation_status == 'approved' %}success{% elif run.moderation_status == 'rejected' %}danger{% else %}primary{% endif %}">
+                                {{ run.moderation_status }}
+                            </span>
+                        </td>
+                        <td>{{ run.created_at.strftime('%Y-%m-%d %H:%M') if run.created_at else '—' }}</td>
+                        <td>
+                            {% if run.generated_text %}
+                            <span class="text-muted">{{ run.generated_text[:100] }}{% if run.generated_text|length > 100 %}...{% endif %}</span>
+                            {% else %}
+                            <span class="text-muted">Нет текста</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <a href="/moderation/{{ run.id }}/view" class="btn btn-outline-primary">Просмотр</a>
+                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/approve" class="btn btn-outline-success">Одобрить</button>
+                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/reject" class="btn btn-outline-danger">Отклонить</button>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </form>
+
+    <nav>
+        <ul class="pagination">
+            {% if offset > 0 %}
+            <li class="page-item">
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id }}&limit={{ limit }}&offset={{ offset - limit }}">Назад</a>
+            </li>
+            {% endif %}
+            {% if pending_runs|length == limit %}
+            <li class="page-item">
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id }}&limit={{ limit }}&offset={{ offset + limit }}">Вперёд</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% else %}
+    <div class="alert alert-info">Нет черновиков на модерации.</div>
+    {% endif %}
+</div>
+
+<script>
+document.getElementById('select-all').addEventListener('change', function() {
+    const checkboxes = document.querySelectorAll('.run-checkbox');
+    checkboxes.forEach(cb => cb.checked = this.checked);
+});
+</script>
+{% endblock %}

--- a/src/web/templates/moderation/view.html
+++ b/src/web/templates/moderation/view.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+
+{% block title %}Просмотр черновика #{{ run.id }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3">Черновик #{{ run.id }}</h1>
+        <div>
+            <a href="/moderation" class="btn btn-outline-secondary">← Назад к очереди</a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-8">
+            <div class="card mb-4">
+                <div class="card-header">
+                    <span class="badge bg-{% if run.moderation_status == 'pending' %}secondary{% elif run.moderation_status == 'approved' %}success{% elif run.moderation_status == 'rejected' %}danger{% else %}primary{% endif %}">
+                        {{ run.moderation_status }}
+                    </span>
+                    <span class="ms-2 text-muted">Pipeline #{{ run.pipeline_id }}</span>
+                </div>
+                <div class="card-body">
+                    {% if run.generated_text %}
+                    <div class="mb-4">
+                        <h5>Сгенерированный текст</h5>
+                        <div class="border rounded p-3 bg-light" style="white-space: pre-wrap;">{{ run.generated_text }}</div>
+                    </div>
+                    {% else %}
+                    <div class="alert alert-warning">Текст отсутствует</div>
+                    {% endif %}
+
+                    {% if run.image_url %}
+                    <div class="mb-4">
+                        <h5>Изображение</h5>
+                        <img src="{{ run.image_url }}" class="img-fluid rounded" alt="Generated image">
+                    </div>
+                    {% endif %}
+
+                    {% if run.prompt %}
+                    <div class="mb-4">
+                        <h5>Промпт</h5>
+                        <div class="text-muted small">{{ run.prompt }}</div>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <div class="card mb-4">
+                <div class="card-header">Информация</div>
+                <div class="card-body">
+                    <dl class="row">
+                        <dt class="col-sm-5">ID</dt>
+                        <dd class="col-sm-7">{{ run.id }}</dd>
+
+                        <dt class="col-sm-5">Pipeline</dt>
+                        <dd class="col-sm-7">{{ run.pipeline_id }}</dd>
+
+                        <dt class="col-sm-5">Статус</dt>
+                        <dd class="col-sm-7">{{ run.status }}</dd>
+
+                        <dt class="col-sm-5">Модерация</dt>
+                        <dd class="col-sm-7">{{ run.moderation_status }}</dd>
+
+                        <dt class="col-sm-5">Создан</dt>
+                        <dd class="col-sm-7">{{ run.created_at.strftime('%Y-%m-%d %H:%M') if run.created_at else '—' }}</dd>
+
+                        {% if run.published_at %}
+                        <dt class="col-sm-5">Опубликован</dt>
+                        <dd class="col-sm-7">{{ run.published_at.strftime('%Y-%m-%d %H:%M') }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+            </div>
+
+            {% if run.moderation_status == "pending" %}
+            <div class="card">
+                <div class="card-header">Действия</div>
+                <div class="card-body">
+                    <form method="post" action="/moderation/{{ run.id }}/approve" class="mb-2">
+                        <button type="submit" class="btn btn-success w-100">Одобрить</button>
+                    </form>
+                    <form method="post" action="/moderation/{{ run.id }}/reject">
+                        <button type="submit" class="btn btn-danger w-100">Отклонить</button>
+                    </form>
+                </div>
+            </div>
+            {% elif run.moderation_status == "approved" and not run.published_at %}
+            <div class="card">
+                <div class="card-header">Публикация</div>
+                <div class="card-body">
+                    <form method="post" action="/moderation/{{ run.id }}/publish">
+                        <button type="submit" class="btn btn-primary w-100">Опубликовать</button>
+                    </form>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -1,0 +1,153 @@
+"""Tests for moderation routes."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import AppConfig
+from src.database import Database
+from src.models import (
+    Account,
+    Channel,
+    ContentPipeline,
+    PipelineGenerationBackend,
+    PipelinePublishMode,
+    PipelineTarget,
+)
+from src.scheduler.manager import SchedulerManager
+from src.search.ai_search import AISearchEngine
+from src.search.engine import SearchEngine
+from src.services.publish_service import PublishResult
+from src.telegram.auth import TelegramAuth
+from src.telegram.collector import Collector
+from src.web.app import create_app
+
+
+@pytest.fixture
+async def client(tmp_path):
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+    app = create_app(config)
+
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+
+    pool_mock = MagicMock()
+    pool_mock.clients = {"+1234567890": MagicMock()}
+    pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
+    app.state.pool = pool_mock
+
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+    app.state.collector = Collector(pool_mock, db, config.scheduler)
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(config.scheduler)
+    app.state.session_secret = "test_secret_key"
+    app.state.shutting_down = False
+
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+    await db.add_channel(Channel(channel_id=100, title="Test Channel"))
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
+    ) as c:
+        yield c
+
+    await db.close()
+
+
+async def _create_pipeline(db: Database, *, publish_mode: PipelinePublishMode) -> int:
+    pipeline = ContentPipeline(
+        name="Moderation Pipeline",
+        prompt_template="Write a summary",
+        publish_mode=publish_mode,
+        generation_backend=PipelineGenerationBackend.CHAIN,
+    )
+    return await db.repos.content_pipelines.add(
+        pipeline,
+        source_channel_ids=[100],
+        targets=[
+            PipelineTarget(
+                pipeline_id=0,
+                phone="+1234567890",
+                dialog_id=200,
+                title="Target Dialog",
+                dialog_type="channel",
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_moderation_page_renders_empty_queue(client):
+    resp = await client.get("/moderation/")
+    assert resp.status_code == 200
+    assert "Нет черновиков на модерации." in resp.text
+    assert "request.query_params.get" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_publish_run_uses_publish_service(client, monkeypatch):
+    db = client._transport.app.state.db
+    pipeline_id = await _create_pipeline(db, publish_mode=PipelinePublishMode.MODERATED)
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "prompt-template")
+    await db.repos.generation_runs.save_result(run_id, "Generated post")
+    await db.repos.generation_runs.set_moderation_status(run_id, "approved")
+
+    observed: dict[str, int] = {}
+
+    class FakePublishService:
+        def __init__(self, injected_db, pool):
+            assert injected_db is db
+            assert pool is client._transport.app.state.pool
+
+        async def publish_run(self, run, pipeline):
+            observed["run_id"] = run.id
+            observed["pipeline_id"] = pipeline.id
+            return [PublishResult(success=True, message_id=777)]
+
+    monkeypatch.setattr("src.web.routes.moderation.PublishService", FakePublishService)
+
+    resp = await client.post(f"/moderation/{run_id}/publish", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=run_published" in resp.headers["location"]
+    assert observed == {"run_id": run_id, "pipeline_id": pipeline_id}
+
+
+@pytest.mark.asyncio
+async def test_publish_run_rejects_unapproved_run(client, monkeypatch):
+    db = client._transport.app.state.db
+    pipeline_id = await _create_pipeline(db, publish_mode=PipelinePublishMode.MODERATED)
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "prompt-template")
+    await db.repos.generation_runs.save_result(run_id, "Generated post")
+
+    fake_publish = AsyncMock()
+
+    class FakePublishService:
+        def __init__(self, injected_db, pool):
+            pass
+
+        async def publish_run(self, run, pipeline):
+            await fake_publish(run, pipeline)
+            return [PublishResult(success=True, message_id=777)]
+
+    monkeypatch.setattr("src.web.routes.moderation.PublishService", FakePublishService)
+
+    resp = await client.post(f"/moderation/{run_id}/publish", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "error=run_not_approved" in resp.headers["location"]
+    fake_publish.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add `/moderation` page — список черновиков на модерации с фильтром по пайплайну
- Add `/moderation/{run_id}/view` — детальный просмотр черновика
- Add actions: approve, reject, publish, bulk-approve, bulk-reject
- Роуты: `GET /moderation`, `GET /moderation/{id}/view`, `POST /moderation/{id}/approve`, `POST /moderation/{id}/reject`, `POST /moderation/{id}/publish`, `POST /moderation/bulk-approve`, `POST /moderation/bulk-reject`

## Files changed
- `src/web/routes/moderation.py` — новый роутер
- `src/web/templates/moderation.html` — страница очереди
- `src/web/templates/moderation/view.html` — страница просмотра
- `src/web/assembly.py` — регистрация роута

## Why
UI для модерации сгенерированного контента перед публикацией. Позволяет:
- Просматривать черновики с фильтром по пайплайну
- Одобрять/отклонять отдельные черновики
- Массовое одобрение/отклонение
- Публиковать одобренные черновики

## Verification
```bash
# Запуск сервера
python -m src.main serve

# Открыть http://localhost:8000/moderation
```

## Notes
- Это PR #5 из 10-пайплайн плана
- Зависит от PR #117 (merged) для `moderation_status` и методов репозитория