### PR TITLE
feat: initialize Telethon client pool in agent TUI

### DIFF
--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -75,6 +75,7 @@ async def _test_escaping(db, config) -> None:
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         config, db = await runtime.init_db(args.config)
+        auth = pool = mgr = None
         try:
             action = args.agent_action
 
@@ -98,7 +99,8 @@ def run(args: argparse.Namespace) -> None:
             elif action == "chat":
                 from src.agent.manager import AgentManager
 
-                mgr = AgentManager(db, config)
+                auth, pool = await runtime.init_pool(config, db)
+                mgr = AgentManager(db, config, client_pool=pool)
                 await mgr.refresh_settings_cache(preflight=True)
                 mgr.initialize()
 
@@ -200,6 +202,12 @@ def run(args: argparse.Namespace) -> None:
             elif action == "test-escaping":
                 await _test_escaping(db, config)
         finally:
+            if mgr is not None:
+                await mgr.close_all()
+            if pool is not None:
+                await pool.disconnect_all()
+            if auth is not None:
+                await auth.cleanup()
             await db.close()
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Initialize `ClientPool` (Telethon) when running `python -m src.main agent chat`
- Pass `client_pool=pool` to `AgentManager` so TUI has access to all Telegram tools
- Add proper cleanup in `finally` block: `mgr.close_all()` → `pool.disconnect_all()` → `auth.cleanup()` → `db.close()`

## Test plan
- [ ] Run `python -m src.main agent chat` and verify Telegram tools are available in the TUI
- [ ] Run `python -m src.main agent chat --prompt "list channels"` to verify one-shot mode works with pool
- [ ] Run `ruff check src/cli/commands/agent.py`
- [ ] Run `pytest tests/ -v -m "not aiosqlite_serial" -n auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)