### PR TITLE
feat: improve agent tool descriptions with cross-references and remove duplicates

### DIFF
--- a/src/agent/prompt_template.py
+++ b/src/agent/prompt_template.py
@@ -8,8 +8,8 @@ AGENT_PROMPT_TEMPLATE_SETTING = "agent_prompt_template"
 ALLOWED_TEMPLATE_VARIABLES = frozenset({"source_messages", "channel_title", "topic", "date"})
 DEFAULT_AGENT_PROMPT_TEMPLATE = (
     "Ты — аналитический ассистент для работы с данными из Telegram-каналов.\n"
-    "Используй search_messages для поиска сообщений и get_channels для списка каналов.\n"
-    "Основной use-case: анализ вопросов и ответов из каналов для создания учебного курса.\n"
+    "Используй search_messages для поиска сообщений и list_channels для списка каналов.\n"
+    "Чтобы загрузить чат в базу: add_channel → list_channels (получить pk) → collect_channel.\n"
     "Отвечай на русском языке. Будь точным и структурированным."
 )
 _VALIDATION_SAMPLE_VALUES = {

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -11,7 +11,12 @@ from src.agent.tools._registry import _text_response, require_confirmation, requ
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
 
-    @tool("list_accounts", "List all connected Telegram accounts with their status", {})
+    @tool(
+        "list_accounts",
+        "List all connected Telegram accounts with their status. "
+        "Returns id (account_id used by toggle_account/delete_account), phone, and flood_wait status.",
+        {},
+    )
     async def list_accounts(args):
         try:
             accounts = await db.get_accounts()
@@ -30,7 +35,11 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_accounts)
 
-    @tool("toggle_account", "Toggle account active/inactive status", {"account_id": int})
+    @tool(
+        "toggle_account",
+        "Toggle account active/inactive status. account_id = id from list_accounts.",
+        {"account_id": int},
+    )
     async def toggle_account(args):
         account_id = args.get("account_id")
         if account_id is None:
@@ -51,7 +60,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "delete_account",
-        "⚠️ DANGEROUS: Delete a Telegram account from the system. Always ask user for confirmation first.",
+        "⚠️ DANGEROUS: Delete a Telegram account from the system. "
+        "account_id = id from list_accounts. Always ask user for confirmation first.",
         {"account_id": int, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -16,7 +16,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "list_channels",
-        "List Telegram channels in the database. Optionally filter by active_only or include_filtered.",
+        "List Telegram channels saved in the local database. Each row includes pk "
+        "(DB primary key used by collect_channel/delete_channel/toggle_channel), "
+        "channel_id (Telegram numeric ID), title, username, channel_type, and is_filtered status.",
         {"active_only": bool, "include_filtered": bool},
     )
     async def list_channels(args):
@@ -47,7 +49,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_channel_stats",
-        "Get subscriber counts and statistics for all channels.",
+        "Get latest subscriber counts and avg_views for all channels. "
+        "Run collect_channel_stats first if stats are stale.",
         {},
     )
     async def get_channel_stats(args):
@@ -74,7 +77,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "add_channel",
-        "Add a Telegram channel by identifier (t.me link, @username, or numeric ID). Requires confirmation.",
+        "Add a Telegram channel to the local database by identifier (t.me link, @username, or numeric ID). "
+        "After adding, use list_channels to get the pk, then call collect_channel to start message collection. "
+        "Requires confirmation.",
         {"identifier": str, "confirm": bool},
     )
     async def add_channel(args):
@@ -103,7 +108,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "delete_channel",
-        "DANGEROUS: Permanently delete a channel and all its messages. Always ask user for confirmation first.",
+        "DANGEROUS: Permanently delete a channel and all its messages from the DB. "
+        "pk = DB primary key — get it from list_channels. Always ask user for confirmation first.",
         {"pk": int, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -133,7 +139,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "toggle_channel",
-        "Toggle channel active/inactive status by primary key.",
+        "Toggle channel active/inactive status. pk = DB primary key — get it from list_channels.",
         {"pk": int},
     )
     async def toggle_channel(args):
@@ -161,7 +167,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "import_channels",
-        "Bulk import channels from a text string (t.me links, @usernames, numeric IDs). Requires confirmation.",
+        "Bulk-import channels from a text string (t.me links, @usernames, or numeric IDs, any separator). "
+        "After import, use collect_all_channels to start collection. Requires confirmation.",
         {"text": str, "confirm": bool},
     )
     async def import_channels(args):
@@ -206,7 +213,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "refresh_channel_types",
-        "Refresh channel_type for all active channels using Telegram API. Requires a connected Telegram client.",
+        "Refresh channel_type (channel/group/supergroup/unavailable) for all active channels "
+        "via Telegram API. Requires a connected Telegram client. Requires confirmation.",
         {"confirm": bool},
     )
     async def refresh_channel_types(args):
@@ -254,7 +262,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "refresh_channel_meta",
         "Refresh channel metadata (about, linked_chat_id, has_comments) from Telegram. "
-        "Pass identifier for a single channel, or omit to refresh all active channels. Requires confirmation.",
+        "Pass identifier (channel_id as string, or @username) for one channel, or omit to refresh all. "
+        "Requires confirmation.",
         {"identifier": str, "confirm": bool},
     )
     async def refresh_channel_meta(args):

--- a/src/agent/tools/collection.py
+++ b/src/agent/tools/collection.py
@@ -12,8 +12,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "collect_channel",
-        "Enqueue a single channel for message collection by its primary key (pk). "
-        "Use force=true to collect even if the channel is filtered.",
+        "Enqueue a single channel for message collection. pk = DB primary key — get it from list_channels. "
+        "If the channel is not in the DB yet, first add it with add_channel, then use pk from list_channels. "
+        "Use force=true to collect filtered channels.",
         {"pk": int, "force": bool},
     )
     async def collect_channel(args):
@@ -41,7 +42,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "collect_all_channels",
-        "Enqueue all active (non-filtered) channels for message collection.",
+        "Enqueue all active non-filtered channels for incremental message collection. "
+        "Collection is processed by the running server worker.",
         {},
     )
     async def collect_all_channels(args):
@@ -64,7 +66,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "collect_channel_stats",
-        "Enqueue statistics collection for a single channel by its primary key (pk).",
+        "Enqueue subscriber/views statistics collection for a single channel. "
+        "pk = DB primary key — get it from list_channels.",
         {"pk": int},
     )
     async def collect_channel_stats(args):
@@ -90,7 +93,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "collect_all_stats",
-        "Enqueue statistics collection for all active channels.",
+        "Enqueue subscriber/views statistics collection for all active channels. "
+        "After completion, use get_channel_stats to view results.",
         {},
     )
     async def collect_all_stats(args):

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -34,7 +34,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     # === Search ===
 
     def search_messages(query_text: str, limit: int = 20) -> str:
-        """Search recent Telegram messages by free-text query and return short previews."""
+        """Full-text search in collected messages stored in the local DB."""
         try:
             messages, total = _run_sync(
                 "search_messages", lambda: db.search_messages(query_text, limit=limit)
@@ -53,7 +53,10 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(search_messages)
 
     def semantic_search(query_text: str, limit: int = 10) -> str:
-        """Search messages by semantic similarity (embedding-based)."""
+        """Search collected messages by semantic (embedding) similarity.
+
+        Requires index_messages first and an embedding API key.
+        """
         try:
             from src.services.embedding_service import EmbeddingService
 
@@ -75,7 +78,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(semantic_search)
 
     def index_messages() -> str:
-        """Index pending messages for semantic search."""
+        """Create semantic embeddings for all not-yet-indexed messages. Required before semantic_search works."""
         try:
             from src.services.embedding_service import EmbeddingService
 
@@ -90,7 +93,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     # === Channels ===
 
     def list_channels(active_only: bool = False) -> str:
-        """List Telegram channels in the database."""
+        """List channels in DB. Each row has pk (for collect/delete/toggle), channel_id (Telegram ID), title."""
         try:
             channels = _run_sync("list_channels", lambda: db.get_channels(active_only=active_only))
         except Exception as exc:
@@ -121,7 +124,10 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(get_channel_stats)
 
     def add_channel(identifier: str) -> str:
-        """Add a channel by identifier (t.me link, @username, or numeric ID). Returns result."""
+        """Add a channel to DB by identifier (t.me link, @username, or numeric ID).
+
+        Then use list_channels to get pk and collect_channel to collect messages.
+        """
         try:
             from src.services.channel_service import ChannelService
 
@@ -134,7 +140,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(add_channel)
 
     def delete_channel(pk: int) -> str:
-        """⚠️ DANGEROUS: Delete a channel permanently."""
+        """⚠️ DANGEROUS: Delete a channel permanently. pk = DB primary key from list_channels."""
         try:
             from src.services.channel_service import ChannelService
 
@@ -147,7 +153,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(delete_channel)
 
     def toggle_channel(pk: int) -> str:
-        """Toggle channel active/inactive status."""
+        """Toggle channel active/inactive status. pk = DB primary key from list_channels."""
         try:
             from src.services.channel_service import ChannelService
 
@@ -300,24 +306,8 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
 
     tools.append(list_pending_moderation)
 
-    def view_moderation_run(run_id: int) -> str:
-        """View full details of a generation run."""
-        try:
-            run = _run_sync("view_run", lambda: db.repos.generation_runs.get(run_id))
-        except Exception as exc:
-            return f"Ошибка: {exc}"
-        if not run:
-            return f"Run id={run_id} не найден."
-        return (
-            f"Run id={run.id}\nStatus: {run.status}\n"
-            f"Moderation: {run.moderation_status}\n"
-            f"Text:\n{run.generated_text or '(пусто)'}"
-        )
-
-    tools.append(view_moderation_run)
-
     def approve_run(run_id: int) -> str:
-        """Approve a generation run for publishing."""
+        """Approve a generation run for publishing. Then use publish_pipeline_run to publish it."""
         try:
             _run_sync("approve_run", lambda: db.repos.generation_runs.set_moderation_status(run_id, "approved"))
             return f"Run id={run_id} одобрен."
@@ -423,7 +413,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     # === Accounts ===
 
     def list_accounts() -> str:
-        """List all connected Telegram accounts."""
+        """List all connected Telegram accounts. Returns id (account_id for toggle/delete), phone, status."""
         try:
             accounts = _run_sync("list_accounts", db.get_accounts)
         except Exception as exc:
@@ -439,7 +429,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(list_accounts)
 
     def toggle_account(account_id: int) -> str:
-        """Toggle account active/inactive."""
+        """Toggle account active/inactive. account_id from list_accounts."""
         try:
             accounts = _run_sync("toggle_acc_get", db.get_accounts)
             acc = next((a for a in accounts if a.id == account_id), None)
@@ -453,7 +443,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(toggle_account)
 
     def delete_account(account_id: int) -> str:
-        """⚠️ DANGEROUS: Delete a Telegram account from the system."""
+        """⚠️ DANGEROUS: Delete a Telegram account from the system. account_id from list_accounts."""
         try:
             _run_sync("delete_acc", lambda: db.delete_account(account_id))
             return f"Аккаунт id={account_id} удалён."
@@ -481,7 +471,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     # === Filters ===
 
     def analyze_filters() -> str:
-        """Analyze channels and compute filter scores."""
+        """Analyze channels and compute filter scores (low_uniqueness, spam, non_cyrillic, etc.)."""
         try:
             from src.filters.analyzer import ChannelAnalyzer
 
@@ -495,7 +485,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(analyze_filters)
 
     def apply_filters() -> str:
-        """⚠️ DANGEROUS: Apply filter analysis — mark flagged channels as filtered."""
+        """⚠️ DANGEROUS: Run analyze_filters and mark flagged channels as filtered."""
         try:
             from src.filters.analyzer import ChannelAnalyzer
 
@@ -522,7 +512,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     tools.append(reset_filters)
 
     def toggle_channel_filter(pk: int) -> str:
-        """Toggle filter status for a channel."""
+        """Toggle filter status for a channel. pk = DB primary key from list_channels."""
         try:
             ch = _run_sync("get_ch", lambda: db.get_channel_by_pk(pk))
             if not ch:
@@ -779,7 +769,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
     def get_settings() -> str:
         """Get current system settings."""
         try:
-            keys = ["scheduler_interval_minutes", "scheduler_enabled", "agent_backend_override"]
+            keys = ["collect_interval_minutes", "scheduler_enabled", "agent_backend_override"]
             lines = ["Настройки:"]
             for key in keys:
                 val = _run_sync(f"setting_{key}", lambda k=key: db.get_setting(k))

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -11,7 +11,12 @@ from src.agent.tools._registry import _text_response, require_confirmation
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
 
-    @tool("analyze_filters", "Analyze all channels and compute filter scores (low uniqueness, spam, etc.)", {})
+    @tool(
+        "analyze_filters",
+        "Analyze all channels and compute filter scores (low_uniqueness, low_subscriber_ratio, "
+        "cross_channel_spam, non_cyrillic, chat_noise). Shows which channels should be filtered.",
+        {},
+    )
     async def analyze_filters(args):
         try:
             from src.filters.analyzer import ChannelAnalyzer
@@ -36,7 +41,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "apply_filters",
-        "⚠️ DANGEROUS: Apply filter analysis results — mark flagged channels as filtered. "
+        "⚠️ DANGEROUS: Run analyze_filters and mark flagged channels as filtered (skipped during collection). "
         "Always ask user for confirmation first.",
         {"confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
@@ -79,7 +84,11 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(reset_filters)
 
-    @tool("toggle_channel_filter", "Toggle filter status for a specific channel", {"pk": int})
+    @tool(
+        "toggle_channel_filter",
+        "Toggle filter status for a specific channel. pk = DB primary key — get it from list_channels.",
+        {"pk": int},
+    )
     async def toggle_channel_filter(args):
         pk = args.get("pk")
         if pk is None:
@@ -99,8 +108,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "purge_filtered_channels",
-        "⚠️ DANGEROUS: Purge messages from filtered channels (soft delete). "
-        "Pass comma-separated pks or empty for all filtered. Always ask user for confirmation first.",
+        "⚠️ DANGEROUS: Soft-delete messages from filtered channels. "
+        "pks = comma-separated DB primary keys from list_channels; "
+        "omit to purge all filtered channels. Always ask user for confirmation first.",
         {"pks": str, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -133,7 +143,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "hard_delete_channels",
         "⚠️ DANGEROUS: Permanently delete channels and ALL their data (irreversible). "
-        "Pass comma-separated pks. Always ask user for confirmation first.",
+        "pks = comma-separated DB primary keys from list_channels. "
+        "Always ask user for confirmation first.",
         {"pks": str, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -36,9 +36,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "generate_image",
-        "Generate an image from a text prompt using configured image providers. "
-        "Model format: 'provider:model_id' (e.g. 'together:black-forest-labs/FLUX.1-schnell'). "
-        "If model is omitted, uses the first registered adapter.",
+        "Generate an image from a text prompt. Model format: 'provider:model_id' "
+        "(e.g. 'together:black-forest-labs/FLUX.1-schnell'). "
+        "Use list_image_providers to see available providers, list_image_models for models.",
         {"prompt": str, "model": str},
     )
     async def generate_image(args):
@@ -99,7 +99,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "list_image_models",
-        "Search available image generation models for a provider",
+        "Search available image models for a provider. "
+        "Get provider name from list_image_providers first. query filters by model name substring.",
         {"provider": str, "query": str},
     )
     async def list_image_models(args):

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -20,9 +20,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "send_message",
-        "Send a direct message to a Telegram user or chat. "
-        "Recipient can be a username (@user), phone number, or numeric ID. "
-        "Ask user for confirmation first.",
+        "Send a message from a connected account (phone = sender's phone). "
+        "recipient accepts @username, phone number, or numeric ID. Ask user for confirmation first.",
         {"phone": str, "recipient": str, "text": str, "confirm": bool},
     )
     async def send_message(args):
@@ -58,8 +57,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "edit_message",
-        "Edit a previously sent message in a Telegram chat. "
-        "Ask user for confirmation first.",
+        "Edit a previously sent message. "
+        "chat_id accepts @username, t.me link, numeric ID, or 'me'. Ask user for confirmation first.",
         {"phone": str, "chat_id": str, "message_id": int, "text": str, "confirm": bool},
     )
     async def edit_message(args):
@@ -97,7 +96,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "delete_message",
         "⚠️ DANGEROUS: Delete messages from a Telegram chat. "
-        "Pass comma-separated message IDs. Always ask user for confirmation first.",
+        "chat_id accepts @username, numeric ID, or 'me'. "
+        "message_ids = comma-separated integers. Always ask user for confirmation first.",
         {"phone": str, "chat_id": str, "message_ids": str, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -179,7 +179,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "pin_message",
-        "Pin a message in a Telegram chat. Ask user for confirmation first.",
+        "Pin a message in a Telegram chat. notify=true sends a notification to all members. "
+        "chat_id accepts @username, numeric ID, or 'me'. Ask user for confirmation first.",
         {"phone": str, "chat_id": str, "message_id": int, "notify": bool, "confirm": bool},
     )
     async def pin_message(args):
@@ -294,7 +295,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_participants",
-        "Get list of participants in a Telegram channel or group.",
+        "Get list of participants in a Telegram group (not broadcast channels). "
+        "search filters by name/username substring.",
         {"phone": str, "chat_id": str, "limit": int, "search": str},
     )
     async def get_participants(args):
@@ -335,9 +337,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "edit_admin",
-        "Promote or demote a user as admin in a Telegram channel/group. "
-        "Set is_admin=true to promote (grants all permissions), is_admin=false to demote. "
-        "Ask user for confirmation first.",
+        "Promote (is_admin=true) or demote (is_admin=false) a user as admin. "
+        "user_id accepts @username or numeric ID. title sets a custom admin badge. "
+        "Requires admin rights. Ask for confirmation first.",
         {"phone": str, "chat_id": str, "user_id": str, "is_admin": bool, "title": str, "confirm": bool},
     )
     async def edit_admin(args):
@@ -379,9 +381,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "edit_permissions",
-        "Restrict or unrestrict a user in a Telegram group. "
-        "Set send_messages=false to mute, send_media=false to block media, etc. "
-        "To unrestrict, set all flags to true. Ask user for confirmation first.",
+        "Restrict (send_messages=false) or unrestrict (all true) a user in a Telegram group. "
+        "until_date = ISO datetime (e.g. '2025-12-31T23:59:59') for temporary restriction. "
+        "Ask for confirmation first.",
         {
             "phone": str, "chat_id": str, "user_id": str,
             "send_messages": bool, "send_media": bool,
@@ -438,7 +440,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "kick_participant",
         "⚠️ DANGEROUS: Kick a participant from a Telegram chat. "
-        "Always ask user for confirmation first.",
+        "user_id accepts @username or numeric ID. Always ask user for confirmation first.",
         {"phone": str, "chat_id": str, "user_id": str, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -475,7 +477,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_broadcast_stats",
-        "Get broadcast statistics for a Telegram channel.",
+        "Get broadcast statistics (followers, views, reactions) for a Telegram channel. "
+        "Requires admin/owner rights on the channel.",
         {"phone": str, "chat_id": str},
     )
     async def get_broadcast_stats(args):
@@ -594,7 +597,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "mark_read",
-        "Mark messages as read in a Telegram chat.",
+        "Mark messages as read in a Telegram chat. "
+        "max_id marks all messages up to that ID as read; omit to mark all.",
         {"phone": str, "chat_id": str, "max_id": int},
     )
     async def mark_read(args):
@@ -624,10 +628,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "read_messages",
-        "Read the last N messages from any Telegram chat or channel without storing them in the database. "
-        "Useful to preview content before deciding whether to collect it. "
-        "chat_id can be a username (@channel), t.me link, numeric ID, or 'me' for Saved Messages. "
-        "Default limit is 100 messages.",
+        "Preview last N messages from any Telegram chat/channel (not stored in DB). "
+        "chat_id accepts @username, t.me link, numeric ID, or 'me'. "
+        "To save messages to DB for search, use add_channel + collect_channel instead.",
         {"phone": str, "chat_id": str, "limit": int},
     )
     async def read_messages(args):

--- a/src/agent/tools/moderation.py
+++ b/src/agent/tools/moderation.py
@@ -17,7 +17,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "list_pending_moderation",
-        "List generation runs awaiting moderation (approval/rejection). Optionally filter by pipeline_id.",
+        "List generation runs awaiting moderation. Filter by pipeline_id. "
+        "Use run_id from results with get_pipeline_run to view full text, then approve_run or reject_run.",
         {"pipeline_id": int, "limit": int},
     )
     async def list_pending_moderation(args):
@@ -43,43 +44,14 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_pending_moderation)
 
-    @tool(
-        "view_moderation_run",
-        "View full details of a generation run: text, status, quality score, metadata.",
-        {"run_id": int},
-    )
-    async def view_moderation_run(args):
-        run_id = args.get("run_id")
-        if run_id is None:
-            return _text_response("Ошибка: run_id обязателен.")
-        try:
-            run = await db.repos.generation_runs.get(int(run_id))
-            if run is None:
-                return _text_response(f"Run id={run_id} не найден.")
-            lines = [
-                f"Run id={run.id}",
-                f"  status: {run.status}",
-                f"  moderation_status: {run.moderation_status}",
-                f"  quality_score: {run.quality_score}",
-                f"  created_at: {run.created_at}",
-                f"  metadata: {run.metadata}",
-                "",
-                "generated_text:",
-                run.generated_text or "(пусто)",
-            ]
-            return _text_response("\n".join(lines))
-        except Exception as e:
-            return _text_response(f"Ошибка получения run: {e}")
-
-    tools.append(view_moderation_run)
-
     # ------------------------------------------------------------------
     # WRITE
     # ------------------------------------------------------------------
 
     @tool(
         "approve_run",
-        "Approve a generation run for publishing. Provide the run_id.",
+        "Approve a generation run for publishing. Then use publish_pipeline_run to publish it. "
+        "run_id from list_pending_moderation or list_pipeline_runs.",
         {"run_id": int},
     )
     async def approve_run(args):

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -91,7 +91,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "refresh_dialogs",
-        "Refresh cached dialog list for an account (fetches from Telegram)",
+        "Refresh cached dialog list for an account from Telegram. "
+        "Use when messaging tools fail to resolve a numeric chat_id.",
         {"phone": str},
     )
     async def refresh_dialogs(args):
@@ -118,7 +119,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "leave_dialogs",
         "⚠️ DANGEROUS: Leave (unsubscribe from) Telegram channels/groups. "
-        "Pass phone and dialog_ids (comma-separated). Always ask user for confirmation first.",
+        "dialog_ids = comma-separated Telegram chat IDs (get from search_my_telegram). "
+        "Always ask user for confirmation first.",
         {"phone": str, "dialog_ids": str, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -209,8 +211,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_forum_topics",
-        "Get forum topics for a channel (supergroup with topics enabled)",
-        {"channel_id": int, "phone": str},
+        "Get forum topics for a supergroup with topics enabled. "
+        "channel_id = Telegram numeric ID (from list_channels or search_my_telegram).",
+        {"channel_id": int},
     )
     async def get_forum_topics(args):
         channel_id = args.get("channel_id")

--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -112,8 +112,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "notification_dry_run",
-        "Preview how many matches each active notification query would produce. "
-        "Does NOT send any notifications.",
+        "Preview how many matches each active search query with notify_on_collect=true would produce. "
+        "Does NOT send notifications. Queries managed via add_search_query / list_search_queries.",
         {},
     )
     async def notification_dry_run(args):

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -59,10 +59,8 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "list_pipeline_runs": ToolCategory.READ,
     "get_pipeline_run": ToolCategory.READ,
     "publish_pipeline_run": ToolCategory.WRITE,
-    "get_pipeline_queue": ToolCategory.READ,
     # Moderation
     "list_pending_moderation": ToolCategory.READ,
-    "view_moderation_run": ToolCategory.READ,
     "approve_run": ToolCategory.WRITE,
     "reject_run": ToolCategory.WRITE,
     "bulk_approve_runs": ToolCategory.WRITE,
@@ -165,7 +163,6 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "list_generated_images": ToolCategory.READ,
     # Settings
     "get_settings": ToolCategory.READ,
-    "save_scheduler_settings": ToolCategory.WRITE,
     "save_agent_settings": ToolCategory.WRITE,
     "save_filter_settings": ToolCategory.WRITE,
     "get_system_info": ToolCategory.READ,

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -17,7 +17,11 @@ from src.agent.tools._registry import (
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
 
-    @tool("list_photo_batches", "List photo upload batches", {"limit": int})
+    @tool(
+        "list_photo_batches",
+        "List photo upload batches with batch_id, phone, target, status, and item count.",
+        {"limit": int},
+    )
     async def list_photo_batches(args):
         try:
             from src.database.bundles import PhotoLoaderBundle
@@ -41,7 +45,12 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_photo_batches)
 
-    @tool("list_photo_items", "List photo batch items with status", {"limit": int})
+    @tool(
+        "list_photo_items",
+        "List photo batch items with item_id, batch_id, status, and scheduled time. "
+        "Use item_id with cancel_photo_item.",
+        {"limit": int},
+    )
     async def list_photo_items(args):
         try:
             from src.database.bundles import PhotoLoaderBundle
@@ -68,8 +77,9 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "send_photos_now",
         "⚠️ Send photos to a Telegram dialog immediately. "
-        "Params: phone, target (dialog_id), file_paths (comma-sep), mode (album/separate), caption. "
-        "Ask user for confirmation first.",
+        "target = dialog_id from list_photo_dialogs (or 'me'). "
+        "file_paths = comma-separated server-local paths. mode: album/separate. "
+        "Ask for confirmation first.",
         {"phone": str, "target": str, "file_paths": str, "mode": str, "caption": str, "confirm": bool},
     )
     async def send_photos_now(args):
@@ -125,8 +135,9 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "schedule_photos",
         "⚠️ Schedule photos to be sent at a specific time. "
-        "Params: phone, target (dialog_id), file_paths (comma-sep), schedule_at (ISO datetime), "
-        "mode (album/separate), caption. Ask user for confirmation first.",
+        "target = dialog_id from list_photo_dialogs. "
+        "schedule_at = ISO datetime (e.g. '2025-12-31T10:00:00'). "
+        "file_paths = comma-separated server-local paths. Ask for confirmation first.",
         {
             "phone": str, "target": str, "file_paths": str,
             "schedule_at": str, "mode": str, "caption": str, "confirm": bool,
@@ -177,7 +188,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "cancel_photo_item",
-        "⚠️ Cancel a scheduled photo item. Ask user for confirmation first.",
+        "⚠️ Cancel a scheduled photo item. item_id from list_photo_items. Ask user for confirmation first.",
         {"item_id": int, "confirm": bool},
     )
     async def cancel_photo_item(args):
@@ -202,7 +213,12 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(cancel_photo_item)
 
-    @tool("list_auto_uploads", "List automatic photo upload jobs", {})
+    @tool(
+        "list_auto_uploads",
+        "List automatic photo upload jobs with job_id, folder, target, interval, and status. "
+        "Use job_id with toggle_auto_upload / delete_auto_upload.",
+        {},
+    )
     async def list_auto_uploads(args):
         try:
             from src.database.bundles import PhotoLoaderBundle
@@ -226,7 +242,11 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_auto_uploads)
 
-    @tool("toggle_auto_upload", "Toggle an auto-upload job active/paused", {"job_id": int})
+    @tool(
+        "toggle_auto_upload",
+        "Toggle an auto-upload job active/paused. job_id from list_auto_uploads.",
+        {"job_id": int},
+    )
     async def toggle_auto_upload(args):
         job_id = args.get("job_id")
         if job_id is None:
@@ -250,7 +270,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "delete_auto_upload",
-        "⚠️ DANGEROUS: Delete an auto-upload job. Always ask user for confirmation first.",
+        "⚠️ DANGEROUS: Delete an auto-upload job. job_id from list_auto_uploads. "
+        "Always ask user for confirmation first.",
         {"job_id": int, "confirm": bool},
         annotations=ToolAnnotations(destructiveHint=True),
     )
@@ -355,8 +376,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "create_auto_upload",
-        "⚠️ Create an auto-upload job to send photos from a folder on a schedule. "
-        "Ask user for confirmation first.",
+        "⚠️ Create an auto-upload job to send photos from a server-side folder on a schedule. "
+        "target = dialog_id from list_photo_dialogs. mode: album/separate. Ask for confirmation first.",
         {
             "phone": str, "target": str, "folder_path": str,
             "interval_minutes": int, "mode": str, "caption": str, "confirm": bool,
@@ -407,7 +428,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "update_auto_upload",
-        "⚠️ Update an existing auto-upload job settings. Ask user for confirmation first.",
+        "⚠️ Update an existing auto-upload job settings. job_id from list_auto_uploads. "
+        "mode: album/separate. Ask user for confirmation first.",
         {
             "job_id": int, "folder_path": str, "mode": str,
             "caption": str, "interval_minutes": int, "is_active": bool, "confirm": bool,

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -39,7 +39,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "list_pipelines",
-        "List all content pipelines with their settings (name, model, publish mode, schedule, backend).",
+        "List all content pipelines with id, name, model, publish_mode (auto/moderated), schedule, "
+        "and backend. Use pipeline_id from this list for other pipeline tools.",
         {"active_only": bool},
     )
     async def list_pipelines(args):
@@ -111,8 +112,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "add_pipeline",
-        "Create a new content pipeline. source_channel_ids and target_refs are comma-separated strings. "
-        "target_refs format: 'phone|dialog_id' per entry. Requires confirm=true.",
+        "Create a new content pipeline. source_channel_ids = comma-separated Telegram channel IDs "
+        "(from list_channels). target_refs = comma-separated 'phone|dialog_id' pairs. "
+        "publish_mode: 'auto' or 'moderated'. Requires confirm=true.",
         {
             "name": str,
             "prompt_template": str,
@@ -296,7 +298,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "run_pipeline",
-        "Trigger content generation for a pipeline by its ID. Returns a preview of the generated text.",
+        "Trigger content generation for a pipeline. Returns a preview of the generated text. "
+        "If publish_mode=auto, the run is published immediately; "
+        "otherwise use approve_run + publish_pipeline_run.",
         {"pipeline_id": int},
     )
     async def run_pipeline(args):
@@ -377,7 +381,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "list_pipeline_runs",
-        "List generation runs for a pipeline. Optionally filter by status.",
+        "List generation runs for a pipeline. "
+        "Filter by status (pending/completed/approved/rejected). "
+        "Use run_id from results with get_pipeline_run, approve_run, publish_pipeline_run.",
         {"pipeline_id": int, "limit": int, "status": str},
     )
     async def list_pipeline_runs(args):
@@ -439,7 +445,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "publish_pipeline_run",
-        "Publish a generation run to its pipeline targets. Requires Telegram client and confirm=true.",
+        "Publish a generation run to its pipeline target channels. "
+        "Approve the run first via approve_run. run_id from list_pipeline_runs. "
+        "Requires Telegram client and confirm=true.",
         {"run_id": int, "confirm": bool},
     )
     async def publish_pipeline_run(args):
@@ -477,34 +485,5 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка публикации: {e}")
 
     tools.append(publish_pipeline_run)
-
-    @tool(
-        "get_pipeline_queue",
-        "Get generation runs pending moderation for a pipeline.",
-        {"pipeline_id": int, "limit": int},
-    )
-    async def get_pipeline_queue(args):
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
-        try:
-            limit = int(args.get("limit", 20))
-            runs = await db.repos.generation_runs.list_pending_moderation(
-                pipeline_id=int(pipeline_id), limit=limit
-            )
-            if not runs:
-                return _text_response(f"Нет черновиков на модерации для пайплайна id={pipeline_id}.")
-            lines = [f"Очередь модерации пайплайна id={pipeline_id} ({len(runs)} шт.):"]
-            for r in runs:
-                preview = (r.generated_text or "")[:200]
-                lines.append(
-                    f"- run_id={r.id}, moderation={r.moderation_status}, "
-                    f"created={r.created_at}: {preview}"
-                )
-            return _text_response("\n".join(lines))
-        except Exception as e:
-            return _text_response(f"Ошибка получения очереди модерации: {e}")
-
-    tools.append(get_pipeline_queue)
 
     return tools

--- a/src/agent/tools/scheduler.py
+++ b/src/agent/tools/scheduler.py
@@ -103,7 +103,11 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(trigger_collection)
 
-    @tool("toggle_scheduler_job", "Toggle a scheduler job on/off by job_id", {"job_id": str})
+    @tool(
+        "toggle_scheduler_job",
+        "Toggle a scheduler job on/off. Get valid job_ids from get_scheduler_status.",
+        {"job_id": str},
+    )
     async def toggle_scheduler_job(args):
         job_id = args.get("job_id", "")
         if not job_id:
@@ -159,9 +163,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "cancel_scheduler_task",
-        "Cancel a collection task by task_id. Works for pending tasks; running tasks will be "
-        "marked cancelled in DB but the active collection may continue until completion. "
-        "Requires confirmation.",
+        "Cancel a collection task by task_id (from get_scheduler_status or DB). "
+        "Pending tasks are cancelled immediately; running tasks are marked cancelled "
+        "but may continue until the current channel finishes. Requires confirmation.",
         {"task_id": int, "confirm": bool},
     )
     async def cancel_scheduler_task(args):

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -34,8 +34,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_messages",
-        "Search messages in Telegram channels by query text. "
-        "Supports optional filters: channel_id, date_from/date_to (YYYY-MM-DD), min_length, max_length, mode.",
+        "Full-text search in collected messages stored in the local DB. "
+        "channel_id is the Telegram numeric ID (from list_channels, not pk). "
+        "Supports date_from/date_to (YYYY-MM-DD), min_length, max_length filters.",
         {
             "query": str,
             "limit": int,
@@ -44,7 +45,6 @@ def register(db, client_pool, embedding_service, **kwargs):
             "date_to": str,
             "min_length": int,
             "max_length": int,
-            "mode": str,
         },
     )
     async def search_messages(args):
@@ -84,7 +84,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "semantic_search",
-        "Search messages in the local database by semantic similarity.",
+        "Search collected messages by semantic (embedding) similarity. "
+        "Requires messages to be indexed first via index_messages, and an OpenAI/embedding API key configured.",
         {"query": str, "limit": int},
     )
     async def semantic_search(args):
@@ -112,7 +113,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "index_messages",
-        "Index pending messages for semantic search. No confirmation required.",
+        "Create semantic embeddings for all not-yet-indexed messages in the DB. "
+        "Required before semantic_search or search_hybrid work. Needs an embedding API key configured.",
         {},
     )
     async def index_messages(args):
@@ -158,8 +160,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_telegram",
-        "Search messages across all public Telegram channels via Telegram API. "
-        "Requires a connected Premium account. Use for discovering content beyond collected channels.",
+        "Search messages across all public Telegram channels via Telegram API. Requires a connected "
+        "Premium account. Use for discovering content beyond collected channels.",
         {"query": str, "limit": int},
     )
     async def search_telegram(args):
@@ -183,8 +185,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_my_chats",
-        "Search messages in your own Telegram dialogs (private chats, groups, saved messages). "
-        "Requires a connected Telegram account.",
+        "Search messages in your own Telegram dialogs (private chats, groups, saved messages) "
+        "via Telegram API. Uses the primary connected account.",
         {"query": str, "limit": int},
     )
     async def search_my_chats(args):
@@ -208,8 +210,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_in_channel",
-        "Search messages within a specific Telegram channel via Telegram API. "
-        "Requires a connected account and channel_id.",
+        "Search messages within a specific channel via Telegram API. "
+        "channel_id = Telegram numeric ID (from list_channels or search_my_telegram). "
+        "Searches live Telegram, not local DB.",
         {"channel_id": int, "query": str, "limit": int},
     )
     async def search_in_channel(args):
@@ -238,8 +241,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_hybrid",
-        "Hybrid search combining full-text and semantic similarity on collected messages. "
-        "Works locally, no Telegram connection needed.",
+        "Hybrid search combining FTS and semantic similarity on collected local messages. "
+        "Semantic part requires prior index_messages call. Supports same filters as search_messages.",
         {
             "query": str,
             "limit": int,

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -52,7 +52,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_search_query",
-        "Get full details of a saved search query by its ID.",
+        "Get full details of a saved search query. sq_id from list_search_queries.",
         {"sq_id": int},
     )
     async def get_search_query(args):
@@ -87,7 +87,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "add_search_query",
-        "Add a new saved search query. Requires confirm=true.",
+        "Add a saved search query. is_fts=true for FTS5 full-text search (default: substring). "
+        "notify_on_collect=true to send notification on new matches. "
+        "track_stats=true to record daily match counts for get_search_query_stats. Requires confirm=true.",
         {
             "query": str,
             "interval_minutes": int,
@@ -269,7 +271,8 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "get_search_query_stats",
-        "Get daily match statistics for a search query over the last N days.",
+        "Get daily match statistics for a search query over the last N days. "
+        "Only works if track_stats=true was set when creating the query. sq_id from list_search_queries.",
         {"sq_id": int, "days": int},
     )
     async def get_search_query_stats(args):

--- a/src/agent/tools/settings.py
+++ b/src/agent/tools/settings.py
@@ -14,7 +14,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def get_settings(args):
         try:
             settings_keys = [
-                "scheduler_interval_minutes",
+                "collect_interval_minutes",
                 "scheduler_enabled",
                 "agent_prompt_template",
                 "agent_backend_override",
@@ -31,31 +31,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     tools.append(get_settings)
 
     @tool(
-        "save_scheduler_settings",
-        "⚠️ Update scheduler settings. Ask user for confirmation first.",
-        {"interval_minutes": int, "enabled": bool, "confirm": bool},
-    )
-    async def save_scheduler_settings(args):
-        gate = require_confirmation("изменит настройки планировщика", args)
-        if gate:
-            return gate
-        try:
-            interval = args.get("interval_minutes")
-            enabled = args.get("enabled")
-            if interval is not None:
-                await db.set_setting("scheduler_interval_minutes", str(int(interval)))
-            if enabled is not None:
-                await db.set_setting("scheduler_enabled", str(bool(enabled)).lower())
-            return _text_response("Настройки планировщика сохранены.")
-        except Exception as e:
-            return _text_response(f"Ошибка сохранения настроек: {e}")
-
-    tools.append(save_scheduler_settings)
-
-    @tool(
         "save_agent_settings",
-        "⚠️ Update agent settings (prompt template, backend override). "
-        "Ask user for confirmation first.",
+        "⚠️ Update agent settings. backend values: 'claude-agent-sdk' or 'deepagents'. Ask user for confirmation first.",
         {"prompt_template": str, "backend": str, "confirm": bool},
     )
     async def save_agent_settings(args):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -202,7 +202,7 @@ def test_deepagents_tools_can_be_converted_to_structured_tools(db):
     search_tool = StructuredTool.from_function(next(t for t in tools if t.__name__ == "search_messages"))
     channels_tool = StructuredTool.from_function(next(t for t in tools if t.__name__ == "list_channels"))
 
-    assert "Search" in search_tool.description
+    assert "search" in search_tool.description.lower()
     assert "channels" in channels_tool.description.lower()
 
 

--- a/tests/test_agent_tools_new1.py
+++ b/tests/test_agent_tools_new1.py
@@ -720,14 +720,14 @@ class TestGetSettingsTool:
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_settings"]({})
         text = _text(result)
-        assert "scheduler_interval_minutes" in text
+        assert "collect_interval_minutes" in text
         assert "agent_prompt_template" in text
         assert "Настройки системы" in text
 
     @pytest.mark.asyncio
     async def test_shows_set_values(self, mock_db):
         async def fake_get(key):
-            return "60" if key == "scheduler_interval_minutes" else None
+            return "60" if key == "collect_interval_minutes" else None
 
         mock_db.get_setting = fake_get
         handlers = _get_tool_handlers(mock_db)
@@ -740,37 +740,6 @@ class TestGetSettingsTool:
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_settings"]({})
         assert "Ошибка получения настроек" in _text(result)
-
-
-class TestSaveSchedulerSettingsTool:
-    @pytest.mark.asyncio
-    async def test_no_confirm_returns_gate(self, mock_db):
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["save_scheduler_settings"]({"interval_minutes": 30})
-        assert "confirm=true" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_with_confirm_saves_interval(self, mock_db):
-        mock_db.set_setting = AsyncMock()
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["save_scheduler_settings"]({"interval_minutes": 30, "confirm": True})
-        assert "сохранены" in _text(result)
-        mock_db.set_setting.assert_any_await("scheduler_interval_minutes", "30")
-
-    @pytest.mark.asyncio
-    async def test_with_confirm_saves_enabled_flag(self, mock_db):
-        mock_db.set_setting = AsyncMock()
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["save_scheduler_settings"]({"enabled": False, "confirm": True})
-        assert "сохранены" in _text(result)
-        mock_db.set_setting.assert_any_await("scheduler_enabled", "false")
-
-    @pytest.mark.asyncio
-    async def test_error_returns_text(self, mock_db):
-        mock_db.set_setting = AsyncMock(side_effect=Exception("write error"))
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["save_scheduler_settings"]({"interval_minutes": 10, "confirm": True})
-        assert "Ошибка сохранения настроек" in _text(result)
 
 
 class TestSaveAgentSettingsTool:

--- a/tests/test_coverage_batch2.py
+++ b/tests/test_coverage_batch2.py
@@ -305,31 +305,8 @@ class TestDeepagentsSyncGetPipelineRun:
 
 
 # ===========================================================================
-# deepagents_sync — view_moderation_run / approve_run / reject_run
+# deepagents_sync — approve_run / reject_run
 # ===========================================================================
-
-
-class TestDeepagentsSyncViewModerationRun:
-    def test_not_found(self, mock_db):
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
-        tool_map = _build_sync_tools(mock_db)
-        result = tool_map["view_moderation_run"](run_id=5)
-        assert "не найден" in result
-
-    def test_found_with_text(self, mock_db):
-        run = SimpleNamespace(id=5, status="done", moderation_status="pending", generated_text="Draft")
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
-        tool_map = _build_sync_tools(mock_db)
-        result = tool_map["view_moderation_run"](run_id=5)
-        assert "Draft" in result
-        assert "id=5" in result
-
-    def test_found_empty_text(self, mock_db):
-        run = SimpleNamespace(id=5, status="done", moderation_status="pending", generated_text=None)
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
-        tool_map = _build_sync_tools(mock_db)
-        result = tool_map["view_moderation_run"](run_id=5)
-        assert "пусто" in result
 
 
 class TestDeepagentsSyncApproveRun:
@@ -1161,49 +1138,6 @@ class TestPipelinesToolPublishPipelineRun:
 
 
 # ===========================================================================
-# pipelines.py MCP tools — get_pipeline_queue
-# ===========================================================================
-
-
-class TestPipelinesToolGetPipelineQueue:
-    @pytest.mark.asyncio
-    async def test_missing_pipeline_id(self, mock_db):
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["get_pipeline_queue"]({})
-        assert "pipeline_id обязателен" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_empty(self, mock_db):
-        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["get_pipeline_queue"]({"pipeline_id": 1})
-        assert "Нет черновиков" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_with_runs(self, mock_db):
-        run = SimpleNamespace(
-            id=7,
-            moderation_status="pending",
-            generated_text="Draft content here",
-            created_at="2026-01-01",
-        )
-        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[run])
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["get_pipeline_queue"]({"pipeline_id": 2})
-        text = _text(result)
-        assert "run_id=7" in text
-        assert "Draft content here" in text
-
-    @pytest.mark.asyncio
-    async def test_error(self, mock_db):
-        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(
-            side_effect=Exception("db fail")
-        )
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["get_pipeline_queue"]({"pipeline_id": 1})
-        assert "Ошибка" in _text(result)
-
-
 # ===========================================================================
 # agent_provider_service — load_provider_configs with invalid JSON
 # ===========================================================================

--- a/tests/test_coverage_batch4.py
+++ b/tests/test_coverage_batch4.py
@@ -243,67 +243,6 @@ class TestListPendingModeration:
         assert "Ошибка получения очереди модерации" in _text(result)
 
 
-class TestViewModerationRun:
-    @pytest.mark.asyncio
-    async def test_requires_run_id(self, mock_db):
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["view_moderation_run"]({})
-        assert "run_id обязателен" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_not_found(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["view_moderation_run"]({"run_id": 999})
-        assert "не найден" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_full_details(self, mock_db):
-        run = SimpleNamespace(
-            id=5,
-            status="completed",
-            moderation_status="pending",
-            quality_score=0.85,
-            created_at="2025-01-01T12:00:00",
-            metadata=json.dumps({"key": "value"}),
-            generated_text="Generated content here",
-        )
-        mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["view_moderation_run"]({"run_id": 5})
-        text = _text(result)
-        assert "Run id=5" in text
-        assert "quality_score: 0.85" in text
-        assert "Generated content here" in text
-
-    @pytest.mark.asyncio
-    async def test_empty_text_shows_placeholder(self, mock_db):
-        run = SimpleNamespace(
-            id=3,
-            status="pending",
-            moderation_status="pending",
-            quality_score=None,
-            created_at="2025-01-01",
-            metadata=None,
-            generated_text=None,
-        )
-        mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["view_moderation_run"]({"run_id": 3})
-        assert "(пусто)" in _text(result)
-
-    @pytest.mark.asyncio
-    async def test_exception(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.get = AsyncMock(side_effect=Exception("db"))
-        handlers = _get_tool_handlers(mock_db)
-        result = await handlers["view_moderation_run"]({"run_id": 1})
-        assert "Ошибка получения run" in _text(result)
-
-
 class TestApproveRun:
     @pytest.mark.asyncio
     async def test_requires_run_id(self, mock_db):

--- a/tests/test_coverage_batch5.py
+++ b/tests/test_coverage_batch5.py
@@ -623,19 +623,6 @@ class TestDeepagentsSyncModeration:
         result = tool_map["bulk_reject_runs"]("10,20")
         assert "Отклонено: 2" in result
 
-    def test_view_moderation_run_not_found(self, mock_db):
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
-        tool_map = _build_sync_tools(mock_db)
-        result = tool_map["view_moderation_run"](99)
-        assert "не найден" in result.lower()
-
-    def test_view_moderation_run_found(self, mock_db):
-        run = SimpleNamespace(id=2, status="pending", moderation_status="review", generated_text="hello")
-        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
-        tool_map = _build_sync_tools(mock_db)
-        result = tool_map["view_moderation_run"](2)
-        assert "hello" in result
-
 
 # ===========================================================================
 # deepagents_sync — accounts / scheduler / threads

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -970,11 +970,6 @@ class TestDeepagentsSyncRemainingTools:
         result = self._call(tm["list_pending_moderation"], lambda n, c: [])
         assert "нет черновиков" in result.lower()
 
-    def test_view_moderation_run_not_found(self):
-        tm = self._build_tools()
-        result = self._call(tm["view_moderation_run"], lambda n, c: None, run_id=999)
-        assert "не найден" in result.lower()
-
     def test_list_search_queries_empty(self):
         tm = self._build_tools()
         result = self._call(tm["list_search_queries"], lambda n, c: [])


### PR DESCRIPTION
## Summary
- **Improved ~60 agent tool descriptions** across 15 tool modules + deepagents_sync.py with cross-references, parameter disambiguation, workflow hints, and prerequisites
- **Removed 3 duplicate tools**: `get_pipeline_queue`, `view_moderation_run`, `save_scheduler_settings` (the latter wrote an orphan DB key that scheduler never read)
- **Fixed dead code**: removed unused `mode` param from `search_messages`, unused `phone` from `get_forum_topics`
- **Fixed system prompt**: `get_channels` → `list_channels` (correct tool name), added `add_channel → list_channels → collect_channel` workflow hint
- **Fixed `get_settings`**: reading orphan key `scheduler_interval_minutes` → `collect_interval_minutes`

## Test plan
- [x] `ruff check` — 0 errors
- [x] `pytest -m "not aiosqlite_serial" -n auto` — 3930 passed
- [x] `pytest -m aiosqlite_serial` — 508 passed
- [ ] Manual test: `python -m src.main agent chat` → "загрузи чат 1877929309 в базу" → agent should chain add_channel + collect_channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)