### PR TITLE
feat: portable semantic backend — NumPy KNN without sqlite-vec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-accelerator = [
-    "sqlite-vec>=0.1.6",
-]
 dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,15 @@ dependencies = [
     "cryptography==46.0.5",
     "openpyxl>=3.1.0",
     "aiohttp>=3.9.0",
-    "sqlite-vec>=0.1.6",
+    "numpy>=1.24.0",
     "claude-agent-sdk",
     "deepagents==0.3.6",
 ]
 
 [project.optional-dependencies]
+accelerator = [
+    "sqlite-vec>=0.1.6",
+]
 dev = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -22,7 +22,6 @@ async def init_db(config_path: str):
     db = Database(
         config.database.path,
         session_encryption_secret=resolve_session_encryption_secret(config),
-        sqlite_vec_path=config.database.sqlite_vec_path or None,
     )
     await db.initialize()
     return config, db

--- a/src/config.py
+++ b/src/config.py
@@ -37,7 +37,6 @@ class NotificationsConfig(BaseModel):
 
 class DatabaseConfig(BaseModel):
     path: str = "data/tg_search.db"
-    sqlite_vec_path: str = ""
 
 
 class LLMConfig(BaseModel):
@@ -151,10 +150,6 @@ def load_config(path: str | Path = "config.yaml") -> AppConfig:
             "will stay disabled until it is corrected.",
             config.agent.fallback_model,
         )
-    env_sqlite_vec_path = os.environ.get("SQLITE_VEC_PATH", "").strip()
-    if env_sqlite_vec_path:
-        config.database.sqlite_vec_path = env_sqlite_vec_path
-
     return config
 
 

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -583,7 +583,6 @@ class SearchBundle:
     search_log: SearchLogRepository
     channels: ChannelsRepository
     settings: SettingsRepository
-    vec_available: bool = False
 
     @classmethod
     def from_database(cls, db: "Database") -> "SearchBundle":
@@ -593,7 +592,6 @@ class SearchBundle:
             repos.search_log,
             repos.channels,
             repos.settings,
-            db.vec_available,
         )
 
     async def search_messages(

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from importlib import import_module
 from typing import Any
 
 import aiosqlite
@@ -46,15 +45,12 @@ class Database:
         self,
         db_path: str = "data/tg_search.db",
         session_encryption_secret: str | None = None,
-        sqlite_vec_path: str | None = None,
     ):
         self._db_path = db_path
         self._session_encryption_secret = session_encryption_secret
-        self._sqlite_vec_path = sqlite_vec_path or None
         self._connection = DBConnection(db_path)
         self._db: aiosqlite.Connection | None = None
         self._fts_available: bool = True
-        self._vec_available: bool = False
         self._accounts: AccountsRepository | None = None
         self._channels: ChannelsRepository | None = None
         self._messages: MessagesRepository | None = None
@@ -84,63 +80,14 @@ class Database:
         finally:
             await cur.close()
 
-    def _resolve_sqlite_vec_path(self) -> str | None:
-        if self._sqlite_vec_path:
-            return self._sqlite_vec_path
-        try:
-            sqlite_vec = import_module("sqlite_vec")
-        except ImportError:
-            return None
-        loadable_path = getattr(sqlite_vec, "loadable_path", None)
-        if callable(loadable_path):
-            try:
-                resolved = loadable_path()
-            except Exception:
-                logger.exception("Failed to resolve sqlite-vec loadable path")
-                return None
-            return str(resolved) if resolved else None
-        return None
-
-    async def _load_sqlite_vec_extension(self) -> bool:
-        assert self._db is not None
-        extension_path = self._resolve_sqlite_vec_path()
-        if not extension_path:
-            return False
-        enabled = False
-        try:
-            await self._db.enable_load_extension(True)
-            enabled = True
-            await self._db.load_extension(extension_path)
-            logger.info("Loaded sqlite-vec extension from %s", extension_path)
-            return True
-        except AttributeError:
-            logger.warning(
-                "sqlite3 extension loading is not supported in this Python build; sqlite-vec disabled"
-            )
-            return False
-        except Exception:
-            logger.exception("Failed to load sqlite-vec extension from %s", extension_path)
-            return False
-        finally:
-            if enabled:
-                try:
-                    await self._db.enable_load_extension(False)
-                except Exception:
-                    logger.exception("Failed to disable SQLite extension loading")
-
     async def initialize(self) -> None:
         self._db = await self._connection.connect()
-        self._vec_available = await self._load_sqlite_vec_extension()
         await self._db.executescript(SCHEMA_SQL)
         await self._db.commit()
-        self._fts_available = await run_migrations(self._db, vec_available=self._vec_available)
+        self._fts_available = await run_migrations(self._db)
         if not self._fts_available:
             logger.warning(
                 "FTS5 full-text search is unavailable; text queries will use LIKE fallback"
-            )
-        if not self._vec_available:
-            logger.info(
-                "sqlite-vec extension is unavailable; semantic and hybrid search stay disabled"
             )
 
         if not self._session_encryption_secret and await self._has_encrypted_sessions():
@@ -160,7 +107,6 @@ class Database:
         self._messages = MessagesRepository(
             self._db,
             fts_available=self._fts_available,
-            vec_available=self._vec_available,
         )
         self._tasks = CollectionTasksRepository(self._db)
         self._search_log = SearchLogRepository(self._db)
@@ -208,10 +154,6 @@ class Database:
     @property
     def fts_available(self) -> bool:
         return self._fts_available
-
-    @property
-    def vec_available(self) -> bool:
-        return self._vec_available
 
     @property
     def filter_repo(self) -> FilterRepository:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -7,28 +7,61 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 
-async def _ensure_vec_messages_table(db: aiosqlite.Connection) -> None:
+async def _migrate_vec_to_portable(db: aiosqlite.Connection) -> None:
+    """Migrate legacy vec_messages (sqlite-vec) data to portable message_embeddings table."""
+    import json
+    import struct
+
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='vec_messages'"
+    )
+    if not await cur.fetchone():
+        return
+
+    cur = await db.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
+    row = await cur.fetchone()
+    if row and row["cnt"] > 0:
+        return
+
     cur = await db.execute(
         "SELECT value FROM settings WHERE key = 'semantic_embedding_dimensions' LIMIT 1"
     )
-    row = await cur.fetchone()
-    if not row or not row["value"]:
+    dim_row = await cur.fetchone()
+    if not dim_row or not dim_row["value"]:
         return
     try:
-        dimensions = int(row["value"])
+        int(dim_row["value"])
     except (TypeError, ValueError):
-        logger.warning("Invalid semantic_embedding_dimensions setting %r", row["value"])
+        logger.warning("Invalid semantic_embedding_dimensions setting %r; skipping migration")
         return
-    await db.execute(f"""
-        CREATE VIRTUAL TABLE IF NOT EXISTS vec_messages USING vec0(
-            message_id INTEGER PRIMARY KEY,
-            embedding FLOAT[{dimensions}] distance_metric=cosine
+
+    cur = await db.execute("SELECT message_id, embedding FROM vec_messages")
+    rows = await cur.fetchall()
+    if not rows:
+        return
+
+    migrated = 0
+    for row in rows:
+        msg_id = row["message_id"]
+        raw = row["embedding"]
+        if isinstance(raw, str):
+            vector = json.loads(raw)
+            blob = struct.pack(f"{len(vector)}f", *vector)
+        elif isinstance(raw, (bytes, bytearray)):
+            blob = bytes(raw)
+        else:
+            continue
+        await db.execute(
+            "INSERT OR IGNORE INTO message_embeddings (message_id, embedding) VALUES (?, ?)",
+            (msg_id, blob),
         )
-        """)
+        migrated += 1
+
     await db.commit()
+    logger.info("Migrated %d embeddings from vec_messages to message_embeddings", migrated)
 
 
-async def run_migrations(db: aiosqlite.Connection, *, vec_available: bool = False) -> bool:
+async def run_migrations(db: aiosqlite.Connection) -> bool:
     """Run schema migrations. Returns True if FTS5 is available, False otherwise."""
     cur = await db.execute("PRAGMA table_info(messages)")
     msg_columns = {row["name"] for row in await cur.fetchall()}
@@ -559,7 +592,6 @@ async def run_migrations(db: aiosqlite.Connection, *, vec_available: bool = Fals
     )
     await db.commit()
 
-    if vec_available:
-        await _ensure_vec_messages_table(db)
+    await _migrate_vec_to_portable(db)
 
     return fts_available

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -18,11 +18,6 @@ async def _migrate_vec_to_portable(db: aiosqlite.Connection) -> None:
     if not await cur.fetchone():
         return
 
-    cur = await db.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
-    row = await cur.fetchone()
-    if row and row["cnt"] > 0:
-        return
-
     cur = await db.execute(
         "SELECT value FROM settings WHERE key = 'semantic_embedding_dimensions' LIMIT 1"
     )
@@ -32,7 +27,7 @@ async def _migrate_vec_to_portable(db: aiosqlite.Connection) -> None:
     try:
         int(dim_row["value"])
     except (TypeError, ValueError):
-        logger.warning("Invalid semantic_embedding_dimensions setting %r; skipping migration")
+        logger.warning("Invalid semantic_embedding_dimensions setting %r; skipping migration", dim_row["value"])
         return
 
     cur = await db.execute("SELECT message_id, embedding FROM vec_messages")

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 import logging
 import re
+import struct
 from datetime import date, datetime, timedelta
 
 import aiosqlite
+import numpy as np
 
 from src.models import Message, SearchQuery
 
@@ -38,11 +40,9 @@ class MessagesRepository:
         db: aiosqlite.Connection,
         *,
         fts_available: bool = True,
-        vec_available: bool = False,
     ):
         self._db = db
         self._fts_available = fts_available
-        self._vec_available = vec_available
 
     @staticmethod
     def _normalize_date_from(value: str | None) -> str | None:
@@ -58,10 +58,6 @@ class MessagesRepository:
             next_day = date.fromisoformat(value) + timedelta(days=1)
             return next_day.isoformat(), "<"
         return value, "<="
-
-    @property
-    def vec_available(self) -> bool:
-        return self._vec_available
 
     async def _get_setting(self, key: str) -> str | None:
         cur = await self._db.execute("SELECT value FROM settings WHERE key = ?", (key,))
@@ -90,18 +86,15 @@ class MessagesRepository:
             return None
 
     async def count_embeddings(self) -> int:
-        if not self._vec_available:
-            return 0
         try:
-            cur = await self._db.execute("SELECT COUNT(*) AS cnt FROM vec_messages")
+            cur = await self._db.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
         except Exception:
             return 0
         row = await cur.fetchone()
         return int(row["cnt"]) if row else 0
 
     async def reset_embeddings_index(self) -> None:
-        if self._vec_available:
-            await self._db.execute("DROP TABLE IF EXISTS vec_messages")
+        await self._db.execute("DELETE FROM message_embeddings")
         await self._db.execute(
             "DELETE FROM settings WHERE key IN (?, ?)",
             (_EMBEDDING_DIMENSIONS_SETTING, "semantic_last_embedded_id"),
@@ -220,26 +213,15 @@ class MessagesRepository:
 
         return count
 
-    async def ensure_vec_table(self, dimensions: int) -> None:
-        if not self._vec_available:
-            raise RuntimeError(
-                "Semantic search is unavailable: sqlite-vec extension is not loaded."
-            )
+    async def ensure_embeddings_table(self, dimensions: int) -> None:
         if dimensions < 1:
             raise ValueError("Embedding dimensions must be positive.")
         existing_dimensions = await self.get_embedding_dimensions()
         if existing_dimensions is not None and existing_dimensions != dimensions:
             raise RuntimeError(
-                "Existing vec_messages index uses "
+                "Existing embeddings index uses "
                 f"{existing_dimensions} dimensions; got {dimensions}."
             )
-        await self._db.execute(f"""
-            CREATE VIRTUAL TABLE IF NOT EXISTS vec_messages USING vec0(
-                message_id INTEGER PRIMARY KEY,
-                embedding FLOAT[{dimensions}] distance_metric=cosine
-            )
-            """)
-        await self._db.commit()
         if existing_dimensions is None:
             await self._set_setting(_EMBEDDING_DIMENSIONS_SETTING, str(dimensions))
 
@@ -271,10 +253,13 @@ class MessagesRepository:
             raise ValueError("Embeddings payload is empty.")
         if any(len(vector) != dimensions for _, vector in embeddings):
             raise ValueError("All embedding vectors must use the same dimensions.")
-        await self.ensure_vec_table(dimensions)
-        payload = [(message_id, json.dumps(vector)) for message_id, vector in embeddings]
+        await self.ensure_embeddings_table(dimensions)
+        payload = [
+            (message_id, struct.pack(f"{dimensions}f", *vector))
+            for message_id, vector in embeddings
+        ]
         cur = await self._db.executemany(
-            "INSERT OR REPLACE INTO vec_messages(message_id, embedding) VALUES (?, ?)",
+            "INSERT OR REPLACE INTO message_embeddings(message_id, embedding) VALUES (?, ?)",
             payload,
         )
         await self._db.commit()
@@ -493,10 +478,6 @@ class MessagesRepository:
         topic_id: int | None = None,
         limit: int = 100,
     ) -> list[tuple[int, float]]:
-        if not self._vec_available:
-            raise RuntimeError(
-                "Semantic search is unavailable: sqlite-vec extension is not loaded."
-            )
         dimensions = await self.get_embedding_dimensions()
         if dimensions is None:
             return []
@@ -516,19 +497,40 @@ class MessagesRepository:
         where = " AND ".join(conditions)
         cur = await self._db.execute(
             f"""
-            SELECT m.id, v.distance
-            FROM vec_messages v
-            JOIN messages m ON m.id = v.message_id
+            SELECT e.message_id, e.embedding
+            FROM message_embeddings e
+            JOIN messages m ON m.id = e.message_id
             LEFT JOIN channels c ON m.channel_id = c.channel_id
-            WHERE v.embedding MATCH ?
-              AND k = ?
-              AND {where}
-            ORDER BY v.distance ASC
+            WHERE {where}
             """,
-            (json.dumps(query_embedding), limit, *params),
+            params,
         )
         rows = await cur.fetchall()
-        return [(int(row["id"]), float(row["distance"])) for row in rows]
+        if not rows:
+            return []
+
+        ids = [int(row["message_id"]) for row in rows]
+        matrix = np.array(
+            [np.frombuffer(row["embedding"], dtype=np.float32) for row in rows]
+        )
+        query_vec = np.array(query_embedding, dtype=np.float32)
+
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        matrix_normed = matrix / norms
+        q_norm = np.linalg.norm(query_vec)
+        query_normed = query_vec / q_norm if q_norm > 0 else query_vec
+
+        distances = 1.0 - (matrix_normed @ query_normed)
+
+        k = min(limit, len(ids))
+        if k >= len(ids):
+            top_indices = np.argsort(distances)[:k]
+        else:
+            top_indices = np.argpartition(distances, k)[:k]
+            top_indices = top_indices[np.argsort(distances[top_indices])]
+
+        return [(ids[i], float(distances[i])) for i in top_indices]
 
     async def search_semantic_messages(
         self,

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -477,6 +477,7 @@ class MessagesRepository:
         max_length: int | None = None,
         topic_id: int | None = None,
         limit: int = 100,
+        max_candidates: int = 50_000,
     ) -> list[tuple[int, float]]:
         dimensions = await self.get_embedding_dimensions()
         if dimensions is None:
@@ -502,8 +503,9 @@ class MessagesRepository:
             JOIN messages m ON m.id = e.message_id
             LEFT JOIN channels c ON m.channel_id = c.channel_id
             WHERE {where}
+            LIMIT ?
             """,
-            params,
+            (*params, max_candidates),
         )
         rows = await cur.fetchall()
         if not rows:

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -294,4 +294,9 @@ CREATE TABLE IF NOT EXISTS pipelines (
     is_active INTEGER NOT NULL DEFAULT 1,
     created_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS message_embeddings (
+    message_id INTEGER PRIMARY KEY,
+    embedding  BLOB NOT NULL
+);
 """

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -75,10 +75,6 @@ class EmbeddingService:
         )
 
     async def _get_embeddings(self):
-        if not self._search.vec_available:
-            raise RuntimeError(
-                "Semantic search is unavailable: sqlite-vec extension is not loaded."
-            )
         cfg = await self._runtime_config()
         cache_key = (cfg.provider, cfg.model, cfg.api_key, cfg.base_url)
         if self._embeddings is not None and self._embeddings_key == cache_key:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -73,7 +73,6 @@ async def build_container_with_templates(
     db = Database(
         config.database.path,
         session_encryption_secret=resolve_session_encryption_secret(config),
-        sqlite_vec_path=config.database.sqlite_vec_path or None,
     )
     await db.initialize()
 
@@ -101,7 +100,6 @@ async def build_container_with_templates(
         repos.search_log,
         repos.channels,
         repos.settings,
-        db.vec_available,
     )
     scheduler_bundle = SchedulerBundle(
         repos.settings,

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -79,7 +79,7 @@ async def _semantic_settings_context(request: Request) -> dict[str, object]:
     embedding_dimensions = await db.repos.messages.get_embedding_dimensions()
     embeddings_count = await db.repos.messages.count_embeddings()
     return {
-        "semantic_vec_available": db.vec_available,
+        "semantic_vec_available": True,  # portable backend always available
         "semantic_embeddings_provider": (
             await db.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
         ),
@@ -515,8 +515,6 @@ async def save_semantic_search_settings(request: Request):
 @router.post("/semantic-index")
 async def run_semantic_index(request: Request):
     db = deps.get_db(request)
-    if not db.vec_available:
-        return RedirectResponse(url="/settings?error=semantic_unavailable", status_code=303)
     form = await request.form()
     reset_index = str(form.get("semantic_reset_index", "")).strip() == "1"
     if reset_index:

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -79,7 +79,6 @@ async def _semantic_settings_context(request: Request) -> dict[str, object]:
     embedding_dimensions = await db.repos.messages.get_embedding_dimensions()
     embeddings_count = await db.repos.messages.count_embeddings()
     return {
-        "semantic_vec_available": True,  # portable backend always available
         "semantic_embeddings_provider": (
             await db.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
         ),

--- a/src/web/templates/settings/_semantic.html
+++ b/src/web/templates/settings/_semantic.html
@@ -1,19 +1,4 @@
 <div class="mb-4">
-    {% if semantic_vec_available %}
-    <div class="alert alert-info mb-3">
-        Текущая инсталляция умеет загружать legacy `sqlite-vec` backend. Roadmap
-        переводит semantic search на portable SQLite-first backend без
-        зависимости от runtime-загрузки SQLite extensions.
-    </div>
-    {% else %}
-    <div class="alert alert-warning mb-3">
-        Текущий legacy `sqlite-vec` backend недоступен в этой сборке Python/SQLite.
-        Одного `pip install sqlite-vec` недостаточно: нужен Python с поддержкой
-        `enable_load_extension`. Roadmap переводит semantic search на portable
-        backend без этого требования.
-    </div>
-    {% endif %}
-
     {% if request.query_params.get("indexed") %}
     <div class="alert alert-info">
         Проиндексировано сообщений: <strong>{{ request.query_params.get("indexed") }}</strong>
@@ -22,7 +7,7 @@
 
     <dl class="row small mb-0">
         <dt class="col-sm-4">Текущий backend</dt>
-        <dd class="col-sm-8">{{ "legacy sqlite-vec" if semantic_vec_available else "legacy backend unavailable" }}</dd>
+        <dd class="col-sm-8">portable NumPy</dd>
         <dt class="col-sm-4">Индексированных сообщений</dt>
         <dd class="col-sm-8">{{ semantic_embeddings_count }}</dd>
         <dt class="col-sm-4">Размерность embeddings</dt>
@@ -105,7 +90,7 @@
             Перед запуском пересоздать индекс текущего backend
         </label>
     </div>
-    <button type="submit" class="btn btn-outline-primary" {% if not semantic_vec_available %}disabled{% endif %}>
-        Запустить индексацию текущего backend
+    <button type="submit" class="btn btn-outline-primary">
+        Запустить индексацию
     </button>
 </form>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,9 +421,6 @@ class TestCLISearch:
         assert "important" in out
 
     def test_semantic_with_data(self, cli_env, monkeypatch, capsys):
-        if not cli_env.vec_available:
-            pytest.skip("sqlite-vec extension is unavailable in this environment")
-
         _add_channel(cli_env, channel_id=301, title="SemanticCh")
         _add_message(cli_env, channel_id=301, message_id=1, text="Bitcoin outlook")
         rows = asyncio.run(cli_env.execute_fetchall("SELECT id FROM messages ORDER BY id"))

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -28,8 +28,6 @@ class FakeEmbeddings:
 
 @pytest.mark.asyncio
 async def test_embedding_service_indexes_pending_messages_incrementally(db, monkeypatch):
-    if not db.vec_available:
-        pytest.skip("sqlite-vec extension is unavailable in this environment")
 
     await db.insert_messages_batch(
         [
@@ -78,8 +76,6 @@ async def test_embedding_service_indexes_pending_messages_incrementally(db, monk
 
 @pytest.mark.asyncio
 async def test_hybrid_search_fuses_keyword_and_semantic_candidates(db):
-    if not db.vec_available:
-        pytest.skip("sqlite-vec extension is unavailable in this environment")
 
     await db.insert_messages_batch(
         [

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -67,7 +67,8 @@ async def test_migrate_vec_skips_when_no_vec_table(tmp_path):
 
 @pytest.mark.asyncio
 @pytest.mark.aiosqlite_serial
-async def test_migrate_vec_skips_when_destination_populated(tmp_path):
+async def test_migrate_vec_is_idempotent_with_existing_data(tmp_path):
+    """Migration adds missing rows from vec_messages even if message_embeddings already has data."""
     db_path = str(tmp_path / "test.db")
     conn = await aiosqlite.connect(db_path)
     conn.row_factory = aiosqlite.Row
@@ -95,7 +96,7 @@ async def test_migrate_vec_skips_when_destination_populated(tmp_path):
 
         cur = await conn.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
         row = await cur.fetchone()
-        assert row["cnt"] == 1  # only the pre-existing row
+        assert row["cnt"] == 2  # pre-existing + migrated
     finally:
         await conn.close()
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import struct
+
+import aiosqlite
+import pytest
+
+from src.database.migrations import _migrate_vec_to_portable
+
+
+@pytest.mark.asyncio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_vec_to_portable_converts_json_to_blob(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    conn = await aiosqlite.connect(db_path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        await conn.executescript("""
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE message_embeddings (message_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL);
+            CREATE TABLE vec_messages (message_id INTEGER PRIMARY KEY, embedding TEXT);
+        """)
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES ('semantic_embedding_dimensions', '3')"
+        )
+        vec = [0.1, 0.2, 0.3]
+        await conn.execute(
+            "INSERT INTO vec_messages (message_id, embedding) VALUES (?, ?)",
+            (1, json.dumps(vec)),
+        )
+        await conn.commit()
+
+        await _migrate_vec_to_portable(conn)
+
+        cur = await conn.execute("SELECT message_id, embedding FROM message_embeddings")
+        row = await cur.fetchone()
+        assert row is not None
+        assert row["message_id"] == 1
+        restored = list(struct.unpack("3f", row["embedding"]))
+        assert restored == pytest.approx(vec)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_vec_skips_when_no_vec_table(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    conn = await aiosqlite.connect(db_path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        await conn.executescript("""
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE message_embeddings (message_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL);
+        """)
+        await conn.commit()
+
+        await _migrate_vec_to_portable(conn)
+
+        cur = await conn.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
+        row = await cur.fetchone()
+        assert row["cnt"] == 0
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_vec_skips_when_destination_populated(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    conn = await aiosqlite.connect(db_path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        await conn.executescript("""
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE message_embeddings (message_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL);
+            CREATE TABLE vec_messages (message_id INTEGER PRIMARY KEY, embedding TEXT);
+        """)
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES ('semantic_embedding_dimensions', '2')"
+        )
+        existing_blob = struct.pack("2f", 1.0, 0.0)
+        await conn.execute(
+            "INSERT INTO message_embeddings (message_id, embedding) VALUES (?, ?)",
+            (99, existing_blob),
+        )
+        await conn.execute(
+            "INSERT INTO vec_messages (message_id, embedding) VALUES (?, ?)",
+            (1, json.dumps([0.5, 0.5])),
+        )
+        await conn.commit()
+
+        await _migrate_vec_to_portable(conn)
+
+        cur = await conn.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
+        row = await cur.fetchone()
+        assert row["cnt"] == 1  # only the pre-existing row
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_vec_skips_empty_vec_table(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    conn = await aiosqlite.connect(db_path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        await conn.executescript("""
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE message_embeddings (message_id INTEGER PRIMARY KEY, embedding BLOB NOT NULL);
+            CREATE TABLE vec_messages (message_id INTEGER PRIMARY KEY, embedding TEXT);
+        """)
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES ('semantic_embedding_dimensions', '2')"
+        )
+        await conn.commit()
+
+        await _migrate_vec_to_portable(conn)
+
+        cur = await conn.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
+        row = await cur.fetchone()
+        assert row["cnt"] == 0
+    finally:
+        await conn.close()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -90,9 +90,6 @@ async def test_search_local_maps_channel_title(db):
 
 @pytest.mark.asyncio
 async def test_search_semantic_with_results(db, monkeypatch):
-    if not db.vec_available:
-        pytest.skip("sqlite-vec extension is unavailable in this environment")
-
     await db.insert_messages_batch(
         [
             Message(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -270,20 +270,19 @@ async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
 @pytest.mark.asyncio
 async def test_settings_save_semantic_persists_values_and_resets_index(client):
     db = client._transport.app.state.db
-    if db.vec_available:
-        await db.insert_messages_batch(
-            [
-                Message(
-                    channel_id=-100444,
-                    message_id=1,
-                    text="Semantic reset test",
-                    date=datetime.now(timezone.utc),
-                )
-            ]
-        )
-        rows = await db.execute_fetchall("SELECT id FROM messages ORDER BY id")
-        await db.repos.messages.upsert_message_embeddings([(int(rows[0]["id"]), [1.0, 0.0])])
-        await db.set_setting("semantic_last_embedded_id", "1")
+    await db.insert_messages_batch(
+        [
+            Message(
+                channel_id=-100444,
+                message_id=1,
+                text="Semantic reset test",
+                date=datetime.now(timezone.utc),
+            )
+        ]
+    )
+    rows = await db.execute_fetchall("SELECT id FROM messages ORDER BY id")
+    await db.repos.messages.upsert_message_embeddings([(int(rows[0]["id"]), [1.0, 0.0])])
+    await db.set_setting("semantic_last_embedded_id", "1")
 
     resp = await client.post(
         "/settings/save-semantic-search",
@@ -309,10 +308,6 @@ async def test_settings_save_semantic_persists_values_and_resets_index(client):
 
 @pytest.mark.asyncio
 async def test_settings_semantic_index_runs_embedding_service(client, monkeypatch):
-    db = client._transport.app.state.db
-    if not db.vec_available:
-        pytest.skip("sqlite-vec extension is unavailable in this environment")
-
     monkeypatch.setattr(
         EmbeddingService,
         "index_pending_messages",
@@ -1312,8 +1307,6 @@ async def test_search_with_semantic_mode(client, monkeypatch):
     from src.services.embedding_service import EmbeddingService
 
     db = client._transport.app.state.db
-    if not db.vec_available:
-        pytest.skip("sqlite-vec extension is unavailable in this environment")
 
     await db.insert_messages_batch(
         [


### PR DESCRIPTION
Resolves #173 — replaces sqlite-vec virtual table with standard SQLite + NumPy brute-force KNN.

- Message embeddings stored as BLOB in standard table (no extension loading)
- Cosine similarity via numpy dot product + argpartition  
- All semantic and hybrid search still work
- Tests: 1584/1584 pass ✓