### PR TITLE
fix: enable infinite connection retries for Telegram clients

### DIFF
--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -188,7 +188,10 @@ class TelegramAuth:
 
     async def create_client_from_session(self, session_string: str) -> TelegramClient:
         """Create and connect a client from saved session string."""
-        client = TelegramClient(StringSession(session_string), self._api_id, self._api_hash)
+        client = TelegramClient(
+            StringSession(session_string), self._api_id, self._api_hash,
+            connection_retries=None, retry_delay=2,
+        )
         await client.connect()
         if not await client.is_user_authorized():
             raise ConnectionError("Session is no longer valid")

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -359,6 +359,8 @@ class TelethonCliBackend(TelegramBackend):
         )
         try:
             client: TelegramClient = telethon_cli_runtime.create_client(namespace)
+            client._connection_retries = None
+            client._retry_delay = 2
             client.flood_sleep_threshold = 60
             await client.connect()
             if not await client.is_user_authorized():


### PR DESCRIPTION
## Summary
- Set `connection_retries=None` and `retry_delay=2` for TelegramClient in both `auth.py` (session validation) and `backends.py` (backend client creation)
- Prevents transient network failures from permanently dropping Telegram sessions

## Test plan
- [ ] Verify existing Telegram connection tests pass
- [ ] Confirm clients reconnect automatically on transient network interruptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)