### PR TITLE
fix: load scheduler interval from DB on startup and add autostart tests

### DIFF
--- a/src/scheduler/manager.py
+++ b/src/scheduler/manager.py
@@ -52,6 +52,18 @@ class SchedulerManager:
     def interval_minutes(self) -> int:
         return self._current_interval_minutes
 
+    async def load_settings(self) -> None:
+        """Load persisted settings from DB without starting the scheduler."""
+        if not self._scheduler_bundle:
+            return
+        saved = await self._scheduler_bundle.get_setting("collect_interval_minutes")
+        self._current_interval_minutes = parse_int_setting(
+            saved,
+            setting_name="collect_interval_minutes",
+            default=self._config.collect_interval_minutes,
+            logger=logger,
+        )
+
     async def start(self) -> None:
         if self._scheduler is not None and self._scheduler.running:
             logger.warning("Scheduler already running")

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -227,6 +227,7 @@ async def start_container(container: AppContainer) -> None:
         await container.agent_manager.refresh_settings_cache(preflight=True)
         container.agent_manager.initialize()
 
+    await container.scheduler.load_settings()
     autostart = await container.db.get_setting("scheduler_autostart")
     if autostart == "1":
         logger.info("Auto-starting scheduler (scheduler_autostart=1)")

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -339,6 +339,27 @@ async def test_stop_scheduler_calls_service(client):
 
 
 @pytest.mark.asyncio
+async def test_start_scheduler_sets_autostart_flag(client):
+    """POST /scheduler/start persists scheduler_autostart=1 to DB."""
+    db = client._transport.app.state.db
+    resp = await client.post("/scheduler/start", follow_redirects=False)
+    assert resp.status_code == 303
+    value = await db.get_setting("scheduler_autostart")
+    assert value == "1"
+
+
+@pytest.mark.asyncio
+async def test_stop_scheduler_clears_autostart_flag(client):
+    """POST /scheduler/stop persists scheduler_autostart=0 to DB."""
+    db = client._transport.app.state.db
+    await db.set_setting("scheduler_autostart", "1")
+    resp = await client.post("/scheduler/stop", follow_redirects=False)
+    assert resp.status_code == 303
+    value = await db.get_setting("scheduler_autostart")
+    assert value == "0"
+
+
+@pytest.mark.asyncio
 async def test_trigger_collection_calls_service(client):
     """Test trigger collection calls collection service."""
     mock_service = MagicMock()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -38,10 +38,11 @@ async def test_start_container_autostarts_scheduler_when_flag_set(tmp_path):
     scheduler_mock.load_settings = AsyncMock()
     container.scheduler = scheduler_mock
 
-    await start_container(container)
-
-    scheduler_mock.start.assert_called_once()
-    await db.close()
+    try:
+        await start_container(container)
+        scheduler_mock.start.assert_called_once()
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio
@@ -56,10 +57,11 @@ async def test_start_container_no_autostart_when_flag_absent(tmp_path):
     scheduler_mock.load_settings = AsyncMock()
     container.scheduler = scheduler_mock
 
-    await start_container(container)
-
-    scheduler_mock.start.assert_not_called()
-    await db.close()
+    try:
+        await start_container(container)
+        scheduler_mock.start.assert_not_called()
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio
@@ -74,10 +76,11 @@ async def test_start_container_no_autostart_when_flag_zero(tmp_path):
     scheduler_mock.load_settings = AsyncMock()
     container.scheduler = scheduler_mock
 
-    await start_container(container)
-
-    scheduler_mock.start.assert_not_called()
-    await db.close()
+    try:
+        await start_container(container)
+        scheduler_mock.start.assert_not_called()
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio
@@ -91,7 +94,8 @@ async def test_start_container_calls_load_settings(tmp_path):
     scheduler_mock.load_settings = AsyncMock()
     container.scheduler = scheduler_mock
 
-    await start_container(container)
-
-    scheduler_mock.load_settings.assert_called_once()
-    await db.close()
+    try:
+        await start_container(container)
+        scheduler_mock.load_settings.assert_called_once()
+    finally:
+        await db.close()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,97 @@
+"""Tests for start_container bootstrap behavior."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.database import Database
+from src.web.bootstrap import start_container
+
+
+def _make_container(db: Database) -> MagicMock:
+    """Build a minimal AppContainer mock backed by a real Database."""
+    container = MagicMock()
+    container.db = db
+    container.auth.is_configured = False
+    container.pool = MagicMock()
+    container.collection_queue = None
+    container.unified_dispatcher = None
+    container.ai_search = MagicMock()
+    container.ai_search.initialize = MagicMock()
+    container.agent_manager = None
+    container.channel_bundle.fail_running_collection_tasks_on_startup = AsyncMock(return_value=0)
+    container.photo_task_service.recover_running = AsyncMock(return_value=0)
+    container.db.repos.generation_runs.reset_running_on_startup = AsyncMock(return_value=0)
+    return container
+
+
+@pytest.mark.asyncio
+async def test_start_container_autostarts_scheduler_when_flag_set(tmp_path):
+    """start_container calls scheduler.start() when scheduler_autostart=1 is in DB."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    await db.set_setting("scheduler_autostart", "1")
+
+    container = _make_container(db)
+    scheduler_mock = AsyncMock()
+    scheduler_mock.load_settings = AsyncMock()
+    container.scheduler = scheduler_mock
+
+    await start_container(container)
+
+    scheduler_mock.start.assert_called_once()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_start_container_no_autostart_when_flag_absent(tmp_path):
+    """start_container does not call scheduler.start() when flag is not set."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    # Do not set scheduler_autostart
+
+    container = _make_container(db)
+    scheduler_mock = AsyncMock()
+    scheduler_mock.load_settings = AsyncMock()
+    container.scheduler = scheduler_mock
+
+    await start_container(container)
+
+    scheduler_mock.start.assert_not_called()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_start_container_no_autostart_when_flag_zero(tmp_path):
+    """start_container does not call scheduler.start() when scheduler_autostart=0."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    await db.set_setting("scheduler_autostart", "0")
+
+    container = _make_container(db)
+    scheduler_mock = AsyncMock()
+    scheduler_mock.load_settings = AsyncMock()
+    container.scheduler = scheduler_mock
+
+    await start_container(container)
+
+    scheduler_mock.start.assert_not_called()
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_start_container_calls_load_settings(tmp_path):
+    """start_container always calls scheduler.load_settings() on startup."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    container = _make_container(db)
+    scheduler_mock = AsyncMock()
+    scheduler_mock.load_settings = AsyncMock()
+    container.scheduler = scheduler_mock
+
+    await start_container(container)
+
+    scheduler_mock.load_settings.assert_called_once()
+    await db.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.config import SchedulerConfig
+from src.database.bundles import SchedulerBundle
 from src.scheduler.manager import SchedulerManager
 
 
@@ -36,6 +37,40 @@ async def test_run_collection_with_enqueuer():
     assert stats["skipped"] == 1
     assert stats["total"] == 3
     assert stats["errors"] == 0
+
+
+@pytest.mark.asyncio
+async def test_load_settings_updates_interval():
+    """load_settings() reads interval from DB and updates _current_interval_minutes."""
+    bundle_mock = MagicMock(spec=SchedulerBundle)
+    bundle_mock.get_setting = AsyncMock(return_value="15")
+
+    manager = SchedulerManager(SchedulerConfig(), scheduler_bundle=bundle_mock)
+    assert manager.interval_minutes == 60  # config default
+
+    await manager.load_settings()
+
+    assert manager.interval_minutes == 15
+
+
+@pytest.mark.asyncio
+async def test_load_settings_no_bundle():
+    """load_settings() is a no-op when no scheduler_bundle is set."""
+    manager = SchedulerManager(SchedulerConfig())
+    await manager.load_settings()  # should not raise
+    assert manager.interval_minutes == 60
+
+
+@pytest.mark.asyncio
+async def test_load_settings_missing_value_keeps_default():
+    """load_settings() keeps config default when DB has no saved interval."""
+    bundle_mock = MagicMock(spec=SchedulerBundle)
+    bundle_mock.get_setting = AsyncMock(return_value=None)
+
+    manager = SchedulerManager(SchedulerConfig(), scheduler_bundle=bundle_mock)
+    await manager.load_settings()
+
+    assert manager.interval_minutes == 60
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Добавляет `SchedulerManager.load_settings()` — читает `collect_interval_minutes` из DB в `_current_interval_minutes` без запуска планировщика, чтобы UI показывал правильный сохранённый интервал даже когда планировщик остановлен
- Вызывает `load_settings()` в `start_container` перед блоком autostart
- Добавляет тесты на флаг `scheduler_autostart` в routes, поведение `load_settings`, и autostart-логику в `start_container`

## Test plan
- [ ] `pytest tests/test_scheduler.py tests/test_bootstrap.py tests/routes/test_scheduler_routes.py -v` — все тесты проходят
- [ ] Сохранить интервал 15 мин → перезапустить → UI показывает 15 мин (не дефолтные 60)
- [ ] Запустить планировщик → перезапустить → автостарт работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)