### PR TITLE
test: add CLI/web and domain-specific coverage tests

### DIFF
--- a/tests/test_cli_web_coverage.py
+++ b/tests/test_cli_web_coverage.py
@@ -1,0 +1,711 @@
+"""Coverage tests for CLI commands and web routes with low existing coverage.
+
+Covers:
+- CLI: image (generate/models/providers)
+- CLI: settings (get/set/info)
+- CLI: analytics (summary/pipeline-stats/daily/trending-topics/trending-channels/velocity/peak-hours/calendar)
+- CLI: scheduler (status/stop/job-toggle/set-interval/task-cancel/clear-pending)
+- Web: /images routes (page/generate/models/search)
+- Web: /accounts routes (flood-status/flood-clear/toggle/delete)
+- Web: /calendar routes (page/api/calendar/api/upcoming/api/stats)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.collection_queue import CollectionQueue
+from src.config import AppConfig
+from src.database import Database
+from src.models import Account, Channel
+from src.scheduler.manager import SchedulerManager
+from src.search.ai_search import AISearchEngine
+from src.search.engine import SearchEngine
+from src.telegram.auth import TelegramAuth
+from src.telegram.collector import Collector
+from src.web.app import create_app
+from tests.helpers import cli_ns as _ns
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_ns(**kwargs) -> argparse.Namespace:
+    defaults = {"config": "config.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# CLI: image command
+# ---------------------------------------------------------------------------
+
+
+class TestCLIImageCommand:
+    """Tests for src/cli/commands/image.py"""
+
+    def test_providers_none_configured(self, capsys):
+        """providers action with no adapters prints help message."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.adapter_names = []
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="providers"))
+            out = capsys.readouterr().out
+            assert "No providers configured" in out
+
+    def test_providers_lists_names(self, capsys):
+        """providers action prints each adapter name."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.adapter_names = ["replicate", "together"]
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="providers"))
+            out = capsys.readouterr().out
+            assert "replicate" in out
+            assert "together" in out
+
+    def test_generate_no_providers(self, capsys):
+        """generate action when no providers configured prints warning."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=False)
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="generate", model=None, prompt="a cat"))
+            out = capsys.readouterr().out
+            assert "No image providers configured" in out
+
+    def test_generate_success(self, capsys):
+        """generate action prints result URL on success."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            svc.generate = AsyncMock(return_value="https://example.com/img.png")
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="generate", model="replicate:flux", prompt="a cat"))
+            out = capsys.readouterr().out
+            assert "https://example.com/img.png" in out
+
+    def test_generate_failure(self, capsys):
+        """generate action prints failure message when result is None."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            svc.generate = AsyncMock(return_value=None)
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="generate", model=None, prompt="a cat"))
+            out = capsys.readouterr().out
+            assert "Generation failed" in out
+
+    def test_models_no_results(self, capsys):
+        """models action with no results prints message."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.search_models = AsyncMock(return_value=[])
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="models", provider="replicate", query=""))
+            out = capsys.readouterr().out
+            assert "No models found" in out
+
+    def test_models_with_results(self, capsys):
+        """models action prints model strings and descriptions."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.search_models = AsyncMock(return_value=[
+                {"model_string": "replicate:flux", "run_count": 1000, "description": "Fast model"},
+                {"model_string": "replicate:sdxl", "run_count": None, "description": ""},
+            ])
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="models", provider="replicate", query="flux"))
+            out = capsys.readouterr().out
+            assert "replicate:flux" in out
+            assert "Fast model" in out
+
+    def test_unknown_action(self, capsys):
+        """Unknown action prints usage help."""
+        from src.cli.commands.image import run
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="unknown"))
+            out = capsys.readouterr().out
+            assert "Usage" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI: settings command
+# ---------------------------------------------------------------------------
+
+
+class TestCLISettingsCommand:
+    """Tests for src/cli/commands/settings.py"""
+
+    def test_get_all_empty(self, cli_env, capsys):
+        """get action with no key lists whatever settings exist (at least header)."""
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="get", key=None))
+        out = capsys.readouterr().out
+        # Either shows "No settings found" or a table header — either way no crash
+        assert out.strip() != ""
+
+    def test_get_all_with_data(self, cli_env, capsys):
+        """get action with no key lists all settings."""
+        asyncio.run(cli_env.set_setting("test_key", "test_value"))
+
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="get", key=None))
+        out = capsys.readouterr().out
+        assert "test_key" in out
+        assert "test_value" in out
+
+    def test_get_specific_key(self, cli_env, capsys):
+        """get action with specific key prints value."""
+        asyncio.run(cli_env.set_setting("my_key", "my_value"))
+
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="get", key="my_key"))
+        out = capsys.readouterr().out
+        assert "my_key" in out
+        assert "my_value" in out
+
+    def test_get_missing_key(self, cli_env, capsys):
+        """get action with missing key prints '(not set)'."""
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="get", key="nonexistent_key"))
+        out = capsys.readouterr().out
+        assert "(not set)" in out
+
+    def test_set_setting(self, cli_env, capsys):
+        """set action prints confirmation (DB access happens inside the CLI run)."""
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="set", key="foo", value="bar"))
+        out = capsys.readouterr().out
+        assert "Set foo = bar" in out
+
+    def test_info_action(self, cli_env, capsys):
+        """info action prints system information."""
+        from src.cli.commands.settings import run
+
+        run(_ns(settings_action="info"))
+        out = capsys.readouterr().out
+        assert "System information" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI: analytics extended commands
+# ---------------------------------------------------------------------------
+
+
+class TestCLIAnalyticsExtended:
+    """Tests for analytics sub-commands not covered by test_cli_analytics.py"""
+
+    def test_summary_empty(self, cli_env, capsys):
+        """summary action works with empty DB."""
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="summary", date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "Total generations" in out
+
+    def test_pipeline_stats_empty(self, cli_env, capsys):
+        """pipeline-stats action with no data prints message."""
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="pipeline-stats", date_from=None, date_to=None, pipeline_id=None))
+        out = capsys.readouterr().out
+        assert "No pipeline stats found" in out
+
+    def test_daily_empty(self, cli_env, capsys):
+        """daily action with no data prints 'No data'."""
+        from src.cli.commands.analytics import run
+
+        _target = "src.services.content_analytics_service.ContentAnalyticsService.get_daily_stats"
+        with patch(_target, new=AsyncMock(return_value=[])):
+            run(_ns(analytics_action="daily", date_from=None, date_to=None, days=30, pipeline_id=None))
+        out = capsys.readouterr().out
+        assert "No data" in out
+
+    def test_trending_topics_empty(self, cli_env, capsys):
+        """trending-topics action with no data prints message."""
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="trending-topics", date_from=None, date_to=None, days=7, limit=20))
+        out = capsys.readouterr().out
+        assert "No trending topics found" in out
+
+    def test_trending_channels_empty(self, cli_env, capsys):
+        """trending-channels action with no data prints message."""
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="trending-channels", date_from=None, date_to=None, days=7, limit=20))
+        out = capsys.readouterr().out
+        assert "No channel data found" in out
+
+    def test_velocity_empty(self, cli_env, capsys):
+        """velocity action with no data prints message."""
+        from src.cli.commands.analytics import run
+
+        with patch("src.services.trend_service.TrendService.get_message_velocity", new=AsyncMock(return_value=[])):
+            run(_ns(analytics_action="velocity", date_from=None, date_to=None, days=30))
+        out = capsys.readouterr().out
+        assert "No velocity data found" in out
+
+    def test_peak_hours_empty(self, cli_env, capsys):
+        """peak-hours action with no data prints message."""
+        from src.cli.commands.analytics import run
+
+        with patch("src.services.trend_service.TrendService.get_peak_hours", new=AsyncMock(return_value=[])):
+            run(_ns(analytics_action="peak-hours", date_from=None, date_to=None))
+        out = capsys.readouterr().out
+        assert "No peak hours data found" in out
+
+    def test_calendar_empty(self, cli_env, capsys):
+        """calendar action with no upcoming publications prints message."""
+        from src.cli.commands.analytics import run
+
+        run(_ns(analytics_action="calendar", date_from=None, date_to=None, limit=20, pipeline_id=None))
+        out = capsys.readouterr().out
+        assert "No upcoming publications" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI: scheduler command (actions that don't need a real pool)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_env_scheduler(cli_env):
+    """Patch runtime.init_pool to return an empty fake pool."""
+    fake_pool = MagicMock()
+    fake_pool.clients = {}
+    fake_pool.disconnect_all = AsyncMock()
+
+    async def fake_init_pool(config, db):
+        from src.telegram.auth import TelegramAuth
+        return TelegramAuth(0, ""), fake_pool
+
+    with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+        yield cli_env, fake_pool
+
+
+class TestCLISchedulerCommand:
+    """Tests for scheduler sub-commands (status/stop/job-toggle/set-interval/task-cancel/clear-pending)."""
+
+    def test_status_prints_interval(self, cli_env_scheduler, capsys):
+        """status action prints interval and autostart."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="status"))
+        out = capsys.readouterr().out
+        assert "Interval" in out
+
+    def test_stop_disables_autostart(self, cli_env_scheduler, capsys):
+        """stop action prints autostart-disabled message."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="stop"))
+        out = capsys.readouterr().out
+        assert "Scheduler autostart disabled" in out
+
+    def test_job_toggle_disables(self, cli_env_scheduler, capsys):
+        """job-toggle disables an enabled job."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="job-toggle", job_id="collect_all"))
+        out = capsys.readouterr().out
+        assert "collect_all" in out
+
+    def test_job_toggle_enables(self, cli_env_scheduler, capsys):
+        """job-toggle re-enables a disabled job."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+        asyncio.run(cli_env.repos.settings.set_setting("scheduler_job_disabled:collect_all", "1"))
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="job-toggle", job_id="collect_all"))
+        out = capsys.readouterr().out
+        assert "enabled" in out
+
+    def test_set_interval_collect_all(self, cli_env_scheduler, capsys):
+        """set-interval for collect_all prints confirmation."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="set-interval", job_id="collect_all", minutes=45))
+        out = capsys.readouterr().out
+        assert "45" in out
+
+    def test_set_interval_clamps_min(self, cli_env_scheduler, capsys):
+        """set-interval clamps below-minimum value to 1."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="set-interval", job_id="some_job", minutes=0))
+        out = capsys.readouterr().out
+        assert "1 min" in out
+
+    def test_task_cancel_not_found(self, cli_env_scheduler, capsys):
+        """task-cancel on missing task prints not-found message."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="task-cancel", task_id=99999))
+        out = capsys.readouterr().out
+        assert "not found" in out or "Task 99999" in out
+
+    def test_clear_pending(self, cli_env_scheduler, capsys):
+        """clear-pending prints deleted count."""
+        cli_env, fake_pool = cli_env_scheduler
+        fake_pool.clients = {"dummy": MagicMock()}
+
+        from src.cli.commands.scheduler import run
+
+        run(_ns(scheduler_action="clear-pending"))
+        out = capsys.readouterr().out
+        assert "Cleared" in out
+
+
+# ---------------------------------------------------------------------------
+# Web fixtures (scoped to this file — mirrors tests/routes/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def base_app(tmp_path):
+    """Minimal app with one account and channel for web route tests."""
+    config = AppConfig()
+    config.database.path = str(tmp_path / "test.db")
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+
+    app = create_app(config)
+    db = Database(config.database.path)
+    await db.initialize()
+    app.state.db = db
+    app.state.config = config
+
+    pool_mock = MagicMock()
+    pool_mock.clients = {"+1234567890": MagicMock()}
+    pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
+    pool_mock.resolve_channel = AsyncMock(return_value={
+        "channel_id": -1001234567890,
+        "title": "Test Channel",
+        "username": "testchannel",
+        "channel_type": "channel",
+    })
+    pool_mock.get_forum_topics = AsyncMock(return_value=[])
+    pool_mock.remove_client = AsyncMock()
+    pool_mock.disconnect_client = AsyncMock()
+    app.state.pool = pool_mock
+    app.state.auth = TelegramAuth(12345, "test_hash")
+    app.state.notifier = None
+
+    collector = Collector(pool_mock, db, config.scheduler)
+    app.state.collector = collector
+    collection_queue = CollectionQueue(collector, db)
+    app.state.collection_queue = collection_queue
+    app.state.search_engine = SearchEngine(db)
+    app.state.ai_search = AISearchEngine(config.llm, db)
+    app.state.scheduler = SchedulerManager(config.scheduler)
+    app.state.session_secret = "test_secret_key"
+    app.state.shutting_down = False
+
+    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+    await db.add_channel(Channel(channel_id=100, title="Test Channel"))
+
+    yield app, db, pool_mock
+
+    await collection_queue.shutdown()
+    await db.close()
+
+
+@pytest.fixture
+async def route_client(base_app):
+    """AsyncClient with Basic auth for web route tests."""
+    app, db, pool_mock = base_app
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=True,
+        headers={
+            "Authorization": f"Basic {auth_header}",
+            "Origin": "http://test",
+        },
+    ) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Web: /images routes
+# ---------------------------------------------------------------------------
+
+
+class TestWebImagesRoutes:
+    """Tests for src/web/routes/images.py"""
+
+    @pytest.mark.asyncio
+    async def test_images_page_renders(self, route_client):
+        """GET /images/ returns 200."""
+        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+            svc = MagicMock()
+            svc.adapter_names = []
+            mock_svc_fn.return_value = svc
+            resp = await route_client.get("/images/")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_generate_no_prompt(self, route_client):
+        """POST /images/generate without prompt returns 400."""
+        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            mock_svc_fn.return_value = svc
+            resp = await route_client.post("/images/generate", data={"prompt": ""})
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_generate_no_providers(self, route_client):
+        """POST /images/generate when no providers returns 409."""
+        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=False)
+            mock_svc_fn.return_value = svc
+            resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self, route_client):
+        """POST /images/generate with valid prompt and provider returns 200 with url."""
+        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            svc.generate = AsyncMock(return_value="https://example.com/img.png")
+            mock_svc_fn.return_value = svc
+            resp = await route_client.post(
+                "/images/generate",
+                data={"prompt": "a cat", "model": "replicate:flux"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert "url" in data
+
+    @pytest.mark.asyncio
+    async def test_generate_provider_failure(self, route_client):
+        """POST /images/generate when generation fails returns 500."""
+        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            svc.generate = AsyncMock(return_value=None)
+            mock_svc_fn.return_value = svc
+            resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
+        assert resp.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_models_search_no_provider(self, route_client):
+        """GET /images/models/search without provider returns 400."""
+        resp = await route_client.get("/images/models/search")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_models_search_with_provider(self, route_client):
+        """GET /images/models/search with provider returns model list."""
+        with (
+            patch("src.web.routes.images._get_provider_api_key", new_callable=AsyncMock, return_value="key"),
+            patch("src.web.routes.images.ImageGenerationService") as mock_svc_cls,
+        ):
+            svc = MagicMock()
+            svc.search_models = AsyncMock(return_value=[])
+            mock_svc_cls.return_value = svc
+            resp = await route_client.get("/images/models/search?provider=replicate&q=flux")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert "models" in data
+
+
+# ---------------------------------------------------------------------------
+# Web: /accounts routes
+# ---------------------------------------------------------------------------
+
+
+class TestWebAccountsRoutes:
+    """Tests for src/web/routes/accounts.py"""
+
+    @pytest.mark.asyncio
+    async def test_flood_status_empty(self, route_client, base_app):
+        """GET /settings/flood-status returns list of accounts."""
+        resp = await route_client.get("/settings/flood-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert "phone" in data[0]
+        assert "flood_wait_until" in data[0]
+
+    @pytest.mark.asyncio
+    async def test_flood_status_ok_field(self, route_client, base_app):
+        """GET /settings/flood-status returns ok status for accounts with no flood."""
+        resp = await route_client.get("/settings/flood-status")
+        data = resp.json()
+        acc = next((a for a in data if a["phone"] == "+1234567890"), None)
+        assert acc is not None
+        assert acc["flood_wait_until"] == "ok"
+        assert acc["remaining_seconds"] == 0
+
+    @pytest.mark.asyncio
+    async def test_flood_clear_not_found(self, route_client):
+        """POST /settings/999/flood-clear with non-existent account redirects with error."""
+        resp = await route_client.post("/settings/999/flood-clear", follow_redirects=False)
+        assert resp.status_code in (303, 200)
+
+    @pytest.mark.asyncio
+    async def test_toggle_account(self, route_client, base_app):
+        """POST /settings/{id}/toggle redirects to settings."""
+        _, db, _ = base_app
+        accounts = await db.get_accounts()
+        acc = accounts[0]
+        resp = await route_client.post(f"/settings/{acc.id}/toggle", follow_redirects=False)
+        assert resp.status_code == 303
+        assert "settings" in resp.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_delete_account(self, route_client, base_app):
+        """POST /settings/{id}/delete redirects to settings."""
+        _, db, _ = base_app
+        accounts = await db.get_accounts()
+        acc = accounts[0]
+        resp = await route_client.post(f"/settings/{acc.id}/delete", follow_redirects=False)
+        assert resp.status_code == 303
+        assert "settings" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# Web: /calendar routes
+# ---------------------------------------------------------------------------
+
+
+class TestWebCalendarRoutes:
+    """Tests for src/web/routes/calendar.py"""
+
+    @pytest.mark.asyncio
+    async def test_calendar_page_renders(self, route_client):
+        """GET /calendar/ returns 200."""
+        resp = await route_client.get("/calendar/")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_calendar_page_with_days_param(self, route_client):
+        """GET /calendar/?days=14 returns 200."""
+        resp = await route_client.get("/calendar/?days=14")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_calendar_page_invalid_days(self, route_client):
+        """GET /calendar/?days=0 returns 422 (out of range)."""
+        resp = await route_client.get("/calendar/?days=0")
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_api_calendar_returns_json(self, route_client):
+        """GET /calendar/api/calendar returns JSON list."""
+        resp = await route_client.get("/calendar/api/calendar")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_api_calendar_with_days(self, route_client):
+        """GET /calendar/api/calendar?days=3 returns JSON."""
+        resp = await route_client.get("/calendar/api/calendar?days=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_api_upcoming_returns_json(self, route_client):
+        """GET /calendar/api/upcoming returns JSON list."""
+        resp = await route_client.get("/calendar/api/upcoming")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_api_upcoming_with_limit(self, route_client):
+        """GET /calendar/api/upcoming?limit=5 returns list."""
+        resp = await route_client.get("/calendar/api/upcoming?limit=5")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_api_stats_returns_json(self, route_client):
+        """GET /calendar/api/stats returns JSON dict."""
+        resp = await route_client.get("/calendar/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, dict)
+
+    @pytest.mark.asyncio
+    async def test_api_calendar_pipeline_filter(self, route_client):
+        """GET /calendar/api/calendar?pipeline_id=999 returns empty list."""
+        resp = await route_client.get("/calendar/api/calendar?pipeline_id=999")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)

--- a/tests/test_misc_coverage.py
+++ b/tests/test_misc_coverage.py
@@ -1,0 +1,1039 @@
+"""Miscellaneous coverage tests for scheduler, CLI commands, process control,
+database connection, and agent manager."""
+
+from __future__ import annotations
+
+import os
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import AppConfig, SchedulerConfig
+from src.models import SearchQuery
+from src.scheduler.manager import SchedulerManager
+from tests.helpers import cli_ns as _ns
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_bundle(setting_val=None):
+    bundle = MagicMock()
+    bundle.get_setting = AsyncMock(return_value=setting_val)
+    bundle.set_setting = AsyncMock()
+    return bundle
+
+
+def _make_mock_sq_bundle(queries=None):
+    bundle = MagicMock()
+    bundle.get_all = AsyncMock(return_value=queries or [])
+    return bundle
+
+
+def _make_mock_pipeline_bundle(pipelines=None):
+    bundle = MagicMock()
+    bundle.get_all = AsyncMock(return_value=pipelines or [])
+    return bundle
+
+
+def _make_task_enqueuer():
+    enqueuer = MagicMock()
+    result = MagicMock()
+    result.queued_count = 2
+    result.skipped_existing_count = 0
+    result.total_candidates = 2
+    enqueuer.enqueue_all_channels = AsyncMock(return_value=result)
+    enqueuer.enqueue_sq_stats = AsyncMock()
+    enqueuer.enqueue_photo_due = AsyncMock()
+    enqueuer.enqueue_photo_auto = AsyncMock()
+    enqueuer.enqueue_pipeline_run = AsyncMock()
+    enqueuer.enqueue_content_generate = AsyncMock()
+    return enqueuer
+
+
+async def _make_mgr(db=None, *, config=None, task_enqueuer=None, sq_bundle=None, pipeline_bundle=None):
+    """Create a SchedulerManager with mock bundles (no real DB required)."""
+    scheduler_bundle = _make_mock_bundle()
+    sq_bundle = sq_bundle or _make_mock_sq_bundle()
+    pipeline_bundle = pipeline_bundle or _make_mock_pipeline_bundle()
+    cfg = config or SchedulerConfig(collect_interval_minutes=30)
+    mgr = SchedulerManager(
+        cfg,
+        scheduler_bundle=scheduler_bundle,
+        search_query_bundle=sq_bundle,
+        pipeline_bundle=pipeline_bundle,
+        task_enqueuer=task_enqueuer,
+    )
+    return mgr
+
+
+# ===========================================================================
+# 1. scheduler/manager.py
+# ===========================================================================
+
+
+class TestSchedulerUpdateInterval:
+    @pytest.mark.asyncio
+    async def test_update_interval_while_running(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            mgr.update_interval(15)
+            assert mgr._current_interval_minutes == 15
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_update_interval_stores_when_job_disabled(self):
+        """update_interval stores value when collect_all job is not registered."""
+        mock_bundle = _make_mock_bundle("1")  # job disabled
+        mgr = SchedulerManager(
+            SchedulerConfig(collect_interval_minutes=60),
+            scheduler_bundle=mock_bundle,
+        )
+        await mgr.start()
+        try:
+            # Even if job was not registered (disabled), interval is stored
+            mgr.update_interval(20)
+            assert mgr._current_interval_minutes == 20
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_update_interval_when_not_running(self):
+        mgr = await _make_mgr()
+        mgr.update_interval(45)
+        assert mgr._current_interval_minutes == 45
+
+
+class TestSchedulerGetJobNextRun:
+    @pytest.mark.asyncio
+    async def test_get_job_next_run_scheduler_none(self):
+        mgr = await _make_mgr()
+        assert mgr.get_job_next_run("collect_all") is None
+
+    @pytest.mark.asyncio
+    async def test_get_job_next_run_existing_job(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            result = mgr.get_job_next_run("collect_all")
+            # job was registered; next_run_time should be a datetime or None
+            assert result is not None or result is None  # just assert no exception
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_get_job_next_run_nonexistent_job(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            result = mgr.get_job_next_run("nonexistent_job_xyz")
+            assert result is None
+        finally:
+            await mgr.stop()
+
+
+class TestSchedulerGetAllJobsNextRun:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_scheduler_none(self):
+        mgr = await _make_mgr()
+        result = mgr.get_all_jobs_next_run()
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_dict_when_running(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            result = mgr.get_all_jobs_next_run()
+            assert isinstance(result, dict)
+            assert "collect_all" in result
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_ttl_cache_returns_same_object_within_5s(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            first = mgr.get_all_jobs_next_run()
+            second = mgr.get_all_jobs_next_run()
+            # Cache should return same object if called quickly
+            assert first is second
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_ttl_cache_refreshes_after_expiry(self):
+        mgr = await _make_mgr()
+        await mgr.start()
+        try:
+            mgr.get_all_jobs_next_run()
+            # Force cache expiry
+            mgr._jobs_cache_ts = time.monotonic() - 10.0
+            second = mgr.get_all_jobs_next_run()
+            # After expiry, a new dict is built (may be equal in content but is refreshed)
+            assert isinstance(second, dict)
+        finally:
+            await mgr.stop()
+
+
+class TestSchedulerSyncSearchQueryJobs:
+    @pytest.mark.asyncio
+    async def test_sync_sq_jobs_adds_job_for_active_query(self):
+        sq = SearchQuery(id=5, name="test", query="test", track_stats=True, interval_minutes=15)
+        sq_bundle = _make_mock_sq_bundle([sq])
+        mgr = await _make_mgr(sq_bundle=sq_bundle)
+        await mgr.start()
+        try:
+            await mgr.sync_search_query_jobs()
+            jobs = mgr._scheduler.get_jobs()
+            assert any(j.id == "sq_5" for j in jobs)
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_sync_sq_jobs_skips_non_track_stats(self):
+        sq = SearchQuery(id=6, name="no_track", query="no_track", track_stats=False, interval_minutes=15)
+        sq_bundle = _make_mock_sq_bundle([sq])
+        mgr = await _make_mgr(sq_bundle=sq_bundle)
+        await mgr.start()
+        try:
+            await mgr.sync_search_query_jobs()
+            jobs = mgr._scheduler.get_jobs()
+            assert not any(j.id == "sq_6" for j in jobs)
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_sync_sq_jobs_removes_stale_job(self):
+        sq = SearchQuery(id=7, name="q7", query="q7", track_stats=True, interval_minutes=10)
+        sq_bundle = _make_mock_sq_bundle([sq])
+        mgr = await _make_mgr(sq_bundle=sq_bundle)
+        await mgr.start()
+        try:
+            await mgr.sync_search_query_jobs()
+            assert any(j.id == "sq_7" for j in mgr._scheduler.get_jobs())
+
+            sq_bundle.get_all.return_value = []
+            await mgr.sync_search_query_jobs()
+            assert not any(j.id == "sq_7" for j in mgr._scheduler.get_jobs())
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_sync_sq_jobs_no_bundle(self):
+        """sync_search_query_jobs should return immediately when bundle is None."""
+        mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=_make_mock_bundle())
+        await mgr.start()
+        try:
+            await mgr.sync_search_query_jobs()  # no exception
+        finally:
+            await mgr.stop()
+
+
+class TestSchedulerSyncPipelineJobs:
+    @pytest.mark.asyncio
+    async def test_sync_pipeline_jobs_adds_jobs(self):
+        pipeline = MagicMock()
+        pipeline.id = 10
+        pipeline.is_active = True
+        pipeline.generate_interval_minutes = 60
+        pl_bundle = _make_mock_pipeline_bundle([pipeline])
+        mgr = await _make_mgr(pipeline_bundle=pl_bundle)
+        await mgr.start()
+        try:
+            await mgr.sync_pipeline_jobs()
+            jobs = mgr._scheduler.get_jobs()
+            job_ids = {j.id for j in jobs}
+            assert "pipeline_run_10" in job_ids
+            assert "content_generate_10" in job_ids
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_sync_pipeline_jobs_removes_stale(self):
+        pipeline = MagicMock()
+        pipeline.id = 11
+        pipeline.is_active = True
+        pipeline.generate_interval_minutes = 30
+        pl_bundle = _make_mock_pipeline_bundle([pipeline])
+        mgr = await _make_mgr(pipeline_bundle=pl_bundle)
+        await mgr.start()
+        try:
+            await mgr.sync_pipeline_jobs()
+            assert any(j.id == "pipeline_run_11" for j in mgr._scheduler.get_jobs())
+
+            pl_bundle.get_all.return_value = []
+            await mgr.sync_pipeline_jobs()
+            assert not any(j.id == "pipeline_run_11" for j in mgr._scheduler.get_jobs())
+        finally:
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_sync_pipeline_jobs_no_bundle(self):
+        mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=_make_mock_bundle())
+        await mgr.start()
+        try:
+            await mgr.sync_pipeline_jobs()  # no exception
+        finally:
+            await mgr.stop()
+
+
+class TestSchedulerGetPotentialJobs:
+    @pytest.mark.asyncio
+    async def test_get_potential_jobs_basic(self):
+        mgr = await _make_mgr()
+        jobs = await mgr.get_potential_jobs()
+        assert any(j["job_id"] == "collect_all" for j in jobs)
+
+    @pytest.mark.asyncio
+    async def test_get_potential_jobs_with_task_enqueuer(self):
+        enqueuer = _make_task_enqueuer()
+        mgr = await _make_mgr(task_enqueuer=enqueuer)
+        jobs = await mgr.get_potential_jobs()
+        job_ids = {j["job_id"] for j in jobs}
+        assert "photo_due" in job_ids
+        assert "photo_auto" in job_ids
+
+    @pytest.mark.asyncio
+    async def test_get_potential_jobs_with_sq_bundle(self):
+        sq = SearchQuery(id=20, name="sq20", query="sq20", track_stats=True, interval_minutes=10)
+        sq_bundle = _make_mock_sq_bundle([sq])
+        mgr = await _make_mgr(sq_bundle=sq_bundle)
+        jobs = await mgr.get_potential_jobs()
+        assert any(j["job_id"] == "sq_20" for j in jobs)
+
+    @pytest.mark.asyncio
+    async def test_get_potential_jobs_with_pipeline_bundle(self):
+        pipeline = MagicMock()
+        pipeline.id = 99
+        pipeline.is_active = True
+        pipeline.generate_interval_minutes = 60
+        pl_bundle = _make_mock_pipeline_bundle([pipeline])
+        mgr = await _make_mgr(pipeline_bundle=pl_bundle)
+        jobs = await mgr.get_potential_jobs()
+        job_ids = {j["job_id"] for j in jobs}
+        assert "pipeline_run_99" in job_ids
+        assert "content_generate_99" in job_ids
+
+
+class TestSchedulerLoadSettings:
+    @pytest.mark.asyncio
+    async def test_load_settings_reads_interval(self):
+        mock_bundle = _make_mock_bundle("25")
+        mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=60), scheduler_bundle=mock_bundle)
+        await mgr.load_settings()
+        assert mgr._current_interval_minutes == 25
+
+    @pytest.mark.asyncio
+    async def test_load_settings_uses_default_when_no_bundle(self):
+        mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=60))
+        await mgr.load_settings()
+        assert mgr._current_interval_minutes == 60
+
+    @pytest.mark.asyncio
+    async def test_load_settings_invalid_value_uses_default(self):
+        mock_bundle = _make_mock_bundle("not_a_number")
+        mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=45), scheduler_bundle=mock_bundle)
+        await mgr.load_settings()
+        assert mgr._current_interval_minutes == 45
+
+
+class TestSchedulerIsJobEnabled:
+    @pytest.mark.asyncio
+    async def test_is_job_enabled_returns_true_when_no_bundle(self):
+        mgr = SchedulerManager(SchedulerConfig())
+        assert await mgr.is_job_enabled("collect_all") is True
+
+    @pytest.mark.asyncio
+    async def test_is_job_enabled_returns_true_by_default(self):
+        mock_bundle = _make_mock_bundle(None)
+        mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
+        assert await mgr.is_job_enabled("collect_all") is True
+
+    @pytest.mark.asyncio
+    async def test_is_job_enabled_returns_false_when_disabled(self):
+        mock_bundle = _make_mock_bundle("1")
+        mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
+        assert await mgr.is_job_enabled("collect_all") is False
+
+    @pytest.mark.asyncio
+    async def test_is_job_enabled_returns_true_when_not_one(self):
+        mock_bundle = _make_mock_bundle("0")
+        mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
+        assert await mgr.is_job_enabled("collect_all") is True
+
+
+class TestSchedulerRunPhotoDue:
+    @pytest.mark.asyncio
+    async def test_run_photo_due_no_enqueuer(self):
+        mgr = await _make_mgr()
+        result = await mgr._run_photo_due()
+        assert result == {"processed": 0}
+
+    @pytest.mark.asyncio
+    async def test_run_photo_due_with_enqueuer(self):
+        enqueuer = _make_task_enqueuer()
+        mgr = await _make_mgr(task_enqueuer=enqueuer)
+        result = await mgr._run_photo_due()
+        assert result == {"enqueued": True}
+        enqueuer.enqueue_photo_due.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_photo_auto_no_enqueuer(self):
+        mgr = await _make_mgr()
+        result = await mgr._run_photo_auto()
+        assert result == {"jobs": 0}
+
+    @pytest.mark.asyncio
+    async def test_run_photo_auto_with_enqueuer(self):
+        enqueuer = _make_task_enqueuer()
+        mgr = await _make_mgr(task_enqueuer=enqueuer)
+        result = await mgr._run_photo_auto()
+        assert result == {"enqueued": True}
+        enqueuer.enqueue_photo_auto.assert_called_once()
+
+
+# ===========================================================================
+# 2. cli/commands/notification.py
+# ===========================================================================
+
+
+class TestCLINotification:
+    def test_notification_status_none(self, cli_env, capsys):
+        from src.cli.commands.notification import run
+
+        fake_pool = AsyncMock()
+        fake_pool.clients = {}
+        fake_pool.disconnect_all = AsyncMock()
+
+        async def fake_init_pool(config, db):
+            from src.telegram.auth import TelegramAuth
+            return TelegramAuth(0, ""), fake_pool
+
+        with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+            with patch(
+                "src.services.notification_service.NotificationService.get_status",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                run(_ns(notification_action="status"))
+        out = capsys.readouterr().out
+        assert "No notification bot configured" in out
+
+    def test_notification_status_with_bot(self, cli_env, capsys):
+        from datetime import datetime, timezone
+
+        from src.cli.commands.notification import run
+        from src.models import NotificationBot
+
+        fake_pool = AsyncMock()
+        fake_pool.clients = {}
+        fake_pool.disconnect_all = AsyncMock()
+
+        bot = NotificationBot(
+            tg_user_id=111,
+            bot_id=123456,
+            bot_username="testbot",
+            bot_token="token123",
+            created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+        async def fake_init_pool(config, db):
+            from src.telegram.auth import TelegramAuth
+            return TelegramAuth(0, ""), fake_pool
+
+        with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+            with patch(
+                "src.services.notification_service.NotificationService.get_status",
+                new_callable=AsyncMock,
+                return_value=bot,
+            ):
+                run(_ns(notification_action="status"))
+        out = capsys.readouterr().out
+        assert "testbot" in out
+        assert "123456" in out
+
+    def test_notification_delete(self, cli_env, capsys):
+        from src.cli.commands.notification import run
+
+        fake_pool = AsyncMock()
+        fake_pool.clients = {}
+        fake_pool.disconnect_all = AsyncMock()
+
+        async def fake_init_pool(config, db):
+            from src.telegram.auth import TelegramAuth
+            return TelegramAuth(0, ""), fake_pool
+
+        with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+            with patch(
+                "src.services.notification_service.NotificationService.teardown_bot",
+                new_callable=AsyncMock,
+            ):
+                run(_ns(notification_action="delete"))
+        out = capsys.readouterr().out
+        assert "deleted" in out.lower()
+
+    def test_notification_test_message(self, cli_env, capsys):
+        from src.cli.commands.notification import run
+
+        fake_pool = AsyncMock()
+        fake_pool.clients = {}
+        fake_pool.disconnect_all = AsyncMock()
+
+        async def fake_init_pool(config, db):
+            from src.telegram.auth import TelegramAuth
+            return TelegramAuth(0, ""), fake_pool
+
+        # Patch the whole NotificationService so send_notification is available
+        fake_svc = MagicMock()
+        fake_svc.send_notification = AsyncMock()
+
+        with patch("src.cli.runtime.init_pool", side_effect=fake_init_pool):
+            with patch(
+                "src.cli.commands.notification.NotificationService",
+                return_value=fake_svc,
+            ):
+                run(_ns(notification_action="test", message="hello"))
+        out = capsys.readouterr().out
+        assert "sent" in out.lower()
+
+
+# ===========================================================================
+# 3. cli/commands/test.py — read/write checks
+# ===========================================================================
+
+
+class TestCLITestReadChecks:
+    @pytest.mark.asyncio
+    async def test_check_get_stats_pass(self, db):
+        from src.cli.commands.test import Status, _check_get_stats
+
+        result = await _check_get_stats(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_account_list_pass(self, db):
+        from src.cli.commands.test import Status, _check_account_list
+
+        result = await _check_account_list(db)
+        assert result.status == Status.PASS
+        assert "accounts" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_check_channel_list_pass(self, db):
+        from src.cli.commands.test import Status, _check_channel_list
+
+        result = await _check_channel_list(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_notification_queries_skip_when_empty(self, db):
+        from src.cli.commands.test import Status, _check_notification_queries
+
+        result = await _check_notification_queries(db)
+        assert result.status == Status.SKIP
+
+    @pytest.mark.asyncio
+    async def test_check_local_search_pass(self, db):
+        from src.cli.commands.test import Status, _check_local_search
+
+        result = await _check_local_search(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_collection_tasks_pass(self, db):
+        from src.cli.commands.test import Status, _check_collection_tasks
+
+        result = await _check_collection_tasks(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_recent_searches_skip_when_empty(self, db):
+        from src.cli.commands.test import Status, _check_recent_searches
+
+        result = await _check_recent_searches(db)
+        assert result.status == Status.SKIP
+
+    @pytest.mark.asyncio
+    async def test_check_pipeline_list_pass(self, db):
+        from src.cli.commands.test import Status, _check_pipeline_list
+
+        result = await _check_pipeline_list(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_notification_bot_pass(self, db):
+        from src.cli.commands.test import Status, _check_notification_bot
+
+        result = await _check_notification_bot(db)
+        assert result.status == Status.PASS
+
+    @pytest.mark.asyncio
+    async def test_check_photo_tasks_pass(self, db):
+        from src.cli.commands.test import Status, _check_photo_tasks
+
+        result = await _check_photo_tasks(db)
+        assert result.status == Status.PASS
+
+    def test_print_result_pass(self, capsys):
+        from src.cli.commands.test import CheckResult, Status, _print_result
+
+        _print_result(CheckResult("test_check", Status.PASS, "all good"))
+        out = capsys.readouterr().out
+        assert "PASS" in out
+        assert "test_check" in out
+
+    def test_print_result_fail(self, capsys):
+        from src.cli.commands.test import CheckResult, Status, _print_result
+
+        _print_result(CheckResult("test_check", Status.FAIL, "broken"))
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+
+    def test_print_result_skip(self, capsys):
+        from src.cli.commands.test import CheckResult, Status, _print_result
+
+        _print_result(CheckResult("test_check", Status.SKIP, "skipped"))
+        out = capsys.readouterr().out
+        assert "SKIP" in out
+
+
+class TestCLITestDataclasses:
+    def test_check_result_attributes(self):
+        from src.cli.commands.test import CheckResult, Status
+
+        r = CheckResult("mycheck", Status.PASS, "detail text")
+        assert r.name == "mycheck"
+        assert r.status == Status.PASS
+        assert r.detail == "detail text"
+
+    def test_benchmark_step_attributes(self):
+        from src.cli.commands.test import BenchmarkStep
+
+        step = BenchmarkStep("my_step", ("python", "-m", "pytest"))
+        assert step.name == "my_step"
+        assert step.command == ("python", "-m", "pytest")
+
+    def test_format_exception_with_message(self):
+        from src.cli.commands.test import _format_exception
+
+        exc = ValueError("something went wrong")
+        result = _format_exception(exc)
+        assert result == "something went wrong"
+
+    def test_format_exception_empty_uses_class_name(self):
+        from src.cli.commands.test import _format_exception
+
+        exc = ValueError("")
+        result = _format_exception(exc)
+        assert result == "ValueError"
+
+    def test_run_benchmark_step_records_time(self, tmp_path):
+        """_run_benchmark_step returns a float elapsed time."""
+        import sys
+
+        from src.cli.commands.test import BenchmarkStep, _run_benchmark_step
+
+        # Run a trivial command that succeeds quickly
+        step = BenchmarkStep("trivial", (sys.executable, "-c", "pass"))
+        elapsed = _run_benchmark_step(step)
+        assert isinstance(elapsed, float)
+        assert elapsed >= 0.0
+
+    def test_run_benchmark_step_raises_on_failure(self):
+        import sys
+
+        from src.cli.commands.test import BenchmarkStep, _run_benchmark_step
+
+        step = BenchmarkStep("failing_step", (sys.executable, "-c", "raise SystemExit(1)"))
+        with pytest.raises(SystemExit):
+            _run_benchmark_step(step)
+
+
+class TestCLITestRun:
+    def test_run_read_action_calls_db(self, cli_env, capsys):
+        from src.cli.commands.test import run
+
+        run(_ns(test_action="read"))
+        out = capsys.readouterr().out
+        assert "Read Tests" in out
+        assert "passed" in out
+
+    def test_run_read_action_db_fail_exits(self, cli_env, capsys):
+        from src.cli.commands.test import run
+
+        with patch("src.cli.runtime.init_db", side_effect=Exception("db crash")):
+            with pytest.raises(SystemExit):
+                run(_ns(test_action="read"))
+
+
+# ===========================================================================
+# 4. cli/process_control.py
+# ===========================================================================
+
+
+class TestProcessControl:
+    def test_read_pid_returns_none_when_no_file(self, tmp_path):
+        from src.cli.process_control import read_pid
+
+        p = tmp_path / "test.pid"
+        assert read_pid(p) is None
+
+    def test_read_pid_returns_int(self, tmp_path):
+        from src.cli.process_control import read_pid
+
+        p = tmp_path / "test.pid"
+        p.write_text("12345\n", encoding="utf-8")
+        assert read_pid(p) == 12345
+
+    def test_read_pid_empty_file_returns_none(self, tmp_path):
+        from src.cli.process_control import read_pid
+
+        p = tmp_path / "test.pid"
+        p.write_text("   \n", encoding="utf-8")
+        assert read_pid(p) is None
+
+    def test_read_pid_invalid_raises(self, tmp_path):
+        from src.cli.process_control import ProcessControlError, read_pid
+
+        p = tmp_path / "test.pid"
+        p.write_text("not_a_pid", encoding="utf-8")
+        with pytest.raises(ProcessControlError):
+            read_pid(p)
+
+    def test_remove_pid_file_removes_existing(self, tmp_path):
+        from src.cli.process_control import remove_pid_file
+
+        p = tmp_path / "test.pid"
+        p.write_text("1", encoding="utf-8")
+        remove_pid_file(p)
+        assert not p.exists()
+
+    def test_remove_pid_file_ignores_missing(self, tmp_path):
+        from src.cli.process_control import remove_pid_file
+
+        p = tmp_path / "nonexistent.pid"
+        remove_pid_file(p)  # should not raise
+
+    def test_is_process_alive_current_process(self):
+        from src.cli.process_control import is_process_alive
+
+        assert is_process_alive(os.getpid()) is True
+
+    def test_is_process_alive_nonexistent_pid(self):
+        from src.cli.process_control import is_process_alive
+
+        # PID 0 is the kernel idle process on Linux/macOS; kill -0 to 0 raises PermissionError
+        # Use a very large PID that's almost certainly not running
+        assert is_process_alive(999999999) is False
+
+    def test_register_and_unregister(self, tmp_path):
+        from src.cli.process_control import register_current_process, unregister_current_process
+
+        p = tmp_path / "test.pid"
+        register_current_process(p)
+        assert p.exists()
+        pid_read = int(p.read_text(encoding="utf-8").strip())
+        assert pid_read == os.getpid()
+
+        unregister_current_process(p)
+        assert not p.exists()
+
+    def test_ensure_server_not_running_no_pid_file(self, tmp_path):
+        from src.cli.process_control import ensure_server_not_running
+
+        p = tmp_path / "no.pid"
+        ensure_server_not_running(p)  # should return silently
+
+    def test_ensure_server_not_running_own_pid_removes_file(self, tmp_path):
+        from src.cli.process_control import ensure_server_not_running
+
+        p = tmp_path / "self.pid"
+        p.write_text(f"{os.getpid()}\n", encoding="utf-8")
+        ensure_server_not_running(p)
+        assert not p.exists()
+
+    def test_stop_server_no_pid_file(self, tmp_path):
+        from src.cli.process_control import StopResult, stop_server
+
+        p = tmp_path / "no.pid"
+        outcome = stop_server(p)
+        assert outcome.result == StopResult.NOT_RUNNING
+
+    def test_stop_server_stale_pid(self, tmp_path):
+        from src.cli.process_control import StopResult, stop_server
+
+        p = tmp_path / "stale.pid"
+        p.write_text("999999999\n", encoding="utf-8")
+        outcome = stop_server(p)
+        assert outcome.result == StopResult.STALE_PID
+        assert not p.exists()
+
+    def test_pid_file_path(self, tmp_path):
+        from src.cli.process_control import pid_file_path
+
+        config = AppConfig()
+        config.database.path = str(tmp_path / "mydb.db")
+        path = pid_file_path(config)
+        assert path.suffix == ".pid"
+        assert path.stem == "mydb"
+
+
+# ===========================================================================
+# 5. database/connection.py
+# ===========================================================================
+
+
+class TestDBConnection:
+    @pytest.mark.asyncio
+    async def test_connect_creates_wal_db(self, tmp_path):
+        from src.database.connection import DBConnection
+
+        db_path = str(tmp_path / "test_conn.db")
+        conn = DBConnection(db_path)
+        try:
+            db = await conn.connect()
+            assert db is not None
+            # WAL mode should be set
+            cursor = await db.execute("PRAGMA journal_mode")
+            row = await cursor.fetchone()
+            assert row[0] == "wal"
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, tmp_path):
+        from src.database.connection import DBConnection
+
+        db_path = str(tmp_path / "test_close.db")
+        conn = DBConnection(db_path)
+        await conn.connect()
+        await conn.close()
+        await conn.close()  # second close should not raise
+
+    @pytest.mark.asyncio
+    async def test_close_when_not_connected(self, tmp_path):
+        from src.database.connection import DBConnection
+
+        db_path = str(tmp_path / "never_opened.db")
+        conn = DBConnection(db_path)
+        await conn.close()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_execute_fetchall(self, tmp_path):
+        from src.database.connection import DBConnection
+
+        db_path = str(tmp_path / "test_exec.db")
+        conn = DBConnection(db_path)
+        try:
+            await conn.connect()
+            rows = await conn.execute_fetchall("SELECT 1 as n")
+            assert len(rows) == 1
+        finally:
+            await conn.close()
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_directory(self, tmp_path):
+        from src.database.connection import DBConnection
+
+        nested = tmp_path / "nested" / "dir" / "db.sqlite"
+        conn = DBConnection(str(nested))
+        try:
+            await conn.connect()
+            assert nested.parent.exists()
+        finally:
+            await conn.close()
+
+
+# ===========================================================================
+# 6. agent/manager.py
+# ===========================================================================
+
+
+class TestAgentRuntimeStatus:
+    def test_dataclass_fields(self):
+        from src.agent.manager import AgentRuntimeStatus
+
+        status = AgentRuntimeStatus(
+            claude_available=True,
+            deepagents_available=False,
+            dev_mode_enabled=False,
+            backend_override="auto",
+            selected_backend="claude",
+            fallback_model="",
+            fallback_provider="",
+            using_override=False,
+            error=None,
+        )
+        assert status.claude_available is True
+        assert status.selected_backend == "claude"
+        assert status.error is None
+
+    def test_dataclass_with_error(self):
+        from src.agent.manager import AgentRuntimeStatus
+
+        status = AgentRuntimeStatus(
+            claude_available=False,
+            deepagents_available=False,
+            dev_mode_enabled=False,
+            backend_override="auto",
+            selected_backend=None,
+            fallback_model="",
+            fallback_provider="",
+            using_override=False,
+            error="No backend configured",
+        )
+        assert status.error == "No backend configured"
+        assert status.selected_backend is None
+
+
+class TestAgentManagerInit:
+    def test_init_with_defaults(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        assert mgr._db is db
+        assert mgr._config is not None
+        assert mgr._claude_backend is not None
+        assert mgr._deepagents_backend is not None
+        assert mgr._active_tasks == {}
+
+    def test_init_with_config(self, db):
+        from src.agent.manager import AgentManager
+
+        config = AppConfig()
+        mgr = AgentManager(db, config=config)
+        assert mgr._config is config
+
+    def test_available_false_when_no_credentials(self, db):
+        from src.agent.manager import AgentManager
+
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove any API keys
+            env_clean = {k: v for k, v in os.environ.items()
+                         if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")}
+            with patch.dict(os.environ, env_clean, clear=True):
+                mgr = AgentManager(db)
+                # Claude available depends on env vars
+                claude_avail = mgr._claude_backend.available
+                assert isinstance(claude_avail, bool)
+
+
+class TestAgentManagerRefreshSettingsCache:
+    @pytest.mark.asyncio
+    async def test_refresh_settings_cache_no_preflight(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        # Should not raise
+        await mgr.refresh_settings_cache(preflight=False)
+
+    @pytest.mark.asyncio
+    async def test_refresh_settings_cache_with_preflight_no_config(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        # preflight=True with no deepagents configured; should not raise
+        await mgr.refresh_settings_cache(preflight=True)
+
+
+class TestAgentManagerGetRuntimeStatus:
+    @pytest.mark.asyncio
+    async def test_get_runtime_status_returns_status(self, db):
+        from src.agent.manager import AgentManager, AgentRuntimeStatus
+
+        mgr = AgentManager(db)
+        status = await mgr.get_runtime_status()
+        assert isinstance(status, AgentRuntimeStatus)
+        assert isinstance(status.claude_available, bool)
+        assert isinstance(status.deepagents_available, bool)
+
+    @pytest.mark.asyncio
+    async def test_get_runtime_status_no_backends(self, db):
+        from src.agent.manager import AgentManager, ClaudeSdkBackend
+
+        mgr = AgentManager(db)
+        # Patch the `available` property at the class level temporarily
+        with patch.object(ClaudeSdkBackend, "available", new_callable=lambda: property(lambda self: False)):
+            status = await mgr.get_runtime_status()
+        assert isinstance(status.selected_backend, (str, type(None)))
+
+    @pytest.mark.asyncio
+    async def test_get_runtime_status_dev_mode_override(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        # Set dev mode and override in DB
+        await db.set_setting("agent_dev_mode_enabled", "1")
+        await db.set_setting("agent_backend_override", "claude")
+
+        status = await mgr.get_runtime_status()
+        assert status.dev_mode_enabled is True
+        assert status.backend_override == "claude"
+
+
+class TestAgentManagerBuildPrompt:
+    def test_build_prompt_no_history(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        prompt, stats = mgr._build_prompt([], "Hello")
+        assert "Hello" in prompt
+        assert stats["total_msgs"] == 0
+        assert stats["kept_msgs"] == 0
+
+    def test_build_prompt_with_history(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        history = [
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "first reply"},
+        ]
+        prompt, stats = mgr._build_prompt(history, "second message")
+        assert "second message" in prompt
+        assert stats["total_msgs"] == 2
+        assert stats["kept_msgs"] == 2
+
+    def test_build_prompt_stats_only(self, db):
+        from src.agent.manager import AgentManager
+
+        mgr = AgentManager(db)
+        stats = mgr._build_prompt_stats_only([], "Hello")
+        assert stats["total_msgs"] == 0
+        assert stats["kept_msgs"] == 0
+        assert stats["prompt_chars"] > 0
+
+
+class TestClaudeSdkBackendAvailable:
+    def test_available_with_api_key(self, db):
+        from src.agent.manager import ClaudeSdkBackend
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            backend = ClaudeSdkBackend(db, AppConfig())
+            assert backend.available is True
+
+    def test_available_with_oauth_token(self, db):
+        from src.agent.manager import ClaudeSdkBackend
+
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        env["CLAUDE_CODE_OAUTH_TOKEN"] = "token-test"
+        with patch.dict(os.environ, env, clear=True):
+            backend = ClaudeSdkBackend(db, AppConfig())
+            assert backend.available is True
+
+    def test_not_available_without_credentials(self, db):
+        from src.agent.manager import ClaudeSdkBackend
+
+        env = {
+            k: v for k, v in os.environ.items()
+            if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+        }
+        with patch.dict(os.environ, env, clear=True):
+            backend = ClaudeSdkBackend(db, AppConfig())
+            assert backend.available is False

--- a/tests/test_misc_coverage.py
+++ b/tests/test_misc_coverage.py
@@ -120,8 +120,7 @@ class TestSchedulerGetJobNextRun:
         await mgr.start()
         try:
             result = mgr.get_job_next_run("collect_all")
-            # job was registered; next_run_time should be a datetime or None
-            assert result is not None or result is None  # just assert no exception
+            assert result is not None
         finally:
             await mgr.stop()
 
@@ -914,14 +913,8 @@ class TestAgentManagerInit:
         from src.agent.manager import AgentManager
 
         with patch.dict(os.environ, {}, clear=True):
-            # Remove any API keys
-            env_clean = {k: v for k, v in os.environ.items()
-                         if k not in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")}
-            with patch.dict(os.environ, env_clean, clear=True):
-                mgr = AgentManager(db)
-                # Claude available depends on env vars
-                claude_avail = mgr._claude_backend.available
-                assert isinstance(claude_avail, bool)
+            mgr = AgentManager(db)
+            assert mgr._claude_backend.available is False
 
 
 class TestAgentManagerRefreshSettingsCache:

--- a/tests/test_my_telegram_coverage.py
+++ b/tests/test_my_telegram_coverage.py
@@ -902,7 +902,7 @@ async def web_client(db, real_pool_harness_factory):
     async with make_auth_client(app) as c:
         yield c, app
     await app.state.collection_queue.shutdown()
-    await app.state.client_pool.disconnect_all()
+    await app.state.pool.disconnect_all()
 
 
 class TestWebPage:

--- a/tests/test_my_telegram_coverage.py
+++ b/tests/test_my_telegram_coverage.py
@@ -902,6 +902,7 @@ async def web_client(db, real_pool_harness_factory):
     async with make_auth_client(app) as c:
         yield c, app
     await app.state.collection_queue.shutdown()
+    await app.state.client_pool.disconnect_all()
 
 
 class TestWebPage:

--- a/tests/test_my_telegram_coverage.py
+++ b/tests/test_my_telegram_coverage.py
@@ -1,0 +1,1680 @@
+"""Extended coverage tests for src/cli/commands/my_telegram.py and src/web/routes/my_telegram.py."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import AppConfig
+from tests.helpers import build_web_app, cli_ns, make_auth_client
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_PHONE = "+79001234567"
+_SVC_DIALOGS = "src.services.channel_service.ChannelService.get_my_dialogs"
+_SVC_LEAVE = "src.services.channel_service.ChannelService.leave_dialogs"
+
+_FAKE_DIALOGS = [
+    {
+        "channel_id": -100111,
+        "title": "My Channel",
+        "username": "mychan",
+        "channel_type": "channel",
+        "deactivate": False,
+        "is_own": False,
+    },
+    {
+        "channel_id": -100222,
+        "title": "My Group",
+        "username": None,
+        "channel_type": "supergroup",
+        "deactivate": False,
+        "is_own": False,
+    },
+]
+
+
+def _mock_pool(*, clients=None, native_result=None, get_forum_topics=None):
+    """Build a mock ClientPool with common defaults."""
+    mock_client = AsyncMock()
+    pool = MagicMock()
+    pool.clients = clients if clients is not None else {_PHONE: mock_client}
+    pool.get_native_client_by_phone = AsyncMock(
+        return_value=(mock_client, _PHONE) if native_result is None else native_result,
+    )
+    pool.invalidate_dialogs_cache = MagicMock()
+    pool.get_forum_topics = AsyncMock(
+        return_value=get_forum_topics if get_forum_topics is not None else [],
+    )
+    pool.disconnect_all = AsyncMock()
+    pool._dialogs_cache = {}
+    pool._dialogs_cache_ttl_sec = 60.0
+    return pool, mock_client
+
+
+def _run_cli(action, pool, db, extra_ns=None):
+    """Run a CLI action with mocked runtime."""
+    ns_kwargs = {"my_telegram_action": action}
+    if extra_ns:
+        ns_kwargs.update(extra_ns)
+    ns = cli_ns(**ns_kwargs)
+
+    async def fake_init_db(_):
+        return AppConfig(), db
+
+    async def fake_init_pool(config, database):
+        from src.telegram.auth import TelegramAuth
+        return TelegramAuth(0, ""), pool
+
+    with (
+        patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+        patch("src.cli.runtime.init_pool", side_effect=fake_init_pool),
+    ):
+        from src.cli.commands.my_telegram import run
+        run(ns)
+
+
+# =========================================================================
+# CLI Tests
+# =========================================================================
+
+
+class TestCliList:
+    """CLI my-telegram list."""
+
+    def test_list_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("list", pool, cli_db)
+        assert "No connected accounts." in capsys.readouterr().out
+
+    def test_list_phone_not_connected(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("list", pool, cli_db, {"phone": "+000"})
+        assert "not connected" in capsys.readouterr().out
+
+    def test_list_no_dialogs(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=[]):
+            _run_cli("list", pool, cli_db, {"phone": _PHONE})
+        assert "No dialogs found." in capsys.readouterr().out
+
+    def test_list_with_dialogs(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS):
+            _run_cli("list", pool, cli_db, {"phone": _PHONE})
+        out = capsys.readouterr().out
+        assert "My Channel" in out
+        assert "@mychan" in out
+        assert "My Group" in out
+
+    def test_list_default_phone(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS):
+            _run_cli("list", pool, cli_db, {"phone": None})
+        assert "My Channel" in capsys.readouterr().out
+
+    def test_list_dialog_without_username(self, cli_db, capsys):
+        dialogs = [
+            {
+                "channel_id": -100222,
+                "title": "No Username Group",
+                "channel_type": "supergroup",
+                "deactivate": False,
+                "is_own": False,
+                "already_added": False,
+            }
+        ]
+        pool, _ = _mock_pool()
+        with patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=dialogs):
+            _run_cli("list", pool, cli_db, {"phone": _PHONE})
+        out = capsys.readouterr().out
+        assert "No Username Group" in out
+
+
+class TestCliRefresh:
+    """CLI my-telegram refresh."""
+
+    def test_refresh_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("refresh", pool, cli_db, {"phone": None})
+        assert "No connected accounts." in capsys.readouterr().out
+
+    def test_refresh_phone_not_connected(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("refresh", pool, cli_db, {"phone": "+000"})
+        assert "not connected" in capsys.readouterr().out
+
+    def test_refresh_ok(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS):
+            _run_cli("refresh", pool, cli_db, {"phone": _PHONE})
+        assert "Dialogs refreshed: 2 total." in capsys.readouterr().out
+
+
+class TestCliCacheClear:
+    """CLI my-telegram cache-clear."""
+
+    def test_cache_clear_single_phone(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.invalidate_dialogs_cache = MagicMock()
+        asyncio.run(cli_db.repos.dialog_cache.replace_dialogs(_PHONE, _FAKE_DIALOGS))
+        _run_cli("cache-clear", pool, cli_db, {"phone": _PHONE})
+        out = capsys.readouterr().out
+        assert f"Cache cleared for {_PHONE}." in out
+        pool.invalidate_dialogs_cache.assert_called_once_with(_PHONE)
+
+    def test_cache_clear_all(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.invalidate_dialogs_cache = MagicMock()
+        _run_cli("cache-clear", pool, cli_db, {"phone": None})
+        out = capsys.readouterr().out
+        assert "Cache cleared for all accounts." in out
+        pool.invalidate_dialogs_cache.assert_called_once_with()
+
+
+class TestCliCacheStatus:
+    """CLI my-telegram cache-status."""
+
+    def test_cache_status_no_cache(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("cache-status", pool, cli_db)
+        assert "No cached dialogs." in capsys.readouterr().out
+
+    def test_cache_status_with_db_entries(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        asyncio.run(cli_db.repos.dialog_cache.replace_dialogs(_PHONE, _FAKE_DIALOGS))
+        _run_cli("cache-status", pool, cli_db)
+        out = capsys.readouterr().out
+        assert _PHONE in out
+        assert "DB entries" in out
+
+
+class TestCliSend:
+    """CLI my-telegram send."""
+
+    def test_send_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("send", pool, cli_db, {"phone": None, "recipient": "@user", "text": "hi", "yes": True})
+        assert "No connected accounts." in capsys.readouterr().out
+
+    def test_send_not_connected(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("send", pool, cli_db, {"phone": "+000", "recipient": "@user", "text": "hi", "yes": True})
+        assert "not connected" in capsys.readouterr().out
+
+    def test_send_confirmed(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=123))
+        client.send_message = AsyncMock()
+        _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@user", "text": "hello", "yes": True})
+        assert "Message sent" in capsys.readouterr().out
+
+    def test_send_abort(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@user", "text": "hello", "yes": False})
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_send_confirm_yes(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=123))
+        client.send_message = AsyncMock()
+        with patch("builtins.input", return_value="y"):
+            _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@user", "text": "hello", "yes": False})
+        assert "Message sent" in capsys.readouterr().out
+
+    def test_send_client_unavailable(self, cli_db, capsys):
+        pool, _ = _mock_pool(native_result=None)
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@user", "text": "hi", "yes": True})
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_send_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("entity error"))
+        _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@user", "text": "hi", "yes": True})
+        assert "Error sending message" in capsys.readouterr().out
+
+    def test_send_long_text_preview(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.send_message = AsyncMock()
+        long_text = "x" * 300
+        with patch("builtins.input", return_value="y"):
+            _run_cli("send", pool, cli_db, {"phone": _PHONE, "recipient": "@u", "text": long_text, "yes": False})
+        out = capsys.readouterr().out
+        assert "..." in out
+
+
+class TestCliForward:
+    """CLI my-telegram forward."""
+
+    def test_forward_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("forward", pool, cli_db, {
+            "phone": None, "from_chat": "A", "to_chat": "B", "message_ids": ["1,2"], "yes": True,
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+    def test_forward_no_valid_ids(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("forward", pool, cli_db, {
+            "phone": _PHONE, "from_chat": "A", "to_chat": "B", "message_ids": ["abc"], "yes": True,
+        })
+        assert "No valid message IDs" in capsys.readouterr().out
+
+    def test_forward_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.forward_messages = AsyncMock()
+        _run_cli("forward", pool, cli_db, {
+            "phone": _PHONE, "from_chat": "A", "to_chat": "B", "message_ids": ["1,2"], "yes": True,
+        })
+        assert "Forwarded 2 message(s)" in capsys.readouterr().out
+
+    def test_forward_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("forward", pool, cli_db, {
+                "phone": _PHONE, "from_chat": "A", "to_chat": "B", "message_ids": ["1"], "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_forward_client_unavailable(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        _run_cli("forward", pool, cli_db, {
+            "phone": _PHONE, "from_chat": "A", "to_chat": "B", "message_ids": ["1"], "yes": True,
+        })
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_forward_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("forward", pool, cli_db, {
+            "phone": _PHONE, "from_chat": "A", "to_chat": "B", "message_ids": ["1"], "yes": True,
+        })
+        assert "Error forwarding" in capsys.readouterr().out
+
+
+class TestCliEditMessage:
+    """CLI my-telegram edit-message."""
+
+    def test_edit_message_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_message = AsyncMock()
+        _run_cli("edit-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 42, "text": "new text", "yes": True,
+        })
+        assert "edited" in capsys.readouterr().out
+
+    def test_edit_message_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("edit-message", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "message_id": 42, "text": "new", "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_edit_message_client_unavailable(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        _run_cli("edit-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 42, "text": "t", "yes": True,
+        })
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_edit_message_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("oops"))
+        _run_cli("edit-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 42, "text": "t", "yes": True,
+        })
+        assert "Error editing" in capsys.readouterr().out
+
+    def test_edit_message_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("edit-message", pool, cli_db, {
+            "phone": None, "chat_id": "@ch", "message_id": 42, "text": "t", "yes": True,
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+
+class TestCliDeleteMessage:
+    """CLI my-telegram delete-message."""
+
+    def test_delete_message_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.delete_messages = AsyncMock()
+        _run_cli("delete-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": ["1,2"], "yes": True,
+        })
+        assert "Deleted 2 message(s)" in capsys.readouterr().out
+
+    def test_delete_message_no_valid_ids(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("delete-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": ["abc"], "yes": True,
+        })
+        assert "No valid message IDs" in capsys.readouterr().out
+
+    def test_delete_message_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("delete-message", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "message_ids": ["1"], "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_delete_message_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("delete-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": ["1"], "yes": True,
+        })
+        assert "Error deleting" in capsys.readouterr().out
+
+
+class TestCliPinUnpin:
+    """CLI my-telegram pin-message / unpin-message."""
+
+    def test_pin_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.pin_message = AsyncMock()
+        _run_cli("pin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 10, "notify": False, "yes": True,
+        })
+        assert "pinned" in capsys.readouterr().out
+
+    def test_pin_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("pin-message", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "message_id": 10, "notify": False, "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_pin_client_unavailable(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        _run_cli("pin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 10, "notify": False, "yes": True,
+        })
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_pin_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("pin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 10, "notify": False, "yes": True,
+        })
+        assert "Error pinning" in capsys.readouterr().out
+
+    def test_unpin_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.unpin_message = AsyncMock()
+        _run_cli("unpin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 10, "yes": True,
+        })
+        assert "unpinned" in capsys.readouterr().out
+
+    def test_unpin_all(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.unpin_message = AsyncMock()
+        _run_cli("unpin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": None, "yes": True,
+        })
+        assert "unpinned" in capsys.readouterr().out
+
+    def test_unpin_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("unpin-message", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "message_id": None, "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_unpin_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("unpin-message", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": None, "yes": True,
+        })
+        assert "Error unpinning" in capsys.readouterr().out
+
+
+class TestCliParticipants:
+    """CLI my-telegram participants."""
+
+    def test_participants_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        p1 = SimpleNamespace(id=1, first_name="Alice", last_name="B", username="alice")
+        p2 = SimpleNamespace(id=2, first_name="Bob", last_name=None, username=None)
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.get_participants = AsyncMock(return_value=[p1, p2])
+        _run_cli("participants", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "limit": 200, "search": "",
+        })
+        out = capsys.readouterr().out
+        assert "Alice" in out
+        assert "Bob" in out
+        assert "Total: 2" in out
+
+    def test_participants_empty(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.get_participants = AsyncMock(return_value=[])
+        _run_cli("participants", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "limit": 200, "search": "",
+        })
+        assert "No participants found." in capsys.readouterr().out
+
+    def test_participants_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("participants", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "limit": 200, "search": "",
+        })
+        assert "Error fetching participants" in capsys.readouterr().out
+
+    def test_participants_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("participants", pool, cli_db, {
+            "phone": None, "chat_id": "@ch", "limit": 200, "search": "",
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+
+class TestCliEditAdmin:
+    """CLI my-telegram edit-admin."""
+
+    def test_edit_admin_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_admin = AsyncMock()
+        _run_cli("edit-admin", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "is_admin": True, "title": "Boss", "yes": True,
+        })
+        assert "Admin rights updated" in capsys.readouterr().out
+
+    def test_edit_admin_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("edit-admin", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "is_admin": True, "title": None, "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_edit_admin_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("edit-admin", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "is_admin": True, "title": None, "yes": True,
+        })
+        assert "Error editing admin" in capsys.readouterr().out
+
+
+class TestCliEditPermissions:
+    """CLI my-telegram edit-permissions."""
+
+    def test_edit_permissions_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_permissions = AsyncMock()
+        _run_cli("edit-permissions", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+            "send_messages": "true", "send_media": None, "until_date": None, "yes": True,
+        })
+        assert "Permissions updated" in capsys.readouterr().out
+
+    def test_edit_permissions_no_flags(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("edit-permissions", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+            "send_messages": None, "send_media": None, "until_date": None, "yes": True,
+        })
+        assert "specify at least one flag" in capsys.readouterr().out
+
+    def test_edit_permissions_with_until_date(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_permissions = AsyncMock()
+        _run_cli("edit-permissions", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+            "send_messages": "true", "send_media": "false", "until_date": "2025-12-31", "yes": True,
+        })
+        assert "Permissions updated" in capsys.readouterr().out
+
+    def test_edit_permissions_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("edit-permissions", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+            "send_messages": "true", "send_media": None, "until_date": None, "yes": True,
+        })
+        assert "Error editing permissions" in capsys.readouterr().out
+
+
+class TestCliKick:
+    """CLI my-telegram kick."""
+
+    def test_kick_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.kick_participant = AsyncMock()
+        _run_cli("kick", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "yes": True,
+        })
+        assert "kicked" in capsys.readouterr().out
+
+    def test_kick_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with patch("builtins.input", return_value="n"):
+            _run_cli("kick", pool, cli_db, {
+                "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_kick_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("kick", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "yes": True,
+        })
+        assert "Error kicking" in capsys.readouterr().out
+
+
+class TestCliArchiveUnarchiveMarkRead:
+    """CLI my-telegram archive, unarchive, mark-read."""
+
+    def test_archive_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_folder = AsyncMock()
+        _run_cli("archive", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch"})
+        assert "archived" in capsys.readouterr().out
+
+    def test_archive_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("archive", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch"})
+        assert "Error archiving" in capsys.readouterr().out
+
+    def test_archive_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("archive", pool, cli_db, {"phone": None, "chat_id": "@ch"})
+        assert "No connected accounts." in capsys.readouterr().out
+
+    def test_archive_client_unavailable(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        _run_cli("archive", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch"})
+        assert "unavailable" in capsys.readouterr().out
+
+    def test_unarchive_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.edit_folder = AsyncMock()
+        _run_cli("unarchive", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch"})
+        assert "unarchived" in capsys.readouterr().out
+
+    def test_unarchive_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("unarchive", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch"})
+        assert "Error unarchiving" in capsys.readouterr().out
+
+    def test_mark_read_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.send_read_acknowledge = AsyncMock()
+        _run_cli("mark-read", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch", "max_id": None})
+        assert "marked as read" in capsys.readouterr().out
+
+    def test_mark_read_with_max_id(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        client.send_read_acknowledge = AsyncMock()
+        _run_cli("mark-read", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch", "max_id": 100})
+        assert "marked as read" in capsys.readouterr().out
+
+    def test_mark_read_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("mark-read", pool, cli_db, {"phone": _PHONE, "chat_id": "@ch", "max_id": None})
+        assert "Error marking" in capsys.readouterr().out
+
+
+class TestCliTopics:
+    """CLI my-telegram topics."""
+
+    def test_topics_from_pool(self, cli_db, capsys):
+        topics = [{"id": 1, "title": "General", "icon_emoji_id": None, "date": "2025-01-01"}]
+        pool, _ = _mock_pool(get_forum_topics=topics)
+        _run_cli("topics", pool, cli_db, {"channel_id": -100111})
+        out = capsys.readouterr().out
+        assert "General" in out
+
+    def test_topics_from_db_fallback(self, cli_db, capsys):
+        pool, _ = _mock_pool(get_forum_topics=[])
+        topics = [{"id": 2, "title": "DB Topic", "icon_emoji_id": 42, "date": None}]
+        with patch.object(cli_db, "get_forum_topics", new_callable=AsyncMock, return_value=topics):
+            _run_cli("topics", pool, cli_db, {"channel_id": -100111})
+        out = capsys.readouterr().out
+        assert "DB Topic" in out
+
+    def test_topics_not_found(self, cli_db, capsys):
+        pool, _ = _mock_pool(get_forum_topics=[])
+        with patch.object(cli_db, "get_forum_topics", new_callable=AsyncMock, return_value=[]):
+            _run_cli("topics", pool, cli_db, {"channel_id": -100111})
+        assert "No forum topics found" in capsys.readouterr().out
+
+
+class TestCliDownloadMedia:
+    """CLI my-telegram download-media."""
+
+    def test_download_media_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        msg = SimpleNamespace(id=1, media=True)
+
+        async def _iter_messages(entity, ids):
+            yield msg
+
+        client.iter_messages = MagicMock(return_value=_iter_messages(None, None))
+        client.download_media = AsyncMock(return_value="/tmp/photo.jpg")
+        _run_cli("download-media", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 1, "output_dir": "/tmp",
+        })
+        assert "Downloaded: /tmp/photo.jpg" in capsys.readouterr().out
+
+    def test_download_media_no_media(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        msg = SimpleNamespace(id=1, media=None)
+
+        async def _iter_messages(entity, ids):
+            yield msg
+
+        client.iter_messages = MagicMock(return_value=_iter_messages(None, None))
+        client.download_media = AsyncMock(return_value=None)
+        _run_cli("download-media", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 1, "output_dir": "/tmp",
+        })
+        assert "No media" in capsys.readouterr().out
+
+    def test_download_media_message_not_found(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+
+        async def _iter_messages(entity, ids):
+            return
+            yield  # make it an async generator
+
+        client.iter_messages = MagicMock(return_value=_iter_messages(None, None))
+        _run_cli("download-media", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 1, "output_dir": "/tmp",
+        })
+        assert "not found" in capsys.readouterr().out
+
+    def test_download_media_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("download-media", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch", "message_id": 1, "output_dir": "/tmp",
+        })
+        assert "Error downloading media" in capsys.readouterr().out
+
+
+class TestCliBroadcastStats:
+    """CLI my-telegram broadcast-stats."""
+
+    def test_broadcast_stats_ok(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        stats = SimpleNamespace(
+            followers=SimpleNamespace(current=1000, previous=900),
+            views_per_post=SimpleNamespace(current=500, previous=400),
+            shares_per_post=100,
+            reactions_per_post=None,
+            forwards_per_post=None,
+            period=SimpleNamespace(min_date="2025-01-01", max_date="2025-01-31"),
+            enabled_notifications=0.8,
+        )
+        client.get_broadcast_stats = AsyncMock(return_value=stats)
+        _run_cli("broadcast-stats", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch",
+        })
+        out = capsys.readouterr().out
+        assert "followers: 1000" in out
+        assert "period:" in out
+        assert "enabled_notifications" in out
+
+    def test_broadcast_stats_error(self, cli_db, capsys):
+        pool, client = _mock_pool()
+        client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        _run_cli("broadcast-stats", pool, cli_db, {
+            "phone": _PHONE, "chat_id": "@ch",
+        })
+        assert "Error fetching broadcast stats" in capsys.readouterr().out
+
+    def test_broadcast_stats_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("broadcast-stats", pool, cli_db, {
+            "phone": None, "chat_id": "@ch",
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+
+class TestCliLeave:
+    """CLI my-telegram leave."""
+
+    def test_leave_ok(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with (
+            patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS),
+            patch(_SVC_LEAVE, new_callable=AsyncMock, return_value={-100111: True}),
+        ):
+            _run_cli("leave", pool, cli_db, {
+                "phone": _PHONE, "dialog_ids": ["-100111"], "yes": True,
+            })
+        out = capsys.readouterr().out
+        assert "1 left" in out
+
+    def test_leave_abort(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with (
+            patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS),
+            patch("builtins.input", return_value="n"),
+        ):
+            _run_cli("leave", pool, cli_db, {
+                "phone": _PHONE, "dialog_ids": ["-100111"], "yes": False,
+            })
+        assert "Aborted." in capsys.readouterr().out
+
+    def test_leave_invalid_ids(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        _run_cli("leave", pool, cli_db, {
+            "phone": _PHONE, "dialog_ids": ["abc"], "yes": True,
+        })
+        out = capsys.readouterr().out
+        assert "No valid dialog IDs" in out
+
+    def test_leave_partial_invalid_ids(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        with (
+            patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS),
+            patch(_SVC_LEAVE, new_callable=AsyncMock, return_value={-100111: True}),
+        ):
+            _run_cli("leave", pool, cli_db, {
+                "phone": _PHONE, "dialog_ids": ["-100111,abc"], "yes": True,
+            })
+        out = capsys.readouterr().out
+        assert "Invalid dialog ID" in out
+        assert "1 left" in out
+
+    def test_leave_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("leave", pool, cli_db, {
+            "phone": None, "dialog_ids": ["1"], "yes": True,
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+
+class TestCliCreateChannel:
+    """CLI my-telegram create-channel."""
+
+    def test_create_channel_ok(self, cli_db, capsys):
+        pool, _ = _mock_pool()
+        mock_client = MagicMock()
+        channel = SimpleNamespace(id=12345, username="newchan")
+        mock_result = SimpleNamespace(chats=[channel])
+        mock_client.__call__ = AsyncMock(return_value=mock_result)
+        pool.clients = {_PHONE: mock_client}
+
+        # Replace the client's __call__ to handle CreateChannelRequest
+        async def fake_call(req):
+            return mock_result
+
+        mock_client.side_effect = fake_call
+
+        with patch("src.cli.commands.my_telegram.pool", pool, create=True):
+            _run_cli("create-channel", pool, cli_db, {
+                "phone": _PHONE, "title": "New Channel", "about": "test", "username": "",
+            })
+        out = capsys.readouterr().out
+        assert "Created channel" in out
+
+    def test_create_channel_no_accounts(self, cli_db, capsys):
+        pool, _ = _mock_pool(clients={})
+        _run_cli("create-channel", pool, cli_db, {
+            "phone": None, "title": "Ch", "about": "", "username": "",
+        })
+        assert "No connected accounts." in capsys.readouterr().out
+
+
+# =========================================================================
+# Web Tests
+# =========================================================================
+
+
+async def _build_web_app(db, real_pool_harness_factory, *, with_account=True):
+    """Build a web app for my-telegram route tests."""
+    from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
+
+    config = AppConfig()
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+    config.web.password = "testpass"
+
+    harness = real_pool_harness_factory()
+    if with_account:
+        harness.queue_cli_client(
+            phone=_PHONE,
+            client=FakeCliTelethonClient(
+                iter_dialogs_factory=lambda: AsyncIterMessages([]),
+                entity_resolver=lambda _peer: MagicMock(),
+            ),
+        )
+        await harness.connect_account(
+            _PHONE,
+            session_string="test_session",
+            is_primary=True,
+        )
+
+    app, db = await build_web_app(config, harness, db=db)
+    return app, db, harness
+
+
+@pytest.fixture
+async def web_client(db, real_pool_harness_factory):
+    app, db, harness = await _build_web_app(db, real_pool_harness_factory)
+    async with make_auth_client(app) as c:
+        yield c, app
+    await app.state.collection_queue.shutdown()
+
+
+class TestWebPage:
+    """GET /my-telegram/."""
+
+    @pytest.mark.asyncio
+    async def test_page_renders(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_page_with_phone(self, web_client):
+        c, app = web_client
+        phone_encoded = "%2B79001234567"
+        resp = await c.get(f"/my-telegram/?phone={phone_encoded}")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_page_invalid_phone_shows_no_dialogs(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/?phone=%2B00000")
+        assert resp.status_code == 200
+
+
+class TestWebRefresh:
+    """POST /my-telegram/refresh."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_ok(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/refresh", data={"phone": _PHONE})
+        assert resp.status_code == 200
+
+
+class TestWebCacheStatus:
+    """GET /my-telegram/cache-status."""
+
+    @pytest.mark.asyncio
+    async def test_cache_status_empty(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/cache-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+
+
+class TestWebCacheClear:
+    """POST /my-telegram/cache-clear."""
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_all(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/cache-clear", data={"phone": ""})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_single(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/cache-clear", data={"phone": _PHONE})
+        assert resp.status_code == 200
+
+
+class TestWebSend:
+    """POST /my-telegram/send."""
+
+    @pytest.mark.asyncio
+    async def test_send_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/send", data={"phone": _PHONE, "recipient": "", "text": ""})
+        assert resp.status_code == 200
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_send_client_unavailable(self, web_client):
+        c, app = web_client
+        pool = app.state.pool
+        pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/send", data={"phone": _PHONE, "recipient": "@u", "text": "hi"})
+        assert resp.status_code == 200
+        assert "error=client_unavailable" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_send_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.send_message = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/send", data={"phone": _PHONE, "recipient": "@u", "text": "hi"})
+        assert resp.status_code == 200
+        assert "msg=message_sent" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_send_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("oops"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/send", data={"phone": _PHONE, "recipient": "@u", "text": "hi"})
+        assert resp.status_code == 200
+        assert "error=send_failed" in str(resp.url)
+
+
+class TestWebEditMessage:
+    """POST /my-telegram/edit-message."""
+
+    @pytest.mark.asyncio
+    async def test_edit_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/edit-message", data={
+            "phone": _PHONE, "chat_id": "", "message_id": "", "text": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.edit_message = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "42", "text": "new",
+        })
+        assert "msg=message_edited" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/edit-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "42", "text": "new",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "42", "text": "new",
+        })
+        assert "error=edit_failed" in str(resp.url)
+
+
+class TestWebDeleteMessage:
+    """POST /my-telegram/delete-message."""
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/delete-message", data={
+            "phone": _PHONE, "chat_id": "", "message_ids": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_delete_invalid_ids(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/delete-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": "abc",
+        })
+        assert "error=invalid_ids" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_delete_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.delete_messages = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/delete-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": "1,2",
+        })
+        assert "msg=messages_deleted" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_delete_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/delete-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_ids": "1",
+        })
+        assert "error=delete_failed" in str(resp.url)
+
+
+class TestWebForwardMessages:
+    """POST /my-telegram/forward-messages."""
+
+    @pytest.mark.asyncio
+    async def test_forward_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/forward-messages", data={
+            "phone": _PHONE, "from_chat": "", "to_chat": "", "message_ids": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_forward_invalid_ids(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/forward-messages", data={
+            "phone": _PHONE, "from_chat": "@a", "to_chat": "@b", "message_ids": "xyz",
+        })
+        assert "error=invalid_ids" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_forward_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.forward_messages = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/forward-messages", data={
+            "phone": _PHONE, "from_chat": "@a", "to_chat": "@b", "message_ids": "1,2",
+        })
+        assert "msg=messages_forwarded" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_forward_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/forward-messages", data={
+            "phone": _PHONE, "from_chat": "@a", "to_chat": "@b", "message_ids": "1",
+        })
+        assert "error=forward_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_forward_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/forward-messages", data={
+            "phone": _PHONE, "from_chat": "@a", "to_chat": "@b", "message_ids": "1",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+
+class TestWebPinMessage:
+    """POST /my-telegram/pin-message."""
+
+    @pytest.mark.asyncio
+    async def test_pin_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/pin-message", data={
+            "phone": "", "chat_id": "", "message_id": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_pin_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.pin_message = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/pin-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "10", "notify": "1",
+        })
+        assert "msg=message_pinned" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_pin_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/pin-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "10",
+        })
+        assert "error=pin_failed" in str(resp.url)
+
+
+class TestWebUnpinMessage:
+    """POST /my-telegram/unpin-message."""
+
+    @pytest.mark.asyncio
+    async def test_unpin_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/unpin-message", data={
+            "phone": "", "chat_id": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unpin_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.unpin_message = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/unpin-message", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "10",
+        })
+        assert "msg=message_unpinned" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unpin_all(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.unpin_message = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/unpin-message", data={
+            "phone": _PHONE, "chat_id": "@ch",
+        })
+        assert "msg=message_unpinned" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unpin_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/unpin-message", data={
+            "phone": _PHONE, "chat_id": "@ch",
+        })
+        assert "error=unpin_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unpin_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/unpin-message", data={
+            "phone": _PHONE, "chat_id": "@ch",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+
+class TestWebParticipants:
+    """GET /my-telegram/participants."""
+
+    @pytest.mark.asyncio
+    async def test_participants_missing_params(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/participants")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_participants_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.get(f"/my-telegram/participants?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_participants_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        p1 = SimpleNamespace(id=1, first_name="Alice", last_name="B", username="alice")
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.get_participants = AsyncMock(return_value=[p1])
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.get(f"/my-telegram/participants?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["participants"][0]["first_name"] == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_participants_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.get(f"/my-telegram/participants?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 500
+
+
+class TestWebArchive:
+    """POST /my-telegram/archive and /unarchive."""
+
+    @pytest.mark.asyncio
+    async def test_archive_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/archive", data={"phone": "", "chat_id": ""})
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_archive_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.edit_folder = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/archive", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "msg=dialog_archived" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_archive_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/archive", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "error=archive_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_archive_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/archive", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "error=client_unavailable" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unarchive_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.edit_folder = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/unarchive", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "msg=dialog_unarchived" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unarchive_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/unarchive", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "error=unarchive_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_unarchive_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/unarchive", data={"phone": "", "chat_id": ""})
+        assert "error=missing_fields" in str(resp.url)
+
+
+class TestWebMarkRead:
+    """POST /my-telegram/mark-read."""
+
+    @pytest.mark.asyncio
+    async def test_mark_read_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/mark-read", data={"phone": "", "chat_id": ""})
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_mark_read_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.send_read_acknowledge = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/mark-read", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "msg=messages_marked_read" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_mark_read_with_max_id(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.send_read_acknowledge = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/mark-read", data={
+            "phone": _PHONE, "chat_id": "@ch", "max_id": "100",
+        })
+        assert "msg=messages_marked_read" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_mark_read_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/mark-read", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "error=mark_read_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_mark_read_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/mark-read", data={"phone": _PHONE, "chat_id": "@ch"})
+        assert "error=client_unavailable" in str(resp.url)
+
+
+class TestWebEditAdmin:
+    """POST /my-telegram/edit-admin."""
+
+    @pytest.mark.asyncio
+    async def test_edit_admin_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/edit-admin", data={
+            "phone": "", "chat_id": "", "user_id": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_admin_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.edit_admin = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-admin", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "is_admin": "1", "title": "Boss",
+        })
+        assert "msg=admin_updated" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_admin_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-admin", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "error=edit_admin_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_admin_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/edit-admin", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+
+class TestWebEditPermissions:
+    """POST /my-telegram/edit-permissions."""
+
+    @pytest.mark.asyncio
+    async def test_edit_permissions_no_flags(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/edit-permissions", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "error=no_permission_flags" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_permissions_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/edit-permissions", data={
+            "phone": "", "chat_id": "", "user_id": "", "send_messages": "true",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_permissions_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.edit_permissions = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-permissions", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "send_messages": "true",
+        })
+        assert "msg=permissions_updated" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_edit_permissions_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/edit-permissions", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u", "send_messages": "1",
+        })
+        assert "error=edit_permissions_failed" in str(resp.url)
+
+
+class TestWebKick:
+    """POST /my-telegram/kick."""
+
+    @pytest.mark.asyncio
+    async def test_kick_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/kick", data={
+            "phone": "", "chat_id": "", "user_id": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_kick_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        mock_client.kick_participant = AsyncMock()
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/kick", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "msg=user_kicked" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_kick_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/kick", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "error=kick_failed" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_kick_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/kick", data={
+            "phone": _PHONE, "chat_id": "@ch", "user_id": "@u",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+
+class TestWebBroadcastStats:
+    """GET /my-telegram/broadcast-stats."""
+
+    @pytest.mark.asyncio
+    async def test_broadcast_stats_missing_params(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/broadcast-stats")
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_broadcast_stats_ok(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        stats = SimpleNamespace(
+            followers=SimpleNamespace(current=100, previous=90),
+            views_per_post=None,
+            shares_per_post=None,
+            reactions_per_post=None,
+            forwards_per_post=None,
+            period=None,
+            enabled_notifications=None,
+        )
+        mock_client.get_broadcast_stats = AsyncMock(return_value=stats)
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.get(f"/my-telegram/broadcast-stats?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "stats" in data
+        assert data["stats"]["followers"]["current"] == 100
+
+    @pytest.mark.asyncio
+    async def test_broadcast_stats_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.get(f"/my-telegram/broadcast-stats?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_broadcast_stats_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.get(f"/my-telegram/broadcast-stats?phone={_PHONE}&chat_id=@ch")
+        assert resp.status_code == 503
+
+
+class TestWebLeave:
+    """POST /my-telegram/leave."""
+
+    @pytest.mark.asyncio
+    async def test_leave_ok(self, web_client):
+        c, app = web_client
+        with patch(
+            _SVC_LEAVE,
+            new_callable=AsyncMock,
+            return_value={-100111: True, -100222: False},
+        ):
+            resp = await c.post("/my-telegram/leave", data={
+                "phone": _PHONE, "channel_ids": ["-100111:channel", "-100222:supergroup"],
+            })
+        assert "left=1" in str(resp.url)
+        assert "failed=1" in str(resp.url)
+
+
+class TestWebDownloadMedia:
+    """POST /my-telegram/download-media."""
+
+    @pytest.mark.asyncio
+    async def test_download_missing_fields(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/download-media", data={
+            "phone": "", "chat_id": "", "message_id": "",
+        })
+        assert "error=missing_fields" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_download_client_unavailable(self, web_client):
+        c, app = web_client
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=None)
+        resp = await c.post("/my-telegram/download-media", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "1",
+        })
+        assert "error=client_unavailable" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_download_message_not_found(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+
+        async def _empty_iter(entity, ids):
+            return
+            yield  # make it an async generator
+
+        mock_client.iter_messages = MagicMock(return_value=_empty_iter(None, None))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/download-media", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "1",
+        })
+        assert "error=message_not_found" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_download_no_media(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(return_value=SimpleNamespace(id=1))
+        msg = SimpleNamespace(id=1, media=None)
+
+        async def _iter(entity, ids):
+            yield msg
+
+        mock_client.iter_messages = MagicMock(return_value=_iter(None, None))
+        mock_client.download_media = AsyncMock(return_value=None)
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/download-media", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "1",
+        })
+        assert "error=no_media" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_download_error(self, web_client):
+        c, app = web_client
+        mock_client = AsyncMock()
+        mock_client.get_entity = AsyncMock(side_effect=RuntimeError("err"))
+        app.state.pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, _PHONE))
+        resp = await c.post("/my-telegram/download-media", data={
+            "phone": _PHONE, "chat_id": "@ch", "message_id": "1",
+        })
+        assert "error=download_failed" in str(resp.url)
+
+
+class TestWebCreateChannel:
+    """GET and POST /my-telegram/create-channel."""
+
+    @pytest.mark.asyncio
+    async def test_create_channel_page(self, web_client):
+        c, app = web_client
+        resp = await c.get("/my-telegram/create-channel")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_create_channel_no_client(self, web_client):
+        c, app = web_client
+        resp = await c.post("/my-telegram/create-channel", data={
+            "phone": "+000", "title": "Test", "about": "", "username": "",
+        })
+        assert resp.status_code == 200
+        assert "error=no_client" in str(resp.url)
+
+    @pytest.mark.asyncio
+    async def test_create_channel_error(self, web_client):
+        c, app = web_client
+        # The pool.clients[phone] will be the real pool client, patch it to raise
+        mock_client = AsyncMock()
+        mock_client.side_effect = RuntimeError("Telegram error")
+        app.state.pool.clients[_PHONE] = mock_client
+        resp = await c.post("/my-telegram/create-channel", data={
+            "phone": _PHONE, "title": "Test", "about": "", "username": "",
+        })
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add CLI commands and web routes coverage tests
- Add scheduler, process control, misc coverage
- Add my_telegram CLI + web route coverage

## Test plan
- [ ] `pytest tests/test_cli_web_coverage.py tests/test_misc_coverage.py tests/test_my_telegram_coverage.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)