### PR TITLE
perf: fix N+1 query in pipelines page, add batch job lookup (#151)

### DIFF
--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -141,7 +141,17 @@ class SchedulerManager:
                         return getattr(job, "next_run_time", None)
             except Exception:
                 return None
-            return None
+        return None
+
+    def get_all_jobs_next_run(self) -> dict[str, object]:
+        """Return dict of job_id -> next_run_time for all scheduled jobs."""
+        if self._scheduler is None:
+            return {}
+        try:
+            jobs = self._scheduler.get_jobs()
+            return {job.id: getattr(job, "next_run_time", None) for job in jobs}
+        except Exception:
+            return {}
 
     async def trigger_now(self) -> dict:
         return await self._run_collection()

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -58,19 +58,18 @@ async def _page_context(request: Request) -> dict:
             logger.warning("Failed to refresh dialog cache for %s", selected_phone, exc_info=True)
     cached_dialogs = await svc.list_cached_dialogs_by_phone()
     items = await svc.get_with_relations()
-    # gather next_run times for pipelines
+    # gather next_run times for pipelines (batch query)
     next_runs = {}
     try:
         scheduler = deps.get_scheduler(request)
+        all_jobs = scheduler.get_all_jobs_next_run()
         for item in items:
             pipeline = item.pipeline
             if pipeline.id is None:
                 continue
-            try:
-                nr = scheduler.get_job_next_run(f"pipeline_run_{pipeline.id}")
-                next_runs[pipeline.id] = nr.isoformat() if nr else None
-            except Exception:
-                next_runs[pipeline.id] = None
+            job_id = f"pipeline_run_{pipeline.id}"
+            nr = all_jobs.get(job_id)
+            next_runs[pipeline.id] = nr.isoformat() if nr else None
     except Exception:
         next_runs = {}
     return {


### PR DESCRIPTION
## Summary
- Add `get_all_jobs_next_run()` to `SchedulerManager` — batch получение всех job next_run times
- Fix N+1 в `_page_context()` — вместо N вызовов `get_job_next_run` теперь один вызов `get_all_jobs_next_run`
- Убирает N запросов к scheduler при отображении страницы пайплайнов

## Files changed
- `src/scheduler/manager.py` — новый batch метод
- `src/web/routes/pipelines.py` — использование batch метода

## Why
На странице со списком пайплайнов было N+1 запросов к scheduler (по одному на каждый пайплайн). Batch запрос снижает это до 1.

## Notes
- Это PR #9 из 10-пайплайн плана