### PR TITLE
fix: persist scheduler autostart flag across redeployments

### DIFF
--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -227,6 +227,11 @@ async def start_container(container: AppContainer) -> None:
         await container.agent_manager.refresh_settings_cache(preflight=True)
         container.agent_manager.initialize()
 
+    autostart = await container.db.get_setting("scheduler_autostart")
+    if autostart == "1":
+        logger.info("Auto-starting scheduler (scheduler_autostart=1)")
+        await container.scheduler.start()
+
 
 async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
     for task in list(tasks):

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -159,12 +159,14 @@ async def start_scheduler(request: Request):
     if getattr(request.app.state, "shutting_down", False):
         return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
     await deps.scheduler_service(request).start()
+    await deps.get_db(request).set_setting("scheduler_autostart", "1")
     return RedirectResponse(url="/scheduler?msg=scheduler_started", status_code=303)
 
 
 @router.post("/stop")
 async def stop_scheduler(request: Request):
     await deps.scheduler_service(request).stop()
+    await deps.get_db(request).set_setting("scheduler_autostart", "0")
     return RedirectResponse(url="/scheduler?msg=scheduler_stopped", status_code=303)
 
 


### PR DESCRIPTION
## Summary
- Сохраняет флаг `scheduler_autostart` в таблице `settings` при старте/остановке планировщика через UI
- При загрузке приложения (`start_container`) читает флаг и автоматически запускает планировщик, если он был включён до редеплоя

## Test plan
- [ ] Запустить `python -m src.main serve`, открыть `/scheduler`, нажать «Запустить»
- [ ] Перезапустить процесс — планировщик должен запуститься автоматически
- [ ] Нажать «Остановить», перезапустить — планировщик должен остаться остановленным
- [ ] Первый запуск без флага в DB — планировщик не стартует автоматически

🤖 Generated with [Claude Code](https://claude.com/claude-code)