### PR TITLE
fix: agent tools — correct service constructors and CLI parity

### DIFF
--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -87,7 +87,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db)
+            svc = ChannelService(db, client_pool, None)
             added = await svc.add_by_identifier(identifier)
             if added:
                 return _text_response(f"Канал '{identifier}' успешно добавлен.")
@@ -119,7 +119,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db)
+            svc = ChannelService(db, client_pool, None)
             await svc.delete(int(pk))
             return _text_response(f"Канал '{name}' удалён.")
         except Exception as e:
@@ -143,7 +143,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db)
+            svc = ChannelService(db, client_pool, None)
             await svc.toggle(int(pk))
             ch = await db.get_channel_by_pk(int(pk))
             if ch:
@@ -179,7 +179,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db)
+            svc = ChannelService(db, client_pool, None)
             added = 0
             errors = []
             for ident in identifiers:

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -513,8 +513,8 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
             from src.filters.analyzer import ChannelAnalyzer
 
             analyzer = ChannelAnalyzer(db)
-            _run_sync("reset_filters", analyzer.reset_filters)
-            return "Фильтры сброшены."
+            count = _run_sync("reset_filters", analyzer.reset_filters)
+            return f"Фильтры сброшены: {count} каналов разблокированы."
         except Exception as exc:
             return f"Ошибка: {exc}"
 

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -125,7 +125,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             result = _run_sync("add_channel", lambda: svc.add_by_identifier(identifier))
             return f"Канал добавлен: {result}" if result else f"Не удалось добавить канал: {identifier}"
         except Exception as exc:
@@ -138,7 +138,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             _run_sync("delete_channel", lambda: svc.delete(pk))
             return f"Канал pk={pk} удалён."
         except Exception as exc:
@@ -151,7 +151,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             _run_sync("toggle_channel", lambda: svc.toggle(pk))
             return f"Канал pk={pk} переключён."
         except Exception as exc:
@@ -510,8 +510,11 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
     def reset_filters() -> str:
         """⚠️ DANGEROUS: Reset all channel filters."""
         try:
-            count = _run_sync("reset_filters", db.reset_all_channel_filters)
-            return f"Фильтры сброшены: {count} каналов разблокированы."
+            from src.filters.analyzer import ChannelAnalyzer
+
+            analyzer = ChannelAnalyzer(db)
+            _run_sync("reset_filters", analyzer.reset_filters)
+            return "Фильтры сброшены."
         except Exception as exc:
             return f"Ошибка: {exc}"
 
@@ -714,8 +717,8 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         """Get notification bot status."""
         try:
             from src.services.notification_service import NotificationService
-
-            svc = NotificationService(db, client_pool)
+            from src.services.notification_target_service import NotificationTargetService
+            svc = NotificationService(db, NotificationTargetService(db, client_pool))
             bot = _run_sync("notif_status", svc.get_status)
             if not bot:
                 return "Бот уведомлений не настроен."
@@ -732,7 +735,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         try:
             from src.services.image_generation_service import ImageGenerationService
 
-            svc = ImageGenerationService(db)
+            svc = ImageGenerationService()
             result = _run_sync("gen_image", lambda: svc.generate(model=model or None, text=prompt))
             return f"Изображение: {result}" if result else "Генерация не вернула результат."
         except Exception as exc:
@@ -745,7 +748,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
         try:
             from src.services.image_generation_service import ImageGenerationService
 
-            svc = ImageGenerationService(db)
+            svc = ImageGenerationService()
             names = svc.adapter_names
             return f"Провайдеры: {', '.join(names)}" if names else "Провайдеры не настроены."
         except Exception as exc:

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -74,8 +74,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.filters.analyzer import ChannelAnalyzer
 
             analyzer = ChannelAnalyzer(db)
-            await analyzer.reset_filters()
-            return _text_response("Фильтры сброшены.")
+            count = await analyzer.reset_filters()
+            return _text_response(f"Фильтры сброшены: {count} каналов разблокированы.")
         except Exception as e:
             return _text_response(f"Ошибка сброса фильтров: {e}")
 

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -71,8 +71,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            count = await db.reset_all_channel_filters()
-            return _text_response(f"Фильтры сброшены: {count} каналов разблокированы.")
+            from src.filters.analyzer import ChannelAnalyzer
+
+            analyzer = ChannelAnalyzer(db)
+            await analyzer.reset_filters()
+            return _text_response("Фильтры сброшены.")
         except Exception as e:
             return _text_response(f"Ошибка сброса фильтров: {e}")
 

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -25,7 +25,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.image_generation_service import ImageGenerationService
 
-            svc = ImageGenerationService(db)
+            svc = ImageGenerationService()
             if not await svc.is_available():
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
             result = await svc.generate(model=model, text=prompt)
@@ -50,7 +50,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.image_generation_service import ImageGenerationService
 
-            svc = ImageGenerationService(db)
+            svc = ImageGenerationService()
             models = await svc.search_models(provider=provider, query=query)
             if not models:
                 return _text_response(f"Модели для {provider} не найдены.")
@@ -71,7 +71,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.image_generation_service import ImageGenerationService
 
-            svc = ImageGenerationService(db)
+            svc = ImageGenerationService()
             names = svc.adapter_names
             if not names:
                 return _text_response("Провайдеры изображений не настроены.")

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -22,7 +22,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             dialogs = await svc.get_my_dialogs(phone)
             if not dialogs:
                 return _text_response(f"Диалоги для {phone} не найдены.")
@@ -55,7 +55,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             dialogs = await svc.get_my_dialogs(phone, refresh=True)
             return _text_response(f"Диалоги обновлены: {len(dialogs)} шт.")
         except Exception as e:
@@ -86,7 +86,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.channel_service import ChannelService
 
-            svc = ChannelService(db, client_pool)
+            svc = ChannelService(db, client_pool, None)
             dialog_ids = [(int(x.strip()), "") for x in dialog_ids_str.split(",") if x.strip()]
             results = await svc.leave_dialogs(phone, dialog_ids)
             success = sum(1 for v in results.values() if v)
@@ -180,11 +180,13 @@ def register(db, client_pool, embedding_service, **kwargs):
             return gate
         try:
             if phone:
-                await db.repos.dialog_cache.clear_dialogs_for_phone(phone)
+                if client_pool is not None:
+                    client_pool.invalidate_dialogs_cache(phone)
+                await db.repos.dialog_cache.clear_dialogs(phone)
             else:
-                accounts = await db.get_accounts()
-                for acc in accounts:
-                    await db.repos.dialog_cache.clear_dialogs_for_phone(acc.phone)
+                if client_pool is not None:
+                    client_pool.invalidate_dialogs_cache()
+                await db.repos.dialog_cache.clear_all_dialogs()
             return _text_response("Кеш диалогов очищен.")
         except Exception as e:
             return _text_response(f"Ошибка очистки кеша: {e}")

--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -15,8 +15,9 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def get_notification_status(args):
         try:
             from src.services.notification_service import NotificationService
+            from src.services.notification_target_service import NotificationTargetService
 
-            svc = NotificationService(db, client_pool)
+            svc = NotificationService(db, NotificationTargetService(db, client_pool))
             bot = await svc.get_status()
             if bot is None:
                 return _text_response("Бот уведомлений не настроен.")
@@ -46,8 +47,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             return gate
         try:
             from src.services.notification_service import NotificationService
+            from src.services.notification_target_service import NotificationTargetService
 
-            svc = NotificationService(db, client_pool)
+            svc = NotificationService(db, NotificationTargetService(db, client_pool))
             bot = await svc.setup_bot()
             return _text_response(
                 f"Бот уведомлений создан!\n"
@@ -74,8 +76,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             return gate
         try:
             from src.services.notification_service import NotificationService
+            from src.services.notification_target_service import NotificationTargetService
 
-            svc = NotificationService(db, client_pool)
+            svc = NotificationService(db, NotificationTargetService(db, client_pool))
             await svc.teardown_bot()
             return _text_response("Бот уведомлений удалён.")
         except Exception as e:
@@ -90,8 +93,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             return pool_gate
         try:
             from src.services.notification_service import NotificationService
+            from src.services.notification_target_service import NotificationTargetService
 
-            svc = NotificationService(db, client_pool)
+            svc = NotificationService(db, NotificationTargetService(db, client_pool))
             bot = await svc.get_status()
             if bot is None:
                 return _text_response("Бот уведомлений не настроен. Сначала вызовите setup_notification_bot.")

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -14,9 +14,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_photo_batches", "List photo upload batches", {"limit": int})
     async def list_photo_batches(args):
         try:
+            from src.database.bundles import PhotoLoaderBundle
+            from src.services.photo_publish_service import PhotoPublishService
             from src.services.photo_task_service import PhotoTaskService
 
-            svc = PhotoTaskService(db, client_pool)
+            svc = PhotoTaskService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             limit = int(args.get("limit", 50))
             batches = await svc.list_batches(limit=limit)
             if not batches:
@@ -36,9 +38,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_photo_items", "List photo batch items with status", {"limit": int})
     async def list_photo_items(args):
         try:
+            from src.database.bundles import PhotoLoaderBundle
+            from src.services.photo_publish_service import PhotoPublishService
             from src.services.photo_task_service import PhotoTaskService
 
-            svc = PhotoTaskService(db, client_pool)
+            svc = PhotoTaskService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             limit = int(args.get("limit", 100))
             items = await svc.list_items(limit=limit)
             if not items:
@@ -70,9 +74,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
+            from src.database.bundles import PhotoLoaderBundle
+            from src.services.photo_publish_service import PhotoPublishService
             from src.services.photo_task_service import PhotoTaskService
 
-            svc = PhotoTaskService(db, client_pool)
+            svc = PhotoTaskService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             phone = args.get("phone", "")
             target = args.get("target", "")
             files = [f.strip() for f in args.get("file_paths", "").split(",") if f.strip()]
@@ -115,10 +121,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from datetime import datetime
 
+            from src.database.bundles import PhotoLoaderBundle
             from src.models import PhotoTarget
+            from src.services.photo_publish_service import PhotoPublishService
             from src.services.photo_task_service import PhotoTaskService
 
-            svc = PhotoTaskService(db, client_pool)
+            svc = PhotoTaskService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             phone = args.get("phone", "")
             target = args.get("target", "")
             files = [f.strip() for f in args.get("file_paths", "").split(",") if f.strip()]
@@ -155,9 +163,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
+            from src.database.bundles import PhotoLoaderBundle
+            from src.services.photo_publish_service import PhotoPublishService
             from src.services.photo_task_service import PhotoTaskService
 
-            svc = PhotoTaskService(db, client_pool)
+            svc = PhotoTaskService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             ok = await svc.cancel_item(int(item_id))
             if ok:
                 return _text_response(f"Фото item_id={item_id} отменено.")
@@ -170,9 +180,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_auto_uploads", "List automatic photo upload jobs", {})
     async def list_auto_uploads(args):
         try:
+            from src.database.bundles import PhotoLoaderBundle
             from src.services.photo_auto_upload_service import PhotoAutoUploadService
+            from src.services.photo_publish_service import PhotoPublishService
 
-            svc = PhotoAutoUploadService(db, client_pool)
+            svc = PhotoAutoUploadService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             jobs = await svc.list_jobs()
             if not jobs:
                 return _text_response("Автозагрузки не настроены.")
@@ -195,9 +207,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         if job_id is None:
             return _text_response("Ошибка: job_id обязателен.")
         try:
+            from src.database.bundles import PhotoLoaderBundle
             from src.services.photo_auto_upload_service import PhotoAutoUploadService
+            from src.services.photo_publish_service import PhotoPublishService
 
-            svc = PhotoAutoUploadService(db, client_pool)
+            svc = PhotoAutoUploadService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             job = await svc.get_job(int(job_id))
             if job is None:
                 return _text_response(f"Автозагрузка id={job_id} не найдена.")
@@ -223,9 +237,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
+            from src.database.bundles import PhotoLoaderBundle
             from src.services.photo_auto_upload_service import PhotoAutoUploadService
+            from src.services.photo_publish_service import PhotoPublishService
 
-            svc = PhotoAutoUploadService(db, client_pool)
+            svc = PhotoAutoUploadService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
             await svc.delete_job(int(job_id))
             return _text_response(f"Автозагрузка id={job_id} удалена.")
         except Exception as e:

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -94,6 +94,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             "is_regex": bool,
             "is_fts": bool,
             "notify_on_collect": bool,
+            "track_stats": bool,
+            "exclude_patterns": str,
+            "max_length": int,
             "confirm": bool,
         },
     )
@@ -112,12 +115,18 @@ def register(db, client_pool, embedding_service, **kwargs):
             is_regex = bool(args.get("is_regex", False))
             is_fts = bool(args.get("is_fts", False))
             notify = bool(args.get("notify_on_collect", False))
+            track_stats = bool(args.get("track_stats", True))
+            exclude_patterns = args.get("exclude_patterns", "")
+            max_length = args.get("max_length")
             sq_id = await svc.add(
                 query,
                 interval_minutes=interval,
                 is_regex=is_regex,
                 is_fts=is_fts,
                 notify_on_collect=notify,
+                track_stats=track_stats,
+                exclude_patterns=exclude_patterns or "",
+                max_length=int(max_length) if max_length is not None else None,
             )
             return _text_response(f"Поисковый запрос создан (id={sq_id}).")
         except Exception as e:
@@ -135,6 +144,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             "is_regex": bool,
             "is_fts": bool,
             "notify_on_collect": bool,
+            "track_stats": bool,
+            "exclude_patterns": str,
+            "max_length": int,
             "confirm": bool,
         },
     )
@@ -157,6 +169,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             is_regex = bool(args.get("is_regex", existing.is_regex))
             is_fts = bool(args.get("is_fts", existing.is_fts))
             notify = bool(args.get("notify_on_collect", existing.notify_on_collect))
+            track_stats = bool(args.get("track_stats", getattr(existing, "track_stats", True)))
+            exclude_patterns = args.get("exclude_patterns", getattr(existing, "exclude_patterns", ""))
+            max_length_raw = args.get("max_length", getattr(existing, "max_length", None))
             ok = await svc.update(
                 int(sq_id),
                 query,
@@ -164,6 +179,9 @@ def register(db, client_pool, embedding_service, **kwargs):
                 is_regex=is_regex,
                 is_fts=is_fts,
                 notify_on_collect=notify,
+                track_stats=track_stats,
+                exclude_patterns=exclude_patterns or "",
+                max_length=int(max_length_raw) if max_length_raw is not None else None,
             )
             if ok:
                 return _text_response(f"Поисковый запрос id={sq_id} обновлён.")

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -220,5 +220,5 @@ class ChannelAnalyzer:
             await self._database.set_channels_filtered_bulk(to_filter)
         return len(to_filter)
 
-    async def reset_filters(self) -> None:
-        await self._database.reset_all_channel_filters()
+    async def reset_filters(self) -> int:
+        return await self._database.reset_all_channel_filters()


### PR DESCRIPTION
## Summary
- **Fix 5 broken constructors** in MCP tools and deepagents_sync: `ChannelService`, `NotificationService`, `ImageGenerationService`, `PhotoTaskService`, `PhotoAutoUploadService` — all would crash with TypeError at runtime
- **Fix CLI parity**: add missing `exclude_patterns`/`track_stats`/`max_length` to search_queries, use `ChannelAnalyzer.reset_filters()` instead of raw DB call, fix dialog cache clearing (wrong method name + missing pool invalidation)

## Test plan
- [x] `ruff check src/agent/tools/` — 0 errors
- [x] `pytest tests/test_agent_tools.py tests/test_agent.py -v` — 100/100 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)