### PR TITLE
feat: add edit/delete message tools and fix _ALLOWED_TOOLS allowlist

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -96,6 +96,7 @@ _ALLOWED_TOOLS = [
     "mcp__telegram_db__toggle_account",
     "mcp__telegram_db__delete_account",
     "mcp__telegram_db__get_flood_status",
+    "mcp__telegram_db__clear_flood_status",
     # Filters
     "mcp__telegram_db__analyze_filters",
     "mcp__telegram_db__apply_filters",
@@ -103,6 +104,7 @@ _ALLOWED_TOOLS = [
     "mcp__telegram_db__toggle_channel_filter",
     "mcp__telegram_db__purge_filtered_channels",
     "mcp__telegram_db__hard_delete_channels",
+    "mcp__telegram_db__precheck_filters",
     # Analytics
     "mcp__telegram_db__get_analytics_summary",
     "mcp__telegram_db__get_pipeline_stats",
@@ -132,6 +134,10 @@ _ALLOWED_TOOLS = [
     "mcp__telegram_db__list_auto_uploads",
     "mcp__telegram_db__toggle_auto_upload",
     "mcp__telegram_db__delete_auto_upload",
+    "mcp__telegram_db__create_photo_batch",
+    "mcp__telegram_db__run_photo_due",
+    "mcp__telegram_db__create_auto_upload",
+    "mcp__telegram_db__update_auto_upload",
     # My Telegram
     "mcp__telegram_db__list_dialogs",
     "mcp__telegram_db__refresh_dialogs",
@@ -139,6 +145,11 @@ _ALLOWED_TOOLS = [
     "mcp__telegram_db__create_telegram_channel",
     "mcp__telegram_db__get_forum_topics",
     "mcp__telegram_db__clear_dialog_cache",
+    "mcp__telegram_db__get_cache_status",
+    # Messaging
+    "mcp__telegram_db__send_message",
+    "mcp__telegram_db__edit_message",
+    "mcp__telegram_db__delete_message",
     # Images
     "mcp__telegram_db__generate_image",
     "mcp__telegram_db__list_image_models",

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -1,8 +1,9 @@
-"""Agent tools for Messaging — sending direct messages via Telegram."""
+"""Agent tools for Messaging — send, edit, delete messages via Telegram."""
 
 from __future__ import annotations
 
 from claude_agent_sdk import tool
+from mcp.types import ToolAnnotations
 
 from src.agent.tools._registry import _text_response, require_confirmation, require_pool
 
@@ -44,5 +45,77 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка отправки сообщения: {e}")
 
     tools.append(send_message)
+
+    @tool(
+        "edit_message",
+        "Edit a previously sent message in a Telegram chat. "
+        "Ask user for confirmation first.",
+        {"phone": str, "chat_id": str, "message_id": int, "text": str, "confirm": bool},
+    )
+    async def edit_message(args):
+        pool_gate = require_pool(client_pool, "Редактирование сообщения")
+        if pool_gate:
+            return pool_gate
+        phone = args.get("phone", "")
+        chat_id = args.get("chat_id", "")
+        message_id = args.get("message_id")
+        text = args.get("text", "")
+        if not phone or not chat_id or not message_id or not text:
+            return _text_response("Ошибка: phone, chat_id, message_id и text обязательны.")
+        preview = text[:120] + ("..." if len(text) > 120 else "")
+        gate = require_confirmation(
+            f"отредактирует сообщение #{message_id} в чате {chat_id}: «{preview}»", args
+        )
+        if gate:
+            return gate
+        try:
+            result = await client_pool.get_native_client_by_phone(phone)
+            if result is None:
+                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            client, _ = result
+            entity = await client.get_entity(chat_id)
+            await client.edit_message(entity, int(message_id), text)
+            return _text_response(f"Сообщение #{message_id} отредактировано.")
+        except Exception as e:
+            return _text_response(f"Ошибка редактирования сообщения: {e}")
+
+    tools.append(edit_message)
+
+    @tool(
+        "delete_message",
+        "⚠️ DANGEROUS: Delete messages from a Telegram chat. "
+        "Pass comma-separated message IDs. Always ask user for confirmation first.",
+        {"phone": str, "chat_id": str, "message_ids": str, "confirm": bool},
+        annotations=ToolAnnotations(destructiveHint=True),
+    )
+    async def delete_message(args):
+        pool_gate = require_pool(client_pool, "Удаление сообщений")
+        if pool_gate:
+            return pool_gate
+        phone = args.get("phone", "")
+        chat_id = args.get("chat_id", "")
+        message_ids_str = args.get("message_ids", "")
+        if not phone or not chat_id or not message_ids_str:
+            return _text_response("Ошибка: phone, chat_id и message_ids обязательны.")
+        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip()]
+        if not ids:
+            return _text_response("Ошибка: не указаны валидные message_ids.")
+        gate = require_confirmation(
+            f"удалит {len(ids)} сообщений из чата {chat_id}: {ids}", args
+        )
+        if gate:
+            return gate
+        try:
+            result = await client_pool.get_native_client_by_phone(phone)
+            if result is None:
+                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            client, _ = result
+            entity = await client.get_entity(chat_id)
+            await client.delete_messages(entity, ids)
+            return _text_response(f"Удалено {len(ids)} сообщений из чата {chat_id}.")
+        except Exception as e:
+            return _text_response(f"Ошибка удаления сообщений: {e}")
+
+    tools.append(delete_message)
 
     return tools

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -97,7 +97,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         message_ids_str = args.get("message_ids", "")
         if not phone or not chat_id or not message_ids_str:
             return _text_response("Ошибка: phone, chat_id и message_ids обязательны.")
-        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip()]
+        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
         if not ids:
             return _text_response("Ошибка: не указаны валидные message_ids.")
         gate = require_confirmation(

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -127,6 +127,8 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "get_cache_status": ToolCategory.READ,
     # Messaging
     "send_message": ToolCategory.WRITE,
+    "edit_message": ToolCategory.WRITE,
+    "delete_message": ToolCategory.DELETE,
     # Images
     "generate_image": ToolCategory.WRITE,
     "list_image_models": ToolCategory.READ,
@@ -205,7 +207,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "get_forum_topics", "clear_dialog_cache", "get_cache_status",
     ]),
     ("Сообщения", [
-        "send_message",
+        "send_message", "edit_message", "delete_message",
     ]),
     ("Изображения", [
         "list_image_models", "list_image_providers", "generate_image",

--- a/src/cli/commands/my_telegram.py
+++ b/src/cli/commands/my_telegram.py
@@ -162,6 +162,61 @@ def run(args: argparse.Namespace) -> None:
                 except Exception as exc:
                     print(f"Error sending message: {exc}")
 
+            elif args.my_telegram_action == "edit-message":
+                accounts = sorted(pool.clients.keys())
+                if not accounts:
+                    print("No connected accounts.")
+                    return
+                phone = args.phone or accounts[0]
+                if phone not in pool.clients:
+                    print(f"Account {phone} not connected.")
+                    return
+                result = await pool.get_native_client_by_phone(phone)
+                if result is None:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
+                    return
+                client, _ = result
+                try:
+                    entity = await client.get_entity(args.chat_id)
+                    await client.edit_message(entity, args.message_id, args.text)
+                    print(f"Message #{args.message_id} edited.")
+                except Exception as exc:
+                    print(f"Error editing message: {exc}")
+
+            elif args.my_telegram_action == "delete-message":
+                accounts = sorted(pool.clients.keys())
+                if not accounts:
+                    print("No connected accounts.")
+                    return
+                phone = args.phone or accounts[0]
+                if phone not in pool.clients:
+                    print(f"Account {phone} not connected.")
+                    return
+                raw_ids: list[str] = []
+                for item in args.message_ids:
+                    raw_ids.extend(i.strip() for i in item.split(",") if i.strip())
+                ids = [int(x) for x in raw_ids if x.isdigit()]
+                if not ids:
+                    print("No valid message IDs provided.")
+                    return
+                if not args.yes:
+                    print(f"Delete {len(ids)} message(s) from {args.chat_id}: {ids}")
+                    answer = input("Continue? [y/N] ").strip().lower()
+                    if answer != "y":
+                        print("Aborted.")
+                        return
+                result = await pool.get_native_client_by_phone(phone)
+                if result is None:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
+                    return
+                client, _ = result
+                try:
+                    entity = await client.get_entity(args.chat_id)
+                    await client.delete_messages(entity, ids)
+                    print(f"Deleted {len(ids)} message(s).")
+                except Exception as exc:
+                    print(f"Error deleting messages: {exc}")
+
             elif args.my_telegram_action == "cache-clear":
                 phone: str | None = getattr(args, "phone", None)
                 if phone:

--- a/src/cli/commands/my_telegram.py
+++ b/src/cli/commands/my_telegram.py
@@ -171,6 +171,14 @@ def run(args: argparse.Namespace) -> None:
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
+                if not args.yes:
+                    preview = args.text[:200] + ("..." if len(args.text) > 200 else "")
+                    print(f"Edit message #{args.message_id} in {args.chat_id}:")
+                    print(f"  {preview}")
+                    answer = input("Continue? [y/N] ").strip().lower()
+                    if answer != "y":
+                        print("Aborted.")
+                        return
                 result = await pool.get_native_client_by_phone(phone)
                 if result is None:
                     print(f"Client for {phone} unavailable (flood-wait or not connected).")

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -430,6 +430,18 @@ def build_parser() -> argparse.ArgumentParser:
     my_tg_send.add_argument("--phone", default=None, help="Account phone (default: first connected)")
     my_tg_send.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
 
+    my_tg_edit = my_tg_sub.add_parser("edit-message", help="Edit a sent message")
+    my_tg_edit.add_argument("chat_id", help="Chat ID or @username")
+    my_tg_edit.add_argument("message_id", type=int, help="Message ID to edit")
+    my_tg_edit.add_argument("text", help="New message text")
+    my_tg_edit.add_argument("--phone", default=None, help="Account phone (default: first connected)")
+
+    my_tg_del_msg = my_tg_sub.add_parser("delete-message", help="Delete messages from a chat")
+    my_tg_del_msg.add_argument("chat_id", help="Chat ID or @username")
+    my_tg_del_msg.add_argument("message_ids", nargs="+", help="Message IDs to delete (space or comma-separated)")
+    my_tg_del_msg.add_argument("--phone", default=None, help="Account phone (default: first connected)")
+    my_tg_del_msg.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
     my_tg_create = my_tg_sub.add_parser("create-channel", help="Create a new Telegram broadcast channel")
     my_tg_create.add_argument("--phone", default=None, help="Account phone (default: first connected)")
     my_tg_create.add_argument("--title", required=True, help="Channel title")

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -435,6 +435,7 @@ def build_parser() -> argparse.ArgumentParser:
     my_tg_edit.add_argument("message_id", type=int, help="Message ID to edit")
     my_tg_edit.add_argument("text", help="New message text")
     my_tg_edit.add_argument("--phone", default=None, help="Account phone (default: first connected)")
+    my_tg_edit.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
 
     my_tg_del_msg = my_tg_sub.add_parser("delete-message", help="Delete messages from a chat")
     my_tg_del_msg.add_argument("chat_id", help="Chat ID or @username")

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -148,6 +148,81 @@ async def send_message(request: Request):
         )
 
 
+@router.post("/edit-message")
+async def edit_message(request: Request):
+    form = await request.form()
+    phone = form.get("phone", "")
+    chat_id = form.get("chat_id", "")
+    message_id = form.get("message_id", "")
+    text = form.get("text", "")
+    pool = deps.get_pool(request)
+    if not phone or not chat_id or not message_id or not text:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=missing_fields",
+            status_code=303,
+        )
+    result = await pool.get_native_client_by_phone(phone)
+    if result is None:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=client_unavailable",
+            status_code=303,
+        )
+    client, _ = result
+    try:
+        entity = await client.get_entity(chat_id)
+        await client.edit_message(entity, int(message_id), text)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&msg=message_edited",
+            status_code=303,
+        )
+    except Exception as exc:
+        logger.exception("Failed to edit message: %s", exc)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=edit_failed",
+            status_code=303,
+        )
+
+
+@router.post("/delete-message")
+async def delete_message(request: Request):
+    form = await request.form()
+    phone = form.get("phone", "")
+    chat_id = form.get("chat_id", "")
+    message_ids_str = form.get("message_ids", "")
+    pool = deps.get_pool(request)
+    if not phone or not chat_id or not message_ids_str:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=missing_fields",
+            status_code=303,
+        )
+    ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
+    if not ids:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=invalid_ids",
+            status_code=303,
+        )
+    result = await pool.get_native_client_by_phone(phone)
+    if result is None:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=client_unavailable",
+            status_code=303,
+        )
+    client, _ = result
+    try:
+        entity = await client.get_entity(chat_id)
+        await client.delete_messages(entity, ids)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&msg=messages_deleted",
+            status_code=303,
+        )
+    except Exception as exc:
+        logger.exception("Failed to delete messages: %s", exc)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=delete_failed",
+            status_code=303,
+        )
+
+
 @router.get("/create-channel", response_class=HTMLResponse)
 async def create_channel_page(request: Request):
     pool = deps.get_pool(request)


### PR DESCRIPTION
## Summary
- Fix 10 agent tools being invisible — registered in permissions.py but missing from `_ALLOWED_TOOLS` in manager.py
- Add `edit_message` and `delete_message` tools across all 3 layers (agent + CLI + web)

## Changes

### Bug fix: _ALLOWED_TOOLS allowlist
Tools from PR #242 were not added to the allowlist, making them invisible to the agent:
- `send_message`, `clear_flood_status`, `precheck_filters`
- `create_photo_batch`, `run_photo_due`, `create_auto_upload`, `update_auto_upload`
- `get_cache_status`

### New: edit_message (3 layers)
- Agent tool with confirmation showing text preview
- CLI: `my-telegram edit-message <chat_id> <message_id> <text>`
- Web: `POST /my-telegram/edit-message`

### New: delete_message (3 layers)
- Agent tool with destructiveHint and confirmation showing IDs
- CLI: `my-telegram delete-message <chat_id> <message_ids> [--yes]`
- Web: `POST /my-telegram/delete-message`

## Test plan
- [x] `ruff check` passes
- [x] 176 related tests pass
- [ ] Verify agent can see send_message tool after enabling in permissions UI
- [ ] Test edit/delete via CLI with real Telegram account

🤖 Generated with [Claude Code](https://claude.com/claude-code)