### PR TITLE
feat: add search query stats agent tool

### DIFF
--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -75,6 +75,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "delete_search_query": ToolCategory.DELETE,
     "toggle_search_query": ToolCategory.WRITE,
     "run_search_query": ToolCategory.WRITE,
+    "get_search_query_stats": ToolCategory.READ,
     # Accounts
     "list_accounts": ToolCategory.READ,
     "toggle_account": ToolCategory.WRITE,
@@ -202,6 +203,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Поисковые запросы", [
         "list_search_queries", "get_search_query", "add_search_query", "edit_search_query",
         "delete_search_query", "toggle_search_query", "run_search_query",
+        "get_search_query_stats",
     ]),
     ("Аккаунты", [
         "list_accounts", "toggle_account", "delete_account", "get_flood_status",

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -263,4 +263,37 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(run_search_query)
 
+    # ------------------------------------------------------------------
+    # get_search_query_stats (READ)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "get_search_query_stats",
+        "Get daily match statistics for a search query over the last N days.",
+        {"sq_id": int, "days": int},
+    )
+    async def get_search_query_stats(args):
+        sq_id = args.get("sq_id")
+        if sq_id is None:
+            return _text_response("Ошибка: sq_id обязателен.")
+        days = int(args.get("days", 30))
+        try:
+            from src.services.search_query_service import SearchQueryService
+
+            svc = SearchQueryService(db)
+            stats = await svc.get_daily_stats(int(sq_id), days)
+            if not stats:
+                return _text_response(f"Нет статистики для запроса id={sq_id} за {days} дней.")
+            max_count = max(s.count for s in stats)
+            lines = [f"Статистика запроса id={sq_id} за {days} дней:"]
+            for s in stats:
+                bar_len = int(s.count / max_count * 30) if max_count else 0
+                bar = "█" * bar_len
+                lines.append(f"  {s.day}  {bar} {s.count}")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка получения статистики: {e}")
+
+    tools.append(get_search_query_stats)
+
     return tools

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -276,7 +276,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         sq_id = args.get("sq_id")
         if sq_id is None:
             return _text_response("Ошибка: sq_id обязателен.")
-        days = int(args.get("days", 30))
+        days = max(1, int(args.get("days", 30)))
         try:
             from src.services.search_query_service import SearchQueryService
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -924,3 +924,42 @@ class TestClearPendingTasksTool:
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["clear_pending_tasks"]({"confirm": True})
         assert "5" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# get_search_query_stats tool
+# ---------------------------------------------------------------------------
+
+
+class TestGetSearchQueryStatsTool:
+    @pytest.mark.asyncio
+    async def test_returns_stats(self, mock_db):
+        fake_stats = [
+            SimpleNamespace(day="2025-01-01", count=10),
+            SimpleNamespace(day="2025-01-02", count=25),
+        ]
+
+        with patch("src.services.search_query_service.SearchQueryService") as mock_svc_cls:
+            mock_svc_cls.return_value.get_daily_stats = AsyncMock(return_value=fake_stats)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_search_query_stats"]({"sq_id": 1, "days": 7})
+
+        text = _text(result)
+        assert "2025-01-01" in text
+        assert "2025-01-02" in text
+        assert "25" in text
+
+    @pytest.mark.asyncio
+    async def test_missing_sq_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_search_query_stats"]({})
+        assert "sq_id обязателен" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_empty_stats(self, mock_db):
+        with patch("src.services.search_query_service.SearchQueryService") as mock_svc_cls:
+            mock_svc_cls.return_value.get_daily_stats = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_search_query_stats"]({"sq_id": 99, "days": 30})
+
+        assert "Нет статистики" in _text(result)


### PR DESCRIPTION
## Summary
- Add `get_search_query_stats` agent tool (part of #274)
- Shows daily match counts with bar chart for a saved search query

## Details
- READ tool, uses `SearchQueryService.get_daily_stats(sq_id, days)`
- Parameters: `sq_id` (required), `days` (default 30)
- 3 new tests

## Test plan
- [x] `ruff check` passes
- [x] All 3 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)