### PR TITLE
fix: entity cache warming for numeric chat IDs + phone permissions default

### DIFF
--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json as _json
 import logging
+import re as _re
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,9 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
     allowed_phones = [p for p, tools in perms.items() if isinstance(tools, dict) and tools.get(tool_name, False)]
     if not allowed_phones:
         return None  # tool not restricted for any phone → allow all
+    # Phone not in perms at all → defaults (all enabled), don't deny based on other phones' config
+    if phone and phone not in perms:
+        return None
     if phone in allowed_phones:
         return None  # phone is allowed
     # Phone not allowed — return list of allowed phones so agent can retry
@@ -105,3 +109,67 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
             f"Разрешённые телефоны: {phones_str}"
         )
     return _text_response(msg)
+
+
+_NUMERIC_ID_RE = _re.compile(r"^-?\d+$")
+
+
+async def resolve_entity(
+    client_pool: object,
+    phone: str,
+    chat_id: str,
+    *,
+    is_user: bool = False,
+) -> tuple[object, object, dict | None]:
+    """Resolve a chat/user entity for Telethon operations with dialog-cache warming fallback.
+
+    For usernames, t.me links, and "me" → uses ``client.get_entity()`` directly (API lookup).
+    For numeric IDs → uses ``ClientPool.resolve_dialog_entity()`` which warms the entity cache
+    automatically when the entity isn't cached yet (e.g. private groups without a username).
+
+    Returns ``(raw_client, entity, None)`` on success or ``(None, None, error_response)`` on failure.
+    Pass ``is_user=True`` when *chat_id* is a user ID (e.g. the ``user_id`` param in admin tools).
+    """
+    result = await client_pool.get_native_client_by_phone(phone)
+    if result is None:
+        return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+    raw_client, _ = result
+
+    # Non-numeric identifiers: let Telethon resolve via API (username/link/self)
+    cid = chat_id.strip()
+    if not _NUMERIC_ID_RE.match(cid):
+        try:
+            entity = await raw_client.get_entity(cid)
+            return raw_client, entity, None
+        except Exception as e:
+            return None, None, _text_response(f"Ошибка: не удалось найти чат/пользователя '{chat_id}': {e}")
+
+    # Numeric ID: use resolve_dialog_entity which handles cache warming
+    dialog_id = int(cid)
+    session_result = await client_pool.get_client_by_phone(phone)
+    if session_result is None:
+        return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+    session, _ = session_result
+
+    target_type = "dm" if is_user else None
+    try:
+        entity = await client_pool.resolve_dialog_entity(session, phone, dialog_id, target_type)
+        if entity is None:
+            raise ValueError("entity is None")
+        return raw_client, entity, None
+    except Exception:
+        pass
+
+    # Fallback: if not is_user, also try as PeerUser (numeric user DMs without username)
+    if not is_user:
+        try:
+            entity = await client_pool.resolve_dialog_entity(session, phone, dialog_id, "dm")
+            if entity is not None:
+                return raw_client, entity, None
+        except Exception:
+            pass
+
+    return None, None, _text_response(
+        f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "
+        f"Попробуйте сначала обновить кэш диалогов (refresh_dialogs)."
+    )

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -157,8 +157,11 @@ async def resolve_entity(
         if entity is None:
             raise ValueError("entity is None")
         return raw_client, entity, None
-    except Exception:
+    except (ValueError, TypeError, KeyError):
         pass
+    except Exception as e:
+        # Propagate flood waits and auth errors — do not retry
+        return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
 
     # Fallback: if not is_user, also try as PeerUser (numeric user DMs without username)
     if not is_user:
@@ -166,8 +169,10 @@ async def resolve_entity(
             entity = await client_pool.resolve_dialog_entity(session, phone, dialog_id, "dm")
             if entity is not None:
                 return raw_client, entity, None
-        except Exception:
+        except (ValueError, TypeError, KeyError):
             pass
+        except Exception as e:
+            return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
 
     return None, None, _text_response(
         f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -10,6 +10,7 @@ from src.agent.tools._registry import (
     require_confirmation,
     require_phone_permission,
     require_pool,
+    resolve_entity,
     resolve_phone,
 )
 
@@ -45,11 +46,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            entity = await client.get_entity(recipient)
+            client, entity, err = await resolve_entity(client_pool, phone, recipient)
+            if err:
+                return err
             await client.send_message(entity, text)
             return _text_response(f"Сообщение отправлено: {recipient}")
         except Exception as e:
@@ -85,11 +84,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.edit_message(entity, int(message_id), text)
             return _text_response(f"Сообщение #{message_id} отредактировано.")
         except Exception as e:
@@ -127,11 +124,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.delete_messages(entity, ids)
             return _text_response(f"Удалено {len(ids)} сообщений из чата {chat_id}.")
         except Exception as e:
@@ -169,12 +164,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            from_entity = await client.get_entity(from_chat)
-            to_entity = await client.get_entity(to_chat)
+            client, from_entity, err = await resolve_entity(client_pool, phone, from_chat)
+            if err:
+                return err
+            _, to_entity, err = await resolve_entity(client_pool, phone, to_chat)
+            if err:
+                return err
             await client.forward_messages(to_entity, ids, from_entity)
             return _text_response(f"Переслано {len(ids)} сообщений из {from_chat} в {to_chat}.")
         except Exception as e:
@@ -206,11 +201,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.pin_message(entity, int(message_id), notify=notify)
             return _text_response(f"Сообщение #{message_id} закреплено в {chat_id}.")
         except Exception as e:
@@ -243,11 +236,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.unpin_message(entity, message_id)
             return _text_response(f"Сообщение(я) откреплено в {chat_id}.")
         except Exception as e:
@@ -278,11 +269,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if not chat_id or not message_id:
             return _text_response("Ошибка: chat_id и message_id обязательны.")
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             msg = None
             async for m in client.iter_messages(entity, ids=int(message_id)):
                 msg = m
@@ -324,11 +313,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             participants = await client.get_participants(entity, limit=limit, search=search)
             if not participants:
                 return _text_response("Участники не найдены.")
@@ -374,12 +361,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
-            user = await client.get_entity(user_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
+            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
+            if err:
+                return err
             kwargs = {"is_admin": is_admin}
             if title:
                 kwargs["title"] = title
@@ -429,12 +416,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
-            user = await client.get_entity(user_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
+            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
+            if err:
+                return err
             until_date = datetime.fromisoformat(until_date_str) if until_date_str else None
             kwargs = {"until_date": until_date}
             if send_messages is not None:
@@ -473,12 +460,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
-            user = await client.get_entity(user_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
+            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
+            if err:
+                return err
             await client.kick_participant(entity, user)
             return _text_response(f"{user_id} исключён из {chat_id}.")
         except Exception as e:
@@ -505,11 +492,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             stats = await client.get_broadcast_stats(entity)
             fields = {}
             for attr in ("followers", "views_per_post", "shares_per_post",
@@ -564,11 +549,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.edit_folder(entity, 1)
             return _text_response(f"Чат {chat_id} архивирован.")
         except Exception as e:
@@ -599,11 +582,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.edit_folder(entity, 0)
             return _text_response(f"Чат {chat_id} разархивирован.")
         except Exception as e:
@@ -631,11 +612,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             await client.send_read_acknowledge(entity, max_id=max_id)
             return _text_response(f"Сообщения отмечены как прочитанные в {chat_id}.")
         except Exception as e:
@@ -669,11 +648,9 @@ def register(db, client_pool, embedding_service, **kwargs):
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            entity = await client.get_entity(chat_id)
+            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            if err:
+                return err
             lines = [f"Последние {limit} сообщений из {chat_id}:\n"]
             count = 0
             total_chars = 0

--- a/tests/test_agent_tools_new4.py
+++ b/tests/test_agent_tools_new4.py
@@ -75,8 +75,11 @@ def _make_mock_pool():
     mock_client.edit_admin = AsyncMock()
     mock_client.edit_permissions = AsyncMock()
 
+    mock_session = MagicMock()
     mock_pool = MagicMock()
     mock_pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, None))
+    mock_pool.get_client_by_phone = AsyncMock(return_value=(mock_session, None))
+    mock_pool.resolve_dialog_entity = AsyncMock(return_value=MagicMock(id=123456))
     return mock_pool, mock_client
 
 

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -2690,13 +2690,17 @@ class TestMessagingPhonePermGates:
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
         mock_db.repos.settings = MagicMock()
-        # Set up tool permission that blocks +1111 but allows +2222
-        perm_data = {"+2222": {"send_message": True, "edit_message": True, "delete_message": True,
-                               "forward_messages": True, "pin_message": True, "unpin_message": True,
-                               "download_media": True, "get_participants": True, "edit_admin": True,
-                               "edit_permissions": True, "kick_participant": True,
-                               "get_broadcast_stats": True, "archive_chat": True,
-                               "unarchive_chat": True, "mark_read": True}}
+        # Set up tool permissions that explicitly block +1111 but allow +2222
+        disabled = {k: False for k in ["send_message", "edit_message", "delete_message",
+                                        "forward_messages", "pin_message", "unpin_message",
+                                        "download_media", "get_participants", "edit_admin",
+                                        "edit_permissions", "kick_participant",
+                                        "get_broadcast_stats", "archive_chat",
+                                        "unarchive_chat", "mark_read"]}
+        perm_data = {
+            "+1111": disabled,
+            "+2222": {k: True for k in disabled},
+        }
         mock_db.get_setting = AsyncMock(return_value=json.dumps(perm_data))
         mock_db.repos.tool_permissions = MagicMock()
         mock_db.repos.tool_permissions.get_by_phone = AsyncMock(return_value=None)

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -162,7 +162,18 @@ class TestRequirePhonePermission:
         assert await require_phone_permission(mock_db, "+79990001111", "leave_dialogs") is None
 
     async def test_phone_not_in_allowed(self, mock_db):
+        # A phone absent from the perms dict entirely gets defaults (all enabled).
+        # Only phones that ARE in perms but with tool=False are denied.
         perms = {"+79990002222": {"leave_dialogs": True}}
+        mock_db.get_setting = AsyncMock(return_value=json.dumps(perms))
+        result = await require_phone_permission(mock_db, "+79990001111", "leave_dialogs")
+        assert result is None  # not in perms → defaults (all enabled)
+
+    async def test_phone_explicitly_denied(self, mock_db):
+        perms = {
+            "+79990001111": {"leave_dialogs": False},
+            "+79990002222": {"leave_dialogs": True},
+        }
         mock_db.get_setting = AsyncMock(return_value=json.dumps(perms))
         result = await require_phone_permission(mock_db, "+79990001111", "leave_dialogs")
         text = _text(result)
@@ -541,7 +552,11 @@ class TestEndToEndPermissionFlow:
         assert "покинут" in _text(r2)
 
     async def test_phone_not_allowed(self, mock_db):
-        perms = {"+79990002222": {"leave_dialogs": True}}
+        # Phone explicitly set to False in perms should be denied
+        perms = {
+            "+79990001111": {"leave_dialogs": False},
+            "+79990002222": {"leave_dialogs": True},
+        }
         mock_db.get_setting = AsyncMock(return_value=json.dumps(perms))
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)


### PR DESCRIPTION
## Summary
- **Entity resolution bug**: все 16 инструментов в `messaging.py` вызывали `client.get_entity()` без прогрева кэша — фейлились на числовых ID приватных супергрупп без username. Добавлен хелпер `resolve_entity()` в `_registry.py`, который роутит числовые ID через `ClientPool.resolve_dialog_entity()` (с `warm_dialog_cache()` fallback).
- **Phone permissions bug**: телефон, отсутствующий в perms dict, получал DENY вместо defaults (all enabled). Теперь запрещаются только телефоны с явным `tool=False`.

## Test plan
- [ ] `pytest tests/ -m "not aiosqlite_serial" -n auto` — 3922 passed
- [ ] `read_messages` с числовым ID приватной супергруппы (например, `1877929309`)
- [ ] `search_my_telegram` на аккаунте без явно настроенных разрешений

🤖 Generated with [Claude Code](https://claude.com/claude-code)