### PR TITLE
feat: add ContentAnalyticsService and dashboard (#127 Phase 1)

### DIFF
--- a/src/services/content_analytics_service.py
+++ b/src/services/content_analytics_service.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from src.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineStats:
+    pipeline_id: int
+    pipeline_name: str
+    total_generations: int
+    total_published: int
+    total_rejected: int
+    pending_moderation: int
+    success_rate: float
+
+
+@dataclass
+class DailyStats:
+    date: str
+    generations: int
+    publications: int
+    rejections: int
+
+
+class ContentAnalyticsService:
+    """Service for content generation and publication analytics.
+    
+    Provides:
+    - Per-pipeline statistics (generations, publications, rejections)
+    - Daily stats over time period
+    - Success rate calculations
+    """
+
+    def __init__(self, db: Database):
+        self._db = db
+
+    async def get_pipeline_stats(self, pipeline_id: int | None = None) -> list[PipelineStats]:
+        """Get statistics for all pipelines or a specific one.
+        
+        Args:
+            pipeline_id: Optional specific pipeline ID, or None for all
+            
+        Returns:
+            List of PipelineStats for each pipeline
+        """
+        if pipeline_id is not None:
+            pipelines = await self._db.repos.content_pipelines.get_by_id(pipeline_id)
+            pipelines = [pipelines] if pipelines else []
+        else:
+            pipelines = await self._db.repos.content_pipelines.get_all()
+
+        results: list[PipelineStats] = []
+        for pipeline in pipelines:
+            if pipeline.id is None:
+                continue
+            
+            runs = await self._db.repos.generation_runs.list_by_pipeline(pipeline.id, limit=1000)
+            
+            total_generations = len(runs)
+            total_published = sum(1 for r in runs if r.moderation_status == "published" or r.published_at is not None)
+            total_rejected = sum(1 for r in runs if r.moderation_status == "rejected")
+            pending_moderation = sum(1 for r in runs if r.moderation_status == "pending")
+            
+            completed = total_generations - sum(1 for r in runs if r.status == "pending" or r.status == "running")
+            success_rate = (completed / total_generations * 100) if total_generations > 0 else 0.0
+            
+            results.append(PipelineStats(
+                pipeline_id=pipeline.id,
+                pipeline_name=pipeline.name,
+                total_generations=total_generations,
+                total_published=total_published,
+                total_rejected=total_rejected,
+                pending_moderation=pending_moderation,
+                success_rate=success_rate,
+            ))
+        
+        return results
+
+    async def get_daily_stats(
+        self,
+        days: int = 30,
+        pipeline_id: int | None = None,
+    ) -> list[DailyStats]:
+        """Get daily statistics for the past N days.
+        
+        Args:
+            days: Number of days to look back
+            pipeline_id: Optional filter by pipeline
+            
+        Returns:
+            List of DailyStats, one per day
+        """
+        results: list[DailyStats] = []
+        now = datetime.now(timezone.utc)
+        
+        for i in range(days):
+            day_start = (now - timedelta(days=days - 1 - i)).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            day_end = day_start + timedelta(days=1)
+            day_str = day_start.strftime("%Y-%m-%d")
+            
+            if pipeline_id is not None:
+                runs = await self._db.repos.generation_runs.list_by_pipeline(
+                    pipeline_id, limit=1000
+                )
+            else:
+                runs = await self._db.repos.generation_runs.list_pending_moderation(
+                    limit=10000
+                )
+                all_runs = await self._db.repos.generation_runs.list_by_pipeline(
+                    (await self._db.repos.content_pipelines.get_all())[0].id if await self._db.repos.content_pipelines.get_all() else 0,
+                    limit=10000
+                ) if await self._db.repos.content_pipelines.get_all() else []
+                runs = all_runs
+            
+            generations = sum(
+                1 for r in runs
+                if r.created_at and day_start <= r.created_at < day_end
+            )
+            publications = sum(
+                1 for r in runs
+                if r.published_at and day_start <= r.published_at < day_end
+            )
+            rejections = sum(
+                1 for r in runs
+                if r.moderation_status == "rejected"
+                and r.updated_at and day_start <= r.updated_at < day_end
+            )
+            
+            results.append(DailyStats(
+                date=day_str,
+                generations=generations,
+                publications=publications,
+                rejections=rejections,
+            ))
+        
+        return results
+
+    async def get_summary(self) -> dict:
+        """Get overall summary statistics.
+        
+        Returns:
+            Dict with total_generations, total_published, total_pending, total_rejected
+        """
+        pipelines = await self._db.repos.content_pipelines.get_all()
+        
+        total_generations = 0
+        total_published = 0
+        total_pending = 0
+        total_rejected = 0
+        
+        for pipeline in pipelines:
+            if pipeline.id is None:
+                continue
+            stats = await self.get_pipeline_stats(pipeline.id)
+            if stats:
+                s = stats[0]
+                total_generations += s.total_generations
+                total_published += s.total_published
+                total_pending += s.pending_moderation
+                total_rejected += s.total_rejected
+        
+        return {
+            "total_generations": total_generations,
+            "total_published": total_published,
+            "total_pending": total_pending,
+            "total_rejected": total_rejected,
+            "pipelines_count": len(pipelines),
+        }

--- a/src/services/content_analytics_service.py
+++ b/src/services/content_analytics_service.py
@@ -30,7 +30,7 @@ class DailyStats:
 
 class ContentAnalyticsService:
     """Service for content generation and publication analytics.
-    
+
     Provides:
     - Per-pipeline statistics (generations, publications, rejections)
     - Daily stats over time period
@@ -40,46 +40,91 @@ class ContentAnalyticsService:
     def __init__(self, db: Database):
         self._db = db
 
+    async def _load_pipeline_rows(self, pipeline_id: int | None = None) -> list[dict]:
+        sql = """
+            SELECT
+                p.id AS pipeline_id,
+                p.name AS pipeline_name,
+                COUNT(gr.id) AS total_generations,
+                COALESCE(SUM(
+                    CASE
+                        WHEN gr.published_at IS NOT NULL OR gr.moderation_status = 'published'
+                        THEN 1 ELSE 0
+                    END
+                ), 0) AS total_published,
+                COALESCE(SUM(
+                    CASE WHEN gr.moderation_status = 'rejected' THEN 1 ELSE 0 END
+                ), 0) AS total_rejected,
+                COALESCE(SUM(
+                    CASE WHEN gr.moderation_status = 'pending' THEN 1 ELSE 0 END
+                ), 0) AS pending_moderation
+            FROM content_pipelines p
+            LEFT JOIN generation_runs gr ON gr.pipeline_id = p.id
+        """
+        params: tuple[object, ...] = ()
+        if pipeline_id is not None:
+            sql += " WHERE p.id = ?"
+            params = (pipeline_id,)
+        sql += " GROUP BY p.id, p.name ORDER BY p.id"
+        return await self._db.execute_fetchall(sql, params)
+
+    async def _load_runs_in_window(
+        self,
+        start: datetime,
+        end: datetime,
+        pipeline_id: int | None = None,
+    ) -> list:
+        sql = """
+            SELECT id, pipeline_id, created_at, published_at, updated_at, moderation_status
+            FROM generation_runs
+            WHERE (
+                (created_at IS NOT NULL AND created_at >= ? AND created_at < ?)
+                OR (published_at IS NOT NULL AND published_at >= ? AND published_at < ?)
+                OR (updated_at IS NOT NULL AND updated_at >= ? AND updated_at < ?)
+            )
+        """
+        params: tuple[object, ...] = (
+            start.isoformat(),
+            end.isoformat(),
+            start.isoformat(),
+            end.isoformat(),
+            start.isoformat(),
+            end.isoformat(),
+        )
+        if pipeline_id is not None:
+            sql += " AND pipeline_id = ?"
+            params += (pipeline_id,)
+        return await self._db.execute_fetchall(sql, params)
+
     async def get_pipeline_stats(self, pipeline_id: int | None = None) -> list[PipelineStats]:
         """Get statistics for all pipelines or a specific one.
-        
+
         Args:
             pipeline_id: Optional specific pipeline ID, or None for all
-            
+
         Returns:
             List of PipelineStats for each pipeline
         """
-        if pipeline_id is not None:
-            pipelines = await self._db.repos.content_pipelines.get_by_id(pipeline_id)
-            pipelines = [pipelines] if pipelines else []
-        else:
-            pipelines = await self._db.repos.content_pipelines.get_all()
-
         results: list[PipelineStats] = []
-        for pipeline in pipelines:
-            if pipeline.id is None:
-                continue
-            
-            runs = await self._db.repos.generation_runs.list_by_pipeline(pipeline.id, limit=1000)
-            
-            total_generations = len(runs)
-            total_published = sum(1 for r in runs if r.moderation_status == "published" or r.published_at is not None)
-            total_rejected = sum(1 for r in runs if r.moderation_status == "rejected")
-            pending_moderation = sum(1 for r in runs if r.moderation_status == "pending")
-            
-            completed = total_generations - sum(1 for r in runs if r.status == "pending" or r.status == "running")
-            success_rate = (completed / total_generations * 100) if total_generations > 0 else 0.0
-            
+        for row in await self._load_pipeline_rows(pipeline_id):
+            total_generations = int(row["total_generations"] or 0)
+            total_published = int(row["total_published"] or 0)
+            total_rejected = int(row["total_rejected"] or 0)
+            pending_moderation = int(row["pending_moderation"] or 0)
+            success_rate = (
+                total_published / total_generations * 100 if total_generations > 0 else 0.0
+            )
+
             results.append(PipelineStats(
-                pipeline_id=pipeline.id,
-                pipeline_name=pipeline.name,
+                pipeline_id=row["pipeline_id"],
+                pipeline_name=row["pipeline_name"],
                 total_generations=total_generations,
                 total_published=total_published,
                 total_rejected=total_rejected,
                 pending_moderation=pending_moderation,
                 success_rate=success_rate,
             ))
-        
+
         return results
 
     async def get_daily_stats(
@@ -88,89 +133,67 @@ class ContentAnalyticsService:
         pipeline_id: int | None = None,
     ) -> list[DailyStats]:
         """Get daily statistics for the past N days.
-        
+
         Args:
             days: Number of days to look back
             pipeline_id: Optional filter by pipeline
-            
+
         Returns:
             List of DailyStats, one per day
         """
-        results: list[DailyStats] = []
         now = datetime.now(timezone.utc)
-        
+        window_start = (now - timedelta(days=days - 1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        window_end = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        runs = await self._load_runs_in_window(window_start, window_end, pipeline_id)
+
+        results: list[DailyStats] = []
         for i in range(days):
             day_start = (now - timedelta(days=days - 1 - i)).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
             day_end = day_start + timedelta(days=1)
             day_str = day_start.strftime("%Y-%m-%d")
-            
-            if pipeline_id is not None:
-                runs = await self._db.repos.generation_runs.list_by_pipeline(
-                    pipeline_id, limit=1000
-                )
-            else:
-                runs = await self._db.repos.generation_runs.list_pending_moderation(
-                    limit=10000
-                )
-                all_runs = await self._db.repos.generation_runs.list_by_pipeline(
-                    (await self._db.repos.content_pipelines.get_all())[0].id if await self._db.repos.content_pipelines.get_all() else 0,
-                    limit=10000
-                ) if await self._db.repos.content_pipelines.get_all() else []
-                runs = all_runs
-            
+
             generations = sum(
                 1 for r in runs
-                if r.created_at and day_start <= r.created_at < day_end
+                if r["created_at"]
+                and day_start <= datetime.fromisoformat(r["created_at"]) < day_end
             )
             publications = sum(
                 1 for r in runs
-                if r.published_at and day_start <= r.published_at < day_end
+                if r["published_at"]
+                and day_start <= datetime.fromisoformat(r["published_at"]) < day_end
             )
             rejections = sum(
                 1 for r in runs
-                if r.moderation_status == "rejected"
-                and r.updated_at and day_start <= r.updated_at < day_end
+                if r["moderation_status"] == "rejected"
+                and r["updated_at"]
+                and day_start <= datetime.fromisoformat(r["updated_at"]) < day_end
             )
-            
+
             results.append(DailyStats(
                 date=day_str,
                 generations=generations,
                 publications=publications,
                 rejections=rejections,
             ))
-        
+
         return results
 
     async def get_summary(self) -> dict:
         """Get overall summary statistics.
-        
+
         Returns:
             Dict with total_generations, total_published, total_pending, total_rejected
         """
-        pipelines = await self._db.repos.content_pipelines.get_all()
-        
-        total_generations = 0
-        total_published = 0
-        total_pending = 0
-        total_rejected = 0
-        
-        for pipeline in pipelines:
-            if pipeline.id is None:
-                continue
-            stats = await self.get_pipeline_stats(pipeline.id)
-            if stats:
-                s = stats[0]
-                total_generations += s.total_generations
-                total_published += s.total_published
-                total_pending += s.pending_moderation
-                total_rejected += s.total_rejected
-        
+        rows = await self._load_pipeline_rows()
+
         return {
-            "total_generations": total_generations,
-            "total_published": total_published,
-            "total_pending": total_pending,
-            "total_rejected": total_rejected,
-            "pipelines_count": len(pipelines),
+            "total_generations": sum(int(row["total_generations"] or 0) for row in rows),
+            "total_published": sum(int(row["total_published"] or 0) for row in rows),
+            "total_pending": sum(int(row["pending_moderation"] or 0) for row in rows),
+            "total_rejected": sum(int(row["total_rejected"] or 0) for row in rows),
+            "pipelines_count": len(rows),
         }

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -44,10 +44,10 @@ async def content_analytics_page(request: Request):
     """Render content analytics dashboard page."""
     db = deps.get_db(request)
     analytics = ContentAnalyticsService(db)
-    
+
     summary = await analytics.get_summary()
     pipeline_stats = await analytics.get_pipeline_stats()
-    
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "analytics/content.html",

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.services.content_analytics_service import ContentAnalyticsService
 from src.web import deps
 
 router = APIRouter()
@@ -36,3 +37,50 @@ async def analytics_page(
             "limit": limit,
         },
     )
+
+
+@router.get("/content", response_class=HTMLResponse)
+async def content_analytics_page(request: Request):
+    """Render content analytics dashboard page."""
+    db = deps.get_db(request)
+    analytics = ContentAnalyticsService(db)
+    
+    summary = await analytics.get_summary()
+    pipeline_stats = await analytics.get_pipeline_stats()
+    
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "analytics/content.html",
+        {
+            "summary": summary,
+            "pipeline_stats": pipeline_stats,
+        },
+    )
+
+
+@router.get("/content/api/summary")
+async def api_content_summary(request: Request):
+    """Get content summary statistics as JSON."""
+    db = deps.get_db(request)
+    analytics = ContentAnalyticsService(db)
+    return JSONResponse(await analytics.get_summary())
+
+
+@router.get("/content/api/pipelines")
+async def api_pipeline_stats(request: Request, pipeline_id: int | None = None):
+    """Get pipeline statistics as JSON."""
+    db = deps.get_db(request)
+    analytics = ContentAnalyticsService(db)
+    stats = await analytics.get_pipeline_stats(pipeline_id)
+    return JSONResponse([
+        {
+            "pipeline_id": s.pipeline_id,
+            "pipeline_name": s.pipeline_name,
+            "total_generations": s.total_generations,
+            "total_published": s.total_published,
+            "total_rejected": s.total_rejected,
+            "pending_moderation": s.pending_moderation,
+            "success_rate": s.success_rate,
+        }
+        for s in stats
+    ])

--- a/src/web/templates/analytics/content.html
+++ b/src/web/templates/analytics/content.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+
+{% block title %}Content Analytics{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <h1 class="h3 mb-4">Content Analytics</h1>
+
+    <div class="row mb-4">
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h2 class="h4">{{ summary.total_generations }}</h2>
+                    <p class="text-muted mb-0">Generations</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h2 class="h4 text-success">{{ summary.total_published }}</h2>
+                    <p class="text-muted mb-0">Published</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h2 class="h4 text-warning">{{ summary.total_pending }}</h2>
+                    <p class="text-muted mb-0">Pending</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h2 class="h4 text-danger">{{ summary.total_rejected }}</h2>
+                    <p class="text-muted mb-0">Rejected</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h5 class="mb-0">Pipeline Statistics</h5>
+        </div>
+        <div class="card-body">
+            {% if pipeline_stats %}
+            <div class="table-responsive">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Pipeline</th>
+                            <th>Generated</th>
+                            <th>Published</th>
+                            <th>Rejected</th>
+                            <th>Pending</th>
+                            <th>Success Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for stat in pipeline_stats %}
+                        <tr>
+                            <td>
+                                <a href="/pipelines/{{ stat.pipeline_id }}">{{ stat.pipeline_name }}</a>
+                            </td>
+                            <td>{{ stat.total_generations }}</td>
+                            <td class="text-success">{{ stat.total_published }}</td>
+                            <td class="text-danger">{{ stat.total_rejected }}</td>
+                            <td class="text-warning">{{ stat.pending_moderation }}</td>
+                            <td>
+                                <div class="progress" style="height: 20px;">
+                                    <div class="progress-bar" role="progressbar" 
+                                         style="width: {{ stat.success_rate }}%;" 
+                                         aria-valuenow="{{ stat.success_rate }}" 
+                                         aria-valuemin="0" 
+                                         aria-valuemax="100">
+                                        {{ "%.1f"|format(stat.success_rate) }}%
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+            <p class="text-muted">No pipelines configured.</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="mt-3">
+        <a href="/moderation" class="btn btn-outline-primary">Moderation Queue</a>
+        <a href="/pipelines" class="btn btn-outline-secondary">Pipelines</a>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_content_analytics_service.py
+++ b/tests/test_content_analytics_service.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models import ContentPipeline, PipelineGenerationBackend, PipelinePublishMode
+from src.services.content_analytics_service import ContentAnalyticsService
+
+
+async def _create_pipeline(db, name: str) -> int:
+    return await db.repos.content_pipelines.add(
+        ContentPipeline(
+            name=name,
+            prompt_template=f"{name} prompt",
+            llm_model="gpt-test",
+            image_model=None,
+            publish_mode=PipelinePublishMode.MODERATED,
+            generation_backend=PipelineGenerationBackend.CHAIN,
+            is_active=True,
+            last_generated_id=0,
+            generate_interval_minutes=60,
+        ),
+        source_channel_ids=[],
+        targets=[],
+    )
+
+
+async def _set_run_times(
+    db,
+    run_id: int,
+    *,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    published_at: datetime | None = None,
+) -> None:
+    await db.execute(
+        """
+        UPDATE generation_runs
+        SET created_at = COALESCE(?, created_at),
+            updated_at = COALESCE(?, updated_at),
+            published_at = COALESCE(?, published_at)
+        WHERE id = ?
+        """,
+        (
+            created_at.isoformat() if created_at else None,
+            updated_at.isoformat() if updated_at else None,
+            published_at.isoformat() if published_at else None,
+            run_id,
+        ),
+    )
+    await db.db.commit()
+
+
+@pytest.mark.asyncio
+async def test_content_analytics_summary_and_pipeline_stats(db):
+    analytics = ContentAnalyticsService(db)
+    pipeline_a = await _create_pipeline(db, "Pipeline A")
+    pipeline_b = await _create_pipeline(db, "Pipeline B")
+
+    published_run = await db.repos.generation_runs.create_run(pipeline_a, "published")
+    await db.repos.generation_runs.save_result(published_run, "post")
+    await db.repos.generation_runs.set_published_at(published_run)
+
+    rejected_run = await db.repos.generation_runs.create_run(pipeline_a, "rejected")
+    await db.repos.generation_runs.save_result(rejected_run, "post")
+    await db.repos.generation_runs.set_moderation_status(rejected_run, "rejected")
+
+    pending_run = await db.repos.generation_runs.create_run(pipeline_b, "pending")
+    await db.repos.generation_runs.save_result(pending_run, "draft")
+
+    summary = await analytics.get_summary()
+    stats = await analytics.get_pipeline_stats()
+
+    assert summary == {
+        "total_generations": 3,
+        "total_published": 1,
+        "total_pending": 1,
+        "total_rejected": 1,
+        "pipelines_count": 2,
+    }
+
+    assert [(row.pipeline_id, row.total_generations, row.total_published) for row in stats] == [
+        (pipeline_a, 2, 1),
+        (pipeline_b, 1, 0),
+    ]
+    assert stats[0].total_rejected == 1
+    assert stats[0].pending_moderation == 0
+    assert stats[0].success_rate == 50.0
+    assert stats[1].pending_moderation == 1
+    assert stats[1].success_rate == 0.0
+
+
+@pytest.mark.asyncio
+async def test_content_analytics_daily_stats_aggregate_all_pipelines(db):
+    analytics = ContentAnalyticsService(db)
+    pipeline_a = await _create_pipeline(db, "Pipeline A")
+    pipeline_b = await _create_pipeline(db, "Pipeline B")
+    now = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+    day_one = now - timedelta(days=1)
+
+    published_run = await db.repos.generation_runs.create_run(pipeline_a, "published")
+    await db.repos.generation_runs.save_result(published_run, "post")
+    await db.repos.generation_runs.set_published_at(published_run)
+    await _set_run_times(
+        db,
+        published_run,
+        created_at=day_one,
+        updated_at=day_one + timedelta(hours=1),
+        published_at=day_one + timedelta(hours=2),
+    )
+
+    rejected_run = await db.repos.generation_runs.create_run(pipeline_b, "rejected")
+    await db.repos.generation_runs.save_result(rejected_run, "post")
+    await db.repos.generation_runs.set_moderation_status(rejected_run, "rejected")
+    await _set_run_times(
+        db,
+        rejected_run,
+        created_at=now,
+        updated_at=now + timedelta(hours=1),
+    )
+
+    stats = await analytics.get_daily_stats(days=2)
+
+    assert [row.date for row in stats] == [
+        day_one.strftime("%Y-%m-%d"),
+        now.strftime("%Y-%m-%d"),
+    ]
+    assert stats[0].generations == 1
+    assert stats[0].publications == 1
+    assert stats[0].rejections == 0
+    assert stats[1].generations == 1
+    assert stats[1].publications == 0
+    assert stats[1].rejections == 1


### PR DESCRIPTION
## Summary
- Add `ContentAnalyticsService` — сервис для аналитики генерации контента
- Добавлены роуты: `/analytics/content`, `/analytics/content/api/summary`, `/analytics/content/api/pipelines`
- Dashboard с метриками: generations, published, pending, rejected
- Статистика по пайплайнам с success rate

## Files changed
- `src/services/content_analytics_service.py` — новый сервис
- `src/web/routes/analytics.py` — новые роуты
- `src/web/templates/analytics/content.html` — dashboard UI

## Why
Phase 1 аналитики для отслеживания:
- Общего количества генераций
- Успешных публикаций
- Отклонённых черновиков
- Очереди на модерацию
- Success rate по пайплайнам

## Notes
- This is PR #5 of milestone 0.1.18 (Phase 1 of #127)
- Depends on PR #117 (moderation_status)
- Future phases: engagement comparison, cost tracking