### PR TITLE
fix: pass DB config to EmbeddingService, SearchEngine in agent tools

### DIFF
--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -25,7 +25,7 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
     """
     from src.services.embedding_service import EmbeddingService
 
-    embedding_service = EmbeddingService(db)
+    embedding_service = EmbeddingService(db, config=config)
 
     # Import all tool modules
     from src.agent.tools import (

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -57,7 +57,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
         try:
             from src.services.embedding_service import EmbeddingService
 
-            svc = EmbeddingService(db)
+            svc = EmbeddingService(db, config=config)
             embedding = _run_sync("semantic_embed", lambda: svc.embed_query(query_text))
             messages, total = _run_sync(
                 "semantic_search", lambda: db.search_semantic_messages(embedding, limit=limit)
@@ -79,7 +79,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
         try:
             from src.services.embedding_service import EmbeddingService
 
-            svc = EmbeddingService(db)
+            svc = EmbeddingService(db, config=config)
             count = _run_sync("index_messages", svc.index_pending_messages)
             return f"Проиндексировано: {count} сообщений."
         except Exception as exc:
@@ -233,8 +233,9 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
             pipeline = _run_sync("run_pipeline_get", lambda: svc.get(pipeline_id))
             if not pipeline:
                 return f"Пайплайн id={pipeline_id} не найден."
-            engine = SearchEngine(db)
-            gen_svc = ContentGenerationService(db, engine)
+            engine = SearchEngine(db, config=config)
+            image_service = _build_image_service_sync()
+            gen_svc = ContentGenerationService(db, engine, image_service=image_service)
             run = _run_sync("run_pipeline", lambda: gen_svc.generate(pipeline))
             preview = (run.generated_text or "")[:300]
             return f"Генерация завершена (run id={run.id}). Превью:\n{preview}"

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -2,14 +2,36 @@
 
 from __future__ import annotations
 
+import logging
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
 from src.agent.tools._registry import _text_response, require_confirmation, require_pool
 
+logger = logging.getLogger(__name__)
+
 
 def register(db, client_pool, embedding_service, **kwargs):
+    config = kwargs.get("config")
     tools = []
+
+    async def _build_image_service():
+        """Build ImageGenerationService with DB providers + env fallback."""
+        from src.services.image_generation_service import ImageGenerationService
+
+        if db and config:
+            try:
+                from src.services.image_provider_service import ImageProviderService
+
+                svc = ImageProviderService(db, config)
+                configs = await svc.load_provider_configs()
+                adapters = svc.build_adapters(configs)
+                if adapters:
+                    return ImageGenerationService(adapters=adapters)
+            except Exception:
+                logger.warning("Failed to load image providers from DB", exc_info=True)
+        return ImageGenerationService()
 
     # ------------------------------------------------------------------
     # Read tools
@@ -293,8 +315,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             if not pipeline.is_active:
                 return _text_response(f"Пайплайн '{pipeline.name}' неактивен.")
 
-            engine = SearchEngine(db)
-            gen_svc = ContentGenerationService(db, engine)
+            engine = SearchEngine(db, config=config)
+            image_service = await _build_image_service()
+            gen_svc = ContentGenerationService(db, engine, image_service=image_service)
             run = await gen_svc.generate(pipeline)
 
             preview = (run.generated_text or "")[:500]
@@ -325,7 +348,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.pipeline_service import PipelineService
             from src.services.provider_service import AgentProviderService
 
-            engine = SearchEngine(db)
+            engine = SearchEngine(db, config=config)
             prompt_template = None
             llm_model = None
             if pipeline_id is not None:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -168,7 +168,7 @@ class TestSemanticSearchTool:
         mock_db.search_semantic_messages = AsyncMock(return_value=(mock_messages, 1))
 
         class FakeEmbeddingService:
-            def __init__(self, _db):
+            def __init__(self, _db, **_kwargs):
                 pass
 
             async def index_pending_messages(self):
@@ -190,7 +190,7 @@ class TestSemanticSearchTool:
     @pytest.mark.asyncio
     async def test_error_returns_text_not_exception(self, mock_db):
         class BrokenEmbeddingService:
-            def __init__(self, _db):
+            def __init__(self, _db, **_kwargs):
                 pass
 
             async def embed_query(self, query):
@@ -696,3 +696,59 @@ class TestImageToolsDBProviders:
             text = _text(result)
 
             assert "together" in text
+
+
+# ---------------------------------------------------------------------------
+# Config propagation — EmbeddingService & SearchEngine
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPropagation:
+    """Tests for config being properly passed to services."""
+
+    async def test_embedding_service_receives_config(self, mock_db):
+        """EmbeddingService should receive config from make_mcp_server."""
+        fake_config = SimpleNamespace()
+
+        with patch("src.services.embedding_service.EmbeddingService") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _get_tool_handlers(mock_db, config=fake_config)
+            mock_cls.assert_called_once_with(mock_db, config=fake_config)
+
+    async def test_embedding_service_none_config(self, mock_db):
+        """EmbeddingService should receive config=None when no config provided."""
+        with patch("src.services.embedding_service.EmbeddingService") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            _get_tool_handlers(mock_db)
+            mock_cls.assert_called_once_with(mock_db, config=None)
+
+    async def test_run_pipeline_passes_config_to_search_engine(self, mock_db):
+        """run_pipeline should pass config to SearchEngine."""
+        fake_config = SimpleNamespace()
+
+        with (
+            patch("src.services.embedding_service.EmbeddingService") as mock_embed_cls,
+            patch("src.search.engine.SearchEngine") as mock_search_cls,
+            patch("src.services.content_generation_service.ContentGenerationService") as mock_gen_cls,
+            patch("src.services.pipeline_service.PipelineService") as mock_pipe_cls,
+            patch("src.services.image_generation_service.ImageGenerationService") as mock_img_cls,
+        ):
+            mock_embed_cls.return_value = MagicMock()
+            mock_search_cls.return_value = MagicMock()
+            mock_img_cls.return_value = MagicMock()
+
+            mock_pipeline = SimpleNamespace(
+                id=1, name="test", is_active=True, llm_model=None,
+                prompt_template="test", publish_mode="moderated",
+            )
+            mock_pipe_cls.return_value.get = AsyncMock(return_value=mock_pipeline)
+
+            mock_run = SimpleNamespace(
+                id=1, generated_text="test output", moderation_status="pending",
+            )
+            mock_gen_cls.return_value.generate = AsyncMock(return_value=mock_run)
+
+            handlers = _get_tool_handlers(mock_db, config=fake_config)
+            await handlers["run_pipeline"]({"pipeline_id": 1})
+
+            mock_search_cls.assert_called_with(mock_db, config=fake_config)


### PR DESCRIPTION
## Summary
- **EmbeddingService** in `make_mcp_server()` and `deepagents_sync` now receives `config` — fixes fallback to `config.llm.provider` / `config.llm.api_key` when DB embedding settings are empty
- **SearchEngine** in pipeline tools (`run_pipeline`, `generate_draft`) now receives `config` — propagates to internal EmbeddingService
- **ContentGenerationService** in pipeline tools now receives `image_service` built from DB providers — enables image generation in `run_pipeline` via agent chat
- Fixes test fake classes (`FakeEmbeddingService`, `BrokenEmbeddingService`) to accept `**kwargs`

Follow-up to #225 which fixed the same pattern for `ImageGenerationService`.

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — 1984 passed
- [ ] Agent chat → semantic search works with DB-configured embedding provider
- [ ] Agent chat → `run_pipeline` generates images when image provider configured
- [ ] Without config → graceful fallback to defaults, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)