### PR TITLE
feat: implement forward-messages for CLI, Web, and Agent (#184)

### DIFF
--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -119,6 +119,44 @@ def register(db, client_pool, embedding_service, **kwargs):
     tools.append(delete_message)
 
     @tool(
+        "forward_messages",
+        "Forward messages from one Telegram chat to another. "
+        "Pass comma-separated message IDs. Always ask user for confirmation first.",
+        {"phone": str, "from_chat": str, "to_chat": str, "message_ids": str, "confirm": bool},
+    )
+    async def forward_messages(args):
+        pool_gate = require_pool(client_pool, "Пересылка сообщений")
+        if pool_gate:
+            return pool_gate
+        phone = args.get("phone", "")
+        from_chat = args.get("from_chat", "")
+        to_chat = args.get("to_chat", "")
+        message_ids_str = args.get("message_ids", "")
+        if not phone or not from_chat or not to_chat or not message_ids_str:
+            return _text_response("Ошибка: phone, from_chat, to_chat и message_ids обязательны.")
+        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
+        if not ids:
+            return _text_response("Ошибка: не указаны валидные message_ids.")
+        gate = require_confirmation(
+            f"перешлёт {len(ids)} сообщений из {from_chat} в {to_chat}: {ids}", args
+        )
+        if gate:
+            return gate
+        try:
+            result = await client_pool.get_native_client_by_phone(phone)
+            if result is None:
+                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            client, _ = result
+            from_entity = await client.get_entity(from_chat)
+            to_entity = await client.get_entity(to_chat)
+            await client.forward_messages(to_entity, ids, from_entity)
+            return _text_response(f"Переслано {len(ids)} сообщений из {from_chat} в {to_chat}.")
+        except Exception as e:
+            return _text_response(f"Ошибка пересылки сообщений: {e}")
+
+    tools.append(forward_messages)
+
+    @tool(
         "pin_message",
         "Pin a message in a Telegram chat. Ask user for confirmation first.",
         {"phone": str, "chat_id": str, "message_id": int, "notify": bool, "confirm": bool},

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -127,6 +127,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "get_cache_status": ToolCategory.READ,
     # Messaging
     "send_message": ToolCategory.WRITE,
+    "forward_messages": ToolCategory.WRITE,
     "edit_message": ToolCategory.WRITE,
     "delete_message": ToolCategory.DELETE,
     "pin_message": ToolCategory.WRITE,
@@ -219,7 +220,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "get_forum_topics", "clear_dialog_cache", "get_cache_status",
     ]),
     ("Сообщения", [
-        "send_message", "edit_message", "delete_message",
+        "send_message", "forward_messages", "edit_message", "delete_message",
         "pin_message", "unpin_message", "download_media",
     ]),
     ("Управление чатом", [

--- a/src/cli/commands/my_telegram.py
+++ b/src/cli/commands/my_telegram.py
@@ -162,6 +162,41 @@ def run(args: argparse.Namespace) -> None:
                 except Exception as exc:
                     print(f"Error sending message: {exc}")
 
+            elif args.my_telegram_action == "forward":
+                accounts = sorted(pool.clients.keys())
+                if not accounts:
+                    print("No connected accounts.")
+                    return
+                phone = args.phone or accounts[0]
+                if phone not in pool.clients:
+                    print(f"Account {phone} not connected.")
+                    return
+                raw_ids: list[str] = []
+                for item in args.message_ids:
+                    raw_ids.extend(i.strip() for i in item.split(",") if i.strip())
+                ids = [int(x) for x in raw_ids if x.isdigit()]
+                if not ids:
+                    print("No valid message IDs provided.")
+                    return
+                if not args.yes:
+                    print(f"Forward {len(ids)} message(s) from {args.from_chat} to {args.to_chat}: {ids}")
+                    answer = input("Continue? [y/N] ").strip().lower()
+                    if answer != "y":
+                        print("Aborted.")
+                        return
+                result = await pool.get_native_client_by_phone(phone)
+                if result is None:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
+                    return
+                client, _ = result
+                try:
+                    from_entity = await client.get_entity(args.from_chat)
+                    to_entity = await client.get_entity(args.to_chat)
+                    await client.forward_messages(to_entity, ids, from_entity)
+                    print(f"Forwarded {len(ids)} message(s) from {args.from_chat} to {args.to_chat}.")
+                except Exception as exc:
+                    print(f"Error forwarding messages: {exc}")
+
             elif args.my_telegram_action == "edit-message":
                 accounts = sorted(pool.clients.keys())
                 if not accounts:

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -430,6 +430,13 @@ def build_parser() -> argparse.ArgumentParser:
     my_tg_send.add_argument("--phone", default=None, help="Account phone (default: first connected)")
     my_tg_send.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
 
+    my_tg_fwd = my_tg_sub.add_parser("forward", help="Forward messages between chats")
+    my_tg_fwd.add_argument("from_chat", help="Source chat ID or @username")
+    my_tg_fwd.add_argument("to_chat", help="Destination chat ID or @username")
+    my_tg_fwd.add_argument("message_ids", nargs="+", help="Message IDs to forward (space or comma-separated)")
+    my_tg_fwd.add_argument("--phone", default=None, help="Account phone (default: first connected)")
+    my_tg_fwd.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
     my_tg_edit = my_tg_sub.add_parser("edit-message", help="Edit a sent message")
     my_tg_edit.add_argument("chat_id", help="Chat ID or @username")
     my_tg_edit.add_argument("message_id", type=int, help="Message ID to edit")

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -223,6 +223,48 @@ async def delete_message(request: Request):
         )
 
 
+@router.post("/forward-messages")
+async def forward_messages(request: Request):
+    form = await request.form()
+    phone = form.get("phone", "")
+    from_chat = form.get("from_chat", "")
+    to_chat = form.get("to_chat", "")
+    message_ids_str = form.get("message_ids", "")
+    pool = deps.get_pool(request)
+    if not phone or not from_chat or not to_chat or not message_ids_str:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=missing_fields",
+            status_code=303,
+        )
+    ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
+    if not ids:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=invalid_ids",
+            status_code=303,
+        )
+    result = await pool.get_native_client_by_phone(phone)
+    if result is None:
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=client_unavailable",
+            status_code=303,
+        )
+    client, _ = result
+    try:
+        from_entity = await client.get_entity(from_chat)
+        to_entity = await client.get_entity(to_chat)
+        await client.forward_messages(to_entity, ids, from_entity)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&msg=messages_forwarded",
+            status_code=303,
+        )
+    except Exception as exc:
+        logger.exception("Failed to forward messages: %s", exc)
+        return RedirectResponse(
+            url=f"/my-telegram/?phone={quote(phone, safe='')}&error=forward_failed",
+            status_code=303,
+        )
+
+
 @router.post("/pin-message")
 async def pin_message(request: Request):
     form = await request.form()


### PR DESCRIPTION
## Summary
- Add CLI command: `my-telegram forward`
- Add Web endpoint: `POST /my-telegram/forward-messages`
- Add Agent tool: `forward_messages`
- Register in tool permissions registry

## Test plan
- `ruff check src/` ✓
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` ✓ 1990 passed
- `pytest tests/ -v -m aiosqlite_serial` ✓ 195 passed
- Manual: `python -m src.main my-telegram forward --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)