### PR TITLE
feat: add interactive TUI chat for agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "openpyxl==3.1.5",
     "aiohttp==3.13.3",
     "numpy==2.4.3",
+    "textual[syntax]>=1.0.0",
     "claude-agent-sdk==0.1.50",
     "deepagents==0.4.12",
     "langchain==1.2.12",
@@ -76,6 +77,7 @@ include = ["src*"]
 src = [
     "web/templates/*.html",
     "web/static/*.css",
+    "cli/commands/*.tcss",
 ]
 
 [tool.ruff]

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -98,40 +98,48 @@ def run(args: argparse.Namespace) -> None:
             elif action == "chat":
                 from src.agent.manager import AgentManager
 
-                if args.thread_id:
-                    thread_id = args.thread_id
-                else:
-                    thread_id = await db.create_agent_thread("Новый тред")
-                    print(f"(создан тред #{thread_id})")
-
-                await db.save_agent_message(thread_id, "user", args.message)
-
                 mgr = AgentManager(db, config)
                 await mgr.refresh_settings_cache(preflight=True)
                 mgr.initialize()
 
-                model = getattr(args, "model", None)
-                print("Агент: ", end="", flush=True)
-                full_text = ""
-                async for chunk in mgr.chat_stream(thread_id, args.message, model=model):
-                    raw = chunk.removeprefix("data: ").strip()
-                    try:
-                        payload = json.loads(raw)
-                    except Exception:
-                        continue
-                    if "text" in payload:
-                        print(payload["text"], end="", flush=True)
-                        full_text += payload.get("text", "")
-                    if payload.get("done"):
-                        print()
-                        break
-                    if "error" in payload:
-                        print(f"\nОшибка: {payload['error']}")
-                        await db.delete_last_agent_exchange(thread_id)
-                        break
+                if args.prompt:
+                    # One-shot mode
+                    if args.thread_id:
+                        thread_id = args.thread_id
+                    else:
+                        thread_id = await db.create_agent_thread("Новый тред")
+                        print(f"(создан тред #{thread_id})")
 
-                if full_text:
-                    await db.save_agent_message(thread_id, "assistant", full_text)
+                    await db.save_agent_message(thread_id, "user", args.prompt)
+
+                    model = getattr(args, "model", None)
+                    print("Агент: ", end="", flush=True)
+                    full_text = ""
+                    async for chunk in mgr.chat_stream(thread_id, args.prompt, model=model):
+                        raw = chunk.removeprefix("data: ").strip()
+                        try:
+                            payload = json.loads(raw)
+                        except Exception:
+                            continue
+                        if "text" in payload:
+                            print(payload["text"], end="", flush=True)
+                            full_text += payload.get("text", "")
+                        if payload.get("done"):
+                            print()
+                            break
+                        if "error" in payload:
+                            print(f"\nОшибка: {payload['error']}")
+                            await db.delete_last_agent_exchange(thread_id)
+                            break
+
+                    if full_text:
+                        await db.save_agent_message(thread_id, "assistant", full_text)
+                else:
+                    # Interactive TUI mode
+                    from src.cli.commands.agent_tui import AgentTuiApp
+
+                    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+                    await app.run_async()
 
             elif action == "thread-rename":
                 await db.rename_agent_thread(args.thread_id, args.title[:100])

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -310,3 +310,7 @@ class AgentTuiApp(App):
             await self.db.delete_last_agent_exchange(thread_id)
             if widget.is_attached:
                 await widget.remove()
+        except Exception as exc:
+            logger.exception("Unexpected error in stream worker")
+            widget.set_error(str(exc))
+            await self.db.delete_last_agent_exchange(thread_id)

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -305,4 +305,5 @@ class AgentTuiApp(App):
                 widget.finalize()
         except asyncio.CancelledError:
             await self.db.delete_last_agent_exchange(thread_id)
-            await widget.remove()
+            if widget.is_attached:
+                await widget.remove()

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -193,6 +193,7 @@ class AgentTuiApp(App):
         await sidebar.refresh_threads(threads, self.current_thread_id)
 
     async def _switch_thread(self, thread_id: int) -> None:
+        self.action_cancel_stream()
         self.current_thread_id = thread_id
         messages_container = self.query_one("#messages", VerticalScroll)
         await messages_container.remove_children()

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual import on
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Button, Footer, Header, Label, Markdown, Static, TextArea
+
+if TYPE_CHECKING:
+    from src.agent.manager import AgentManager
+    from src.config import AppConfig
+    from src.database import Database
+
+logger = logging.getLogger(__name__)
+
+CSS_PATH = Path(__file__).parent / "agent_tui.tcss"
+
+
+class ThreadItem(Widget):
+    """Clickable thread item in sidebar."""
+
+    DEFAULT_CSS = ""
+
+    def __init__(self, thread_id: int, title: str, active: bool = False) -> None:
+        super().__init__()
+        self.thread_id = thread_id
+        self._title = title
+        if active:
+            self.add_class("active")
+
+    def compose(self) -> ComposeResult:
+        yield Label(self._title)
+
+    def on_click(self) -> None:
+        self.app.post_message(ThreadSelected(self.thread_id))
+
+    def set_active(self, active: bool) -> None:
+        if active:
+            self.add_class("active")
+        else:
+            self.remove_class("active")
+
+
+class ThreadSelected(App.Message if False else object):
+    """Custom message for thread selection."""
+
+    def __new__(cls, thread_id: int):  # type: ignore[override]
+        return object.__new__(cls)
+
+    def __init__(self, thread_id: int) -> None:
+        self.thread_id = thread_id
+
+
+# Use proper Textual message system
+from textual.message import Message  # noqa: E402
+
+
+class ThreadSelected(Message):  # noqa: F811
+    def __init__(self, thread_id: int) -> None:
+        super().__init__()
+        self.thread_id = thread_id
+
+
+class MessageBubble(Static):
+    """Static message bubble (user or assistant)."""
+
+    def __init__(self, role: str, content: str) -> None:
+        css_class = "user-bubble" if role == "user" else "assistant-bubble"
+        border_title = "Вы" if role == "user" else "Агент"
+        super().__init__(classes=css_class)
+        self.border_title = border_title
+        self._role = role
+        self._content = content
+
+    def compose(self) -> ComposeResult:
+        if self._role == "assistant":
+            yield Markdown(self._content)
+        else:
+            yield Label(self._content)
+
+
+class StreamingMessage(Static):
+    """Message bubble that accumulates streamed text with throttled Markdown updates."""
+
+    def __init__(self) -> None:
+        super().__init__(classes="streaming-bubble")
+        self.border_title = "Агент (печатает…)"
+        self._content = ""
+        self._md: Markdown | None = None
+        self._render_timer: asyncio.TimerHandle | None = None
+        self._pending_render = False
+
+    def compose(self) -> ComposeResult:
+        md = Markdown("")
+        self._md = md
+        yield md
+
+    def append_text(self, text: str) -> None:
+        self._content += text
+        if not self._pending_render:
+            self._pending_render = True
+            self.set_timer(0.1, self._do_render)
+
+    def _do_render(self) -> None:
+        self._pending_render = False
+        if self._md is not None:
+            self._md.update(self._content)
+
+    def set_error(self, error: str) -> None:
+        self.add_class("user-bubble")
+        self.remove_class("streaming-bubble")
+        self.border_title = "Ошибка"
+        if self._md is not None:
+            self._md.update(f"**Ошибка:** {error}")
+
+    def finalize(self) -> None:
+        """Convert to static assistant bubble after streaming completes."""
+        self._pending_render = False
+        self.remove_class("streaming-bubble")
+        self.add_class("assistant-bubble")
+        self.border_title = "Агент"
+        if self._md is not None and self._content:
+            self._md.update(self._content)
+
+
+class ThreadSidebar(Container):
+    """Left sidebar with thread list."""
+
+    def compose(self) -> ComposeResult:
+        yield Label("Треды", id="sidebar-title")
+        yield Button("+ Новый тред", id="new-thread-btn", variant="primary")
+        yield Container(id="thread-list")
+
+    async def refresh_threads(self, threads: list[dict], active_id: int | None) -> None:
+        thread_list = self.query_one("#thread-list")
+        await thread_list.remove_children()
+        for t in threads:
+            item = ThreadItem(t["id"], t["title"], active=t["id"] == active_id)
+            await thread_list.mount(item)
+
+    def set_active(self, thread_id: int) -> None:
+        for item in self.query(ThreadItem):
+            item.set_active(item.thread_id == thread_id)
+
+
+class AgentTuiApp(App):
+    """Interactive TUI chat with agent."""
+
+    CSS_PATH = str(CSS_PATH)
+
+    BINDINGS = [
+        Binding("ctrl+n", "new_thread", "Новый тред", show=True),
+        Binding("ctrl+d", "delete_thread", "Удалить тред", show=True),
+        Binding("ctrl+t", "toggle_sidebar", "Sidebar", show=True),
+        Binding("escape", "cancel_stream", "Отмена", show=True),
+        Binding("ctrl+q", "quit", "Выход", show=True),
+        Binding("ctrl+s", "send_message", "Отправить", show=False),
+    ]
+
+    current_thread_id: reactive[int | None] = reactive(None)
+
+    def __init__(self, db: "Database", config: "AppConfig", agent_manager: "AgentManager") -> None:
+        super().__init__()
+        self.db = db
+        self.config = config
+        self.agent_manager = agent_manager
+        self._stream_worker = None
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal():
+            with ThreadSidebar(id="sidebar"):
+                pass
+            with Vertical(id="chat-area"):
+                with VerticalScroll(id="messages"):
+                    pass
+                with Horizontal(id="input-bar"):
+                    yield TextArea(id="input")
+                    yield Button("Отправить", id="send-btn", variant="success")
+        yield Footer()
+
+    async def on_mount(self) -> None:
+        threads = await self.db.get_agent_threads()
+        if threads:
+            await self._switch_thread(threads[0]["id"])
+        else:
+            tid = await self.db.create_agent_thread("Новый тред")
+            await self._switch_thread(tid)
+        await self._refresh_sidebar()
+
+    async def _refresh_sidebar(self) -> None:
+        threads = await self.db.get_agent_threads()
+        sidebar = self.query_one(ThreadSidebar)
+        await sidebar.refresh_threads(threads, self.current_thread_id)
+
+    async def _switch_thread(self, thread_id: int) -> None:
+        self.current_thread_id = thread_id
+        messages_container = self.query_one("#messages", VerticalScroll)
+        await messages_container.remove_children()
+        msgs = await self.db.get_agent_messages(thread_id)
+        for msg in msgs:
+            bubble = MessageBubble(msg["role"], msg["content"])
+            await messages_container.mount(bubble)
+        messages_container.scroll_end(animate=False)
+        try:
+            sidebar = self.query_one(ThreadSidebar)
+            sidebar.set_active(thread_id)
+        except NoMatches:
+            pass
+
+    @on(ThreadSelected)
+    async def on_thread_selected(self, message: ThreadSelected) -> None:
+        if message.thread_id != self.current_thread_id:
+            await self._switch_thread(message.thread_id)
+
+    @on(Button.Pressed, "#new-thread-btn")
+    async def on_new_thread_btn(self) -> None:
+        await self.action_new_thread()
+
+    @on(Button.Pressed, "#send-btn")
+    async def on_send_btn(self) -> None:
+        await self.action_send_message()
+
+    async def action_new_thread(self) -> None:
+        tid = await self.db.create_agent_thread("Новый тред")
+        await self._switch_thread(tid)
+        await self._refresh_sidebar()
+
+    async def action_delete_thread(self) -> None:
+        if self.current_thread_id is None:
+            return
+        await self.db.delete_agent_thread(self.current_thread_id)
+        threads = await self.db.get_agent_threads()
+        if threads:
+            await self._switch_thread(threads[0]["id"])
+        else:
+            tid = await self.db.create_agent_thread("Новый тред")
+            await self._switch_thread(tid)
+        await self._refresh_sidebar()
+
+    async def action_toggle_sidebar(self) -> None:
+        sidebar = self.query_one("#sidebar", ThreadSidebar)
+        sidebar.display = not sidebar.display
+
+    def action_cancel_stream(self) -> None:
+        if self._stream_worker is not None and not self._stream_worker.is_cancelled:
+            self._stream_worker.cancel()
+
+    async def action_send_message(self) -> None:
+        input_area = self.query_one("#input", TextArea)
+        message = input_area.text.strip()
+        if not message or self.current_thread_id is None:
+            return
+        input_area.clear()
+
+        thread_id = self.current_thread_id
+        await self.db.save_agent_message(thread_id, "user", message)
+
+        messages_container = self.query_one("#messages", VerticalScroll)
+        await messages_container.mount(MessageBubble("user", message))
+        messages_container.scroll_end(animate=False)
+
+        # Auto-rename thread on first user message
+        thread = await self.db.get_agent_thread(thread_id)
+        if thread and thread["title"] == "Новый тред":
+            new_title = message[:60]
+            await self.db.rename_agent_thread(thread_id, new_title)
+            await self._refresh_sidebar()
+
+        streaming_msg = StreamingMessage()
+        await messages_container.mount(streaming_msg)
+        messages_container.scroll_end(animate=False)
+
+        self._stream_worker = self.run_worker(
+            self._stream_response(thread_id, message, streaming_msg),
+            exclusive=False,
+            group="chat",
+            thread=False,
+        )
+
+    async def _stream_response(self, thread_id: int, message: str, widget: StreamingMessage) -> None:
+        model = getattr(self.config, "agent", None)
+        model = None  # let AgentManager pick default
+
+        messages_container = self.query_one("#messages", VerticalScroll)
+        full_text = ""
+        try:
+            async for chunk in self.agent_manager.chat_stream(thread_id, message, model=model):
+                raw = chunk.removeprefix("data: ").strip()
+                try:
+                    payload = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if "text" in payload:
+                    full_text += payload["text"]
+                    widget.append_text(payload["text"])
+                    messages_container.scroll_end(animate=False)
+                if payload.get("done"):
+                    break
+                if "error" in payload:
+                    widget.set_error(payload["error"])
+                    await self.db.delete_last_agent_exchange(thread_id)
+                    return
+            if full_text:
+                await self.db.save_agent_message(thread_id, "assistant", full_text)
+                widget.finalize()
+        except asyncio.CancelledError:
+            await self.db.delete_last_agent_exchange(thread_id)
+            await widget.remove()

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -305,7 +305,7 @@ class AgentTuiApp(App):
                     return
             if full_text:
                 await self.db.save_agent_message(thread_id, "assistant", full_text)
-                widget.finalize()
+            widget.finalize()
         except asyncio.CancelledError:
             await self.db.delete_last_agent_exchange(thread_id)
             if widget.is_attached:

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -247,6 +247,8 @@ class AgentTuiApp(App):
             self._stream_worker.cancel()
 
     async def action_send_message(self) -> None:
+        if self._stream_worker is not None and not self._stream_worker.is_cancelled:
+            return  # prevent double-send while streaming to avoid delete_last_agent_exchange deleting next user message
         input_area = self.query_one("#input", TextArea)
         message = input_area.text.strip()
         if not message or self.current_thread_id is None:

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -50,21 +50,10 @@ class ThreadItem(Widget):
             self.remove_class("active")
 
 
-class ThreadSelected(App.Message if False else object):
-    """Custom message for thread selection."""
-
-    def __new__(cls, thread_id: int):  # type: ignore[override]
-        return object.__new__(cls)
-
-    def __init__(self, thread_id: int) -> None:
-        self.thread_id = thread_id
-
-
-# Use proper Textual message system
 from textual.message import Message  # noqa: E402
 
 
-class ThreadSelected(Message):  # noqa: F811
+class ThreadSelected(Message):
     def __init__(self, thread_id: int) -> None:
         super().__init__()
         self.thread_id = thread_id
@@ -116,6 +105,7 @@ class StreamingMessage(Static):
             self._md.update(self._content)
 
     def set_error(self, error: str) -> None:
+        self._pending_render = False
         self.add_class("user-bubble")
         self.remove_class("streaming-bubble")
         self.border_title = "Ошибка"
@@ -282,13 +272,12 @@ class AgentTuiApp(App):
 
         self._stream_worker = self.run_worker(
             self._stream_response(thread_id, message, streaming_msg),
-            exclusive=False,
+            exclusive=True,
             group="chat",
             thread=False,
         )
 
     async def _stream_response(self, thread_id: int, message: str, widget: StreamingMessage) -> None:
-        model = getattr(self.config, "agent", None)
         model = None  # let AgentManager pick default
 
         messages_container = self.query_one("#messages", VerticalScroll)

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -14,6 +14,7 @@ from textual.css.query import NoMatches
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Button, Footer, Header, Label, Markdown, Static, TextArea
+from textual.worker import WorkerState
 
 if TYPE_CHECKING:
     from src.agent.manager import AgentManager
@@ -247,7 +248,7 @@ class AgentTuiApp(App):
             self._stream_worker.cancel()
 
     async def action_send_message(self) -> None:
-        if self._stream_worker is not None and not self._stream_worker.is_cancelled:
+        if self._stream_worker is not None and self._stream_worker.state in (WorkerState.PENDING, WorkerState.RUNNING):
             return  # prevent double-send while streaming to avoid delete_last_agent_exchange deleting next user message
         input_area = self.query_one("#input", TextArea)
         message = input_area.text.strip()

--- a/src/cli/commands/agent_tui.tcss
+++ b/src/cli/commands/agent_tui.tcss
@@ -1,0 +1,110 @@
+AgentTuiApp {
+    background: $background;
+}
+
+#sidebar {
+    width: 30;
+    border-right: solid $primary-darken-2;
+    background: $surface;
+}
+
+#sidebar-title {
+    width: 1fr;
+    height: 1;
+    content-align: center middle;
+    background: $primary-darken-3;
+    color: $text;
+    text-style: bold;
+}
+
+#new-thread-btn {
+    width: 1fr;
+    margin: 1 1 0 1;
+}
+
+#thread-list {
+    width: 1fr;
+    height: 1fr;
+    margin-top: 1;
+}
+
+ThreadItem {
+    width: 1fr;
+    height: 2;
+    padding: 0 1;
+    border-bottom: solid $primary-darken-3;
+}
+
+ThreadItem:hover {
+    background: $primary-darken-2;
+}
+
+ThreadItem.active {
+    background: $primary-darken-1;
+}
+
+ThreadItem Label {
+    width: 1fr;
+    overflow: hidden hidden;
+}
+
+#chat-area {
+    width: 1fr;
+    background: $background;
+}
+
+#messages {
+    width: 1fr;
+    height: 1fr;
+    padding: 0 1;
+}
+
+.user-bubble {
+    margin: 1 0;
+    padding: 1 2;
+    background: $surface;
+    border: solid $primary-darken-2;
+    border-title-color: $accent;
+    color: $text;
+}
+
+.assistant-bubble {
+    margin: 1 0;
+    padding: 1 2;
+    background: $background;
+    border: solid $success-darken-2;
+    border-title-color: $success;
+    color: $text;
+}
+
+.streaming-bubble {
+    margin: 1 0;
+    padding: 1 2;
+    background: $background;
+    border: dashed $warning-darken-1;
+    border-title-color: $warning;
+}
+
+#input-bar {
+    height: auto;
+    max-height: 8;
+    min-height: 3;
+    dock: bottom;
+    border-top: solid $primary-darken-2;
+    padding: 0 1;
+    background: $surface;
+}
+
+#input {
+    width: 1fr;
+    height: auto;
+    min-height: 1;
+    max-height: 6;
+    margin: 0 1 0 0;
+    border: solid $primary-darken-2;
+}
+
+#send-btn {
+    width: 12;
+    height: 3;
+}

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -549,8 +549,8 @@ def build_parser() -> argparse.ArgumentParser:
     agent_delete = agent_sub.add_parser("thread-delete", help="Delete thread")
     agent_delete.add_argument("thread_id", type=int, help="Thread ID")
 
-    agent_chat = agent_sub.add_parser("chat", help="Send message to agent")
-    agent_chat.add_argument("message", help="Message text")
+    agent_chat = agent_sub.add_parser("chat", help="Interactive TUI chat or one-shot message (with -p)")
+    agent_chat.add_argument("-p", "--prompt", default=None, dest="prompt", help="Message text (non-interactive mode)")
     agent_chat.add_argument("--thread-id", type=int, default=None, dest="thread_id")
     agent_chat.add_argument("--model", default=None, help="Model name")
 

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -1,0 +1,450 @@
+"""Tests for the agent TUI (agent_tui.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.config import AppConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sse_chunk(text: str) -> str:
+    return f"data: {json.dumps({'text': text})}\n\n"
+
+
+def _make_sse_done(full_text: str) -> str:
+    return f"data: {json.dumps({'done': True, 'full_text': full_text})}\n\n"
+
+
+def _make_sse_error(msg: str) -> str:
+    return f"data: {json.dumps({'error': msg})}\n\n"
+
+
+async def _fake_stream(*chunks: str):
+    """Async generator yielding SSE chunks."""
+    for chunk in chunks:
+        yield chunk
+
+
+def _make_manager(*chunks: str) -> MagicMock:
+    """AgentManager mock whose chat_stream yields the given chunks."""
+    mgr = MagicMock()
+    mgr.chat_stream = MagicMock(return_value=_fake_stream(*chunks))
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# StreamingMessage unit tests (no Textual pilot needed)
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_message_append_accumulates():
+    from unittest.mock import MagicMock
+
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._content = ""
+    widget.set_timer = MagicMock()  # avoid needing event loop
+    widget.append_text("hello")
+    widget.append_text(" world")
+    assert widget._content == "hello world"
+
+
+def test_streaming_message_finalize_changes_class():
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._content = "done"
+    widget._md = MagicMock()
+    widget.finalize()
+    assert "assistant-bubble" in widget.classes
+    assert "streaming-bubble" not in widget.classes
+
+
+def test_streaming_message_set_error_changes_class():
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._md = MagicMock()
+    widget.set_error("boom")
+    assert "user-bubble" in widget.classes
+    assert "streaming-bubble" not in widget.classes
+    assert widget.border_title == "Ошибка"
+
+
+# ---------------------------------------------------------------------------
+# ThreadItem unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_thread_item_active_class():
+    from src.cli.commands.agent_tui import ThreadItem
+
+    item = ThreadItem(thread_id=1, title="test", active=True)
+    assert "active" in item.classes
+
+    item2 = ThreadItem(thread_id=2, title="test2", active=False)
+    assert "active" not in item2.classes
+
+
+def test_thread_item_set_active():
+    from src.cli.commands.agent_tui import ThreadItem
+
+    item = ThreadItem(thread_id=1, title="test")
+    item.set_active(True)
+    assert "active" in item.classes
+    item.set_active(False)
+    assert "active" not in item.classes
+
+
+# ---------------------------------------------------------------------------
+# AgentTuiApp integration tests via Textual pilot
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_factory(db):
+    """Returns a factory that builds AgentTuiApp with fresh mock manager."""
+
+    def _factory(chunks=None):
+        from src.cli.commands.agent_tui import AgentTuiApp
+
+        if chunks is None:
+            chunks = [_make_sse_chunk("hi"), _make_sse_done("hi")]
+        config = AppConfig()
+        mgr = _make_manager(*chunks)
+        return AgentTuiApp(db=db, config=config, agent_manager=mgr)
+
+    return _factory
+
+
+@pytest.mark.asyncio
+async def test_tui_mounts_and_shows_threads(db, app_factory):
+    """App mounts, auto-creates a thread, sidebar renders it."""
+    app = app_factory()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from src.cli.commands.agent_tui import ThreadItem
+
+        items = app.query(ThreadItem)
+        assert len(items) >= 1
+
+
+@pytest.mark.asyncio
+async def test_tui_shows_existing_thread_messages(db, app_factory):
+    """Existing messages are rendered when thread loads."""
+    tid = await db.create_agent_thread("my thread")
+    await db.save_agent_message(tid, "user", "hello from user")
+    await db.save_agent_message(tid, "assistant", "hello from agent")
+
+    app = app_factory()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from src.cli.commands.agent_tui import MessageBubble
+
+        bubbles = app.query(MessageBubble)
+        roles = [b._role for b in bubbles]
+        assert "user" in roles
+        assert "assistant" in roles
+
+
+@pytest.mark.asyncio
+async def test_tui_send_message_calls_chat_stream(db, app_factory):
+    """Sending a message triggers chat_stream on the AgentManager."""
+    config = AppConfig()
+    chunks = [_make_sse_chunk("response"), _make_sse_done("response")]
+    mgr = _make_manager(*chunks)
+
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from textual.widgets import TextArea
+
+        input_area = app.query_one("#input", TextArea)
+        input_area.load_text("test message")
+        await pilot.click("#send-btn")
+        await pilot.pause(0.2)
+
+    mgr.chat_stream.assert_called_once()
+    call_args = mgr.chat_stream.call_args
+    assert call_args[0][1] == "test message" or call_args[1].get("message") == "test message" or True
+    # thread_id and message are positional args
+    assert "test message" in str(call_args)
+
+
+@pytest.mark.asyncio
+async def test_tui_send_message_saves_to_db(db, app_factory):
+    """User message and assistant response are saved to DB."""
+    config = AppConfig()
+    chunks = [_make_sse_chunk("agent reply"), _make_sse_done("agent reply")]
+    mgr = _make_manager(*chunks)
+
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        thread_id = app.current_thread_id
+        from textual.widgets import TextArea
+
+        input_area = app.query_one("#input", TextArea)
+        input_area.load_text("my question")
+        await pilot.click("#send-btn")
+        await pilot.pause(0.3)
+
+    msgs = await db.get_agent_messages(thread_id)
+    roles = [m["role"] for m in msgs]
+    assert "user" in roles
+    contents = [m["content"] for m in msgs]
+    assert "my question" in contents
+
+
+@pytest.mark.asyncio
+async def test_tui_new_thread_action(db, app_factory):
+    """Ctrl+N creates a new thread."""
+    app = app_factory()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        threads_before = await db.get_agent_threads()
+        await pilot.press("ctrl+n")
+        await pilot.pause(0.1)
+        threads_after = await db.get_agent_threads()
+        assert len(threads_after) == len(threads_before) + 1
+
+
+@pytest.mark.asyncio
+async def test_tui_delete_thread_action(db, app_factory):
+    """Ctrl+D deletes the active thread and auto-creates a new one if needed."""
+    app = app_factory()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        threads_before = await db.get_agent_threads()
+        assert len(threads_before) >= 1
+        active_id = app.current_thread_id
+        await pilot.press("ctrl+d")
+        await pilot.pause(0.1)
+        threads_after = await db.get_agent_threads()
+        remaining_ids = [t["id"] for t in threads_after]
+        assert active_id not in remaining_ids
+
+
+@pytest.mark.asyncio
+async def test_tui_toggle_sidebar(db, app_factory):
+    """Ctrl+T toggles sidebar visibility."""
+    app = app_factory()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from src.cli.commands.agent_tui import ThreadSidebar
+
+        sidebar = app.query_one(ThreadSidebar)
+        assert sidebar.display is True
+        await pilot.press("ctrl+t")
+        await pilot.pause(0.1)
+        assert sidebar.display is False
+        await pilot.press("ctrl+t")
+        await pilot.pause(0.1)
+        assert sidebar.display is True
+
+
+@pytest.mark.asyncio
+async def test_tui_thread_auto_rename(db, app_factory):
+    """First message auto-renames 'Новый тред'."""
+    config = AppConfig()
+    chunks = [_make_sse_chunk("ok"), _make_sse_done("ok")]
+    mgr = _make_manager(*chunks)
+
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        thread_id = app.current_thread_id
+        from textual.widgets import TextArea
+
+        input_area = app.query_one("#input", TextArea)
+        input_area.load_text("Hello world!")
+        await pilot.click("#send-btn")
+        await pilot.pause(0.2)
+
+    thread = await db.get_agent_thread(thread_id)
+    assert thread["title"] == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_tui_error_chunk_cleans_up(db, app_factory):
+    """SSE error chunk triggers cleanup via delete_last_agent_exchange."""
+    config = AppConfig()
+    chunks = [_make_sse_error("something went wrong")]
+    mgr = _make_manager(*chunks)
+    db.delete_last_agent_exchange = AsyncMock()
+
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from textual.widgets import TextArea
+
+        input_area = app.query_one("#input", TextArea)
+        input_area.load_text("trigger error")
+        await pilot.click("#send-btn")
+        await pilot.pause(0.2)
+
+    db.delete_last_agent_exchange.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI one-shot mode (prompt=) tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentChatOneShotMode:
+    """Tests for `agent chat -p <message>` one-shot mode."""
+
+    def _run_chat(self, cli_env, prompt: str, thread_id=None, monkeypatch=None, capsys=None):
+        """Helper: run agent chat in one-shot mode with mocked AgentManager."""
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
+
+        from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+        from src.cli.commands.agent import run
+        from tests.helpers import cli_ns as _ns
+
+        if monkeypatch:
+            monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        text_block = TextBlock(text="one-shot reply")
+        assistant_msg = MagicMock(spec=AssistantMessage)
+        assistant_msg.content = [text_block]
+        result_msg = MagicMock(spec=ResultMessage)
+
+        async def mock_query(prompt, options):
+            yield assistant_msg
+            yield result_msg
+
+        async def fake_init_db(_path):
+            return AppConfig(), cli_env
+
+        with (
+            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            _patch("src.agent.manager.query", mock_query),
+        ):
+            run(_ns(agent_action="chat", prompt=prompt, thread_id=thread_id, model=None))
+
+    def test_one_shot_prints_response(self, cli_env, capsys, monkeypatch):
+        self._run_chat(cli_env, "hello", monkeypatch=monkeypatch)
+        assert "one-shot reply" in capsys.readouterr().out
+
+    def test_one_shot_creates_thread_if_none(self, cli_env, monkeypatch):
+        import sqlite3
+
+        self._run_chat(cli_env, "hi", monkeypatch=monkeypatch)
+        conn = sqlite3.connect(cli_env._db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM agent_threads").fetchone()[0]
+        finally:
+            conn.close()
+        assert count >= 1
+
+    def test_one_shot_uses_existing_thread(self, cli_env, monkeypatch):
+        import sqlite3
+
+        tid = asyncio.run(cli_env.create_agent_thread("existing"))
+        self._run_chat(cli_env, "hi", thread_id=tid, monkeypatch=monkeypatch)
+        # CLI closes the aiosqlite connection, use raw sqlite3 to read state
+        conn = sqlite3.connect(cli_env._db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = [dict(r) for r in conn.execute(
+                "SELECT role, content FROM agent_messages WHERE thread_id = ?", (tid,)
+            ).fetchall()]
+        finally:
+            conn.close()
+        assert any(r["role"] == "user" and r["content"] == "hi" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# CLI interactive mode (no prompt) launches TUI
+# ---------------------------------------------------------------------------
+
+
+class TestAgentChatInteractiveMode:
+    """Tests that `agent chat` without --prompt launches TUI."""
+
+    def test_no_prompt_launches_tui(self, cli_env, monkeypatch):
+        """When prompt is None, AgentTuiApp.run_async() is called."""
+        from unittest.mock import AsyncMock
+        from unittest.mock import patch as _patch
+
+        from src.cli.commands.agent import run
+        from tests.helpers import cli_ns as _ns
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        async def fake_init_db(_path):
+            return AppConfig(), cli_env
+
+        mock_run_async = AsyncMock()
+
+        with (
+            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            _patch("src.cli.commands.agent_tui.AgentTuiApp.run_async", mock_run_async),
+        ):
+            run(_ns(agent_action="chat", prompt=None, thread_id=None, model=None))
+
+        mock_run_async.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentChatParser:
+    def test_prompt_flag_long(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["agent", "chat", "--prompt", "hello"])
+        assert args.agent_action == "chat"
+        assert args.prompt == "hello"
+
+    def test_prompt_flag_short(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["agent", "chat", "-p", "hello"])
+        assert args.prompt == "hello"
+
+    def test_no_prompt_is_none(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["agent", "chat"])
+        assert args.prompt is None
+
+    def test_prompt_with_model(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["agent", "chat", "-p", "hi", "--model", "claude-haiku-4-5-20251001"])
+        assert args.prompt == "hi"
+        assert args.model == "claude-haiku-4-5-20251001"
+
+    def test_prompt_with_thread_id(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["agent", "chat", "-p", "hi", "--thread-id", "5"])
+        assert args.prompt == "hi"
+        assert args.thread_id == 5

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -176,7 +176,7 @@ async def test_tui_send_message_calls_chat_stream(db, app_factory):
 
     mgr.chat_stream.assert_called_once()
     call_args = mgr.chat_stream.call_args
-    assert call_args[0][1] == "test message" or call_args[1].get("message") == "test message" or True
+    assert call_args[0][1] == "test message" or call_args[1].get("message") == "test message"
     # thread_id and message are positional args
     assert "test message" in str(call_args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,7 +513,7 @@ class TestCLIAgentDbProviders:
             patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
             patch("deepagents.create_deep_agent", return_value=fake_agent),
         ):
-            run(_ns(agent_action="chat", thread_id=thread_id, message="hello", model=None))
+            run(_ns(agent_action="chat", thread_id=thread_id, prompt="hello", model=None))
 
         assert "ok-from-db-provider" in capsys.readouterr().out
 
@@ -1189,7 +1189,7 @@ class TestCLIAgent:
             run(
                 _ns(
                     agent_action="chat",
-                    message="hello",
+                    prompt="hello",
                     thread_id=None,
                     model="claude-haiku-4-5-20251001",
                 )
@@ -1260,9 +1260,18 @@ class TestCLIAgent:
         assert args.channel_id == 100
         assert args.topic_id == 42
 
-        args = parser.parse_args(["agent", "chat", "hi", "--model", "claude-haiku-4-5-20251001"])
+        args = parser.parse_args(["agent", "chat", "--prompt", "hi", "--model", "claude-haiku-4-5-20251001"])
         assert args.agent_action == "chat"
+        assert args.prompt == "hi"
         assert args.model == "claude-haiku-4-5-20251001"
+
+        args = parser.parse_args(["agent", "chat", "-p", "hi"])
+        assert args.agent_action == "chat"
+        assert args.prompt == "hi"
+
+        args = parser.parse_args(["agent", "chat"])
+        assert args.agent_action == "chat"
+        assert args.prompt is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -15,4 +15,5 @@ def test_packaging_config_keeps_src_namespace_for_console_script() -> None:
     assert data["tool"]["setuptools"]["package-data"]["src"] == [
         "web/templates/*.html",
         "web/static/*.css",
+        "cli/commands/*.tcss",
     ]


### PR DESCRIPTION
## Summary
- Add Textual-based interactive terminal UI for `agent chat` command
- `agent chat` now launches TUI by default; one-shot mode via `-p/--prompt` flag
- Includes `.tcss` stylesheet, tests, and `textual` dependency

## Test plan
- [ ] `python -m src.main agent chat` — launches TUI
- [ ] `python -m src.main agent chat -p "hello"` — one-shot mode
- [ ] `pytest tests/test_agent_tui.py tests/test_cli.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)