### PR TITLE
refactor: rename list_dialogs → search_my_telegram, remove hardcoded limits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,9 @@ Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline**
 - **Image generation**: `ImageGenerationService` routes to provider-specific HTTP adapters (Together/HuggingFace/OpenAI/Replicate) via `provider:model_id` convention; auto-registers from env vars; adapters defined in `src/services/provider_adapters.py`
 - **UnifiedDispatcher** (`src/services/unified_dispatcher.py`): polls DB for generic tasks (CONTENT_GENERATE, CONTENT_PUBLISH, PIPELINE_RUN, PHOTO_DUE, etc.) and dispatches to handler methods; recovers interrupted tasks on startup
 - **Photo publishing**: `PhotoAutoUploadService` / `PhotoPublishService` / `PhotoTaskService` — separate upload, schedule, publish tasks tracked in DB
+- **Agent tools**: `src/agent/tools/` — modular tool files (channels, search, pipelines, images, etc.); `_registry.py` provides `require_confirmation()` gate for destructive ops and `normalize_phone()`; `react_agent.py` is ReAct fallback when claude-agent-sdk is unavailable; `manager.py` orchestrates backend selection
+- **Agent tool permissions**: `TOOL_CATEGORIES` in `src/agent/tools/permissions.py` classifies every tool as read/write/delete; per-phone ACL overrides stored in DB setting `agent_tool_permissions` (JSON); `get_all_allowed_tools()` derives MCP-prefixed allow-list
+- **S3 storage**: `src/services/s3_store.py` — optional S3-compatible backend for media (images); used by `ImageGenerationService` when S3 config is present
 
 ### Database access pattern
 
@@ -107,6 +110,7 @@ Each repository has a `_to_<model>(row)` static helper that maps `aiosqlite.Row`
 - **Collection service**: `enqueue_channel_by_pk(pk, force)` respects `is_filtered` flag; `enqueue_all_channels()` uses `full=False` for incremental collection
 - **Image adapter convention**: `ImageAdapter = Callable[[str, str], Awaitable[str | None]]` — signature is `(prompt, model_id) → URL/path`; model string format `provider:model_id` (e.g. `together:black-forest-labs/FLUX.1-schnell`); without prefix falls back to first registered adapter
 - **Content pipeline flow**: CONTENT_GENERATE task → `ContentGenerationService.generate()` → LLM text → optional image → `generation_runs` record → if AUTO publish mode, enqueues CONTENT_PUBLISH → `PublishService.publish_run()` sends to target channel
+- **Destructive tool confirmation**: agent tools that delete data require `confirm=true` argument; `require_confirmation()` in `_registry.py` returns a warning response if not confirmed
 - **HTMX progressive enhancement**: collect routes check `HX-Request` header to return HTML fragments vs redirects
 - **Identifier parsing**: `parse_identifiers()` splits text by comma/semicolon/newline; `extract_identifiers()` regex-extracts t.me links, @usernames, negative IDs; `parse_file()` handles txt/csv/xlsx
 - **aiosqlite connection cleanup**: in tests using raw `aiosqlite.connect()`, always wrap in `try/finally` with `await conn.close()` — an unclosed worker-thread blocks pytest process exit
@@ -125,6 +129,11 @@ Each repository has a `_to_<model>(row)` static helper that maps `aiosqlite.Row`
 - ruff for linting: line-length=120, target py311, rules E/F/I/N/W
 - Tests: pytest-asyncio with `asyncio_mode="auto"`
 - Session strings stored as `enc:v2:*` when `SESSION_ENCRYPTION_KEY` is set; legacy `enc:v1:*` auto-migrated; startup fails fast if encrypted rows exist without key
+
+## CI
+
+- GitHub Actions: `.github/workflows/ci.yml` — ruff lint + pytest on push to `main`/`fix/**`/`codex/**` and all PRs
+- CI runs parallel tests first (`-n auto -m "not aiosqlite_serial"`), then serial (`-m aiosqlite_serial`)
 
 ## Real Telegram Testing
 

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -146,7 +146,7 @@
 
 | Tool | Категория | Описание |
 |------|-----------|----------|
-| `list_dialogs` | READ | Список диалогов |
+| `search_my_telegram` | READ | Поиск диалогов по названию (search, type, limit) |
 | `refresh_dialogs` | WRITE | Обновить кеш |
 | `leave_dialogs` | DELETE | Покинуть диалоги |
 | `create_telegram_channel` | WRITE | Создать канал |

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -143,7 +143,7 @@
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
-| Список диалогов | `my-telegram list` | `GET /my-telegram/` | `list_dialogs` |
+| Список диалогов | `my-telegram list` | `GET /my-telegram/` | `search_my_telegram` |
 | Обновить кеш | `my-telegram refresh` | `POST /my-telegram/refresh` | `refresh_dialogs` |
 | Покинуть диалоги | `my-telegram leave` | `POST /my-telegram/leave` | `leave_dialogs` |
 | Статус кеша | `my-telegram cache-status` | `GET /my-telegram/cache-status` | `get_cache_status` |

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -98,7 +98,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
         if not channels:
             return "Каналы не найдены."
         lines = [f"Каналы ({len(channels)}):"]
-        for ch in channels[:200]:
+        for ch in channels:
             status = "активен" if ch.is_active else "неактивен"
             lines.append(f"- {ch.title} (id={ch.channel_id}, {status})")
         return "\n".join(lines)

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -25,11 +25,9 @@ def register(db, client_pool, embedding_service, **kwargs):
                 f"Анализ фильтров: {len(report.results)} каналов проверено, "
                 f"{len(flagged)} рекомендовано к фильтрации."
             ]
-            for r in flagged[:30]:
+            for r in flagged:
                 flags = ", ".join(r.flags) if r.flags else "—"
                 lines.append(f"- {r.title} (id={r.channel_id}): {flags}")
-            if len(flagged) > 30:
-                lines.append(f"... и ещё {len(flagged) - 30}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка анализа фильтров: {e}")

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -113,7 +113,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             if not models:
                 return _text_response(f"Модели для {provider} не найдены.")
             lines = [f"Модели {provider} ({len(models)}):"]
-            for m in models[:30]:
+            for m in models:
                 name = m.get("id", m.get("name", "?"))
                 parts = [f"- {name}"]
                 rc = m.get("run_count")
@@ -123,8 +123,6 @@ def register(db, client_pool, embedding_service, **kwargs):
                 if rank is not None:
                     parts.append(f"[rank {rank}]")
                 lines.append(" ".join(parts))
-            if len(models) > 30:
-                lines.append(f"... и ещё {len(models) - 30}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка поиска моделей: {e}")

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -333,15 +333,13 @@ def register(db, client_pool, embedding_service, **kwargs):
             if not participants:
                 return _text_response("Участники не найдены.")
             lines = [f"Участники {chat_id} ({len(participants)}):"]
-            for p in participants[:50]:
+            for p in participants:
                 name = " ".join(filter(None, [
                     getattr(p, "first_name", None) or "",
                     getattr(p, "last_name", None) or "",
                 ]))
                 username = f" (@{p.username})" if getattr(p, "username", None) else ""
                 lines.append(f"  {p.id}: {name}{username}")
-            if len(participants) > 50:
-                lines.append(f"  ... и ещё {len(participants) - 50}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения участников: {e}")

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -49,6 +49,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             svc = ChannelService(db, client_pool, None)
             dialogs = await svc.get_my_dialogs(phone)
+            total = len(dialogs)
             type_filter = (args.get("type") or "").strip().lower()
             if type_filter:
                 allowed = _TYPE_ALIASES.get(type_filter, {type_filter})
@@ -64,7 +65,18 @@ def register(db, client_pool, embedding_service, **kwargs):
                 except (TypeError, ValueError):
                     pass
             if not dialogs:
-                return _text_response(f"Диалоги для {phone} не найдены.")
+                if total == 0:
+                    return _text_response(f"Диалоги для {phone} не найдены.")
+                parts = []
+                if type_filter:
+                    parts.append(f"тип: {type_filter}")
+                if search_query:
+                    parts.append(f"поиск: '{search_query}'")
+                filters_desc = ", ".join(parts)
+                return _text_response(
+                    f"Нет диалогов по запросу ({filters_desc}). "
+                    f"Всего диалогов для {phone}: {total}."
+                )
             lines = [f"Диалоги ({len(dialogs)}):"]
             for d in dialogs:
                 title = d.get("title", "?")

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -14,24 +14,34 @@ from src.agent.tools._registry import (
     resolve_phone,
 )
 
+_TYPE_ALIASES: dict[str, set[str]] = {
+    "channels": {"channel"},
+    "groups": {"group", "supergroup", "gigagroup", "forum", "monoforum"},
+    "chats": {"dm", "bot", "saved"},
+}
+
 
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
 
     @tool(
-        "list_dialogs",
-        "List Telegram dialogs (chats/channels) for an account. "
-        "Saved Messages shown as type='saved'.",
-        {"phone": str},
+        "search_my_telegram",
+        "Search your Telegram account dialogs by title — channels, groups, private chats, bots, "
+        "saved messages. This does NOT search message content (use search_messages for that). "
+        "Params: search — filter by title (case-insensitive substring); "
+        "type — filter: 'channels' (channel), 'groups' (group/supergroup/gigagroup/forum/monoforum), "
+        "'chats' (dm/bot/saved), or exact type like 'supergroup', 'dm', 'bot'; "
+        "limit — cap results (default: all).",
+        {"phone": str, "search": str, "type": str, "limit": int},
     )
-    async def list_dialogs(args):
-        pool_gate = require_pool(client_pool, "Список диалогов")
+    async def search_my_telegram(args):
+        pool_gate = require_pool(client_pool, "Поиск диалогов")
         if pool_gate:
             return pool_gate
         phone, err = await resolve_phone(db, args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "list_dialogs")
+        perm_gate = await require_phone_permission(db, phone, "search_my_telegram")
         if perm_gate:
             return perm_gate
         try:
@@ -39,21 +49,33 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             svc = ChannelService(db, client_pool, None)
             dialogs = await svc.get_my_dialogs(phone)
+            type_filter = (args.get("type") or "").strip().lower()
+            if type_filter:
+                allowed = _TYPE_ALIASES.get(type_filter, {type_filter})
+                dialogs = [d for d in dialogs if (d.get("channel_type") or "") in allowed]
+            search_query = (args.get("search") or "").strip().lower()
+            if search_query:
+                dialogs = [d for d in dialogs if search_query in (d.get("title") or "").lower()]
+            limit = args.get("limit")
+            if limit is not None:
+                try:
+                    limit = max(1, int(limit))
+                    dialogs = dialogs[:limit]
+                except (TypeError, ValueError):
+                    pass
             if not dialogs:
                 return _text_response(f"Диалоги для {phone} не найдены.")
             lines = [f"Диалоги ({len(dialogs)}):"]
-            for d in dialogs[:100]:
+            for d in dialogs:
                 title = d.get("title", "?")
                 did = d.get("channel_id", "?")
                 dtype = d.get("channel_type", "?")
                 lines.append(f"- id={did}, type={dtype}: {title}")
-            if len(dialogs) > 100:
-                lines.append(f"... и ещё {len(dialogs) - 100}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения диалогов: {e}")
 
-    tools.append(list_dialogs)
+    tools.append(search_my_telegram)
 
     @tool(
         "refresh_dialogs",

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -118,7 +118,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "create_auto_upload": ToolCategory.WRITE,
     "update_auto_upload": ToolCategory.WRITE,
     # My Telegram
-    "list_dialogs": ToolCategory.READ,
+    "search_my_telegram": ToolCategory.READ,
     "refresh_dialogs": ToolCategory.WRITE,
     "leave_dialogs": ToolCategory.DELETE,
     "create_telegram_channel": ToolCategory.WRITE,
@@ -217,7 +217,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "create_photo_batch", "run_photo_due", "create_auto_upload", "update_auto_upload",
     ]),
     ("Мой Telegram", [
-        "list_dialogs", "refresh_dialogs", "leave_dialogs", "create_telegram_channel",
+        "search_my_telegram", "refresh_dialogs", "leave_dialogs", "create_telegram_channel",
         "get_forum_topics", "clear_dialog_cache", "get_cache_status",
     ]),
     ("Сообщения", [

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -649,4 +649,45 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
         """)
     await db.commit()
 
+    # Rename tool key list_dialogs → search_my_telegram in agent_tool_permissions (issue #272)
+    await _migrate_tool_permission_key(db, "list_dialogs", "search_my_telegram")
+
     return fts_available
+
+
+async def _migrate_tool_permission_key(db: aiosqlite.Connection, old_key: str, new_key: str) -> None:
+    """Rename a tool name key inside the agent_tool_permissions JSON setting (both flat and per-phone formats)."""
+    import json
+
+    cur = await db.execute("SELECT value FROM settings WHERE key = 'agent_tool_permissions' LIMIT 1")
+    row = await cur.fetchone()
+    if not row or not row["value"]:
+        return
+    try:
+        data = json.loads(row["value"])
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(data, dict):
+        return
+
+    changed = False
+    first_val = next(iter(data.values()), None) if data else None
+    if isinstance(first_val, dict):
+        # Per-phone format: {"phone": {"tool_name": bool, ...}, ...}
+        for phone, perms in data.items():
+            if isinstance(perms, dict) and old_key in perms:
+                perms[new_key] = perms.pop(old_key)
+                changed = True
+    else:
+        # Flat format: {"tool_name": bool, ...}
+        if old_key in data:
+            data[new_key] = data.pop(old_key)
+            changed = True
+
+    if changed:
+        await db.execute(
+            "UPDATE settings SET value = ? WHERE key = 'agent_tool_permissions'",
+            (json.dumps(data, ensure_ascii=False),),
+        )
+        await db.commit()
+        logger.info("Migrated tool permission key %r → %r in agent_tool_permissions", old_key, new_key)

--- a/tests/test_agent_tools_new2.py
+++ b/tests/test_agent_tools_new2.py
@@ -106,8 +106,8 @@ class TestAnalyzeFiltersTool:
         assert "1 рекомендовано" in text
 
     @pytest.mark.asyncio
-    async def test_report_truncates_beyond_30(self, mock_db):
-        """More than 30 flagged channels triggers truncation message."""
+    async def test_report_shows_all_beyond_30(self, mock_db):
+        """More than 30 flagged channels are all shown without truncation."""
 
         def _make_result(i):
             r = MagicMock()
@@ -124,7 +124,8 @@ class TestAnalyzeFiltersTool:
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["analyze_filters"]({})
         text = _text(result)
-        assert "и ещё 5" in text
+        assert "35 рекомендовано" in text
+        assert "и ещё" not in text
 
     @pytest.mark.asyncio
     async def test_report_non_flagged_not_listed(self, mock_db):

--- a/tests/test_agent_tools_new3.py
+++ b/tests/test_agent_tools_new3.py
@@ -848,11 +848,11 @@ class TestImagesToolListGeneratedImages:
 # ---------------------------------------------------------------------------
 
 
-class TestMyTelegramToolListDialogs:
+class TestMyTelegramToolSearchMyTelegram:
     @pytest.mark.asyncio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
-        result = await handlers["list_dialogs"]({"phone": "+7123456"})
+        result = await handlers["search_my_telegram"]({"phone": "+7123456"})
         assert "CLI-режиме" in _text(result)
 
     @pytest.mark.asyncio
@@ -866,7 +866,7 @@ class TestMyTelegramToolListDialogs:
         ch_svc.get_my_dialogs = AsyncMock(return_value=[])
         with patch("src.services.channel_service.ChannelService", return_value=ch_svc):
             handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         assert "не найдены" in _text(result)
 
     @pytest.mark.asyncio
@@ -884,7 +884,7 @@ class TestMyTelegramToolListDialogs:
         ch_svc.get_my_dialogs = AsyncMock(return_value=dialogs)
         with patch("src.services.channel_service.ChannelService", return_value=ch_svc):
             handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         text = _text(result)
         assert "My Channel" in text
         assert "id=111" in text

--- a/tests/test_coverage_batch4.py
+++ b/tests/test_coverage_batch4.py
@@ -439,11 +439,11 @@ def _make_pool_with_account(phone="+79001234567"):
     return pool
 
 
-class TestListDialogs:
+class TestSearchMyTelegram:
     @pytest.mark.asyncio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
-        result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+        result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         assert "CLI-режиме" in _text(result)
 
     @pytest.mark.asyncio
@@ -459,7 +459,7 @@ class TestListDialogs:
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
             handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         text = _text(result)
         assert "Диалоги (2)" in text
 
@@ -472,11 +472,11 @@ class TestListDialogs:
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=[])
             handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         assert "не найдены" in _text(result)
 
     @pytest.mark.asyncio
-    async def test_more_than_100_dialogs(self, mock_db):
+    async def test_all_dialogs_shown_without_limit(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -487,9 +487,104 @@ class TestListDialogs:
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
             handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         text = _text(result)
-        assert "и ещё 5" in text
+        assert "Диалоги (105)" in text
+        assert "и ещё" not in text
+
+    @pytest.mark.asyncio
+    async def test_limit_param(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": i, "title": f"Chan{i}", "channel_type": "channel"} for i in range(10)
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "limit": 3})
+        text = _text(result)
+        assert "Диалоги (3)" in text
+
+    @pytest.mark.asyncio
+    async def test_search_param(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": 1, "title": "Python News", "channel_type": "channel"},
+            {"channel_id": 2, "title": "Golang Daily", "channel_type": "channel"},
+            {"channel_id": 3, "title": "Python Weekly", "channel_type": "channel"},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "search": "python"})
+        text = _text(result)
+        assert "Диалоги (2)" in text
+        assert "Python News" in text
+        assert "Python Weekly" in text
+        assert "Golang Daily" not in text
+
+    @pytest.mark.asyncio
+    async def test_type_alias_channels(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": 1, "title": "Chan", "channel_type": "channel"},
+            {"channel_id": 2, "title": "Group", "channel_type": "supergroup"},
+            {"channel_id": 3, "title": "DM", "channel_type": "dm"},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "type": "channels"})
+        text = _text(result)
+        assert "Диалоги (1)" in text
+        assert "Chan" in text
+        assert "Group" not in text
+
+    @pytest.mark.asyncio
+    async def test_type_alias_groups(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": 1, "title": "Chan", "channel_type": "channel"},
+            {"channel_id": 2, "title": "SuperG", "channel_type": "supergroup"},
+            {"channel_id": 3, "title": "Forum", "channel_type": "forum"},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "type": "groups"})
+        text = _text(result)
+        assert "Диалоги (2)" in text
+        assert "Chan" not in text
+
+    @pytest.mark.asyncio
+    async def test_type_exact(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": 1, "title": "Chan", "channel_type": "channel"},
+            {"channel_id": 2, "title": "Bot1", "channel_type": "bot"},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "type": "bot"})
+        text = _text(result)
+        assert "Диалоги (1)" in text
+        assert "Bot1" in text
 
     @pytest.mark.asyncio
     async def test_exception(self, mock_db):
@@ -500,7 +595,7 @@ class TestListDialogs:
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.get_my_dialogs = AsyncMock(side_effect=Exception("fail"))
             handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["list_dialogs"]({"phone": "+79001234567"})
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567"})
         assert "Ошибка получения диалогов" in _text(result)
 
 

--- a/tests/test_coverage_batch4.py
+++ b/tests/test_coverage_batch4.py
@@ -493,6 +493,24 @@ class TestSearchMyTelegram:
         assert "и ещё" not in text
 
     @pytest.mark.asyncio
+    async def test_filter_empty_distinguishes_from_no_dialogs(self, mock_db):
+        pool = _make_pool_with_account()
+        mock_db.get_accounts = AsyncMock(
+            return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
+        )
+        dialogs = [
+            {"channel_id": 1, "title": "Test", "channel_type": "channel"},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_my_dialogs = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["search_my_telegram"]({"phone": "+79001234567", "type": "dm"})
+        text = _text(result)
+        assert "Нет диалогов по запросу" in text
+        assert "Всего диалогов" in text
+        assert "не найдены" not in text
+
+    @pytest.mark.asyncio
     async def test_limit_param(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(

--- a/tests/test_coverage_batch7.py
+++ b/tests/test_coverage_batch7.py
@@ -1059,14 +1059,15 @@ class TestListImageModelsTool:
         assert "rank 1" in text
 
     @pytest.mark.asyncio
-    async def test_models_truncated_at_30(self, mock_db):
+    async def test_models_all_shown_beyond_30(self, mock_db):
         models = [{"id": f"m{i}"} for i in range(35)]
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
         with patch(f"{_svc_path}.search_models", new=AsyncMock(return_value=models)):
             handlers = _get_channel_tool_handlers(mock_db)
             result = await handlers["list_image_models"]({"provider": "replicate"})
         text = _text(result)
-        assert "ещё 5" in text
+        assert "Модели replicate (35)" in text
+        assert "ещё" not in text
 
 
 class TestListGeneratedImagesTool:

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -2015,7 +2015,7 @@ class TestMyTelegramToolErrors:
         handlers, _, _ = mytg_setup
         with patch("src.services.channel_service.ChannelService.get_my_dialogs",
                     new_callable=AsyncMock, side_effect=RuntimeError("fail")):
-            result = await handlers["list_dialogs"]({"phone": "+1111"})
+            result = await handlers["search_my_telegram"]({"phone": "+1111"})
             assert "ошибка" in _text(result).lower()
 
     async def test_refresh_dialogs_exception(self, mytg_setup):
@@ -3502,7 +3502,7 @@ class TestMyTelegramToolPhoneGates:
 
     async def test_list_dialogs_phone_err(self, mytg_phone_err):
         handlers, _ = mytg_phone_err
-        r = await handlers["list_dialogs"]({"phone": ""})
+        r = await handlers["search_my_telegram"]({"phone": ""})
         assert "аккаунт" in _text(r).lower()
 
     async def test_refresh_dialogs_phone_err(self, mytg_phone_err):


### PR DESCRIPTION
## Summary
- **Renamed** `list_dialogs` → `search_my_telegram` agent tool with new `search`, `type`, `limit` parameters for flexible dialog filtering
- **Removed hardcoded display limits** in `messaging.py` (50), `filters.py` (30), `images.py` (30), `deepagents_sync.py` (200) — all results shown by default
- **Updated** permissions, docs, and all affected tests; added 7 new tests for search/type/limit filtering

Closes #272

## Test plan
- [x] `ruff check` passes on all modified source files
- [x] 3920 parallel tests pass (`pytest -n auto -m "not aiosqlite_serial"`)
- [x] 508 serial tests pass (`pytest -m aiosqlite_serial`)
- [ ] Verify agent correctly uses `search_my_telegram` with `search`/`type`/`limit` params in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)