### PR TITLE
feat: add Telegram search agent tools

### DIFF
--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -29,6 +29,10 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "search_messages": ToolCategory.READ,
     "semantic_search": ToolCategory.READ,
     "index_messages": ToolCategory.WRITE,
+    "search_telegram": ToolCategory.READ,
+    "search_my_chats": ToolCategory.READ,
+    "search_in_channel": ToolCategory.READ,
+    "search_hybrid": ToolCategory.READ,
     # Channels
     "list_channels": ToolCategory.READ,
     "get_channel_stats": ToolCategory.READ,
@@ -169,6 +173,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
 MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Поиск", [
         "search_messages", "semantic_search", "index_messages",
+        "search_telegram", "search_my_chats", "search_in_channel", "search_hybrid",
     ]),
     ("Каналы", [
         "list_channels", "get_channel_stats", "add_channel", "delete_channel",

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from claude_agent_sdk import tool
 
-from src.agent.tools._registry import _text_response
+from src.agent.tools._registry import _text_response, require_pool
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -124,5 +124,153 @@ def register(db, client_pool, embedding_service, **kwargs):
         return _text_response(text)
 
     tools.append(index_messages)
+
+    # ------------------------------------------------------------------
+    # Lazy SearchEngine — created once on first Telegram/hybrid search
+    # ------------------------------------------------------------------
+
+    _engine_cache: list = []
+
+    def _get_engine():
+        if not _engine_cache:
+            from src.search.engine import SearchEngine
+
+            _engine_cache.append(SearchEngine(db, pool=client_pool, config=kwargs.get("config")))
+        return _engine_cache[0]
+
+    def _render_search_response(result) -> str:
+        """Render SearchResult into text, handling .error field."""
+        if result.error:
+            return f"Ошибка: {result.error}"
+        return _render_search_result(
+            query=result.query,
+            messages=result.messages,
+            total=result.total,
+            empty_prefix="Ничего не найдено по запросу",
+            found_prefix="Найдено",
+        )
+
+    # ------------------------------------------------------------------
+    # search_telegram  (Telegram Premium global search)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "search_telegram",
+        "Search messages across all public Telegram channels via Telegram API. "
+        "Requires a connected Premium account. Use for discovering content beyond collected channels.",
+        {"query": str, "limit": int},
+    )
+    async def search_telegram(args):
+        pool_gate = require_pool(client_pool, "Telegram-поиск")
+        if pool_gate:
+            return pool_gate
+        query = args.get("query", "")
+        limit = int(args.get("limit", 50))
+        try:
+            result = await _get_engine().search_telegram(query, limit=limit)
+            text = _render_search_response(result)
+        except Exception as e:
+            text = f"Ошибка Telegram-поиска: {e}"
+        return _text_response(text)
+
+    tools.append(search_telegram)
+
+    # ------------------------------------------------------------------
+    # search_my_chats  (search across user's own dialogs)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "search_my_chats",
+        "Search messages in your own Telegram dialogs (private chats, groups, saved messages). "
+        "Requires a connected Telegram account.",
+        {"query": str, "limit": int},
+    )
+    async def search_my_chats(args):
+        pool_gate = require_pool(client_pool, "Поиск по личным чатам")
+        if pool_gate:
+            return pool_gate
+        query = args.get("query", "")
+        limit = int(args.get("limit", 50))
+        try:
+            result = await _get_engine().search_my_chats(query, limit=limit)
+            text = _render_search_response(result)
+        except Exception as e:
+            text = f"Ошибка поиска по чатам: {e}"
+        return _text_response(text)
+
+    tools.append(search_my_chats)
+
+    # ------------------------------------------------------------------
+    # search_in_channel  (search within a specific channel via Telegram)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "search_in_channel",
+        "Search messages within a specific Telegram channel via Telegram API. "
+        "Requires a connected account and channel_id.",
+        {"channel_id": int, "query": str, "limit": int},
+    )
+    async def search_in_channel(args):
+        pool_gate = require_pool(client_pool, "Поиск в канале")
+        if pool_gate:
+            return pool_gate
+        channel_id = args.get("channel_id")
+        if not channel_id:
+            return _text_response("Ошибка: channel_id обязателен.")
+        query = args.get("query", "")
+        limit = int(args.get("limit", 50))
+        try:
+            result = await _get_engine().search_in_channel(
+                int(channel_id), query, limit=limit,
+            )
+            text = _render_search_response(result)
+        except Exception as e:
+            text = f"Ошибка поиска в канале: {e}"
+        return _text_response(text)
+
+    tools.append(search_in_channel)
+
+    # ------------------------------------------------------------------
+    # search_hybrid  (FTS + semantic combined, local DB)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "search_hybrid",
+        "Hybrid search combining full-text and semantic similarity on collected messages. "
+        "Works locally, no Telegram connection needed.",
+        {
+            "query": str,
+            "limit": int,
+            "channel_id": int,
+            "date_from": str,
+            "date_to": str,
+            "min_length": int,
+            "max_length": int,
+        },
+    )
+    async def search_hybrid(args):
+        query = args.get("query", "")
+        limit = int(args.get("limit", 20))
+        channel_id = args.get("channel_id")
+        date_from = args.get("date_from")
+        date_to = args.get("date_to")
+        min_length = args.get("min_length")
+        max_length = args.get("max_length")
+        try:
+            result = await _get_engine().search_hybrid(
+                query=query,
+                channel_id=int(channel_id) if channel_id else None,
+                date_from=date_from,
+                date_to=date_to,
+                limit=limit,
+                min_length=int(min_length) if min_length is not None else None,
+                max_length=int(max_length) if max_length is not None else None,
+            )
+            text = _render_search_response(result)
+        except Exception as e:
+            text = f"Ошибка гибридного поиска: {e}"
+        return _text_response(text)
+
+    tools.append(search_hybrid)
 
     return tools

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -118,6 +118,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def index_messages(args):
         try:
             indexed = await embedding_service.index_pending_messages()
+            if _engine_cache:
+                _engine_cache[0].invalidate_numpy_index()
             text = f"Индексация завершена. Проиндексировано сообщений: {indexed}"
         except Exception as e:
             text = f"Ошибка индексации: {e}"

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -752,3 +752,173 @@ class TestConfigPropagation:
             await handlers["run_pipeline"]({"pipeline_id": 1})
 
             mock_search_cls.assert_called_with(mock_db, config=fake_config)
+
+
+# ---------------------------------------------------------------------------
+# Telegram Search tools  (search_telegram, search_my_chats, search_in_channel, search_hybrid)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchTelegramTool:
+    """Tests for the search_telegram tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["search_telegram"]({"query": "test"})
+        assert "требует Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_results(self, mock_db):
+        mock_pool = MagicMock()
+        fake_result = SimpleNamespace(
+            messages=[
+                SimpleNamespace(channel_id=100, message_id=1, text="Global result", date="2025-01-01"),
+            ],
+            total=1,
+            query="test",
+            error=None,
+        )
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_telegram = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["search_telegram"]({"query": "test", "limit": 10})
+
+        text = _text(result)
+        assert "Найдено 1 сообщений" in text
+        assert "Global result" in text
+
+    @pytest.mark.asyncio
+    async def test_error_in_search_result(self, mock_db):
+        mock_pool = MagicMock()
+        fake_result = SimpleNamespace(
+            messages=[], total=0, query="test",
+            error="Нет аккаунтов с Telegram Premium.",
+        )
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_telegram = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["search_telegram"]({"query": "test"})
+
+        assert "Нет аккаунтов с Telegram Premium" in _text(result)
+
+
+class TestSearchMyChatsTool:
+    """Tests for the search_my_chats tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["search_my_chats"]({"query": "test"})
+        assert "требует Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_results(self, mock_db):
+        mock_pool = MagicMock()
+        fake_result = SimpleNamespace(
+            messages=[
+                SimpleNamespace(channel_id=200, message_id=5, text="My chat msg", date="2025-03-01"),
+            ],
+            total=1,
+            query="hello",
+            error=None,
+        )
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_my_chats = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["search_my_chats"]({"query": "hello", "limit": 5})
+
+        text = _text(result)
+        assert "Найдено 1 сообщений" in text
+        assert "My chat msg" in text
+
+
+class TestSearchInChannelTool:
+    """Tests for the search_in_channel tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_no_pool_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["search_in_channel"]({"channel_id": 123, "query": "test"})
+        assert "требует Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_id(self, mock_db):
+        mock_pool = MagicMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["search_in_channel"]({"query": "test"})
+        assert "channel_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_results(self, mock_db):
+        mock_pool = MagicMock()
+        fake_result = SimpleNamespace(
+            messages=[
+                SimpleNamespace(channel_id=999, message_id=10, text="Channel msg", date="2025-02-01"),
+            ],
+            total=1,
+            query="news",
+            error=None,
+        )
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_in_channel = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["search_in_channel"](
+                {"channel_id": 999, "query": "news", "limit": 20}
+            )
+
+        text = _text(result)
+        assert "Найдено 1 сообщений" in text
+        assert "Channel msg" in text
+
+
+class TestSearchHybridTool:
+    """Tests for the search_hybrid tool handler."""
+
+    @pytest.mark.asyncio
+    async def test_returns_results(self, mock_db):
+        fake_result = SimpleNamespace(
+            messages=[
+                SimpleNamespace(channel_id=300, message_id=7, text="Hybrid hit", date="2025-04-01"),
+            ],
+            total=1,
+            query="topic",
+            error=None,
+        )
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_hybrid = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["search_hybrid"]({"query": "topic", "limit": 10})
+
+        text = _text(result)
+        assert "Найдено 1 сообщений" in text
+        assert "Hybrid hit" in text
+
+    @pytest.mark.asyncio
+    async def test_no_pool_still_works(self, mock_db):
+        """Hybrid search works without pool (local only)."""
+        fake_result = SimpleNamespace(messages=[], total=0, query="empty", error=None)
+
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_hybrid = AsyncMock(return_value=fake_result)
+            handlers = _get_tool_handlers(mock_db, client_pool=None)
+            result = await handlers["search_hybrid"]({"query": "empty"})
+
+        assert "Ничего не найдено" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.search.engine.SearchEngine") as mock_engine_cls:
+            mock_engine_cls.return_value.search_hybrid = AsyncMock(
+                side_effect=RuntimeError("vec not available")
+            )
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["search_hybrid"]({"query": "test"})
+
+        assert "Ошибка гибридного поиска" in _text(result)
+        assert "vec not available" in _text(result)


### PR DESCRIPTION
## Summary
- Add 4 new agent tools for Telegram search modes (closes part of #274)
- `search_telegram` — global Premium search across public channels
- `search_my_chats` — search user's own dialogs
- `search_in_channel` — search within a specific channel via Telegram API
- `search_hybrid` — combined FTS + semantic local search

## Details
- Tools use lazy `SearchEngine` instance (created once on first call)
- `search_telegram`, `search_my_chats`, `search_in_channel` require `ClientPool` (guarded by `require_pool()`)
- `search_hybrid` works locally without pool
- All tools registered in `TOOL_CATEGORIES` and `MODULE_GROUPS` in `permissions.py`
- 11 new tests covering success, error, no-pool scenarios

## Test plan
- [x] `ruff check` passes
- [x] All 11 new tests pass
- [x] Existing 330 search-related tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)