### PR TITLE
fix: add resolve_phone fallback and permission gates to all tool handlers

### DIFF
--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -49,6 +49,24 @@ def require_pool(client_pool: object | None, action: str = "Эта операц�
     )
 
 
+async def resolve_phone(db: object, raw_phone: str) -> tuple[str, dict | None]:
+    """Normalize phone, default to primary account if empty.
+
+    Returns ``(phone, None)`` on success or ``("", error_response)`` on failure.
+    """
+    phone = normalize_phone(raw_phone)
+    if phone:
+        return phone, None
+    try:
+        accounts = await db.get_accounts()
+    except Exception:
+        return "", _text_response("Ошибка: не удалось получить список аккаунтов.")
+    if not accounts:
+        return "", _text_response("Ошибка: нет подключённых аккаунтов.")
+    primary = next((a for a in accounts if a.is_primary), accounts[0])
+    return primary.phone, None
+
+
 async def require_phone_permission(db: object, phone: str, tool_name: str) -> dict | None:
     """Return helpful response with allowed phones if not permitted, else None.
 

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, require_confirmation
+from src.agent.tools._registry import _text_response, require_confirmation, resolve_phone
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -97,9 +97,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"phone": str, "confirm": bool},
     )
     async def clear_flood_status(args):
-        phone = args.get("phone", "")
-        if not phone:
-            return _text_response("Ошибка: phone обязателен.")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
         gate = require_confirmation(f"сбросит flood-wait для аккаунта {phone}", args)
         if gate:
             return gate

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, require_confirmation, require_pool
+from src.agent.tools._registry import (
+    _text_response,
+    require_confirmation,
+    require_phone_permission,
+    require_pool,
+    resolve_phone,
+)
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -22,11 +28,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Отправка сообщения")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "send_message")
+        if perm_gate:
+            return perm_gate
         recipient = args.get("recipient", "")
         text = args.get("text", "")
-        if not phone or not recipient or not text:
-            return _text_response("Ошибка: phone, recipient и text обязательны.")
+        if not recipient or not text:
+            return _text_response("Ошибка: recipient и text обязательны.")
         preview = text[:120] + ("..." if len(text) > 120 else "")
         gate = require_confirmation(
             f"отправит сообщение от {phone} пользователю {recipient}: «{preview}»", args
@@ -56,12 +67,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Редактирование сообщения")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "edit_message")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         message_id = args.get("message_id")
         text = args.get("text", "")
-        if not phone or not chat_id or not message_id or not text:
-            return _text_response("Ошибка: phone, chat_id, message_id и text обязательны.")
+        if not chat_id or not message_id or not text:
+            return _text_response("Ошибка: chat_id, message_id и text обязательны.")
         preview = text[:120] + ("..." if len(text) > 120 else "")
         gate = require_confirmation(
             f"отредактирует сообщение #{message_id} в чате {chat_id}: «{preview}»", args
@@ -92,11 +108,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Удаление сообщений")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "delete_message")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         message_ids_str = args.get("message_ids", "")
-        if not phone or not chat_id or not message_ids_str:
-            return _text_response("Ошибка: phone, chat_id и message_ids обязательны.")
+        if not chat_id or not message_ids_str:
+            return _text_response("Ошибка: chat_id и message_ids обязательны.")
         ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
         if not ids:
             return _text_response("Ошибка: не указаны валидные message_ids.")
@@ -128,12 +149,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Пересылка сообщений")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "forward_messages")
+        if perm_gate:
+            return perm_gate
         from_chat = args.get("from_chat", "")
         to_chat = args.get("to_chat", "")
         message_ids_str = args.get("message_ids", "")
-        if not phone or not from_chat or not to_chat or not message_ids_str:
-            return _text_response("Ошибка: phone, from_chat, to_chat и message_ids обязательны.")
+        if not from_chat or not to_chat or not message_ids_str:
+            return _text_response("Ошибка: from_chat, to_chat и message_ids обязательны.")
         ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
         if not ids:
             return _text_response("Ошибка: не указаны валидные message_ids.")
@@ -165,12 +191,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Закрепление сообщения")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "pin_message")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         message_id = args.get("message_id")
         notify = args.get("notify", False)
-        if not phone or not chat_id or not message_id:
-            return _text_response("Ошибка: phone, chat_id и message_id обязательны.")
+        if not chat_id or not message_id:
+            return _text_response("Ошибка: chat_id и message_id обязательны.")
         gate = require_confirmation(f"закрепит сообщение #{message_id} в чате {chat_id}", args)
         if gate:
             return gate
@@ -197,11 +228,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Открепление сообщения")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "unpin_message")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         message_id = args.get("message_id") or None
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         target = f"#{message_id}" if message_id else "все сообщения"
         gate = require_confirmation(f"открепит {target} в чате {chat_id}", args)
         if gate:
@@ -230,11 +266,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Загрузка медиа")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "download_media")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         message_id = args.get("message_id")
-        if not phone or not chat_id or not message_id:
-            return _text_response("Ошибка: phone, chat_id и message_id обязательны.")
+        if not chat_id or not message_id:
+            return _text_response("Ошибка: chat_id и message_id обязательны.")
         try:
             result = await client_pool.get_native_client_by_phone(phone)
             if result is None:
@@ -270,12 +311,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Получение участников")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "get_participants")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         limit = args.get("limit") or 200
         search = args.get("search", "")
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         try:
             result = await client_pool.get_native_client_by_phone(phone)
             if result is None:
@@ -312,13 +358,18 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Изменение прав администратора")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "edit_admin")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         user_id = args.get("user_id", "")
         is_admin = args.get("is_admin", True)
         title = args.get("title") or None
-        if not phone or not chat_id or not user_id:
-            return _text_response("Ошибка: phone, chat_id и user_id обязательны.")
+        if not chat_id or not user_id:
+            return _text_response("Ошибка: chat_id и user_id обязательны.")
         action = "повысит" if is_admin else "понизит"
         gate = require_confirmation(f"{action} {user_id} в {chat_id}", args)
         if gate:
@@ -357,14 +408,19 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Изменение ограничений пользователя")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "edit_permissions")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         user_id = args.get("user_id", "")
         until_date_str = args.get("until_date") or None
         send_messages = args.get("send_messages")
         send_media = args.get("send_media")
-        if not phone or not chat_id or not user_id:
-            return _text_response("Ошибка: phone, chat_id и user_id обязательны.")
+        if not chat_id or not user_id:
+            return _text_response("Ошибка: chat_id и user_id обязательны.")
         if send_messages is None and send_media is None:
             return _text_response(
                 "Ошибка: укажите хотя бы один флаг ограничения "
@@ -404,11 +460,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Исключение участника")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "kick_participant")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         user_id = args.get("user_id", "")
-        if not phone or not chat_id or not user_id:
-            return _text_response("Ошибка: phone, chat_id и user_id обязательны.")
+        if not chat_id or not user_id:
+            return _text_response("Ошибка: chat_id и user_id обязательны.")
         gate = require_confirmation(f"исключит {user_id} из чата {chat_id}", args)
         if gate:
             return gate
@@ -435,10 +496,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Получение статистики")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "get_broadcast_stats")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         try:
             result = await client_pool.get_native_client_by_phone(phone)
             if result is None:
@@ -486,10 +552,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Архивирование чата")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "archive_chat")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         gate = require_confirmation(f"архивирует чат {chat_id}", args)
         if gate:
             return gate
@@ -516,10 +587,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Разархивирование чата")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "unarchive_chat")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         gate = require_confirmation(f"разархивирует чат {chat_id}", args)
         if gate:
             return gate
@@ -545,11 +621,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Отметка сообщений как прочитанных")
         if pool_gate:
             return pool_gate
-        phone = args.get("phone", "")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "mark_read")
+        if perm_gate:
+            return perm_gate
         chat_id = args.get("chat_id", "")
         max_id = args.get("max_id") or None
-        if not phone or not chat_id:
-            return _text_response("Ошибка: phone и chat_id обязательны.")
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
         try:
             result = await client_pool.get_native_client_by_phone(phone)
             if result is None:

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -11,6 +11,7 @@ from src.agent.tools._registry import (
     require_confirmation,
     require_phone_permission,
     require_pool,
+    resolve_phone,
 )
 
 
@@ -22,9 +23,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Список диалогов")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
-        if not phone:
-            return _text_response("Ошибка: phone обязателен.")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
         perm_gate = await require_phone_permission(db, phone, "list_dialogs")
         if perm_gate:
             return perm_gate
@@ -58,9 +59,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Обновление диалогов")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
-        if not phone:
-            return _text_response("Ошибка: phone обязателен.")
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
         perm_gate = await require_phone_permission(db, phone, "refresh_dialogs")
         if perm_gate:
             return perm_gate
@@ -86,10 +87,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Выход из диалогов")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
         dialog_ids_str = args.get("dialog_ids", "")
-        if not phone or not dialog_ids_str:
-            return _text_response("Ошибка: phone и dialog_ids обязательны.")
+        if not dialog_ids_str:
+            return _text_response("Ошибка: dialog_ids обязателен.")
         perm_gate = await require_phone_permission(db, phone, "leave_dialogs")
         if perm_gate:
             return perm_gate
@@ -121,10 +124,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Создание канала")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
         title = args.get("title", "")
-        if not phone or not title:
-            return _text_response("Ошибка: phone и title обязательны.")
+        if not title:
+            return _text_response("Ошибка: title обязателен.")
         perm_gate = await require_phone_permission(db, phone, "create_telegram_channel")
         if perm_gate:
             return perm_gate

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -351,6 +351,15 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     if saved and not _is_per_phone_format(saved):
         # Migrate legacy flat → per-phone: existing flat becomes the phone's entry
         saved = {}
+    # Seed unsaved accounts with all-enabled defaults so they are not implicitly denied
+    defaults = _default_permissions()
+    try:
+        accounts = await db.get_accounts()
+        for acc in accounts:
+            if acc.phone not in saved:
+                saved[acc.phone] = dict(defaults)
+    except Exception:
+        pass  # DB error — proceed with what we have
     saved[phone] = permissions
     await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(saved, ensure_ascii=False))
 

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -7,10 +7,10 @@ from mcp.types import ToolAnnotations
 
 from src.agent.tools._registry import (
     _text_response,
-    normalize_phone,
     require_confirmation,
     require_phone_permission,
     require_pool,
+    resolve_phone,
 )
 
 
@@ -76,11 +76,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Отправка фото")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
-        if phone:
-            perm_gate = await require_phone_permission(db, phone, "send_photos_now")
-            if perm_gate:
-                return perm_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "send_photos_now")
+        if perm_gate:
+            return perm_gate
         gate = require_confirmation("отправит фото в Telegram-диалог", args)
         if gate:
             return gate
@@ -135,11 +136,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Планирование фото")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
-        if phone:
-            perm_gate = await require_phone_permission(db, phone, "schedule_photos")
-            if perm_gate:
-                return perm_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "schedule_photos")
+        if perm_gate:
+            return perm_gate
         gate = require_confirmation("запланирует отправку фото", args)
         if gate:
             return gate
@@ -283,12 +285,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Создание батча фото")
         if pool_gate:
             return pool_gate
-        phone = normalize_phone(args.get("phone", ""))
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "create_photo_batch")
+        if perm_gate:
+            return perm_gate
         target = args.get("target", "")
         files = [f.strip() for f in args.get("file_paths", "").split(",") if f.strip()]
         caption = args.get("caption")
-        if not phone or not target or not files:
-            return _text_response("Ошибка: phone, target и file_paths обязательны.")
+        if not target or not files:
+            return _text_response("Ошибка: target и file_paths обязательны.")
         gate = require_confirmation(
             f"создаст батч фото для отправки: файлы={files}, target={target}", args
         )
@@ -359,8 +366,19 @@ def register(db, client_pool, embedding_service, **kwargs):
         pool_gate = require_pool(client_pool, "Создание автозагрузки")
         if pool_gate:
             return pool_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "create_auto_upload")
+        if perm_gate:
+            return perm_gate
         folder_path = args.get("folder_path", "")
         target = args.get("target", "")
+        interval = int(args.get("interval_minutes", 60))
+        mode = args.get("mode", "album")
+        caption = args.get("caption")
+        if not target or not folder_path:
+            return _text_response("Ошибка: target и folder_path обязательны.")
         gate = require_confirmation(
             f"создаст автозагрузку фото: folder={folder_path}, target={target}", args
         )
@@ -373,14 +391,6 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.photo_publish_service import PhotoPublishService
 
             svc = PhotoAutoUploadService(PhotoLoaderBundle.from_database(db), PhotoPublishService(client_pool))
-            phone = normalize_phone(args.get("phone", ""))
-            target = args.get("target", "")
-            folder_path = args.get("folder_path", "")
-            interval = int(args.get("interval_minutes", 60))
-            mode = args.get("mode", "album")
-            caption = args.get("caption")
-            if not phone or not target or not folder_path:
-                return _text_response("Ошибка: phone, target и folder_path обязательны.")
             job_id = await svc.create_job(PhotoAutoUploadJob(
                 phone=phone,
                 target_dialog_id=int(target),

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -13,6 +13,7 @@ from src.agent.tools._registry import (
     require_confirmation,
     require_phone_permission,
     require_pool,
+    resolve_phone,
 )
 from src.agent.tools.permissions import (
     MCP_PREFIX,
@@ -105,6 +106,39 @@ class TestRequirePool:
 
 
 # ---------------------------------------------------------------------------
+# _registry.resolve_phone
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePhone:
+    async def test_phone_provided(self, mock_db):
+        phone, err = await resolve_phone(mock_db, "79990001111")
+        assert phone == "+79990001111"
+        assert err is None
+
+    async def test_empty_phone_uses_primary(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79990001111", is_primary=True)]
+        )
+        phone, err = await resolve_phone(mock_db, "")
+        assert phone == "+79990001111"
+        assert err is None
+
+    async def test_empty_phone_no_accounts(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        phone, err = await resolve_phone(mock_db, "")
+        assert phone == ""
+        assert err is not None
+        assert "нет подключённых" in _text(err)
+
+    async def test_empty_phone_db_error(self, mock_db):
+        mock_db.get_accounts = AsyncMock(side_effect=Exception("DB down"))
+        phone, err = await resolve_phone(mock_db, "")
+        assert phone == ""
+        assert err is not None
+
+
+# ---------------------------------------------------------------------------
 # _registry.require_phone_permission
 # ---------------------------------------------------------------------------
 
@@ -139,6 +173,17 @@ class TestRequirePhonePermission:
         perms = {"+79990001111": {"some_other_tool": True}}
         mock_db.get_setting = AsyncMock(return_value=json.dumps(perms))
         assert await require_phone_permission(mock_db, "+79990001111", "leave_dialogs") is None
+
+    async def test_tool_missing_from_saved_denies(self, mock_db):
+        """Tool not explicitly saved for a phone defaults to denied."""
+        perms = {
+            "+79990001111": {"send_photos_now": True},
+            "+79990002222": {"some_other_tool": True},  # send_photos_now missing → denied
+        }
+        mock_db.get_setting = AsyncMock(return_value=json.dumps(perms))
+        result = await require_phone_permission(mock_db, "+79990002222", "send_photos_now")
+        assert result is not None
+        assert "не разрешён" in _text(result)
 
     async def test_empty_phone_hint(self, mock_db):
         perms = {"+79990001111": {"leave_dialogs": True}}
@@ -295,6 +340,9 @@ class TestSaveToolPermissions:
 
     async def test_per_phone_new_entry(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=json.dumps({"+7111": {"a": True}}))
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(phone="+7111"), SimpleNamespace(phone="+7222"),
+        ])
         mock_db.set_setting = AsyncMock()
         await save_tool_permissions(mock_db, {"b": True}, phone="+7222")
         saved = json.loads(mock_db.set_setting.await_args[0][1])
@@ -303,13 +351,29 @@ class TestSaveToolPermissions:
 
     async def test_per_phone_overwrite(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=json.dumps({"+7111": {"a": True}}))
+        mock_db.get_accounts = AsyncMock(return_value=[SimpleNamespace(phone="+7111")])
         mock_db.set_setting = AsyncMock()
         await save_tool_permissions(mock_db, {"a": False}, phone="+7111")
         saved = json.loads(mock_db.set_setting.await_args[0][1])
         assert saved["+7111"] == {"a": False}
 
+    async def test_per_phone_seeds_unsaved_accounts(self, mock_db):
+        """Saving for one phone seeds other accounts with all-enabled defaults."""
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(phone="+7111"), SimpleNamespace(phone="+7222"),
+        ])
+        mock_db.set_setting = AsyncMock()
+        await save_tool_permissions(mock_db, {"send_photos_now": False}, phone="+7111")
+        saved = json.loads(mock_db.set_setting.await_args[0][1])
+        assert saved["+7111"]["send_photos_now"] is False
+        # +7222 was seeded with defaults (all True)
+        assert "+7222" in saved
+        assert all(v is True for v in saved["+7222"].values())
+
     async def test_per_phone_migrates_legacy_flat(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=json.dumps({"search_messages": True}))
+        mock_db.get_accounts = AsyncMock(return_value=[SimpleNamespace(phone="+7111")])
         mock_db.set_setting = AsyncMock()
         await save_tool_permissions(mock_db, {"leave_dialogs": False}, phone="+7111")
         saved = json.loads(mock_db.set_setting.await_args[0][1])


### PR DESCRIPTION
## Summary
- Add `resolve_phone()` helper in `_registry.py` — defaults to primary account when phone param is empty, replacing manual `normalize_phone` + empty check across 24 handlers
- Add missing `require_phone_permission` gate to all 15 `messaging.py` handlers and 2 `photo_loader.py` handlers (`create_photo_batch`, `create_auto_upload`) — these previously bypassed per-phone access control entirely
- Fix inverted gate order in `create_auto_upload` — confirmation fired before phone was resolved
- Seed unsaved accounts with all-enabled defaults in `save_tool_permissions` to prevent implicit denial of unconfigured phones

## Test plan
- [x] `pytest tests/test_tool_permissions.py -v -n auto` — 62 passed
- [x] `ruff check src/agent/tools/ tests/test_tool_permissions.py` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)