### PR TITLE
feat: add CLI publish/queue/approve/reject commands (#122)

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -11,6 +11,7 @@ from src.services.pipeline_service import (
     PipelineTargetRef,
     PipelineValidationError,
 )
+from src.services.publish_service import PublishService
 
 
 def _parse_target_refs(values: list[str]) -> list[PipelineTargetRef]:
@@ -27,9 +28,19 @@ def _parse_target_refs(values: list[str]) -> list[PipelineTargetRef]:
     return refs
 
 
+def _preview_text(value: str | None, limit: int = 60) -> str:
+    if not value:
+        return "—"
+    compact = " ".join(value.split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3]}..."
+
+
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
-        _, db = await runtime.init_db(args.config)
+        config, db = await runtime.init_db(args.config)
+        pool = None
         try:
             svc = PipelineService(db)
 
@@ -197,7 +208,80 @@ def run(args: argparse.Namespace) -> None:
                 except Exception as exc:
                     await db.repos.generation_runs.set_status(run_id, "failed")
                     print(f"Generation failed: {exc}")
+
+            elif args.pipeline_action == "queue":
+                pipeline = await svc.get(args.id)
+                if pipeline is None:
+                    print(f"Pipeline id={args.id} not found")
+                    return
+                runs = await db.repos.generation_runs.list_pending_moderation(
+                    pipeline_id=args.id,
+                    limit=args.limit,
+                )
+                if not runs:
+                    print(f"No pending moderation runs for pipeline id={args.id}")
+                    return
+                print(f"{'Run ID':<8} {'Status':<12} {'Created':<19} Preview")
+                print("-" * 80)
+                for run in runs:
+                    created_at = (
+                        run.created_at.strftime("%Y-%m-%d %H:%M:%S") if run.created_at else "—"
+                    )
+                    print(
+                        f"{run.id or 0:<8} {run.moderation_status:<12} "
+                        f"{created_at:<19} {_preview_text(run.generated_text)}"
+                    )
+
+            elif args.pipeline_action == "approve":
+                run = await db.repos.generation_runs.get(args.run_id)
+                if run is None:
+                    print(f"Run id={args.run_id} not found")
+                    return
+                await db.repos.generation_runs.set_moderation_status(args.run_id, "approved")
+                print(f"Approved run id={args.run_id}")
+
+            elif args.pipeline_action == "reject":
+                run = await db.repos.generation_runs.get(args.run_id)
+                if run is None:
+                    print(f"Run id={args.run_id} not found")
+                    return
+                await db.repos.generation_runs.set_moderation_status(args.run_id, "rejected")
+                print(f"Rejected run id={args.run_id}")
+
+            elif args.pipeline_action == "publish":
+                run = await db.repos.generation_runs.get(args.run_id)
+                if run is None:
+                    print(f"Run id={args.run_id} not found")
+                    return
+                if run.pipeline_id is None:
+                    print(f"Run id={args.run_id} has no pipeline")
+                    return
+
+                pipeline = await svc.get(run.pipeline_id)
+                if pipeline is None:
+                    print(f"Pipeline id={run.pipeline_id} not found")
+                    return
+
+                _, pool = await runtime.init_pool(config, db)
+                if not pool.clients:
+                    print("ERROR: Нет доступных аккаунтов Telegram.")
+                    return
+
+                publish_service = PublishService(db, pool)
+                results = await publish_service.publish_run(run, pipeline)
+                if not results or not all(result.success for result in results):
+                    print(f"Failed to publish run id={args.run_id}")
+                    for result in results:
+                        if not result.success:
+                            print(f"  - {result.error or 'Unknown publish error'}")
+                    return
+
+                print(
+                    f"Published run id={args.run_id} to {len(results)} target(s)"
+                )
         finally:
+            if pool is not None:
+                await pool.disconnect_all()
             await db.close()
 
     asyncio.run(_run())

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -275,6 +275,19 @@ def build_parser() -> argparse.ArgumentParser:
         "--temperature", type=float, default=0.0, help="Sampling temperature for generation"
     )
 
+    pipeline_queue = pipeline_sub.add_parser("queue", help="Show moderation queue")
+    pipeline_queue.add_argument("id", type=int, help="Pipeline id")
+    pipeline_queue.add_argument("--limit", type=int, default=20, help="Max runs to show")
+
+    pipeline_publish = pipeline_sub.add_parser("publish", help="Publish a generation run")
+    pipeline_publish.add_argument("run_id", type=int, help="Run id to publish")
+
+    pipeline_approve = pipeline_sub.add_parser("approve", help="Approve a generation run")
+    pipeline_approve.add_argument("run_id", type=int, help="Run id to approve")
+
+    pipeline_reject = pipeline_sub.add_parser("reject", help="Reject a generation run")
+    pipeline_reject.add_argument("run_id", type=int, help="Run id to reject")
+
     acc_parser = sub.add_parser("account", help="Account management")
     acc_sub = acc_parser.add_subparsers(dest="account_action")
     acc_sub.add_parser("list", help="List accounts")

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.config import AppConfig
 from src.database import Database
-from src.models import Account, Channel
+from src.models import Account, Channel, ContentPipeline, PipelineTarget
+from src.services.publish_service import PublishResult
 
 
 def _ns(**kwargs) -> argparse.Namespace:
@@ -90,3 +91,98 @@ def test_pipeline_show_not_found(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "not found" in out
+
+
+def test_pipeline_queue_approve_reject_and_publish(tmp_path, capsys):
+    db_path = str(tmp_path / "cli_pipeline_actions.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="Digest",
+                prompt_template="Summarize {source_messages}",
+                publish_mode="moderated",
+            ),
+            source_channel_ids=[1001],
+            targets=[
+                PipelineTarget(
+                    pipeline_id=0,
+                    phone="+100",
+                    dialog_id=77,
+                    title="Target A",
+                    dialog_type="channel",
+                )
+            ],
+        )
+    )
+    run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
+    asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated draft for CLI"))
+    asyncio.run(db.close())
+
+    async def fake_init_db(_config_path: str):
+        config = AppConfig()
+        database = Database(db_path)
+        await database.initialize()
+        return config, database
+
+    async def fake_init_pool(_config, _db):
+        pool = MagicMock()
+        pool.clients = {"+100": object()}
+        pool.disconnect_all = AsyncMock()
+        return MagicMock(), pool
+
+    class FakePublishService:
+        def __init__(self, db, pool):
+            self.db = db
+            self.pool = pool
+
+        async def publish_run(self, run, pipeline):
+            return [PublishResult(success=True, message_id=123)]
+
+    with (
+        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        patch("src.cli.commands.pipeline.runtime.init_pool", side_effect=fake_init_pool),
+        patch("src.cli.commands.pipeline.PublishService", FakePublishService),
+    ):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="queue", id=pipeline_id, limit=20))
+        run(_ns(pipeline_action="approve", run_id=run_id))
+        run(_ns(pipeline_action="publish", run_id=run_id))
+        run(_ns(pipeline_action="reject", run_id=run_id))
+
+    out = capsys.readouterr().out
+    assert f"{run_id}" in out
+    assert f"Approved run id={run_id}" in out
+    assert f"Published run id={run_id} to 1 target(s)" in out
+    assert f"Rejected run id={run_id}" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    run_after = asyncio.run(verify_db.repos.generation_runs.get(run_id))
+    asyncio.run(verify_db.close())
+    assert run_after is not None
+    assert run_after.moderation_status == "rejected"
+
+
+def test_pipeline_publish_not_found(tmp_path, capsys):
+    db_path = str(tmp_path / "cli_pipeline_publish_not_found.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    asyncio.run(db.close())
+
+    async def fake_init_db(_config_path: str):
+        config = AppConfig()
+        database = Database(db_path)
+        await database.initialize()
+        return config, database
+
+    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="publish", run_id=999))
+
+    out = capsys.readouterr().out
+    assert "Run id=999 not found" in out


### PR DESCRIPTION
## Summary
- Add `pipeline queue <id>` — показать очередь модерации для пайплайна
- Add `pipeline publish <run_id>` — опубликовать одобренный run
- Add `pipeline approve <run_id>` — одобрить run
- Add `pipeline reject <run_id>` — отклонить run

## Files changed
- `src/cli/parser.py` — новые subcommands
- `src/cli/commands/pipeline.py` — обработчики

## Why
CLI parity для управления очередью модерации. Позволяет:
- Просматривать очередь без веб-интерфейса
- Одобрять/отклонять/публиковать черновики

## Usage
```bash
# Показать очередь
python -m src.main pipeline queue 1

# Одобрить
python -m src.main pipeline approve 123

# Опубликовать
python -m src.main pipeline publish 123

# Отклонить
python -m src.main pipeline reject 123
```

## Notes
- Это PR #8 из 10-пайплайн плана
- Зависит от PR #117 (moderation_status)