### PR TITLE
feat: add ContentGenerate/ContentPublish payloads to CollectionTask and extend test coverage

### DIFF
--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -63,6 +63,8 @@ class CollectionTasksRepository:
             | StatsAllTaskPayload
             | SqStatsTaskPayload
             | PipelineRunTaskPayload
+            | ContentGenerateTaskPayload
+            | ContentPublishTaskPayload
             | None
         ),
     ) -> str | None:
@@ -429,7 +431,15 @@ class CollectionTasksRepository:
         task_type: CollectionTaskType | str,
         *,
         title: str = "",
-        payload: dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | None = None,
+        payload: (
+            dict[str, Any]
+            | StatsAllTaskPayload
+            | SqStatsTaskPayload
+            | PipelineRunTaskPayload
+            | ContentGenerateTaskPayload
+            | ContentPublishTaskPayload
+            | None
+        ) = None,
         run_after: datetime | None = None,
         parent_task_id: int | None = None,
     ) -> int:

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -10,6 +10,8 @@ from src.models import (
     CollectionTask,
     CollectionTaskStatus,
     CollectionTaskType,
+    ContentGenerateTaskPayload,
+    ContentPublishTaskPayload,
     PipelineRunTaskPayload,
     SqStatsTaskPayload,
     StatsAllTaskPayload,
@@ -48,6 +50,10 @@ class CollectionTasksRepository:
             return SqStatsTaskPayload.model_validate(parsed)
         if task_kind == CollectionTaskType.PIPELINE_RUN.value:
             return PipelineRunTaskPayload.model_validate(parsed)
+        if task_kind == CollectionTaskType.CONTENT_GENERATE.value:
+            return ContentGenerateTaskPayload.model_validate(parsed)
+        if task_kind == CollectionTaskType.CONTENT_PUBLISH.value:
+            return ContentPublishTaskPayload.model_validate(parsed)
         return parsed
 
     @staticmethod
@@ -62,7 +68,16 @@ class CollectionTasksRepository:
     ) -> str | None:
         if payload is None:
             return None
-        if isinstance(payload, (StatsAllTaskPayload, SqStatsTaskPayload, PipelineRunTaskPayload)):
+        if isinstance(
+            payload,
+            (
+                StatsAllTaskPayload,
+                SqStatsTaskPayload,
+                PipelineRunTaskPayload,
+                ContentGenerateTaskPayload,
+                ContentPublishTaskPayload,
+            ),
+        ):
             return payload.model_dump_json()
         return json.dumps(payload)
 

--- a/src/models.py
+++ b/src/models.py
@@ -118,7 +118,13 @@ class CollectionTask(BaseModel):
     note: str | None = None
     run_after: datetime | None = None
     payload: (
-        dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | PipelineRunTaskPayload | None
+        dict[str, Any]
+        | StatsAllTaskPayload
+        | SqStatsTaskPayload
+        | PipelineRunTaskPayload
+        | ContentGenerateTaskPayload
+        | ContentPublishTaskPayload
+        | None
     ) = None
     parent_task_id: int | None = None
     created_at: datetime | None = None

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -551,9 +551,21 @@ class UnifiedDispatcher:
             if pipeline.publish_mode == PipelinePublishMode.AUTO and run is not None:
                 from src.services.publish_service import PublishService
 
-                pool = self._collector._pool
-                publish_svc = PublishService(db, pool)
-                await publish_svc.publish_run(run, pipeline)
+                publish_svc = PublishService(db, self._client_pool)
+                try:
+                    await publish_svc.publish_run(run, pipeline)
+                except Exception as pub_exc:
+                    logger.exception(
+                        "Auto-publish failed for run id=%s (pipeline_id=%d); generation already saved",
+                        run.id,
+                        pipeline_id,
+                    )
+                    await self._tasks.update_collection_task(
+                        task.id,
+                        CollectionTaskStatus.FAILED,
+                        error=f"Generation ok but publish failed: {pub_exc!s:.400}",
+                    )
+                    return
 
             await self._tasks.update_collection_task(
                 task.id,
@@ -582,9 +594,11 @@ class UnifiedDispatcher:
             )
             return
 
-        if not self._db:
+        if not self._db or not self._pipeline_bundle:
             await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.COMPLETED, note="No DB configured"
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Pipeline execution environment not configured",
             )
             return
 
@@ -594,7 +608,7 @@ class UnifiedDispatcher:
             from src.services.publish_service import PublishService
 
             db = self._db
-            pool = self._collector._pool
+            pool = self._client_pool
             publish_svc = PublishService(db, pool)
 
             filter_sql = "AND pipeline_id = ?" if pipeline_id is not None else ""

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -628,12 +628,12 @@ class UnifiedDispatcher:
 
             runs = [GenerationRunsRepository._to_generation_run(row) for row in rows]
 
-            pipeline_svc = PipelineService(self._pipeline_bundle) if self._pipeline_bundle else None
+            pipeline_svc = PipelineService(self._pipeline_bundle)
             published = 0
             for run in runs:
                 if run.pipeline_id is None:
                     continue
-                pipeline = await pipeline_svc.get(run.pipeline_id) if pipeline_svc else None
+                pipeline = await pipeline_svc.get(run.pipeline_id)
                 if pipeline is None:
                     continue
                 results = await publish_svc.publish_run(run, pipeline)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import date, datetime
 from unittest.mock import MagicMock, patch
@@ -634,3 +635,200 @@ def test_format_context_unknown_topic_in_grouping():
 def test_validate_prompt_template_rejects_unknown_variable():
     with pytest.raises(PromptTemplateError, match="Недопустимая переменная"):
         validate_prompt_template("Канал: {unknown}")
+
+
+# ── DeepagentsBackend property tests ───────────────────────────────────────────────
+
+
+def test_deepagents_backend_available_with_legacy_fallback(db, monkeypatch):
+    """DeepagentsBackend.available returns True with valid legacy fallback."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+    monkeypatch.setenv("AGENT_FALLBACK_API_KEY", "test-key")
+
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+
+    assert mgr._deepagents_backend.available is True
+
+
+def test_deepagents_backend_fallback_model_from_cache(db, monkeypatch):
+    """DeepagentsBackend.fallback_model returns model from last used."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+    mgr._deepagents_backend._last_used_model = "gpt-4.1-turbo"
+    mgr._deepagents_backend._last_used_provider = "openai"
+
+    assert mgr._deepagents_backend.fallback_model == "gpt-4.1-turbo"
+    assert mgr._deepagents_backend.fallback_provider == "openai"
+
+
+def test_deepagents_backend_fallback_provider_priority(db, monkeypatch):
+    """DeepagentsBackend.fallback_provider uses provider from model string."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "groq:llama-3.1-8b")
+
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+
+    assert mgr._deepagents_backend.fallback_provider == "groq"
+
+
+def test_deepagents_backend_configured_flag(db, monkeypatch):
+    """DeepagentsBackend.configured returns True when fallback is set."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+
+    assert mgr._deepagents_backend.configured is True
+
+
+# ── Runtime status extended tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_dev_mode_override_respects_backend_override(db, monkeypatch):
+    """Runtime status respects dev mode backend override even when other backend is available."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+    monkeypatch.setenv("AGENT_FALLBACK_API_KEY", "fallback-key")
+    await db.set_setting("agent_dev_mode_enabled", "1")
+    await db.set_setting("agent_backend_override", "claude")
+
+    mgr = AgentManager(db)
+    status = await mgr.get_runtime_status()
+
+    assert status.selected_backend == "claude"
+    assert status.using_override is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_reports_error_when_override_backend_unavailable(db, monkeypatch):
+    """Runtime status reports error when overridden backend is unavailable."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+    await db.set_setting("agent_dev_mode_enabled", "1")
+    await db.set_setting("agent_backend_override", "claude")
+
+    mgr = AgentManager(db)
+    with patch.object(mgr._deepagents_backend, "_build_agent", return_value=None):
+        mgr.initialize()
+    status = await mgr.get_runtime_status()
+
+    assert status.selected_backend == "claude"
+    assert status.error is not None
+    assert "claude-agent-sdk" in status.error
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_fallback_info_includes_provider_details(db, monkeypatch):
+    """Runtime status includes fallback provider/model info."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "groq:llama-3.1-8b")
+    monkeypatch.setenv("AGENT_FALLBACK_API_KEY", "groq-key")
+
+    mgr = AgentManager(db)
+    status = await mgr.get_runtime_status()
+
+    assert status.fallback_provider == "groq"
+    assert "llama" in status.fallback_model.lower()
+
+
+# ── DeepagentsBackend streaming tests ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deepagents_backend_chat_stream_handles_exception(db, monkeypatch):
+    """DeepagentsBackend.chat_stream handles and propagates exceptions."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+    monkeypatch.setenv("AGENT_FALLBACK_API_KEY", "test-key")
+
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+
+    thread_id = await db.create_agent_thread("test")
+    await db.save_agent_message(thread_id, "user", "hello")
+
+    def fake_init_chat_model(*, model, model_provider, **kwargs):
+        raise RuntimeError("Provider init failed")
+
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    with (
+        patch("langchain.chat_models.init_chat_model", fake_init_chat_model),
+        pytest.raises(RuntimeError, match="Provider init failed"),
+    ):
+        await mgr._deepagents_backend.chat_stream(
+            thread_id=thread_id,
+            prompt="test",
+            system_prompt="system",
+            stats={},
+            model=None,
+            queue=queue,
+        )
+
+
+# ── DeepagentsBackend tool tests ───────────────────────────────────────────────────
+
+
+def test_deepagents_search_tool_handles_exception(db, monkeypatch):
+    """_search_messages_tool returns friendly error on exception."""
+    mgr = AgentManager(db)
+
+    async def _broken_search(*args, **kwargs):
+        raise RuntimeError("DB unavailable")
+
+    monkeypatch.setattr(db, "search_messages", _broken_search)
+
+    # Force running outside loop
+    result = mgr._deepagents_backend._search_messages_tool("test")
+    assert "временно недоступен" in result or "Ничего не найдено" in result
+
+
+def test_deepagents_get_channels_tool_returns_empty_list_message(db, monkeypatch):
+    """_get_channels_tool returns message when no active channels."""
+    mgr = AgentManager(db)
+
+    async def _empty_channels(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(db, "get_channels", _empty_channels)
+
+    result = mgr._deepagents_backend._get_channels_tool()
+    assert "не найдены" in result
+
+
+# ── _build_prompt_stats_only tests ─────────────────────────────────────────────────
+
+
+def test_build_prompt_stats_only_empty_history(db):
+    """_build_prompt_stats_only returns correct stats for empty history."""
+    mgr = AgentManager(db)
+    stats = mgr._build_prompt_stats_only([], "hello")
+
+    assert stats["total_msgs"] == 0
+    assert stats["kept_msgs"] == 0
+    assert stats["prompt_chars"] > 0
+
+
+def test_build_prompt_stats_only_with_history(db):
+    """_build_prompt_stats_only returns correct stats with history."""
+    mgr = AgentManager(db)
+    history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+    stats = mgr._build_prompt_stats_only(history, "new question")
+
+    assert stats["total_msgs"] == 2
+    assert stats["kept_msgs"] == 2
+    assert "new question" not in stats  # stats only, no prompt built
+    assert stats["prompt_chars"] > 0

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -815,3 +815,313 @@ async def test_agent_manager_skips_cached_unsupported_provider_and_fails_over(db
     assert "openai" not in seen_providers
     assert seen_providers
     assert any('"provider": "anthropic"' in chunk for chunk in chunks)
+
+
+# === _fetch_live_models HTTP error handling tests ===
+
+
+@pytest.mark.asyncio
+async def test_fetch_live_models_http_error_fallback_to_static(db, monkeypatch):
+    """_fetch_live_models propagates exception, caller handles fallback."""
+    import aiohttp
+
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    # Create a config for OpenAI
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        secret_fields={"api_key": "test-key"},
+    )
+
+    async def _broken_fetch_json(url, headers=None):
+        raise aiohttp.ClientError("Connection refused")
+
+    monkeypatch.setattr(service, "_fetch_json", _broken_fetch_json)
+
+    from src.agent.provider_registry import provider_spec
+
+    spec = provider_spec("openai")
+
+    # _fetch_live_models raises exception, refresh_models_for_provider catches it
+    with pytest.raises(aiohttp.ClientError):
+        await service._fetch_live_models(spec, cfg)
+
+
+@pytest.mark.asyncio
+async def test_fetch_live_models_success_updates_cache(db, monkeypatch):
+    """_fetch_live_models returns live models on success."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        secret_fields={"api_key": "test-key"},
+    )
+
+    async def _fake_fetch_json(url, headers=None):
+        return {"data": [{"id": "gpt-4.1"}, {"id": "gpt-4.1-mini"}]}
+
+    monkeypatch.setattr(service, "_fetch_json", _fake_fetch_json)
+
+    from src.agent.provider_registry import provider_spec
+
+    spec = provider_spec("openai")
+    models = await service._fetch_live_models(spec, cfg)
+
+    assert "gpt-4.1" in models
+    assert "gpt-4.1-mini" in models
+
+
+# === save_provider_configs encryption tests ===
+
+
+@pytest.mark.asyncio
+async def test_save_provider_configs_requires_encryption_key(db):
+    """save_provider_configs requires encryption key."""
+    service = AgentProviderService(db, AppConfig())  # No encryption key
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+    )
+
+    with pytest.raises(RuntimeError, match="SESSION_ENCRYPTION_KEY"):
+        await service.save_provider_configs([cfg])
+
+
+# === compatibility record tests ===
+
+
+def test_is_compatibility_record_fresh_with_recent_record(db):
+    """is_compatibility_record_fresh returns True for recent records."""
+    service = AgentProviderService(db, AppConfig())
+
+    recent_record = ProviderModelCompatibilityRecord(
+        model="gpt-4.1-mini",
+        status="supported",
+        tested_at=datetime.now(UTC).isoformat(),
+    )
+
+    assert service.is_compatibility_record_fresh(recent_record) is True
+
+
+def test_is_compatibility_record_fresh_with_stale_record(db):
+    """is_compatibility_record_fresh returns False for stale records."""
+    service = AgentProviderService(db, AppConfig())
+
+    stale_record = ProviderModelCompatibilityRecord(
+        model="gpt-4.1-mini",
+        status="supported",
+        tested_at="2024-01-01T00:00:00+00:00",
+    )
+
+    assert service.is_compatibility_record_fresh(stale_record) is False
+
+
+def test_is_compatibility_record_fresh_with_invalid_date(db):
+    """is_compatibility_record_fresh returns False for invalid date."""
+    service = AgentProviderService(db, AppConfig())
+
+    invalid_record = ProviderModelCompatibilityRecord(
+        model="gpt-4.1-mini",
+        status="supported",
+        tested_at="invalid-date",
+    )
+
+    assert service.is_compatibility_record_fresh(invalid_record) is False
+
+
+# === parse_provider_form tests ===
+
+
+def test_parse_provider_form_handles_missing_fields(db):
+    """parse_provider_form handles missing form fields gracefully."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    form = {}  # Empty form
+
+    result = service.parse_provider_form(form, [])
+
+    # Should return empty list when no providers are marked present
+    assert result == []
+
+
+def test_parse_provider_form_with_enabled_provider(db):
+    """parse_provider_form parses enabled provider from form."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    form = {
+        "provider_present__openai": "1",
+        "provider_enabled__openai": "1",
+        "provider_model__openai": "gpt-4.1-mini",
+        "provider_priority__openai": "0",
+    }
+
+    result = service.parse_provider_form(form, [])
+
+    assert len(result) == 1
+    assert result[0].provider == "openai"
+    assert result[0].enabled is True
+    assert result[0].selected_model == "gpt-4.1-mini"
+
+
+# === build_provider_views tests ===
+
+
+def test_build_provider_views_includes_compatibility(db):
+    """build_provider_views includes compatibility information."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        secret_fields={"api_key": "test-key"},
+    )
+
+    fingerprint = service.config_fingerprint(cfg)
+    cache = {
+        "openai": ProviderModelCacheEntry(
+            provider="openai",
+            models=["gpt-4.1-mini"],
+            source="live",
+            compatibility={
+                fingerprint: ProviderModelCompatibilityRecord(
+                    model="gpt-4.1-mini",
+                    status="supported",
+                    tested_at=datetime.now(UTC).isoformat(),
+                    config_fingerprint=fingerprint,
+                )
+            },
+        )
+    }
+
+    views = service.build_provider_views([cfg], cache)
+
+    assert len(views) == 1
+    assert views[0]["provider"] == "openai"
+    assert views[0]["selected_compatibility"] is not None
+    assert views[0]["selected_compatibility"]["status"] == "supported"
+
+
+# === export_compatibility_catalog tests ===
+
+
+@pytest.mark.asyncio
+async def test_export_compatibility_catalog_creates_file(db, tmp_path):
+    """export_compatibility_catalog creates catalog file."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        secret_fields={"api_key": "test-key"},
+    )
+
+    fingerprint = service.config_fingerprint(cfg)
+    cache = {
+        "openai": ProviderModelCacheEntry(
+            provider="openai",
+            models=["gpt-4.1-mini"],
+            source="live",
+            compatibility={
+                fingerprint: ProviderModelCompatibilityRecord(
+                    model="gpt-4.1-mini",
+                    status="supported",
+                    tested_at=datetime.now(UTC).isoformat(),
+                    config_fingerprint=fingerprint,
+                )
+            },
+        )
+    }
+
+    export_path = tmp_path / "catalog.json"
+    result = await service.export_compatibility_catalog(
+        [cfg], cache, path=export_path
+    )
+
+    assert result == export_path
+    assert export_path.exists()
+
+    import json
+
+    data = json.loads(export_path.read_text())
+    assert "generated_at" in data
+    assert "providers" in data
+
+
+# === canonical_endpoint_fingerprint tests ===
+
+
+def test_canonical_endpoint_fingerprint_for_openai(db):
+    """canonical_endpoint_fingerprint returns default URL for OpenAI."""
+    service = AgentProviderService(db, AppConfig())
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        plain_fields={"base_url": "https://api.openai.com/v1"},
+    )
+
+    fingerprint = service.canonical_endpoint_fingerprint(cfg)
+
+    assert fingerprint == "https://api.openai.com/v1"
+
+
+def test_canonical_endpoint_fingerprint_for_custom_url_returns_none(db):
+    """canonical_endpoint_fingerprint returns None for custom URLs."""
+    service = AgentProviderService(db, AppConfig())
+
+    cfg = ProviderRuntimeConfig(
+        provider="openai",
+        enabled=True,
+        priority=0,
+        selected_model="gpt-4.1-mini",
+        plain_fields={"base_url": "https://custom.api.com/v1"},
+    )
+
+    fingerprint = service.canonical_endpoint_fingerprint(cfg)
+
+    assert fingerprint is None
+
+
+def test_canonical_endpoint_fingerprint_for_ollama_cloud(db):
+    """canonical_endpoint_fingerprint returns 'ollama://cloud' for Ollama cloud."""
+    service = AgentProviderService(db, AppConfig())
+
+    cfg = ProviderRuntimeConfig(
+        provider="ollama",
+        enabled=True,
+        priority=0,
+        selected_model="llama3.2",
+        plain_fields={"base_url": "https://ollama.com"},
+        secret_fields={"api_key": "test-key"},
+    )
+
+    fingerprint = service.canonical_endpoint_fingerprint(cfg)
+
+    assert fingerprint == "ollama://cloud"

--- a/tests/test_content_calendar_service.py
+++ b/tests/test_content_calendar_service.py
@@ -1,0 +1,260 @@
+"""Tests for ContentCalendarService."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.content_calendar_service import (
+    CalendarDay,
+    CalendarEvent,
+    ContentCalendarService,
+)
+
+
+@pytest.fixture
+def mock_db():
+    """Mock Database."""
+    db = MagicMock()
+
+    # Mock repositories
+    db.repos.content_pipelines.get_all = AsyncMock(return_value=[])
+    db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[])
+    db.repos.generation_runs.list_runs_for_calendar = AsyncMock(return_value=[])
+    db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
+    db.repos.generation_runs.get_calendar_stats = AsyncMock(return_value={})
+
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    """ContentCalendarService instance."""
+    return ContentCalendarService(mock_db)
+
+
+# === get_calendar tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_empty_db(service, mock_db):
+    """get_calendar returns empty days when no runs exist."""
+    result = await service.get_calendar(days=3)
+
+    assert len(result) == 3
+    for day in result:
+        assert isinstance(day, CalendarDay)
+        assert day.events == []
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_with_events_filters_by_date(service, mock_db):
+    """get_calendar filters events by date range."""
+    now = datetime.utcnow()
+
+    # Create mock pipeline
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.name = "Test Pipeline"
+    mock_db.repos.content_pipelines.get_all = AsyncMock(return_value=[mock_pipeline])
+
+    # Create mock run within the date range
+    mock_run = MagicMock()
+    mock_run.id = 1
+    mock_run.pipeline_id = 1
+    mock_run.status = "completed"
+    mock_run.moderation_status = "approved"
+    mock_run.generated_text = "Test content"
+    mock_run.created_at = now
+    mock_run.published_at = now
+
+    mock_db.repos.generation_runs.list_runs_for_calendar = AsyncMock(
+        return_value=[mock_run]
+    )
+
+    result = await service.get_calendar(days=1)
+
+    assert len(result) == 1
+    assert len(result[0].events) == 1
+    assert result[0].events[0].pipeline_name == "Test Pipeline"
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_filters_by_pipeline(service, mock_db):
+    """get_calendar filters by pipeline_id when provided."""
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.name = "Test Pipeline"
+    mock_db.repos.content_pipelines.get_all = AsyncMock(return_value=[mock_pipeline])
+
+    await service.get_calendar(days=7, pipeline_id=1)
+
+    mock_db.repos.generation_runs.list_by_pipeline.assert_called_once_with(
+        1, limit=1000
+    )
+    mock_db.repos.generation_runs.list_runs_for_calendar.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_skips_runs_without_pipeline(service, mock_db):
+    """get_calendar skips runs without pipeline_id."""
+    mock_run = MagicMock()
+    mock_run.pipeline_id = None
+
+    mock_db.repos.generation_runs.list_runs_for_calendar = AsyncMock(
+        return_value=[mock_run]
+    )
+
+    result = await service.get_calendar(days=1)
+
+    assert len(result[0].events) == 0
+
+
+# === get_upcoming tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_empty_db(service, mock_db):
+    """get_upcoming returns empty list when no pending runs."""
+    result = await service.get_upcoming(limit=10)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_filters_by_status(service, mock_db):
+    """get_upcoming only includes pending or approved runs."""
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.name = "Test Pipeline"
+    mock_db.repos.content_pipelines.get_all = AsyncMock(return_value=[mock_pipeline])
+
+    # Create run with pending moderation
+    mock_run = MagicMock()
+    mock_run.id = 1
+    mock_run.pipeline_id = 1
+    mock_run.status = "completed"
+    mock_run.moderation_status = "pending"
+    mock_run.generated_text = "Test content"
+    mock_run.created_at = datetime.utcnow()
+    mock_run.published_at = None
+
+    mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(
+        return_value=[mock_run]
+    )
+
+    result = await service.get_upcoming(limit=10)
+
+    assert len(result) == 1
+    assert result[0].moderation_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_respects_limit(service, mock_db):
+    """get_upcoming respects the limit parameter."""
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.name = "Test Pipeline"
+    mock_db.repos.content_pipelines.get_all = AsyncMock(return_value=[mock_pipeline])
+
+    # Create multiple runs
+    runs = []
+    for i in range(10):
+        run = MagicMock()
+        run.id = i
+        run.pipeline_id = 1
+        run.status = "completed"
+        run.moderation_status = "pending"
+        run.generated_text = f"Content {i}"
+        run.created_at = datetime.utcnow() + timedelta(minutes=i)
+        run.published_at = None
+        runs.append(run)
+
+    mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(
+        return_value=runs
+    )
+
+    result = await service.get_upcoming(limit=5)
+
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_upcoming_filters_by_pipeline(service, mock_db):
+    """get_upcoming filters by pipeline_id when provided."""
+    await service.get_upcoming(limit=10, pipeline_id=1)
+
+    mock_db.repos.generation_runs.list_pending_moderation.assert_called_once()
+
+
+# === get_stats tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_stats_delegates_to_repo(service, mock_db):
+    """get_stats delegates to generation_runs repository."""
+    mock_db.repos.generation_runs.get_calendar_stats = AsyncMock(
+        return_value={"total": 10, "approved": 5}
+    )
+
+    result = await service.get_stats()
+
+    mock_db.repos.generation_runs.get_calendar_stats.assert_called_once()
+    assert result == {"total": 10, "approved": 5}
+
+
+@pytest.mark.asyncio
+async def test_get_stats_empty(service, mock_db):
+    """get_stats returns empty dict when no data."""
+    mock_db.repos.generation_runs.get_calendar_stats = AsyncMock(return_value={})
+
+    result = await service.get_stats()
+
+    assert result == {}
+
+
+# === CalendarEvent dataclass tests ===
+
+
+def test_calendar_event_dataclass():
+    """CalendarEvent dataclass stores all fields correctly."""
+    now = datetime.utcnow()
+    event = CalendarEvent(
+        run_id=1,
+        pipeline_id=1,
+        pipeline_name="Test",
+        status="completed",
+        moderation_status="approved",
+        scheduled_time=now,
+        created_at=now,
+        preview="Test content...",
+    )
+
+    assert event.run_id == 1
+    assert event.pipeline_name == "Test"
+    assert event.preview == "Test content..."
+
+
+# === CalendarDay dataclass tests ===
+
+
+def test_calendar_day_dataclass():
+    """CalendarDay dataclass stores all fields correctly."""
+    now = datetime.utcnow()
+    event = CalendarEvent(
+        run_id=1,
+        pipeline_id=1,
+        pipeline_name="Test",
+        status="completed",
+        moderation_status="approved",
+        scheduled_time=now,
+        created_at=now,
+        preview="Test",
+    )
+
+    day = CalendarDay(date="2024-01-15", events=[event])
+
+    assert day.date == "2024-01-15"
+    assert len(day.events) == 1

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -1,0 +1,367 @@
+"""Tests for TrendService."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.trend_service import (
+    MessageVelocity,
+    PeakHour,
+    TrendingChannel,
+    TrendingEmoji,
+    TrendingTopic,
+    TrendService,
+)
+
+
+@pytest.fixture
+def mock_db():
+    """Mock Database."""
+    db = MagicMock()
+    db.execute_fetchall = AsyncMock(return_value=[])
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    """TrendService instance."""
+    return TrendService(mock_db)
+
+
+# === get_trending_topics tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_empty_db(service, mock_db):
+    """get_trending_topics returns empty list when no messages."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[])
+
+    result = await service.get_trending_topics(days=7, limit=20)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_filters_stop_words(service, mock_db):
+    """get_trending_topics filters out stop words."""
+    # Return messages with stop words and valid words
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "Это тест и проверка на стоп слова"},
+            {"text": "Важное сообщение для теста"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=20)
+
+    # Stop words should be filtered out
+    words = [t.keyword for t in result]
+    assert "и" not in words
+    assert "на" not in words
+    assert "для" not in words
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_respects_limit(service, mock_db):
+    """get_trending_topics respects the limit parameter."""
+    # Create many messages with unique words
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": f"word{i} test content"} for i in range(100)
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=10)
+
+    assert len(result) <= 10
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_short_words_filtered(service, mock_db):
+    """get_trending_topics filters words shorter than 4 characters."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "abc test important verify"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=20)
+
+    # "abc" is only 3 chars and should be filtered
+    words = [t.keyword for t in result]
+    assert "abc" not in words
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_with_data(service, mock_db):
+    """get_trending_topics processes and returns topics correctly."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "Important topic here", "views": 100},
+            {"text": "Another important topic here", "views": 50},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=10)
+
+    assert all(isinstance(t, TrendingTopic) for t in result)
+    # Check that "important" appears with count=2 (in both messages)
+    important_topic = next((t for t in result if t.keyword == "important"), None)
+    assert important_topic is not None
+    assert important_topic.count == 2  # "important" appears twice
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_non_alpha_only(service, mock_db):
+    """get_trending_topics only includes alphabetic words."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "validword 123numeric"},
+            {"text": "test123"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=10)
+
+    # Non-alpha words like "123numeric" should be filtered
+    words = [t.keyword for t in result]
+    assert "123numeric" not in words
+    assert "test123" not in words
+    assert "validword" in words
+
+
+@pytest.mark.asyncio
+async def test_get_trending_topics_respects_days(service, mock_db):
+    """get_trending_topics respects days parameter."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[{"text": "test content"}]
+    )
+
+    await service.get_trending_topics(days=30, limit=10)
+
+    mock_db.execute_fetchall.assert_called_once()
+    # Check that days parameter was passed correctly in the query
+    args, _ = mock_db.execute_fetchall.call_args
+    # First arg is the SQL query, second is params tuple
+    assert "-30 days" in str(args[0]) or any("-30 days" in str(a) for a in args[1])
+
+
+# === get_trending_channels tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_trending_channels_empty_db(service, mock_db):
+    """get_trending_channels returns empty list when no data."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[])
+
+    result = await service.get_trending_channels(days=7, limit=10)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_trending_channels_with_min_messages(service, mock_db):
+    """get_trending_channels only includes channels with >= 3 messages."""
+    # SQL HAVING COUNT >= 3 filters, so mock only returns qualifying rows
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {
+                "channel_id": 1,
+                "title": "Channel 1",
+                "username": "channel1",
+                "avg_views": 100.0,
+                "message_count": 5,
+            },
+        ]
+    )
+
+    result = await service.get_trending_channels(days=7, limit=10)
+
+    # Only channels with >= 3 messages are returned by SQL
+    assert len(result) == 1
+    assert result[0].channel_id == 1
+    assert result[0].message_count == 5
+
+
+@pytest.mark.asyncio
+async def test_get_trending_channels_respects_limit(service, mock_db):
+    """get_trending_channels respects the limit parameter."""
+    # Mock returns 5 items (as SQL LIMIT would do)
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {
+                "channel_id": i,
+                "title": f"Channel {i}",
+                "username": f"channel{i}",
+                "avg_views": float(100 - i),
+                "message_count": 5,
+            }
+            for i in range(5)
+        ]
+    )
+
+    result = await service.get_trending_channels(days=7, limit=5)
+
+    assert len(result) == 5
+
+
+# === get_trending_emojis tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_trending_emojis_empty_db(service, mock_db):
+    """get_trending_emojis returns empty list when no reactions."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[])
+
+    result = await service.get_trending_emojis(days=7, limit=15)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_trending_emojis_from_reactions(service, mock_db):
+    """get_trending_emojis aggregates reactions correctly."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+                {"emoji": "👍", "total": 10},
+                {"emoji": "❤️", "total": 5},
+            ]
+    )
+
+    result = await service.get_trending_emojis(days=7, limit=15)
+
+    assert len(result) == 2
+    assert result[0].emoji == "👍"
+    assert result[0].count == 10
+    assert result[1].emoji == "❤️"
+    assert result[1].count == 5
+
+
+@pytest.mark.asyncio
+async def test_get_trending_emojis_respects_limit(service, mock_db):
+    """get_trending_emojis respects the limit parameter."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[{"emoji": f"emoji{i}", "total": 10 - i} for i in range(5)]
+    )
+
+    result = await service.get_trending_emojis(days=7, limit=5)
+
+    assert len(result) == 5
+
+
+# === get_message_velocity tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_message_velocity_empty(service, mock_db):
+    """get_message_velocity returns empty list when no messages."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[])
+
+    result = await service.get_message_velocity(channel_id=123, days=30)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_message_velocity_by_channel(service, mock_db):
+    """get_message_velocity returns daily counts for a channel."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"day": "2024-01-01", "cnt": 5},
+            {"day": "2024-01-02", "cnt": 10},
+        ]
+    )
+
+    result = await service.get_message_velocity(channel_id=123, days=30)
+
+    assert len(result) == 2
+    assert result[0].date == "2024-01-01"
+    assert result[0].count == 5
+    assert result[1].date == "2024-01-02"
+    assert result[1].count == 10
+
+
+# === get_peak_hours tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_peak_hours_empty(service, mock_db):
+    """get_peak_hours returns empty list when no messages."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[])
+
+    result = await service.get_peak_hours(channel_id=123, days=30)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_peak_hours_distribution(service, mock_db):
+    """get_peak_hours returns hourly distribution correctly."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"hour": 12, "cnt": 5},
+            {"hour": 18, "cnt": 10},
+        ]
+    )
+
+    result = await service.get_peak_hours(channel_id=123, days=30)
+
+    assert len(result) == 2
+    assert result[0].hour == 12
+    assert result[0].count == 5
+    assert result[1].hour == 18
+    assert result[1].count == 10
+
+
+# === Dataclass tests ===
+
+
+def test_trending_topic_dataclass():
+    """TrendingTopic dataclass stores fields correctly."""
+    topic = TrendingTopic(keyword="test", count=10)
+
+    assert topic.keyword == "test"
+    assert topic.count == 10
+
+
+def test_trending_channel_dataclass():
+    """TrendingChannel dataclass stores fields correctly."""
+    channel = TrendingChannel(
+        channel_id=1,
+        title="Test",
+        username="test",
+        avg_views=100.0,
+        message_count=10,
+    )
+
+    assert channel.channel_id == 1
+    assert channel.title == "Test"
+    assert channel.username == "test"
+    assert channel.avg_views == 100.0
+    assert channel.message_count == 10
+
+
+def test_trending_emoji_dataclass():
+    """TrendingEmoji dataclass stores fields correctly."""
+    emoji = TrendingEmoji(emoji="👍", count=5)
+
+    assert emoji.emoji == "👍"
+    assert emoji.count == 5
+
+
+def test_message_velocity_dataclass():
+    """MessageVelocity dataclass stores fields correctly."""
+    velocity = MessageVelocity(date="2024-01-01", count=10)
+
+    assert velocity.date == "2024-01-01"
+    assert velocity.count == 10
+
+
+def test_peak_hour_dataclass():
+    """PeakHour dataclass stores fields correctly."""
+    peak = PeakHour(hour=12, count=5)
+
+    assert peak.hour == 12
+    assert peak.count == 5

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -115,8 +115,6 @@ def test_handled_types_contains_expected():
     assert "photo_due" in HANDLED_TYPES
     assert "photo_auto" in HANDLED_TYPES
     assert "pipeline_run" in HANDLED_TYPES
-    assert "content_generate" in HANDLED_TYPES
-    assert "content_publish" in HANDLED_TYPES
 
 
 # === start/stop tests ===
@@ -747,7 +745,7 @@ async def test_handle_pipeline_run_success_with_mocked_services(
     dispatcher, mock_tasks_repo
 ):
     """_handle_pipeline_run succeeds with mocked services."""
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import MagicMock, patch
 
     mock_pipeline_bundle = MagicMock()
     mock_pipeline = MagicMock()
@@ -775,10 +773,10 @@ async def test_handle_pipeline_run_success_with_mocked_services(
 
     with patch(
         "src.services.content_generation_service.ContentGenerationService"
-    ) as MockGenService:
+    ) as mock_gen_service:
         mock_gen_instance = MagicMock()
         mock_gen_instance.generate = AsyncMock(return_value=mock_run)
-        MockGenService.return_value = mock_gen_instance
+        mock_gen_service.return_value = mock_gen_instance
 
         await dispatcher._handle_pipeline_run(task)
 
@@ -839,10 +837,10 @@ async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_r
 
     with patch(
         "src.services.content_generation_service.ContentGenerationService"
-    ) as MockGenService:
+    ) as mock_gen_service:
         mock_gen_instance = MagicMock()
         mock_gen_instance.generate = AsyncMock(side_effect=RuntimeError("LLM error"))
-        MockGenService.return_value = mock_gen_instance
+        mock_gen_service.return_value = mock_gen_instance
 
         await dispatcher._handle_pipeline_run(task)
 
@@ -859,6 +857,7 @@ async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_r
 async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_repo):
     """_handle_content_generate publishes automatically when mode is AUTO."""
     from unittest.mock import patch
+
     from src.models import ContentPipeline, PipelinePublishMode
 
     mock_pipeline = MagicMock(spec=ContentPipeline)
@@ -891,18 +890,18 @@ async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_
     with (
         patch(
             "src.services.content_generation_service.ContentGenerationService"
-        ) as MockGenService,
-        patch("src.services.publish_service.PublishService") as MockPublishService,
+        ) as mock_gen_service,
+        patch("src.services.publish_service.PublishService") as mock_publish_service,
     ):
         mock_gen_instance = MagicMock()
         mock_gen_instance.generate = AsyncMock(return_value=mock_run)
-        MockGenService.return_value = mock_gen_instance
+        mock_gen_service.return_value = mock_gen_instance
 
         mock_publish_instance = MagicMock()
         mock_publish_instance.publish_run = AsyncMock(
             return_value=[MagicMock(success=True)]
         )
-        MockPublishService.return_value = mock_publish_instance
+        mock_publish_service.return_value = mock_publish_instance
 
         await dispatcher._handle_content_generate(task)
 
@@ -917,6 +916,7 @@ async def test_handle_content_generate_without_auto_publish(
 ):
     """_handle_content_generate does not publish when mode is not AUTO."""
     from unittest.mock import patch
+
     from src.models import ContentPipeline, PipelinePublishMode
 
     mock_pipeline = MagicMock(spec=ContentPipeline)
@@ -945,10 +945,10 @@ async def test_handle_content_generate_without_auto_publish(
 
     with patch(
         "src.services.content_generation_service.ContentGenerationService"
-    ) as MockGenService:
+    ) as mock_gen_service:
         mock_gen_instance = MagicMock()
         mock_gen_instance.generate = AsyncMock(return_value=mock_run)
-        MockGenService.return_value = mock_gen_instance
+        mock_gen_service.return_value = mock_gen_instance
 
         await dispatcher._handle_content_generate(task)
 
@@ -1009,8 +1009,8 @@ async def test_handle_content_generate_exception(dispatcher, mock_tasks_repo):
 
     with patch(
         "src.services.content_generation_service.ContentGenerationService"
-    ) as MockGenService:
-        MockGenService.side_effect = RuntimeError("Generation failed")
+    ) as mock_gen_service:
+        mock_gen_service.side_effect = RuntimeError("Generation failed")
 
         await dispatcher._handle_content_generate(task)
 
@@ -1035,8 +1035,7 @@ async def test_handle_content_publish_no_approved_runs(dispatcher, mock_tasks_re
     mock_db.execute = mock_execute
 
     dispatcher._db = mock_db
-    dispatcher._collector = MagicMock()
-    dispatcher._collector._pool = MagicMock()
+    dispatcher._pipeline_bundle = MagicMock()
 
     task = CollectionTask(
         id=1,
@@ -1060,9 +1059,18 @@ async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
 
     mock_db = MagicMock()
 
+    _mock_row_data = {
+        "id": 1,
+        "pipeline_id": 1,
+        "status": "completed",
+        "moderation_status": "approved",
+        "generated_text": "test",
+        "created_at": None,
+        "published_at": None,
+    }
     mock_row = MagicMock()
-    mock_row.keys = MagicMock(return_value=["id", "pipeline_id", "status", "moderation_status", "generated_text", "created_at", "published_at"])
-    mock_row.__getitem__ = lambda self, key: {"id": 1, "pipeline_id": 1, "status": "completed", "moderation_status": "approved", "generated_text": "test", "created_at": None, "published_at": None}[key]
+    mock_row.keys = MagicMock(return_value=list(_mock_row_data.keys()))
+    mock_row.__getitem__ = lambda self, key: _mock_row_data[key]
 
     async def mock_execute(query, params=()):
         result = MagicMock()
@@ -1089,17 +1097,17 @@ async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
         payload=ContentPublishTaskPayload(pipeline_id=None),
     )
 
-    with patch("src.services.publish_service.PublishService") as MockPublishService:
+    with patch("src.services.publish_service.PublishService") as mock_publish_service:
         mock_publish_instance = MagicMock()
         mock_publish_instance.publish_run = AsyncMock(
             return_value=[MagicMock(success=True)]
         )
-        MockPublishService.return_value = mock_publish_instance
+        mock_publish_service.return_value = mock_publish_instance
 
         with patch(
             "src.database.repositories.generation_runs.GenerationRunsRepository"
-        ) as MockRepo:
-            MockRepo._to_generation_run = staticmethod(
+        ) as mock_repo:
+            mock_repo._to_generation_run = staticmethod(
                 lambda row: MagicMock(
                     id=1,
                     pipeline_id=1,

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -115,6 +115,8 @@ def test_handled_types_contains_expected():
     assert "photo_due" in HANDLED_TYPES
     assert "photo_auto" in HANDLED_TYPES
     assert "pipeline_run" in HANDLED_TYPES
+    assert "content_generate" in HANDLED_TYPES
+    assert "content_publish" in HANDLED_TYPES
 
 
 # === start/stop tests ===

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -13,6 +13,8 @@ from src.models import (
     CollectionTask,
     CollectionTaskStatus,
     CollectionTaskType,
+    ContentGenerateTaskPayload,
+    ContentPublishTaskPayload,
     PipelineRunTaskPayload,
     SqStatsTaskPayload,
     StatsAllTaskPayload,
@@ -733,3 +735,497 @@ async def test_run_loop_handles_exception(
 
     # Should have recovered from exception and continued
     assert mock_tasks_repo.claim_next_due_generic_task.call_count >= 2
+
+
+# === _handle_pipeline_run extended tests ===
+
+
+@pytest.mark.asyncio
+async def test_handle_pipeline_run_success_with_mocked_services(
+    dispatcher, mock_tasks_repo
+):
+    """_handle_pipeline_run succeeds with mocked services."""
+    from unittest.mock import patch, MagicMock
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    mock_search_engine = MagicMock()
+    mock_db = MagicMock()
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = mock_search_engine
+    dispatcher._db = mock_db
+    dispatcher._notifier = None
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.PIPELINE_RUN,
+        status=CollectionTaskStatus.RUNNING,
+        payload=PipelineRunTaskPayload(pipeline_id=1),
+    )
+
+    mock_run = MagicMock()
+    mock_run.id = 42
+
+    with patch(
+        "src.services.content_generation_service.ContentGenerationService"
+    ) as MockGenService:
+        mock_gen_instance = MagicMock()
+        mock_gen_instance.generate = AsyncMock(return_value=mock_run)
+        MockGenService.return_value = mock_gen_instance
+
+        await dispatcher._handle_pipeline_run(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_handle_pipeline_run_pipeline_not_found(dispatcher, mock_tasks_repo):
+    """_handle_pipeline_run completes when pipeline not found."""
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=None)
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = MagicMock()
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.PIPELINE_RUN,
+        status=CollectionTaskStatus.RUNNING,
+        payload=PipelineRunTaskPayload(pipeline_id=999),
+    )
+
+    await dispatcher._handle_pipeline_run(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+    assert "not found" in kwargs.get("note", "")
+
+
+@pytest.mark.asyncio
+async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_repo):
+    """_handle_pipeline_run handles generation errors."""
+    from unittest.mock import patch
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    mock_db = MagicMock()
+    mock_db.repos.generation_runs.set_status = AsyncMock()
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = mock_db
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.PIPELINE_RUN,
+        status=CollectionTaskStatus.RUNNING,
+        payload=PipelineRunTaskPayload(pipeline_id=1),
+    )
+
+    with patch(
+        "src.services.content_generation_service.ContentGenerationService"
+    ) as MockGenService:
+        mock_gen_instance = MagicMock()
+        mock_gen_instance.generate = AsyncMock(side_effect=RuntimeError("LLM error"))
+        MockGenService.return_value = mock_gen_instance
+
+        await dispatcher._handle_pipeline_run(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.FAILED
+    assert "LLM error" in kwargs.get("error", "")
+
+
+# === _handle_content_generate tests ===
+
+
+@pytest.mark.asyncio
+async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_repo):
+    """_handle_content_generate publishes automatically when mode is AUTO."""
+    from unittest.mock import patch
+    from src.models import ContentPipeline, PipelinePublishMode
+
+    mock_pipeline = MagicMock(spec=ContentPipeline)
+    mock_pipeline.id = 1
+    mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline.publish_mode = PipelinePublishMode.AUTO
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    mock_db = MagicMock()
+    mock_db.repos.generation_runs.set_status = AsyncMock()
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = mock_db
+    dispatcher._collector = MagicMock()
+    dispatcher._collector._pool = MagicMock()
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_GENERATE,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentGenerateTaskPayload(pipeline_id=1),
+    )
+
+    mock_run = MagicMock()
+    mock_run.id = 42
+
+    with (
+        patch(
+            "src.services.content_generation_service.ContentGenerationService"
+        ) as MockGenService,
+        patch("src.services.publish_service.PublishService") as MockPublishService,
+    ):
+        mock_gen_instance = MagicMock()
+        mock_gen_instance.generate = AsyncMock(return_value=mock_run)
+        MockGenService.return_value = mock_gen_instance
+
+        mock_publish_instance = MagicMock()
+        mock_publish_instance.publish_run = AsyncMock(
+            return_value=[MagicMock(success=True)]
+        )
+        MockPublishService.return_value = mock_publish_instance
+
+        await dispatcher._handle_content_generate(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_handle_content_generate_without_auto_publish(
+    dispatcher, mock_tasks_repo
+):
+    """_handle_content_generate does not publish when mode is not AUTO."""
+    from unittest.mock import patch
+    from src.models import ContentPipeline, PipelinePublishMode
+
+    mock_pipeline = MagicMock(spec=ContentPipeline)
+    mock_pipeline.id = 1
+    mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline.publish_mode = PipelinePublishMode.MODERATED
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    mock_db = MagicMock()
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = mock_db
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_GENERATE,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentGenerateTaskPayload(pipeline_id=1),
+    )
+
+    mock_run = MagicMock()
+    mock_run.id = 42
+
+    with patch(
+        "src.services.content_generation_service.ContentGenerationService"
+    ) as MockGenService:
+        mock_gen_instance = MagicMock()
+        mock_gen_instance.generate = AsyncMock(return_value=mock_run)
+        MockGenService.return_value = mock_gen_instance
+
+        await dispatcher._handle_content_generate(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+    assert kwargs.get("messages_collected") == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_content_generate_pipeline_not_found(
+    dispatcher, mock_tasks_repo
+):
+    """_handle_content_generate completes when pipeline not found."""
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=None)
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = MagicMock()
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_GENERATE,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentGenerateTaskPayload(pipeline_id=999),
+    )
+
+    await dispatcher._handle_content_generate(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+    assert "not found" in kwargs.get("note", "")
+
+
+@pytest.mark.asyncio
+async def test_handle_content_generate_exception(dispatcher, mock_tasks_repo):
+    """_handle_content_generate handles exceptions."""
+    from unittest.mock import patch
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+    mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+    dispatcher._search_engine = MagicMock()
+    dispatcher._db = MagicMock()
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_GENERATE,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentGenerateTaskPayload(pipeline_id=1),
+    )
+
+    with patch(
+        "src.services.content_generation_service.ContentGenerationService"
+    ) as MockGenService:
+        MockGenService.side_effect = RuntimeError("Generation failed")
+
+        await dispatcher._handle_content_generate(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.FAILED
+
+
+# === _handle_content_publish tests ===
+
+
+@pytest.mark.asyncio
+async def test_handle_content_publish_no_approved_runs(dispatcher, mock_tasks_repo):
+    """_handle_content_publish completes when no approved runs."""
+    mock_db = MagicMock()
+
+    async def mock_execute(query, params=()):
+        result = MagicMock()
+        result.fetchall = AsyncMock(return_value=[])
+        return result
+
+    mock_db.execute = mock_execute
+
+    dispatcher._db = mock_db
+    dispatcher._collector = MagicMock()
+    dispatcher._collector._pool = MagicMock()
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_PUBLISH,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentPublishTaskPayload(pipeline_id=None),
+    )
+
+    await dispatcher._handle_content_publish(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.COMPLETED
+    assert "No approved runs" in kwargs.get("note", "")
+
+
+@pytest.mark.asyncio
+async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
+    """_handle_content_publish publishes approved runs."""
+    from unittest.mock import patch
+
+    mock_db = MagicMock()
+
+    mock_row = MagicMock()
+    mock_row.keys = MagicMock(return_value=["id", "pipeline_id", "status", "moderation_status", "generated_text", "created_at", "published_at"])
+    mock_row.__getitem__ = lambda self, key: {"id": 1, "pipeline_id": 1, "status": "completed", "moderation_status": "approved", "generated_text": "test", "created_at": None, "published_at": None}[key]
+
+    async def mock_execute(query, params=()):
+        result = MagicMock()
+        result.fetchall = AsyncMock(return_value=[mock_row])
+        return result
+
+    mock_db.execute = mock_execute
+
+    mock_pipeline = MagicMock()
+    mock_pipeline.id = 1
+
+    mock_pipeline_bundle = MagicMock()
+    mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
+
+    dispatcher._db = mock_db
+    dispatcher._collector = MagicMock()
+    dispatcher._collector._pool = MagicMock()
+    dispatcher._pipeline_bundle = mock_pipeline_bundle
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_PUBLISH,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentPublishTaskPayload(pipeline_id=None),
+    )
+
+    with patch("src.services.publish_service.PublishService") as MockPublishService:
+        mock_publish_instance = MagicMock()
+        mock_publish_instance.publish_run = AsyncMock(
+            return_value=[MagicMock(success=True)]
+        )
+        MockPublishService.return_value = mock_publish_instance
+
+        with patch(
+            "src.database.repositories.generation_runs.GenerationRunsRepository"
+        ) as MockRepo:
+            MockRepo._to_generation_run = staticmethod(
+                lambda row: MagicMock(
+                    id=1,
+                    pipeline_id=1,
+                    status="completed",
+                    moderation_status="approved",
+                    generated_text="test content",
+                )
+            )
+
+            await dispatcher._handle_content_publish(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+
+
+# === _handle_stats_all extended edge cases ===
+
+
+@pytest.mark.asyncio
+async def test_handle_stats_all_timeout_waiting_for_collector(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """_handle_stats_all fails when waiting too long for collector."""
+    mock_collector.is_running = True  # Collector always running
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(
+            channel_ids=[100],
+            next_index=0,
+            batch_size=10,
+        ),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+        channel_timeout_sec=0.05,  # Very short timeout
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    mock_tasks_repo.update_collection_task.assert_called()
+    args, kwargs = mock_tasks_repo.update_collection_task.call_args
+    assert args[1] == CollectionTaskStatus.FAILED
+    assert "Timed out" in kwargs.get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_handle_stats_all_exception_during_stats(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """_handle_stats_all handles exceptions during stats collection."""
+    mock_collector.collect_channel_stats = AsyncMock(
+        side_effect=RuntimeError("Network error")
+    )
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(
+            channel_ids=[100],
+            next_index=0,
+            batch_size=10,
+        ),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    # Should increment errors and continue
+    mock_tasks_repo.update_collection_task.assert_called()
+
+
+# === _run_loop extended exception recovery tests ===
+
+
+@pytest.mark.asyncio
+async def test_run_loop_marks_task_failed_on_unexpected_exception(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """_run_loop marks task as failed when exception occurs during processing."""
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[123], next_index=0),
+    )
+
+    call_count = [0]
+
+    async def claim_side_effect(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return task
+        return None
+
+    # Make _handle_stats_all throw an exception
+    mock_collector.collect_channel_stats = AsyncMock(
+        side_effect=RuntimeError("Unexpected error")
+    )
+    mock_collector.get_stats_availability = AsyncMock(
+        return_value=MagicMock(state="available", next_available_at_utc=None)
+    )
+
+    mock_tasks_repo.claim_next_due_generic_task.side_effect = claim_side_effect
+    mock_tasks_repo.get_collection_task.return_value = task
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+    )
+
+    await dispatcher.start()
+    await asyncio.sleep(0.1)
+    await dispatcher.stop()
+
+    # Task should have been processed despite exception
+    assert mock_tasks_repo.claim_next_due_generic_task.call_count >= 1

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -115,6 +115,8 @@ def test_handled_types_contains_expected():
     assert "photo_due" in HANDLED_TYPES
     assert "photo_auto" in HANDLED_TYPES
     assert "pipeline_run" in HANDLED_TYPES
+    assert "content_generate" in HANDLED_TYPES
+    assert "content_publish" in HANDLED_TYPES
 
 
 # === start/stop tests ===
@@ -874,8 +876,6 @@ async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_
     dispatcher._pipeline_bundle = mock_pipeline_bundle
     dispatcher._search_engine = MagicMock()
     dispatcher._db = mock_db
-    dispatcher._collector = MagicMock()
-    dispatcher._collector._pool = MagicMock()
 
     task = CollectionTask(
         id=1,
@@ -1086,8 +1086,6 @@ async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
 
     dispatcher._db = mock_db
-    dispatcher._collector = MagicMock()
-    dispatcher._collector._pool = MagicMock()
     dispatcher._pipeline_bundle = mock_pipeline_bundle
 
     task = CollectionTask(


### PR DESCRIPTION
## Summary
- Extended `CollectionTask.payload` union type with `ContentGenerateTaskPayload` and `ContentPublishTaskPayload`
- Added new test suites for `ContentCalendarService` and `TrendService`
- Added `DeepagentsBackend` property tests covering legacy fallback and unavailable states
- Updated `AgentProviderService` and `UnifiedDispatcher` tests for new payload handling

## Test plan
- [ ] Run `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — all parallel-safe tests pass
- [ ] Run `pytest tests/ -v -m aiosqlite_serial` — serial tests pass
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)