### PR TITLE
feat: images page — test generation, model catalog, CLI

### DIFF
--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -1,0 +1,53 @@
+"""CLI commands for image generation."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from src.services.image_generation_service import ImageGenerationService
+
+
+def run(args: argparse.Namespace) -> None:
+    async def _run() -> None:
+        action = args.image_action
+        svc = ImageGenerationService()
+
+        if action == "generate":
+            if not await svc.is_available():
+                print("No image providers configured. Set REPLICATE_API_TOKEN or similar env var.")
+                return
+            model = args.model or None
+            prompt = args.prompt
+            print(f"Generating image: model={model or 'default'}, prompt={prompt!r}")
+            result = await svc.generate(model, prompt)
+            if result:
+                print(f"Result: {result}")
+            else:
+                print("Generation failed — check logs")
+
+        elif action == "models":
+            provider = args.provider
+            query = args.query or ""
+            models = await svc.search_models(provider, query)
+            if not models:
+                print(f"No models found for provider={provider} query={query!r}")
+                return
+            for m in models:
+                runs = f" ({m['run_count']:,} runs)" if m.get("run_count") else ""
+                print(f"  {m['model_string']}{runs}")
+                if m.get("description"):
+                    print(f"    {m['description']}")
+
+        elif action == "providers":
+            names = svc.adapter_names
+            if not names:
+                print("No providers configured. Set env vars: REPLICATE_API_TOKEN, TOGETHER_API_KEY, etc.")
+                return
+            for name in names:
+                print(f"  {name}")
+
+        else:
+            print("Usage: image {generate|models|providers}")
+
+    asyncio.run(_run())

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,6 +8,7 @@ from src.cli.commands import (
     account,
     channel,
     collect,
+    image,
     notification,
     photo_loader,
     scheduler,
@@ -51,6 +52,7 @@ def main() -> None:
         "test": test_cmd.run,
         "agent": agent_cmd.run,
         "analytics": analytics_cmd.run,
+        "image": image.run,
     }
 
     handler = commands.get(args.command)
@@ -68,6 +70,7 @@ def main() -> None:
             "test": "test_action",
             "agent": "agent_action",
             "analytics": "analytics_action",
+            "image": "image_action",
         }
         if args.command in sub_attr and not getattr(args, sub_attr[args.command], None):
             parser.parse_args([args.command, "--help"])

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -313,6 +313,20 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_reject = pipeline_sub.add_parser("reject", help="Reject a generation run")
     pipeline_reject.add_argument("run_id", type=int, help="Run id to reject")
 
+    # ── image ──
+    image_parser = sub.add_parser("image", help="Image generation")
+    image_sub = image_parser.add_subparsers(dest="image_action")
+
+    image_gen = image_sub.add_parser("generate", help="Generate an image from prompt")
+    image_gen.add_argument("prompt", help="Text prompt for image generation")
+    image_gen.add_argument("--model", default=None, help="Model string (e.g. replicate:flux-schnell)")
+
+    image_models = image_sub.add_parser("models", help="Search available models")
+    image_models.add_argument("--provider", required=True, help="Provider name (replicate, together, openai)")
+    image_models.add_argument("--query", default="", help="Search query")
+
+    image_sub.add_parser("providers", help="List configured image providers")
+
     acc_parser = sub.add_parser("account", help="Account management")
     acc_sub = acc_parser.add_subparsers(dest="account_action")
     acc_sub.add_parser("list", help="List accounts")

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from src.cli.commands import (
     account,
     channel,
     collect,
+    image,
     photo_loader,
     pipeline,
     scheduler,
@@ -75,6 +76,10 @@ def cmd_photo_loader(args: argparse.Namespace) -> None:
 
 def cmd_pipeline(args: argparse.Namespace) -> None:
     _run_with_legacy_runtime(pipeline.run, args)
+
+
+def cmd_image(args: argparse.Namespace) -> None:
+    image.run(args)
 
 
 def cmd_test(args: argparse.Namespace) -> None:

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -100,3 +100,63 @@ class ImageGenerationService:
         if self._adapters:
             return next(iter(self._adapters.values()))
         return None
+
+    # ── model catalog ──
+
+    async def search_models(self, provider: str, query: str = "", *, api_key: str = "") -> list[dict]:
+        """Search available models for a provider. Returns list of dicts with name, description, etc."""
+        import aiohttp
+
+        if provider == "replicate":
+            token = api_key or os.environ.get("REPLICATE_API_TOKEN", "")
+            if not token:
+                return []
+            url = "https://api.replicate.com/v1/models"
+            params = {}
+            if query:
+                params["query"] = query
+            headers = {"Authorization": f"Bearer {token}"}
+            timeout = aiohttp.ClientTimeout(total=15)
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(url, headers=headers, params=params, timeout=timeout) as resp:
+                        if resp.status != 200:
+                            return []
+                        data = await resp.json()
+                        results = data.get("results", [])
+                        return [
+                            {
+                                "id": f"{r.get('owner', '')}/{r.get('name', '')}",
+                                "model_string": f"replicate:{r.get('owner', '')}/{r.get('name', '')}",
+                                "description": (r.get("description") or "")[:200],
+                                "run_count": r.get("run_count", 0),
+                            }
+                            for r in results[:20]
+                        ]
+            except Exception:
+                logger.warning("Failed to search Replicate models", exc_info=True)
+                return []
+
+        # Static catalogs for providers without search API
+        def _m(mid: str, provider: str, desc: str) -> dict:
+            return {"id": mid, "model_string": f"{provider}:{mid}", "description": desc, "run_count": 0}
+
+        catalogs: dict[str, list[dict]] = {
+            "together": [
+                _m("black-forest-labs/FLUX.1-schnell", "together", "FLUX.1 Schnell — fast"),
+                _m("black-forest-labs/FLUX.1-dev", "together", "FLUX.1 Dev — high quality"),
+            ],
+            "openai": [
+                _m("dall-e-3", "openai", "DALL-E 3 — OpenAI image generation"),
+                _m("dall-e-2", "openai", "DALL-E 2 — OpenAI image generation"),
+            ],
+            "huggingface": [
+                _m("stabilityai/stable-diffusion-xl-base-1.0", "huggingface", "Stable Diffusion XL"),
+                _m("black-forest-labs/FLUX.1-dev", "huggingface", "FLUX.1 Dev on HuggingFace"),
+            ],
+        }
+        models = catalogs.get(provider, [])
+        if query:
+            q = query.lower()
+            models = [m for m in models if q in m["id"].lower() or q in m["description"].lower()]
+        return models

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -116,6 +116,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.dashboard import router as dashboard_router
     from src.web.routes.debug import router as debug_router
     from src.web.routes.filter import router as filter_router
+    from src.web.routes.images import router as images_router
     from src.web.routes.import_channels import router as import_router
     from src.web.routes.moderation import router as moderation_router
     from src.web.routes.my_telegram import router as my_telegram_router
@@ -144,6 +145,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(my_telegram_router, prefix="/my-telegram")
     app.include_router(photo_loader_router, prefix="/my-telegram/photos")
     app.include_router(debug_router, prefix="/debug")
+    app.include_router(images_router, prefix="/images")
     app.include_router(pipelines_router, prefix="/pipelines")
 
 

--- a/src/web/routes/images.py
+++ b/src/web/routes/images.py
@@ -1,0 +1,100 @@
+"""Image generation playground — test generation, browse models, view history."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from src.services.image_generation_service import ImageGenerationService
+from src.web import deps
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+async def _get_image_service(request: Request) -> ImageGenerationService:
+    """Build ImageGenerationService with DB-configured providers + env fallback."""
+    try:
+        from src.services.image_provider_service import ImageProviderService
+
+        db = deps.get_db(request)
+        config = request.app.state.config
+        svc = ImageProviderService(db, config)
+        configs = await svc.load_provider_configs()
+        adapters = svc.build_adapters(configs)
+        if adapters:
+            return ImageGenerationService(adapters=adapters)
+    except Exception:
+        logger.warning("Failed to load image providers from DB", exc_info=True)
+    return ImageGenerationService()
+
+
+async def _get_provider_api_key(request: Request, provider: str) -> str:
+    """Get API key for provider from DB config, falling back to env."""
+    import os
+
+    try:
+        from src.services.image_provider_service import IMAGE_PROVIDER_SPECS, ImageProviderService
+
+        db = deps.get_db(request)
+        config = request.app.state.config
+        svc = ImageProviderService(db, config)
+        configs = await svc.load_provider_configs()
+        for cfg in configs:
+            if cfg.provider == provider and cfg.api_key:
+                return cfg.api_key
+        spec = IMAGE_PROVIDER_SPECS.get(provider)
+        if spec:
+            for var in spec.env_vars:
+                val = os.environ.get(var, "").strip()
+                if val:
+                    return val
+    except Exception:
+        pass
+    return ""
+
+
+@router.get("/", response_class=HTMLResponse)
+async def images_page(request: Request):
+    svc = await _get_image_service(request)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "images.html",
+        {
+            "providers": svc.adapter_names,
+        },
+    )
+
+
+@router.post("/generate")
+async def generate_image(request: Request):
+    form = await request.form()
+    prompt = str(form.get("prompt", "")).strip()
+    model = str(form.get("model", "")).strip()
+    if not prompt:
+        return JSONResponse({"ok": False, "error": "Prompt is required"}, status_code=400)
+
+    svc = await _get_image_service(request)
+    if not await svc.is_available():
+        return JSONResponse({"ok": False, "error": "No image providers configured"}, status_code=409)
+
+    result = await svc.generate(model or None, prompt)
+    if result is None:
+        return JSONResponse({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
+
+    return JSONResponse({"ok": True, "url": result, "model": model, "prompt": prompt})
+
+
+@router.get("/models/search")
+async def search_models_route(request: Request):
+    provider = request.query_params.get("provider", "").strip()
+    query = request.query_params.get("q", "").strip()
+    if not provider:
+        return JSONResponse({"ok": False, "error": "provider is required"}, status_code=400)
+
+    api_key = await _get_provider_api_key(request, provider)
+    svc = await _get_image_service(request)
+    models = await svc.search_models(provider, query, api_key=api_key)
+    return JSONResponse({"ok": True, "models": models, "provider": provider})

--- a/src/web/routes/images.py
+++ b/src/web/routes/images.py
@@ -95,6 +95,6 @@ async def search_models_route(request: Request):
         return JSONResponse({"ok": False, "error": "provider is required"}, status_code=400)
 
     api_key = await _get_provider_api_key(request, provider)
-    svc = await _get_image_service(request)
+    svc = ImageGenerationService()
     models = await svc.search_models(provider, query, api_key=api_key)
     return JSONResponse({"ok": True, "models": models, "provider": provider})

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -37,6 +37,7 @@
                     <li class="nav-item"><a class="nav-link" href="/channels/filter/manage">Очистка</a></li>
                     <li class="nav-item"><a class="nav-link" href="/search-queries">Запросы</a></li>
                     <li class="nav-item"><a class="nav-link" href="/pipelines">Пайплайны</a></li>
+                    <li class="nav-item"><a class="nav-link" href="/images">Картинки</a></li>
                     <li class="nav-item"><a class="nav-link" href="/calendar">Календарь</a></li>
                     <li class="nav-item"><a class="nav-link" href="/my-telegram">Мой Телеграм</a></li>
                     <li class="nav-item"><a class="nav-link" href="/scheduler">Планировщик</a></li>

--- a/src/web/templates/images.html
+++ b/src/web/templates/images.html
@@ -1,0 +1,183 @@
+{% extends "base.html" %}
+{% block title %}Изображения — TG Agent{% endblock %}
+{% block content %}
+<h1 class="mb-4">Изображения</h1>
+
+<div class="row g-4">
+    <div class="col-12 col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-body-secondary fw-semibold">Генерация</div>
+            <div class="card-body">
+                {% if providers %}
+                <form id="generate-form">
+                    <div class="mb-3">
+                        <label for="img-prompt" class="form-label">Prompt</label>
+                        <textarea class="form-control" id="img-prompt" name="prompt" rows="3" placeholder="A cat riding a bicycle through Tokyo at sunset..." required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="img-model" class="form-label">Модель</label>
+                        <input type="text" class="form-control" id="img-model" name="model"
+                               placeholder="replicate:black-forest-labs/flux-schnell"
+                               list="model-suggestions">
+                        <datalist id="model-suggestions">
+                            <option value="replicate:black-forest-labs/flux-schnell">
+                            <option value="replicate:black-forest-labs/flux-1.1-pro">
+                            <option value="together:black-forest-labs/FLUX.1-schnell">
+                            <option value="together:black-forest-labs/FLUX.1-dev">
+                            <option value="openai:dall-e-3">
+                            <option value="huggingface:stabilityai/stable-diffusion-xl-base-1.0">
+                        </datalist>
+                        <div class="form-text">Формат: <code>provider:model_id</code>. Без префикса — первый доступный провайдер.</div>
+                    </div>
+                    <button type="submit" class="btn btn-primary" id="generate-btn">
+                        <i class="bi bi-image me-1"></i>Сгенерировать
+                    </button>
+                </form>
+
+                <div id="generate-result" class="mt-3 d-none">
+                    <div id="generate-error" class="alert alert-danger d-none"></div>
+                    <div id="generate-success" class="d-none">
+                        <img id="generated-image" class="img-fluid rounded shadow-sm mb-2" alt="Generated image">
+                        <div class="small text-muted" id="generated-meta"></div>
+                    </div>
+                </div>
+                <div id="generate-spinner" class="text-center mt-3 d-none">
+                    <div class="spinner-border text-primary" role="status"></div>
+                    <div class="small text-muted mt-1">Генерация...</div>
+                </div>
+                {% else %}
+                <div class="text-muted">
+                    Нет настроенных провайдеров. Добавьте API ключ в
+                    <a href="/settings">Настройки &rarr; Изображения</a>.
+                </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 col-lg-6">
+        <div class="card shadow-sm">
+            <div class="card-header bg-body-secondary fw-semibold">Каталог моделей</div>
+            <div class="card-body">
+                <div class="row g-2 mb-3">
+                    <div class="col">
+                        <select id="catalog-provider" class="form-select">
+                            <option value="">Провайдер</option>
+                            {% for p in providers %}
+                            <option value="{{ p }}">{{ p }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col">
+                        <input type="text" id="catalog-query" class="form-control" placeholder="flux, sdxl...">
+                    </div>
+                    <div class="col-auto">
+                        <button class="btn btn-outline-secondary" id="catalog-search-btn" type="button">
+                            <i class="bi bi-search"></i>
+                        </button>
+                    </div>
+                </div>
+                <div id="catalog-results"></div>
+                <div id="catalog-spinner" class="text-center d-none">
+                    <div class="spinner-border spinner-border-sm text-secondary" role="status"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block head_scripts %}
+<script defer>
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('generate-form');
+    if (!form) return;
+    const btn = document.getElementById('generate-btn');
+    const spinner = document.getElementById('generate-spinner');
+    const resultDiv = document.getElementById('generate-result');
+    const errorDiv = document.getElementById('generate-error');
+    const successDiv = document.getElementById('generate-success');
+    const img = document.getElementById('generated-image');
+    const meta = document.getElementById('generated-meta');
+
+    form.addEventListener('submit', async function(e) {
+        e.preventDefault();
+        btn.disabled = true;
+        spinner.classList.remove('d-none');
+        resultDiv.classList.add('d-none');
+        errorDiv.classList.add('d-none');
+        successDiv.classList.add('d-none');
+
+        try {
+            const formData = new FormData(form);
+            const resp = await fetch('/images/generate', { method: 'POST', body: formData });
+            const data = await resp.json();
+            resultDiv.classList.remove('d-none');
+            if (data.ok) {
+                img.src = data.url;
+                meta.textContent = `Model: ${data.model || 'default'} | Prompt: ${data.prompt}`;
+                successDiv.classList.remove('d-none');
+            } else {
+                errorDiv.textContent = data.error || 'Unknown error';
+                errorDiv.classList.remove('d-none');
+            }
+        } catch (err) {
+            resultDiv.classList.remove('d-none');
+            errorDiv.textContent = err.message;
+            errorDiv.classList.remove('d-none');
+        } finally {
+            btn.disabled = false;
+            spinner.classList.add('d-none');
+        }
+    });
+
+    // Catalog search
+    const catalogBtn = document.getElementById('catalog-search-btn');
+    const catalogResults = document.getElementById('catalog-results');
+    const catalogSpinner = document.getElementById('catalog-spinner');
+    const catalogProvider = document.getElementById('catalog-provider');
+    const catalogQuery = document.getElementById('catalog-query');
+
+    catalogBtn.addEventListener('click', async function() {
+        const provider = catalogProvider.value;
+        if (!provider) return;
+        catalogSpinner.classList.remove('d-none');
+        catalogResults.innerHTML = '';
+        try {
+            const q = catalogQuery.value.trim();
+            const url = `/images/models/search?provider=${encodeURIComponent(provider)}&q=${encodeURIComponent(q)}`;
+            const resp = await fetch(url);
+            const data = await resp.json();
+            if (!data.ok || !data.models.length) {
+                catalogResults.innerHTML = '<p class="text-muted small">Ничего не найдено</p>';
+                return;
+            }
+            let html = '<div class="list-group list-group-flush">';
+            for (const m of data.models) {
+                html += `<div class="list-group-item d-flex justify-content-between align-items-start">
+                    <div>
+                        <div class="fw-semibold small">${m.id}</div>
+                        <div class="text-muted small">${m.description || ''}</div>
+                        ${m.run_count ? `<span class="badge text-bg-secondary">${m.run_count.toLocaleString()} runs</span>` : ''}
+                    </div>
+                    <button class="btn btn-outline-primary btn-sm ms-2 use-model-btn" data-model="${m.model_string}">
+                        Выбрать
+                    </button>
+                </div>`;
+            }
+            html += '</div>';
+            catalogResults.innerHTML = html;
+            catalogResults.querySelectorAll('.use-model-btn').forEach(function(b) {
+                b.addEventListener('click', function() {
+                    document.getElementById('img-model').value = this.dataset.model;
+                });
+            });
+        } catch (err) {
+            catalogResults.innerHTML = `<p class="text-danger small">${err.message}</p>`;
+        } finally {
+            catalogSpinner.classList.add('d-none');
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/src/web/templates/images.html
+++ b/src/web/templates/images.html
@@ -152,28 +152,49 @@ document.addEventListener('DOMContentLoaded', function() {
                 catalogResults.innerHTML = '<p class="text-muted small">Ничего не найдено</p>';
                 return;
             }
-            let html = '<div class="list-group list-group-flush">';
+            const list = document.createElement('div');
+            list.className = 'list-group list-group-flush';
             for (const m of data.models) {
-                html += `<div class="list-group-item d-flex justify-content-between align-items-start">
-                    <div>
-                        <div class="fw-semibold small">${m.id}</div>
-                        <div class="text-muted small">${m.description || ''}</div>
-                        ${m.run_count ? `<span class="badge text-bg-secondary">${m.run_count.toLocaleString()} runs</span>` : ''}
-                    </div>
-                    <button class="btn btn-outline-primary btn-sm ms-2 use-model-btn" data-model="${m.model_string}">
-                        Выбрать
-                    </button>
-                </div>`;
-            }
-            html += '</div>';
-            catalogResults.innerHTML = html;
-            catalogResults.querySelectorAll('.use-model-btn').forEach(function(b) {
-                b.addEventListener('click', function() {
+                const item = document.createElement('div');
+                item.className = 'list-group-item d-flex justify-content-between align-items-start';
+
+                const info = document.createElement('div');
+                const title = document.createElement('div');
+                title.className = 'fw-semibold small';
+                title.textContent = m.id;
+                info.appendChild(title);
+
+                const desc = document.createElement('div');
+                desc.className = 'text-muted small';
+                desc.textContent = m.description || '';
+                info.appendChild(desc);
+
+                if (m.run_count) {
+                    const badge = document.createElement('span');
+                    badge.className = 'badge text-bg-secondary';
+                    badge.textContent = m.run_count.toLocaleString() + ' runs';
+                    info.appendChild(badge);
+                }
+                item.appendChild(info);
+
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-outline-primary btn-sm ms-2 use-model-btn';
+                btn.setAttribute('data-model', m.model_string);
+                btn.textContent = 'Выбрать';
+                btn.addEventListener('click', function() {
                     document.getElementById('img-model').value = this.dataset.model;
                 });
-            });
+                item.appendChild(btn);
+                list.appendChild(item);
+            }
+            catalogResults.innerHTML = '';
+            catalogResults.appendChild(list);
         } catch (err) {
-            catalogResults.innerHTML = `<p class="text-danger small">${err.message}</p>`;
+            catalogResults.textContent = '';
+            const errP = document.createElement('p');
+            errP.className = 'text-danger small';
+            errP.textContent = err.message;
+            catalogResults.appendChild(errP);
         } finally {
             catalogSpinner.classList.add('d-none');
         }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -273,6 +273,25 @@ async def test_delete_image_provider(client):
 
 
 @pytest.mark.asyncio
+async def test_images_page_shows_db_configured_provider(client):
+    """Provider added via Settings should appear on /images page."""
+    # Add provider with API key via settings
+    await client.post("/settings/image-providers/add", data={"provider": "replicate"})
+    await client.post(
+        "/settings/image-providers/save",
+        data={
+            "img_provider_present__replicate": "1",
+            "img_provider_enabled__replicate": "1",
+            "img_provider_secret__replicate__api_key": "r8_test_key",
+        },
+    )
+    # Verify it shows up on /images
+    resp = await client.get("/images/")
+    assert resp.status_code == 200
+    assert "replicate" in resp.text
+
+
+@pytest.mark.asyncio
 async def test_startup_continues_after_pool_initialize_timeout(tmp_path, db, caplog, monkeypatch):
     """start_container proceeds when pool.initialize() hangs past the timeout."""
     import asyncio


### PR DESCRIPTION
## Summary
- Новая страница `/images` с тестовой генерацией изображений и каталогом моделей
- Поддержка DB-configured провайдеров (из Settings), не только env vars
- Каталог моделей: Replicate API search + статические каталоги Together/OpenAI/HuggingFace
- CLI: `image generate "prompt" --model ...`, `image models --provider ...`, `image providers`
- "Картинки" в главном меню навигации

## Test plan
- [ ] `ruff check src/ tests/`
- [ ] `pytest tests/test_web.py -v -k image`
- [ ] `pytest tests/test_image_generation_service.py -v`
- [ ] Открыть `/images`, добавить Replicate в Settings, проверить что провайдер виден
- [ ] Сгенерировать изображение через UI
- [ ] `python -m src.main image providers`
- [ ] `python -m src.main image models --provider together`

🤖 Generated with [Claude Code](https://claude.com/claude-code)