### PR TITLE
test: add agent tools coverage tests

### DIFF
--- a/tests/test_agent_tools_new1.py
+++ b/tests/test_agent_tools_new1.py
@@ -301,7 +301,7 @@ class TestAddChannelTool:
             mock_svc.return_value.add_by_identifier = AsyncMock(return_value=False)
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["add_channel"]({"identifier": "@existing", "confirm": True})
-        assert "уже существует" in _text(result) or "не удалось добавить" in _text(result)
+        assert "уже существует" in _text(result)
 
     @pytest.mark.asyncio
     async def test_error_returns_text(self, mock_db):

--- a/tests/test_agent_tools_new1.py
+++ b/tests/test_agent_tools_new1.py
@@ -1,0 +1,965 @@
+"""Tests for agent tools: accounts, channels, collection, notifications, settings, messaging.
+
+These tests call actual tool handler functions via the @tool decorator's
+.handler attribute, ensuring argument parsing, formatting, and error handling
+are all exercised.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.database import Database
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock Database for testing tools."""
+    return MagicMock(spec=Database)
+
+
+def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
+    """Build MCP tools and return their handlers keyed by name."""
+    captured_tools = []
+
+    with patch(
+        "src.agent.tools.create_sdk_mcp_server",
+        side_effect=lambda **kw: captured_tools.extend(kw.get("tools", [])),
+    ):
+        from src.agent.tools import make_mcp_server
+
+        make_mcp_server(mock_db, client_pool=client_pool, config=config, **kwargs)
+
+    return {t.name: t.handler for t in captured_tools}
+
+
+def _text(result: dict) -> str:
+    """Extract text from tool result payload."""
+    return result["content"][0]["text"]
+
+
+def _make_account(
+    acc_id=1,
+    phone="+79001234567",
+    is_active=True,
+    flood_wait_until=None,
+    is_primary=True,
+):
+    a = MagicMock()
+    a.id = acc_id
+    a.phone = phone
+    a.is_active = is_active
+    a.flood_wait_until = flood_wait_until
+    a.is_primary = is_primary
+    return a
+
+
+def _make_channel(
+    pk=1,
+    channel_id=100,
+    title="TestChan",
+    username="testchan",
+    is_active=True,
+    is_filtered=False,
+    channel_type="channel",
+):
+    ch = MagicMock()
+    ch.id = pk
+    ch.channel_id = channel_id
+    ch.title = title
+    ch.username = username
+    ch.is_active = is_active
+    ch.is_filtered = is_filtered
+    ch.channel_type = channel_type
+    return ch
+
+
+# ===========================================================================
+# accounts.py
+# ===========================================================================
+
+
+class TestListAccountsTool:
+    @pytest.mark.asyncio
+    async def test_empty_returns_not_found(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_accounts"]({})
+        assert "Аккаунты не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_accounts_shows_phone_and_status(self, mock_db):
+        acc = _make_account(phone="+71112223344", is_active=True)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_accounts"]({})
+        text = _text(result)
+        assert "+71112223344" in text
+        assert "активен" in text
+        assert "Аккаунты (1)" in text
+
+    @pytest.mark.asyncio
+    async def test_inactive_account_shows_inactive(self, mock_db):
+        acc = _make_account(phone="+70000000000", is_active=False)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_accounts"]({})
+        assert "неактивен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_flood_wait_shown(self, mock_db):
+        acc = _make_account(flood_wait_until="2025-01-01 12:00:00")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_accounts"]({})
+        assert "flood_wait" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_accounts = AsyncMock(side_effect=Exception("conn error"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_accounts"]({})
+        assert "Ошибка получения аккаунтов" in _text(result)
+        assert "conn error" in _text(result)
+
+
+class TestToggleAccountTool:
+    @pytest.mark.asyncio
+    async def test_missing_account_id_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_account"]({})
+        assert "account_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_account_not_found_returns_error(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_account"]({"account_id": 999})
+        assert "не найден" in _text(result)
+        assert "999" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_active_account_gets_deactivated(self, mock_db):
+        acc = _make_account(acc_id=1, phone="+71111111111", is_active=True)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.set_account_active = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_account"]({"account_id": 1})
+        text = _text(result)
+        assert "деактивирован" in text
+        mock_db.set_account_active.assert_awaited_once_with(1, False)
+
+    @pytest.mark.asyncio
+    async def test_inactive_account_gets_activated(self, mock_db):
+        acc = _make_account(acc_id=2, phone="+72222222222", is_active=False)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.set_account_active = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_account"]({"account_id": 2})
+        text = _text(result)
+        assert "активирован" in text
+        mock_db.set_account_active.assert_awaited_once_with(2, True)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_accounts = AsyncMock(side_effect=Exception("db fail"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_account"]({"account_id": 1})
+        assert "Ошибка переключения аккаунта" in _text(result)
+
+
+class TestDeleteAccountTool:
+    @pytest.mark.asyncio
+    async def test_missing_account_id_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_account"]({})
+        assert "account_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_account"]({"account_id": 1})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deletes_account(self, mock_db):
+        acc = _make_account(acc_id=5, phone="+75555555555")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.delete_account = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_account"]({"account_id": 5, "confirm": True})
+        assert "удалён" in _text(result)
+        mock_db.delete_account.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        mock_db.delete_account = AsyncMock(side_effect=Exception("constraint"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_account"]({"account_id": 1, "confirm": True})
+        assert "Ошибка удаления аккаунта" in _text(result)
+
+
+class TestGetFloodStatusTool:
+    @pytest.mark.asyncio
+    async def test_no_accounts_returns_not_found(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_flood_status"]({})
+        assert "Аккаунты не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_flood_shows_no_restrictions(self, mock_db):
+        acc = _make_account(phone="+71234567890", flood_wait_until=None)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_flood_status"]({})
+        assert "нет ограничений" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_flood_wait_until_shown(self, mock_db):
+        acc = _make_account(phone="+70001112233", flood_wait_until="2025-06-01 10:00")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_flood_status"]({})
+        assert "заблокирован" in _text(result)
+        assert "2025-06-01 10:00" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_accounts = AsyncMock(side_effect=RuntimeError("oops"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_flood_status"]({})
+        assert "Ошибка получения flood-статуса" in _text(result)
+
+
+class TestClearFloodStatusTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account(phone="+71111111111")])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_flood_status"]({"phone": "+71111111111"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_account_not_found_returns_error(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_flood_status"]({"phone": "+79999999999", "confirm": True})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_clears_flood(self, mock_db):
+        acc = _make_account(phone="+71111111111", flood_wait_until="2025-01-01")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_flood_status"]({"phone": "+71111111111", "confirm": True})
+        assert "сброшен" in _text(result)
+        mock_db.update_account_flood.assert_awaited_once_with("+71111111111", None)
+
+
+# ===========================================================================
+# channels.py
+# ===========================================================================
+
+
+class TestAddChannelTool:
+    @pytest.mark.asyncio
+    async def test_missing_identifier_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_channel"]({})
+        assert "identifier обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_channel"]({"identifier": "@testchan"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_adds_channel(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_by_identifier = AsyncMock(return_value=True)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channel"]({"identifier": "@mychan", "confirm": True})
+        assert "успешно добавлен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_already_exists_returns_message(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_by_identifier = AsyncMock(return_value=False)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channel"]({"identifier": "@existing", "confirm": True})
+        assert "уже существует" in _text(result) or "не удалось добавить" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_by_identifier = AsyncMock(side_effect=Exception("API error"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channel"]({"identifier": "@broken", "confirm": True})
+        assert "Ошибка добавления канала" in _text(result)
+
+
+class TestDeleteChannelTool:
+    @pytest.mark.asyncio
+    async def test_missing_pk_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_channel"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel())
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_channel"]({"pk": 1})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deletes_channel(self, mock_db):
+        ch = _make_channel(title="DeleteMe")
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.delete = AsyncMock()
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["delete_channel"]({"pk": 1, "confirm": True})
+        assert "удалён" in _text(result)
+        assert "DeleteMe" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel())
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.delete = AsyncMock(side_effect=Exception("fk constraint"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["delete_channel"]({"pk": 1, "confirm": True})
+        assert "Ошибка удаления канала" in _text(result)
+
+
+class TestToggleChannelTool:
+    @pytest.mark.asyncio
+    async def test_missing_pk_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_active_channel_gets_deactivated(self, mock_db):
+        ch_after = _make_channel(is_active=False, title="MyChan")
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.toggle = AsyncMock()
+            mock_db.get_channel_by_pk = AsyncMock(return_value=ch_after)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["toggle_channel"]({"pk": 1})
+        assert "неактивен" in _text(result)
+        assert "MyChan" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.toggle = AsyncMock(side_effect=Exception("not found"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["toggle_channel"]({"pk": 1})
+        assert "Ошибка переключения канала" in _text(result)
+
+
+class TestImportChannelsTool:
+    @pytest.mark.asyncio
+    async def test_missing_text_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_channels"]({})
+        assert "text обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_identifiers_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_channels"]({"text": "hello world nothing here"})
+        assert "Не удалось распознать" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_channels"]({"text": "@chan1 @chan2"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_imports_channels(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_by_identifier = AsyncMock(return_value=True)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["import_channels"]({"text": "@chan1 @chan2", "confirm": True})
+        text = _text(result)
+        assert "Импорт завершён" in text
+        assert "2/2" in text
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_reported(self, mock_db):
+        call_count = 0
+
+        async def flaky_add(ident):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return True
+            raise Exception("API error")
+
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_by_identifier = flaky_add
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["import_channels"]({"text": "@chan1 @chan2", "confirm": True})
+        text = _text(result)
+        assert "Ошибки" in text
+
+
+# ===========================================================================
+# collection.py
+# ===========================================================================
+
+
+class TestCollectChannelTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["collect_channel"]({"pk": 1})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_pk_returns_error(self, mock_db):
+        pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_channel_by_pk = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel"]({"pk": 999})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_filtered_channel_without_force_returns_warning(self, mock_db):
+        pool = MagicMock()
+        ch = _make_channel(is_filtered=True, title="SpamChan")
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel"]({"pk": 1})
+        assert "отфильтрован" in _text(result)
+        assert "force=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_filtered_channel_with_force_enqueues(self, mock_db):
+        pool = MagicMock()
+        ch = _make_channel(is_filtered=True, title="SpamChan")
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        mock_db.create_collection_task = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel"]({"pk": 1, "force": True})
+        assert "поставлен в очередь" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_normal_channel_enqueues(self, mock_db):
+        pool = MagicMock()
+        ch = _make_channel(title="GoodChan")
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        mock_db.create_collection_task = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel"]({"pk": 1})
+        assert "поставлен в очередь" in _text(result)
+        assert "GoodChan" in _text(result)
+        mock_db.create_collection_task.assert_awaited_once()
+
+
+class TestCollectAllChannelsTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["collect_all_channels"]({})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_channels_returns_message(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_channels = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_all_channels"]({})
+        assert "Нет активных каналов" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_enqueues_all_active_channels(self, mock_db):
+        pool = MagicMock()
+        channels = [_make_channel(pk=i, channel_id=i * 100, title=f"Chan{i}") for i in range(3)]
+        mock_db.get_channels = AsyncMock(return_value=channels)
+        mock_db.create_collection_task = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_all_channels"]({})
+        text = _text(result)
+        assert "3 каналов" in text
+        assert mock_db.create_collection_task.await_count == 3
+
+
+class TestCollectChannelStatsTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["collect_channel_stats"]({"pk": 1})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_pk_returns_error(self, mock_db):
+        pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel_stats"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_channel_by_pk = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel_stats"]({"pk": 99})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_enqueues_stats_task(self, mock_db):
+        pool = MagicMock()
+        ch = _make_channel(title="StatsChan")
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        mock_db.create_stats_task = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_channel_stats"]({"pk": 1})
+        assert "поставлен в очередь" in _text(result)
+        assert "StatsChan" in _text(result)
+        mock_db.create_stats_task.assert_awaited_once()
+
+
+class TestCollectAllStatsTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["collect_all_stats"]({})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_channels_returns_message(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_channels = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_all_stats"]({})
+        assert "Нет активных каналов" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_enqueues_stats_for_all(self, mock_db):
+        pool = MagicMock()
+        channels = [_make_channel(pk=i, channel_id=i * 100) for i in range(5)]
+        mock_db.get_channels = AsyncMock(return_value=channels)
+        mock_db.create_stats_task = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["collect_all_stats"]({})
+        assert "5 каналов" in _text(result)
+        mock_db.create_stats_task.assert_awaited_once()
+
+
+# ===========================================================================
+# notifications.py
+# ===========================================================================
+
+
+class TestGetNotificationStatusTool:
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_message(self, mock_db):
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.get_status = AsyncMock(return_value=None)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_notification_status"]({})
+        assert "не настроен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_configured_shows_bot_info(self, mock_db):
+        bot = SimpleNamespace(bot_username="mybot", chat_id=12345, created_at="2025-01-01")
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.get_status = AsyncMock(return_value=bot)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_notification_status"]({})
+        text = _text(result)
+        assert "@mybot" in text
+        assert "12345" in text
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.get_status = AsyncMock(side_effect=Exception("db fail"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_notification_status"]({})
+        assert "Ошибка получения статуса бота" in _text(result)
+
+
+class TestSetupNotificationBotTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["setup_notification_bot"]({"confirm": True})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["setup_notification_bot"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_creates_bot(self, mock_db):
+        pool = MagicMock()
+        bot = SimpleNamespace(bot_username="newbot", chat_id=99999)
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.setup_bot = AsyncMock(return_value=bot)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["setup_notification_bot"]({"confirm": True})
+        text = _text(result)
+        assert "создан" in text
+        assert "@newbot" in text
+
+
+class TestDeleteNotificationBotTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["delete_notification_bot"]({"confirm": True})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["delete_notification_bot"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deletes_bot(self, mock_db):
+        pool = MagicMock()
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.teardown_bot = AsyncMock()
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["delete_notification_bot"]({"confirm": True})
+        assert "удалён" in _text(result)
+
+
+class TestTestNotificationTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["test_notification"]({})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_message(self, mock_db):
+        pool = MagicMock()
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            mock_ns.return_value.get_status = AsyncMock(return_value=None)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["test_notification"]({})
+        assert "не настроен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_sends_notification(self, mock_db):
+        pool = MagicMock()
+        bot = SimpleNamespace(bot_username="testbot", chat_id=1)
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            inst = mock_ns.return_value
+            inst.get_status = AsyncMock(return_value=bot)
+            inst.send_notification = AsyncMock()
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["test_notification"]({})
+        assert "отправлено" in _text(result)
+        inst.send_notification.assert_awaited_once()
+
+
+# ===========================================================================
+# settings.py
+# ===========================================================================
+
+
+class TestGetSettingsTool:
+    @pytest.mark.asyncio
+    async def test_shows_all_settings_keys(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_settings"]({})
+        text = _text(result)
+        assert "scheduler_interval_minutes" in text
+        assert "agent_prompt_template" in text
+        assert "Настройки системы" in text
+
+    @pytest.mark.asyncio
+    async def test_shows_set_values(self, mock_db):
+        async def fake_get(key):
+            return "60" if key == "scheduler_interval_minutes" else None
+
+        mock_db.get_setting = fake_get
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_settings"]({})
+        assert "60" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_setting = AsyncMock(side_effect=Exception("no table"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_settings"]({})
+        assert "Ошибка получения настроек" in _text(result)
+
+
+class TestSaveSchedulerSettingsTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"]({"interval_minutes": 30})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_saves_interval(self, mock_db):
+        mock_db.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"]({"interval_minutes": 30, "confirm": True})
+        assert "сохранены" in _text(result)
+        mock_db.set_setting.assert_any_await("scheduler_interval_minutes", "30")
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_saves_enabled_flag(self, mock_db):
+        mock_db.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"]({"enabled": False, "confirm": True})
+        assert "сохранены" in _text(result)
+        mock_db.set_setting.assert_any_await("scheduler_enabled", "false")
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.set_setting = AsyncMock(side_effect=Exception("write error"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"]({"interval_minutes": 10, "confirm": True})
+        assert "Ошибка сохранения настроек" in _text(result)
+
+
+class TestSaveAgentSettingsTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_agent_settings"]({"backend": "claude"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_saves_prompt_template(self, mock_db):
+        mock_db.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_agent_settings"](
+            {"prompt_template": "You are a helpful bot.", "confirm": True}
+        )
+        assert "сохранены" in _text(result)
+        mock_db.set_setting.assert_any_await("agent_prompt_template", "You are a helpful bot.")
+
+    @pytest.mark.asyncio
+    async def test_saves_backend_override(self, mock_db):
+        mock_db.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_agent_settings"]({"backend": "deepagents", "confirm": True})
+        assert "сохранены" in _text(result)
+        mock_db.set_setting.assert_any_await("agent_backend_override", "deepagents")
+
+
+class TestSaveFilterSettingsTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_filter_settings"]({"low_uniqueness_threshold": 0.5})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_saves_thresholds(self, mock_db):
+        mock_db.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_filter_settings"](
+            {"low_uniqueness_threshold": 0.3, "low_subscriber_ratio_threshold": 0.1, "confirm": True}
+        )
+        assert "сохранены" in _text(result)
+        mock_db.set_setting.assert_any_await("low_uniqueness_threshold", "0.3")
+        mock_db.set_setting.assert_any_await("low_subscriber_ratio_threshold", "0.1")
+
+
+class TestGetSystemInfoTool:
+    @pytest.mark.asyncio
+    async def test_shows_stats(self, mock_db):
+        mock_db.get_stats = AsyncMock(return_value={"channels": 10, "messages": 1000})
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_system_info"]({})
+        text = _text(result)
+        assert "channels" in text
+        assert "10" in text
+        assert "Системная информация" in text
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_stats = AsyncMock(side_effect=Exception("no stats"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_system_info"]({})
+        assert "Ошибка получения системной информации" in _text(result)
+
+
+# ===========================================================================
+# messaging.py — no-pool & validation tests (no real Telegram)
+# ===========================================================================
+
+
+class TestSendMessageTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["send_message"](
+            {"recipient": "@user", "text": "hello", "confirm": True}
+        )
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_recipient_or_text_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["send_message"](
+            {"recipient": "", "text": "", "confirm": True, "phone": "+71111111111"}
+        )
+        assert "обязательны" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["send_message"](
+            {"recipient": "@user", "text": "hi", "phone": "+71111111111"}
+        )
+        assert "confirm=true" in _text(result)
+
+
+class TestEditMessageTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["edit_message"](
+            {"chat_id": "100", "message_id": 1, "text": "new", "confirm": True}
+        )
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["edit_message"](
+            {"chat_id": "", "message_id": None, "text": "", "confirm": True, "phone": "+71111111111"}
+        )
+        assert "обязательны" in _text(result)
+
+
+class TestDeleteMessageTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["delete_message"](
+            {"chat_id": "100", "message_ids": "1,2", "confirm": True}
+        )
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["delete_message"](
+            {"chat_id": "", "message_ids": "1", "confirm": True, "phone": "+71111111111"}
+        )
+        assert "обязательны" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_invalid_message_ids_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["delete_message"](
+            {"chat_id": "100", "message_ids": "abc,xyz", "confirm": True, "phone": "+71111111111"}
+        )
+        assert "валидные message_ids" in _text(result)
+
+
+class TestGetParticipantsTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["get_participants"]({"chat_id": "@grp"})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_returns_error(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["get_participants"](
+            {"chat_id": "", "phone": "+71111111111"}
+        )
+        assert "обязателен" in _text(result)
+
+
+class TestKickParticipantTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["kick_participant"](
+            {"chat_id": "100", "user_id": "@bad", "confirm": True}
+        )
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["kick_participant"](
+            {"chat_id": "100", "user_id": "@bad", "phone": "+71111111111"}
+        )
+        assert "confirm=true" in _text(result)

--- a/tests/test_agent_tools_new1.py
+++ b/tests/test_agent_tools_new1.py
@@ -22,7 +22,9 @@ from src.database import Database
 @pytest.fixture
 def mock_db():
     """Create a mock Database for testing tools."""
-    return MagicMock(spec=Database)
+    db = MagicMock(spec=Database)
+    db.get_setting = AsyncMock(return_value=None)
+    return db
 
 
 def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):

--- a/tests/test_agent_tools_new2.py
+++ b/tests/test_agent_tools_new2.py
@@ -21,7 +21,9 @@ from src.database import Database
 @pytest.fixture
 def mock_db():
     """Create a mock Database for testing tools."""
-    return MagicMock(spec=Database)
+    db = MagicMock(spec=Database)
+    db.get_setting = AsyncMock(return_value=None)
+    return db
 
 
 def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):

--- a/tests/test_agent_tools_new2.py
+++ b/tests/test_agent_tools_new2.py
@@ -1,0 +1,797 @@
+"""Tests for agent tools: filters.py, scheduler.py, search_queries.py.
+
+These tests call actual tool handler functions via the @tool decorator's
+.handler attribute, ensuring argument parsing, formatting, and error handling
+are all exercised.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.database import Database
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock Database for testing tools."""
+    return MagicMock(spec=Database)
+
+
+def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
+    """Build MCP tools and return their handlers keyed by name."""
+    captured_tools = []
+
+    with patch(
+        "src.agent.tools.create_sdk_mcp_server",
+        side_effect=lambda **kw: captured_tools.extend(kw.get("tools", [])),
+    ):
+        from src.agent.tools import make_mcp_server
+
+        make_mcp_server(mock_db, client_pool=client_pool, config=config, **kwargs)
+
+    return {t.name: t.handler for t in captured_tools}
+
+
+def _text(result: dict) -> str:
+    """Extract text from tool result payload."""
+    return result["content"][0]["text"]
+
+
+def _make_scheduler_mgr():
+    """Build a standard mock SchedulerManager."""
+    mgr = MagicMock()
+    mgr.is_running = True
+    mgr.interval_minutes = 60
+    mgr.get_potential_jobs = AsyncMock(return_value=[{"id": "collect", "enabled": True}])
+    mgr.get_all_jobs_next_run = MagicMock(return_value={"collect": "2025-01-01 12:00"})
+    mgr.is_job_enabled = AsyncMock(return_value=True)
+    mgr.sync_job_state = AsyncMock()
+    mgr.start = AsyncMock()
+    mgr.stop = AsyncMock()
+    mgr.trigger_now = AsyncMock(return_value="ok")
+    return mgr
+
+
+def _make_purge_result(purged=2, deleted=50):
+    r = MagicMock()
+    r.purged_count = purged
+    r.total_messages_deleted = deleted
+    return r
+
+
+# ---------------------------------------------------------------------------
+# filters.py — analyze_filters
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeFiltersTool:
+    @pytest.mark.asyncio
+    async def test_empty_report(self, mock_db):
+        """Empty report returns appropriate message."""
+        report = MagicMock()
+        report.results = []
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(return_value=report)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["analyze_filters"]({})
+        assert "Нет каналов для анализа" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_report_with_flagged_channels(self, mock_db):
+        """Flagged channels are listed with their flags."""
+        r = MagicMock()
+        r.should_filter = True
+        r.title = "SpamChan"
+        r.channel_id = 100
+        r.flags = ["low_uniqueness", "spam"]
+        report = MagicMock()
+        report.results = [r]
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(return_value=report)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["analyze_filters"]({})
+        text = _text(result)
+        assert "SpamChan" in text
+        assert "low_uniqueness" in text
+        assert "spam" in text
+        assert "1 рекомендовано" in text
+
+    @pytest.mark.asyncio
+    async def test_report_truncates_beyond_30(self, mock_db):
+        """More than 30 flagged channels triggers truncation message."""
+
+        def _make_result(i):
+            r = MagicMock()
+            r.should_filter = True
+            r.title = f"Chan{i}"
+            r.channel_id = i
+            r.flags = ["low_uniqueness"]
+            return r
+
+        report = MagicMock()
+        report.results = [_make_result(i) for i in range(35)]
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(return_value=report)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["analyze_filters"]({})
+        text = _text(result)
+        assert "и ещё 5" in text
+
+    @pytest.mark.asyncio
+    async def test_report_non_flagged_not_listed(self, mock_db):
+        """Non-flagged channels don't appear in the flagged list."""
+        ok = MagicMock()
+        ok.should_filter = False
+        ok.title = "GoodChan"
+        ok.channel_id = 1
+        ok.flags = []
+        report = MagicMock()
+        report.results = [ok]
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(return_value=report)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["analyze_filters"]({})
+        text = _text(result)
+        assert "GoodChan" not in text
+        assert "0 рекомендовано" in text
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(side_effect=RuntimeError("DB fail"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["analyze_filters"]({})
+        assert "Ошибка анализа фильтров" in _text(result)
+        assert "DB fail" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# filters.py — apply_filters
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFiltersTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["apply_filters"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_applies_and_returns_count(self, mock_db):
+        report = MagicMock()
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            inst = mock_analyzer.return_value
+            inst.analyze_all = AsyncMock(return_value=report)
+            inst.apply_filters = AsyncMock(return_value=3)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["apply_filters"]({"confirm": True})
+        text = _text(result)
+        assert "3 каналов" in text
+        assert "Фильтры применены" in text
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.analyze_all = AsyncMock(side_effect=Exception("oops"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["apply_filters"]({"confirm": True})
+        assert "Ошибка применения фильтров" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# filters.py — reset_filters
+# ---------------------------------------------------------------------------
+
+
+class TestResetFiltersTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["reset_filters"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_resets_and_returns_count(self, mock_db):
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.reset_filters = AsyncMock(return_value=7)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["reset_filters"]({"confirm": True})
+        text = _text(result)
+        assert "7 каналов" in text
+        assert "разблокированы" in text
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
+            mock_analyzer.return_value.reset_filters = AsyncMock(side_effect=Exception("nope"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["reset_filters"]({"confirm": True})
+        assert "Ошибка сброса фильтров" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# filters.py — toggle_channel_filter
+# ---------------------------------------------------------------------------
+
+
+class TestToggleChannelFilterTool:
+    @pytest.mark.asyncio
+    async def test_missing_pk_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel_filter"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_channel_not_found(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel_filter"]({"pk": 999})
+        assert "не найден" in _text(result)
+        assert "999" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_filtered_false_becomes_filtered(self, mock_db):
+        ch = MagicMock()
+        ch.is_filtered = False
+        ch.title = "NewsChan"
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        mock_db.set_channel_filtered = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel_filter"]({"pk": 1})
+        text = _text(result)
+        assert "NewsChan" in text
+        assert "отфильтрован" in text
+        mock_db.set_channel_filtered.assert_awaited_once_with(1, True)
+
+    @pytest.mark.asyncio
+    async def test_filtered_true_becomes_unblocked(self, mock_db):
+        ch = MagicMock()
+        ch.is_filtered = True
+        ch.title = "SpamChan"
+        mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
+        mock_db.set_channel_filtered = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel_filter"]({"pk": 2})
+        text = _text(result)
+        assert "SpamChan" in text
+        assert "разблокирован" in text
+        mock_db.set_channel_filtered.assert_awaited_once_with(2, False)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(side_effect=Exception("db error"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_channel_filter"]({"pk": 1})
+        assert "Ошибка переключения фильтра" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# filters.py — purge_filtered_channels
+# ---------------------------------------------------------------------------
+
+
+class TestPurgeFilteredChannelsTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_filtered_channels"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pks_and_confirm_purges_by_pks(self, mock_db):
+        purge_result = _make_purge_result(purged=2, deleted=40)
+        with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
+            mock_svc.return_value.purge_channels_by_pks = AsyncMock(return_value=purge_result)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["purge_filtered_channels"]({"pks": "1,2", "confirm": True})
+        text = _text(result)
+        assert "2 каналов" in text
+        assert "40 сообщений" in text
+        mock_svc.return_value.purge_channels_by_pks.assert_awaited_once_with([1, 2])
+
+    @pytest.mark.asyncio
+    async def test_empty_pks_and_confirm_purges_all(self, mock_db):
+        purge_result = _make_purge_result(purged=5, deleted=200)
+        with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
+            mock_svc.return_value.purge_all_filtered = AsyncMock(return_value=purge_result)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["purge_filtered_channels"]({"pks": "", "confirm": True})
+        text = _text(result)
+        assert "5 каналов" in text
+        assert "200 сообщений" in text
+        mock_svc.return_value.purge_all_filtered.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
+            mock_svc.return_value.purge_all_filtered = AsyncMock(side_effect=Exception("disk full"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["purge_filtered_channels"]({"confirm": True})
+        assert "Ошибка очистки каналов" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# filters.py — hard_delete_channels
+# ---------------------------------------------------------------------------
+
+
+class TestHardDeleteChannelsTool:
+    @pytest.mark.asyncio
+    async def test_empty_pks_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["hard_delete_channels"]({})
+        assert "pks обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["hard_delete_channels"]({"pks": "1,2"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pks_and_confirm_deletes(self, mock_db):
+        del_result = _make_purge_result(purged=2, deleted=0)
+        with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
+            mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(return_value=del_result)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["hard_delete_channels"]({"pks": "3,4", "confirm": True})
+        text = _text(result)
+        assert "2 каналов" in text
+        assert "безвозвратно" in text
+        mock_svc.return_value.hard_delete_channels_by_pks.assert_awaited_once_with([3, 4])
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
+            mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(side_effect=Exception("err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["hard_delete_channels"]({"pks": "1", "confirm": True})
+        assert "Ошибка удаления каналов" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py — get_scheduler_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetSchedulerStatusTool:
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_error(self, mock_db):
+        """Without a scheduler_manager the tool catches RuntimeError and returns text."""
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_scheduler_status"]({})
+        assert "Ошибка получения статуса планировщика" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_manager_shows_running_state(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["get_scheduler_status"]({})
+        text = _text(result)
+        assert "запущен" in text
+        assert "60 мин" in text
+
+    @pytest.mark.asyncio
+    async def test_with_manager_lists_jobs(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["get_scheduler_status"]({})
+        text = _text(result)
+        assert "collect" in text
+        assert "вкл" in text
+        assert "2025-01-01 12:00" in text
+
+    @pytest.mark.asyncio
+    async def test_with_manager_stopped(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.is_running = False
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["get_scheduler_status"]({})
+        assert "остановлен" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py — start_scheduler
+# ---------------------------------------------------------------------------
+
+
+class TestStartSchedulerTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["start_scheduler"]({"confirm": True})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["start_scheduler"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pool_and_confirm_starts(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool, scheduler_manager=mgr)
+        result = await handlers["start_scheduler"]({"confirm": True})
+        assert "Планировщик запущен" in _text(result)
+        mgr.start.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.start = AsyncMock(side_effect=Exception("already running"))
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool, scheduler_manager=mgr)
+        result = await handlers["start_scheduler"]({"confirm": True})
+        assert "Ошибка запуска планировщика" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py — stop_scheduler
+# ---------------------------------------------------------------------------
+
+
+class TestStopSchedulerTool:
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["stop_scheduler"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_stops(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["stop_scheduler"]({"confirm": True})
+        assert "Планировщик остановлен" in _text(result)
+        mgr.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.stop = AsyncMock(side_effect=Exception("not running"))
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["stop_scheduler"]({"confirm": True})
+        assert "Ошибка остановки планировщика" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py — trigger_collection
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerCollectionTool:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_pool_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["trigger_collection"]({"confirm": True})
+        assert "Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["trigger_collection"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pool_and_confirm_triggers(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool, scheduler_manager=mgr)
+        result = await handlers["trigger_collection"]({"confirm": True})
+        text = _text(result)
+        assert "Сбор запущен" in text
+        mgr.trigger_now.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.trigger_now = AsyncMock(side_effect=Exception("busy"))
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool, scheduler_manager=mgr)
+        result = await handlers["trigger_collection"]({"confirm": True})
+        assert "Ошибка запуска сбора" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# scheduler.py — toggle_scheduler_job
+# ---------------------------------------------------------------------------
+
+
+class TestToggleSchedulerJobTool:
+    @pytest.mark.asyncio
+    async def test_missing_job_id_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_scheduler_job"]({})
+        assert "job_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_enabled_job_becomes_disabled(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.is_job_enabled = AsyncMock(return_value=True)
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["toggle_scheduler_job"]({"job_id": "collect"})
+        text = _text(result)
+        assert "collect" in text
+        assert "выключена" in text
+        mgr.sync_job_state.assert_awaited_once_with("collect", False)
+
+    @pytest.mark.asyncio
+    async def test_disabled_job_becomes_enabled(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.is_job_enabled = AsyncMock(return_value=False)
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["toggle_scheduler_job"]({"job_id": "notify"})
+        text = _text(result)
+        assert "notify" in text
+        assert "включена" in text
+        mgr.sync_job_state.assert_awaited_once_with("notify", True)
+
+    @pytest.mark.asyncio
+    async def test_no_manager_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_scheduler_job"]({"job_id": "collect"})
+        assert "Ошибка переключения задачи" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        mgr = _make_scheduler_mgr()
+        mgr.is_job_enabled = AsyncMock(side_effect=Exception("unknown job"))
+        handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
+        result = await handlers["toggle_scheduler_job"]({"job_id": "bad_job"})
+        assert "Ошибка переключения задачи" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — use real DB fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def sq_handlers(db):
+    """Tool handlers backed by a real in-memory DB."""
+    return _get_tool_handlers(db)
+
+
+async def _add_query(db, query="test query", interval_minutes=30, is_active=True):
+    """Helper: add a search query via the service and return its id."""
+    from src.services.search_query_service import SearchQueryService
+
+    svc = SearchQueryService(db)
+    sq_id = await svc.add(query, interval_minutes=interval_minutes)
+    if not is_active:
+        await svc.toggle(sq_id)  # toggle off since created as active
+    return sq_id
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — list_search_queries
+# ---------------------------------------------------------------------------
+
+
+class TestListSearchQueriesTool:
+    @pytest.mark.asyncio
+    async def test_empty_returns_not_found(self, sq_handlers):
+        result = await sq_handlers["list_search_queries"]({"active_only": False})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_lists_all_when_active_only_false(self, db, sq_handlers):
+        await _add_query(db, "query1", is_active=True)
+        await _add_query(db, "query2", is_active=False)
+        result = await sq_handlers["list_search_queries"]({"active_only": False})
+        text = _text(result)
+        assert "query1" in text
+        assert "query2" in text
+        assert "Поисковые запросы (2)" in text
+
+    @pytest.mark.asyncio
+    async def test_active_only_filters_inactive(self, db, sq_handlers):
+        await _add_query(db, "active_query", is_active=True)
+        await _add_query(db, "inactive_query", is_active=False)
+        result = await sq_handlers["list_search_queries"]({"active_only": True})
+        text = _text(result)
+        assert "active_query" in text
+        assert "inactive_query" not in text
+
+    @pytest.mark.asyncio
+    async def test_shows_status_labels(self, db, sq_handlers):
+        await _add_query(db, "myquery", is_active=True)
+        result = await sq_handlers["list_search_queries"]({})
+        text = _text(result)
+        assert "активен" in text
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — get_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestGetSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_sq_id_returns_error(self, sq_handlers):
+        result = await sq_handlers["get_search_query"]({})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self, sq_handlers):
+        result = await sq_handlers["get_search_query"]({"sq_id": 9999})
+        assert "не найден" in _text(result)
+        assert "9999" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_found_shows_fields(self, db, sq_handlers):
+        sq_id = await _add_query(db, "find this")
+        result = await sq_handlers["get_search_query"]({"sq_id": sq_id})
+        text = _text(result)
+        assert "find this" in text
+        assert f"id: {sq_id}" in text
+        assert "is_active" in text
+        assert "interval_minutes" in text
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — add_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestAddSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_query_returns_error(self, sq_handlers):
+        result = await sq_handlers["add_search_query"]({"confirm": True})
+        assert "query обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, sq_handlers):
+        result = await sq_handlers["add_search_query"]({"query": "hello"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_query_and_confirm_creates(self, sq_handlers):
+        result = await sq_handlers["add_search_query"]({"query": "new query", "confirm": True})
+        text = _text(result)
+        assert "создан" in text
+        assert "id=" in text
+
+    @pytest.mark.asyncio
+    async def test_with_custom_interval_creates(self, sq_handlers):
+        result = await sq_handlers["add_search_query"](
+            {"query": "custom interval", "interval_minutes": 120, "confirm": True}
+        )
+        assert "создан" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — edit_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestEditSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_sq_id_returns_error(self, sq_handlers):
+        result = await sq_handlers["edit_search_query"]({"confirm": True})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, sq_handlers):
+        result = await sq_handlers["edit_search_query"]({"sq_id": 1})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self, sq_handlers):
+        result = await sq_handlers["edit_search_query"]({"sq_id": 9999, "confirm": True})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_found_updates_query(self, db, sq_handlers):
+        sq_id = await _add_query(db, "original")
+        result = await sq_handlers["edit_search_query"](
+            {"sq_id": sq_id, "query": "updated", "confirm": True}
+        )
+        assert "обновлён" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_updates_interval(self, db, sq_handlers):
+        sq_id = await _add_query(db, "some query")
+        result = await sq_handlers["edit_search_query"](
+            {"sq_id": sq_id, "interval_minutes": 90, "confirm": True}
+        )
+        assert "обновлён" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — delete_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_sq_id_returns_error(self, sq_handlers):
+        result = await sq_handlers["delete_search_query"]({})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, sq_handlers):
+        result = await sq_handlers["delete_search_query"]({"sq_id": 1})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deletes(self, db, sq_handlers):
+        sq_id = await _add_query(db, "to delete")
+        result = await sq_handlers["delete_search_query"]({"sq_id": sq_id, "confirm": True})
+        text = _text(result)
+        assert "удалён" in text
+        assert str(sq_id) in text
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — toggle_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestToggleSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_sq_id_returns_error(self, sq_handlers):
+        result = await sq_handlers["toggle_search_query"]({})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self, sq_handlers):
+        result = await sq_handlers["toggle_search_query"]({"sq_id": 9999})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_active_query_gets_deactivated(self, db, sq_handlers):
+        sq_id = await _add_query(db, "active one", is_active=True)
+        result = await sq_handlers["toggle_search_query"]({"sq_id": sq_id})
+        text = _text(result)
+        assert "деактивирован" in text
+        assert str(sq_id) in text
+
+    @pytest.mark.asyncio
+    async def test_inactive_query_gets_activated(self, db, sq_handlers):
+        sq_id = await _add_query(db, "inactive one", is_active=False)
+        result = await sq_handlers["toggle_search_query"]({"sq_id": sq_id})
+        text = _text(result)
+        assert "активирован" in text
+        assert str(sq_id) in text
+
+
+# ---------------------------------------------------------------------------
+# search_queries.py — run_search_query
+# ---------------------------------------------------------------------------
+
+
+class TestRunSearchQueryTool:
+    @pytest.mark.asyncio
+    async def test_missing_sq_id_returns_error(self, sq_handlers):
+        result = await sq_handlers["run_search_query"]({})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_run_returns_count(self, db, sq_handlers):
+        sq_id = await _add_query(db, "search term")
+        result = await sq_handlers["run_search_query"]({"sq_id": sq_id})
+        text = _text(result)
+        assert "выполнен" in text
+        assert "совпадений" in text
+        assert str(sq_id) in text
+
+    @pytest.mark.asyncio
+    async def test_run_nonexistent_returns_zero_matches(self, sq_handlers):
+        """run_search_query with a nonexistent id returns 0 matches (service is lenient)."""
+        result = await sq_handlers["run_search_query"]({"sq_id": 9999})
+        text = _text(result)
+        assert "выполнен" in text
+        assert "0 совпадений" in text

--- a/tests/test_agent_tools_new3.py
+++ b/tests/test_agent_tools_new3.py
@@ -25,7 +25,9 @@ from src.database import Database
 @pytest.fixture
 def mock_db():
     """Create a mock Database for testing tools."""
-    return MagicMock(spec=Database)
+    db = MagicMock(spec=Database)
+    db.get_setting = AsyncMock(return_value=None)
+    return db
 
 
 def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
@@ -309,30 +311,28 @@ class TestDeepagentsSyncGetNotificationStatus:
 
 
 class TestDeepagentsSyncListImageProviders:
-    def test_no_providers(self):
+    def test_no_providers(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        mock_db2 = MagicMock()
         img_svc_mock = MagicMock()
         img_svc_mock.adapter_names = []
         with patch(
             "src.services.image_generation_service.ImageGenerationService", return_value=img_svc_mock
         ):
-            tools = build_deepagents_tools(mock_db2)
+            tools = build_deepagents_tools(mock_db)
             tool_map = {t.__name__: t for t in tools}
             result = tool_map["list_image_providers"]()
         assert "не настроены" in result
 
-    def test_with_providers(self):
+    def test_with_providers(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        mock_db2 = MagicMock()
         img_svc_mock = MagicMock()
         img_svc_mock.adapter_names = ["together", "hf"]
         with patch(
             "src.services.image_generation_service.ImageGenerationService", return_value=img_svc_mock
         ):
-            tools = build_deepagents_tools(mock_db2)
+            tools = build_deepagents_tools(mock_db)
             tool_map = {t.__name__: t for t in tools}
             result = tool_map["list_image_providers"]()
         assert "together" in result

--- a/tests/test_agent_tools_new3.py
+++ b/tests/test_agent_tools_new3.py
@@ -1,0 +1,1320 @@
+"""Comprehensive tests for agent tools: deepagents_sync, pipelines, images, my_telegram, analytics.
+
+Tests cover:
+- deepagents_sync.build_deepagents_tools() — sync wrappers
+- pipelines.register() — pipeline management MCP tools
+- images.register() — image generation MCP tools
+- my_telegram.register() — dialog and cache tools
+- analytics.register() — content analytics tools
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.database import Database
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock Database for testing tools."""
+    return MagicMock(spec=Database)
+
+
+def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
+    """Build MCP tools and return their handlers keyed by name."""
+    captured_tools = []
+    with patch(
+        "src.agent.tools.create_sdk_mcp_server",
+        side_effect=lambda **kw: captured_tools.extend(kw.get("tools", [])),
+    ):
+        from src.agent.tools import make_mcp_server
+
+        make_mcp_server(mock_db, client_pool=client_pool, config=config, **kwargs)
+    return {t.name: t.handler for t in captured_tools}
+
+
+def _text(result: dict) -> str:
+    """Extract text from MCP tool result payload."""
+    return result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# deepagents_sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeepagentsSyncListChannels:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_channels = AsyncMock(return_value=[])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_channels"](active_only=False)
+        assert "не найдены" in result
+
+    def test_with_channels(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        ch = SimpleNamespace(channel_id=100, title="TestCh", is_active=True)
+        mock_db.get_channels = AsyncMock(return_value=[ch])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_channels"](active_only=False)
+        assert "TestCh" in result
+        assert "активен" in result
+
+    def test_error_returns_text(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_channels = AsyncMock(side_effect=Exception("boom"))
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_channels"](active_only=False)
+        assert "Ошибка" in result
+
+
+class TestDeepagentsSyncGetChannelStats:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.repos = MagicMock()
+        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_channel_stats"]()
+        assert "не собрана" in result
+
+    def test_with_stats(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        stat = SimpleNamespace(subscriber_count=9999)
+        mock_db.repos = MagicMock()
+        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={42: stat})
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_channel_stats"]()
+        assert "9999" in result
+        assert "channel_id=42" in result
+
+
+class TestDeepagentsSyncListAccounts:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_accounts"]()
+        assert "не найдены" in result
+
+    def test_with_accounts(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        acc = SimpleNamespace(id=1, phone="+79001234567", is_active=True)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_accounts"]()
+        assert "+79001234567" in result
+        assert "активен" in result
+
+
+class TestDeepagentsSyncGetFloodStatus:
+    def test_no_accounts(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_flood_status"]()
+        assert "не найдены" in result
+
+    def test_with_accounts(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        acc = SimpleNamespace(phone="+79001234567", flood_wait_until=None)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_flood_status"]()
+        assert "+79001234567" in result
+        assert "Flood-статус" in result
+
+
+class TestDeepagentsSyncAgentThreads:
+    def test_list_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_agent_threads = AsyncMock(return_value=[])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_agent_threads"]()
+        assert "не найдены" in result
+
+    def test_list_with_threads(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_agent_threads = AsyncMock(return_value=[{"id": 5, "title": "Chat 1"}])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_agent_threads"]()
+        assert "Chat 1" in result
+        assert "id=5" in result
+
+    def test_create_thread(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.create_agent_thread = AsyncMock(return_value=7)
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["create_agent_thread"](title="New Thread")
+        assert "id=7" in result
+        assert "создан" in result
+
+
+class TestDeepagentsSyncGetSettings:
+    def test_returns_settings(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_setting = AsyncMock(return_value="30")
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_settings"]()
+        assert "Настройки" in result
+
+    def test_unset_value(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_setting = AsyncMock(return_value=None)
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_settings"]()
+        assert "не задано" in result
+
+
+class TestDeepagentsSyncGetSystemInfo:
+    def test_returns_info(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_stats = AsyncMock(return_value={"channels": 5, "messages": 100})
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_system_info"]()
+        assert "channels" in result
+        assert "5" in result
+
+    def test_error_returns_text(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.get_stats = AsyncMock(side_effect=Exception("db fail"))
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_system_info"]()
+        assert "Ошибка" in result
+
+
+class TestDeepagentsSyncListSearchQueries:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        svc_mock = MagicMock()
+        svc_mock.list = AsyncMock(return_value=[])
+        with patch("src.services.search_query_service.SearchQueryService", return_value=svc_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_search_queries"](active_only=False)
+        assert "не найдены" in result
+
+    def test_with_queries(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        q = SimpleNamespace(id=3, query="crypto", is_active=True, interval_minutes=60)
+        svc_mock = MagicMock()
+        svc_mock.list = AsyncMock(return_value=[q])
+        with patch("src.services.search_query_service.SearchQueryService", return_value=svc_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_search_queries"](active_only=False)
+        assert "crypto" in result
+        assert "id=3" in result
+
+
+class TestDeepagentsSyncGetSchedulerStatus:
+    def test_returns_status(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mgr_mock = MagicMock()
+        mgr_mock.load_settings = AsyncMock(return_value=None)
+        mgr_mock.is_running = True
+        mgr_mock.interval_minutes = 15
+        with patch("src.scheduler.manager.SchedulerManager", return_value=mgr_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["get_scheduler_status"]()
+        assert "Планировщик" in result
+
+    def test_error_returns_text(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        with patch("src.scheduler.manager.SchedulerManager", side_effect=Exception("no sched")):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["get_scheduler_status"]()
+        assert "Ошибка" in result
+
+
+class TestDeepagentsSyncGetNotificationStatus:
+    def test_not_configured(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        svc_mock = MagicMock()
+        svc_mock.get_status = AsyncMock(return_value=None)
+        target_svc_mock = MagicMock()
+        with patch("src.services.notification_service.NotificationService", return_value=svc_mock):
+            with patch(
+                "src.services.notification_target_service.NotificationTargetService",
+                return_value=target_svc_mock,
+            ):
+                tools = build_deepagents_tools(mock_db)
+                tool_map = {t.__name__: t for t in tools}
+                result = tool_map["get_notification_status"]()
+        assert "не настроен" in result
+
+    def test_configured(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        bot = SimpleNamespace(bot_username="mybot", chat_id=12345)
+        svc_mock = MagicMock()
+        svc_mock.get_status = AsyncMock(return_value=bot)
+        target_svc_mock = MagicMock()
+        with patch("src.services.notification_service.NotificationService", return_value=svc_mock):
+            with patch(
+                "src.services.notification_target_service.NotificationTargetService",
+                return_value=target_svc_mock,
+            ):
+                tools = build_deepagents_tools(mock_db)
+                tool_map = {t.__name__: t for t in tools}
+                result = tool_map["get_notification_status"]()
+        assert "@mybot" in result
+        assert "12345" in result
+
+
+class TestDeepagentsSyncListImageProviders:
+    def test_no_providers(self):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db2 = MagicMock()
+        img_svc_mock = MagicMock()
+        img_svc_mock.adapter_names = []
+        with patch(
+            "src.services.image_generation_service.ImageGenerationService", return_value=img_svc_mock
+        ):
+            tools = build_deepagents_tools(mock_db2)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_image_providers"]()
+        assert "не настроены" in result
+
+    def test_with_providers(self):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db2 = MagicMock()
+        img_svc_mock = MagicMock()
+        img_svc_mock.adapter_names = ["together", "hf"]
+        with patch(
+            "src.services.image_generation_service.ImageGenerationService", return_value=img_svc_mock
+        ):
+            tools = build_deepagents_tools(mock_db2)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_image_providers"]()
+        assert "together" in result
+        assert "hf" in result
+
+
+class TestDeepagentsSyncAnalyzeFilters:
+    def test_returns_analysis(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        analyzer_mock = MagicMock()
+        result_item = SimpleNamespace(should_filter=True)
+        report = SimpleNamespace(results=[result_item, SimpleNamespace(should_filter=False)])
+        analyzer_mock.analyze_all = AsyncMock(return_value=report)
+        with patch("src.filters.analyzer.ChannelAnalyzer", return_value=analyzer_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["analyze_filters"]()
+        assert "Анализ" in result
+        assert "2 проверено" in result
+        assert "1 к фильтрации" in result
+
+    def test_error_returns_text(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        with patch("src.filters.analyzer.ChannelAnalyzer", side_effect=Exception("no filter")):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["analyze_filters"]()
+        assert "Ошибка" in result
+
+
+class TestDeepagentsSyncListPendingModeration:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_pending_moderation"](limit=10)
+        assert "Нет черновиков" in result
+
+    def test_with_runs(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        run = SimpleNamespace(id=9, pipeline_id=2, generated_text="Draft content")
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[run])
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["list_pending_moderation"](limit=10)
+        assert "run_id=9" in result
+        assert "Draft content" in result
+
+
+class TestDeepagentsSyncListPipelines:
+    def test_empty(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        svc_mock = MagicMock()
+        svc_mock.list = AsyncMock(return_value=[])
+        with patch("src.services.pipeline_service.PipelineService", return_value=svc_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_pipelines"](active_only=False)
+        assert "не найдены" in result
+
+    def test_with_pipelines(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        p = SimpleNamespace(id=1, name="Pipeline A", is_active=True, llm_model="gpt-4o")
+        svc_mock = MagicMock()
+        svc_mock.list = AsyncMock(return_value=[p])
+        with patch("src.services.pipeline_service.PipelineService", return_value=svc_mock):
+            tools = build_deepagents_tools(mock_db)
+            tool_map = {t.__name__: t for t in tools}
+            result = tool_map["list_pipelines"](active_only=False)
+        assert "Pipeline A" in result
+        assert "gpt-4o" in result
+
+
+# ---------------------------------------------------------------------------
+# pipelines.py MCP tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestPipelinesToolListPipelines:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.list = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_pipelines"]({"active_only": False})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pipeline(self, mock_db):
+        p = SimpleNamespace(
+            id=5,
+            name="Test Pipeline",
+            is_active=True,
+            llm_model="gpt-4",
+            publish_mode="moderated",
+            schedule_cron="0 * * * *",
+            generation_backend="chain",
+        )
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.list = AsyncMock(return_value=[p])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_pipelines"]({"active_only": True})
+        text = _text(result)
+        assert "Test Pipeline" in text
+        assert "id=5" in text
+        assert "gpt-4" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.list = AsyncMock(side_effect=Exception("db err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_pipelines"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestPipelinesToolGetPipelineDetail:
+    @pytest.mark.asyncio
+    async def test_missing_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_detail"]({})
+        assert "pipeline_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get_detail = AsyncMock(return_value=None)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_detail"]({"pipeline_id": 999})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_found(self, mock_db):
+        p = SimpleNamespace(
+            id=2,
+            name="Detail Pipeline",
+            is_active=True,
+            llm_model="claude-3",
+            publish_mode="auto",
+            generation_backend="sdk",
+            schedule_cron=None,
+            generate_interval_minutes=120,
+            prompt_template="Generate about {topic}",
+        )
+        detail = {
+            "pipeline": p,
+            "source_titles": ["Channel A", "Channel B"],
+            "target_refs": ["@target"],
+        }
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get_detail = AsyncMock(return_value=detail)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_detail"]({"pipeline_id": 2})
+        text = _text(result)
+        assert "Detail Pipeline" in text
+        assert "Channel A" in text
+
+
+class TestPipelinesToolAddPipeline:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_pipeline"]({
+            "name": "New",
+            "prompt_template": "tmpl",
+            "source_channel_ids": "1,2",
+            "target_refs": "+7123|456",
+            "confirm": False,
+        })
+        assert "Подтвердите" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_required_fields(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_pipeline"]({"confirm": True, "name": "only name"})
+        assert "обязательны" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_invalid_target_ref_format(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_pipeline"]({
+            "confirm": True,
+            "name": "P",
+            "prompt_template": "t",
+            "source_channel_ids": "1",
+            "target_refs": "invalidformat",
+        })
+        assert "Неверный формат" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_creates_pipeline(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            with patch("src.services.pipeline_service.PipelineTargetRef"):
+                mock_svc.return_value.add = AsyncMock(return_value=10)
+                handlers = _get_tool_handlers(mock_db)
+                result = await handlers["add_pipeline"]({
+                    "confirm": True,
+                    "name": "My Pipeline",
+                    "prompt_template": "Write about {topic}",
+                    "source_channel_ids": "1,2",
+                    "target_refs": "+7123456|789",
+                    "llm_model": "gpt-4",
+                    "publish_mode": "auto",
+                })
+        text = _text(result)
+        assert "id=10" in text
+        assert "My Pipeline" in text
+
+
+class TestPipelinesToolTogglePipeline:
+    @pytest.mark.asyncio
+    async def test_missing_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["toggle_pipeline"]({})
+        assert "pipeline_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.toggle = AsyncMock(return_value=False)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["toggle_pipeline"]({"pipeline_id": 99})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_toggled(self, mock_db):
+        p = SimpleNamespace(id=1, name="P1", is_active=True)
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.toggle = AsyncMock(return_value=True)
+            mock_svc.return_value.get = AsyncMock(return_value=p)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["toggle_pipeline"]({"pipeline_id": 1})
+        text = _text(result)
+        assert "P1" in text
+        assert "активирован" in text
+
+
+class TestPipelinesToolDeletePipeline:
+    @pytest.mark.asyncio
+    async def test_missing_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["delete_pipeline"]({})
+        assert "pipeline_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        p = SimpleNamespace(id=1, name="PipeX")
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get = AsyncMock(return_value=p)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["delete_pipeline"]({"pipeline_id": 1, "confirm": False})
+        assert "Подтвердите" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_deletes_with_confirmation(self, mock_db):
+        p = SimpleNamespace(id=1, name="PipeToDelete")
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get = AsyncMock(return_value=p)
+            mock_svc.return_value.delete = AsyncMock()
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["delete_pipeline"]({"pipeline_id": 1, "confirm": True})
+        text = _text(result)
+        assert "PipeToDelete" in text
+        assert "удалён" in text
+
+
+class TestPipelinesToolListPipelineRuns:
+    @pytest.mark.asyncio
+    async def test_missing_pipeline_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_pipeline_runs"]({})
+        assert "pipeline_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_pipeline_runs"]({"pipeline_id": 1})
+        assert "Нет генераций" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_runs(self, mock_db):
+        run = SimpleNamespace(
+            id=10,
+            status="done",
+            moderation_status="approved",
+            generated_text="Content here",
+            created_at="2026-01-01",
+        )
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[run])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_pipeline_runs"]({"pipeline_id": 1, "limit": 10})
+        text = _text(result)
+        assert "run_id=10" in text
+        assert "approved" in text
+
+
+class TestPipelinesToolGetPipelineRun:
+    @pytest.mark.asyncio
+    async def test_missing_run_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_run"]({})
+        assert "run_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_run"]({"run_id": 99})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_found(self, mock_db):
+        run = SimpleNamespace(
+            id=5,
+            pipeline_id=2,
+            status="published",
+            moderation_status="approved",
+            quality_score=0.9,
+            created_at="2026-01-01",
+            updated_at="2026-01-02",
+            generated_text="Full content text",
+        )
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_run"]({"run_id": 5})
+        text = _text(result)
+        assert "Run id=5" in text
+        assert "Full content text" in text
+        assert "approved" in text
+
+
+# ---------------------------------------------------------------------------
+# images.py MCP tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestImagesToolGenerateImage:
+    @pytest.mark.asyncio
+    async def test_missing_prompt(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["generate_image"]({"prompt": ""})
+        assert "prompt обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_available(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=False)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+        assert "не настроена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_local_path_result(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a dog"})
+        text = _text(result)
+        assert "/local/path/image.png" in text
+
+    @pytest.mark.asyncio
+    async def test_no_result(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.generate = AsyncMock(return_value=None)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "something"})
+        assert "не вернула результат" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(side_effect=Exception("provider down"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "test"})
+        assert "Ошибка" in _text(result)
+
+
+class TestImagesToolListImageModels:
+    @pytest.mark.asyncio
+    async def test_missing_provider(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_image_models"]({"provider": ""})
+        assert "provider обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_models(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.search_models = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_image_models"]({"provider": "together"})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_models(self, mock_db):
+        models = [
+            {"id": "flux-schnell", "run_count": 10000, "rank": 1},
+            {"id": "flux-dev", "run_count": 5000},
+        ]
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.search_models = AsyncMock(return_value=models)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_image_models"]({"provider": "together", "query": "flux"})
+        text = _text(result)
+        assert "flux-schnell" in text
+        assert "10,000 runs" in text
+        assert "rank 1" in text
+
+
+class TestImagesToolListImageProviders:
+    @pytest.mark.asyncio
+    async def test_no_providers(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.adapter_names = []
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_image_providers"]({})
+        assert "не настроены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_providers(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.adapter_names = ["together", "hf", "replicate"]
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_image_providers"]({})
+        text = _text(result)
+        assert "together" in text
+        assert "hf" in text
+        assert "replicate" in text
+        assert "Провайдеры изображений (3)" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.side_effect = Exception("provider fail")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_image_providers"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestImagesToolListGeneratedImages:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.generated_images.list_recent = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_generated_images"]({})
+        assert "Нет сгенерированных" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_images(self, mock_db):
+        img = SimpleNamespace(
+            id=1,
+            prompt="a beautiful cat",
+            model="together:flux",
+            local_path="/data/img/abc.png",
+            created_at="2026-01-01",
+        )
+        mock_db.repos = MagicMock()
+        mock_db.repos.generated_images.list_recent = AsyncMock(return_value=[img])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_generated_images"]({"limit": 5})
+        text = _text(result)
+        assert "a beautiful cat" in text
+        assert "together:flux" in text
+        assert "/data/img/abc.png" in text
+
+    @pytest.mark.asyncio
+    async def test_long_prompt_truncated(self, mock_db):
+        long_prompt = "x" * 100
+        img = SimpleNamespace(
+            id=2,
+            prompt=long_prompt,
+            model=None,
+            local_path=None,
+            created_at="2026-01-01",
+        )
+        mock_db.repos = MagicMock()
+        mock_db.repos.generated_images.list_recent = AsyncMock(return_value=[img])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_generated_images"]({})
+        text = _text(result)
+        assert "..." in text
+        # truncated to 60 chars + "..."
+        assert "x" * 60 in text
+        assert "x" * 61 not in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.generated_images.list_recent = AsyncMock(side_effect=Exception("db err"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_generated_images"]({})
+        assert "Ошибка" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# my_telegram.py MCP tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestMyTelegramToolListDialogs:
+    @pytest.mark.asyncio
+    async def test_no_pool(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["list_dialogs"]({"phone": "+7123456"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_dialogs(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_pool = MagicMock()
+        ch_svc = MagicMock()
+        ch_svc.get_my_dialogs = AsyncMock(return_value=[])
+        with patch("src.services.channel_service.ChannelService", return_value=ch_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_dialogs(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_pool = MagicMock()
+        dialogs = [
+            {"title": "My Channel", "channel_id": 111, "channel_type": "channel"},
+            {"title": "My Group", "channel_id": 222, "channel_type": "group"},
+        ]
+        ch_svc = MagicMock()
+        ch_svc.get_my_dialogs = AsyncMock(return_value=dialogs)
+        with patch("src.services.channel_service.ChannelService", return_value=ch_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+        text = _text(result)
+        assert "My Channel" in text
+        assert "id=111" in text
+
+
+class TestMyTelegramToolRefreshDialogs:
+    @pytest.mark.asyncio
+    async def test_no_pool(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["refresh_dialogs"]({"phone": "+7123456"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_refresh_success(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_pool = MagicMock()
+        ch_svc = MagicMock()
+        ch_svc.get_my_dialogs = AsyncMock(return_value=[{"title": "X", "channel_id": 1, "channel_type": "channel"}])
+        with patch("src.services.channel_service.ChannelService", return_value=ch_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["refresh_dialogs"]({"phone": "+79001234567"})
+        text = _text(result)
+        assert "обновлены" in text
+        assert "1" in text
+
+
+class TestMyTelegramToolLeaveDialogs:
+    @pytest.mark.asyncio
+    async def test_no_pool(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["leave_dialogs"]({"phone": "+7123456", "dialog_ids": "1,2"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_dialog_ids(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["leave_dialogs"]({"phone": "+79001234567", "dialog_ids": "", "confirm": True})
+        assert "dialog_ids обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["leave_dialogs"]({"phone": "+79001234567", "dialog_ids": "1,2", "confirm": False})
+        assert "Подтвердите" in _text(result)
+
+
+class TestMyTelegramToolGetForumTopics:
+    @pytest.mark.asyncio
+    async def test_missing_channel_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_forum_topics"]({})
+        assert "channel_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_topics(self, mock_db):
+        mock_db.get_forum_topics = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_forum_topics"]({"channel_id": 123})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_topics(self, mock_db):
+        topics = [
+            {"topic_id": 1, "title": "General"},
+            {"topic_id": 2, "title": "Off-topic"},
+        ]
+        mock_db.get_forum_topics = AsyncMock(return_value=topics)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_forum_topics"]({"channel_id": 123})
+        text = _text(result)
+        assert "General" in text
+        assert "Off-topic" in text
+        assert "id=1" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        mock_db.get_forum_topics = AsyncMock(side_effect=Exception("no access"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_forum_topics"]({"channel_id": 123})
+        assert "Ошибка" in _text(result)
+
+
+class TestMyTelegramToolClearDialogCache:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_dialog_cache"]({"phone": "+79001234567", "confirm": False})
+        assert "Подтвердите" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_clears_for_phone(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value=None)
+        mock_db.repos = MagicMock()
+        mock_db.repos.dialog_cache.clear_dialogs = AsyncMock()
+        mock_pool = MagicMock()
+        mock_pool.invalidate_dialogs_cache = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["clear_dialog_cache"]({"phone": "+79001234567", "confirm": True})
+        assert "очищен" in _text(result)
+        mock_db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+79001234567")
+
+    @pytest.mark.asyncio
+    async def test_clears_all_when_no_phone(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.dialog_cache.clear_all_dialogs = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_dialog_cache"]({"phone": "", "confirm": True})
+        assert "очищен" in _text(result)
+        mock_db.repos.dialog_cache.clear_all_dialogs.assert_awaited_once()
+
+
+class TestMyTelegramToolGetCacheStatus:
+    @pytest.mark.asyncio
+    async def test_empty_cache(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_cache_status"]({})
+        assert "пуст" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_cache_entries(self, mock_db):
+        from datetime import datetime, timezone
+
+        mock_db.repos = MagicMock()
+        mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=["+79001234567"])
+        mock_db.repos.dialog_cache.count_dialogs = AsyncMock(return_value=42)
+        mock_db.repos.dialog_cache.get_cached_at = AsyncMock(
+            return_value=datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        )
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_cache_status"]({})
+        text = _text(result)
+        assert "+79001234567" in text
+        assert "42" in text
+        assert "2026-01-01" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.dialog_cache.get_all_phones = AsyncMock(side_effect=Exception("cache err"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_cache_status"]({})
+        assert "Ошибка" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# analytics.py MCP tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyticsToolGetAnalyticsSummary:
+    @pytest.mark.asyncio
+    async def test_returns_summary(self, mock_db):
+        summary = {
+            "total_generations": 100,
+            "total_published": 60,
+            "total_pending": 20,
+            "total_rejected": 10,
+            "pipelines_count": 5,
+        }
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_summary = AsyncMock(return_value=summary)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_analytics_summary"]({})
+        text = _text(result)
+        assert "100" in text
+        assert "60" in text
+        assert "Аналитика контента" in text
+        assert "Пайплайнов: 5" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_summary = AsyncMock(side_effect=Exception("analytics down"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_analytics_summary"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetPipelineStats:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_pipeline_stats = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_stats"]({})
+        assert "не найдена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_stats(self, mock_db):
+        stat = SimpleNamespace(
+            pipeline_id=1,
+            pipeline_name="Pipeline X",
+            total_generations=50,
+            total_published=40,
+            total_rejected=5,
+            pending_moderation=5,
+            success_rate=0.80,
+        )
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_pipeline_stats = AsyncMock(return_value=[stat])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_stats"]({"pipeline_id": 1})
+        text = _text(result)
+        assert "Pipeline X" in text
+        assert "генераций=50" in text
+        assert "80%" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_pipeline_stats = AsyncMock(side_effect=Exception("err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_stats"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetTrendingTopics:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_topics = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_topics"]({"days": 7, "limit": 10})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_topics(self, mock_db):
+        topics = [
+            SimpleNamespace(keyword="Python", count=500),
+            SimpleNamespace(keyword="AI", count=300),
+        ]
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_topics = AsyncMock(return_value=topics)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_topics"]({"days": 14, "limit": 5})
+        text = _text(result)
+        assert "Python" in text
+        assert "500 упоминаний" in text
+        assert "AI" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_topics = AsyncMock(side_effect=Exception("trend err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_topics"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetTrendingChannels:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_channels = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_channels"]({})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_channels(self, mock_db):
+        channels = [
+            SimpleNamespace(title="TechChannel", channel_id=100, count=200),
+            SimpleNamespace(title="NewsChannel", channel_id=200, count=150),
+        ]
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_channels = AsyncMock(return_value=channels)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_channels"]({"days": 7, "limit": 10})
+        text = _text(result)
+        assert "TechChannel" in text
+        assert "id=100" in text
+        assert "200 сообщений" in text
+
+
+class TestAnalyticsToolGetMessageVelocity:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_message_velocity = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_message_velocity"]({"days": 30})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_velocity(self, mock_db):
+        velocity = [
+            SimpleNamespace(date="2026-01-01", count=1000),
+            SimpleNamespace(date="2026-01-02", count=1200),
+        ]
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_message_velocity = AsyncMock(return_value=velocity)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_message_velocity"]({"days": 7})
+        text = _text(result)
+        assert "2026-01-01" in text
+        assert "1000 сообщений" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_message_velocity = AsyncMock(side_effect=Exception("err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_message_velocity"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetPeakHours:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_peak_hours = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_peak_hours"]({})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_hours(self, mock_db):
+        hours = [
+            SimpleNamespace(hour=9, count=500),
+            SimpleNamespace(hour=18, count=800),
+        ]
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_peak_hours = AsyncMock(return_value=hours)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_peak_hours"]({})
+        text = _text(result)
+        assert "09:00" in text
+        assert "500 сообщений" in text
+        assert "18:00" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_peak_hours = AsyncMock(side_effect=Exception("err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_peak_hours"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetCalendar:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
+            mock_svc.return_value.get_upcoming = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_calendar"]({"limit": 10})
+        assert "Нет запланированных" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_events(self, mock_db):
+        event = SimpleNamespace(
+            run_id=7,
+            pipeline_id=2,
+            pipeline_name="Content Pipe",
+            moderation_status="approved",
+            scheduled_time="2026-05-01T09:00:00",
+            created_at="2026-04-30",
+            preview="Preview of upcoming post",
+        )
+        with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
+            mock_svc.return_value.get_upcoming = AsyncMock(return_value=[event])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_calendar"]({})
+        text = _text(result)
+        assert "run_id=7" in text
+        assert "Content Pipe" in text
+        assert "Preview of upcoming post" in text
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
+            mock_svc.return_value.get_upcoming = AsyncMock(side_effect=Exception("cal err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_calendar"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestAnalyticsToolGetDailyStats:
+    @pytest.mark.asyncio
+    async def test_empty(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_daily_stats = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_daily_stats"]({"days": 7})
+        assert "Нет данных" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_data(self, mock_db):
+        rows = [
+            {"date": "2026-01-01", "count": 10, "published": 8},
+            {"date": "2026-01-02", "count": 15, "published": 12},
+        ]
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_daily_stats = AsyncMock(return_value=rows)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_daily_stats"]({"days": 7, "pipeline_id": 1})
+        text = _text(result)
+        assert "2026-01-01" in text
+        assert "генераций=10" in text
+        assert "опубл.=8" in text
+
+    @pytest.mark.asyncio
+    async def test_default_days(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_daily_stats = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            await handlers["get_daily_stats"]({})
+            # Should call with days=30 by default
+            mock_svc.return_value.get_daily_stats.assert_awaited_once_with(days=30, pipeline_id=None)
+
+    @pytest.mark.asyncio
+    async def test_error(self, mock_db):
+        with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_daily_stats = AsyncMock(side_effect=Exception("stats err"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_daily_stats"]({})
+        assert "Ошибка" in _text(result)

--- a/tests/test_agent_tools_new4.py
+++ b/tests/test_agent_tools_new4.py
@@ -618,7 +618,7 @@ class TestSendMessage:
         # no recipient, no text
         result = await handlers["send_message"]({"phone": "+79001234567"})
         text = _text(result)
-        assert "обязательны" in text or "confirm=true" in text
+        assert "обязательны" in text
 
 
 class TestEditMessage:
@@ -658,7 +658,7 @@ class TestEditMessage:
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_message"]({"phone": "+79001234567", "chat_id": "123", "text": "new"})
         text = _text(result)
-        assert "обязательны" in text or "confirm=true" in text
+        assert "обязательны" in text
 
 
 class TestDeleteMessage:
@@ -953,7 +953,7 @@ class TestEditPermissions:
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_permissions"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
         text = _text(result)
-        assert "флаг" in text or "confirm=true" in text
+        assert "флаг" in text
 
     @pytest.mark.asyncio
     async def test_with_confirm_success(self, mock_db):

--- a/tests/test_agent_tools_new4.py
+++ b/tests/test_agent_tools_new4.py
@@ -228,7 +228,7 @@ class TestSendPhotosNow:
                 {"phone": "+79001234567", "target": "12345", "file_paths": "a.jpg,b.jpg", "confirm": True}
             )
         text = _text(result)
-        assert "Фото отправлены" in text or "id=42" in text
+        assert "Фото отправлены" in text
 
 
 class TestSchedulePhotos:
@@ -271,7 +271,7 @@ class TestSchedulePhotos:
                 }
             )
         text = _text(result)
-        assert "запланированы" in text or "id=" in text
+        assert "запланированы" in text
 
 
 class TestCancelPhotoItem:
@@ -458,7 +458,7 @@ class TestCreatePhotoBatch:
                 {"phone": "+79001234567", "target": "12345", "file_paths": "a.jpg,b.jpg", "confirm": True}
             )
         text = _text(result)
-        assert "Батч создан" in text or "id=99" in text
+        assert "Батч создан" in text
 
 
 class TestRunPhotoDue:
@@ -535,7 +535,7 @@ class TestCreateAutoUpload:
                 }
             )
         text = _text(result)
-        assert "Автозагрузка создана" in text or "id=5" in text
+        assert "Автозагрузка создана" in text
 
 
 class TestUpdateAutoUpload:
@@ -649,7 +649,7 @@ class TestEditMessage:
             {"phone": "+79001234567", "chat_id": "123", "message_id": 5, "text": "updated text", "confirm": True}
         )
         text = _text(result)
-        assert "отредактировано" in text or "#5" in text
+        assert "отредактировано" in text
 
     @pytest.mark.asyncio
     async def test_missing_message_id_returns_error(self, mock_db):
@@ -1034,7 +1034,7 @@ class TestSetupNotificationBot:
             handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
             result = await handlers["setup_notification_bot"]({"confirm": True})
         text = _text(result)
-        assert "test_notify_bot" in text or "создан" in text
+        assert "создан" in text
 
 
 class TestDeleteNotificationBot:

--- a/tests/test_agent_tools_new4.py
+++ b/tests/test_agent_tools_new4.py
@@ -1,0 +1,1096 @@
+"""Tests for agent tools: photo_loader, messaging, notifications.
+
+These tests call actual tool handler functions via the @tool decorator's
+.handler attribute, ensuring argument parsing, formatting, and error handling
+are all exercised.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.database import Database
+from src.models import Account
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock Database for testing tools."""
+    db = MagicMock(spec=Database)
+    db.get_setting = AsyncMock(return_value=None)
+    return db
+
+
+def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
+    """Build MCP tools and return their handlers keyed by name."""
+    captured_tools = []
+
+    with patch(
+        "src.agent.tools.create_sdk_mcp_server",
+        side_effect=lambda **kw: captured_tools.extend(kw.get("tools", [])),
+    ):
+        from src.agent.tools import make_mcp_server
+
+        make_mcp_server(mock_db, client_pool=client_pool, config=config, **kwargs)
+
+    return {t.name: t.handler for t in captured_tools}
+
+
+def _text(result: dict) -> str:
+    """Extract text from tool result payload."""
+    return result["content"][0]["text"]
+
+
+def _make_account(phone="+79001234567", is_active=True, is_primary=True):
+    acc = MagicMock(spec=Account)
+    acc.id = 1
+    acc.phone = phone
+    acc.is_active = is_active
+    acc.is_primary = is_primary
+    acc.session_string = "fake"
+    return acc
+
+
+def _make_mock_pool():
+    """Create a mock client pool that returns a native client."""
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=MagicMock(id=123456))
+    mock_client.send_message = AsyncMock()
+    mock_client.edit_message = AsyncMock()
+    mock_client.delete_messages = AsyncMock(return_value=[MagicMock(pts_count=1)])
+    mock_client.forward_messages = AsyncMock(return_value=[MagicMock()])
+    mock_client.pin_message = AsyncMock()
+    mock_client.unpin_message = AsyncMock()
+    mock_client.get_participants = AsyncMock(return_value=[])
+    mock_client.kick_participant = AsyncMock()
+    mock_client.edit_folder = AsyncMock()
+    mock_client.send_read_acknowledge = AsyncMock()
+    mock_client.edit_admin = AsyncMock()
+    mock_client.edit_permissions = AsyncMock()
+
+    mock_pool = MagicMock()
+    mock_pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, None))
+    return mock_pool, mock_client
+
+
+def _make_photo_services():
+    """Create mocked PhotoTaskService and PhotoAutoUploadService."""
+    photo_task_svc = MagicMock()
+    photo_task_svc.list_batches = AsyncMock(return_value=[])
+    photo_task_svc.list_items = AsyncMock(return_value=[])
+    send_result = MagicMock()
+    send_result.id = 42
+    send_result.status = "pending"
+    photo_task_svc.send_now = AsyncMock(return_value=send_result)
+    schedule_result = MagicMock()
+    schedule_result.id = 7
+    photo_task_svc.schedule_send = AsyncMock(return_value=schedule_result)
+    photo_task_svc.cancel_item = AsyncMock(return_value=True)
+    photo_task_svc.create_batch = AsyncMock(return_value=99)
+    photo_task_svc.run_due = AsyncMock(return_value=3)
+
+    auto_upload_svc = MagicMock()
+    auto_upload_svc.list_jobs = AsyncMock(return_value=[])
+    auto_upload_svc.get_job = AsyncMock(return_value=None)
+    auto_upload_svc.update_job = AsyncMock()
+    auto_upload_svc.delete_job = AsyncMock()
+    auto_upload_svc.create_job = AsyncMock(return_value=5)
+    auto_upload_svc.run_due = AsyncMock(return_value=2)
+
+    return photo_task_svc, auto_upload_svc
+
+
+@contextmanager
+def _photo_ctx(photo_task_svc, auto_upload_svc):
+    """Context manager that patches photo services at their source modules."""
+    with (
+        patch("src.services.photo_task_service.PhotoTaskService", return_value=photo_task_svc),
+        patch("src.services.photo_auto_upload_service.PhotoAutoUploadService", return_value=auto_upload_svc),
+        patch("src.database.bundles.PhotoLoaderBundle"),
+        patch("src.services.photo_publish_service.PhotoPublishService"),
+    ):
+        yield
+
+
+@contextmanager
+def _notif_ctx(notif_svc):
+    """Context manager that patches notification services at their source modules."""
+    with (
+        patch("src.services.notification_service.NotificationService", return_value=notif_svc),
+        patch("src.services.notification_target_service.NotificationTargetService", return_value=MagicMock()),
+    ):
+        yield
+
+
+# ===========================================================================
+# photo_loader.py tools
+# ===========================================================================
+
+
+class TestListPhotoBatches:
+    @pytest.mark.asyncio
+    async def test_empty_returns_not_found(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_photo_batches"]({})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_batches_shows_info(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        batch = MagicMock()
+        batch.id = 1
+        batch.phone = "+79001234567"
+        batch.target_dialog_id = 100
+        batch.status = "pending"
+        batch.total_items = 5
+        batch.created_at = "2025-01-01"
+        photo_task_svc.list_batches = AsyncMock(return_value=[batch])
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_photo_batches"]({})
+        text = _text(result)
+        assert "Батчи фото (1)" in text
+        assert "batch_id=1" in text
+
+
+class TestListPhotoItems:
+    @pytest.mark.asyncio
+    async def test_empty_returns_not_found(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_photo_items"]({})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_items_shows_info(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        item = MagicMock()
+        item.id = 10
+        item.batch_id = 1
+        item.status = "scheduled"
+        item.scheduled_at = "2025-01-01T12:00:00"
+        photo_task_svc.list_items = AsyncMock(return_value=[item])
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_photo_items"]({})
+        text = _text(result)
+        assert "Элементы (1)" in text
+        assert "item_id=10" in text
+
+
+class TestSendPhotosNow:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["send_photos_now"]({"phone": "+79001234567", "target": "123", "file_paths": "a.jpg"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["send_photos_now"]({"phone": "+79001234567", "target": "123", "file_paths": "a.jpg"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        with (
+            _photo_ctx(photo_task_svc, auto_upload_svc),
+            patch("src.services.photo_task_service.PhotoTarget"),
+        ):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["send_photos_now"](
+                {"phone": "+79001234567", "target": "12345", "file_paths": "a.jpg,b.jpg", "confirm": True}
+            )
+        text = _text(result)
+        assert "Фото отправлены" in text or "id=42" in text
+
+
+class TestSchedulePhotos:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["schedule_photos"](
+            {"phone": "+79001234567", "target": "123", "file_paths": "a.jpg", "schedule_at": "2025-01-01T10:00:00"}
+        )
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["schedule_photos"](
+            {"phone": "+79001234567", "target": "123", "file_paths": "a.jpg", "schedule_at": "2025-01-01T10:00:00"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        with (
+            _photo_ctx(photo_task_svc, auto_upload_svc),
+            patch("src.services.photo_task_service.PhotoTarget"),
+        ):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["schedule_photos"](
+                {
+                    "phone": "+79001234567",
+                    "target": "12345",
+                    "file_paths": "a.jpg",
+                    "schedule_at": "2025-01-01T10:00:00",
+                    "confirm": True,
+                }
+            )
+        text = _text(result)
+        assert "запланированы" in text or "id=" in text
+
+
+class TestCancelPhotoItem:
+    @pytest.mark.asyncio
+    async def test_missing_item_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["cancel_photo_item"]({})
+        assert "item_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["cancel_photo_item"]({"item_id": 5})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_found_item_cancelled(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        photo_task_svc.cancel_item = AsyncMock(return_value=True)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["cancel_photo_item"]({"item_id": 5, "confirm": True})
+        assert "отменено" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_message(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        photo_task_svc.cancel_item = AsyncMock(return_value=False)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["cancel_photo_item"]({"item_id": 99, "confirm": True})
+        assert "Не удалось отменить" in _text(result)
+
+
+class TestListAutoUploads:
+    @pytest.mark.asyncio
+    async def test_empty_returns_not_configured(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_auto_uploads"]({})
+        assert "не настроены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_jobs_shows_info(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        job = MagicMock()
+        job.id = 3
+        job.phone = "+79001234567"
+        job.target_dialog_id = 555
+        job.folder_path = "/photos"
+        job.interval_minutes = 30
+        job.is_active = True
+        auto_upload_svc.list_jobs = AsyncMock(return_value=[job])
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_auto_uploads"]({})
+        text = _text(result)
+        assert "Автозагрузки (1)" in text
+        assert "id=3" in text
+
+
+class TestToggleAutoUpload:
+    @pytest.mark.asyncio
+    async def test_missing_job_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["toggle_auto_upload"]({})
+        assert "job_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        auto_upload_svc.get_job = AsyncMock(return_value=None)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["toggle_auto_upload"]({"job_id": 999})
+        assert "не найдена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_active_job_gets_paused(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        job = MagicMock()
+        job.is_active = True
+        auto_upload_svc.get_job = AsyncMock(return_value=job)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["toggle_auto_upload"]({"job_id": 3})
+        assert "приостановлена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_inactive_job_gets_activated(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        job = MagicMock()
+        job.is_active = False
+        auto_upload_svc.get_job = AsyncMock(return_value=job)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["toggle_auto_upload"]({"job_id": 4})
+        assert "активирована" in _text(result)
+
+
+class TestDeleteAutoUpload:
+    @pytest.mark.asyncio
+    async def test_missing_job_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_auto_upload"]({})
+        assert "job_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_auto_upload"]({"job_id": 5})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deleted(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["delete_auto_upload"]({"job_id": 5, "confirm": True})
+        assert "удалена" in _text(result)
+
+
+class TestCreatePhotoBatch:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["create_photo_batch"]({"phone": "+79001234567", "target": "123", "file_paths": "a.jpg"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        # empty file_paths and no target → validation error
+        result = await handlers["create_photo_batch"]({"phone": "+79001234567"})
+        assert "обязательны" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["create_photo_batch"](
+            {"phone": "+79001234567", "target": "123", "file_paths": "a.jpg"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_batch_created(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        with (
+            _photo_ctx(photo_task_svc, auto_upload_svc),
+            patch("src.services.photo_task_service.PhotoTarget"),
+        ):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["create_photo_batch"](
+                {"phone": "+79001234567", "target": "12345", "file_paths": "a.jpg,b.jpg", "confirm": True}
+            )
+        text = _text(result)
+        assert "Батч создан" in text or "id=99" in text
+
+
+class TestRunPhotoDue:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["run_photo_due"]({"confirm": True})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["run_photo_due"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_processes_items_and_jobs(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["run_photo_due"]({"confirm": True})
+        text = _text(result)
+        assert "items=3" in text
+        assert "auto_jobs=2" in text
+
+
+class TestCreateAutoUpload:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["create_auto_upload"](
+            {"phone": "+79001234567", "target": "123", "folder_path": "/photos"}
+        )
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        # neither target nor folder_path provided
+        result = await handlers["create_auto_upload"]({"phone": "+79001234567"})
+        assert "обязательны" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["create_auto_upload"](
+            {"phone": "+79001234567", "target": "123", "folder_path": "/photos"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_job_created(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["create_auto_upload"](
+                {
+                    "phone": "+79001234567",
+                    "target": "12345",
+                    "folder_path": "/photos",
+                    "interval_minutes": 30,
+                    "mode": "album",
+                    "confirm": True,
+                }
+            )
+        text = _text(result)
+        assert "Автозагрузка создана" in text or "id=5" in text
+
+
+class TestUpdateAutoUpload:
+    @pytest.mark.asyncio
+    async def test_missing_job_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["update_auto_upload"]({})
+        assert "job_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["update_auto_upload"]({"job_id": 1, "folder_path": "/new"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_found_returns_error(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        auto_upload_svc.get_job = AsyncMock(return_value=None)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["update_auto_upload"]({"job_id": 999, "confirm": True})
+        assert "не найдена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_updated(self, mock_db):
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        existing = MagicMock()
+        auto_upload_svc.get_job = AsyncMock(return_value=existing)
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["update_auto_upload"](
+                {"job_id": 3, "folder_path": "/new_folder", "interval_minutes": 60, "confirm": True}
+            )
+        assert "обновлена" in _text(result)
+
+
+# ===========================================================================
+# messaging.py tools
+# ===========================================================================
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["send_message"]({"phone": "+79001234567", "recipient": "@user", "text": "hi"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["send_message"]({"phone": "+79001234567", "recipient": "@user", "text": "hello"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["send_message"](
+            {"phone": "+79001234567", "recipient": "@user", "text": "hello", "confirm": True}
+        )
+        text = _text(result)
+        assert "отправлено" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_recipient_or_text_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        # no recipient, no text
+        result = await handlers["send_message"]({"phone": "+79001234567"})
+        text = _text(result)
+        assert "обязательны" in text or "confirm=true" in text
+
+
+class TestEditMessage:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["edit_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_id": 1, "text": "new"}
+        )
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_id": 1, "text": "new"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_id": 5, "text": "updated text", "confirm": True}
+        )
+        text = _text(result)
+        assert "отредактировано" in text or "#5" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_message_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_message"]({"phone": "+79001234567", "chat_id": "123", "text": "new"})
+        text = _text(result)
+        assert "обязательны" in text or "confirm=true" in text
+
+
+class TestDeleteMessage:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["delete_message"]({"phone": "+79001234567", "chat_id": "123", "message_ids": "1,2"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_invalid_message_ids_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_ids": "abc,xyz"}
+        )
+        assert "валидные message_ids" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_ids": "1,2,3"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_message"](
+            {"phone": "+79001234567", "chat_id": "123", "message_ids": "1,2", "confirm": True}
+        )
+        text = _text(result)
+        assert "Удалено" in text
+
+
+class TestForwardMessages:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["forward_messages"](
+            {"phone": "+79001234567", "from_chat": "A", "to_chat": "B", "message_ids": "1"}
+        )
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_invalid_ids_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["forward_messages"](
+            {"phone": "+79001234567", "from_chat": "A", "to_chat": "B", "message_ids": "abc"}
+        )
+        assert "валидные message_ids" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["forward_messages"](
+            {"phone": "+79001234567", "from_chat": "A", "to_chat": "B", "message_ids": "1,2"}
+        )
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["forward_messages"](
+            {
+                "phone": "+79001234567",
+                "from_chat": "chatA",
+                "to_chat": "chatB",
+                "message_ids": "1,2",
+                "confirm": True,
+            }
+        )
+        assert "Переслано" in _text(result)
+
+
+class TestPinMessage:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["pin_message"]({"phone": "+79001234567", "chat_id": "chat", "message_id": 1})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["pin_message"]({"phone": "+79001234567", "chat_id": "chat", "message_id": 10})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["pin_message"](
+            {"phone": "+79001234567", "chat_id": "chat", "message_id": 10, "confirm": True}
+        )
+        assert "закреплено" in _text(result)
+
+
+class TestUnpinMessage:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["unpin_message"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["unpin_message"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["unpin_message"]({"phone": "+79001234567", "chat_id": "chat", "confirm": True})
+        assert "откреплено" in _text(result)
+
+
+class TestGetParticipants:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["get_participants"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_participants(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        mock_client.get_participants = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["get_participants"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_participants(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        participant = MagicMock()
+        participant.id = 111
+        participant.first_name = "John"
+        participant.last_name = "Doe"
+        participant.username = "johndoe"
+        mock_client.get_participants = AsyncMock(return_value=[participant])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["get_participants"]({"phone": "+79001234567", "chat_id": "chat"})
+        text = _text(result)
+        assert "111" in text
+        assert "John" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["get_participants"]({"phone": "+79001234567"})
+        assert "chat_id обязателен" in _text(result)
+
+
+class TestKickParticipant:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["kick_participant"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["kick_participant"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["kick_participant"](
+            {"phone": "+79001234567", "chat_id": "chat", "user_id": "111", "confirm": True}
+        )
+        assert "исключён" in _text(result)
+
+
+class TestArchiveChat:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["archive_chat"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["archive_chat"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["archive_chat"]({"phone": "+79001234567", "chat_id": "chat", "confirm": True})
+        assert "архивирован" in _text(result)
+
+
+class TestMarkRead:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["mark_read"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["mark_read"]({"phone": "+79001234567"})
+        assert "chat_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pool_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["mark_read"]({"phone": "+79001234567", "chat_id": "chat"})
+        assert "прочитанные" in _text(result)
+
+
+class TestEditAdmin:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["edit_admin"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_admin"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_promote_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_admin"](
+            {"phone": "+79001234567", "chat_id": "chat", "user_id": "111", "is_admin": True, "confirm": True}
+        )
+        assert "обновлены" in _text(result)
+
+
+class TestEditPermissions:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["edit_permissions"](
+            {"phone": "+79001234567", "chat_id": "chat", "user_id": "111", "send_messages": False}
+        )
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_flags_returns_error(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_permissions"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
+        text = _text(result)
+        assert "флаг" in text or "confirm=true" in text
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_success(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["edit_permissions"](
+            {
+                "phone": "+79001234567",
+                "chat_id": "chat",
+                "user_id": "111",
+                "send_messages": False,
+                "confirm": True,
+            }
+        )
+        assert "обновлены" in _text(result)
+
+
+# ===========================================================================
+# notifications.py tools
+# ===========================================================================
+
+
+class TestGetNotificationStatus:
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_message(self, mock_db):
+        notif_svc = MagicMock()
+        notif_svc.get_status = AsyncMock(return_value=None)
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["get_notification_status"]({})
+        assert "не настроен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_configured_shows_bot_details(self, mock_db):
+        notif_svc = MagicMock()
+        bot = MagicMock()
+        bot.bot_username = "my_bot"
+        bot.chat_id = 123456
+        bot.created_at = "2025-01-01"
+        notif_svc.get_status = AsyncMock(return_value=bot)
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["get_notification_status"]({})
+        text = _text(result)
+        assert "my_bot" in text
+        assert "123456" in text
+
+
+class TestSetupNotificationBot:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["setup_notification_bot"]({"confirm": True})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["setup_notification_bot"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_pool_and_confirm_success(self, mock_db):
+        notif_svc = MagicMock()
+        bot = MagicMock()
+        bot.bot_username = "test_notify_bot"
+        bot.chat_id = 789
+        notif_svc.setup_bot = AsyncMock(return_value=bot)
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["setup_notification_bot"]({"confirm": True})
+        text = _text(result)
+        assert "test_notify_bot" in text or "создан" in text
+
+
+class TestDeleteNotificationBot:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["delete_notification_bot"]({"confirm": True})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["delete_notification_bot"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_with_confirm_deleted(self, mock_db):
+        notif_svc = MagicMock()
+        notif_svc.teardown_bot = AsyncMock()
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["delete_notification_bot"]({"confirm": True})
+        assert "удалён" in _text(result)
+
+
+class TestTestNotification:
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["test_notification"]({})
+        assert "CLI-режиме" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_message(self, mock_db):
+        notif_svc = MagicMock()
+        notif_svc.get_status = AsyncMock(return_value=None)
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["test_notification"]({})
+        assert "не настроен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_configured_sends_test(self, mock_db):
+        notif_svc = MagicMock()
+        bot = MagicMock()
+        notif_svc.get_status = AsyncMock(return_value=bot)
+        notif_svc.send_notification = AsyncMock()
+        mock_pool, _ = _make_mock_pool()
+
+        with _notif_ctx(notif_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["test_notification"]({})
+        text = _text(result)
+        assert "отправлено" in text


### PR DESCRIPTION
## Summary
- Add 4 test files covering agent tool handlers
- Covers: accounts, channels, collection, filters, scheduler, search_queries, deepagents_sync, pipelines, images, my_telegram, analytics, photo_loader, messaging, notifications

## Test plan
- [ ] `pytest tests/test_agent_tools_new1.py tests/test_agent_tools_new2.py tests/test_agent_tools_new3.py tests/test_agent_tools_new4.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)