### PR TITLE
feat: image generation provider settings UI

### DIFF
--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -19,9 +19,12 @@ class ImageGenerationService:
     first available adapter is used as fallback.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, adapters: dict[str, "ImageAdapter"] | None = None) -> None:
         self._adapters: dict[str, ImageAdapter] = {}
-        self._register_from_env()
+        if adapters is not None:
+            self._adapters = dict(adapters)
+        else:
+            self._register_from_env()
 
     # ── public API ──
 

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -1,0 +1,218 @@
+"""Settings-driven image generation provider management.
+
+Stores provider API keys (encrypted) in the DB settings table and builds
+image adapters from them, falling back to environment variables when no
+DB config exists for a given provider.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from src.config import AppConfig, resolve_session_encryption_secret
+from src.database import Database
+from src.security import SessionCipher
+
+if TYPE_CHECKING:
+    from src.services.provider_adapters import ImageAdapter
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_KEY = "image_providers_v1"
+
+
+@dataclass(slots=True)
+class ImageProviderSpec:
+    name: str
+    display_name: str
+    env_vars: list[str]
+
+
+IMAGE_PROVIDER_SPECS: dict[str, ImageProviderSpec] = {
+    "together": ImageProviderSpec("together", "Together AI", ["TOGETHER_API_KEY"]),
+    "huggingface": ImageProviderSpec("huggingface", "HuggingFace", ["HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN"]),
+    "openai": ImageProviderSpec("openai", "OpenAI", ["OPENAI_API_KEY"]),
+    "replicate": ImageProviderSpec("replicate", "Replicate", ["REPLICATE_API_TOKEN"]),
+}
+
+IMAGE_PROVIDER_ORDER: list[str] = ["together", "huggingface", "openai", "replicate"]
+
+
+@dataclass(slots=True)
+class ImageProviderConfig:
+    provider: str
+    enabled: bool = True
+    api_key: str = ""
+    _api_key_enc_preserved: str = ""  # raw encrypted value kept on decrypt failure
+
+
+def image_provider_spec(name: str) -> ImageProviderSpec | None:
+    return IMAGE_PROVIDER_SPECS.get(name)
+
+
+class ImageProviderService:
+    def __init__(self, db: Database, config: AppConfig) -> None:
+        self._db = db
+        secret = resolve_session_encryption_secret(config)
+        self._cipher = SessionCipher(secret) if secret else None
+
+    @property
+    def writes_enabled(self) -> bool:
+        return self._cipher is not None
+
+    # ── load / save ──
+
+    async def load_provider_configs(self) -> list[ImageProviderConfig]:
+        raw = await self._db.get_setting(SETTINGS_KEY)
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Invalid image provider JSON in settings", exc_info=True)
+            return []
+        if not isinstance(parsed, list):
+            return []
+
+        configs: list[ImageProviderConfig] = []
+        for item in parsed:
+            if not isinstance(item, dict):
+                continue
+            provider = str(item.get("provider", "")).strip()
+            if provider not in IMAGE_PROVIDER_SPECS:
+                continue
+            api_key = ""
+            preserved_enc = ""
+            enc_key = str(item.get("api_key_enc", "")).strip()
+            if enc_key:
+                try:
+                    api_key = self._cipher.decrypt(enc_key) if self._cipher else ""
+                except ValueError:
+                    logger.warning("Failed to decrypt image provider key for %s", provider, exc_info=True)
+                    preserved_enc = enc_key  # keep raw so save doesn't destroy it
+            configs.append(
+                ImageProviderConfig(
+                    provider=provider,
+                    enabled=bool(item.get("enabled", True)),
+                    api_key=api_key,
+                    _api_key_enc_preserved=preserved_enc,
+                )
+            )
+        return configs
+
+    async def save_provider_configs(self, configs: list[ImageProviderConfig]) -> None:
+        if not self.writes_enabled:
+            raise RuntimeError("SESSION_ENCRYPTION_KEY is required to manage image providers.")
+        payload = []
+        for cfg in configs:
+            entry: dict[str, Any] = {
+                "provider": cfg.provider,
+                "enabled": cfg.enabled,
+            }
+            if cfg.api_key.strip():
+                assert self._cipher is not None
+                entry["api_key_enc"] = self._cipher.encrypt(cfg.api_key.strip())
+            elif cfg._api_key_enc_preserved:
+                entry["api_key_enc"] = cfg._api_key_enc_preserved
+            payload.append(entry)
+        await self._db.set_setting(SETTINGS_KEY, json.dumps(payload, ensure_ascii=False))
+
+    # ── UI helpers ──
+
+    def create_empty_config(self, provider_name: str) -> ImageProviderConfig:
+        return ImageProviderConfig(provider=provider_name, enabled=True, api_key="")
+
+    def build_provider_views(
+        self, configs: list[ImageProviderConfig]
+    ) -> list[dict[str, Any]]:
+        views = []
+        for cfg in configs:
+            spec = IMAGE_PROVIDER_SPECS.get(cfg.provider)
+            if spec is None:
+                continue
+            env_var_set = any(os.environ.get(v, "").strip() for v in spec.env_vars)
+            views.append(
+                {
+                    "provider": cfg.provider,
+                    "display_name": spec.display_name,
+                    "enabled": cfg.enabled,
+                    "has_key": bool(cfg.api_key.strip()),
+                    "env_var_set": env_var_set,
+                    "env_var_names": ", ".join(spec.env_vars),
+                }
+            )
+        return views
+
+    def parse_provider_form(
+        self,
+        form: Any,
+        existing: list[ImageProviderConfig],
+    ) -> list[ImageProviderConfig]:
+        existing_map = {cfg.provider: cfg for cfg in existing}
+        configs: list[ImageProviderConfig] = []
+        for name in IMAGE_PROVIDER_ORDER:
+            if not form.get(f"img_provider_present__{name}"):
+                continue
+            enabled = str(form.get(f"img_provider_enabled__{name}", "")).strip() == "1"
+            new_key = str(form.get(f"img_provider_secret__{name}__api_key", "")).strip()
+            old_cfg = existing_map.get(name)
+            if new_key:
+                api_key = new_key
+            elif old_cfg:
+                api_key = old_cfg.api_key
+            else:
+                api_key = ""
+            configs.append(ImageProviderConfig(provider=name, enabled=enabled, api_key=api_key))
+        return configs
+
+    # ── adapter construction ──
+
+    def build_adapters(self, configs: list[ImageProviderConfig]) -> dict[str, "ImageAdapter"]:
+        """Build image adapters from DB configs with env-var fallback."""
+        from src.services.provider_adapters import (
+            make_huggingface_image_adapter,
+            make_openai_image_adapter,
+            make_replicate_image_adapter,
+            make_together_image_adapter,
+        )
+
+        _factories: dict[str, tuple[Any, list[str]]] = {
+            "together": (make_together_image_adapter, ["TOGETHER_API_KEY"]),
+            "huggingface": (make_huggingface_image_adapter, ["HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN"]),
+            "openai": (make_openai_image_adapter, ["OPENAI_API_KEY"]),
+            "replicate": (make_replicate_image_adapter, ["REPLICATE_API_TOKEN"]),
+        }
+
+        adapters: dict[str, "ImageAdapter"] = {}
+        configured_providers = {cfg.provider for cfg in configs}
+
+        # 1. DB-configured providers
+        for cfg in configs:
+            if not cfg.enabled:
+                continue
+            key = cfg.api_key.strip()
+            if not key:
+                # fallback to env var even for configured providers
+                spec = IMAGE_PROVIDER_SPECS.get(cfg.provider)
+                if spec:
+                    key = next(
+                        (os.environ.get(v, "").strip() for v in spec.env_vars if os.environ.get(v, "").strip()),
+                        "",
+                    )
+            if key and cfg.provider in _factories:
+                factory, _ = _factories[cfg.provider]
+                adapters[cfg.provider] = factory(key)
+
+        # 2. Env-var fallback for unconfigured providers
+        for name, (factory, env_vars) in _factories.items():
+            if name in configured_providers:
+                continue
+            key = next((os.environ.get(v, "").strip() for v in env_vars if os.environ.get(v, "").strip()), "")
+            if key:
+                adapters[name] = factory(key)
+
+        return adapters

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -160,13 +160,19 @@ class ImageProviderService:
             enabled = str(form.get(f"img_provider_enabled__{name}", "")).strip() == "1"
             new_key = str(form.get(f"img_provider_secret__{name}__api_key", "")).strip()
             old_cfg = existing_map.get(name)
+            preserved = ""
             if new_key:
                 api_key = new_key
             elif old_cfg:
                 api_key = old_cfg.api_key
+                preserved = old_cfg._api_key_enc_preserved
             else:
                 api_key = ""
-            configs.append(ImageProviderConfig(provider=name, enabled=enabled, api_key=api_key))
+            configs.append(
+                ImageProviderConfig(
+                    provider=name, enabled=enabled, api_key=api_key, _api_key_enc_preserved=preserved,
+                )
+            )
         return configs
 
     # ── adapter construction ──

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -92,7 +92,11 @@ class UnifiedDispatcher:
                 svc = ImageProviderService(self._db, self._config)
                 configs = await svc.load_provider_configs()
                 built = svc.build_adapters(configs)
-                if built:
+                if configs:
+                    # DB has entries — honour them, even if all disabled → {}
+                    adapters = built
+                elif built:
+                    # No DB entries but env-only adapters found by build_adapters
                     adapters = built
             except Exception:
                 logger.warning("Failed to load image provider configs from DB", exc_info=True)

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -22,6 +22,7 @@ from src.telegram.collector import Collector
 if TYPE_CHECKING:
     from src.database import Database
     from src.search.engine import SearchEngine
+    from src.services.image_generation_service import ImageGenerationService
     from src.services.photo_auto_upload_service import PhotoAutoUploadService
     from src.services.photo_task_service import PhotoTaskService
     from src.telegram.notifier import Notifier
@@ -59,6 +60,7 @@ class UnifiedDispatcher:
         db: "Database" | None = None,
         client_pool: object | None = None,
         notifier: "Notifier | None" = None,
+        config: object | None = None,
     ):
 
         self._collector = collector
@@ -75,8 +77,27 @@ class UnifiedDispatcher:
         self._db = db
         self._client_pool = client_pool
         self._notifier = notifier
+        self._config = config
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
+
+    async def _build_image_service(self) -> "ImageGenerationService":
+        from src.services.image_generation_service import ImageGenerationService
+
+        adapters = None
+        if self._db and self._config:
+            try:
+                from src.services.image_provider_service import ImageProviderService
+
+                svc = ImageProviderService(self._db, self._config)
+                configs = await svc.load_provider_configs()
+                built = svc.build_adapters(configs)
+                if built:
+                    adapters = built
+            except Exception:
+                logger.warning("Failed to load image provider configs from DB", exc_info=True)
+                adapters = {}  # don't fall back to env-only; honour user's saved state
+        return ImageGenerationService(adapters=adapters)
 
     async def start(self) -> None:
         if self._task and not self._task.done():
@@ -452,9 +473,7 @@ class UnifiedDispatcher:
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
 
-            from src.services.image_generation_service import ImageGenerationService
-
-            image_service = ImageGenerationService()
+            image_service = await self._build_image_service()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
@@ -536,9 +555,7 @@ class UnifiedDispatcher:
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
 
-            from src.services.image_generation_service import ImageGenerationService
-
-            image_service = ImageGenerationService()
+            image_service = await self._build_image_service()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -163,6 +163,7 @@ async def build_container_with_templates(
         db=db,
         client_pool=pool,
         notifier=notifier,
+        config=config,
     )
     scheduler = SchedulerManager(
         config.scheduler,

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -33,6 +33,12 @@ from src.services.embedding_service import (
     LAST_EMBEDDED_ID_SETTING,
     EmbeddingService,
 )
+from src.services.image_provider_service import (
+    IMAGE_PROVIDER_ORDER,
+    IMAGE_PROVIDER_SPECS,
+    ImageProviderService,
+    image_provider_spec,
+)
 from src.services.notification_service import NotificationService
 from src.settings_utils import parse_int_setting
 from src.telegram.notifier import Notifier
@@ -52,6 +58,10 @@ def _notification_service(request: Request) -> NotificationService:
         notif_cfg.bot_name_prefix,
         notif_cfg.bot_username_prefix,
     )
+
+
+def _image_provider_service(request: Request) -> ImageProviderService:
+    return ImageProviderService(deps.get_db(request), request.app.state.config)
 
 
 def _wants_json(request: Request) -> bool:
@@ -415,6 +425,13 @@ async def settings_page(request: Request):
         for name in PROVIDER_ORDER
         if name not in configured_names
     ]
+    img_provider_service = _image_provider_service(request)
+    img_provider_configs = await img_provider_service.load_provider_configs()
+    img_provider_views = img_provider_service.build_provider_views(img_provider_configs)
+    configured_img_names = {cfg.provider for cfg in img_provider_configs}
+    available_img_options = [
+        IMAGE_PROVIDER_SPECS[name] for name in IMAGE_PROVIDER_ORDER if name not in configured_img_names
+    ]
     semantic_context = await _semantic_settings_context(request)
     return deps.get_templates(request).TemplateResponse(
         request,
@@ -444,6 +461,9 @@ async def settings_page(request: Request):
             "agent_provider_writes_enabled": provider_service.writes_enabled,
             "agent_provider_views": provider_views,
             "agent_provider_options": available_provider_options,
+            "img_provider_writes_enabled": img_provider_service.writes_enabled,
+            "img_provider_views": img_provider_views,
+            "img_provider_options": available_img_options,
             **semantic_context,
         },
     )
@@ -1041,6 +1061,49 @@ async def test_notification(request: Request):
     if ok:
         return RedirectResponse(url="/settings?msg=notification_test_sent", status_code=303)
     return RedirectResponse(url="/settings?error=notification_test_failed", status_code=303)
+
+
+# ── Image Providers ──
+
+
+@router.post("/image-providers/add")
+async def add_image_provider(request: Request):
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
+    form = await request.form()
+    provider_name = str(form.get("provider", "")).strip()
+    if image_provider_spec(provider_name) is None:
+        return RedirectResponse(url="/settings?error=image_provider_invalid", status_code=303)
+    configs = await service.load_provider_configs()
+    if any(cfg.provider == provider_name for cfg in configs):
+        return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+    configs.append(service.create_empty_config(provider_name))
+    await service.save_provider_configs(configs)
+    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+
+
+@router.post("/image-providers/save")
+async def save_image_providers(request: Request):
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
+    form = await request.form()
+    existing = await service.load_provider_configs()
+    configs = service.parse_provider_form(form, existing)
+    await service.save_provider_configs(configs)
+    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+
+
+@router.post("/image-providers/{provider_name}/delete")
+async def delete_image_provider(request: Request, provider_name: str):
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
+    configs = await service.load_provider_configs()
+    configs = [cfg for cfg in configs if cfg.provider != provider_name]
+    await service.save_provider_configs(configs)
+    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
 
 
 @router.post("/{account_id}/toggle")

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -33,6 +33,13 @@
         </button>
     </li>
     <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-image" data-bs-toggle="pill"
+                data-bs-target="#pane-image" type="button" role="tab"
+                aria-controls="pane-image" aria-selected="false">
+            <i class="bi bi-image me-1"></i>Изображения
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
         <button class="nav-link" id="tab-devmode" data-bs-toggle="pill"
                 data-bs-target="#pane-devmode" type="button" role="tab"
                 aria-controls="pane-devmode" aria-selected="false">
@@ -88,6 +95,15 @@
             <div class="card-header bg-body-secondary fw-semibold">Semantic Search & Embeddings</div>
             <div class="card-body">
                 {% include "settings/_semantic.html" %}
+            </div>
+        </div>
+    </div>
+
+    <div class="tab-pane fade" id="pane-image" role="tabpanel" aria-labelledby="tab-image">
+        <div class="card shadow-sm">
+            <div class="card-header bg-body-secondary fw-semibold">Image Generation Providers</div>
+            <div class="card-body">
+                {% include "settings/_image_providers.html" %}
             </div>
         </div>
     </div>

--- a/src/web/templates/settings/_image_providers.html
+++ b/src/web/templates/settings/_image_providers.html
@@ -1,0 +1,80 @@
+{% if not img_provider_writes_enabled %}
+<div class="alert alert-warning py-2">
+    Для управления API-ключами генерации изображений требуется <code>SESSION_ENCRYPTION_KEY</code>. Без него настройки доступны только для чтения.
+</div>
+{% endif %}
+
+<form method="post" action="/settings/image-providers/add" class="row g-2 align-items-end mb-4" data-busy>
+    <div class="col-12 col-md-6">
+        <label for="img_provider_add" class="form-label">Добавить провайдера</label>
+        <select id="img_provider_add" name="provider" class="form-select" {% if not img_provider_writes_enabled %}disabled{% endif %}>
+            <option value="">Выберите провайдера</option>
+            {% for spec in img_provider_options %}
+            <option value="{{ spec.name }}">{{ spec.display_name }} ({{ spec.name }})</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-12 col-md-auto">
+        <button type="submit" class="btn btn-outline-primary btn-sm" {% if not img_provider_writes_enabled %}disabled{% endif %}>
+            <i class="bi bi-plus-lg me-1"></i>Добавить
+        </button>
+    </div>
+</form>
+
+{% if img_provider_views %}
+<form method="post" action="/settings/image-providers/save" data-busy>
+    {% for item in img_provider_views %}
+    <div class="card shadow-sm mb-3">
+        <div class="card-body">
+            <input type="hidden" name="img_provider_present__{{ item.provider }}" value="1">
+            <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+                <div>
+                    <div class="fw-semibold">{{ item.display_name }}</div>
+                    <div class="small text-muted">
+                        provider: <code>{{ item.provider }}</code>
+                        {% if item.env_var_set %}
+                        | <span class="badge text-bg-success">env</span> <code>{{ item.env_var_names }}</code>
+                        {% endif %}
+                    </div>
+                </div>
+                <button type="submit"
+                        class="btn btn-outline-danger btn-sm"
+                        formaction="/settings/image-providers/{{ item.provider }}/delete"
+                        formmethod="post"
+                        {% if not img_provider_writes_enabled %}disabled{% endif %}>
+                    <i class="bi bi-trash me-1"></i>Удалить
+                </button>
+            </div>
+
+            <div class="row g-3 mb-2">
+                <div class="col-12 col-md-3">
+                    <label class="form-label" for="img_provider_enabled__{{ item.provider }}">Статус</label>
+                    <select class="form-select" id="img_provider_enabled__{{ item.provider }}"
+                            name="img_provider_enabled__{{ item.provider }}" {% if not img_provider_writes_enabled %}disabled{% endif %}>
+                        <option value="1" {{ 'selected' if item.enabled else '' }}>Enabled</option>
+                        <option value="" {{ 'selected' if not item.enabled else '' }}>Disabled</option>
+                    </select>
+                </div>
+                <div class="col-12 col-md-5">
+                    <label class="form-label" for="img_provider_secret__{{ item.provider }}__api_key">API Key</label>
+                    <input type="password" class="form-control"
+                           id="img_provider_secret__{{ item.provider }}__api_key"
+                           name="img_provider_secret__{{ item.provider }}__api_key"
+                           placeholder="{{ '••••••••' if item.has_key else 'Введите API ключ' }}"
+                           {% if not img_provider_writes_enabled %}disabled{% endif %}>
+                    <div class="form-text">
+                        {% if item.has_key %}Ключ сохранён и скрыт. Оставьте пустым, чтобы не менять.{% elif item.env_var_set %}Ключ из env будет использован как fallback.{% else %}Значение ещё не задано.{% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+
+    <div class="d-flex justify-content-end">
+        <button type="submit" class="btn btn-primary" {% if not img_provider_writes_enabled %}disabled{% endif %}>Сохранить</button>
+    </div>
+</form>
+{% else %}
+<p class="text-muted mb-0">Провайдеры изображений ещё не добавлены.</p>
+{% endif %}


### PR DESCRIPTION
## Summary
- Новый таб "Изображения" в настройках для управления API-ключами провайдеров генерации изображений (Together AI, HuggingFace, OpenAI, Replicate)
- `ImageProviderService` — хранение/шифрование ключей в БД по аналогии с `AgentProviderService`
- `ImageGenerationService` принимает pre-built адаптеры из DB с fallback на env vars
- Защита от потери данных при decrypt failure (сохранение raw encrypted value)

## Test plan
- [ ] `ruff check src/ tests/` — линтер проходит
- [ ] `pytest tests/test_image_generation_service.py -v` — 12 тестов
- [ ] `pytest tests/test_unified_dispatcher.py -v` — 41 тест
- [ ] `pytest tests/test_web.py -v -k settings` — 39 тестов
- [ ] Запустить `python -m src.main serve` и проверить новый таб "Изображения" в настройках
- [ ] Добавить/удалить провайдера, сохранить API ключ, проверить env badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)