### PR TITLE
fix: list_generated_images tool + CLI/Web parity gaps (#254)

### DIFF
--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -134,4 +134,30 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_image_providers)
 
+    @tool(
+        "list_generated_images",
+        "List recently generated images stored in the database. "
+        "Returns image ID, prompt, model, local file path, and creation date.",
+        {"limit": int},
+    )
+    async def list_generated_images(args):
+        limit = args.get("limit") or 20
+        try:
+            images = await db.repos.generated_images.list_recent(limit=limit)
+            if not images:
+                return _text_response("Нет сгенерированных изображений.")
+            lines = [f"Последние {len(images)} изображений:"]
+            for img in images:
+                prompt_preview = (img.prompt[:60] + "...") if len(img.prompt) > 60 else img.prompt
+                lines.append(f"  [{img.id}] {img.created_at} — {prompt_preview}")
+                if img.local_path:
+                    lines.append(f"       Файл: /{img.local_path}")
+                if img.model:
+                    lines.append(f"       Модель: {img.model}")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка получения списка изображений: {e}")
+
+    tools.append(list_generated_images)
+
     return tools

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -133,6 +133,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "generate_image": ToolCategory.WRITE,
     "list_image_models": ToolCategory.READ,
     "list_image_providers": ToolCategory.READ,
+    "list_generated_images": ToolCategory.READ,
     # Settings
     "get_settings": ToolCategory.READ,
     "save_scheduler_settings": ToolCategory.WRITE,
@@ -210,7 +211,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "send_message", "edit_message", "delete_message",
     ]),
     ("Изображения", [
-        "list_image_models", "list_image_providers", "generate_image",
+        "list_image_models", "list_image_providers", "generate_image", "list_generated_images",
     ]),
     ("Настройки", [
         "get_settings", "save_scheduler_settings", "save_agent_settings",

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -1,7 +1,9 @@
 """Account management routes — split from settings.py for clarity."""
 
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from src.web import deps
 
@@ -18,3 +20,42 @@ async def toggle_account(request: Request, account_id: int):
 async def delete_account(request: Request, account_id: int):
     await deps.account_service(request).delete(account_id)
     return RedirectResponse(url="/settings?msg=account_deleted", status_code=303)
+
+
+@router.get("/flood-status")
+async def flood_status(request: Request):
+    db = deps.get_db(request)
+    accounts = await db.get_accounts()
+    now = datetime.now(timezone.utc)
+    result = []
+    for acc in accounts:
+        if acc.flood_wait_until is None:
+            status = "ok"
+            remaining = 0
+        else:
+            flood_until = acc.flood_wait_until
+            if flood_until.tzinfo is None:
+                flood_until = flood_until.replace(tzinfo=timezone.utc)
+            if flood_until > now:
+                status = flood_until.strftime("%Y-%m-%d %H:%M:%S UTC")
+                remaining = int((flood_until - now).total_seconds())
+            else:
+                status = "ok"
+                remaining = 0
+        result.append({
+            "phone": acc.phone,
+            "flood_wait_until": status,
+            "remaining_seconds": remaining,
+        })
+    return JSONResponse(result)
+
+
+@router.post("/{account_id}/flood-clear")
+async def flood_clear(request: Request, account_id: int):
+    db = deps.get_db(request)
+    accounts = await db.get_accounts()
+    acc = next((a for a in accounts if a.id == account_id), None)
+    if not acc:
+        return RedirectResponse(url="/settings?error=account_not_found", status_code=303)
+    await db.update_account_flood(acc.phone, None)
+    return RedirectResponse(url="/settings?msg=flood_cleared", status_code=303)

--- a/src/web/routes/channels.py
+++ b/src/web/routes/channels.py
@@ -111,3 +111,31 @@ async def refresh_channel_types(request: Request):
         url=f"/channels?msg=types_refreshed&updated={updated}&failed={failed}",
         status_code=303,
     )
+
+
+@router.post("/refresh-meta")
+async def refresh_channel_meta(request: Request):
+    db = deps.get_db(request)
+    pool = deps.get_pool(request)
+    channels = await db.get_channels(active_only=True)
+    ok = 0
+    failed = 0
+    for ch in channels:
+        try:
+            meta = await pool.fetch_channel_meta(ch.channel_id, ch.channel_type)
+        except Exception:
+            meta = None
+        if meta:
+            await db.update_channel_full_meta(
+                ch.channel_id,
+                about=meta["about"],
+                linked_chat_id=meta["linked_chat_id"],
+                has_comments=meta["has_comments"],
+            )
+            ok += 1
+        else:
+            failed += 1
+    return RedirectResponse(
+        url=f"/channels?msg=meta_refreshed&updated={ok}&failed={failed}",
+        status_code=303,
+    )

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -527,7 +527,7 @@ async def photo_update_auto(request: Request, job_id: int):
     interval = form.get("interval_minutes")
     if interval and str(interval).isdigit():
         kwargs["interval_minutes"] = int(interval)
-    if form.get("is_active") is not None:
+    if form.get("is_active"):
         kwargs["is_active"] = form["is_active"] in ("1", "true", "on")
     await service.update_job(job_id, **kwargs)
     return _redirect(phone, "photo_auto_updated")

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -507,6 +507,32 @@ async def photo_toggle_auto(request: Request, job_id: int, phone: str = Form("")
     return _redirect(phone, "photo_auto_toggled")
 
 
+@router.post("/auto/{job_id}/update")
+async def photo_update_auto(request: Request, job_id: int):
+    form = await request.form()
+    phone = form.get("phone", "")
+    service = deps.get_photo_auto_upload_service(request)
+    job = await service.get_job(job_id)
+    if job is None:
+        return _redirect(phone, "photo_auto_failed", error=True)
+    kwargs: dict = {}
+    if form.get("folder"):
+        kwargs["folder_path"] = form["folder"]
+    if form.get("mode"):
+        from src.models import PhotoSendMode
+
+        kwargs["send_mode"] = PhotoSendMode(form["mode"])
+    if form.get("caption") is not None:
+        kwargs["caption"] = form["caption"]
+    interval = form.get("interval_minutes")
+    if interval and str(interval).isdigit():
+        kwargs["interval_minutes"] = int(interval)
+    if form.get("is_active") is not None:
+        kwargs["is_active"] = form["is_active"] in ("1", "true", "on")
+    await service.update_job(job_id, **kwargs)
+    return _redirect(phone, "photo_auto_updated")
+
+
 @router.post("/auto/{job_id}/delete")
 async def photo_delete_auto(request: Request, job_id: int, phone: str = Form("")):
     await deps.get_photo_auto_upload_service(request).delete_job(job_id)


### PR DESCRIPTION
## Summary
- Fix agent bug: can't list generated images (no tool for it)
- Close 4 CLI/Web parity gaps

## Bug Fix
Agent generates images to `data/image/` and saves records in `generated_images` DB table, but had no tool to query that table. When user asks "show my images" — agent was lost. 

**Solution**: new `list_generated_images` agent tool (READ category) that calls `db.repos.generated_images.list_recent()`. No system prompt changes needed.

## Parity Gaps Closed

| CLI Command | New Web Endpoint |
|-------------|-----------------|
| `channel refresh-meta --all` | `POST /channels/refresh-meta` |
| `account flood-status` | `GET /settings/flood-status` (JSON) |
| `account flood-clear` | `POST /settings/{id}/flood-clear` |
| `photo-loader auto-update` | `POST /my-telegram/photos/auto/{id}/update` |

`analytics summary` already has `GET /analytics/content/api/summary` — considered at parity.

## Test plan
- [ ] `ruff check src/` passes
- [ ] Agent: "покажи последние изображения" → returns list from DB
- [ ] `POST /channels/refresh-meta` refreshes about/linked_chat_id
- [ ] `GET /settings/flood-status` returns JSON array
- [ ] `POST /settings/1/flood-clear` clears flood wait
- [ ] `POST /my-telegram/photos/auto/1/update` updates job params

🤖 Generated with [Claude Code](https://claude.com/claude-code)