### PR TITLE
fix: FTS5 wildcard matching & dry-run disabled job filter

### DIFF
--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -76,6 +76,7 @@ def _fts_query_matches(fts_query: str, text: str) -> bool:
     for part in parts:
         part = part.strip().strip("()")
         alternatives = re.split(r"\bOR\b", part, flags=re.IGNORECASE)
-        if not any(alt.strip().strip('"').rstrip("*").lower() in text_lower for alt in alternatives):
+        terms = [alt.strip().strip('"').rstrip("*").lower() for alt in alternatives]
+        if not any(t and t in text_lower for t in terms):
             return False
     return True

--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -76,6 +76,6 @@ def _fts_query_matches(fts_query: str, text: str) -> bool:
     for part in parts:
         part = part.strip().strip("()")
         alternatives = re.split(r"\bOR\b", part, flags=re.IGNORECASE)
-        if not any(alt.strip().strip('"').lower() in text_lower for alt in alternatives):
+        if not any(alt.strip().strip('"').rstrip("*").lower() in text_lower for alt in alternatives):
             return False
     return True

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -314,6 +314,13 @@ async def dry_run_notifications(request: Request):
         since = None
 
     queries = await db.get_notification_queries(active_only=True)
+    # Exclude queries whose scheduler job is disabled
+    filtered = []
+    for sq in queries:
+        val = await db.repos.settings.get_setting(f"scheduler_job_disabled:sq_{sq.id}")
+        if val != "1":
+            filtered.append(sq)
+    queries = filtered
     if not queries:
         return deps.get_templates(request).TemplateResponse(
             request,

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -524,6 +524,10 @@ async def test_dry_run_excludes_inactive_queries(client):
 async def test_dry_run_excludes_disabled_scheduler_job(client):
     """Dry-run excludes queries whose scheduler job is disabled."""
     db = client._transport.app.state.db
+    # Create a completed collection task so dry-run has a time window
+    task_id = await db.create_collection_task(channel_id=-1001234567890, channel_title="Test")
+    await db.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
+
     await db.repos.search_queries.add(SearchQuery(
         query="enabled_job_query", notify_on_collect=True, is_active=True, is_fts=False,
     ))
@@ -535,4 +539,5 @@ async def test_dry_run_excludes_disabled_scheduler_job(client):
 
     resp = await client.post("/scheduler/dry-run-notifications")
     assert resp.status_code == 200
+    assert "enabled_job_query" in resp.text
     assert "disabled_job_query" not in resp.text

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -11,7 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from src.collection_queue import CollectionQueue
 from src.config import AppConfig
 from src.database import Database
-from src.models import Account, CollectionTaskStatus, StatsAllTaskPayload
+from src.models import Account, CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
 from src.scheduler.manager import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -492,3 +492,47 @@ async def test_scheduler_page_with_cancelled_task(client):
 
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
+
+
+# ── Dry-run notification tests ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dry_run_no_queries(client):
+    """Dry-run with no notification queries shows empty state."""
+    resp = await client.post("/scheduler/dry-run-notifications")
+    assert resp.status_code == 200
+    assert "Нет активных запросов" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_dry_run_excludes_inactive_queries(client):
+    """Dry-run excludes queries with is_active=False."""
+    db = client._transport.app.state.db
+    await db.repos.search_queries.add(SearchQuery(
+        query="active_query", notify_on_collect=True, is_active=True, is_fts=False,
+    ))
+    await db.repos.search_queries.add(SearchQuery(
+        query="inactive_query", notify_on_collect=True, is_active=False, is_fts=False,
+    ))
+    resp = await client.post("/scheduler/dry-run-notifications")
+    assert resp.status_code == 200
+    assert "inactive_query" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_dry_run_excludes_disabled_scheduler_job(client):
+    """Dry-run excludes queries whose scheduler job is disabled."""
+    db = client._transport.app.state.db
+    await db.repos.search_queries.add(SearchQuery(
+        query="enabled_job_query", notify_on_collect=True, is_active=True, is_fts=False,
+    ))
+    disabled_id = await db.repos.search_queries.add(SearchQuery(
+        query="disabled_job_query", notify_on_collect=True, is_active=True, is_fts=False,
+    ))
+    # Disable the scheduler job for the second query
+    await db.repos.settings.set_setting(f"scheduler_job_disabled:sq_{disabled_id}", "1")
+
+    resp = await client.post("/scheduler/dry-run-notifications")
+    assert resp.status_code == 200
+    assert "disabled_job_query" not in resp.text

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -151,6 +151,11 @@ async def test_fts_query_matches_logic():
     assert not _fts_query_matches("(apple OR orange) AND fruit", "I love apple juice")
     assert _fts_query_matches("simple", "Simple query test")
 
+    # FTS5 wildcard support
+    assert _fts_query_matches("apple*", "I love apples")
+    assert _fts_query_matches("(apple* OR orange*) AND fruit*", "fresh apple fruits")
+    assert not _fts_query_matches("apple*", "I love bananas")
+
 
 @pytest.mark.asyncio
 async def test_collect_channel_stats_flooded_error(collector, mock_pool):

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -281,6 +281,9 @@ async def test_fts_query_matches_wildcards():
     assert _fts_query_matches("джомтьен*", "пляж джомтьена")
     assert not _fts_query_matches("джомтьен*", "паттайя центр")
 
+    # Bare wildcard should not match everything
+    assert not _fts_query_matches("* AND байк*", "аренда квартиры")
+
 
 @pytest.mark.asyncio
 async def test_exclude_patterns_list_property():

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -260,6 +260,29 @@ async def test_fts_collector_matching():
 
 
 @pytest.mark.asyncio
+async def test_fts_query_matches_wildcards():
+    """Test _fts_query_matches handles FTS5 trailing wildcards."""
+    from src.services.notification_matcher import _fts_query_matches
+
+    # Single wildcard term
+    assert _fts_query_matches("байк*", "аренда байка на день")
+    assert _fts_query_matches("байк*", "байки в аренду")
+    assert not _fts_query_matches("байк*", "аренда машины")
+
+    # Full user query with wildcards in both AND groups
+    query = "(байк* OR мотобайк* OR мотоцикл* OR скутер*) AND (аренд* OR сня* OR взя*)"
+    assert _fts_query_matches(query, "хочу снять байк на неделю")
+    assert _fts_query_matches(query, "аренда мотоцикла в Бали")
+    assert _fts_query_matches(query, "взять скутер напрокат")
+    assert not _fts_query_matches(query, "продажа байка")
+    assert not _fts_query_matches(query, "аренда квартиры")
+
+    # Simple wildcard
+    assert _fts_query_matches("джомтьен*", "пляж джомтьена")
+    assert not _fts_query_matches("джомтьен*", "паттайя центр")
+
+
+@pytest.mark.asyncio
 async def test_exclude_patterns_list_property():
     sq = SearchQuery(query="test", exclude_patterns="foo\nbar\n  baz  \n\n")
     assert sq.exclude_patterns_list == ["foo", "bar", "baz"]


### PR DESCRIPTION
## Summary
- **FTS5 wildcard fix**: `_fts_query_matches()` now strips trailing `*` from query terms, so queries like `байк*`, `джомтьен*` correctly match during notification checks
- **Dry-run filter**: dry-run endpoint now excludes queries whose scheduler job is disabled (`scheduler_job_disabled:sq_{id}`)
- **5 new tests**: wildcard unit tests, dry-run endpoint tests (no queries, inactive queries, disabled scheduler job)

## Test plan
- [ ] Verify `pytest tests/test_search_queries.py::test_fts_query_matches_wildcards -v` passes
- [ ] Verify `pytest tests/routes/test_scheduler_routes.py::test_dry_run_excludes_disabled_scheduler_job -v` passes
- [ ] Manual: disable a scheduler job for a search query, confirm dry-run no longer shows it
- [ ] Manual: trigger collection with FTS wildcard query, confirm bot notification is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)