### PR TITLE
feat: enable WebSearch and WebFetch built-in tools for agent

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -124,6 +124,7 @@ class ClaudeSdkBackend:
         logger.info("claude-cli path: %s", cli_path)
 
         from src.agent.tools.permissions import (
+            BUILTIN_TOOLS,
             MCP_PREFIX,
             filter_allowed_tools,
             get_all_allowed_tools,
@@ -139,9 +140,12 @@ class ClaudeSdkBackend:
         else:
             logger.debug("Agent tools: all %d tools allowed", len(allowed))
 
+        enabled_builtins = [t for t in BUILTIN_TOOLS if t in allowed]
+
         options = ClaudeAgentOptions(
             system_prompt=system_prompt,
             mcp_servers={"telegram_db": self._server},
+            tools=enabled_builtins or None,
             allowed_tools=allowed,
             cli_path=cli_path or None,
             stderr=_on_stderr,

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 TOOL_PERMISSIONS_SETTING = "agent_tool_permissions"
 MCP_PREFIX = "mcp__telegram_db__"
+BUILTIN_TOOLS = ["WebSearch", "WebFetch"]
 
 
 class ToolCategory(str, Enum):
@@ -175,6 +176,9 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "delete_agent_thread": ToolCategory.DELETE,
     "rename_agent_thread": ToolCategory.WRITE,
     "get_thread_messages": ToolCategory.READ,
+    # Built-in Claude tools (no MCP prefix)
+    "WebSearch": ToolCategory.READ,
+    "WebFetch": ToolCategory.READ,
 }
 
 # ---------------------------------------------------------------------------
@@ -260,6 +264,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "list_agent_threads", "create_agent_thread", "delete_agent_thread",
         "rename_agent_thread", "get_thread_messages",
     ]),
+    ("Веб-поиск", ["WebSearch", "WebFetch"]),
 ])
 
 
@@ -407,20 +412,30 @@ async def load_tool_permissions_union(db) -> dict[str, bool]:
 
 
 def get_all_allowed_tools() -> list[str]:
-    """Build the full list of MCP-prefixed tool names from TOOL_CATEGORIES."""
-    return [f"{MCP_PREFIX}{name}" for name in TOOL_CATEGORIES]
+    """Build the full list of tool names from TOOL_CATEGORIES.
+
+    MCP tools get the prefix; built-in tools use bare names.
+    """
+    result = []
+    for name in TOOL_CATEGORIES:
+        if name in BUILTIN_TOOLS:
+            result.append(name)
+        else:
+            result.append(f"{MCP_PREFIX}{name}")
+    return result
 
 
 def filter_allowed_tools(all_tools: list[str], permissions: dict[str, bool]) -> list[str]:
-    """Filter MCP-prefixed tool names by permissions.
+    """Filter tool names by permissions.
 
+    Handles both MCP-prefixed and bare built-in tool names.
     Unknown tools (not in permissions dict) are denied by default.
     """
     result = []
-    for prefixed_name in all_tools:
-        bare = prefixed_name.removeprefix(MCP_PREFIX)
+    for tool_name in all_tools:
+        bare = tool_name.removeprefix(MCP_PREFIX) if tool_name.startswith(MCP_PREFIX) else tool_name
         if permissions.get(bare, False):
-            result.append(prefixed_name)
+            result.append(tool_name)
     return result
 
 

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -483,12 +483,15 @@ class TestGetAllAllowedTools:
         assert len(get_all_allowed_tools()) == len(TOOL_CATEGORIES)
 
     def test_all_prefixed(self):
-        from src.agent.tools.permissions import get_all_allowed_tools
+        from src.agent.tools.permissions import BUILTIN_TOOLS, get_all_allowed_tools
 
         for tool in get_all_allowed_tools():
-            assert tool.startswith(MCP_PREFIX), f"{tool} missing prefix"
-            bare = tool.removeprefix(MCP_PREFIX)
-            assert bare in TOOL_CATEGORIES, f"{bare} not in TOOL_CATEGORIES"
+            if tool in BUILTIN_TOOLS:
+                assert tool in TOOL_CATEGORIES, f"{tool} not in TOOL_CATEGORIES"
+            else:
+                assert tool.startswith(MCP_PREFIX), f"{tool} missing prefix"
+                bare = tool.removeprefix(MCP_PREFIX)
+                assert bare in TOOL_CATEGORIES, f"{bare} not in TOOL_CATEGORIES"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Enable WebSearch and WebFetch as built-in Claude Code tools for the claude-agent-sdk agent backend
- Integrate into existing permission system (`TOOL_CATEGORIES`, `MODULE_GROUPS`) — appear in Settings UI under "Веб-поиск"
- Enabled by default, controllable per-phone via tool permissions

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/test_tool_permissions.py` — all 63 tests pass
- [ ] Verify "Веб-поиск" group appears in Settings → Tool Permissions UI
- [ ] Verify agent can use WebSearch/WebFetch in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)