### PR TITLE
test: add DB assertions to filter purge/hard-delete tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,12 @@ pip install -e ".[dev]"
 # Run the web server
 python -m src.main serve [--web-pass PASS]
 
- # Lint
- ruff check src/ tests/ conftest.py
- 
+# Lint
+ruff check src/ tests/ conftest.py
+
+# Auto-fix lint issues
+ruff check --fix src/ tests/ conftest.py
+
 # Run parallel-safe tests (all available CPUs minus one worker)
 pytest tests/ -v -m "not aiosqlite_serial" -n auto
 
@@ -55,11 +58,11 @@ python -m src.main analytics summary|export
 
 Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline** → **SQLite**
 
-- CLI (`src/main.py`) and Web (`src/web/`) are parallel entry points to the same logic
+- CLI (`src/main.py` → `src/cli/commands/`) and Web (`src/web/`) are parallel entry points to the same logic
 - Telegram layer: `ClientPool` manages multi-account connections, `Collector` fetches messages, `Notifier` sends alerts
 - Search layer: `SearchEngine` (local DB), `AISearchEngine` (LLM-powered)
 - Scheduler: APScheduler wrapper (`src/scheduler/manager.py`) triggers periodic collection
-- DB: single SQLite file via aiosqlite (`src/database.py`), schema auto-created on init
+- DB: single SQLite file via aiosqlite; schema in `src/database/schema.py`, migrations in `src/database/migrations.py`, connection in `src/database/connection.py`
 - Filters: `ChannelAnalyzer` (`src/filters/analyzer.py`) scores channels by uniqueness, subscriber ratio, cross-channel spam, language; thresholds in `src/filters/criteria.py`
 - Collection service (`src/services/collection_service.py`): orchestration layer between web/CLI and Collector/Queue — handles enqueue logic, stats collection
 - Parsers (`src/parsers.py`): identifier extraction for channel import — t.me links, @usernames, negative IDs; file parsing (txt/csv/xlsx)
@@ -69,6 +72,23 @@ Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline**
 - **Content pipelines**: `PipelineService` + `ContentGenerationService` orchestrate generate → draft → notify → publish flow; tracked via `generation_runs` DB table
 - **Photo publishing**: `PhotoAutoUploadService` / `PhotoPublishService` / `PhotoTaskService` — separate upload, schedule, publish tasks tracked in DB
 - **LangChain integration**: optional, lazy-loaded via `src/services/langchain_adapters.py`; enabled with `USE_LANGCHAIN=1`
+
+### Database access pattern
+
+Repositories are accessed via `db.repos.<repo_name>.<method>()`. The `Database` facade exposes a `repos` bundle:
+
+```python
+db.repos.channels.get_all()
+db.repos.generation_runs.list_pending_moderation(pipeline_id=1)
+db.repos.settings.get("key")
+```
+
+Each repository has a `_to_<model>(row)` static helper that maps `aiosqlite.Row` → Pydantic model, including safe `.keys()` checks for nullable/optional columns added by migrations.
+
+### Web app wiring
+
+- `src/web/assembly.py` — `register_routes()` imports and mounts all routers; `configure_app()` binds the `AppContainer` to `app.state.*`
+- `src/web/container.py` — `AppContainer` dataclass aggregates all services; injected into FastAPI `app.state` at startup; accessed in routes via `src/web/deps.py` helpers (`deps.get_db()`, `deps.get_templates()`, etc.)
 
 ## Key Patterns
 
@@ -80,7 +100,7 @@ Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline**
 - **Cancellation**: `Collector._cancel_event` is an `asyncio.Event`, checked every 10 messages in the iter loop and at each channel boundary
 - **Session tokens**: custom HMAC-SHA256 signed tokens in `src/web/session.py` — payload is `{user, exp}`, secret persisted in DB settings table, cookie max-age 30 days (`Secure` on HTTPS)
 - **CollectionQueue** (`src/collection_queue.py`): `asyncio.Queue` + single worker task, task status (`pending/running/completed/failed/cancelled`) tracked in DB
-- **DB migrations**: `_migrate()` in database.py uses `PRAGMA table_info` to detect missing columns and issues `ALTER TABLE ADD COLUMN` as needed
+- **DB migrations**: `_migrate()` in `src/database/migrations.py` uses `PRAGMA table_info` to detect missing columns and issues `ALTER TABLE ADD COLUMN` as needed
 - **Keyword matching**: plain text (case-insensitive substring) and regex (`re.IGNORECASE`)
 - **Channel filters**: `ChannelAnalyzer` checks `low_uniqueness`, `low_subscriber_ratio`, `cross_channel_spam`, `non_cyrillic`, `chat_noise`; filtered channels skipped during collection unless `force=True`
 - **Collection service**: `enqueue_channel_by_pk(pk, force)` respects `is_filtered` flag; `enqueue_all_channels()` uses `full=False` for incremental collection
@@ -89,7 +109,7 @@ Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline**
 - **aiosqlite connection cleanup**: in tests using raw `aiosqlite.connect()`, always wrap in `try/finally` with `await conn.close()` — an unclosed worker-thread blocks pytest process exit
 - **SQL in triple-quoted strings**: Python does NOT concatenate adjacent string literals inside `"""..."""`; for values with quotes use parameterized `execute()` with `?`-placeholders, not inline values in `executescript()`
 - **pytest-timeout**: global 30s timeout configured in `pyproject.toml` (`timeout = 30`), dependency `pytest-timeout` in `[dev]`
-- **Test parallelism split**: root `conftest.py` auto-marks tests as `aiosqlite_serial` if they use the `cli_db` fixture or contain `import aiosqlite` (raw aiosqlite calls); everything else runs with `-n auto`. Currently ~724 parallel / ~111 serial.
+- **Test parallelism split**: root `conftest.py` auto-marks tests as `aiosqlite_serial` if they use the `cli_db` fixture or contain `import aiosqlite` (raw aiosqlite calls); everything else runs with `-n auto`
 - **`db` fixture is `:memory:`**: `tests/conftest.py` provides `db` as `Database(":memory:")`. The `real_pool_harness_factory` fixture depends on `db` and passes it to the harness. Any fixture/test that creates a web app and calls `real_pool_harness_factory()` **must** accept `db` as a parameter and use it for `app.state.db` — creating a separate `Database(tmp_path / "test.db")` would give the app and the harness different DB instances, breaking account lookups.
 
 ## Conventions

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -28,6 +28,7 @@ TELEGRAM_TIMEOUT = 30
 TELEGRAM_DIALOG_TIMEOUT = 120
 TELEGRAM_SEARCH_TIMEOUT = 120
 SHORT_FLOOD_WAIT_RETRY_SEC = 30
+# keep in sync with _run_telegram_live_checks check ordering
 _TG_CHECKS_AFTER_POOL = [
     "tg_users_info",
     "tg_get_dialogs",
@@ -337,7 +338,7 @@ async def _check_pipeline_list(db: Database) -> CheckResult:
 
 async def _check_notification_bot(db: Database) -> CheckResult:
     try:
-        cur = await db.repos.notification_bots._db.execute("SELECT COUNT(*) FROM notification_bots")
+        cur = await db._db.execute("SELECT COUNT(*) FROM notification_bots")
         row = await cur.fetchone()
         count = row[0] if row else 0
         detail = f"{count} configured" if count else "none configured"

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -25,8 +25,21 @@ from src.telegram.flood_wait import FloodWaitInfo, HandledFloodWaitError, run_wi
 logger = logging.getLogger(__name__)
 
 TELEGRAM_TIMEOUT = 30
+TELEGRAM_DIALOG_TIMEOUT = 120
 TELEGRAM_SEARCH_TIMEOUT = 120
 SHORT_FLOOD_WAIT_RETRY_SEC = 30
+_TG_CHECKS_AFTER_POOL = [
+    "tg_users_info",
+    "tg_get_dialogs",
+    "tg_resolve_channel",
+    "tg_warm_dialog_cache",
+    "tg_iter_messages",
+    "tg_channel_stats",
+    "tg_search_my_chats",
+    "tg_search_in_channel",
+    "tg_search_premium",
+    "tg_search_quota",
+]
 # src/cli/commands/test.py → src/cli/commands → src/cli → src → repo root
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SERIAL_PYTEST_COMMAND = (sys.executable, "-m", "pytest", "tests", "-q")
@@ -312,6 +325,33 @@ async def _check_recent_searches(db) -> CheckResult:
         return CheckResult("recent_searches", Status.PASS, f"{len(searches)} entries")
     except Exception as exc:
         return CheckResult("recent_searches", Status.FAIL, str(exc))
+
+
+async def _check_pipeline_list(db: Database) -> CheckResult:
+    try:
+        pipelines = await db.repos.content_pipelines.get_all()
+        return CheckResult("pipeline_list", Status.PASS, f"{len(pipelines)} pipelines")
+    except Exception as exc:
+        return CheckResult("pipeline_list", Status.FAIL, str(exc))
+
+
+async def _check_notification_bot(db: Database) -> CheckResult:
+    try:
+        cur = await db.repos.notification_bots._db.execute("SELECT COUNT(*) FROM notification_bots")
+        row = await cur.fetchone()
+        count = row[0] if row else 0
+        detail = f"{count} configured" if count else "none configured"
+        return CheckResult("notification_bot", Status.PASS, detail)
+    except Exception as exc:
+        return CheckResult("notification_bot", Status.FAIL, str(exc))
+
+
+async def _check_photo_tasks(db: Database) -> CheckResult:
+    try:
+        batches = await db.repos.photo_loader.list_batches()
+        return CheckResult("photo_tasks", Status.PASS, f"{len(batches)} batches")
+    except Exception as exc:
+        return CheckResult("photo_tasks", Status.FAIL, str(exc))
 
 
 # ---------------------------------------------------------------------------
@@ -660,6 +700,7 @@ async def _run_warm_dialog_cache_step(pool) -> CheckResult:
         try:
             await _tg_call(
                 session.warm_dialog_cache(),
+                TELEGRAM_DIALOG_TIMEOUT,
                 pool=pool,
                 phone=phone,
                 check_name=check_name,
@@ -676,8 +717,17 @@ async def _run_warm_dialog_cache_step(pool) -> CheckResult:
             except TelegramLiveStepSkipError as stop_exc:
                 return CheckResult(check_name, Status.SKIP, str(stop_exc))
             continue
+        except TimeoutError as exc:
+            return CheckResult(check_name, Status.FAIL, _format_exception(exc))
+        except Exception as exc:
+            return CheckResult(check_name, Status.FAIL, _format_exception(exc))
         finally:
             await pool.release_client(phone)
+
+
+def _skip_remaining_tg_checks(results: list, reason: str, names: list[str]) -> None:
+    for name in names:
+        results.append(CheckResult(name, Status.SKIP, reason))
 
 
 async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
@@ -706,6 +756,7 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         clients = pool.clients if hasattr(pool, "clients") else {}
         if not clients:
             results.append(CheckResult("tg_pool_init", Status.SKIP, "No accounts connected"))
+            _skip_remaining_tg_checks(results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
             await _cleanup_telegram(pool, copy_db, tmp_path, results)
             return results
         await _disable_flood_auto_sleep(pool)
@@ -714,10 +765,12 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
         )
     except HandledFloodWaitError as exc:
         results.append(CheckResult("tg_pool_init", Status.SKIP, exc.info.detail))
+        _skip_remaining_tg_checks(results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
         await _cleanup_telegram(pool, copy_db, tmp_path, results)
         return results
     except Exception as exc:
         results.append(CheckResult("tg_pool_init", Status.FAIL, _format_exception(exc)))
+        _skip_remaining_tg_checks(results, "pool init failed", _TG_CHECKS_AFTER_POOL)
         await _cleanup_telegram(pool, copy_db, tmp_path, results)
         return results
 
@@ -1063,6 +1116,9 @@ def run(args: argparse.Namespace) -> None:
                     _check_local_search(db),
                     _check_collection_tasks(db),
                     _check_recent_searches(db),
+                    _check_pipeline_list(db),
+                    _check_notification_bot(db),
+                    _check_photo_tasks(db),
                 ]
                 for coro in db_checks:
                     check_result = await coro

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -338,9 +338,7 @@ async def _check_pipeline_list(db: Database) -> CheckResult:
 
 async def _check_notification_bot(db: Database) -> CheckResult:
     try:
-        cur = await db._db.execute("SELECT COUNT(*) FROM notification_bots")
-        row = await cur.fetchone()
-        count = row[0] if row else 0
+        count = await db.repos.notification_bots.count()
         detail = f"{count} configured" if count else "none configured"
         return CheckResult("notification_bot", Status.PASS, detail)
     except Exception as exc:

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -717,8 +717,6 @@ async def _run_warm_dialog_cache_step(pool) -> CheckResult:
             except TelegramLiveStepSkipError as stop_exc:
                 return CheckResult(check_name, Status.SKIP, str(stop_exc))
             continue
-        except TimeoutError as exc:
-            return CheckResult(check_name, Status.FAIL, _format_exception(exc))
         except Exception as exc:
             return CheckResult(check_name, Status.FAIL, _format_exception(exc))
         finally:

--- a/src/database/repositories/notification_bots.py
+++ b/src/database/repositories/notification_bots.py
@@ -37,6 +37,11 @@ class NotificationBotsRepository:
         await self._db.commit()
         return cur.lastrowid or 0
 
+    async def count(self) -> int:
+        cur = await self._db.execute("SELECT COUNT(*) FROM notification_bots")
+        row = await cur.fetchone()
+        return row[0] if row else 0
+
     async def delete_bot(self, tg_user_id: int) -> None:
         await self._db.execute(
             "DELETE FROM notification_bots WHERE tg_user_id = ?",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Collection, Mapping
+from unittest.mock import patch
 
 import pytest
 from telethon import TelegramClient
@@ -42,6 +44,28 @@ async def db():
     await database.initialize()
     yield database
     await database.close()
+
+
+@pytest.fixture
+def cli_db(tmp_path):
+    """Sync fixture: real SQLite for CLI tests."""
+    db_path = str(tmp_path / "cli_test.db")
+    database = Database(db_path)
+    asyncio.run(database.initialize())
+    yield database
+    asyncio.run(database.close())
+
+
+@pytest.fixture
+def cli_env(cli_db):
+    """Patch runtime.init_db to return real db without loading config.yaml."""
+    config = AppConfig()
+
+    async def fake_init_db(config_path: str):
+        return config, cli_db
+
+    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+        yield cli_db
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import asyncio
 import base64
 import hashlib
 from contextlib import asynccontextmanager
@@ -18,7 +20,7 @@ from httpx import ASGITransport, AsyncClient
 from src.collection_queue import CollectionQueue
 from src.config import AppConfig, TelegramRuntimeConfig
 from src.database import Database
-from src.models import Account
+from src.models import Account, Channel
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -26,6 +28,18 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.web.app import create_app
+
+
+def cli_ns(**kwargs) -> argparse.Namespace:
+    """Build a CLI Namespace with config default for use in CLI tests."""
+    defaults = {"config": "config.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def cli_add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
+    """Synchronously insert a channel row and return its PK."""
+    return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))
 
 
 class AsyncIterEmpty:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,28 +18,6 @@ NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.fixture
-def cli_db(tmp_path):
-    """Sync fixture: real SQLite for CLI tests."""
-    db_path = str(tmp_path / "cli_test.db")
-    database = Database(db_path)
-    asyncio.run(database.initialize())
-    yield database
-    asyncio.run(database.close())
-
-
-@pytest.fixture
-def cli_env(cli_db):
-    """Patch runtime.init_db to return real db without loading config.yaml."""
-    config = AppConfig()
-
-    async def fake_init_db(config_path: str):
-        return config, cli_db
-
-    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
-        yield cli_db
-
-
-@pytest.fixture
 def cli_env_with_pool(cli_env):
     """Additionally patch runtime.init_pool to return a pool with no clients."""
     fake_pool = AsyncMock()
@@ -352,10 +330,10 @@ class TestCLIFilter:
         assert "FilteredCh" in out
 
         rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (999,))
-        assert rows[0]["cnt"] == 0  # сообщения удалены
+        assert rows[0]["cnt"] == 0  # messages deleted
 
         rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM channels WHERE channel_id=?", (999,))
-        assert rows[0]["cnt"] == 1  # канал остался
+        assert rows[0]["cnt"] == 1  # channel row retained
 
     def test_purge_with_pks(self, cli_env, capsys):
         ch1_pk = _add_channel(cli_env, channel_id=990, title="PurgeCh1")
@@ -373,10 +351,10 @@ class TestCLIFilter:
         assert "PurgeCh2" not in out
 
         rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (990,))
-        assert rows[0]["cnt"] == 0  # сообщения ch1 удалены
+        assert rows[0]["cnt"] == 0  # ch1 messages deleted
 
         rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (991,))
-        assert rows[0]["cnt"] == 1  # сообщения ch2 остались
+        assert rows[0]["cnt"] == 1  # ch2 messages untouched
 
     def test_hard_delete_requires_dev_mode(self, cli_env, capsys):
         from src.cli.commands.filter import run

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,18 @@ def _add_message(db: Database, channel_id: int = 100, message_id: int = 1, text:
     )
 
 
+def _query_db(db, sql: str, params: tuple = ()) -> list[dict]:
+    """Read DB state after cli run() has closed the aiosqlite connection."""
+    import sqlite3
+
+    conn = sqlite3.connect(db._db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # account
 # ---------------------------------------------------------------------------
@@ -321,6 +333,82 @@ class TestCLIFilter:
         run(_ns(filter_action="precheck"))
         assert "Pre-filter applied" in capsys.readouterr().out
 
+    def test_purge_no_filtered(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="purge", pks=None))
+        assert "No filtered channels affected." in capsys.readouterr().out
+
+    def test_purge_filtered_channel(self, cli_env, capsys):
+        ch_pk = _add_channel(cli_env, channel_id=999, title="FilteredCh")
+        asyncio.run(cli_env.set_channel_filtered(ch_pk, True))
+        _add_message(cli_env, channel_id=999, message_id=1, text="to be deleted")
+
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="purge", pks=None))
+        out = capsys.readouterr().out
+        assert "1 channels" in out
+        assert "FilteredCh" in out
+
+        rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (999,))
+        assert rows[0]["cnt"] == 0  # сообщения удалены
+
+        rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM channels WHERE channel_id=?", (999,))
+        assert rows[0]["cnt"] == 1  # канал остался
+
+    def test_purge_with_pks(self, cli_env, capsys):
+        ch1_pk = _add_channel(cli_env, channel_id=990, title="PurgeCh1")
+        ch2_pk = _add_channel(cli_env, channel_id=991, title="PurgeCh2")
+        asyncio.run(cli_env.set_channel_filtered(ch1_pk, True))
+        asyncio.run(cli_env.set_channel_filtered(ch2_pk, True))
+        _add_message(cli_env, channel_id=990, message_id=1)
+        _add_message(cli_env, channel_id=991, message_id=1)
+
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="purge", pks=str(ch1_pk)))
+        out = capsys.readouterr().out
+        assert "PurgeCh1" in out
+        assert "PurgeCh2" not in out
+
+        rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (990,))
+        assert rows[0]["cnt"] == 0  # сообщения ch1 удалены
+
+        rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id=?", (991,))
+        assert rows[0]["cnt"] == 1  # сообщения ch2 остались
+
+    def test_hard_delete_requires_dev_mode(self, cli_env, capsys):
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="hard-delete", pks=None, yes=True))
+        assert "dev" in capsys.readouterr().out.lower()
+
+    def test_hard_delete_removes_channel(self, cli_env, capsys):
+        asyncio.run(cli_env.set_setting("agent_dev_mode_enabled", "1"))
+        ch_pk = _add_channel(cli_env, channel_id=888, title="ToDelete")
+        asyncio.run(cli_env.set_channel_filtered(ch_pk, True))
+
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="hard-delete", pks=None, yes=True))
+        out = capsys.readouterr().out
+        # _print_result prints channel title when deletion succeeds
+        assert "ToDelete" in out
+        assert "1 channels" in out
+
+        rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM channels WHERE channel_id=?", (888,))
+        assert rows[0]["cnt"] == 0  # канал удалён
+
+    def test_hard_delete_no_filtered(self, cli_env, capsys):
+        asyncio.run(cli_env.set_setting("agent_dev_mode_enabled", "1"))
+        _add_channel(cli_env, channel_id=887, title="NotFiltered")
+
+        from src.cli.commands.filter import run
+
+        run(_ns(filter_action="hard-delete", pks=None, yes=True))
+        assert "No filtered channels to delete." in capsys.readouterr().out
+
 
 # ---------------------------------------------------------------------------
 # search
@@ -562,6 +650,29 @@ class TestCLISearchQuery:
 
         run(_sq_ns(search_query_action="delete", id=sq_id))
         assert "Deleted search query" in capsys.readouterr().out
+
+    def test_stats_no_data(self, cli_env, capsys):
+        sq_id = _add_search_query(cli_env, query="bitcoin")
+        from src.cli.commands.search_query import run
+
+        run(_sq_ns(search_query_action="stats", id=sq_id, days=30))
+        assert "No stats found." in capsys.readouterr().out
+
+    def test_stats_with_data(self, cli_env, capsys):
+        from src.database.bundles import SearchQueryBundle
+
+        sq_id = _add_search_query(cli_env, query="bitcoin")
+
+        async def _record():
+            bundle = SearchQueryBundle.from_database(cli_env)
+            await bundle.record_stat(sq_id, 42)
+
+        asyncio.run(_record())
+
+        from src.cli.commands.search_query import run
+
+        run(_sq_ns(search_query_action="stats", id=sq_id, days=30))
+        assert "42" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,9 @@ import pytest
 
 from src.config import AppConfig
 from src.database import Database
-from src.models import Account, Channel, Message
+from src.models import Account, Message
+from tests.helpers import cli_add_channel as _add_channel
+from tests.helpers import cli_ns as _ns
 
 NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
@@ -33,19 +35,9 @@ def cli_env_with_pool(cli_env):
         yield cli_env
 
 
-def _ns(**kwargs) -> argparse.Namespace:
-    """Build Namespace with defaults."""
-    defaults = {"config": "config.yaml"}
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
-
-
 def _add_account(db: Database, phone: str = "+70001112233") -> int:
     return asyncio.run(db.add_account(Account(phone=phone, session_string="sess")))
 
-
-def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
-    return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))
 
 
 def _add_message(db: Database, channel_id: int = 100, message_id: int = 1, text: str = "hello"):
@@ -376,7 +368,7 @@ class TestCLIFilter:
         assert "1 channels" in out
 
         rows = _query_db(cli_env, "SELECT COUNT(*) AS cnt FROM channels WHERE channel_id=?", (888,))
-        assert rows[0]["cnt"] == 0  # канал удалён
+        assert rows[0]["cnt"] == 0  # channel deleted
 
     def test_hard_delete_no_filtered(self, cli_env, capsys):
         asyncio.run(cli_env.set_setting("agent_dev_mode_enabled", "1"))

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = pytest.mark.aiosqlite_serial
+
 from src.config import AppConfig
 from src.database import Database
 from src.models import Channel, Message

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -5,39 +5,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import patch
 
-import pytest
-
-pytestmark = pytest.mark.aiosqlite_serial
-
-from src.config import AppConfig
 from src.database import Database
 from src.models import Channel, Message
 
 NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-
-@pytest.fixture
-def cli_db(tmp_path):
-    """Sync fixture: real SQLite for CLI tests."""
-    db_path = str(tmp_path / "cli_analytics_test.db")
-    database = Database(db_path)
-    asyncio.run(database.initialize())
-    yield database
-    asyncio.run(database.close())
-
-
-@pytest.fixture
-def cli_env(cli_db):
-    """Patch runtime.init_db to return real db without loading config.yaml."""
-    config = AppConfig()
-
-    async def fake_init_db(config_path: str):
-        return config, cli_db
-
-    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
-        yield cli_db
 
 
 def _ns(**kwargs) -> argparse.Namespace:

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -1,0 +1,149 @@
+"""CLI analytics command tests — top/content-types/hourly subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.config import AppConfig
+from src.database import Database
+from src.models import Channel, Message
+
+NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def cli_db(tmp_path):
+    """Sync fixture: real SQLite for CLI tests."""
+    db_path = str(tmp_path / "cli_analytics_test.db")
+    database = Database(db_path)
+    asyncio.run(database.initialize())
+    yield database
+    asyncio.run(database.close())
+
+
+@pytest.fixture
+def cli_env(cli_db):
+    """Patch runtime.init_db to return real db without loading config.yaml."""
+    config = AppConfig()
+
+    async def fake_init_db(config_path: str):
+        return config, cli_db
+
+    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+        yield cli_db
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    defaults = {"config": "config.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
+    return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))
+
+
+def _insert_message(db: Database, msg: Message) -> None:
+    asyncio.run(db.insert_message(msg))
+
+
+class TestCLIAnalytics:
+    def test_top_empty(self, cli_env, capsys):
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="top", limit=20, date_from=None, date_to=None))
+        assert "No messages with reactions found." in capsys.readouterr().out
+
+    def test_top_with_reactions(self, cli_env, capsys):
+        _add_channel(cli_env, channel_id=700, title="ReactCh")
+        _insert_message(
+            cli_env,
+            Message(
+                channel_id=700,
+                message_id=1,
+                text="hot post",
+                date=NOW,
+                reactions_json='[{"emoji": "👍", "count": 10}]',
+            ),
+        )
+
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="top", limit=20, date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "10" in out
+        assert "hot post" in out
+
+    def test_top_limit(self, cli_env, capsys):
+        _add_channel(cli_env, channel_id=701, title="LimitCh")
+        for i in range(5):
+            _insert_message(
+                cli_env,
+                Message(
+                    channel_id=701,
+                    message_id=i + 1,
+                    text=f"msg{i + 1:04d}",
+                    date=NOW,
+                    reactions_json=f'[{{"emoji": "👍", "count": {i + 1}}}]',
+                ),
+            )
+
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="top", limit=2, date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "msg0005" in out   # top post (count=5)
+        assert "msg0001" not in out  # lowest post not in top 2
+
+    def test_content_types_empty(self, cli_env, capsys):
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="content-types", date_from=None, date_to=None))
+        assert "No data." in capsys.readouterr().out
+
+    def test_content_types_with_data(self, cli_env, capsys):
+        _add_channel(cli_env, channel_id=702, title="MediaCh")
+        _insert_message(
+            cli_env,
+            Message(channel_id=702, message_id=1, text="text post", date=NOW),
+        )
+        _insert_message(
+            cli_env,
+            Message(channel_id=702, message_id=2, media_type="photo", date=NOW),
+        )
+
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="content-types", date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "photo" in out
+        assert "text" in out
+
+    def test_hourly_empty(self, cli_env, capsys):
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="hourly", date_from=None, date_to=None))
+        assert "No data." in capsys.readouterr().out
+
+    def test_hourly_with_data(self, cli_env, capsys):
+        _add_channel(cli_env, channel_id=703, title="HourlyCh")
+        _insert_message(
+            cli_env,
+            Message(
+                channel_id=703,
+                message_id=1,
+                text="morning post",
+                date=datetime(2025, 1, 1, 9, 0, 0, tzinfo=timezone.utc),
+            ),
+        )
+
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="hourly", date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "09:00" in out

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -2,24 +2,15 @@
 
 from __future__ import annotations
 
-import argparse
 import asyncio
 from datetime import datetime, timezone
 
 from src.database import Database
-from src.models import Channel, Message
+from src.models import Message
+from tests.helpers import cli_add_channel as _add_channel
+from tests.helpers import cli_ns as _ns
 
 NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-
-
-def _ns(**kwargs) -> argparse.Namespace:
-    defaults = {"config": "config.yaml"}
-    defaults.update(kwargs)
-    return argparse.Namespace(**defaults)
-
-
-def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
-    return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))
 
 
 def _insert_message(db: Database, msg: Message) -> None:


### PR DESCRIPTION
## Summary
- Add `_query_db()` helper to verify DB state after `cli run()` closes the aiosqlite connection
- Add DB assertions to `test_purge_filtered_channel`, `test_purge_with_pks`, `test_hard_delete_removes_channel`
- Add pipeline/notification/photo task checks and pool-failure skip logic to `src/cli/commands/test.py`
- Add new `tests/test_cli_analytics.py` for analytics CLI coverage

## Test plan
- [ ] `pytest tests/test_cli.py::TestCLIFilter -v` — all 10 tests pass
- [ ] `pytest tests/test_cli.py -v -m aiosqlite_serial` — serial suite passes
- [ ] `pytest tests/test_cli_analytics.py -v -m aiosqlite_serial` — new analytics tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)