### PR TITLE
feat: add t.me message link to search query notifications

### DIFF
--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -24,8 +24,8 @@ class NotificationMatcher:
         if not messages or not queries:
             return {}
 
-        # Collect matches per query: {sq_id: (query_name, count, first_preview)}
-        matches: dict[int, tuple[str, int, str]] = {}
+        # Collect matches per query: {sq_id: (query_name, count, first_preview, first_link)}
+        matches: dict[int, tuple[str, int, str, str]] = {}
         for msg in messages:
             if not msg.text:
                 continue
@@ -51,22 +51,30 @@ class NotificationMatcher:
                         continue
                     key = sq.id
                     if key in matches:
-                        name, count, preview = matches[key]
-                        matches[key] = (name, count + 1, preview)
+                        name, count, preview, link = matches[key]
+                        matches[key] = (name, count + 1, preview, link)
                     else:
-                        matches[key] = (sq.query, 1, msg.text[:200])
+                        matches[key] = (sq.query, 1, msg.text[:200], _make_message_link(msg))
 
         result: dict[int, int] = {}
-        for sq_id, (name, count, preview) in matches.items():
+        for sq_id, (name, count, preview, link) in matches.items():
             result[sq_id] = count
             if count == 1:
-                await self._notifier.notify(f"Query '{name}' matched in channel:\n{preview}")
+                await self._notifier.notify(f"Query '{name}' matched in channel:\n{preview}\n{link}")
             else:
                 await self._notifier.notify(
-                    f"Query '{name}' matched {count} times. First:\n{preview}"
+                    f"Query '{name}' matched {count} times. First:\n{preview}\n{link}"
                 )
 
         return result
+
+
+def _make_message_link(msg: Message) -> str:
+    """Build a t.me link for the message."""
+    if msg.channel_username:
+        return f"https://t.me/{msg.channel_username}/{msg.message_id}"
+    bare_id = str(msg.channel_id).lstrip("-").removeprefix("100")
+    return f"https://t.me/c/{bare_id}/{msg.message_id}"
 
 
 def _fts_query_matches(fts_query: str, text: str) -> bool:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -657,6 +657,8 @@ class Collector:
                 return total_collected + len(all_messages)
 
             if should_notify and all_messages:
+                for m in all_messages:
+                    m.channel_username = channel.username
                 await self._check_notification_queries(all_messages)
 
             # Update forum topics in DB if messages with topic_id

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -137,10 +137,35 @@ async def test_notification_queries_logic(collector, mock_db):
     sq = SearchQuery(id=1, query="test", is_regex=False, is_fts=False)
     mock_db.get_notification_queries.return_value = [sq]
 
-    # Need messages with actual text
-    msgs = [Message(channel_id=1, message_id=1, text="This is a test message", date=datetime.now())]
+    # Need messages with actual text and channel_username for link
+    msgs = [
+        Message(
+            channel_id=1, message_id=42, text="This is a test message",
+            date=datetime.now(), channel_username="mychan",
+        )
+    ]
     await collector._check_notification_queries(msgs)
     notifier.notify.assert_called_once()
+    call_text = notifier.notify.call_args[0][0]
+    assert "https://t.me/mychan/42" in call_text
+
+
+@pytest.mark.asyncio
+async def test_notification_queries_private_channel_link(collector, mock_db):
+    """Private channel (no username) should produce t.me/c/ link."""
+    notifier = AsyncMock()
+    collector._notifier = notifier
+    collector._notification_matcher = NotificationMatcher(notifier)
+    sq = SearchQuery(id=1, query="hello", is_regex=False, is_fts=False)
+    mock_db.get_notification_queries.return_value = [sq]
+
+    msgs = [
+        Message(channel_id=-1001234567890, message_id=99, text="hello world", date=datetime.now())
+    ]
+    await collector._check_notification_queries(msgs)
+    notifier.notify.assert_called_once()
+    call_text = notifier.notify.call_args[0][0]
+    assert "https://t.me/c/1234567890/99" in call_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `_make_message_link()` helper to build `t.me` links for matched messages (public channels → `t.me/{username}/{id}`, private → `t.me/c/{bare_id}/{id}`)
- Include the link in notification text sent by `NotificationMatcher`
- Set `channel_username` on messages in collector before passing to notification matcher
- Add test for private channel link format (`t.me/c/`)

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/test_collector_extended.py -v -k notification` — 2 tests pass
- [x] `pytest tests/test_search_queries.py -v` — 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)