### PR TITLE
fix: load image providers from DB in agent tools

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -192,6 +192,7 @@ class ClaudeSdkBackend:
         os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "300000")
         self._server = make_mcp_server(
             self._db, client_pool=self._client_pool, scheduler_manager=self._scheduler_manager,
+            config=self._config,
         )
         logger.info("Claude SDK backend initialized")
 
@@ -493,7 +494,7 @@ class DeepagentsBackend:
         """Return the tool set for deepagents backend, filtered by permissions."""
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        all_tools = build_deepagents_tools(self._db)
+        all_tools = build_deepagents_tools(self._db, config=self._config)
         if permissions is None:
             return all_tools
         return [t for t in all_tools if permissions.get(t.__name__, True)]

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -13,7 +13,7 @@ from claude_agent_sdk import create_sdk_mcp_server
 from src.agent.tools._registry import _text_response  # noqa: F401
 
 
-def make_mcp_server(db, client_pool=None, scheduler_manager=None):
+def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
     """Create an in-process MCP server with all agent tools.
 
     Args:
@@ -48,7 +48,7 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None):
     )
 
     # Extra context passed alongside the standard (db, client_pool, embedding_service)
-    extras = {"scheduler_manager": scheduler_manager}
+    extras = {"scheduler_manager": scheduler_manager, "config": config}
 
     all_tools = []
     for module in [

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -24,7 +24,7 @@ def _run_sync(tool_name: str, operation: Callable[[], Awaitable[_T]]) -> _T:
     raise RuntimeError(f"Deepagents tool '{tool_name}' cannot run inside an active event loop")
 
 
-def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C901
+def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:  # noqa: C901
     """Build all sync tools for the deepagents backend.
 
     Returns a list of callables compatible with LangChain tool registration.
@@ -730,12 +730,31 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
 
     # === Images ===
 
+    def _build_image_service_sync():
+        """Build ImageGenerationService with DB providers + env fallback (sync)."""
+        from src.services.image_generation_service import ImageGenerationService
+
+        if db and config:
+            try:
+                from src.services.image_provider_service import ImageProviderService
+
+                svc = ImageProviderService(db, config)
+
+                async def _load():
+                    configs = await svc.load_provider_configs()
+                    return svc.build_adapters(configs)
+
+                adapters = _run_sync("load_image_providers", _load)
+                if adapters:
+                    return ImageGenerationService(adapters=adapters)
+            except Exception:
+                logger.warning("Failed to load image providers from DB", exc_info=True)
+        return ImageGenerationService()
+
     def generate_image(prompt: str, model: str = "") -> str:
         """Generate an image from text prompt."""
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = _build_image_service_sync()
             result = _run_sync("gen_image", lambda: svc.generate(model=model or None, text=prompt))
             return f"Изображение: {result}" if result else "Генерация не вернула результат."
         except Exception as exc:
@@ -746,9 +765,7 @@ def build_deepagents_tools(db, client_pool=None) -> list[Callable]:  # noqa: C90
     def list_image_providers() -> str:
         """List configured image generation providers."""
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = _build_image_service_sync()
             names = svc.adapter_names
             return f"Провайдеры: {', '.join(names)}" if names else "Провайдеры не настроены."
         except Exception as exc:

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -2,13 +2,35 @@
 
 from __future__ import annotations
 
+import logging
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response
 
+logger = logging.getLogger(__name__)
+
 
 def register(db, client_pool, embedding_service, **kwargs):
+    config = kwargs.get("config")
     tools = []
+
+    async def _build_image_service():
+        """Build ImageGenerationService with DB providers + env fallback."""
+        from src.services.image_generation_service import ImageGenerationService
+
+        if db and config:
+            try:
+                from src.services.image_provider_service import ImageProviderService
+
+                svc = ImageProviderService(db, config)
+                configs = await svc.load_provider_configs()
+                adapters = svc.build_adapters(configs)
+                if adapters:
+                    return ImageGenerationService(adapters=adapters)
+            except Exception:
+                logger.warning("Failed to load image providers from DB", exc_info=True)
+        return ImageGenerationService()
 
     @tool(
         "generate_image",
@@ -23,9 +45,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: prompt обязателен.")
         model = args.get("model")
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             if not await svc.is_available():
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
             result = await svc.generate(model=model, text=prompt)
@@ -48,9 +68,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: provider обязателен.")
         query = args.get("query", "")
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             models = await svc.search_models(provider=provider, query=query)
             if not models:
                 return _text_response(f"Модели для {provider} не найдены.")
@@ -69,9 +87,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_image_providers", "List configured image generation providers", {})
     async def list_image_providers(args):
         try:
-            from src.services.image_generation_service import ImageGenerationService
-
-            svc = ImageGenerationService()
+            svc = await _build_image_service()
             names = svc.adapter_names
             if not names:
                 return _text_response("Провайдеры изображений не настроены.")

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -683,7 +683,9 @@ class TestImageToolsDBProviders:
             ) as mock_img_svc,
         ):
             prov_instance = mock_prov_svc.return_value
-            prov_instance.load_provider_configs = AsyncMock(return_value=[])
+            prov_instance.load_provider_configs = AsyncMock(
+                return_value=[SimpleNamespace(provider="together", enabled=True, api_key="test-key")]
+            )
             prov_instance.build_adapters.return_value = {"together": mock_adapter}
 
             img_instance = mock_img_svc.return_value

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -21,7 +21,7 @@ def mock_db():
     return MagicMock(spec=Database)
 
 
-def _get_tool_handlers(mock_db, client_pool=None):
+def _get_tool_handlers(mock_db, client_pool=None, config=None):
     """Build MCP tools and return their handlers keyed by name."""
     captured_tools = []
 
@@ -31,7 +31,7 @@ def _get_tool_handlers(mock_db, client_pool=None):
     ):
         from src.agent.tools import make_mcp_server
 
-        make_mcp_server(mock_db, client_pool=client_pool)
+        make_mcp_server(mock_db, client_pool=client_pool, config=config)
 
     return {t.name: t.handler for t in captured_tools}
 
@@ -610,3 +610,87 @@ class TestMakeMcpServer:
 
         server = make_mcp_server(mock_db)
         assert "instance" in server
+
+
+# ---------------------------------------------------------------------------
+# Image tools — DB provider loading
+# ---------------------------------------------------------------------------
+
+
+class TestImageToolsDBProviders:
+    """Tests for image tools loading providers from DB."""
+
+    async def test_generate_image_uses_db_providers(self, mock_db):
+        """generate_image should load adapters from DB when config is provided."""
+        fake_config = SimpleNamespace()
+
+        mock_adapter = AsyncMock(return_value="/tmp/image.png")
+        fake_configs = [SimpleNamespace(provider="together", enabled=True, api_key="test-key")]
+
+        with (
+            patch(
+                "src.services.image_provider_service.ImageProviderService",
+            ) as mock_prov_svc,
+            patch(
+                "src.services.image_generation_service.ImageGenerationService",
+            ) as mock_img_svc,
+        ):
+            # Setup provider service mock
+            prov_instance = mock_prov_svc.return_value
+            prov_instance.load_provider_configs = AsyncMock(return_value=fake_configs)
+            prov_instance.build_adapters.return_value = {"together": mock_adapter}
+
+            # Setup image service mock
+            img_instance = mock_img_svc.return_value
+            img_instance.is_available = AsyncMock(return_value=True)
+            img_instance.generate = AsyncMock(return_value="/tmp/image.png")
+
+            handlers = _get_tool_handlers(mock_db, config=fake_config)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+            text = _text(result)
+
+            assert "сгенерировано" in text.lower() or "/tmp/image.png" in text
+            # Should have been created with adapters from DB
+            mock_img_svc.assert_called_once_with(adapters={"together": mock_adapter})
+
+    async def test_generate_image_falls_back_to_env(self, mock_db):
+        """generate_image should fall back to env vars when no config provided."""
+        with patch(
+            "src.services.image_generation_service.ImageGenerationService",
+        ) as mock_img_svc:
+            img_instance = mock_img_svc.return_value
+            img_instance.is_available = AsyncMock(return_value=False)
+
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+            text = _text(result)
+
+            assert "не настроена" in text.lower() or "настройках" in text.lower()
+            # Should have been created without adapters (env fallback)
+            mock_img_svc.assert_called_once_with()
+
+    async def test_list_image_providers_uses_db(self, mock_db):
+        """list_image_providers should load from DB when config provided."""
+        fake_config = SimpleNamespace()
+        mock_adapter = AsyncMock()
+
+        with (
+            patch(
+                "src.services.image_provider_service.ImageProviderService",
+            ) as mock_prov_svc,
+            patch(
+                "src.services.image_generation_service.ImageGenerationService",
+            ) as mock_img_svc,
+        ):
+            prov_instance = mock_prov_svc.return_value
+            prov_instance.load_provider_configs = AsyncMock(return_value=[])
+            prov_instance.build_adapters.return_value = {"together": mock_adapter}
+
+            img_instance = mock_img_svc.return_value
+            img_instance.adapter_names = ["together"]
+
+            handlers = _get_tool_handlers(mock_db, config=fake_config)
+            result = await handlers["list_image_providers"]({})
+            text = _text(result)
+
+            assert "together" in text


### PR DESCRIPTION
## Summary
- Agent image tools (`generate_image`, `list_image_providers`, `list_image_models`) now load providers configured via Settings UI (stored in DB), not just env vars
- Passes `config` through `make_mcp_server()` and `build_deepagents_tools()` to image tool closures
- Adds `_build_image_service()` async helper (MCP tools) and `_build_image_service_sync()` (deepagents tools) that load DB providers via `ImageProviderService` with env-var fallback
- Adds 3 tests covering DB provider loading, env fallback, and list providers

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — 1981 passed
- [ ] Web UI: Settings → Images → configure provider → Agent chat → `generate_image` works
- [ ] Without configured providers + without env vars → correct error message
- [ ] With env vars, without DB providers → env fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)