### PR TITLE
perf: cache scheduler jobs with 5s TTL (#151)

### DIFF
--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -150,11 +150,11 @@ class SchedulerManager:
 
     def get_all_jobs_next_run(self) -> dict[str, object]:
         """Return dict of job_id -> next_run_time for all scheduled jobs (TTL-cached 5s)."""
+        if self._scheduler is None:
+            return {}
         now = time.monotonic()
         if now - self._jobs_cache_ts < 5.0:
             return self._jobs_cache
-        if self._scheduler is None:
-            return {}
         try:
             jobs = self._scheduler.get_jobs()
             self._jobs_cache = {job.id: getattr(job, "next_run_time", None) for job in jobs}

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -40,6 +41,8 @@ class SchedulerManager:
         self._photo_auto_job_id = "photo_auto"
         self._current_interval_minutes: int = config.collect_interval_minutes
         self._bg_task: asyncio.Task | None = None
+        self._jobs_cache: dict[str, object] = {}
+        self._jobs_cache_ts: float = 0.0
 
     @property
     def is_running(self) -> bool:
@@ -146,12 +149,17 @@ class SchedulerManager:
         return None
 
     def get_all_jobs_next_run(self) -> dict[str, object]:
-        """Return dict of job_id -> next_run_time for all scheduled jobs."""
+        """Return dict of job_id -> next_run_time for all scheduled jobs (TTL-cached 5s)."""
+        now = time.monotonic()
+        if now - self._jobs_cache_ts < 5.0:
+            return self._jobs_cache
         if self._scheduler is None:
             return {}
         try:
             jobs = self._scheduler.get_jobs()
-            return {job.id: getattr(job, "next_run_time", None) for job in jobs}
+            self._jobs_cache = {job.id: getattr(job, "next_run_time", None) for job in jobs}
+            self._jobs_cache_ts = now
+            return self._jobs_cache
         except Exception:
             return {}
 


### PR DESCRIPTION
## Summary
- Adds TTL cache (5 seconds) to `SchedulerManager.get_all_jobs_next_run()`
- Avoids repeated `APScheduler.get_jobs()` calls on every HTTP request that calls `_page_context()`
- Cache stored in `_jobs_cache` / `_jobs_cache_ts` instance fields using `time.monotonic()`

## Test plan
- [ ] Verify scheduler jobs still appear correctly in web UI
- [ ] Verify cache refreshes after 5 seconds

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)