### PR TITLE
feat: agent tool permissions with read/write/delete grouping

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -490,10 +490,17 @@ class DeepagentsBackend:
         )
 
     def _default_tools(self) -> list[Callable]:
-        """Return the full tool set for deepagents backend."""
+        """Return the tool set for deepagents backend, filtered by permissions."""
         from src.agent.tools.deepagents_sync import build_deepagents_tools
+        from src.agent.tools.permissions import load_tool_permissions
 
-        return build_deepagents_tools(self._db)
+        all_tools = build_deepagents_tools(self._db)
+        try:
+            permissions = asyncio.run(load_tool_permissions(self._db))
+        except RuntimeError:
+            # Inside event loop — permissions unavailable, allow all
+            return all_tools
+        return [t for t in all_tools if permissions.get(t.__name__, True)]
 
     def _search_messages_tool(self, query_text: str) -> str:
         """Search messages — used by probe. Delegates to sync tools."""

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -489,16 +489,12 @@ class DeepagentsBackend:
             f"Deepagents tool '{tool_name}' cannot run inside an active event loop: {loop}"
         )
 
-    def _default_tools(self) -> list[Callable]:
+    def _default_tools(self, permissions: dict[str, bool] | None = None) -> list[Callable]:
         """Return the tool set for deepagents backend, filtered by permissions."""
         from src.agent.tools.deepagents_sync import build_deepagents_tools
-        from src.agent.tools.permissions import load_tool_permissions
 
         all_tools = build_deepagents_tools(self._db)
-        try:
-            permissions = asyncio.run(load_tool_permissions(self._db))
-        except RuntimeError:
-            # Inside event loop — permissions unavailable, allow all
+        if permissions is None:
             return all_tools
         return [t for t in all_tools if permissions.get(t.__name__, True)]
 
@@ -523,6 +519,7 @@ class DeepagentsBackend:
         cfg: ProviderRuntimeConfig,
         *,
         tools: list[Callable] | None = None,
+        permissions: dict[str, bool] | None = None,
         record_last_used: bool = True,
         system_prompt: str = DEFAULT_AGENT_PROMPT_TEMPLATE,
     ):
@@ -581,7 +578,7 @@ class DeepagentsBackend:
         try:
             agent = create_deep_agent(
                 model=model,
-                tools=tools or self._default_tools(),
+                tools=tools or self._default_tools(permissions=permissions),
                 system_prompt=system_prompt,
             )
             if record_last_used:
@@ -701,8 +698,9 @@ class DeepagentsBackend:
         *,
         history_msgs: list[dict] | None = None,
         system_prompt: str = DEFAULT_AGENT_PROMPT_TEMPLATE,
+        permissions: dict[str, bool] | None = None,
     ) -> str:
-        agent = self._build_agent(cfg, system_prompt=system_prompt)
+        agent = self._build_agent(cfg, system_prompt=system_prompt, permissions=permissions)
         # Different agent frameworks have different history handling:
         # - `.run(prompt_str)` agents receive history embedded as XML tags in a single string
         # - `.invoke({"messages": [...]})` agents receive history as a structured message list
@@ -879,6 +877,11 @@ class DeepagentsBackend:
         history_msgs: list[dict] | None = None,
     ) -> None:
         del thread_id, stats, model
+
+        from src.agent.tools.permissions import load_tool_permissions
+
+        permissions = await load_tool_permissions(self._db)
+
         errors: list[str] = []
         for cfg in await self._candidate_configs():
             validation_error = self._validation_error(cfg)
@@ -892,6 +895,7 @@ class DeepagentsBackend:
                     cfg,
                     history_msgs=history_msgs,
                     system_prompt=system_prompt,
+                    permissions=permissions,
                 )
                 self._init_error = None
                 if full_text:

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -228,10 +228,15 @@ class ClaudeSdkBackend:
         cli_path = shutil.which("claude")
         logger.info("claude-cli path: %s", cli_path)
 
+        from src.agent.tools.permissions import filter_allowed_tools, load_tool_permissions
+
+        permissions = await load_tool_permissions(self._db)
+        allowed = filter_allowed_tools(_ALLOWED_TOOLS, permissions)
+
         options = ClaudeAgentOptions(
             system_prompt=system_prompt,
             mcp_servers={"telegram_db": self._server},
-            allowed_tools=_ALLOWED_TOOLS,
+            allowed_tools=allowed,
             cli_path=cli_path or None,
             stderr=_on_stderr,
             **extra,

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -1,0 +1,286 @@
+"""Agent tool permission registry — classifies tools into read/write/delete categories."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import OrderedDict
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+TOOL_PERMISSIONS_SETTING = "agent_tool_permissions"
+MCP_PREFIX = "mcp__telegram_db__"
+
+
+class ToolCategory(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+
+
+# ---------------------------------------------------------------------------
+# Authoritative tool → category mapping.  Every tool in _ALLOWED_TOOLS must
+# appear here.  The bare name (without the MCP prefix) is used as the key.
+# ---------------------------------------------------------------------------
+
+TOOL_CATEGORIES: dict[str, ToolCategory] = {
+    # Search
+    "search_messages": ToolCategory.READ,
+    "semantic_search": ToolCategory.READ,
+    "index_messages": ToolCategory.WRITE,
+    # Channels
+    "list_channels": ToolCategory.READ,
+    "get_channel_stats": ToolCategory.READ,
+    "add_channel": ToolCategory.WRITE,
+    "delete_channel": ToolCategory.DELETE,
+    "toggle_channel": ToolCategory.WRITE,
+    "import_channels": ToolCategory.WRITE,
+    "refresh_channel_types": ToolCategory.WRITE,
+    # Collection
+    "collect_channel": ToolCategory.WRITE,
+    "collect_all_channels": ToolCategory.WRITE,
+    "collect_channel_stats": ToolCategory.READ,
+    "collect_all_stats": ToolCategory.READ,
+    # Pipelines
+    "list_pipelines": ToolCategory.READ,
+    "get_pipeline_detail": ToolCategory.READ,
+    "add_pipeline": ToolCategory.WRITE,
+    "edit_pipeline": ToolCategory.WRITE,
+    "toggle_pipeline": ToolCategory.WRITE,
+    "delete_pipeline": ToolCategory.DELETE,
+    "run_pipeline": ToolCategory.WRITE,
+    "generate_draft": ToolCategory.WRITE,
+    "list_pipeline_runs": ToolCategory.READ,
+    "get_pipeline_run": ToolCategory.READ,
+    "publish_pipeline_run": ToolCategory.WRITE,
+    "get_pipeline_queue": ToolCategory.READ,
+    # Moderation
+    "list_pending_moderation": ToolCategory.READ,
+    "view_moderation_run": ToolCategory.READ,
+    "approve_run": ToolCategory.WRITE,
+    "reject_run": ToolCategory.WRITE,
+    "bulk_approve_runs": ToolCategory.WRITE,
+    "bulk_reject_runs": ToolCategory.WRITE,
+    # Search Queries
+    "list_search_queries": ToolCategory.READ,
+    "get_search_query": ToolCategory.READ,
+    "add_search_query": ToolCategory.WRITE,
+    "edit_search_query": ToolCategory.WRITE,
+    "delete_search_query": ToolCategory.DELETE,
+    "toggle_search_query": ToolCategory.WRITE,
+    "run_search_query": ToolCategory.WRITE,
+    # Accounts
+    "list_accounts": ToolCategory.READ,
+    "toggle_account": ToolCategory.WRITE,
+    "delete_account": ToolCategory.DELETE,
+    "get_flood_status": ToolCategory.READ,
+    # Filters
+    "analyze_filters": ToolCategory.READ,
+    "apply_filters": ToolCategory.WRITE,
+    "reset_filters": ToolCategory.WRITE,
+    "toggle_channel_filter": ToolCategory.WRITE,
+    "purge_filtered_channels": ToolCategory.DELETE,
+    "hard_delete_channels": ToolCategory.DELETE,
+    # Analytics
+    "get_analytics_summary": ToolCategory.READ,
+    "get_pipeline_stats": ToolCategory.READ,
+    "get_daily_stats": ToolCategory.READ,
+    "get_trending_topics": ToolCategory.READ,
+    "get_trending_channels": ToolCategory.READ,
+    "get_message_velocity": ToolCategory.READ,
+    "get_peak_hours": ToolCategory.READ,
+    "get_calendar": ToolCategory.READ,
+    # Scheduler
+    "get_scheduler_status": ToolCategory.READ,
+    "start_scheduler": ToolCategory.WRITE,
+    "stop_scheduler": ToolCategory.WRITE,
+    "trigger_collection": ToolCategory.WRITE,
+    "toggle_scheduler_job": ToolCategory.WRITE,
+    # Notifications
+    "get_notification_status": ToolCategory.READ,
+    "setup_notification_bot": ToolCategory.WRITE,
+    "delete_notification_bot": ToolCategory.DELETE,
+    "test_notification": ToolCategory.WRITE,
+    # Photo Loader
+    "list_photo_batches": ToolCategory.READ,
+    "list_photo_items": ToolCategory.READ,
+    "send_photos_now": ToolCategory.WRITE,
+    "schedule_photos": ToolCategory.WRITE,
+    "cancel_photo_item": ToolCategory.WRITE,
+    "list_auto_uploads": ToolCategory.READ,
+    "toggle_auto_upload": ToolCategory.WRITE,
+    "delete_auto_upload": ToolCategory.DELETE,
+    # My Telegram
+    "list_dialogs": ToolCategory.READ,
+    "refresh_dialogs": ToolCategory.WRITE,
+    "leave_dialogs": ToolCategory.DELETE,
+    "create_telegram_channel": ToolCategory.WRITE,
+    "get_forum_topics": ToolCategory.READ,
+    "clear_dialog_cache": ToolCategory.WRITE,
+    # Images
+    "generate_image": ToolCategory.WRITE,
+    "list_image_models": ToolCategory.READ,
+    "list_image_providers": ToolCategory.READ,
+    # Settings
+    "get_settings": ToolCategory.READ,
+    "save_scheduler_settings": ToolCategory.WRITE,
+    "save_agent_settings": ToolCategory.WRITE,
+    "save_filter_settings": ToolCategory.WRITE,
+    "get_system_info": ToolCategory.READ,
+    # Agent Threads
+    "list_agent_threads": ToolCategory.READ,
+    "create_agent_thread": ToolCategory.WRITE,
+    "delete_agent_thread": ToolCategory.DELETE,
+    "rename_agent_thread": ToolCategory.WRITE,
+    "get_thread_messages": ToolCategory.READ,
+}
+
+# ---------------------------------------------------------------------------
+# Module groups — ordered dict mapping display name → list of bare tool names.
+# Order matches the registration order in tools/__init__.py.
+# ---------------------------------------------------------------------------
+
+MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
+    ("Поиск", [
+        "search_messages", "semantic_search", "index_messages",
+    ]),
+    ("Каналы", [
+        "list_channels", "get_channel_stats", "add_channel", "delete_channel",
+        "toggle_channel", "import_channels", "refresh_channel_types",
+    ]),
+    ("Сбор", [
+        "collect_channel", "collect_all_channels", "collect_channel_stats", "collect_all_stats",
+    ]),
+    ("Пайплайны", [
+        "list_pipelines", "get_pipeline_detail", "add_pipeline", "edit_pipeline",
+        "toggle_pipeline", "delete_pipeline", "run_pipeline", "generate_draft",
+        "list_pipeline_runs", "get_pipeline_run", "publish_pipeline_run", "get_pipeline_queue",
+    ]),
+    ("Модерация", [
+        "list_pending_moderation", "view_moderation_run", "approve_run", "reject_run",
+        "bulk_approve_runs", "bulk_reject_runs",
+    ]),
+    ("Поисковые запросы", [
+        "list_search_queries", "get_search_query", "add_search_query", "edit_search_query",
+        "delete_search_query", "toggle_search_query", "run_search_query",
+    ]),
+    ("Аккаунты", [
+        "list_accounts", "toggle_account", "delete_account", "get_flood_status",
+    ]),
+    ("Фильтры", [
+        "analyze_filters", "apply_filters", "reset_filters", "toggle_channel_filter",
+        "purge_filtered_channels", "hard_delete_channels",
+    ]),
+    ("Аналитика", [
+        "get_analytics_summary", "get_pipeline_stats", "get_daily_stats",
+        "get_trending_topics", "get_trending_channels", "get_message_velocity",
+        "get_peak_hours", "get_calendar",
+    ]),
+    ("Планировщик", [
+        "get_scheduler_status", "start_scheduler", "stop_scheduler",
+        "trigger_collection", "toggle_scheduler_job",
+    ]),
+    ("Уведомления", [
+        "get_notification_status", "setup_notification_bot", "delete_notification_bot",
+        "test_notification",
+    ]),
+    ("Фото", [
+        "list_photo_batches", "list_photo_items", "send_photos_now", "schedule_photos",
+        "cancel_photo_item", "list_auto_uploads", "toggle_auto_upload", "delete_auto_upload",
+    ]),
+    ("Мой Telegram", [
+        "list_dialogs", "refresh_dialogs", "leave_dialogs", "create_telegram_channel",
+        "get_forum_topics", "clear_dialog_cache",
+    ]),
+    ("Изображения", [
+        "list_image_models", "list_image_providers", "generate_image",
+    ]),
+    ("Настройки", [
+        "get_settings", "save_scheduler_settings", "save_agent_settings",
+        "save_filter_settings", "get_system_info",
+    ]),
+    ("Треды агента", [
+        "list_agent_threads", "create_agent_thread", "delete_agent_thread",
+        "rename_agent_thread", "get_thread_messages",
+    ]),
+])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def load_tool_permissions(db) -> dict[str, bool]:
+    """Load per-tool permissions from DB.  Missing setting → all tools allowed."""
+    raw = await db.get_setting(TOOL_PERMISSIONS_SETTING)
+    if not raw:
+        return {name: True for name in TOOL_CATEGORIES}
+    try:
+        saved: dict = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Corrupted tool permissions setting, using defaults")
+        return {name: True for name in TOOL_CATEGORIES}
+    # Merge: saved values take precedence, new tools default to True
+    return {name: saved.get(name, True) for name in TOOL_CATEGORIES}
+
+
+async def save_tool_permissions(db, permissions: dict[str, bool]) -> None:
+    """Persist per-tool permissions as JSON."""
+    await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(permissions, ensure_ascii=False))
+
+
+def filter_allowed_tools(all_tools: list[str], permissions: dict[str, bool]) -> list[str]:
+    """Filter MCP-prefixed tool names by permissions.
+
+    Tools not present in TOOL_CATEGORIES pass through unchanged (future-proof).
+    """
+    result = []
+    for prefixed_name in all_tools:
+        bare = prefixed_name.removeprefix(MCP_PREFIX)
+        if permissions.get(bare, True):
+            result.append(prefixed_name)
+    return result
+
+
+def build_template_context(permissions: dict[str, bool]) -> dict:
+    """Build template context dicts for the permissions UI.
+
+    Returns dict with keys:
+        tool_permission_categories: {category_value: [{name, module, enabled}, ...]}
+        tool_permission_modules: [{name, display_name, tools: [{name, category, enabled}]}]
+    """
+    # By category
+    categories: dict[str, list[dict]] = {"read": [], "write": [], "delete": []}
+    # Reverse lookup: tool → module display name
+    tool_to_module: dict[str, str] = {}
+    for mod_name, tool_names in MODULE_GROUPS.items():
+        for t in tool_names:
+            tool_to_module[t] = mod_name
+
+    for tool_name, cat in TOOL_CATEGORIES.items():
+        entry = {
+            "name": tool_name,
+            "module": tool_to_module.get(tool_name, ""),
+            "enabled": permissions.get(tool_name, True),
+        }
+        categories[cat.value].append(entry)
+
+    # By module
+    modules = []
+    for mod_name, tool_names in MODULE_GROUPS.items():
+        tools = []
+        for t in tool_names:
+            cat = TOOL_CATEGORIES.get(t, ToolCategory.READ)
+            tools.append({
+                "name": t,
+                "category": cat.value,
+                "enabled": permissions.get(t, True),
+            })
+        modules.append({"name": mod_name, "display_name": mod_name, "tools": tools})
+
+    return {
+        "tool_permission_categories": categories,
+        "tool_permission_modules": modules,
+    }

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -434,6 +434,12 @@ async def settings_page(request: Request):
         IMAGE_PROVIDER_SPECS[name] for name in IMAGE_PROVIDER_ORDER if name not in configured_img_names
     ]
     semantic_context = await _semantic_settings_context(request)
+
+    from src.agent.tools.permissions import build_template_context, load_tool_permissions
+
+    tool_permissions = await load_tool_permissions(db)
+    tool_perm_context = build_template_context(tool_permissions)
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "settings.html",
@@ -466,6 +472,7 @@ async def settings_page(request: Request):
             "img_provider_views": img_provider_views,
             "img_provider_options": available_img_options,
             **semantic_context,
+            **tool_perm_context,
         },
     )
 
@@ -557,6 +564,16 @@ async def save_agent_settings(request: Request):
     db = deps.get_db(request)
 
     form_scope = str(form.get("agent_form_scope", "dev_mode")).strip()
+
+    if form_scope == "tool_permissions":
+        from src.agent.tools.permissions import TOOL_CATEGORIES, save_tool_permissions
+
+        permissions = {}
+        for tool_name in TOOL_CATEGORIES:
+            permissions[tool_name] = form.get(f"tool_perm__{tool_name}") == "1"
+        await save_tool_permissions(db, permissions)
+        return RedirectResponse(url="/settings?msg=tool_permissions_saved", status_code=303)
+
     current_dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
     current_backend_override = await db.get_setting("agent_backend_override") or "auto"
     current_prompt_template = (

--- a/src/web/static/settings.js
+++ b/src/web/static/settings.js
@@ -394,6 +394,50 @@ function initSettingsTabs() {
     });
 }
 
+/* ---- Tool Permissions ---- */
+
+function toggleToolCategory(category, checked) {
+    document.querySelectorAll('.tool-perm-cb[data-category="' + category + '"]').forEach(function(cb) {
+        cb.checked = checked;
+    });
+    updateToolPermToggles();
+}
+
+function toggleToolModule(moduleIdx, checked) {
+    document.querySelectorAll('.tool-perm-cb[data-module-idx="' + moduleIdx + '"]').forEach(function(cb) {
+        cb.checked = checked;
+    });
+    updateToolPermToggles();
+}
+
+function updateToolPermToggles() {
+    /* Update category master toggles */
+    ['read', 'write', 'delete'].forEach(function(cat) {
+        var cbs = document.querySelectorAll('.tool-perm-cb[data-category="' + cat + '"]');
+        var toggle = document.getElementById('cat_toggle_' + cat);
+        var countEl = document.getElementById('cat_count_' + cat);
+        if (!toggle || cbs.length === 0) return;
+        var checked = 0;
+        cbs.forEach(function(cb) { if (cb.checked) checked++; });
+        toggle.checked = checked === cbs.length;
+        toggle.indeterminate = checked > 0 && checked < cbs.length;
+        if (countEl) countEl.textContent = checked + '/' + cbs.length;
+    });
+
+    /* Update module toggles */
+    document.querySelectorAll('.module-toggle').forEach(function(toggle) {
+        var idx = toggle.getAttribute('data-module-idx');
+        var cbs = document.querySelectorAll('.tool-perm-cb[data-module-idx="' + idx + '"]');
+        var countEl = document.getElementById('mod_count_' + idx);
+        if (cbs.length === 0) return;
+        var checked = 0;
+        cbs.forEach(function(cb) { if (cb.checked) checked++; });
+        toggle.checked = checked === cbs.length;
+        toggle.indeterminate = checked > 0 && checked < cbs.length;
+        if (countEl) countEl.textContent = checked + '/' + cbs.length;
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     /* Agent provider model change handlers */
     document.querySelectorAll('select[id^="provider_model__"]').forEach(function(select) {
@@ -408,4 +452,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /* Tab navigation */
     initSettingsTabs();
+
+    /* Initialize tool permission toggles state */
+    if (document.querySelector('.tool-perm-cb')) {
+        updateToolPermToggles();
+    }
 });

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -60,6 +60,13 @@
             <i class="bi bi-bell me-1"></i>Уведомления
         </button>
     </li>
+    <li class="nav-item" role="presentation">
+        <button class="nav-link" id="tab-tool-permissions" data-bs-toggle="pill"
+                data-bs-target="#pane-tool-permissions" type="button" role="tab"
+                aria-controls="pane-tool-permissions" aria-selected="false">
+            <i class="bi bi-shield-lock me-1"></i>Разрешения агента
+        </button>
+    </li>
 </ul>
 
 <div class="tab-content" id="settings-tab-content">
@@ -133,6 +140,15 @@
             <div class="card-header bg-body-secondary fw-semibold">Уведомления</div>
             <div class="card-body">
                 {% include "settings/_notifications.html" %}
+            </div>
+        </div>
+    </div>
+
+    <div class="tab-pane fade" id="pane-tool-permissions" role="tabpanel" aria-labelledby="tab-tool-permissions">
+        <div class="card shadow-sm">
+            <div class="card-header bg-body-secondary fw-semibold">Разрешения инструментов агента</div>
+            <div class="card-body">
+                {% include "settings/_tool_permissions.html" %}
             </div>
         </div>
     </div>

--- a/src/web/templates/settings/_tool_permissions.html
+++ b/src/web/templates/settings/_tool_permissions.html
@@ -69,7 +69,7 @@
                     </button>
                 </div>
             </h2>
-            <div id="toolMod_{{ loop.index }}" class="accordion-collapse collapse"
+            <div id="toolMod_{{ loop.index }}" class="accordion-collapse collapse">
                 <div class="accordion-body py-2">
                     {% set mod_idx = loop.index %}
                     {% for tool in module.tools %}

--- a/src/web/templates/settings/_tool_permissions.html
+++ b/src/web/templates/settings/_tool_permissions.html
@@ -1,0 +1,105 @@
+<p class="form-text mb-3">
+    Управление разрешениями инструментов AI-агента. Отключённые инструменты не будут доступны агенту.
+    По умолчанию все инструменты разрешены.
+</p>
+
+<form method="post" action="/settings/save-agent" data-busy>
+    <input type="hidden" name="agent_form_scope" value="tool_permissions">
+
+    <div class="row g-3 mb-4">
+        <div class="col-12 col-md-4">
+            <div class="card border-success">
+                <div class="card-body py-2">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="cat_toggle_read"
+                               onchange="toggleToolCategory('read', this.checked)">
+                        <label class="form-check-label fw-semibold" for="cat_toggle_read">
+                            <span class="badge text-bg-success me-1">Read</span>
+                            <span class="text-muted small" id="cat_count_read"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-md-4">
+            <div class="card border-warning">
+                <div class="card-body py-2">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="cat_toggle_write"
+                               onchange="toggleToolCategory('write', this.checked)">
+                        <label class="form-check-label fw-semibold" for="cat_toggle_write">
+                            <span class="badge text-bg-warning me-1">Write</span>
+                            <span class="text-muted small" id="cat_count_write"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-md-4">
+            <div class="card border-danger">
+                <div class="card-body py-2">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="cat_toggle_delete"
+                               onchange="toggleToolCategory('delete', this.checked)">
+                        <label class="form-check-label fw-semibold" for="cat_toggle_delete">
+                            <span class="badge text-bg-danger me-1">Delete</span>
+                            <span class="text-muted small" id="cat_count_delete"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="accordion" id="toolPermModules">
+        {% for module in tool_permission_modules %}
+        <div class="accordion-item">
+            <h2 class="accordion-header">
+                <div class="d-flex align-items-center w-100">
+                    <div class="form-check form-switch ms-3 me-2 flex-shrink-0" onclick="event.stopPropagation()">
+                        <input class="form-check-input module-toggle" type="checkbox"
+                               id="mod_toggle_{{ loop.index }}"
+                               data-module-idx="{{ loop.index }}"
+                               onchange="toggleToolModule({{ loop.index }}, this.checked)">
+                    </div>
+                    <button class="accordion-button collapsed flex-grow-1 py-2 ps-0" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#toolMod_{{ loop.index }}">
+                        {{ module.display_name }}
+                        <span class="text-muted small ms-2" id="mod_count_{{ loop.index }}"></span>
+                    </button>
+                </div>
+            </h2>
+            <div id="toolMod_{{ loop.index }}" class="accordion-collapse collapse"
+                <div class="accordion-body py-2">
+                    {% set mod_idx = loop.index %}
+                    {% for tool in module.tools %}
+                    <div class="form-check">
+                        <input class="form-check-input tool-perm-cb" type="checkbox"
+                               id="tp_{{ tool.name }}"
+                               name="tool_perm__{{ tool.name }}" value="1"
+                               data-category="{{ tool.category }}"
+                               data-module-idx="{{ mod_idx }}"
+                               {% if tool.enabled %}checked{% endif %}
+                               onchange="updateToolPermToggles()">
+                        <label class="form-check-label" for="tp_{{ tool.name }}">
+                            <code>{{ tool.name }}</code>
+                            {% if tool.category == 'read' %}
+                            <span class="badge text-bg-success">R</span>
+                            {% elif tool.category == 'write' %}
+                            <span class="badge text-bg-warning">W</span>
+                            {% else %}
+                            <span class="badge text-bg-danger">D</span>
+                            {% endif %}
+                        </label>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <div class="d-flex justify-content-end mt-3">
+        <button type="submit" class="btn btn-primary">Сохранить разрешения</button>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- Add new "Разрешения агента" tab in Settings with per-tool permission controls
- Group tools by category (Read/Write/Delete) with master toggles and by module (16 groups) with module-level toggles
- Dynamically filter `allowed_tools` in `ClaudeSdkBackend` based on saved permissions
- Backward compatible: all tools allowed when no permissions are configured

## Test plan
- [ ] Open Settings → "Разрешения агента" tab renders correctly
- [ ] Toggle a category (e.g. Delete) → all delete checkboxes toggle
- [ ] Toggle a module (e.g. Каналы) → all tools in module toggle
- [ ] Save → reload page → permissions persisted
- [ ] Disable a tool → agent chat cannot use that tool
- [ ] No saved permissions → all tools available (backward compat)
- [ ] `pytest tests/ -v -m "not aiosqlite_serial" -n auto` passes (1978 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)