### PR TITLE
fix(tui): native clipboard copy/paste via pbcopy/xclip

### DIFF
--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import subprocess
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -161,7 +163,55 @@ class AgentTuiApp(App):
     """Interactive TUI chat with agent."""
 
     CSS_PATH = str(CSS_PATH)
-    MOUSE_SUPPORT = False  # disable mouse tracking so native terminal selection + Cmd+C works
+    ALLOW_SELECT = True  # built-in text selection; ctrl+c / super+c (Cmd+C) copies
+
+    # ------------------------------------------------------------------
+    # Native system clipboard (pbcopy/pbpaste on macOS, xclip/xsel on Linux)
+    # Textual's default uses OSC 52 which doesn't work in Terminal.app
+    # and has patchy Linux support (e.g. Gnome Terminal).
+    # ------------------------------------------------------------------
+
+    def copy_to_clipboard(self, text: str) -> None:
+        """Write *text* to the system clipboard via native OS tools."""
+        self._clipboard = text
+        if sys.platform == "darwin":
+            try:
+                subprocess.run(["pbcopy"], input=text.encode(), check=True)
+                return
+            except Exception:
+                pass
+        else:
+            for cmd in (
+                ["xclip", "-selection", "clipboard"],
+                ["xsel", "--clipboard", "--input"],
+            ):
+                try:
+                    subprocess.run(cmd, input=text.encode(), check=True)
+                    return
+                except FileNotFoundError:
+                    continue
+        super().copy_to_clipboard(text)
+
+    @property
+    def clipboard(self) -> str:
+        """Read from the system clipboard so Ctrl+V pastes external content too."""
+        if sys.platform == "darwin":
+            try:
+                r = subprocess.run(["pbpaste"], capture_output=True, text=True, check=True)
+                return r.stdout
+            except Exception:
+                pass
+        else:
+            for cmd in (
+                ["xclip", "-selection", "clipboard", "-o"],
+                ["xsel", "--clipboard", "--output"],
+            ):
+                try:
+                    r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                    return r.stdout
+                except FileNotFoundError:
+                    continue
+        return self._clipboard
 
     BINDINGS = [
         Binding("ctrl+n", "new_thread", "Новый тред", show=True),

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -176,7 +176,7 @@ class AgentTuiApp(App):
         self._clipboard = text
         if sys.platform == "darwin":
             try:
-                subprocess.run(["pbcopy"], input=text.encode(), check=True)
+                subprocess.run(["pbcopy"], input=text.encode(), check=True, timeout=2)
                 return
             except Exception:
                 pass
@@ -186,9 +186,9 @@ class AgentTuiApp(App):
                 ["xsel", "--clipboard", "--input"],
             ):
                 try:
-                    subprocess.run(cmd, input=text.encode(), check=True)
+                    subprocess.run(cmd, input=text.encode(), check=True, timeout=2)
                     return
-                except FileNotFoundError:
+                except (FileNotFoundError, subprocess.SubprocessError):
                     continue
         super().copy_to_clipboard(text)
 
@@ -197,7 +197,7 @@ class AgentTuiApp(App):
         """Read from the system clipboard so Ctrl+V pastes external content too."""
         if sys.platform == "darwin":
             try:
-                r = subprocess.run(["pbpaste"], capture_output=True, text=True, check=True)
+                r = subprocess.run(["pbpaste"], capture_output=True, text=True, check=True, timeout=2)
                 return r.stdout
             except Exception:
                 pass
@@ -207,9 +207,9 @@ class AgentTuiApp(App):
                 ["xsel", "--clipboard", "--output"],
             ):
                 try:
-                    r = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                    r = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=2)
                     return r.stdout
-                except FileNotFoundError:
+                except (FileNotFoundError, subprocess.SubprocessError):
                     continue
         return self._clipboard
 

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -300,6 +302,78 @@ async def test_tui_error_chunk_cleans_up(db, app_factory):
         await pilot.pause(0.2)
 
     db.delete_last_agent_exchange.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ALLOW_SELECT / copy tests
+# ---------------------------------------------------------------------------
+
+
+def test_allow_select_enabled():
+    """ALLOW_SELECT must be True so Textual's built-in text selection works."""
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    assert getattr(AgentTuiApp, "ALLOW_SELECT", False) is True
+
+
+def test_ctrl_c_not_bound():
+    """ctrl+c must not be captured by app bindings — it's reserved for copy."""
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    bound_keys = {b.key for b in AgentTuiApp.BINDINGS}
+    assert "ctrl+c" not in bound_keys
+
+
+@pytest.mark.asyncio
+async def test_copy_to_clipboard_called(db, app_factory, monkeypatch):
+    """action_copy_text() delegates to copy_to_clipboard()."""
+    app = app_factory()
+    captured = []
+    monkeypatch.setattr(app, "copy_to_clipboard", lambda text: captured.append(text))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Manually set selected text on the screen and call the action
+        screen = app.screen
+        monkeypatch.setattr(screen, "get_selected_text", lambda: "copied text")
+        screen.action_copy_text()
+    assert captured == ["copied text"]
+
+
+def test_copy_to_clipboard_uses_native_tool(monkeypatch):
+    """copy_to_clipboard calls pbcopy on macOS / xclip on Linux, not OSC 52."""
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp.__new__(AgentTuiApp)
+    app._clipboard = ""
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("input")))
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("sys.platform", "darwin")
+
+    app.copy_to_clipboard("hello")
+    assert calls == [(["pbcopy"], b"hello")]
+    assert app._clipboard == "hello"
+
+
+def test_clipboard_reads_from_native_tool(monkeypatch):
+    """clipboard property reads from pbpaste/xclip instead of internal buffer."""
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp.__new__(AgentTuiApp)
+    app._clipboard = "internal"
+
+    monkeypatch.setattr("sys.platform", "darwin")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda cmd, **kw: MagicMock(stdout="from-system", returncode=0),
+    )
+
+    assert app.clipboard == "from-system"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import subprocess
-import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest


### PR DESCRIPTION
## Summary
- Replace `MOUSE_SUPPORT = False` with `ALLOW_SELECT = True` to use Textual's built-in text selection (click+drag, clean content without TUI borders)
- Override `copy_to_clipboard()` to use `pbcopy` on macOS and `xclip`/`xsel` on Linux — Textual's default OSC 52 is unsupported in Terminal.app and Gnome Terminal
- Override `clipboard` property to read from `pbpaste`/`xclip -o` so `Ctrl+V` pastes from system clipboard, not just internal buffer

## How it works
| Action | macOS | Linux |
|---|---|---|
| Select text | click+drag in widget | click+drag in widget |
| Copy | `Ctrl+C` or `Cmd+C` (`super+c`) | `Ctrl+C` |
| Paste in chat | `Cmd+V` (terminal) or `Ctrl+V` | `Ctrl+V` |

Textual 8.1.1 already has `Binding("ctrl+c,super+c", ...)` at Screen and TextArea level — no custom bindings needed.

## Test plan
- [ ] `pytest tests/test_agent_tui.py -v` — 28 tests pass
- [ ] macOS: run TUI, click+drag to select message text, `Ctrl+C` copies to clipboard
- [ ] macOS: `Ctrl+V` or `Cmd+V` pastes into chat input
- [ ] Linux: same with `xclip` or `xsel` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)