### PR TITLE
feat: implement image generation adapters (#116)

### DIFF
--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -1,25 +1,99 @@
 from __future__ import annotations
 
 import logging
+import os
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from src.services.provider_adapters import ImageAdapter
 
 logger = logging.getLogger(__name__)
 
 
 class ImageGenerationService:
-    """Stub image generation service. Returns None until a real provider is wired up."""
+    """Routes image generation requests to provider-specific HTTP adapters.
+
+    Adapters are auto-registered from environment variables at init time.
+    Model strings use ``provider:model_id`` convention (e.g.
+    ``together:black-forest-labs/FLUX.1-schnell``).  Without a prefix the
+    first available adapter is used as fallback.
+    """
 
     def __init__(self) -> None:
-        pass
+        self._adapters: dict[str, ImageAdapter] = {}
+        self._register_from_env()
+
+    # ── public API ──
 
     async def generate(self, model: str | None, text: str) -> str | None:
-        """Return None — image generation is not yet implemented."""
-        logger.warning(
-            "ImageGenerationService.generate() called but not implemented "
-            "(model=%s, prompt_len=%d); returning None",
-            model or "default",
-            len(text),
-        )
-        return None
+        """Generate an image for *text* using *model*.  Returns URL/path or ``None``."""
+        if not text or not self._adapters:
+            return None
+        provider_name, model_id = self._parse_model_string(model)
+        adapter = self._resolve_adapter(provider_name)
+        if adapter is None:
+            logger.warning("No image adapter available for model=%s", model)
+            return None
+        try:
+            return await adapter(text, model_id)
+        except Exception:
+            logger.exception("Image generation failed (model=%s)", model)
+            return None
 
     async def is_available(self) -> bool:
-        return False
+        return len(self._adapters) > 0
+
+    def register_adapter(self, name: str, adapter: ImageAdapter) -> None:
+        """Register an adapter manually (useful for tests)."""
+        self._adapters[name] = adapter
+
+    @property
+    def adapter_names(self) -> list[str]:
+        return list(self._adapters.keys())
+
+    # ── internals ──
+
+    def _register_from_env(self) -> None:
+        from src.services.provider_adapters import (
+            make_huggingface_image_adapter,
+            make_openai_image_adapter,
+            make_replicate_image_adapter,
+            make_together_image_adapter,
+        )
+
+        together_key = os.environ.get("TOGETHER_API_KEY")
+        if together_key:
+            self._adapters["together"] = make_together_image_adapter(together_key)
+
+        hf_key = os.environ.get("HUGGINGFACE_API_KEY") or os.environ.get("HUGGINGFACE_TOKEN")
+        if hf_key:
+            self._adapters["huggingface"] = make_huggingface_image_adapter(hf_key)
+
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if openai_key:
+            self._adapters["openai"] = make_openai_image_adapter(openai_key)
+
+        replicate_token = os.environ.get("REPLICATE_API_TOKEN")
+        if replicate_token:
+            self._adapters["replicate"] = make_replicate_image_adapter(replicate_token)
+
+    @staticmethod
+    def _parse_model_string(model: Optional[str]) -> tuple[Optional[str], str]:
+        """Split ``'provider:model_id'`` → ``(provider, model_id)``.
+
+        If no colon is present, returns ``(None, model)`` so the fallback
+        adapter is used.
+        """
+        if not model:
+            return None, ""
+        if ":" in model:
+            provider, _, model_id = model.partition(":")
+            return provider, model_id
+        return None, model
+
+    def _resolve_adapter(self, provider_name: Optional[str]) -> Optional[ImageAdapter]:
+        if provider_name and provider_name in self._adapters:
+            return self._adapters[provider_name]
+        if self._adapters:
+            return next(iter(self._adapters.values()))
+        return None

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -264,7 +264,7 @@ def make_together_image_adapter(api_key: str) -> ImageAdapter:
                 items = data.get("data")
                 if not items:
                     raise RuntimeError(f"Together image: empty 'data' in response: {data}")
-                return items[0]["url"]
+                return items[0].get("url") or items[0].get("b64_json")
 
     return adapter
 
@@ -321,7 +321,7 @@ def make_openai_image_adapter(api_key: str) -> ImageAdapter:
                 items = data.get("data")
                 if not items:
                     raise RuntimeError(f"OpenAI image: empty 'data' in response: {data}")
-                return items[0]["url"]
+                return items[0].get("url") or items[0].get("b64_json")
 
     return adapter
 
@@ -346,7 +346,9 @@ def make_replicate_image_adapter(api_token: str, timeout: float = 60.0) -> Image
                 prediction = await resp.json()
 
             # Poll for completion
-            poll_url = prediction["urls"]["get"]
+            poll_url = prediction.get("urls", {}).get("get")
+            if not poll_url:
+                raise RuntimeError(f"Replicate: missing poll URL in response: {prediction}")
             elapsed = 0.0
             while elapsed < timeout:
                 await asyncio.sleep(1.0)

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import os
+import uuid
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 import aiohttp
+
+# Type alias for image generation adapters
+ImageAdapter = Callable[[str, str], Awaitable[Optional[str]]]
 
 
 async def _parse_json_for_text(data: Any) -> str:
@@ -232,3 +238,122 @@ def make_ollama(
 
 def make_huggingface(api_token: str) -> Callable[..., Awaitable[str]]:
     return make_huggingface_adapter(api_token)
+
+
+# ── Image generation adapters ──────────────────────────────────────────
+
+
+def make_together_image_adapter(api_key: str) -> ImageAdapter:
+    """Together AI image generation via FLUX models."""
+
+    async def adapter(prompt: str, model: str = "") -> Optional[str]:
+        url = "https://api.together.xyz/v1/images/generations"
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        payload: Dict[str, Any] = {
+            "model": model or "black-forest-labs/FLUX.1-schnell",
+            "prompt": prompt,
+            "n": 1,
+            "steps": 4,
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(f"Together image error {resp.status}: {text}")
+                data = await resp.json()
+                return data["data"][0]["url"]
+
+    return adapter
+
+
+def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/images") -> ImageAdapter:
+    """HuggingFace Inference API — returns binary image, saved to local file."""
+
+    async def adapter(prompt: str, model: str = "") -> Optional[str]:
+        model_id = model or "stabilityai/stable-diffusion-xl-base-1.0"
+        url = f"https://api-inference.huggingface.co/models/{model_id}"
+        headers = {"Authorization": f"Bearer {api_token}"}
+        payload = {"inputs": prompt}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(f"HuggingFace image error {resp.status}: {text}")
+                image_bytes = await resp.read()
+                out = Path(output_dir)
+                out.mkdir(parents=True, exist_ok=True)
+                filename = f"{uuid.uuid4().hex}.png"
+                filepath = out / filename
+                filepath.write_bytes(image_bytes)
+                return str(filepath)
+
+    return adapter
+
+
+def make_openai_image_adapter(api_key: str) -> ImageAdapter:
+    """OpenAI DALL-E image generation."""
+
+    async def adapter(prompt: str, model: str = "") -> Optional[str]:
+        base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
+        url = f"{base.rstrip('/')}/images/generations"
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        payload: Dict[str, Any] = {
+            "model": model or "dall-e-3",
+            "prompt": prompt,
+            "n": 1,
+            "size": "1024x1024",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(f"OpenAI image error {resp.status}: {text}")
+                data = await resp.json()
+                return data["data"][0]["url"]
+
+    return adapter
+
+
+def make_replicate_image_adapter(api_token: str, timeout: float = 60.0) -> ImageAdapter:
+    """Replicate async prediction API with polling."""
+
+    async def adapter(prompt: str, model: str = "") -> Optional[str]:
+        model_id = model or "black-forest-labs/flux-schnell"
+        url = "https://api.replicate.com/v1/predictions"
+        headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
+        payload: Dict[str, Any] = {
+            "version": model_id,
+            "input": {"prompt": prompt},
+        }
+        async with aiohttp.ClientSession() as session:
+            # Create prediction
+            async with session.post(url, json=payload, headers=headers) as resp:
+                if resp.status not in (200, 201):
+                    text = await resp.text()
+                    raise RuntimeError(f"Replicate create error {resp.status}: {text}")
+                prediction = await resp.json()
+
+            # Poll for completion
+            poll_url = prediction["urls"]["get"]
+            elapsed = 0.0
+            while elapsed < timeout:
+                await asyncio.sleep(1.0)
+                elapsed += 1.0
+                async with session.get(poll_url, headers=headers) as resp:
+                    if resp.status != 200:
+                        continue
+                    result = await resp.json()
+                    status = result.get("status")
+                    if status == "succeeded":
+                        output = result.get("output")
+                        if isinstance(output, list) and output:
+                            return output[0]
+                        if isinstance(output, str):
+                            return output
+                        return None
+                    if status in ("failed", "canceled"):
+                        error = result.get("error", "unknown error")
+                        raise RuntimeError(f"Replicate prediction failed: {error}")
+            raise RuntimeError(f"Replicate prediction timed out after {timeout}s")
+
+    return adapter

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -261,7 +261,10 @@ def make_together_image_adapter(api_key: str) -> ImageAdapter:
                     text = await resp.text()
                     raise RuntimeError(f"Together image error {resp.status}: {text}")
                 data = await resp.json()
-                return data["data"][0]["url"]
+                items = data.get("data")
+                if not items:
+                    raise RuntimeError(f"Together image: empty 'data' in response: {data}")
+                return items[0]["url"]
 
     return adapter
 
@@ -279,6 +282,12 @@ def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/image
                 if resp.status != 200:
                     text = await resp.text()
                     raise RuntimeError(f"HuggingFace image error {resp.status}: {text}")
+                content_type = resp.content_type or ""
+                if not content_type.startswith("image/"):
+                    body_preview = (await resp.text())[:200]
+                    raise RuntimeError(
+                        f"HuggingFace image: expected image/* content-type, got {content_type}: {body_preview}"
+                    )
                 image_bytes = await resp.read()
                 out = Path(output_dir)
                 out.mkdir(parents=True, exist_ok=True)
@@ -309,7 +318,10 @@ def make_openai_image_adapter(api_key: str) -> ImageAdapter:
                     text = await resp.text()
                     raise RuntimeError(f"OpenAI image error {resp.status}: {text}")
                 data = await resp.json()
-                return data["data"][0]["url"]
+                items = data.get("data")
+                if not items:
+                    raise RuntimeError(f"OpenAI image: empty 'data' in response: {data}")
+                return items[0]["url"]
 
     return adapter
 
@@ -319,10 +331,10 @@ def make_replicate_image_adapter(api_token: str, timeout: float = 60.0) -> Image
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
         model_id = model or "black-forest-labs/flux-schnell"
-        url = "https://api.replicate.com/v1/predictions"
+        # Use the model route: POST /v1/models/{owner}/{name}/predictions
+        url = f"https://api.replicate.com/v1/models/{model_id}/predictions"
         headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}
         payload: Dict[str, Any] = {
-            "version": model_id,
             "input": {"prompt": prompt},
         }
         async with aiohttp.ClientSession() as session:

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -451,9 +451,14 @@ class UnifiedDispatcher:
             db = self._db
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
+
+            from src.services.image_generation_service import ImageGenerationService
+
+            image_service = ImageGenerationService()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,
             )
@@ -529,9 +534,14 @@ class UnifiedDispatcher:
             db = self._db
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
+
+            from src.services.image_generation_service import ImageGenerationService
+
+            image_service = ImageGenerationService()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,
             )

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -475,8 +475,9 @@ class UnifiedDispatcher:
                     note=f"Pipeline run id={run_id}",
                 )
             except Exception as exc:
-                logger.exception("Pipeline run failed for pipeline_id=%d run_id=%d", pipeline_id, run_id)
-                await db.repos.generation_runs.set_status(run_id, "failed")
+                logger.exception("Pipeline run failed for pipeline_id=%d run_id=%s", pipeline_id, run_id)
+                if run_id is not None:
+                    await db.repos.generation_runs.set_status(run_id, "failed")
                 await self._tasks.update_collection_task(
                     task.id,
                     CollectionTaskStatus.FAILED,

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -38,7 +38,14 @@
                 </div>
                 <div class="col-12 col-md-6 col-lg-3">
                     <label class="form-label">Image model</label>
-                    <input class="form-control" type="text" name="image_model" placeholder="optional">
+                    <input class="form-control" type="text" name="image_model" placeholder="optional" list="image-model-list">
+                    <datalist id="image-model-list">
+                        <option value="together:black-forest-labs/FLUX.1-schnell">
+                        <option value="together:black-forest-labs/FLUX.1-dev">
+                        <option value="openai:dall-e-3">
+                        <option value="huggingface:stabilityai/stable-diffusion-xl-base-1.0">
+                        <option value="replicate:black-forest-labs/flux-schnell">
+                    </datalist>
                 </div>
             </div>
             <div class="mb-3">
@@ -187,7 +194,7 @@
                             </div>
                             <div class="col-12 col-md-6">
                                 <label class="form-label">Image model</label>
-                                <input class="form-control" type="text" name="image_model" value="{{ pipeline.image_model or '' }}">
+                                <input class="form-control" type="text" name="image_model" value="{{ pipeline.image_model or '' }}" list="image-model-list">
                             </div>
                         </div>
                         <div class="mb-3">

--- a/tests/test_image_adapters.py
+++ b/tests/test_image_adapters.py
@@ -1,0 +1,160 @@
+"""Tests for image generation adapter factories in provider_adapters.py."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from src.services.provider_adapters import (
+    make_huggingface_image_adapter,
+    make_openai_image_adapter,
+    make_replicate_image_adapter,
+    make_together_image_adapter,
+)
+
+
+def _mock_response(*, status: int = 200, json_data: dict | None = None, content: bytes = b""):
+    """Build a mock aiohttp response."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.text = AsyncMock(return_value=json.dumps(json_data) if json_data else "")
+    resp.json = AsyncMock(return_value=json_data)
+    resp.read = AsyncMock(return_value=content)
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+def _mock_session(responses: list):
+    """Build a mock aiohttp.ClientSession that returns *responses* in order."""
+    session = MagicMock()
+    call_idx = {"i": 0}
+
+    def _next_response(*args, **kwargs):
+        idx = call_idx["i"]
+        call_idx["i"] += 1
+        return responses[idx]
+
+    session.post = MagicMock(side_effect=_next_response)
+    session.get = MagicMock(side_effect=_next_response)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+# ── Together AI ──
+
+
+@pytest.mark.asyncio
+async def test_together_image_adapter_success():
+    adapter = make_together_image_adapter("test-key")
+    resp = _mock_response(json_data={"data": [{"url": "https://img.together.xyz/abc.png"}]})
+    session = _mock_session([resp])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session):
+        url = await adapter("A cat", "black-forest-labs/FLUX.1-schnell")
+
+    assert url == "https://img.together.xyz/abc.png"
+
+
+@pytest.mark.asyncio
+async def test_together_image_adapter_error():
+    adapter = make_together_image_adapter("test-key")
+    resp = _mock_response(status=429, json_data={})
+    session = _mock_session([resp])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session):
+        with pytest.raises(RuntimeError, match="Together image error 429"):
+            await adapter("A cat", "")
+
+
+# ── HuggingFace ──
+
+
+@pytest.mark.asyncio
+async def test_huggingface_image_adapter_saves_binary(tmp_path):
+    adapter = make_huggingface_image_adapter("test-token", output_dir=str(tmp_path))
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    resp = _mock_response(status=200, content=fake_png)
+    session = _mock_session([resp])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session):
+        path = await adapter("A dog", "stabilityai/sdxl")
+
+    assert path is not None
+    assert path.startswith(str(tmp_path))
+    assert path.endswith(".png")
+    # Verify file was written
+    from pathlib import Path
+
+    assert Path(path).read_bytes() == fake_png
+
+
+# ── OpenAI ──
+
+
+@pytest.mark.asyncio
+async def test_openai_image_adapter_success():
+    adapter = make_openai_image_adapter("test-key")
+    resp = _mock_response(json_data={"data": [{"url": "https://oaidalleapi.blob/img.png"}]})
+    session = _mock_session([resp])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session):
+        url = await adapter("A sunset", "dall-e-3")
+
+    assert url == "https://oaidalleapi.blob/img.png"
+
+
+# ── Replicate ──
+
+
+@pytest.mark.asyncio
+async def test_replicate_image_adapter_polls_until_complete():
+    adapter = make_replicate_image_adapter("test-token", timeout=5.0)
+
+    create_resp = _mock_response(
+        status=201,
+        json_data={"urls": {"get": "https://api.replicate.com/v1/predictions/abc123"}},
+    )
+    poll_processing = _mock_response(
+        status=200,
+        json_data={"status": "processing", "output": None},
+    )
+    poll_succeeded = _mock_response(
+        status=200,
+        json_data={"status": "succeeded", "output": ["https://replicate.delivery/img.png"]},
+    )
+
+    session = _mock_session([create_resp, poll_processing, poll_succeeded])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session), patch(
+        "src.services.provider_adapters.asyncio.sleep", new_callable=AsyncMock
+    ):
+        url = await adapter("A mountain", "flux-schnell")
+
+    assert url == "https://replicate.delivery/img.png"
+
+
+@pytest.mark.asyncio
+async def test_replicate_image_adapter_failed_prediction():
+    adapter = make_replicate_image_adapter("test-token", timeout=5.0)
+
+    create_resp = _mock_response(
+        status=201,
+        json_data={"urls": {"get": "https://api.replicate.com/v1/predictions/abc"}},
+    )
+    poll_failed = _mock_response(
+        status=200,
+        json_data={"status": "failed", "error": "model crashed"},
+    )
+
+    session = _mock_session([create_resp, poll_failed])
+
+    with patch.object(aiohttp, "ClientSession", return_value=session), patch(
+        "src.services.provider_adapters.asyncio.sleep", new_callable=AsyncMock
+    ):
+        with pytest.raises(RuntimeError, match="model crashed"):
+            await adapter("A test", "some-model")

--- a/tests/test_image_adapters.py
+++ b/tests/test_image_adapters.py
@@ -16,10 +16,13 @@ from src.services.provider_adapters import (
 )
 
 
-def _mock_response(*, status: int = 200, json_data: dict | None = None, content: bytes = b""):
+def _mock_response(
+    *, status: int = 200, json_data: dict | None = None, content: bytes = b"", content_type: str = ""
+):
     """Build a mock aiohttp response."""
     resp = AsyncMock()
     resp.status = status
+    resp.content_type = content_type
     resp.text = AsyncMock(return_value=json.dumps(json_data) if json_data else "")
     resp.json = AsyncMock(return_value=json_data)
     resp.read = AsyncMock(return_value=content)
@@ -78,7 +81,7 @@ async def test_together_image_adapter_error():
 async def test_huggingface_image_adapter_saves_binary(tmp_path):
     adapter = make_huggingface_image_adapter("test-token", output_dir=str(tmp_path))
     fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
-    resp = _mock_response(status=200, content=fake_png)
+    resp = _mock_response(status=200, content=fake_png, content_type="image/png")
     session = _mock_session([resp])
 
     with patch.object(aiohttp, "ClientSession", return_value=session):

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -3,29 +3,141 @@ import pytest
 from src.services.image_generation_service import ImageGenerationService
 
 
-@pytest.mark.asyncio
-async def test_generate_returns_none():
-    service = ImageGenerationService()
-    result = await service.generate("dall-e-3", "A beautiful sunset over mountains")
-    assert result is None
+def _make_clean_service():
+    """Create service without env-based auto-registration."""
+    svc = ImageGenerationService.__new__(ImageGenerationService)
+    svc._adapters = {}
+    return svc
+
+
+# ── generate() ──
 
 
 @pytest.mark.asyncio
-async def test_generate_with_none_model_returns_none():
-    service = ImageGenerationService()
-    result = await service.generate(None, "Test prompt")
+async def test_generate_returns_url_with_adapter():
+    svc = _make_clean_service()
+
+    async def fake_adapter(prompt: str, model: str) -> str:
+        return f"https://img.example.com/{model}.png"
+
+    svc.register_adapter("fake", fake_adapter)
+    result = await svc.generate("fake:my-model", "A sunset")
+    assert result == "https://img.example.com/my-model.png"
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_none_no_adapters():
+    svc = _make_clean_service()
+    result = await svc.generate("some-model", "A sunset")
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_generate_empty_text_returns_none():
-    service = ImageGenerationService()
-    result = await service.generate("test-model", "")
+    svc = _make_clean_service()
+
+    async def fake_adapter(prompt: str, model: str) -> str:
+        return "url"
+
+    svc.register_adapter("fake", fake_adapter)
+    result = await svc.generate("fake:m", "")
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_is_available_returns_false():
-    service = ImageGenerationService()
-    result = await service.is_available()
-    assert result is False
+async def test_generate_catches_adapter_error():
+    svc = _make_clean_service()
+
+    async def broken_adapter(prompt: str, model: str) -> str:
+        raise RuntimeError("boom")
+
+    svc.register_adapter("broken", broken_adapter)
+    result = await svc.generate("broken:m", "test prompt")
+    assert result is None
+
+
+# ── is_available() ──
+
+
+@pytest.mark.asyncio
+async def test_is_available_false_when_empty():
+    svc = _make_clean_service()
+    assert await svc.is_available() is False
+
+
+@pytest.mark.asyncio
+async def test_is_available_true_with_adapter():
+    svc = _make_clean_service()
+
+    async def noop(prompt: str, model: str) -> str:
+        return ""
+
+    svc.register_adapter("x", noop)
+    assert await svc.is_available() is True
+
+
+# ── _parse_model_string() ──
+
+
+def test_parse_model_string_with_prefix():
+    provider, model_id = ImageGenerationService._parse_model_string("together:flux-schnell")
+    assert provider == "together"
+    assert model_id == "flux-schnell"
+
+
+def test_parse_model_string_without_prefix():
+    provider, model_id = ImageGenerationService._parse_model_string("flux-schnell")
+    assert provider is None
+    assert model_id == "flux-schnell"
+
+
+def test_parse_model_string_none():
+    provider, model_id = ImageGenerationService._parse_model_string(None)
+    assert provider is None
+    assert model_id == ""
+
+
+def test_parse_model_string_with_slashes():
+    provider, model_id = ImageGenerationService._parse_model_string(
+        "together:black-forest-labs/FLUX.1-schnell"
+    )
+    assert provider == "together"
+    assert model_id == "black-forest-labs/FLUX.1-schnell"
+
+
+# ── fallback ──
+
+
+@pytest.mark.asyncio
+async def test_fallback_to_first_adapter():
+    svc = _make_clean_service()
+    calls = []
+
+    async def first_adapter(prompt: str, model: str) -> str:
+        calls.append(("first", prompt, model))
+        return "first-url"
+
+    async def second_adapter(prompt: str, model: str) -> str:
+        calls.append(("second", prompt, model))
+        return "second-url"
+
+    svc.register_adapter("alpha", first_adapter)
+    svc.register_adapter("beta", second_adapter)
+
+    result = await svc.generate("no-prefix-model", "prompt")
+    assert result == "first-url"
+    assert calls[0][0] == "first"
+
+
+# ── adapter_names ──
+
+
+def test_adapter_names():
+    svc = _make_clean_service()
+
+    async def noop(prompt: str, model: str) -> str:
+        return ""
+
+    svc.register_adapter("a", noop)
+    svc.register_adapter("b", noop)
+    assert svc.adapter_names == ["a", "b"]


### PR DESCRIPTION
## Summary
- **4 image adapters** added to `provider_adapters.py`: Together AI (FLUX), HuggingFace (SDXL), OpenAI (DALL-E), Replicate (async polling)
- **ImageGenerationService** rewritten from stub to real service with env-based auto-registration, `provider:model_id` routing, and graceful fallback
- **Wired into pipeline** via `unified_dispatcher.py` — both `_handle_pipeline_run` and `_handle_content_generate` now pass `image_service`
- **UI datalist** with model suggestions for the `image_model` field in pipeline forms

## Test plan
- [x] 18 new unit tests for service + adapters (all passing)
- [x] Full test suite: 2027 passed, 0 failed
- [x] ruff lint: all checks passed
- [ ] Manual test with `TOGETHER_API_KEY` set and a pipeline with `image_model=together:black-forest-labs/FLUX.1-schnell`

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)