### PR TITLE
feat: add notification and photo loader agent tools

### DIFF
--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -106,4 +106,51 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(test_notification)
 
+    # ------------------------------------------------------------------
+    # notification_dry_run (READ)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "notification_dry_run",
+        "Preview how many matches each active notification query would produce. "
+        "Does NOT send any notifications.",
+        {},
+    )
+    async def notification_dry_run(args):
+        try:
+            from datetime import timezone
+
+            last_task = await db.repos.tasks.get_last_completed_collect_task()
+            since = None
+            if last_task and last_task.completed_at:
+                since = last_task.completed_at.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            queries = await db.get_notification_queries(active_only=True)
+            # Filter out disabled jobs
+            filtered = []
+            for sq in queries:
+                val = await db.repos.settings.get_setting(f"scheduler_job_disabled:sq_{sq.id}")
+                if val != "1":
+                    filtered.append(sq)
+            queries = filtered
+            if not queries:
+                return _text_response("Нет активных запросов уведомлений.")
+            total_matches = 0
+            lines = [f"Dry-run уведомлений (с {since or 'N/A'}):"]
+            for sq in queries:
+                count = 0
+                if since:
+                    try:
+                        _, count = await db.search_messages_for_query_since(sq, since, limit=0)
+                    except Exception:
+                        count = 0
+                name = getattr(sq, "name", None) or sq.query
+                lines.append(f"  {name}: {count} совпадений")
+                total_matches += count
+            lines.append(f"\nИтого: {total_matches} совпадений")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка dry-run уведомлений: {e}")
+
+    tools.append(notification_dry_run)
+
     return tools

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -117,6 +117,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "setup_notification_bot": ToolCategory.WRITE,
     "delete_notification_bot": ToolCategory.DELETE,
     "test_notification": ToolCategory.WRITE,
+    "notification_dry_run": ToolCategory.READ,
     # Photo Loader
     "list_photo_batches": ToolCategory.READ,
     "list_photo_items": ToolCategory.READ,
@@ -130,6 +131,8 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "run_photo_due": ToolCategory.WRITE,
     "create_auto_upload": ToolCategory.WRITE,
     "update_auto_upload": ToolCategory.WRITE,
+    "list_photo_dialogs": ToolCategory.READ,
+    "refresh_photo_dialogs": ToolCategory.WRITE,
     # My Telegram
     "search_my_telegram": ToolCategory.READ,
     "refresh_dialogs": ToolCategory.WRITE,
@@ -226,12 +229,13 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ]),
     ("Уведомления", [
         "get_notification_status", "setup_notification_bot", "delete_notification_bot",
-        "test_notification",
+        "test_notification", "notification_dry_run",
     ]),
     ("Фото", [
         "list_photo_batches", "list_photo_items", "send_photos_now", "schedule_photos",
         "cancel_photo_item", "list_auto_uploads", "toggle_auto_upload", "delete_auto_upload",
         "create_photo_batch", "run_photo_due", "create_auto_upload", "update_auto_upload",
+        "list_photo_dialogs", "refresh_photo_dialogs",
     ]),
     ("Мой Telegram", [
         "search_my_telegram", "refresh_dialogs", "leave_dialogs", "create_telegram_channel",

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -457,4 +457,76 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(update_auto_upload)
 
+    # ------------------------------------------------------------------
+    # list_photo_dialogs (READ) — list Telegram dialogs for photo targeting
+    # ------------------------------------------------------------------
+
+    @tool(
+        "list_photo_dialogs",
+        "List Telegram dialogs available as photo upload targets (channels, groups, chats).",
+        {"phone": str},
+    )
+    async def list_photo_dialogs(args):
+        pool_gate = require_pool(client_pool, "Список диалогов для фото")
+        if pool_gate:
+            return pool_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "list_photo_dialogs")
+        if perm_gate:
+            return perm_gate
+        try:
+            from src.services.channel_service import ChannelService
+
+            svc = ChannelService(db, client_pool, None)
+            dialogs = await svc.get_my_dialogs(phone)
+            if not dialogs:
+                return _text_response(f"Диалоги для {phone} не найдены.")
+            lines = [f"Диалоги ({len(dialogs)}):"]
+            for d in dialogs:
+                lines.append(
+                    f"- id={d['channel_id']}, type={d.get('channel_type', '?')}: "
+                    f"{d.get('title', '?')}"
+                )
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка получения диалогов: {e}")
+
+    tools.append(list_photo_dialogs)
+
+    # ------------------------------------------------------------------
+    # refresh_photo_dialogs (WRITE) — refresh dialog cache
+    # ------------------------------------------------------------------
+
+    @tool(
+        "refresh_photo_dialogs",
+        "Refresh the Telegram dialog cache for photo upload targeting. "
+        "Use when new channels/groups are not appearing in the list.",
+        {"phone": str, "confirm": bool},
+    )
+    async def refresh_photo_dialogs(args):
+        pool_gate = require_pool(client_pool, "Обновление кэша диалогов")
+        if pool_gate:
+            return pool_gate
+        phone, err = await resolve_phone(db, args.get("phone", ""))
+        if err:
+            return err
+        perm_gate = await require_phone_permission(db, phone, "refresh_photo_dialogs")
+        if perm_gate:
+            return perm_gate
+        gate = require_confirmation(f"обновит кэш диалогов для {phone}", args)
+        if gate:
+            return gate
+        try:
+            from src.services.channel_service import ChannelService
+
+            svc = ChannelService(db, client_pool, None)
+            dialogs = await svc.get_my_dialogs(phone, refresh=True)
+            return _text_response(f"Кэш диалогов обновлён: {len(dialogs)} диалогов.")
+        except Exception as e:
+            return _text_response(f"Ошибка обновления кэша диалогов: {e}")
+
+    tools.append(refresh_photo_dialogs)
+
     return tools

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -981,7 +981,7 @@ class TestNotificationDryRunTool:
         assert "Нет активных" in _text(result)
 
     @pytest.mark.asyncio
-    async def test_returns_match_counts(self, mock_db):
+    async def test_returns_zero_when_no_since(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=None)
         sq = SimpleNamespace(id=1, query="test", name="Test Query")
@@ -992,6 +992,25 @@ class TestNotificationDryRunTool:
         text = _text(result)
         assert "Test Query" in text
         assert "0 совпадений" in text
+
+    @pytest.mark.asyncio
+    async def test_returns_actual_match_counts(self, mock_db):
+        from datetime import datetime, timezone
+
+        mock_db.repos = MagicMock()
+        completed_task = SimpleNamespace(
+            completed_at=datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+        )
+        mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=completed_task)
+        sq = SimpleNamespace(id=1, query="test", name="Test Query")
+        mock_db.get_notification_queries = AsyncMock(return_value=[sq])
+        mock_db.repos.settings.get_setting = AsyncMock(return_value=None)
+        mock_db.search_messages_for_query_since = AsyncMock(return_value=([], 5))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["notification_dry_run"]({})
+        text = _text(result)
+        assert "5 совпадений" in text
+        mock_db.search_messages_for_query_since.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -963,3 +963,100 @@ class TestGetSearchQueryStatsTool:
             result = await handlers["get_search_query_stats"]({"sq_id": 99, "days": 30})
 
         assert "Нет статистики" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# notification_dry_run tool
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationDryRunTool:
+    @pytest.mark.asyncio
+    async def test_no_active_queries(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=None)
+        mock_db.get_notification_queries = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["notification_dry_run"]({})
+        assert "Нет активных" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_match_counts(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=None)
+        sq = SimpleNamespace(id=1, query="test", name="Test Query")
+        mock_db.get_notification_queries = AsyncMock(return_value=[sq])
+        mock_db.repos.settings.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["notification_dry_run"]({})
+        text = _text(result)
+        assert "Test Query" in text
+        assert "0 совпадений" in text
+
+
+# ---------------------------------------------------------------------------
+# list_photo_dialogs tool
+# ---------------------------------------------------------------------------
+
+
+class TestListPhotoDialogsTool:
+    @pytest.mark.asyncio
+    async def test_no_pool(self, mock_db):
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        result = await handlers["list_photo_dialogs"]({})
+        assert "требует Telegram-клиент" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_dialogs(self, mock_db):
+        mock_pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(id=1, phone="+1234", is_primary=True),
+        ])
+        mock_db.get_setting = AsyncMock(return_value=None)
+
+        with patch("src.services.channel_service.ChannelService") as mock_svc_cls:
+            mock_svc_cls.return_value.get_my_dialogs = AsyncMock(return_value=[
+                {"channel_id": 100, "channel_type": "channel", "title": "My Channel"},
+            ])
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["list_photo_dialogs"]({})
+
+        text = _text(result)
+        assert "My Channel" in text
+        assert "id=100" in text
+
+
+# ---------------------------------------------------------------------------
+# refresh_photo_dialogs tool
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshPhotoDialogsTool:
+    @pytest.mark.asyncio
+    async def test_requires_confirmation(self, mock_db):
+        mock_pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(id=1, phone="+1234", is_primary=True),
+        ])
+        mock_db.get_setting = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["refresh_photo_dialogs"]({})
+        assert "confirm=true" in _text(result)
+
+    @pytest.mark.asyncio
+    async def test_refreshes(self, mock_db):
+        mock_pool = MagicMock()
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(id=1, phone="+1234", is_primary=True),
+        ])
+        mock_db.get_setting = AsyncMock(return_value=None)
+
+        with patch("src.services.channel_service.ChannelService") as mock_svc_cls:
+            mock_svc_cls.return_value.get_my_dialogs = AsyncMock(return_value=[
+                {"channel_id": 1, "title": "A"},
+                {"channel_id": 2, "title": "B"},
+            ])
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["refresh_photo_dialogs"]({"confirm": True})
+
+        assert "2 диалогов" in _text(result)


### PR DESCRIPTION
## Summary
- Add 3 new agent tools (closes #274)
- `notification_dry_run` — preview match counts for notification queries without sending
- `list_photo_dialogs` — list Telegram dialogs as photo upload targets
- `refresh_photo_dialogs` — refresh dialog cache for photo targeting

## Details
- `notification_dry_run`: READ, matches CLI `notification dry-run` logic
- `list_photo_dialogs`: READ, requires pool + phone permission
- `refresh_photo_dialogs`: WRITE, requires pool + phone permission + confirm
- 6 new tests

## Test plan
- [x] `ruff check` passes
- [x] All 6 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)