### PR TITLE
feat: normalize_identifier() + fix agent search by @username / t.me link

### DIFF
--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -67,10 +67,10 @@ def register(db, client_pool, embedding_service, **kwargs):
                         or clean in (d.get("title") or "").lower()
                     ]
                 elif kind == "numeric_id":
-                    dialogs = [
-                        d for d in dialogs
-                        if str(d.get("channel_id", "")) in (clean, clean.lstrip("-"))
-                    ]
+                    # channel_id stores Telethon entity.id (bare positive int).
+                    # Users may provide Bot API format (-1001234567890) where -100 is a prefix.
+                    bare_id = clean[4:] if clean.startswith("-100") else clean.lstrip("-")
+                    dialogs = [d for d in dialogs if str(d.get("channel_id", "")) == bare_id]
                 else:
                     dialogs = [
                         d for d in dialogs

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -13,6 +13,7 @@ from src.agent.tools._registry import (
     require_pool,
     resolve_phone,
 )
+from src.parsers import normalize_identifier
 
 _TYPE_ALIASES: dict[str, set[str]] = {
     "channels": {"channel"},
@@ -26,9 +27,10 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "search_my_telegram",
-        "Search your Telegram account dialogs by title — channels, groups, private chats, bots, "
-        "saved messages. This does NOT search message content (use search_messages for that). "
-        "Params: search — filter by title (case-insensitive substring); "
+        "Search your Telegram account dialogs — channels, groups, private chats, bots, saved messages. "
+        "This does NOT search message content (use search_messages for that). "
+        "Params: search — find by @username, t.me/username, https://t.me/username, numeric ID, "
+        "or title substring (case-insensitive); matches username field exactly or title as substring; "
         "type — filter: 'channels' (channel), 'groups' (group/supergroup/gigagroup/forum/monoforum), "
         "'chats' (dm/bot/saved), or exact type like 'supergroup', 'dm', 'bot'; "
         "limit — cap results (default: all).",
@@ -54,9 +56,27 @@ def register(db, client_pool, embedding_service, **kwargs):
             if type_filter:
                 allowed = _TYPE_ALIASES.get(type_filter, {type_filter})
                 dialogs = [d for d in dialogs if (d.get("channel_type") or "") in allowed]
-            search_query = (args.get("search") or "").strip().lower()
-            if search_query:
-                dialogs = [d for d in dialogs if search_query in (d.get("title") or "").lower()]
+            raw_query = (args.get("search") or "").strip()
+            search_query = raw_query.lower()  # kept for error message display
+            if raw_query:
+                clean, kind = normalize_identifier(raw_query)
+                if kind == "username":
+                    dialogs = [
+                        d for d in dialogs
+                        if clean == (d.get("username") or "").lower()
+                        or clean in (d.get("title") or "").lower()
+                    ]
+                elif kind == "numeric_id":
+                    dialogs = [
+                        d for d in dialogs
+                        if str(d.get("channel_id", "")) in (clean, clean.lstrip("-"))
+                    ]
+                else:
+                    dialogs = [
+                        d for d in dialogs
+                        if clean in (d.get("title") or "").lower()
+                        or clean in (d.get("username") or "").lower()
+                    ]
             limit = args.get("limit")
             if limit is not None:
                 try:

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -3,6 +3,55 @@ from __future__ import annotations
 import re
 from io import BytesIO
 
+# Pattern for a single t.me link — used by normalize_identifier.
+# Captures the username from: https://t.me/user, t.me/user, t.me/+invite, t.me/user/123
+_TME_LINK_RE = re.compile(
+    r"^(?:https?://)?t\.me/\+?([a-zA-Z][a-zA-Z0-9_]{3,31})(?:/\d+)?$"
+)
+
+# Bare username pattern (without @) — 5-32 chars, starts with letter.
+_BARE_USERNAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{3,31}$")
+
+
+def normalize_identifier(raw: str) -> tuple[str, str]:
+    """Normalize any Telegram identifier to ``(clean_value, kind)``.
+
+    Accepts:
+    - ``@username`` / ``username``
+    - ``t.me/username`` / ``https://t.me/username`` / ``https://t.me/username/123``
+    - Numeric IDs: ``-100123456789``, ``123456``
+
+    Returns ``(clean_value, kind)`` where *kind* is:
+    - ``'username'`` — *clean_value* is the lowercase username without ``@``
+    - ``'numeric_id'`` — *clean_value* is the numeric string (may be negative)
+    - ``'unknown'`` — couldn't parse; *clean_value* is the stripped original
+    """
+    raw = raw.strip()
+    if not raw:
+        return raw, "unknown"
+
+    # t.me link (with or without scheme, with optional post id)
+    m = _TME_LINK_RE.match(raw)
+    if m:
+        return m.group(1).lower(), "username"
+
+    # @username
+    if raw.startswith("@"):
+        candidate = raw[1:]
+        if _BARE_USERNAME_RE.match(candidate):
+            return candidate.lower(), "username"
+
+    # Numeric ID (positive or negative)
+    if raw.lstrip("-").isdigit():
+        return raw, "numeric_id"
+
+    # Bare username
+    if _BARE_USERNAME_RE.match(raw):
+        return raw.lower(), "username"
+
+    return raw, "unknown"
+
+
 # Compiled pattern for extracting Telegram identifiers from arbitrary text.
 # Order matters: full URLs first, then bare t.me/, then @username, then negative IDs.
 _IDENTIFIER_RE = re.compile(


### PR DESCRIPTION
## Summary
- Add `normalize_identifier(raw) -> (clean, kind)` to `src/parsers.py` — universal parser for any Telegram identifier format
- Fix `search_my_telegram` agent tool to find dialogs by `@username`, `t.me/username`, `https://t.me/username`, numeric ID — not just display name

## normalize_identifier() supports

| Input | clean | kind |
|---|---|---|
| `@alxz500` | `alxz500` | `username` |
| `alxz500` | `alxz500` | `username` |
| `t.me/alxz500` | `alxz500` | `username` |
| `https://t.me/alxz500` | `alxz500` | `username` |
| `https://t.me/alxz500/123` | `alxz500` | `username` |
| `-100123456789` | `-100123456789` | `numeric_id` |
| `123456` | `123456` | `numeric_id` |

## search_my_telegram fix
- `username` kind → exact match on `username` field OR substring match on `title`
- `numeric_id` kind → exact match on `channel_id`
- `unknown` kind → substring on both `title` and `username` (fallback)

## Test plan
- [ ] `@alxz500` finds the correct dialog
- [ ] `t.me/alxz500` finds the same dialog
- [ ] `https://t.me/alxz500` finds the same dialog
- [ ] Plain title substring still works
- [ ] Numeric ID `-100123456789` finds by channel_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)