### PR TITLE
fix: load image providers from DB in all agent/CLI/dispatcher paths

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -191,7 +191,10 @@ class ClaudeSdkBackend:
 
         os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "300000")
         self._server = make_mcp_server(
-            self._db, client_pool=self._client_pool, scheduler_manager=self._scheduler_manager,
+            self._db,
+            client_pool=self._client_pool,
+            scheduler_manager=self._scheduler_manager,
+            config=self._config,
         )
         logger.info("Claude SDK backend initialized")
 
@@ -488,7 +491,7 @@ class DeepagentsBackend:
         """Return the full tool set for deepagents backend."""
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        return build_deepagents_tools(self._db)
+        return build_deepagents_tools(self._db, config=self._config)
 
     def _search_messages_tool(self, query_text: str) -> str:
         """Search messages — used by probe. Delegates to sync tools."""

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -13,7 +13,7 @@ from claude_agent_sdk import create_sdk_mcp_server
 from src.agent.tools._registry import _text_response  # noqa: F401
 
 
-def make_mcp_server(db, client_pool=None, scheduler_manager=None):
+def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
     """Create an in-process MCP server with all agent tools.
 
     Args:
@@ -48,7 +48,7 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None):
     )
 
     # Extra context passed alongside the standard (db, client_pool, embedding_service)
-    extras = {"scheduler_manager": scheduler_manager}
+    extras = {"scheduler_manager": scheduler_manager, "config": config}
 
     all_tools = []
     for module in [

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -24,7 +24,7 @@ def _run_sync(tool_name: str, operation: Callable[[], Awaitable[_T]]) -> _T:
     raise RuntimeError(f"Deepagents tool '{tool_name}' cannot run inside an active event loop")
 
 
-def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C901
+def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:  # noqa: C901
     """Build all sync tools for the deepagents backend.
 
     Returns a list of callables compatible with LangChain tool registration.
@@ -732,11 +732,25 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
 
     def generate_image(prompt: str, model: str = "") -> str:
         """Generate an image from text prompt."""
-        try:
+        async def _run():
             from src.services.image_generation_service import ImageGenerationService
 
             svc = ImageGenerationService()
-            result = _run_sync("gen_image", lambda: svc.generate(model=model or None, text=prompt))
+            if db is not None and config is not None:
+                try:
+                    from src.services.image_provider_service import ImageProviderService
+
+                    ip_svc = ImageProviderService(db, config)
+                    ip_configs = await ip_svc.load_provider_configs()
+                    adapters = ip_svc.build_adapters(ip_configs)
+                    if adapters:
+                        svc = ImageGenerationService(adapters=adapters)
+                except Exception:
+                    pass
+            return await svc.generate(model=model or None, text=prompt)
+
+        try:
+            result = _run_sync("gen_image", _run)
             return f"Изображение: {result}" if result else "Генерация не вернула результат."
         except Exception as exc:
             return f"Ошибка: {exc}"
@@ -745,11 +759,25 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
 
     def list_image_providers() -> str:
         """List configured image generation providers."""
-        try:
+        async def _run():
             from src.services.image_generation_service import ImageGenerationService
 
             svc = ImageGenerationService()
-            names = svc.adapter_names
+            if db is not None and config is not None:
+                try:
+                    from src.services.image_provider_service import ImageProviderService
+
+                    ip_svc = ImageProviderService(db, config)
+                    ip_configs = await ip_svc.load_provider_configs()
+                    adapters = ip_svc.build_adapters(ip_configs)
+                    if adapters:
+                        svc = ImageGenerationService(adapters=adapters)
+                except Exception:
+                    pass
+            return svc.adapter_names
+
+        try:
+            names = _run_sync("list_providers", _run)
             return f"Провайдеры: {', '.join(names)}" if names else "Провайдеры не настроены."
         except Exception as exc:
             return f"Ошибка: {exc}"

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -9,6 +9,25 @@ from src.agent.tools._registry import _text_response
 
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
+    config = kwargs.get("config")
+
+    async def _build_image_service():
+        """Load ImageGenerationService with DB-backed providers + env fallback."""
+        try:
+            from src.services.image_generation_service import ImageGenerationService
+            from src.services.image_provider_service import ImageProviderService
+
+            if db is not None and config is not None:
+                svc = ImageProviderService(db, config)
+                configs = await svc.load_provider_configs()
+                adapters = svc.build_adapters(configs)
+                if adapters:
+                    return ImageGenerationService(adapters=adapters)
+        except Exception:
+            pass
+        from src.services.image_generation_service import ImageGenerationService
+
+        return ImageGenerationService()
 
     @tool(
         "generate_image",
@@ -23,9 +42,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: prompt обязателен.")
         model = args.get("model")
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             if not await svc.is_available():
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
             result = await svc.generate(model=model, text=prompt)
@@ -48,9 +65,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: provider обязателен.")
         query = args.get("query", "")
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             models = await svc.search_models(provider=provider, query=query)
             if not models:
                 return _text_response(f"Модели для {provider} не найдены.")
@@ -69,9 +84,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_image_providers", "List configured image generation providers", {})
     async def list_image_providers(args):
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             names = svc.adapter_names
             if not names:
                 return _text_response("Провайдеры изображений не настроены.")

--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -4,18 +4,41 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 
+from src.cli import runtime
 from src.services.image_generation_service import ImageGenerationService
+
+logger = logging.getLogger(__name__)
+
+
+async def _build_service(config_path: str) -> ImageGenerationService:
+    """Build ImageGenerationService with DB-configured providers + env fallback."""
+    try:
+        from src.services.image_provider_service import ImageProviderService
+
+        config, db = await runtime.init_db(config_path)
+        try:
+            svc = ImageProviderService(db, config)
+            configs = await svc.load_provider_configs()
+            adapters = svc.build_adapters(configs)
+            if adapters:
+                return ImageGenerationService(adapters=adapters)
+        finally:
+            await db.close()
+    except Exception:
+        logger.warning("Failed to load image providers from DB, falling back to env vars", exc_info=True)
+    return ImageGenerationService()
 
 
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         action = args.image_action
-        svc = ImageGenerationService()
+        svc = await _build_service(args.config)
 
         if action == "generate":
             if not await svc.is_available():
-                print("No image providers configured. Set REPLICATE_API_TOKEN or similar env var.")
+                print("No image providers configured. Set REPLICATE_API_TOKEN or similar env var, or configure via Settings UI.")
                 return
             model = args.model or None
             prompt = args.prompt
@@ -42,7 +65,7 @@ def run(args: argparse.Namespace) -> None:
         elif action == "providers":
             names = svc.adapter_names
             if not names:
-                print("No providers configured. Set env vars: REPLICATE_API_TOKEN, TOGETHER_API_KEY, etc.")
+                print("No providers configured. Set env vars: REPLICATE_API_TOKEN, TOGETHER_API_KEY, etc., or configure via Settings UI.")
                 return
             for name in names:
                 print(f"  {name}")

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -217,12 +217,24 @@ def run(args: argparse.Namespace) -> None:
                     from src.agent.manager import AgentManager
 
                     agent_manager = AgentManager(db, config)
+                image_service = None
+                try:
+                    from src.services.image_generation_service import ImageGenerationService
+                    from src.services.image_provider_service import ImageProviderService
+
+                    ip_svc = ImageProviderService(db, config)
+                    ip_configs = await ip_svc.load_provider_configs()
+                    adapters = ip_svc.build_adapters(ip_configs)
+                    image_service = ImageGenerationService(adapters=adapters) if adapters else ImageGenerationService()
+                except Exception:
+                    pass
                 from src.services.quality_scoring_service import QualityScoringService
 
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
                     agent_manager=agent_manager,
+                    image_service=image_service,
                     quality_service=QualityScoringService(db),
                 )
                 try:

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -477,10 +477,17 @@ class UnifiedDispatcher:
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
 
+            agent_manager = None
+            _backend = getattr(pipeline, "generation_backend", None)
+            if _backend is not None and getattr(_backend, "value", _backend) == "deep_agents":
+                from src.agent.manager import AgentManager
+
+                agent_manager = AgentManager(self._db, self._config)
             image_service = await self._build_image_service()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                agent_manager=agent_manager,
                 image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,
@@ -559,10 +566,17 @@ class UnifiedDispatcher:
             notification_service = DraftNotificationService(db, self._notifier)
             quality_service = QualityScoringService(db)
 
+            agent_manager = None
+            _backend = getattr(pipeline, "generation_backend", None)
+            if _backend is not None and getattr(_backend, "value", _backend) == "deep_agents":
+                from src.agent.manager import AgentManager
+
+                agent_manager = AgentManager(self._db, self._config)
             image_service = await self._build_image_service()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                agent_manager=agent_manager,
                 image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -610,3 +610,201 @@ class TestMakeMcpServer:
 
         server = make_mcp_server(mock_db)
         assert "instance" in server
+
+
+# ---------------------------------------------------------------------------
+# image tools (generate_image, list_image_providers, list_image_models)
+# ---------------------------------------------------------------------------
+
+
+class TestImageTools:
+    """Tests for image generation agent tools, verifying DB-backed provider loading."""
+
+    def _get_image_handlers(self, mock_db, config=None):
+        captured = []
+        with patch(
+            "src.agent.tools.create_sdk_mcp_server",
+            side_effect=lambda **kw: captured.extend(kw.get("tools", [])),
+        ):
+            from src.agent.tools import make_mcp_server
+
+            make_mcp_server(mock_db, config=config)
+        return {t.name: t.handler for t in captured}
+
+    # ── generate_image ──
+
+    @pytest.mark.asyncio
+    async def test_generate_image_missing_prompt(self, mock_db):
+        handlers = self._get_image_handlers(mock_db)
+        result = await handlers["generate_image"]({"prompt": ""})
+        assert "prompt обязателен" in result["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_generate_image_uses_db_provider(self, mock_db):
+        """generate_image must load providers from DB, not just env vars."""
+        from src.config import AppConfig
+        from src.services.image_provider_service import ImageProviderConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        fake_cfg = ImageProviderConfig(provider="together", enabled=True, api_key="sk-db-key")
+
+        with (
+            patch(
+                "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+                new_callable=AsyncMock,
+                return_value=[fake_cfg],
+            ),
+            patch(
+                "src.services.image_generation_service.ImageGenerationService.generate",
+                new_callable=AsyncMock,
+                return_value="https://example.com/opossum.png",
+            ),
+            patch(
+                "src.services.image_generation_service.ImageGenerationService.is_available",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            handlers = self._get_image_handlers(mock_db, config=config)
+            result = await handlers["generate_image"]({"prompt": "cute opossum"})
+
+        text = result["content"][0]["text"]
+        assert "https://example.com/opossum.png" in text
+
+    @pytest.mark.asyncio
+    async def test_generate_image_no_providers_message(self, mock_db):
+        """When no providers configured, return a helpful error message."""
+        from src.config import AppConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        with patch(
+            "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            handlers = self._get_image_handlers(mock_db, config=config)
+            result = await handlers["generate_image"]({"prompt": "opossum"})
+
+        text = result["content"][0]["text"]
+        assert "не настроен" in text.lower() or "не доступн" in text.lower()
+
+    # ── list_image_providers ──
+
+    @pytest.mark.asyncio
+    async def test_list_image_providers_from_db(self, mock_db):
+        """list_image_providers must show providers loaded from DB."""
+        from src.config import AppConfig
+        from src.services.image_provider_service import ImageProviderConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        fake_cfg = ImageProviderConfig(provider="replicate", enabled=True, api_key="r8_test")
+
+        with (
+            patch(
+                "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+                new_callable=AsyncMock,
+                return_value=[fake_cfg],
+            ),
+        ):
+            handlers = self._get_image_handlers(mock_db, config=config)
+            result = await handlers["list_image_providers"]({})
+
+        text = result["content"][0]["text"]
+        assert "replicate" in text
+
+    @pytest.mark.asyncio
+    async def test_list_image_providers_empty(self, mock_db):
+        from src.config import AppConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        with patch(
+            "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            handlers = self._get_image_handlers(mock_db, config=config)
+            result = await handlers["list_image_providers"]({})
+
+        assert "не настроен" in result["content"][0]["text"].lower()
+
+    # ── list_image_models ──
+
+    @pytest.mark.asyncio
+    async def test_list_image_models_missing_provider(self, mock_db):
+        handlers = self._get_image_handlers(mock_db)
+        result = await handlers["list_image_models"]({"provider": ""})
+        assert "provider обязателен" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# deepagents_sync image tools
+# ---------------------------------------------------------------------------
+
+
+class TestDeepagentsSyncImageTools:
+    """Tests for generate_image / list_image_providers in deepagents_sync.py."""
+
+    def _get_tools(self, mock_db, config=None):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        tools = build_deepagents_tools(mock_db, config=config)
+        return {t.__name__: t for t in tools}
+
+    def test_generate_image_uses_db_provider(self, mock_db):
+        from src.config import AppConfig
+        from src.services.image_provider_service import ImageProviderConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        fake_cfg = ImageProviderConfig(provider="replicate", enabled=True, api_key="r8_test")
+
+        with (
+            patch(
+                "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+                new_callable=AsyncMock,
+                return_value=[fake_cfg],
+            ),
+            patch(
+                "src.services.image_generation_service.ImageGenerationService.generate",
+                new_callable=AsyncMock,
+                return_value="https://example.com/opossum.png",
+            ),
+        ):
+            tools = self._get_tools(mock_db, config=config)
+            result = tools["generate_image"]("cute opossum")
+
+        assert "https://example.com/opossum.png" in result
+
+    def test_list_image_providers_from_db(self, mock_db):
+        from src.config import AppConfig
+        from src.services.image_provider_service import ImageProviderConfig
+
+        config = AppConfig()
+        config.security.session_encryption_key = "test-secret"
+
+        fake_cfg = ImageProviderConfig(provider="together", enabled=True, api_key="sk-test")
+
+        with patch(
+            "src.services.image_provider_service.ImageProviderService.load_provider_configs",
+            new_callable=AsyncMock,
+            return_value=[fake_cfg],
+        ):
+            tools = self._get_tools(mock_db, config=config)
+            result = tools["list_image_providers"]()
+
+        assert "together" in result
+
+    def test_list_image_providers_no_config(self, mock_db):
+        """When config=None, falls back to env-only path (no DB lookup)."""
+        tools = self._get_tools(mock_db, config=None)
+        result = tools["list_image_providers"]()
+        assert "не настроен" in result.lower()


### PR DESCRIPTION
## Summary

- **Root cause**: `ImageGenerationService()` was constructed without adapters in multiple places, silently ignoring providers configured via Settings UI (stored encrypted in DB)
- **Affected paths**: `image` CLI, `pipeline generate` CLI, `UnifiedDispatcher`, agent MCP tools (`ClaudeSdkBackend`), and deepagents sync tools (`DeepagentsBackend`) — all fixed
- **Key finding**: `DeepagentsBackend._default_tools()` passed only `db` to `build_deepagents_tools()`, so `config` (needed for decryption) never reached the image tools

## Changes

| File | Fix |
|------|-----|
| `src/cli/commands/image.py` | Load providers from DB via `ImageProviderService` |
| `src/cli/commands/pipeline.py` | Inject `image_service` into `ContentGenerationService` |
| `src/services/unified_dispatcher.py` | Inject `agent_manager` for `deep_agents` pipelines in both handlers |
| `src/agent/tools/images.py` | `_build_image_service()` uses `ImageProviderService(db, config)` |
| `src/agent/tools/__init__.py` | Pass `config` through `make_mcp_server` → `extras` |
| `src/agent/manager.py` | Pass `config` to `make_mcp_server` and `build_deepagents_tools` |
| `src/agent/tools/deepagents_sync.py` | `generate_image` + `list_image_providers` load DB-configured adapters |
| `tests/test_agent_tools.py` | +9 tests for `TestImageTools` and `TestDeepagentsSyncImageTools` |

## Test plan

- [x] `pytest tests/test_agent_tools.py -v -k "Image or Deepagents"` — 9 passed
- [x] `pytest tests/ -m "not aiosqlite_serial" -n auto -q` — 2007 passed
- [x] `pytest tests/ -m aiosqlite_serial -q` — 197 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)