### PR TITLE
perf: critical performance optimization — agent, DB, dispatcher

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -5,11 +5,12 @@ import json
 import logging
 import os
 import shutil
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, TextBlock, query
 
@@ -79,8 +80,14 @@ class ClaudeSdkBackend:
         self._client_pool = client_pool
         self._scheduler_manager = scheduler_manager
         self._server = None
+        self._initialized = False
 
     def initialize(self) -> None:
+        self._ensure_initialized()
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
         from src.agent.tools import make_mcp_server
 
         os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "300000")
@@ -88,6 +95,7 @@ class ClaudeSdkBackend:
             self._db, client_pool=self._client_pool, scheduler_manager=self._scheduler_manager,
             config=self._config,
         )
+        self._initialized = True
         logger.info("Claude SDK backend initialized")
 
     @property
@@ -107,6 +115,7 @@ class ClaudeSdkBackend:
         queue: asyncio.Queue[str | None],
         history_msgs: list[dict] | None = None,
     ) -> None:
+        self._ensure_initialized()
         if history_msgs:
             prompt = _embed_history_in_prompt(history_msgs, prompt)
         resolved_model = model or self._config.agent.model.strip() or os.environ.get("AGENT_MODEL")
@@ -132,7 +141,7 @@ class ClaudeSdkBackend:
         )
 
         all_tools = get_all_allowed_tools()
-        permissions = await load_tool_permissions_union(self._db)
+        permissions = await load_tool_permissions_union(self._db, use_cache=True)
         allowed = filter_allowed_tools(all_tools, permissions)
         if len(allowed) < len(all_tools):
             denied = [t.removeprefix(MCP_PREFIX) for t in all_tools if t not in allowed]
@@ -932,6 +941,37 @@ class DeepagentsBackend:
         raise RuntimeError(self._init_error)
 
 
+_SETTINGS_CACHE_TTL = 60.0  # seconds
+
+
+class _SettingsCache:
+    """Simple TTL cache for DB settings to avoid repeated queries per chat message."""
+
+    __slots__ = ("_entries",)
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[Any, float]] = {}
+
+    def get(self, key: str) -> Any | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        value, expires = entry
+        if time.monotonic() > expires:
+            del self._entries[key]
+            return None
+        return value
+
+    def set(self, key: str, value: Any, ttl: float = _SETTINGS_CACHE_TTL) -> None:
+        self._entries[key] = (value, time.monotonic() + ttl)
+
+    def invalidate(self, key: str | None = None) -> None:
+        if key is None:
+            self._entries.clear()
+        else:
+            self._entries.pop(key, None)
+
+
 class AgentManager:
     def __init__(
         self, db: Database, config: AppConfig | None = None, client_pool=None, scheduler_manager=None,
@@ -943,6 +983,9 @@ class AgentManager:
         )
         self._deepagents_backend = DeepagentsBackend(db, self._config)
         self._active_tasks: dict[int, asyncio.Task] = {}
+        self._settings_cache = _SettingsCache()
+        self._cached_allowed_tools: list[str] | None = None
+        self._cached_filtered_tools: tuple[list[str], dict[str, bool]] | None = None
 
     async def refresh_settings_cache(self, *, preflight: bool = False) -> None:
         await self._deepagents_backend.refresh_settings_cache()
@@ -1021,11 +1064,19 @@ class AgentManager:
         }
         return prompt, stats
 
+    async def _get_setting_cached(self, key: str, default: str = "") -> str:
+        cached = self._settings_cache.get(key)
+        if cached is not None:
+            return cached
+        value = await self._db.get_setting(key) or default
+        self._settings_cache.set(key, value)
+        return value
+
     async def _dev_mode_enabled(self) -> bool:
-        return (await self._db.get_setting("agent_dev_mode_enabled") or "0") == "1"
+        return (await self._get_setting_cached("agent_dev_mode_enabled", "0")) == "1"
 
     async def _backend_override(self) -> str:
-        override = (await self._db.get_setting("agent_backend_override") or "auto").strip()
+        override = (await self._get_setting_cached("agent_backend_override", "auto")).strip()
         if override not in {"auto", "claude", "deepagents"}:
             return "auto"
         return override
@@ -1107,8 +1158,7 @@ class AgentManager:
             stats["total_msgs"],
         )
         prompt_template = (
-            await self._db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING)
-            or DEFAULT_AGENT_PROMPT_TEMPLATE
+            await self._get_setting_cached(AGENT_PROMPT_TEMPLATE_SETTING, DEFAULT_AGENT_PROMPT_TEMPLATE)
         )
         try:
             system_prompt = render_prompt_template(

--- a/src/agent/react_agent.py
+++ b/src/agent/react_agent.py
@@ -44,15 +44,15 @@ def _describe_tools(tools: list[Callable]) -> str:
     return "\n".join(parts)
 
 
-def _try_call_tool(name: str, args: dict, tools: list[Callable]) -> str:
-    for fn in tools:
-        if fn.__name__ == name:
-            try:
-                result = fn(**args)
-                return str(result)
-            except Exception as exc:
-                return f"[Tool error: {exc}]"
-    return f"[Unknown tool: {name}]"
+def _try_call_tool(name: str, args: dict, tool_map: dict[str, Callable]) -> str:
+    fn = tool_map.get(name)
+    if fn is None:
+        return f"[Unknown tool: {name}]"
+    try:
+        result = fn(**args)
+        return str(result)
+    except Exception as exc:
+        return f"[Tool error: {exc}]"
 
 
 def _chat_sync(base_url: str, model: str, messages: list[dict], api_key: str = "") -> str:
@@ -86,7 +86,7 @@ class OllamaReActAgent:
     ) -> None:
         self._base_url = base_url
         self._model = model
-        self._tools = tools
+        self._tool_map = {fn.__name__: fn for fn in tools}
         self._api_key = api_key
         self._max_steps = max_steps
 
@@ -118,7 +118,7 @@ class OllamaReActAgent:
             except (json.JSONDecodeError, AttributeError):
                 return {"messages": [_MockMessage(response)]}
 
-            tool_result = _try_call_tool(tool_name, tool_args, self._tools)
+            tool_result = _try_call_tool(tool_name, tool_args, self._tool_map)
             logger.debug("ReAct tool %r → %r", tool_name, tool_result[:100])
 
             messages.append({"role": "assistant", "content": response})

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections import OrderedDict
 from enum import Enum
 
 logger = logging.getLogger(__name__)
+
+_PERMISSIONS_CACHE_TTL = 60.0  # seconds
+_permissions_cache: tuple[dict[str, bool], float] | None = None
 
 TOOL_PERMISSIONS_SETTING = "agent_tool_permissions"
 MCP_PREFIX = "mcp__telegram_db__"
@@ -367,6 +371,9 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     If *phone* is given, saves under the per-phone key without touching other phones.
     If *phone* is ``None``, saves in legacy flat format (backward compat).
     """
+    global _permissions_cache  # noqa: PLW0603
+    _permissions_cache = None  # invalidate cache on save
+
     if phone is None:
         await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(permissions, ensure_ascii=False))
         return
@@ -388,37 +395,57 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(saved, ensure_ascii=False))
 
 
-async def load_tool_permissions_union(db) -> dict[str, bool]:
+async def load_tool_permissions_union(db, *, use_cache: bool = False) -> dict[str, bool]:
     """Union across all phones — True if ANY phone allows the tool.
 
     Used by agent backends so that tools visible to at least one account
     remain available for the session.  Per-phone handler gates do fine-grained blocking.
+
+    When *use_cache* is True, returns a cached result for up to 60 seconds
+    to avoid repeated DB queries during agent chat.
     """
+    global _permissions_cache  # noqa: PLW0603
+    if use_cache and _permissions_cache is not None:
+        cached_value, expires = _permissions_cache
+        if time.monotonic() < expires:
+            return cached_value
+
     defaults = _default_permissions()
     saved = await _load_raw_permissions(db)
     if not saved:
-        return defaults
+        result = defaults
+    elif not _is_per_phone_format(saved):
+        result = {name: saved.get(name, defaults[name]) for name in TOOL_CATEGORIES}
+    else:
+        phone_dicts = [v for v in saved.values() if isinstance(v, dict)]
+        if not phone_dicts:
+            result = defaults
+        else:
+            result = {name: any(pd.get(name, defaults[name]) for pd in phone_dicts) for name in TOOL_CATEGORIES}
 
-    if not _is_per_phone_format(saved):
-        return {name: saved.get(name, defaults[name]) for name in TOOL_CATEGORIES}
+    _permissions_cache = (result, time.monotonic() + _PERMISSIONS_CACHE_TTL)
+    return result
 
-    phone_dicts = [v for v in saved.values() if isinstance(v, dict)]
-    if not phone_dicts:
-        return defaults
-    return {name: any(pd.get(name, defaults[name]) for pd in phone_dicts) for name in TOOL_CATEGORIES}
+
+_all_allowed_tools_cache: list[str] | None = None
 
 
 def get_all_allowed_tools() -> list[str]:
     """Build the full list of tool names from TOOL_CATEGORIES.
 
     MCP tools get the prefix; built-in tools use bare names.
+    Result is computed once and cached (TOOL_CATEGORIES is static).
     """
+    global _all_allowed_tools_cache  # noqa: PLW0603
+    if _all_allowed_tools_cache is not None:
+        return _all_allowed_tools_cache
     result = []
     for name in TOOL_CATEGORIES:
         if name in BUILTIN_TOOLS:
             result.append(name)
         else:
             result.append(f"{MCP_PREFIX}{name}")
+    _all_allowed_tools_cache = result
     return result
 
 

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -180,6 +180,11 @@ class ChannelBundle:
     async def get_previous_subscriber_counts(self) -> dict[int, int | None]:
         return await self.channel_stats.get_previous_subscriber_counts()
 
+    async def get_latest_and_previous_stats(
+        self,
+    ) -> tuple[dict[int, ChannelStats], dict[int, int | None]]:
+        return await self.channel_stats.get_latest_and_previous_stats()
+
     async def create_collection_task(
         self,
         channel_id: int,

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -81,6 +81,9 @@ class DBConnection:
         await self.db.execute("PRAGMA journal_mode=WAL")
         await self.db.execute("PRAGMA synchronous=NORMAL")
         await self.db.execute("PRAGMA foreign_keys=ON")
+        await self.db.execute("PRAGMA cache_size=-64000")  # 64MB
+        await self.db.execute("PRAGMA temp_store=MEMORY")
+        await self.db.execute("PRAGMA mmap_size=30000000")  # 30MB
         if _PROFILING_ENABLED:
             self.db = ProfilingConnection(self.db)  # type: ignore[assignment]
         return self.db

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -87,3 +87,39 @@ class ChannelStatsRepository:
                SELECT channel_id, subscriber_count FROM ranked WHERE rn = 2""")
         rows = await cur.fetchall()
         return {r["channel_id"]: r["subscriber_count"] for r in rows}
+
+    async def get_latest_and_previous_stats(
+        self,
+    ) -> tuple[dict[int, ChannelStats], dict[int, int | None]]:
+        """Fetch latest stats and previous subscriber counts in a single query.
+
+        Returns (latest_stats, prev_subscriber_counts) — same as calling
+        get_latest_stats_for_all() + get_previous_subscriber_counts() but with
+        one DB round-trip instead of two.
+        """
+        cur = await self._db.execute("""WITH ranked AS (
+                   SELECT *, ROW_NUMBER() OVER (
+                       PARTITION BY channel_id ORDER BY collected_at DESC, id DESC
+                   ) AS rn FROM channel_stats
+               )
+               SELECT * FROM ranked WHERE rn <= 2""")
+        rows = await cur.fetchall()
+        latest: dict[int, ChannelStats] = {}
+        previous: dict[int, int | None] = {}
+        for r in rows:
+            rn = r["rn"]
+            if rn == 1:
+                latest[r["channel_id"]] = ChannelStats(
+                    id=r["id"],
+                    channel_id=r["channel_id"],
+                    subscriber_count=r["subscriber_count"],
+                    avg_views=r["avg_views"],
+                    avg_reactions=r["avg_reactions"],
+                    avg_forwards=r["avg_forwards"],
+                    collected_at=(
+                        datetime.fromisoformat(r["collected_at"]) if r["collected_at"] else None
+                    ),
+                )
+            elif rn == 2:
+                previous[r["channel_id"]] = r["subscriber_count"]
+        return latest, previous

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -471,21 +471,24 @@ class CollectionTasksRepository:
             return None
         now_iso = now.astimezone(timezone.utc).isoformat()
         placeholders = ", ".join("?" for _ in handled_types)
+
+        # Phase 1: lightweight read-only peek — no write lock
+        cur = await self._db.execute(
+            f"SELECT id FROM collection_tasks "
+            f"WHERE task_type IN ({placeholders}) "
+            "AND status = ? "
+            "AND (run_after IS NULL OR run_after <= ?) "
+            "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
+            (*handled_types, CollectionTaskStatus.PENDING.value, now_iso),
+        )
+        peek = await cur.fetchone()
+        if peek is None:
+            return None
+
+        # Phase 2: acquire write lock only when there is work to claim
         try:
             await self._db.execute("BEGIN IMMEDIATE")
-            cur = await self._db.execute(
-                f"SELECT id FROM collection_tasks "
-                f"WHERE task_type IN ({placeholders}) "
-                "AND status = ? "
-                "AND (run_after IS NULL OR run_after <= ?) "
-                "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
-                (*handled_types, CollectionTaskStatus.PENDING.value, now_iso),
-            )
-            row = await cur.fetchone()
-            if row is None:
-                await self._db.commit()
-                return None
-            selected_id = row["id"]
+            selected_id = peek["id"]
             updated = await self._db.execute(
                 "UPDATE collection_tasks "
                 "SET status = 'running', started_at = ?, completed_at = NULL "

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -904,18 +904,22 @@ class MessagesRepository:
         return cur.rowcount or 0
 
     async def get_stats(self) -> dict:
-        stats: dict[str, int] = {}
-        queries = {
-            "accounts": "SELECT COUNT(*) as cnt FROM accounts",
-            "channels": "SELECT COUNT(*) as cnt FROM channels",
-            "messages": "SELECT COUNT(*) as cnt FROM messages",
-            "search_queries": "SELECT COUNT(*) as cnt FROM search_queries",
+        cur = await self._db.execute(
+            "SELECT"
+            " (SELECT COUNT(*) FROM accounts) AS accounts,"
+            " (SELECT COUNT(*) FROM channels) AS channels,"
+            " (SELECT COUNT(*) FROM messages) AS messages,"
+            " (SELECT COUNT(*) FROM search_queries) AS search_queries"
+        )
+        row = await cur.fetchone()
+        if not row:
+            return {"accounts": 0, "channels": 0, "messages": 0, "search_queries": 0}
+        return {
+            "accounts": row["accounts"],
+            "channels": row["channels"],
+            "messages": row["messages"],
+            "search_queries": row["search_queries"],
         }
-        for table, sql in queries.items():
-            cur = await self._db.execute(sql)
-            row = await cur.fetchone()
-            stats[table] = row["cnt"] if row else 0
-        return stats
 
     async def get_trending_emojis(self, limit: int = 10, days: int | None = None) -> list[dict]:
         """Return top emojis by total reaction count across all messages.

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -32,8 +32,7 @@ class ChannelService:
         self, include_filtered: bool = True
     ) -> tuple[list[Channel], dict, dict]:
         channels = await self._channels.list_channels_with_counts(include_filtered=include_filtered)
-        latest_stats = await self._channels.get_latest_stats_for_all()
-        prev_subscriber_counts = await self._channels.get_previous_subscriber_counts()
+        latest_stats, prev_subscriber_counts = await self._channels.get_latest_and_previous_stats()
         return channels, latest_stats, prev_subscriber_counts
 
     async def add_by_identifier(self, identifier: str) -> bool:

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -53,7 +53,7 @@ class UnifiedDispatcher:
         photo_task_service: PhotoTaskService | None = None,
         photo_auto_upload_service: PhotoAutoUploadService | None = None,
         default_batch_size: int = 20,
-        poll_interval_sec: float = 1.0,
+        poll_interval_sec: float = 5.0,
         channel_timeout_sec: float = 120.0,
         search_engine: "SearchEngine" | None = None,
         pipeline_bundle: PipelineBundle | None = None,
@@ -125,6 +125,10 @@ class UnifiedDispatcher:
         self._task = None
 
     async def _run_loop(self) -> None:
+        idle_interval = self._poll_interval_sec
+        active_interval = max(1.0, self._poll_interval_sec / 5)
+        current_interval = idle_interval
+
         while not self._stop_event.is_set():
             task: CollectionTask | None = None
             try:
@@ -132,9 +136,11 @@ class UnifiedDispatcher:
                     datetime.now(timezone.utc), HANDLED_TYPES
                 )
                 if task is None:
-                    await asyncio.sleep(self._poll_interval_sec)
+                    current_interval = idle_interval
+                    await asyncio.sleep(current_interval)
                     continue
 
+                current_interval = active_interval
                 await self._dispatch(task)
             except asyncio.CancelledError:
                 raise
@@ -151,18 +157,25 @@ class UnifiedDispatcher:
                             )
                     except Exception:
                         logger.exception("Failed to mark broken task as failed")
-                await asyncio.sleep(self._poll_interval_sec)
+                await asyncio.sleep(current_interval)
+
+    def _handler_map(self) -> dict:
+        try:
+            return self.__handler_map
+        except AttributeError:
+            self.__handler_map = {
+                CollectionTaskType.STATS_ALL: self._handle_stats_all,
+                CollectionTaskType.SQ_STATS: self._handle_sq_stats,
+                CollectionTaskType.PHOTO_DUE: self._handle_photo_due,
+                CollectionTaskType.PHOTO_AUTO: self._handle_photo_auto,
+                CollectionTaskType.PIPELINE_RUN: self._handle_pipeline_run,
+                CollectionTaskType.CONTENT_GENERATE: self._handle_content_generate,
+                CollectionTaskType.CONTENT_PUBLISH: self._handle_content_publish,
+            }
+            return self.__handler_map
 
     async def _dispatch(self, task: CollectionTask) -> None:
-        handler = {
-            CollectionTaskType.STATS_ALL: self._handle_stats_all,
-            CollectionTaskType.SQ_STATS: self._handle_sq_stats,
-            CollectionTaskType.PHOTO_DUE: self._handle_photo_due,
-            CollectionTaskType.PHOTO_AUTO: self._handle_photo_auto,
-            CollectionTaskType.PIPELINE_RUN: self._handle_pipeline_run,
-            CollectionTaskType.CONTENT_GENERATE: self._handle_content_generate,
-            CollectionTaskType.CONTENT_PUBLISH: self._handle_content_publish,
-        }.get(task.task_type)
+        handler = self._handler_map().get(task.task_type)
         if handler is None:
             await self._tasks.update_collection_task(
                 task.id,


### PR DESCRIPTION
## Summary
- **Agent hot path**: TTL settings cache eliminates 4 DB round-trips per chat message; permissions and allowed tools cached with 60s TTL
- **Dispatcher**: read-only peek before acquiring write lock; adaptive poll interval (5s idle / 1s active)
- **DB queries**: SQLite PRAGMA tuning (64MB cache, mmap, temp_store=MEMORY); dashboard stats 4→1 query; channel stats 2→1 query
- **ReAct agent**: O(1) dict tool lookup; lazy MCP server initialization

Closes #285

## Test plan
- [x] `ruff check` — all checks passed
- [x] `pytest -n auto` — 3930 passed
- [x] `pytest -m aiosqlite_serial` — 508 passed
- [ ] Manual: verify `/debug/timing` shows faster routes
- [ ] Manual: `python -m src.main agent chat` — check first response time

🤖 Generated with [Claude Code](https://claude.com/claude-code)