### PR TITLE
fix: use union permissions so agent sees tools allowed by any account

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -122,11 +122,11 @@ class ClaudeSdkBackend:
             MCP_PREFIX,
             filter_allowed_tools,
             get_all_allowed_tools,
-            load_tool_permissions,
+            load_tool_permissions_union,
         )
 
         all_tools = get_all_allowed_tools()
-        permissions = await load_tool_permissions(self._db)
+        permissions = await load_tool_permissions_union(self._db)
         allowed = filter_allowed_tools(all_tools, permissions)
         if len(allowed) < len(all_tools):
             denied = [t.removeprefix(MCP_PREFIX) for t in all_tools if t not in allowed]
@@ -797,9 +797,9 @@ class DeepagentsBackend:
     ) -> None:
         del thread_id, stats, model
 
-        from src.agent.tools.permissions import load_tool_permissions
+        from src.agent.tools.permissions import load_tool_permissions_union
 
-        permissions = await load_tool_permissions(self._db)
+        permissions = await load_tool_permissions_union(self._db)
         enabled_count = sum(1 for v in permissions.values() if v)
         logger.info(
             "Deepagents tool permissions: %d/%d enabled",

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -355,6 +355,26 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(saved, ensure_ascii=False))
 
 
+async def load_tool_permissions_union(db) -> dict[str, bool]:
+    """Union across all phones — True if ANY phone allows the tool.
+
+    Used by agent backends so that tools visible to at least one account
+    remain available for the session.  Per-phone handler gates do fine-grained blocking.
+    """
+    defaults = _default_permissions()
+    saved = await _load_raw_permissions(db)
+    if not saved:
+        return defaults
+
+    if not _is_per_phone_format(saved):
+        return {name: saved.get(name, defaults[name]) for name in TOOL_CATEGORIES}
+
+    phone_dicts = [v for v in saved.values() if isinstance(v, dict)]
+    if not phone_dicts:
+        return defaults
+    return {name: any(pd.get(name, defaults[name]) for pd in phone_dicts) for name in TOOL_CATEGORIES}
+
+
 def get_all_allowed_tools() -> list[str]:
     """Build the full list of MCP-prefixed tool names from TOOL_CATEGORIES."""
     return [f"{MCP_PREFIX}{name}" for name in TOOL_CATEGORIES]

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -22,6 +22,7 @@ from src.agent.tools.permissions import (
     filter_allowed_tools,
     load_tool_permissions,
     load_tool_permissions_all_phones,
+    load_tool_permissions_union,
     save_tool_permissions,
 )
 from src.database import Database
@@ -238,6 +239,44 @@ class TestLoadToolPermissionsAllPhones:
         result = await load_tool_permissions_all_phones(mock_db, accounts)
         assert result["+7111"]["search_messages"] is False
         assert result["+7222"]["search_messages"] is False
+
+
+# ---------------------------------------------------------------------------
+# permissions.load_tool_permissions_union
+# ---------------------------------------------------------------------------
+
+
+class TestLoadToolPermissionsUnion:
+    async def test_no_setting_returns_defaults(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value=None)
+        result = await load_tool_permissions_union(mock_db)
+        assert all(v is True for v in result.values())
+
+    async def test_flat_format(self, mock_db):
+        saved = {"search_messages": False}
+        mock_db.get_setting = AsyncMock(return_value=json.dumps(saved))
+        result = await load_tool_permissions_union(mock_db)
+        assert result["search_messages"] is False
+        assert result["list_channels"] is True
+
+    async def test_per_phone_union_any_allows(self, mock_db):
+        saved = {
+            "+7111": {"send_photos_now": False, "leave_dialogs": False},
+            "+7222": {"send_photos_now": True, "leave_dialogs": False},
+        }
+        mock_db.get_setting = AsyncMock(return_value=json.dumps(saved))
+        result = await load_tool_permissions_union(mock_db)
+        assert result["send_photos_now"] is True  # +7222 allows
+        assert result["leave_dialogs"] is False  # both deny
+
+    async def test_per_phone_all_deny(self, mock_db):
+        saved = {
+            "+7111": {"send_photos_now": False},
+            "+7222": {"send_photos_now": False},
+        }
+        mock_db.get_setting = AsyncMock(return_value=json.dumps(saved))
+        result = await load_tool_permissions_union(mock_db)
+        assert result["send_photos_now"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pre-call filtering in `manager.py` loaded permissions for the primary account only via `load_tool_permissions(db)`, hiding tools from the agent session even when a secondary account had them enabled (e.g. `send_photos_now` blocked for primary but allowed for secondary)
- Added `load_tool_permissions_union(db)` that returns `True` if ANY phone allows the tool — the per-phone handler gate (`require_phone_permission`) still blocks at call time for specific phones
- Both backends (Claude SDK and Deepagents) now use union permissions

## Test plan
- [x] `pytest tests/test_tool_permissions.py -v -n auto` — 56 passed
- [x] `ruff check src/agent/manager.py src/agent/tools/permissions.py tests/test_tool_permissions.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)