### PR TITLE
feat: add read_messages agent tool for previewing chat content

### DIFF
--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -664,7 +664,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if perm_gate:
             return perm_gate
         chat_id = args.get("chat_id", "")
-        limit = args.get("limit") or 100
+        limit = min(int(args.get("limit") or 100), 500)
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -675,14 +675,21 @@ def register(db, client_pool, embedding_service, **kwargs):
             entity = await client.get_entity(chat_id)
             lines = [f"Последние {limit} сообщений из {chat_id}:\n"]
             count = 0
+            total_chars = 0
+            budget = 50_000
             async for msg in client.iter_messages(entity, limit=limit):
                 if not msg.text:
                     continue
                 sender = f" [id:{msg.sender_id}]" if msg.sender_id else ""
                 date_str = msg.date.strftime("%Y-%m-%d %H:%M") if msg.date else ""
                 preview = msg.text[:500]
-                lines.append(f"#{msg.id} {date_str}{sender}: {preview}")
+                line = f"#{msg.id} {date_str}{sender}: {preview}"
+                lines.append(line)
+                total_chars += len(line)
                 count += 1
+                if total_chars >= budget:
+                    lines.append(f"\n[Вывод обрезан после {count} сообщений, достигнут лимит символов]")
+                    break
             if count == 0:
                 return _text_response("Сообщений с текстом не найдено.")
             lines.append(f"\nИтого: {count} сообщений.")

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -645,4 +645,51 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(mark_read)
 
+    @tool(
+        "read_messages",
+        "Read the last N messages from any Telegram chat or channel without storing them in the database. "
+        "Useful to preview content before deciding whether to collect it. "
+        "chat_id can be a username (@channel), t.me link, numeric ID, or 'me' for Saved Messages. "
+        "Default limit is 100 messages.",
+        {"phone": str, "chat_id": str, "limit": int},
+    )
+    async def read_messages(args):
+        pool_gate = require_pool(client_pool, "Чтение сообщений")
+        if pool_gate:
+            return pool_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "read_messages")
+        if perm_gate:
+            return perm_gate
+        chat_id = args.get("chat_id", "")
+        limit = args.get("limit") or 100
+        if not chat_id:
+            return _text_response("Ошибка: chat_id обязателен.")
+        try:
+            result = await client_pool.get_native_client_by_phone(phone)
+            if result is None:
+                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            client, _ = result
+            entity = await client.get_entity(chat_id)
+            lines = [f"Последние {limit} сообщений из {chat_id}:\n"]
+            count = 0
+            async for msg in client.iter_messages(entity, limit=limit):
+                if not msg.text:
+                    continue
+                sender = f" [id:{msg.sender_id}]" if msg.sender_id else ""
+                date_str = msg.date.strftime("%Y-%m-%d %H:%M") if msg.date else ""
+                preview = msg.text[:500]
+                lines.append(f"#{msg.id} {date_str}{sender}: {preview}")
+                count += 1
+            if count == 0:
+                return _text_response("Сообщений с текстом не найдено.")
+            lines.append(f"\nИтого: {count} сообщений.")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка чтения сообщений: {e}")
+
+    tools.append(read_messages)
+
     return tools

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -664,7 +664,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if perm_gate:
             return perm_gate
         chat_id = args.get("chat_id", "")
-        limit = min(int(args.get("limit") or 100), 500)
+        limit = max(1, min(int(args.get("limit") or 100), 500))
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -664,7 +664,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         if perm_gate:
             return perm_gate
         chat_id = args.get("chat_id", "")
-        limit = max(1, min(int(args.get("limit") or 100), 500))
+        try:
+            limit = max(1, min(int(args.get("limit") or 100), 500))
+        except (TypeError, ValueError):
+            limit = 100
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -141,6 +141,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "archive_chat": ToolCategory.WRITE,
     "unarchive_chat": ToolCategory.WRITE,
     "mark_read": ToolCategory.WRITE,
+    "read_messages": ToolCategory.READ,
     # Images
     "generate_image": ToolCategory.WRITE,
     "list_image_models": ToolCategory.READ,
@@ -221,7 +222,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ]),
     ("Сообщения", [
         "send_message", "forward_messages", "edit_message", "delete_message",
-        "pin_message", "unpin_message", "download_media",
+        "pin_message", "unpin_message", "download_media", "read_messages",
     ]),
     ("Управление чатом", [
         "get_participants", "edit_admin", "edit_permissions", "kick_participant",


### PR DESCRIPTION
## Summary
- New agent tool `read_messages` that reads the last N messages (default 100) from any Telegram chat or channel directly via Telethon
- Does **not** store messages in the database — useful for previewing content before deciding whether to collect it
- Registered as `READ` in `TOOL_CATEGORIES` and added to `"Сообщения"` group in `MODULE_GROUPS`

## Details
- Accepts: `phone` (optional, defaults to primary account), `chat_id` (required — @username, t.me link, numeric ID, or `me`), `limit` (optional, default 100)
- Works with channels, groups, personal chats, and Saved Messages
- Skips messages without text (media without captions)
- Output format: `#id date [id:sender]: text (up to 500 chars)`

## Test plan
- [ ] Start agent: `python -m src.main agent chat`
- [ ] Ask agent: "Прочитай последние 20 сообщений из @durov"
- [ ] Verify `read_messages` tool is called and returns message text without DB writes
- [ ] Check tool appears in Settings UI under "Сообщения" group
- [ ] Run tests: `pytest tests/ -v -m "not aiosqlite_serial" -n auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)