### PR TITLE
chore: bump version to 0.1.18, fix image adapters and release script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tg-agent"
-version = "0.1.17"
+version = "0.1.18"
 description = "Telegram Post Search & Monitoring"
 readme = "README.md"
 license = {text = "MIT"}
@@ -53,6 +53,9 @@ dependencies = [
     "httpx==0.28.1",
     "ruff==0.14.13",
 ]
+
+[project.optional-dependencies]
+docs = ["mkdocs-material>=9.5"]
 
 [project.urls]
 Homepage = "https://github.com/axisrow/tg_content_factory"

--- a/scripts/release_pypi.sh
+++ b/scripts/release_pypi.sh
@@ -86,17 +86,18 @@ build_artifacts() {
 }
 
 upload_target() {
-  local repository="$1"
+  local repo_url="$1"
   local password_var="$2"
+  local label="$3"
 
   require_var "${password_var}"
 
-  echo "Uploading to ${repository}"
+  echo "Uploading to ${label}"
   (
     cd "${ROOT_DIR}"
     TWINE_USERNAME="${TWINE_USERNAME}" \
     TWINE_PASSWORD="${!password_var}" \
-    python3 -m twine upload --non-interactive --repository "${repository}" dist/*
+    python3 -m twine upload --non-interactive --repository-url "${repo_url}" dist/*
   )
 }
 
@@ -104,13 +105,13 @@ build_artifacts
 
 case "${TARGET}" in
   testpypi)
-    upload_target "testpypi" "TEST_PYPI_TOKEN"
+    upload_target "https://test.pypi.org/legacy/" "TEST_PYPI_TOKEN" "TestPyPI"
     ;;
   pypi)
-    upload_target "pypi" "PYPI_TOKEN"
+    upload_target "https://upload.pypi.org/legacy/" "PYPI_TOKEN" "PyPI"
     ;;
   all)
-    upload_target "testpypi" "TEST_PYPI_TOKEN"
-    upload_target "pypi" "PYPI_TOKEN"
+    upload_target "https://test.pypi.org/legacy/" "TEST_PYPI_TOKEN" "TestPyPI"
+    upload_target "https://upload.pypi.org/legacy/" "PYPI_TOKEN" "PyPI"
     ;;
 esac

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -86,7 +86,7 @@ def register(db, client_pool, embedding_service, **kwargs):
                 )
                 return _text_response(
                     f"Изображение создано!\n\n"
-                    f"![{prompt}](/{local_path})"
+                    f"![{prompt}](/data/image/{filename})"
                 )
             if result:
                 return _text_response(f"Изображение сгенерировано:\n{result}")

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -81,9 +81,10 @@ def register(db, client_pool, embedding_service, **kwargs):
                                 os.unlink(local_path)
                             raise
                 logger.info("Image downloaded to %s", local_path)
-                await db.repos.generated_images.save(
-                    prompt=prompt, model=model, image_url=result, local_path=local_path,
-                )
+                if db:
+                    await db.repos.generated_images.save(
+                        prompt=prompt, model=model, image_url=result, local_path=local_path,
+                    )
                 return _text_response(
                     f"Изображение создано!\n\n"
                     f"![{prompt}](/data/image/{filename})"

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -79,9 +79,8 @@ def register(db, client_pool, embedding_service, **kwargs):
                     prompt=prompt, model=model, image_url=result, local_path=local_path,
                 )
                 return _text_response(
-                    f"Изображение сгенерировано:\n"
-                    f"- URL: {result}\n"
-                    f"- Файл: {local_path}"
+                    f"Изображение создано!\n\n"
+                    f"![{prompt}](/{local_path})"
                 )
             if result:
                 return _text_response(f"Изображение сгенерировано:\n{result}")

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging
+import os
 
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response
+from src.web.paths import DATA_IMAGE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -51,29 +53,33 @@ def register(db, client_pool, embedding_service, **kwargs):
             result = await svc.generate(model=model, text=prompt)
             if result and (result.startswith("https://") or result.startswith("http://")):
                 import hashlib
-                import os
 
                 import httpx
 
-                os.makedirs("data/image", exist_ok=True)
+                DATA_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
                 from urllib.parse import urlparse
 
                 url_path = urlparse(result).path
                 _, dot, suffix = url_path.rpartition(".")
                 ext = suffix[:4] if dot and suffix.isalnum() else "png"
                 filename = hashlib.md5(result.encode()).hexdigest()[:12] + "." + ext
-                local_path = os.path.join("data/image", filename)
+                local_path = str(DATA_IMAGE_DIR / filename)
                 max_image_bytes = 50 * 1024 * 1024  # 50 MB
                 async with httpx.AsyncClient() as http_client:
                     async with http_client.stream("GET", result, follow_redirects=True, timeout=30) as resp:
                         resp.raise_for_status()
-                        with open(local_path, "wb") as f:
-                            total = 0
-                            async for chunk in resp.aiter_bytes(chunk_size=65536):
-                                total += len(chunk)
-                                if total > max_image_bytes:
-                                    raise ValueError("Image exceeds 50 MB limit")
-                                f.write(chunk)
+                        try:
+                            with open(local_path, "wb") as f:
+                                total = 0
+                                async for chunk in resp.aiter_bytes(chunk_size=65536):
+                                    total += len(chunk)
+                                    if total > max_image_bytes:
+                                        raise ValueError("Image exceeds 50 MB limit")
+                                    f.write(chunk)
+                        except BaseException:
+                            if os.path.exists(local_path):
+                                os.unlink(local_path)
+                            raise
                 logger.info("Image downloaded to %s", local_path)
                 await db.repos.generated_images.save(
                     prompt=prompt, model=model, image_url=result, local_path=local_path,

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 
 # Type alias for image generation adapters
 ImageAdapter = Callable[[str, str], Awaitable[Optional[str]]]
@@ -274,6 +277,8 @@ def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/image
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
         default_model = "stabilityai/stable-diffusion-xl-base-1.0"
+        if model and "/" not in model:
+            logger.warning("HuggingFace: model %r lacks '/' separator, falling back to %s", model, default_model)
         model_id = model if model and "/" in model else default_model
         url = f"https://api-inference.huggingface.co/models/{model_id}"
         headers = {"Authorization": f"Bearer {api_token}"}
@@ -332,6 +337,8 @@ def make_replicate_image_adapter(api_token: str, timeout: float = 60.0) -> Image
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
         default_model = "black-forest-labs/flux-schnell"
+        if model and "/" not in model:
+            logger.warning("Replicate: model %r lacks '/' separator, falling back to %s", model, default_model)
         model_id = model if model and "/" in model else default_model
         # Use the model route: POST /v1/models/{owner}/{name}/predictions
         url = f"https://api.replicate.com/v1/models/{model_id}/predictions"

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -273,7 +273,8 @@ def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/image
     """HuggingFace Inference API — returns binary image, saved to local file."""
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
-        model_id = model or "stabilityai/stable-diffusion-xl-base-1.0"
+        default_model = "stabilityai/stable-diffusion-xl-base-1.0"
+        model_id = model if model and "/" in model else default_model
         url = f"https://api-inference.huggingface.co/models/{model_id}"
         headers = {"Authorization": f"Bearer {api_token}"}
         payload = {"inputs": prompt}
@@ -330,7 +331,8 @@ def make_replicate_image_adapter(api_token: str, timeout: float = 60.0) -> Image
     """Replicate async prediction API with polling."""
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
-        model_id = model or "black-forest-labs/flux-schnell"
+        default_model = "black-forest-labs/flux-schnell"
+        model_id = model if model and "/" in model else default_model
         # Use the model route: POST /v1/models/{owner}/{name}/predictions
         url = f"https://api.replicate.com/v1/models/{model_id}/predictions"
         headers = {"Authorization": f"Bearer {api_token}", "Content-Type": "application/json"}

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -50,6 +50,13 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         mount_names = {route.name for route in app.routes}
         if "static" not in mount_names:
             app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+    # Serve generated images from data/image/
+    import pathlib
+
+    _data_image_dir = pathlib.Path("data/image")
+    _data_image_dir.mkdir(parents=True, exist_ok=True)
+    if "data-image" not in {r.name for r in app.routes}:
+        app.mount("/data/image", StaticFiles(directory=str(_data_image_dir)), name="data-image")
 
 
 def register_builtin_endpoints(app: FastAPI) -> None:

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -10,7 +10,7 @@ from fastapi.templating import Jinja2Templates
 
 from src.web.container import AppContainer
 from src.web.panel_auth import get_cookie_user, sanitize_next, set_session_cookie
-from src.web.paths import STATIC_DIR, TEMPLATES_DIR
+from src.web.paths import DATA_IMAGE_DIR, STATIC_DIR, TEMPLATES_DIR
 from src.web.session import COOKIE_NAME
 from src.web.template_globals import configure_template_globals
 
@@ -51,12 +51,9 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         if "static" not in mount_names:
             app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     # Serve generated images from data/image/
-    import pathlib
-
-    _data_image_dir = pathlib.Path("data/image")
-    _data_image_dir.mkdir(parents=True, exist_ok=True)
+    DATA_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
     if "data-image" not in {r.name for r in app.routes}:
-        app.mount("/data/image", StaticFiles(directory=str(_data_image_dir)), name="data-image")
+        app.mount("/data/image", StaticFiles(directory=str(DATA_IMAGE_DIR)), name="data-image")
 
 
 def register_builtin_endpoints(app: FastAPI) -> None:

--- a/src/web/paths.py
+++ b/src/web/paths.py
@@ -5,3 +5,5 @@ from pathlib import Path
 WEB_DIR = Path(__file__).parent
 STATIC_DIR = WEB_DIR / "static"
 TEMPLATES_DIR = WEB_DIR / "templates"
+PROJECT_ROOT = WEB_DIR.parent.parent
+DATA_IMAGE_DIR = PROJECT_ROOT / "data" / "image"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.18
- Fix `release_pypi.sh` to use `--repository-url` instead of `--repository`
- Return markdown image `![prompt](/path)` in agent image tool response
- Fix HuggingFace/Replicate adapters to validate `model_id` format (requires `/`)
- Serve generated images from `data/image/` via static mount at `/data/image`

## Test plan
- [ ] `ruff check src/` passes
- [ ] Image generation returns markdown image tag in agent
- [ ] `scripts/release_pypi.sh testpypi` uploads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)