### PR TITLE
feat: convert UTC dates to browser local time via local_dt filter

### DIFF
--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 import os
+import re
 import tomllib
 from datetime import datetime, timezone
 
@@ -93,8 +94,8 @@ def local_dt_filter(value: datetime | str | None, fmt: str = "datetime") -> Mark
         s = str(value).strip()
         if not s:
             return Markup("—")
-        # Append Z if there is no timezone indicator already
-        if "+" not in s and s[-1] != "Z" and not s.endswith("+00:00"):
+        # Append Z if there is no timezone indicator already (handles both +HH:MM and -HH:MM)
+        if s[-1] != "Z" and not re.search(r"[+-]\d{2}:\d{2}$", s):
             s = s + "Z"
         iso = s
 
@@ -104,7 +105,7 @@ def local_dt_filter(value: datetime | str | None, fmt: str = "datetime") -> Mark
     else:
         fallback = str(value)[:16]
 
-    return Markup(f'<span class="local-dt" data-utc="{iso}" data-fmt="{escape(fmt)}">{fallback}</span>')
+    return Markup(f'<span class="local-dt" data-utc="{escape(iso)}" data-fmt="{escape(fmt)}">{escape(fallback)}</span>')
 
 
 def configure_template_globals(

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -4,9 +4,11 @@ import importlib.metadata
 import logging
 import os
 import tomllib
+from datetime import datetime, timezone
 
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
+from markupsafe import Markup
 
 from src.config import AppConfig, is_provider_model_ref
 from src.web.paths import TEMPLATES_DIR
@@ -71,10 +73,45 @@ def _agent_available_for_request(request: Request) -> bool:
     return _agent_available(getattr(request.app.state, "config", None))
 
 
+def local_dt_filter(value: datetime | str | None, fmt: str = "datetime") -> Markup:
+    """Jinja2 filter: renders a UTC datetime as a client-side localised span.
+
+    The span contains the ISO-8601 UTC string in ``data-utc`` and the desired
+    format key in ``data-fmt``.  A small JS snippet in base.html converts it to
+    the browser's local time on load and after every HTMX swap.
+    """
+    if value is None:
+        return Markup("—")
+
+    # Normalise to an ISO-8601 string with explicit UTC offset so that
+    # JavaScript's Date() always interprets it as UTC.
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        iso = value.isoformat()
+    else:
+        s = str(value).strip()
+        if not s:
+            return Markup("—")
+        # Append Z if there is no timezone indicator already
+        if "+" not in s and s[-1] != "Z" and not s.endswith("+00:00"):
+            s = s + "Z"
+        iso = s
+
+    # Server-side fallback text shown before JS runs
+    if isinstance(value, datetime):
+        fallback = value.strftime("%Y-%m-%d %H:%M")
+    else:
+        fallback = str(value)[:16]
+
+    return Markup(f'<span class="local-dt" data-utc="{iso}" data-fmt="{fmt}">{fallback}</span>')
+
+
 def configure_template_globals(
     templates: Jinja2Templates,
     config: AppConfig | None = None,
 ) -> Jinja2Templates:
     templates.env.globals["agent_available"] = _agent_available_for_request
     templates.env.globals["app_version"] = get_app_version()
+    templates.env.filters["local_dt"] = local_dt_filter
     return templates

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from src.config import AppConfig, is_provider_model_ref
 from src.web.paths import TEMPLATES_DIR
@@ -104,7 +104,7 @@ def local_dt_filter(value: datetime | str | None, fmt: str = "datetime") -> Mark
     else:
         fallback = str(value)[:16]
 
-    return Markup(f'<span class="local-dt" data-utc="{iso}" data-fmt="{fmt}">{fallback}</span>')
+    return Markup(f'<span class="local-dt" data-utc="{iso}" data-fmt="{escape(fmt)}">{fallback}</span>')
 
 
 def configure_template_globals(

--- a/src/web/templates/_timing_rows.html
+++ b/src/web/templates/_timing_rows.html
@@ -1,6 +1,6 @@
 {% for r in records %}
 <tr{% if r.ms > 1000 %} class="table-danger"{% elif r.ms > 500 %} class="table-warning"{% endif %}>
-  <td><code>{{ r.time }}</code></td>
+  <td><code>{{ r.time|local_dt("time") }}</code></td>
   <td><strong>{{ r.ms }} ms</strong></td>
   <td>{{ r.method }}</td>
   <td><code>{{ r.path }}</code></td>

--- a/src/web/templates/analytics.html
+++ b/src/web/templates/analytics.html
@@ -49,7 +49,7 @@
             {% for msg in top_messages %}
             <tr>
                 <td class="text-muted">{{ loop.index }}</td>
-                <td class="text-nowrap">{{ msg.date[:16] if msg.date else '—' }}</td>
+                <td class="text-nowrap">{{ msg.date|local_dt }}</td>
                 <td>{{ msg.channel_title or msg.channel_username or msg.channel_id }}</td>
                 <td><span class="badge text-bg-secondary">{{ msg.media_type or 'text' }}</span></td>
                 <td>{{ msg_text(msg.text) }}</td>
@@ -75,7 +75,7 @@
                     <strong class="text-truncate me-2">{{ msg.channel_title or msg.channel_username or msg.channel_id }}</strong>
                     <span class="badge text-bg-primary">{{ msg.total_reactions }} 👍</span>
                 </div>
-                <small class="text-muted">{{ msg.date[:16] if msg.date else '—' }} &middot; {{ msg.media_type or 'text' }}</small>
+                <small class="text-muted">{{ msg.date|local_dt }} &middot; {{ msg.media_type or 'text' }}</small>
                 <p class="mb-1 mt-1" style="font-size:0.85rem">{{ msg_text(msg.text) }}</p>
                 {% if msg.channel_username %}
                 <a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary">Открыть &#8599;</a>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -238,6 +238,23 @@
         var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
     });
+    // Local date conversion: replace .local-dt[data-utc] spans with browser-local time
+    function convertLocalDates() {
+        document.querySelectorAll('.local-dt[data-utc]').forEach(function(el) {
+            var d = new Date(el.dataset.utc);
+            if (isNaN(d)) return;
+            var fmt = el.dataset.fmt || 'datetime';
+            if (fmt === 'time') {
+                el.textContent = d.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', second: '2-digit'});
+            } else if (fmt === 'date') {
+                el.textContent = d.toLocaleDateString();
+            } else {
+                el.textContent = d.toLocaleString([], {year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit'});
+            }
+        });
+    }
+    document.addEventListener('DOMContentLoaded', convertLocalDates);
+    document.body.addEventListener('htmx:afterSwap', convertLocalDates);
     // Reusable spinner helper for fetch-based (non-form) buttons
     window.setAsyncButtonBusy = function(button, busy, busyLabel) {
         if (!button) return;

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -238,9 +238,10 @@
         var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
     });
-    // Local date conversion: replace .local-dt[data-utc] spans with browser-local time
-    function convertLocalDates() {
-        document.querySelectorAll('.local-dt[data-utc]').forEach(function(el) {
+    // Local date conversion: replace .local-dt[data-utc] spans with browser-local time.
+    // Initial textContent is a server-side UTC fallback; JS replaces it once the page loads.
+    function convertLocalDates(root) {
+        (root || document).querySelectorAll('.local-dt[data-utc]').forEach(function(el) {
             var d = new Date(el.dataset.utc);
             if (isNaN(d)) return;
             var fmt = el.dataset.fmt || 'datetime';
@@ -253,8 +254,8 @@
             }
         });
     }
-    document.addEventListener('DOMContentLoaded', convertLocalDates);
-    document.body.addEventListener('htmx:afterSwap', convertLocalDates);
+    document.addEventListener('DOMContentLoaded', function() { convertLocalDates(); });
+    document.body.addEventListener('htmx:afterSwap', function(e) { convertLocalDates(e.detail.target); });
     // Reusable spinner helper for fetch-based (non-form) buttons
     window.setAsyncButtonBusy = function(button, busy, busyLabel) {
         if (!button) return;

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -64,7 +64,7 @@
                                 {{ run.moderation_status }}
                             </span>
                         </td>
-                        <td>{{ run.created_at.strftime('%Y-%m-%d %H:%M') if run.created_at else '—' }}</td>
+                        <td>{{ run.created_at|local_dt }}</td>
                         <td>
                             {% if run.generated_text %}
                             <span class="text-muted">{{ run.generated_text[:100] }}{% if run.generated_text|length > 100 %}...{% endif %}</span>

--- a/src/web/templates/moderation/view.html
+++ b/src/web/templates/moderation/view.html
@@ -65,11 +65,11 @@
                         <dd class="col-sm-7">{{ run.moderation_status }}</dd>
 
                         <dt class="col-sm-5">Создан</dt>
-                        <dd class="col-sm-7">{{ run.created_at.strftime('%Y-%m-%d %H:%M') if run.created_at else '—' }}</dd>
+                        <dd class="col-sm-7">{{ run.created_at|local_dt }}</dd>
 
                         {% if run.published_at %}
                         <dt class="col-sm-5">Опубликован</dt>
-                        <dd class="col-sm-7">{{ run.published_at.strftime('%Y-%m-%d %H:%M') }}</dd>
+                        <dd class="col-sm-7">{{ run.published_at|local_dt }}</dd>
                         {% endif %}
                     </dl>
                 </div>

--- a/src/web/templates/my_telegram.html
+++ b/src/web/templates/my_telegram.html
@@ -41,7 +41,7 @@
         </form>
         {% if selected_phone %}
         <small class="text-muted d-block mt-2">
-            Показан сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at.strftime("%Y-%m-%d %H:%M") }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
+            Показан сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at|local_dt }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
         </small>
         {% endif %}
     </div>

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -58,7 +58,7 @@
         </form>
         <div class="col-12">
             <small class="text-muted">
-                Используется сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at.strftime("%Y-%m-%d %H:%M") }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
+                Используется сохранённый список диалогов{% if dialogs_cached_at %} от {{ dialogs_cached_at|local_dt }}{% endif %}. Кнопка обновления заново загружает данные из Telegram.
             </small>
         </div>
         </div>
@@ -309,7 +309,7 @@
                             <td>{{ batch.target_title or batch.target_dialog_id }}</td>
                             <td>{{ batch.send_mode }}</td>
                             <td>{{ batch.status }}</td>
-                            <td>{{ batch.created_at or "—" }}</td>
+                            <td>{{ batch.created_at|local_dt }}</td>
                         </tr>
                         {% endfor %}
                         </tbody>
@@ -338,7 +338,7 @@
                             <td class="font-monospace">{{ job.folder_path }}</td>
                             <td>{{ job.interval_minutes }} мин.</td>
                             <td>{{ "active" if job.is_active else "paused" }}</td>
-                            <td>{{ job.last_run_at or "—" }}</td>
+                            <td>{{ job.last_run_at|local_dt }}</td>
                             <td class="d-flex gap-2">
                                 <form method="post" action="/my-telegram/photos/auto/{{ job.id }}/toggle" data-busy>
                                     <input type="hidden" name="phone" value="{{ selected_phone }}">
@@ -376,7 +376,7 @@
                             <td>{{ item.id }}</td>
                             <td>{{ item.target_title or item.target_dialog_id }}</td>
                             <td>{{ item.file_paths|length }}</td>
-                            <td>{{ item.schedule_at or item.created_at }}</td>
+                            <td>{{ (item.schedule_at or item.created_at)|local_dt }}</td>
                             <td>{{ item.status }}</td>
                             <td>
                                 <form method="post" action="/my-telegram/photos/items/{{ item.id }}/cancel" data-busy>

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -141,7 +141,7 @@
                     {{ pipeline.generate_interval_minutes }} мин
                     {% set nr = next_runs.get(pipeline.id) %}
                     {% if nr %}
-                    <div class="small text-muted">Next: {{ nr }}</div>
+                    <div class="small text-muted">Next: {{ nr|local_dt }}</div>
                     {% else %}
                     <div class="small text-muted">Не запланировано</div>
                     {% endif %}

--- a/src/web/templates/pipelines/generate.html
+++ b/src/web/templates/pipelines/generate.html
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', function(){
         <h5 class="mt-3">Citations</h5>
         <ul>
             {% for c in run.metadata.citations %}
-            <li>{{ c.channel_title }} id={{ c.message_id }} date={{ c.date }}</li>
+            <li>{{ c.channel_title }} id={{ c.message_id }} date={{ c.date|local_dt(fmt="date") }}</li>
             {% endfor %}
         </ul>
         <form method="post" action="/pipelines/{{ pipeline.id }}/publish" data-busy>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -105,7 +105,7 @@
                     </td>
                     <td>
                         {% if j.next_run %}
-                            {{ j.next_run.strftime('%H:%M:%S') }}
+                            {{ j.next_run|local_dt("time") }}
                         {% elif is_running and j.enabled %}
                             —
                         {% elif not j.enabled %}
@@ -150,7 +150,7 @@
                     <td>{{ entry.query }}</td>
                     <td>{{ entry.phone }}</td>
                     <td>{{ entry.results_count }}</td>
-                    <td>{{ entry.created_at }}</td>
+                    <td>{{ entry.created_at|local_dt }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -165,7 +165,7 @@
                         <strong class="text-truncate">{{ entry.query }}</strong>
                         <span class="badge text-bg-secondary">{{ entry.results_count }}</span>
                     </div>
-                    <small class="text-muted">{{ entry.phone }} &middot; {{ entry.created_at }}</small>
+                    <small class="text-muted">{{ entry.phone }} &middot; {{ entry.created_at|local_dt }}</small>
                 </div>
             </div>
             {% endfor %}
@@ -233,7 +233,7 @@
                             Отменена
                         {% else %}
                             {% if t.run_after %}
-                                Ожидание до {{ t.run_after.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+                                Ожидание до {{ t.run_after|local_dt }}
                             {% else %}
                                 Ожидание
                             {% endif %}
@@ -246,8 +246,8 @@
                             {{ t.messages_collected }}
                         {% endif %}
                     </td>
-                    <td>{{ t.created_at.strftime('%Y-%m-%d %H:%M') if t.created_at else '—' }}</td>
-                    <td>{{ t.completed_at.strftime('%Y-%m-%d %H:%M') if t.completed_at else '—' }}</td>
+                    <td>{{ t.created_at|local_dt }}</td>
+                    <td>{{ t.completed_at|local_dt }}</td>
                     <td>
                         {% if t.status == 'running' %}
                             <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel" class="mb-0" data-busy>
@@ -295,7 +295,7 @@
                         {% else %}
                             {{ t.messages_collected }} сообщ.
                         {% endif %}
-                        {% if t.created_at %}&middot; {{ t.created_at.strftime('%m-%d %H:%M') }}{% endif %}
+                        {% if t.created_at %}&middot; {{ t.created_at|local_dt }}{% endif %}
                     </small>
                     {% if t.status == 'running' or t.status == 'pending' %}
                     <div class="mt-1">

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -113,7 +113,7 @@
     <tbody>
         {% for msg in result.messages %}
         <tr>
-            <td class="text-nowrap">{{ msg.date.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td class="text-nowrap">{{ msg.date|local_dt }}</td>
             <td>{{ msg.channel_title or msg.channel_username or msg.channel_id }}</td>
             <td>{{ msg.sender_name or "—" }}</td>
             <td>{{ msg.media_type or "—" }}</td>
@@ -140,7 +140,7 @@
                 <strong class="text-truncate">{{ msg.channel_title or msg.channel_username or msg.channel_id }}</strong>
                 {% if msg.channel_username %}<a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener">&#8599;</a>{% else %}<a href="https://t.me/c/{{ msg.channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener">&#8599;</a>{% endif %}
             </div>
-            <small class="text-muted">{{ msg.date.strftime('%Y-%m-%d %H:%M') }}{% if msg.sender_name %} &middot; {{ msg.sender_name }}{% endif %}{% if msg.media_type %} &middot; {{ msg.media_type }}{% endif %}</small>
+            <small class="text-muted">{{ msg.date|local_dt }}{% if msg.sender_name %} &middot; {{ msg.sender_name }}{% endif %}{% if msg.media_type %} &middot; {{ msg.media_type }}{% endif %}</small>
             <p class="mb-0 mt-1" style="font-size:0.85rem">{{ msg.text[:200] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 200 else "" }}</p>
             {%- if msg.views is not none or msg.forwards is not none or msg.reply_count is not none %}
             <small class="text-muted">

--- a/src/web/templates/settings/_accounts.html
+++ b/src/web/templates/settings/_accounts.html
@@ -24,8 +24,8 @@
             <td class="text-center">{% if acc.is_premium %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
             <td class="text-center">{% if acc.is_primary %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
             <td class="text-center">{% if acc.phone in connected_phones %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
-            <td>{{ acc.flood_wait_until.strftime('%H:%M:%S') if acc.flood_wait_until else "\u2014" }}</td>
-            <td>{{ acc.created_at.strftime('%Y-%m-%d') if acc.created_at else "\u2014" }}</td>
+            <td>{{ acc.flood_wait_until|local_dt("time") }}</td>
+            <td>{{ acc.created_at|local_dt("date") }}</td>
             <td class="text-nowrap">
                 <form method="post" action="/settings/{{ acc.id }}/toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm"
@@ -58,8 +58,8 @@
                 {% if acc.is_premium %}Premium{% endif %}
                 {% if acc.is_primary %}&middot; Primary{% endif %}
                 {% if acc.phone in connected_phones %}&middot; Подключён{% endif %}
-                {% if acc.flood_wait_until %}&middot; Flood: {{ acc.flood_wait_until.strftime('%H:%M:%S') }}{% endif %}
-                {% if acc.created_at %}&middot; {{ acc.created_at.strftime('%Y-%m-%d') }}{% endif %}
+                {% if acc.flood_wait_until %}&middot; Flood: {{ acc.flood_wait_until|local_dt("time") }}{% endif %}
+                {% if acc.created_at %}&middot; {{ acc.created_at|local_dt("date") }}{% endif %}
             </small>
             <div class="card-actions">
                 <form method="post" action="/settings/{{ acc.id }}/toggle" class="d-inline" data-busy>

--- a/src/web/templates/settings/_devmode.html
+++ b/src/web/templates/settings/_devmode.html
@@ -175,7 +175,7 @@
                     <div class="form-text" id="provider_model_meta__{{ item.provider }}">
                         source:
                         <span class="badge text-bg-{{ 'success' if item.model_source == 'live' else 'secondary' }}">{{ item.model_source }}</span>
-                        {% if item.model_fetched_at %}| {{ item.model_fetched_at }}{% endif %}
+                        {% if item.model_fetched_at %}| {{ item.model_fetched_at|local_dt }}{% endif %}
                     </div>
                     <div class="small text-muted{{ '' if item.model_fetch_error else ' d-none' }}"
                          id="provider_model_error__{{ item.provider }}">{{ item.model_fetch_error }}</div>
@@ -184,7 +184,7 @@
                         <div>
                             compatibility:
                             <span class="badge text-bg-{{ 'success' if item.selected_compatibility.status == 'supported' else ('warning' if item.selected_compatibility.status == 'unknown' else 'danger') }}">{{ item.selected_compatibility.status }}</span>
-                            {% if item.selected_compatibility.tested_at %}| {{ item.selected_compatibility.tested_at }}{% endif %}
+                            {% if item.selected_compatibility.tested_at %}| {{ item.selected_compatibility.tested_at|local_dt }}{% endif %}
                         </div>
                         {% if item.selected_compatibility.reason %}
                         <div class="text-muted">{{ item.selected_compatibility.reason }}</div>

--- a/tests/test_template_globals.py
+++ b/tests/test_template_globals.py
@@ -42,9 +42,18 @@ def test_string_with_z_unchanged():
     assert "ZZ" not in result
 
 
-def test_string_with_offset_unchanged():
+def test_string_with_positive_offset_unchanged():
     result = str(local_dt_filter("2024-03-15T12:30:00+02:00"))
     assert "2024-03-15T12:30:00+02:00" in result
+    assert "ZZ" not in result
+    assert result.count("Z") == 0
+
+
+def test_string_with_negative_offset_unchanged():
+    # Negative UTC offsets like -05:00 must not get Z appended (would produce invalid ISO)
+    result = str(local_dt_filter("2024-03-15T10:30:00-05:00"))
+    assert "2024-03-15T10:30:00-05:00" in result
+    assert "Z" not in result
 
 
 def test_fmt_date_attribute():

--- a/tests/test_template_globals.py
+++ b/tests/test_template_globals.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+
+from src.web.template_globals import local_dt_filter
+
+
+def test_none_returns_dash():
+    assert local_dt_filter(None) == "—"
+
+
+def test_empty_string_returns_dash():
+    assert local_dt_filter("") == "—"
+
+
+def test_whitespace_string_returns_dash():
+    assert local_dt_filter("   ") == "—"
+
+
+def test_naive_datetime_gets_utc_suffix():
+    dt = datetime(2024, 3, 15, 10, 30, 0)
+    result = str(local_dt_filter(dt))
+    assert "data-utc=" in result
+    # naive datetime should have +00:00 appended (via replace(tzinfo=utc))
+    assert "+00:00" in result
+
+
+def test_aware_datetime_utc_preserved():
+    dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt))
+    assert "+00:00" in result
+    assert 'class="local-dt"' in result
+
+
+def test_string_without_tz_gets_z():
+    result = str(local_dt_filter("2024-03-15T10:30:00"))
+    assert "2024-03-15T10:30:00Z" in result
+
+
+def test_string_with_z_unchanged():
+    result = str(local_dt_filter("2024-03-15T10:30:00Z"))
+    assert "2024-03-15T10:30:00Z" in result
+    # must not double-append Z
+    assert "ZZ" not in result
+
+
+def test_string_with_offset_unchanged():
+    result = str(local_dt_filter("2024-03-15T12:30:00+02:00"))
+    assert "2024-03-15T12:30:00+02:00" in result
+
+
+def test_fmt_date_attribute():
+    dt = datetime(2024, 3, 15, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt, fmt="date"))
+    assert 'data-fmt="date"' in result
+
+
+def test_fmt_time_attribute():
+    dt = datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt, fmt="time"))
+    assert 'data-fmt="time"' in result
+
+
+def test_fmt_default_datetime_attribute():
+    dt = datetime(2024, 3, 15, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt))
+    assert 'data-fmt="datetime"' in result
+
+
+def test_fmt_with_quotes_is_escaped():
+    # XSS: fmt value containing a quote must be escaped in HTML attribute
+    dt = datetime(2024, 3, 15, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt, fmt='"><script>'))
+    assert "<script>" not in result
+    assert "&lt;" in result or "&#34;" in result or "&quot;" in result
+
+
+def test_output_is_span():
+    dt = datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt))
+    assert result.startswith("<span") and result.endswith("</span>")
+
+
+def test_fallback_text_present_for_datetime():
+    dt = datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc)
+    result = str(local_dt_filter(dt))
+    assert "2024-03-15 10:30" in result
+
+
+def test_fallback_text_present_for_string():
+    result = str(local_dt_filter("2024-03-15T10:30:00"))
+    # fallback is str(value)[:16] of original string
+    assert "2024-03-15T10:30" in result


### PR DESCRIPTION
## Summary

- Add `local_dt` Jinja2 filter in `src/web/template_globals.py` that renders a UTC datetime as a `<span class="local-dt" data-utc="ISO8601" data-fmt="...">` element
- Add ~17-line JS snippet in `base.html` that converts all such spans to the browser's local timezone on `DOMContentLoaded` and `htmx:afterSwap`
- Replace all `.strftime()` calls and raw date strings across 13 templates with the new `|local_dt`, `|local_dt("time")`, or `|local_dt("date")` filter

## Test plan

- [ ] All 153 existing web tests pass (`pytest tests/test_web.py -v -n auto`)
- [ ] Open the scheduler page — task timestamps show in local time
- [ ] Open search results — message dates show in local time
- [ ] Open settings/accounts — flood wait and created_at show in local time
- [ ] Verify HTMX-loaded fragments (e.g. timing rows) also convert after swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)