### PR TITLE
feat: add scheduler agent tools

### DIFF
--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -108,6 +108,9 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "stop_scheduler": ToolCategory.WRITE,
     "trigger_collection": ToolCategory.WRITE,
     "toggle_scheduler_job": ToolCategory.WRITE,
+    "set_scheduler_interval": ToolCategory.WRITE,
+    "cancel_scheduler_task": ToolCategory.WRITE,
+    "clear_pending_tasks": ToolCategory.WRITE,
     # Notifications
     "get_notification_status": ToolCategory.READ,
     "setup_notification_bot": ToolCategory.WRITE,
@@ -217,6 +220,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Планировщик", [
         "get_scheduler_status", "start_scheduler", "stop_scheduler",
         "trigger_collection", "toggle_scheduler_job",
+        "set_scheduler_interval", "cancel_scheduler_task", "clear_pending_tasks",
     ]),
     ("Уведомления", [
         "get_notification_status", "setup_notification_bot", "delete_notification_bot",

--- a/src/agent/tools/scheduler.py
+++ b/src/agent/tools/scheduler.py
@@ -120,4 +120,85 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(toggle_scheduler_job)
 
+    # ------------------------------------------------------------------
+    # set_scheduler_interval (WRITE + confirm)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "set_scheduler_interval",
+        "Set the collection interval (in minutes) for a scheduler job. "
+        "job_id can be 'collect_all' or a specific job name. Range: 1–1440.",
+        {"job_id": str, "minutes": int, "confirm": bool},
+    )
+    async def set_scheduler_interval(args):
+        job_id = args.get("job_id", "")
+        if not job_id:
+            return _text_response("Ошибка: job_id обязателен.")
+        minutes = args.get("minutes")
+        if minutes is None:
+            return _text_response("Ошибка: minutes обязателен.")
+        minutes = max(1, min(int(minutes), 1440))
+        gate = require_confirmation(f"установит интервал задачи '{job_id}' = {minutes} мин", args)
+        if gate:
+            return gate
+        try:
+            if job_id == "collect_all":
+                await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
+            else:
+                await db.repos.settings.set_setting(
+                    f"scheduler_job_{job_id}_interval", str(minutes)
+                )
+            return _text_response(f"Интервал задачи '{job_id}' установлен: {minutes} мин.")
+        except Exception as e:
+            return _text_response(f"Ошибка установки интервала: {e}")
+
+    tools.append(set_scheduler_interval)
+
+    # ------------------------------------------------------------------
+    # cancel_scheduler_task (WRITE + confirm)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "cancel_scheduler_task",
+        "Cancel a pending collection task by task_id. Requires confirmation.",
+        {"task_id": int, "confirm": bool},
+    )
+    async def cancel_scheduler_task(args):
+        task_id = args.get("task_id")
+        if task_id is None:
+            return _text_response("Ошибка: task_id обязателен.")
+        gate = require_confirmation(f"отменит задачу id={task_id}", args)
+        if gate:
+            return gate
+        try:
+            ok = await db.repos.tasks.cancel_collection_task(int(task_id))
+            if ok:
+                return _text_response(f"Задача {task_id} отменена.")
+            return _text_response(f"Задача {task_id} не найдена или уже завершена.")
+        except Exception as e:
+            return _text_response(f"Ошибка отмены задачи: {e}")
+
+    tools.append(cancel_scheduler_task)
+
+    # ------------------------------------------------------------------
+    # clear_pending_tasks (WRITE + confirm)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "clear_pending_tasks",
+        "Clear all pending collection tasks from the queue. Requires confirmation.",
+        {"confirm": bool},
+    )
+    async def clear_pending_tasks(args):
+        gate = require_confirmation("удалит все ожидающие задачи сбора из очереди", args)
+        if gate:
+            return gate
+        try:
+            deleted = await db.repos.tasks.delete_pending_channel_tasks()
+            return _text_response(f"Удалено ожидающих задач: {deleted}.")
+        except Exception as e:
+            return _text_response(f"Ошибка очистки очереди: {e}")
+
+    tools.append(clear_pending_tasks)
+
     return tools

--- a/src/agent/tools/scheduler.py
+++ b/src/agent/tools/scheduler.py
@@ -126,29 +126,28 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "set_scheduler_interval",
-        "Set the collection interval (in minutes) for a scheduler job. "
-        "job_id can be 'collect_all' or a specific job name. Range: 1–1440.",
+        "Set the collection interval (in minutes). Currently only 'collect_all' is supported. Range: 1–1440.",
         {"job_id": str, "minutes": int, "confirm": bool},
     )
     async def set_scheduler_interval(args):
         job_id = args.get("job_id", "")
         if not job_id:
             return _text_response("Ошибка: job_id обязателен.")
+        if job_id != "collect_all":
+            return _text_response(
+                f"Ошибка: интервал можно установить только для 'collect_all'. "
+                f"Получено: '{job_id}'."
+            )
         minutes = args.get("minutes")
         if minutes is None:
             return _text_response("Ошибка: minutes обязателен.")
         minutes = max(1, min(int(minutes), 1440))
-        gate = require_confirmation(f"установит интервал задачи '{job_id}' = {minutes} мин", args)
+        gate = require_confirmation(f"установит интервал сбора = {minutes} мин", args)
         if gate:
             return gate
         try:
-            if job_id == "collect_all":
-                await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
-            else:
-                await db.repos.settings.set_setting(
-                    f"scheduler_job_{job_id}_interval", str(minutes)
-                )
-            return _text_response(f"Интервал задачи '{job_id}' установлен: {minutes} мин.")
+            await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
+            return _text_response(f"Интервал сбора установлен: {minutes} мин.")
         except Exception as e:
             return _text_response(f"Ошибка установки интервала: {e}")
 
@@ -160,7 +159,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "cancel_scheduler_task",
-        "Cancel a pending collection task by task_id. Requires confirmation.",
+        "Cancel a collection task by task_id. Works for pending tasks; running tasks will be "
+        "marked cancelled in DB but the active collection may continue until completion. "
+        "Requires confirmation.",
         {"task_id": int, "confirm": bool},
     )
     async def cancel_scheduler_task(args):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -873,9 +873,17 @@ class TestSetSchedulerIntervalTool:
         mock_db.repos.settings.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_scheduler_interval"](
-            {"job_id": "custom_job", "minutes": 9999, "confirm": True}
+            {"job_id": "collect_all", "minutes": 9999, "confirm": True}
         )
         assert "1440 мин" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_collect_all(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["set_scheduler_interval"](
+            {"job_id": "custom_job", "minutes": 30, "confirm": True}
+        )
+        assert "только для 'collect_all'" in _text(result)
 
 
 class TestCancelSchedulerTaskTool:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -836,3 +836,83 @@ class TestGetAccountInfoTool:
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["get_account_info"]({})
         assert "не найдены" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler tools  (set_scheduler_interval, cancel_scheduler_task, clear_pending_tasks)
+# ---------------------------------------------------------------------------
+
+
+class TestSetSchedulerIntervalTool:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["set_scheduler_interval"]({"job_id": "collect_all", "minutes": 30})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_missing_job_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["set_scheduler_interval"]({"minutes": 30, "confirm": True})
+        assert "job_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_sets_interval(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.settings.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["set_scheduler_interval"](
+            {"job_id": "collect_all", "minutes": 60, "confirm": True}
+        )
+        assert "60 мин" in _text(result)
+        mock_db.repos.settings.set_setting.assert_awaited_once_with("collect_interval_minutes", "60")
+
+    @pytest.mark.asyncio
+    async def test_clamps_minutes(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.settings.set_setting = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["set_scheduler_interval"](
+            {"job_id": "custom_job", "minutes": 9999, "confirm": True}
+        )
+        assert "1440 мин" in _text(result)
+
+
+class TestCancelSchedulerTaskTool:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["cancel_scheduler_task"]({"task_id": 1})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_cancels_task(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.tasks.cancel_collection_task = AsyncMock(return_value=True)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["cancel_scheduler_task"]({"task_id": 42, "confirm": True})
+        assert "отменена" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_task_not_found(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.tasks.cancel_collection_task = AsyncMock(return_value=False)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["cancel_scheduler_task"]({"task_id": 999, "confirm": True})
+        assert "не найдена" in _text(result)
+
+
+class TestClearPendingTasksTool:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_pending_tasks"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_clears_tasks(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.tasks.delete_pending_channel_tasks = AsyncMock(return_value=5)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_pending_tasks"]({"confirm": True})
+        assert "5" in _text(result)


### PR DESCRIPTION
## Summary
- Add 3 new scheduler agent tools (part of #274)
- `set_scheduler_interval` — set collection interval per job (1–1440 min, clamped)
- `cancel_scheduler_task` — cancel a pending collection task by task_id
- `clear_pending_tasks` — clear all pending collection tasks from queue

## Details
- All WRITE tools, require `confirm`
- Uses `db.repos.settings.set_setting()` and `db.repos.tasks.*` methods matching CLI implementation
- 9 new tests

## Test plan
- [x] `ruff check` passes
- [x] All 9 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)