### PR TITLE
Fix session cursor cleanup and pipeline CLI test doubles

### DIFF
--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -79,7 +79,10 @@ class Database:
                OR session_string LIKE 'enc:v2:%'
             LIMIT 1
             """)
-        return bool(await cur.fetchone())
+        try:
+            return bool(await cur.fetchone())
+        finally:
+            await cur.close()
 
     def _resolve_sqlite_vec_path(self) -> str | None:
         if self._sqlite_vec_path:

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -230,7 +230,7 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, capsys):
         return config, database
 
     class FakeContentGenerationService:
-        def __init__(self, db, engine, agent_manager=None):
+        def __init__(self, db, engine, agent_manager=None, **kwargs):
             self.db = db
             self.engine = engine
             self.agent_manager = agent_manager
@@ -308,7 +308,7 @@ def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, capsys)
             captured["config"] = config
 
     class FakeContentGenerationService:
-        def __init__(self, db, engine, agent_manager=None):
+        def __init__(self, db, engine, agent_manager=None, **kwargs):
             captured["agent_manager"] = agent_manager
 
         async def generate(self, pipeline, model=None, max_tokens=512, temperature=0.7):


### PR DESCRIPTION
## Summary
- close the cursor used by `Database._has_encrypted_sessions()` after fetching the row
- update pipeline CLI test doubles to accept new optional service kwargs
- leave out the unneeded database test warning suppression

## Testing
- pytest -q tests/test_pipeline_cli.py -k "pipeline_generate_prints_draft_preview or pipeline_generate_wires_agent_manager_for_deep_agents"
- pytest -q tests/test_database.py -k "initialize_fails_without_key_when_encrypted_sessions_exist"