### PR TITLE
feat: scheduler observability and notification dry-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline**
 - Notification bot: personal bot created via BotFather through a connected account (`src/telegram/notifier.py`)
 - **Agent system**: `AgentProviderService` selects backend — `claude-agent-sdk` when `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` is set, otherwise falls back to `deepagents` with provider adapters; developer override available in Settings UI
 - **Provider system**: `ProviderService` auto-registers LLM providers from env vars (`OPENAI_API_KEY`, `COHERE_API_KEY`, `OLLAMA_BASE`, etc.); provider adapters in `src/services/provider_adapters.py` are lightweight HTTP wrappers (no heavy SDK deps)
-- **Content pipelines**: `PipelineService` + `ContentGenerationService` orchestrate generate → draft → notify → publish flow; tracked via `generation_runs` DB table
+- **Content pipelines**: `PipelineService` + `ContentGenerationService` orchestrate generate → image → draft → notify → publish flow; tracked via `generation_runs` DB table
+- **Image generation**: `ImageGenerationService` routes to provider-specific HTTP adapters (Together/HuggingFace/OpenAI/Replicate) via `provider:model_id` convention; auto-registers from env vars; adapters defined in `src/services/provider_adapters.py`
+- **UnifiedDispatcher** (`src/services/unified_dispatcher.py`): polls DB for generic tasks (CONTENT_GENERATE, CONTENT_PUBLISH, PIPELINE_RUN, PHOTO_DUE, etc.) and dispatches to handler methods; recovers interrupted tasks on startup
 - **Photo publishing**: `PhotoAutoUploadService` / `PhotoPublishService` / `PhotoTaskService` — separate upload, schedule, publish tasks tracked in DB
 - **LangChain integration**: optional, lazy-loaded via `src/services/langchain_adapters.py`; enabled with `USE_LANGCHAIN=1`
 
@@ -104,6 +106,8 @@ Each repository has a `_to_<model>(row)` static helper that maps `aiosqlite.Row`
 - **Keyword matching**: plain text (case-insensitive substring) and regex (`re.IGNORECASE`)
 - **Channel filters**: `ChannelAnalyzer` checks `low_uniqueness`, `low_subscriber_ratio`, `cross_channel_spam`, `non_cyrillic`, `chat_noise`; filtered channels skipped during collection unless `force=True`
 - **Collection service**: `enqueue_channel_by_pk(pk, force)` respects `is_filtered` flag; `enqueue_all_channels()` uses `full=False` for incremental collection
+- **Image adapter convention**: `ImageAdapter = Callable[[str, str], Awaitable[str | None]]` — signature is `(prompt, model_id) → URL/path`; model string format `provider:model_id` (e.g. `together:black-forest-labs/FLUX.1-schnell`); without prefix falls back to first registered adapter
+- **Content pipeline flow**: CONTENT_GENERATE task → `ContentGenerationService.generate()` → LLM text → optional image → `generation_runs` record → if AUTO publish mode, enqueues CONTENT_PUBLISH → `PublishService.publish_run()` sends to target channel
 - **HTMX progressive enhancement**: collect routes check `HX-Request` header to return HTML fragments vs redirects
 - **Identifier parsing**: `parse_identifiers()` splits text by comma/semicolon/newline; `extract_identifiers()` regex-extracts t.me links, @usernames, negative IDs; `parse_file()` handles txt/csv/xlsx
 - **aiosqlite connection cleanup**: in tests using raw `aiosqlite.connect()`, always wrap in `try/finally` with `await conn.close()` — an unclosed worker-thread blocks pytest process exit

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -296,6 +296,15 @@ class Database:
         self._require()
         return await self._messages.search_messages_for_query(sq, limit)
 
+    async def search_messages_for_query_since(
+        self,
+        sq: "SearchQuery",
+        since: str,
+        limit: int = 3,
+    ) -> tuple[int, list[Message]]:
+        self._require()
+        return await self._messages.search_messages_for_query_since(sq, since, limit)
+
     async def search_messages(
         self,
         query: str = "",

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -301,7 +301,7 @@ class Database:
         sq: "SearchQuery",
         since: str,
         limit: int = 3,
-    ) -> tuple[int, list[Message]]:
+    ) -> tuple[list[Message], int]:
         self._require()
         return await self._messages.search_messages_for_query_since(sq, since, limit)
 

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -544,3 +544,19 @@ class CollectionTasksRepository:
         )
         await self._db.commit()
         return cur.rowcount > 0
+
+    async def get_last_completed_collect_task(self) -> CollectionTask | None:
+        """Return the most recently completed channel_collect task."""
+        cur = await self._db.execute(
+            "SELECT * FROM collection_tasks "
+            "WHERE task_type = ? AND status = ? "
+            "ORDER BY completed_at DESC LIMIT 1",
+            (
+                CollectionTaskType.CHANNEL_COLLECT.value,
+                CollectionTaskStatus.COMPLETED.value,
+            ),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return self._to_task(row)

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -778,6 +778,39 @@ class MessagesRepository:
         messages = self._rows_to_messages(rows)
         return messages, total
 
+    async def search_messages_for_query_since(
+        self,
+        sq: SearchQuery,
+        since: str,
+        limit: int = 3,
+    ) -> tuple[int, list[Message]]:
+        """Count + preview matches for sq among messages collected since `since`."""
+        self._require_fts()
+        fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
+        where_parts = [self._BASE_FILTER, "m.collected_at >= ?", *extra_conds]
+        where_clause = " AND ".join(where_parts)
+        params = (fts_query, since, *extra_params)
+
+        count_cur = await self._db.execute(
+            f"SELECT COUNT(*) AS cnt FROM messages m"
+            f"{self._FTS_JOIN}{self._CHANNEL_JOIN}"
+            f" WHERE {where_clause}",
+            params,
+        )
+        row = await count_cur.fetchone()
+        total = row["cnt"] if row else 0
+
+        cur = await self._db.execute(
+            f"SELECT m.*, c.title as channel_title, c.username as channel_username"
+            f" FROM messages m{self._FTS_JOIN}{self._CHANNEL_JOIN}"
+            f" WHERE {where_clause}"
+            f" ORDER BY m.date DESC LIMIT ?",
+            (*params, limit),
+        )
+        rows = await cur.fetchall()
+        messages = self._rows_to_messages(rows)
+        return total, messages
+
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:
         self._require_fts()
         fts_query, extra_conds, extra_params = self._build_sq_parts(sq)

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -783,7 +783,7 @@ class MessagesRepository:
         sq: SearchQuery,
         since: str,
         limit: int = 3,
-    ) -> tuple[int, list[Message]]:
+    ) -> tuple[list[Message], int]:
         """Count + preview matches for sq among messages collected since `since`."""
         self._require_fts()
         fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
@@ -809,7 +809,7 @@ class MessagesRepository:
         )
         rows = await cur.fetchall()
         messages = self._rows_to_messages(rows)
-        return total, messages
+        return messages, total
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:
         self._require_fts()

--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -81,6 +81,7 @@ class SchedulerManager:
             id=self._job_id,
             replace_existing=True,
         )
+        logger.info("Registered job %s (every %d min)", self._job_id, collect_interval)
 
         if self._sq_bundle:
             await self.sync_search_query_jobs()
@@ -95,15 +96,18 @@ class SchedulerManager:
                 id=self._photo_due_job_id,
                 replace_existing=True,
             )
+            logger.info("Registered job %s (every 1 min)", self._photo_due_job_id)
             self._scheduler.add_job(
                 self._run_photo_auto,
                 IntervalTrigger(minutes=1),
                 id=self._photo_auto_job_id,
                 replace_existing=True,
             )
+            logger.info("Registered job %s (every 1 min)", self._photo_auto_job_id)
 
         self._scheduler.start()
-        logger.info("Scheduler started: collecting every %d minutes", collect_interval)
+        total_jobs = len(self._scheduler.get_jobs())
+        logger.info("Scheduler started with %d jobs, collecting every %d min", total_jobs, collect_interval)
 
     async def stop(self) -> None:
         if self._bg_task and not self._bg_task.done():
@@ -116,9 +120,10 @@ class SchedulerManager:
 
         if self._scheduler is None or not self._scheduler.running:
             return
+        job_count = len(self._scheduler.get_jobs())
         self._scheduler.shutdown(wait=False)
         self._scheduler = None
-        logger.info("Scheduler stopped")
+        logger.info("Scheduler stopped, %d jobs removed", job_count)
 
     def update_interval(self, minutes: int) -> None:
         if self._scheduler and self._scheduler.running:
@@ -305,3 +310,39 @@ class SchedulerManager:
         except Exception:
             logger.exception("Error enqueuing photo_auto")
         return {"enqueued": True}
+
+    async def get_potential_jobs(self) -> list[dict]:
+        """Return jobs that would be registered on start (for UI when scheduler is stopped)."""
+        jobs: list[dict] = [
+            {"job_id": "collect_all", "interval_minutes": self._current_interval_minutes},
+        ]
+        if self._task_enqueuer is not None:
+            jobs.append({"job_id": "photo_due", "interval_minutes": 1})
+            jobs.append({"job_id": "photo_auto", "interval_minutes": 1})
+        if self._sq_bundle:
+            try:
+                all_active = await self._sq_bundle.get_all(active_only=True)
+                for sq in all_active:
+                    if sq.track_stats:
+                        jobs.append({
+                            "job_id": f"sq_{sq.id}",
+                            "interval_minutes": sq.interval_minutes,
+                        })
+            except Exception:
+                logger.exception("Error fetching search queries for potential jobs")
+        if self._pipeline_bundle:
+            try:
+                all_active = await self._pipeline_bundle.get_all(active_only=True)
+                for p in all_active:
+                    if p.id is not None and p.is_active:
+                        jobs.append({
+                            "job_id": f"pipeline_run_{p.id}",
+                            "interval_minutes": p.generate_interval_minutes,
+                        })
+                        jobs.append({
+                            "job_id": f"content_generate_{p.id}",
+                            "interval_minutes": p.generate_interval_minutes,
+                        })
+            except Exception:
+                logger.exception("Error fetching pipelines for potential jobs")
+        return jobs

--- a/src/services/task_enqueuer.py
+++ b/src/services/task_enqueuer.py
@@ -41,7 +41,7 @@ class TaskEnqueuer:
             payload_filter_value=sq_id,
         )
         if has:
-            logger.debug("SQ_STATS task for sq_id=%d already active, skipping", sq_id)
+            logger.info("SQ_STATS task for sq_id=%d already active, skipping", sq_id)
             return None
         task_id = await self._db.repos.tasks.create_generic_task(
             CollectionTaskType.SQ_STATS,
@@ -81,7 +81,7 @@ class TaskEnqueuer:
             payload_filter_value=pipeline_id,
         )
         if has:
-            logger.debug("PIPELINE_RUN for pipeline_id=%d already active, skipping", pipeline_id)
+            logger.info("PIPELINE_RUN for pipeline_id=%d already active, skipping", pipeline_id)
             return None
         task_id = await self._db.repos.tasks.create_generic_task(
             CollectionTaskType.PIPELINE_RUN,
@@ -99,7 +99,7 @@ class TaskEnqueuer:
             payload_filter_value=pipeline_id,
         )
         if has:
-            logger.debug("CONTENT_GENERATE for pipeline_id=%d already active, skipping", pipeline_id)
+            logger.info("CONTENT_GENERATE for pipeline_id=%d already active, skipping", pipeline_id)
             return None
         task_id = await self._db.repos.tasks.create_generic_task(
             CollectionTaskType.CONTENT_GENERATE,
@@ -113,7 +113,7 @@ class TaskEnqueuer:
         """Create a CONTENT_PUBLISH task for publishing approved drafts."""
         has = await self._db.repos.tasks.has_active_task(CollectionTaskType.CONTENT_PUBLISH)
         if has:
-            logger.debug("CONTENT_PUBLISH task already active, skipping")
+            logger.info("CONTENT_PUBLISH task already active, skipping")
             return None
         task_id = await self._db.repos.tasks.create_generic_task(
             CollectionTaskType.CONTENT_PUBLISH,

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timezone
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -227,7 +228,8 @@ async def dry_run_notifications(request: Request):
     # Find the last completed channel_collect task to determine the time window
     last_task = await db.repos.tasks.get_last_completed_collect_task()
     if last_task and last_task.completed_at:
-        since = last_task.completed_at.isoformat()
+        # SQLite datetime('now') stores as 'YYYY-MM-DD HH:MM:SS' (no T, no tz)
+        since = last_task.completed_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     else:
         since = None
 

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -245,12 +245,12 @@ async def dry_run_notifications(request: Request):
     for sq in queries:
         if since:
             try:
-                total, previews = await db.search_messages_for_query_since(sq, since, limit=2)
+                previews, total = await db.search_messages_for_query_since(sq, since, limit=2)
             except Exception:
                 logger.exception("Dry-run match error for sq_id=%s", sq.id)
-                total, previews = 0, []
+                previews, total = [], 0
         else:
-            total, previews = 0, []
+            previews, total = [], 0
         results.append({
             "query": sq.name or sq.query,
             "count": total,

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -5,7 +7,27 @@ from src.telegram.notifier import Notifier
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+JOB_LABELS = {
+    "collect_all": "Сбор всех каналов",
+    "photo_due": "Фото по расписанию",
+    "photo_auto": "Автозагрузка фото",
+}
+
+
+def _job_label(job_id: str) -> str:
+    if job_id in JOB_LABELS:
+        return JOB_LABELS[job_id]
+    if job_id.startswith("sq_"):
+        return f"Стат. запроса #{job_id.removeprefix('sq_')}"
+    if job_id.startswith("pipeline_run_"):
+        return f"Пайплайн #{job_id.removeprefix('pipeline_run_')}"
+    if job_id.startswith("content_generate_"):
+        return f"Генерация #{job_id.removeprefix('content_generate_')}"
+    return job_id
 
 
 @router.post("/tasks/{task_id}/cancel")
@@ -28,6 +50,32 @@ async def clear_pending_collect_tasks(request: Request):
 
 
 VALID_STATUS_FILTERS = {"all", "active", "completed"}
+
+
+async def _build_jobs_context(sched) -> list[dict]:
+    """Build a list of job dicts for the scheduler page template."""
+    if sched.is_running:
+        raw = sched.get_all_jobs_next_run()
+        jobs = []
+        for job_id, next_run in raw.items():
+            jobs.append({
+                "job_id": job_id,
+                "label": _job_label(job_id),
+                "next_run": next_run,
+                "interval_minutes": None,
+            })
+        return jobs
+
+    potential = await sched.get_potential_jobs()
+    return [
+        {
+            "job_id": j["job_id"],
+            "label": _job_label(j["job_id"]),
+            "next_run": None,
+            "interval_minutes": j["interval_minutes"],
+        }
+        for j in potential
+    ]
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -78,6 +126,9 @@ async def scheduler_page(
     bot_configured = (
         notifier is not None and notifier.admin_chat_id is not None
     ) or bot is not None
+
+    scheduler_jobs = await _build_jobs_context(sched)
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "scheduler.html",
@@ -97,6 +148,7 @@ async def scheduler_page(
             "search_log": search_log,
             "bot_configured": bot_configured,
             "pending_collect_count": pending_collect_count,
+            "scheduler_jobs": scheduler_jobs,
         },
     )
 
@@ -165,3 +217,46 @@ async def test_notification(request: Request):
     ok = await test_notifier.notify(text)
     msg = "test_notification_sent" if ok else "test_notification_failed"
     return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
+
+
+@router.post("/dry-run-notifications", response_class=HTMLResponse)
+async def dry_run_notifications(request: Request):
+    """Count notification matches from the last collection cycle without sending."""
+    db = deps.get_db(request)
+
+    # Find the last completed channel_collect task to determine the time window
+    last_task = await db.repos.tasks.get_last_completed_collect_task()
+    if last_task and last_task.completed_at:
+        since = last_task.completed_at.isoformat()
+    else:
+        since = None
+
+    queries = await db.get_notification_queries(active_only=True)
+    if not queries:
+        return deps.get_templates(request).TemplateResponse(
+            request,
+            "_dry_run_results.html",
+            {"results": [], "since": since, "no_queries": True},
+        )
+
+    results = []
+    for sq in queries:
+        if since:
+            try:
+                total, previews = await db.search_messages_for_query_since(sq, since, limit=2)
+            except Exception:
+                logger.exception("Dry-run match error for sq_id=%s", sq.id)
+                total, previews = 0, []
+        else:
+            total, previews = 0, []
+        results.append({
+            "query": sq.name or sq.query,
+            "count": total,
+            "previews": [(m.text or "")[:150] for m in previews],
+        })
+
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "_dry_run_results.html",
+        {"results": results, "since": since, "no_queries": False},
+    )

--- a/src/web/templates/_dry_run_results.html
+++ b/src/web/templates/_dry_run_results.html
@@ -1,0 +1,51 @@
+<div class="card">
+    <div class="card-header fw-semibold">
+        Dry-run уведомлений
+        {% if since %}
+        <small class="text-muted ms-2">сообщения собранные с {{ since[:19] }}</small>
+        {% endif %}
+    </div>
+    <div class="card-body">
+        {% if no_queries %}
+            <p class="text-muted mb-0">Нет активных запросов с notify_on_collect.</p>
+        {% elif not since %}
+            <p class="text-muted mb-0">Нет завершённых задач сбора — невозможно определить окно.</p>
+        {% elif not results %}
+            <p class="text-muted mb-0">Нет совпадений.</p>
+        {% else %}
+            <table class="table table-sm table-striped mb-0">
+                <thead>
+                    <tr>
+                        <th>Запрос</th>
+                        <th>Совпадений</th>
+                        <th>Превью</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for r in results %}
+                    <tr>
+                        <td><strong>{{ r.query }}</strong></td>
+                        <td>
+                            {% if r.count > 0 %}
+                                <span class="badge text-bg-warning">{{ r.count }}</span>
+                            {% else %}
+                                <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% for p in r.previews %}
+                                <small class="d-block text-truncate" style="max-width:400px">{{ p }}</small>
+                            {% endfor %}
+                            {% if not r.previews %}
+                                <small class="text-muted">—</small>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% set total = results|map(attribute='count')|sum %}
+            <p class="mt-2 mb-0"><strong>Итого: {{ total }} совпадений, {{ results|length }} запросов</strong></p>
+        {% endif %}
+    </div>
+</div>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -45,12 +45,69 @@
             <form method="post" action="/scheduler/test-notification" data-busy>
                 <button type="submit" class="btn btn-outline-secondary"
                         {% if not bot_configured %}disabled title="Подключите бот в Настройках → Уведомления"{% endif %}>
-                    Тест уведомлений
+                    Тест
                 </button>
             </form>
+            <button type="button" class="btn btn-outline-info"
+                    onclick="dryRunNotifications()"
+                    id="dry-run-btn">
+                Dry-run
+            </button>
         </div>
     </div>
 </div>
+
+<!-- Scheduler Jobs -->
+{% if scheduler_jobs %}
+<div class="card mb-4">
+    <div class="card-header fw-semibold">
+        Джобы планировщика
+        <span class="badge text-bg-secondary ms-1">{{ scheduler_jobs|length }}</span>
+        {% if not is_running %}
+        <small class="text-muted ms-2">(будут зарегистрированы при запуске)</small>
+        {% endif %}
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+        <table class="table table-sm table-striped mb-0">
+            <thead>
+                <tr>
+                    <th>Джоб</th>
+                    <th>Интервал</th>
+                    <th>Следующий запуск</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for j in scheduler_jobs %}
+                <tr>
+                    <td>{{ j.label }}</td>
+                    <td>
+                        {% if j.interval_minutes %}
+                            {{ j.interval_minutes }} мин.
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if j.next_run %}
+                            {{ j.next_run.strftime('%H:%M:%S') }}
+                        {% elif is_running %}
+                            —
+                        {% else %}
+                            <span class="text-muted">остановлен</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Dry-run results (populated via fetch) -->
+<div id="dry-run-results" class="mb-4" style="display:none"></div>
 
 {% if search_log %}
 <div class="card mb-4">
@@ -262,5 +319,26 @@ setTimeout(function() {
     window.location.reload();
 }, 5000);
 {% endif %}
+
+function dryRunNotifications() {
+    var btn = document.getElementById('dry-run-btn');
+    var container = document.getElementById('dry-run-results');
+    btn.disabled = true;
+    btn.textContent = 'Загрузка...';
+    fetch('/scheduler/dry-run-notifications', {method: 'POST'})
+        .then(function(r) { return r.text(); })
+        .then(function(html) {
+            container.innerHTML = html;
+            container.style.display = '';
+        })
+        .catch(function() {
+            container.innerHTML = '<div class="alert alert-danger">Ошибка при выполнении dry-run</div>';
+            container.style.display = '';
+        })
+        .finally(function() {
+            btn.disabled = false;
+            btn.textContent = 'Dry-run';
+        });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- **Карточка джобов на /scheduler**: показывает зарегистрированные APScheduler джобы с next_run_time (когда запущен) или потенциальные джобы с интервалами (когда остановлен)
- **Dry-run уведомлений**: новая кнопка считает совпадения notification-запросов среди сообщений последнего цикла сбора, без реальной отправки в Telegram
- **Улучшенное логирование**: каждый джоб логируется при регистрации, дедупликация задач видна на /debug/ (info вместо debug)
- **Переименование кнопки**: "Тест уведомлений" → "Тест" + новая "Dry-run"

## Test plan
- [ ] Запустить `ruff check src/ tests/` — lint clean
- [ ] Запустить `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — все тесты зелёные
- [ ] Открыть /scheduler при остановленном планировщике — видны потенциальные джобы
- [ ] Запустить планировщик — видны реальные джобы с next_run_time
- [ ] Проверить /debug/ — видны логи "Registered job ...", "Scheduler started with N jobs"
- [ ] Нажать "Dry-run" — inline результаты без отправки
- [ ] Нажать "Тест" — реальная отправка в Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)