### PR TITLE
feat: interactive permission request dialog for agent TUI and web

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -142,12 +142,20 @@ class ClaudeSdkBackend:
 
         all_tools = get_all_allowed_tools()
         permissions = await load_tool_permissions_union(self._db, use_cache=True)
-        allowed = filter_allowed_tools(all_tools, permissions)
-        if len(allowed) < len(all_tools):
-            denied = [t.removeprefix(MCP_PREFIX) for t in all_tools if t not in allowed]
-            logger.debug("Agent tools: %d/%d allowed, denied: %s", len(allowed), len(all_tools), denied[:20])
+        # When a PermissionGate is active (TUI/web mode), pass ALL tools to the LLM —
+        # the gate intercepts restricted calls at runtime instead of hiding them.
+        from src.agent.permission_gate import get_gate
+
+        if get_gate() is not None:
+            allowed = all_tools
+            logger.debug("Agent tools: gate active, all %d tools visible to LLM", len(all_tools))
         else:
-            logger.debug("Agent tools: all %d tools allowed", len(allowed))
+            allowed = filter_allowed_tools(all_tools, permissions)
+            if len(allowed) < len(all_tools):
+                denied = [t.removeprefix(MCP_PREFIX) for t in all_tools if t not in allowed]
+                logger.debug("Agent tools: %d/%d allowed, denied: %s", len(allowed), len(all_tools), denied[:20])
+            else:
+                logger.debug("Agent tools: all %d tools allowed", len(allowed))
 
         enabled_builtins = [t for t in BUILTIN_TOOLS if t in allowed]
 
@@ -986,6 +994,29 @@ class AgentManager:
         self._settings_cache = _SettingsCache()
         self._cached_allowed_tools: list[str] | None = None
         self._cached_filtered_tools: tuple[list[str], dict[str, bool]] | None = None
+        from src.agent.permission_gate import PermissionGate
+
+        self._permission_gate = PermissionGate()
+
+    @property
+    def permission_gate(self):
+        """Return the PermissionGate for this manager (used by TUI/web to resolve dialogs)."""
+        return self._permission_gate
+
+    def enable_permission_gate(self) -> None:
+        """Activate the permission gate (registers it globally for tool handlers).
+
+        Call this in TUI/web mode to enable interactive permission dialogs.
+        """
+        from src.agent.permission_gate import set_gate
+
+        set_gate(self._permission_gate)
+
+    def disable_permission_gate(self) -> None:
+        """Deactivate the permission gate (reverts to text-error behaviour)."""
+        from src.agent.permission_gate import set_gate
+
+        set_gate(None)
 
     async def refresh_settings_cache(self, *, preflight: bool = False) -> None:
         await self._deepagents_backend.refresh_settings_cache()
@@ -1137,7 +1168,7 @@ class AgentManager:
         return await self._deepagents_backend.probe_config(cfg, probe_kind=probe_kind)
 
     async def chat_stream(
-        self, thread_id: int, message: str, model: str | None = None
+        self, thread_id: int, message: str, model: str | None = None, session_id: str = "web",
     ) -> AsyncGenerator[str, None]:
         history = await self._db.get_agent_messages(thread_id)
         assert (
@@ -1197,10 +1228,35 @@ class AgentManager:
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
 
+        # Capture gate state and compute DB permissions before spawning the task.
+        # The ContextVar token must be created AND reset inside the same asyncio task,
+        # so the actual set/reset happens inside _run_backend (not in the generator).
+        from src.agent.permission_gate import (
+            AgentRequestContext,
+            get_gate,
+            reset_request_context,
+            set_request_context,
+        )
+
+        _gate = get_gate()
+        _req_ctx: AgentRequestContext | None = None
+        if _gate is not None:
+            from src.agent.tools.permissions import load_tool_permissions_union
+
+            _db_perms = await load_tool_permissions_union(self._db, use_cache=True)
+            _req_ctx = AgentRequestContext(
+                session_id=session_id,
+                thread_id=thread_id,
+                queue=queue,
+                db_permissions=_db_perms,
+            )
+
         async def _run_backend(
             selected_backend: ClaudeSdkBackend | DeepagentsBackend,
             failure_prefix: Callable[[str], str],
         ) -> None:
+            # Set ContextVar here so token is created and reset in the same task context.
+            _token = set_request_context(_req_ctx) if _req_ctx is not None else None
             try:
                 await selected_backend.chat_stream(
                     thread_id=thread_id,
@@ -1238,6 +1294,9 @@ class AgentManager:
                     ensure_ascii=False,
                 )
                 await queue.put(f"data: {err_payload}\n\n")
+            finally:
+                if _token is not None:
+                    reset_request_context(_token)
             await queue.put(None)
 
         # Cleanup stale done tasks before adding new one

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -1,0 +1,182 @@
+"""Permission gate for agent tool access — interactive TUI/web dialogs instead of text errors.
+
+Flow:
+1. AgentManager.chat_stream() sets AgentRequestContext via ContextVar before spawning the backend task.
+2. Tool handlers (session-level wrapper in __init__.py, phone-level in _registry.py) call
+   PermissionGate.check() when a tool is blocked.
+3. check() puts a "permission_request" SSE event in ctx.queue and awaits an asyncio.Future.
+4. TUI: _stream_response() intercepts the event, shows PermissionDialog, resolves the future.
+   Web: JS intercepts the event, shows a menu, POSTs to /agent/threads/.../permission/<request_id>.
+5. choice "once"  → allow this single call (no override stored)
+   choice "session" → store in _session_overrides[(session_id, thread_id)], allow
+   choice "deny"  → return _text_response error to the LLM
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Per-request context (set by AgentManager.chat_stream, inherited by the
+# backend task via asyncio.create_task which copies the current context).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentRequestContext:
+    session_id: str                   # "tui" in TUI mode, HTTP session cookie in web
+    thread_id: int
+    queue: asyncio.Queue              # SSE queue for this request
+    db_permissions: dict[str, bool]   # from load_tool_permissions_union at call time
+
+
+_request_ctx: ContextVar[AgentRequestContext | None] = ContextVar(
+    "agent_request_ctx", default=None
+)
+
+
+def get_request_context() -> AgentRequestContext | None:
+    """Return the current request context (None outside of agent chat_stream)."""
+    return _request_ctx.get()
+
+
+def set_request_context(ctx: AgentRequestContext):
+    """Set the request context and return the reset token."""
+    return _request_ctx.set(ctx)
+
+
+def reset_request_context(token) -> None:
+    _request_ctx.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Module-level gate accessor (set by AgentManager after construction).
+# Allows _registry.py to access the gate without circular imports.
+# ---------------------------------------------------------------------------
+
+_active_gate: PermissionGate | None = None
+
+
+def get_gate() -> PermissionGate | None:
+    """Return the active PermissionGate, or None if not in use."""
+    return _active_gate
+
+
+def set_gate(gate: PermissionGate | None) -> None:
+    global _active_gate  # noqa: PLW0603
+    _active_gate = gate
+
+
+# ---------------------------------------------------------------------------
+# PermissionGate
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PermissionGate:
+    """Manages runtime permission overrides for agent tool access.
+
+    Session overrides are in-memory only, never persisted to DB.
+    Each (session_id, thread_id) pair has its own set of approved tools.
+    """
+
+    # (session_id, thread_id) → set of tool bare names approved for the session
+    _session_overrides: dict[tuple[str, int], set[str]] = field(default_factory=dict)
+    # request_id (UUID str) → Future that resolves with "once"|"session"|"deny"
+    _pending: dict[str, asyncio.Future] = field(default_factory=dict)
+
+    def is_session_approved(self, tool_name: str, session_id: str, thread_id: int) -> bool:
+        """True if tool was previously approved for this (session_id, thread_id)."""
+        key = (session_id, thread_id)
+        return tool_name in self._session_overrides.get(key, set())
+
+    async def check(self, tool_name: str, phone: str) -> dict | None:
+        """Check if tool/phone is allowed; show permission dialog if not.
+
+        Returns None (proceed) or a _text_response dict (deny).
+        Reads context from ContextVar — must be called inside a backend task.
+
+        Args:
+            tool_name: bare tool name (e.g. "refresh_dialogs")
+            phone: phone number for phone-level checks, or "" for session-level
+        """
+        ctx = get_request_context()
+        if ctx is None:
+            # No context set (e.g. one-shot CLI mode) — fall through to caller
+            return None
+
+        # Already approved for this session+thread?
+        if self.is_session_approved(tool_name, ctx.session_id, ctx.thread_id):
+            return None
+
+        # Ask user
+        request_id = str(uuid.uuid4())
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+        self._pending[request_id] = future
+
+        event = json.dumps(
+            {
+                "type": "permission_request",
+                "request_id": request_id,
+                "tool": tool_name,
+                "phone": phone,
+            },
+            ensure_ascii=False,
+        )
+        await ctx.queue.put(f"data: {event}\n\n")
+
+        try:
+            choice: str = await future
+        except asyncio.CancelledError:
+            self._pending.pop(request_id, None)
+            return _text_response(f"❌ Запрос разрешения для '{tool_name}' отменён.")
+        finally:
+            self._pending.pop(request_id, None)
+
+        if choice == "session":
+            key = (ctx.session_id, ctx.thread_id)
+            self._session_overrides.setdefault(key, set()).add(tool_name)
+            logger.info("Session permission granted: %s for (%s, %d)", tool_name, ctx.session_id, ctx.thread_id)
+            return None
+        elif choice == "once":
+            logger.info("One-time permission granted: %s", tool_name)
+            return None
+        else:
+            logger.info("Permission denied by user: %s", tool_name)
+            return _text_response(f"❌ Доступ к '{tool_name}' запрещён пользователем.")
+
+    def resolve(self, request_id: str, choice: str) -> bool:
+        """Resolve a pending permission request.
+
+        Args:
+            request_id: UUID from the "permission_request" SSE event
+            choice: "once", "session", or "deny"
+
+        Returns True if the request was found and resolved, False otherwise.
+        """
+        future = self._pending.get(request_id)
+        if future is None:
+            logger.warning("resolve() called for unknown request_id=%s", request_id)
+            return False
+        if not future.done():
+            future.set_result(choice)
+        return True
+
+    def clear_session(self, session_id: str, thread_id: int) -> None:
+        """Clear session overrides for a specific (session_id, thread_id) pair.
+
+        Called when switching threads in TUI.
+        """
+        self._session_overrides.pop((session_id, thread_id), None)
+
+
+def _text_response(text: str) -> dict:
+    return {"content": [{"type": "text", "text": text}]}

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -118,8 +118,7 @@ class PermissionGate:
 
         # Ask user
         request_id = str(uuid.uuid4())
-        loop = asyncio.get_event_loop()
-        future: asyncio.Future = loop.create_future()
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
 
         event = json.dumps(
@@ -134,10 +133,13 @@ class PermissionGate:
         await ctx.queue.put(f"data: {event}\n\n")
 
         try:
-            choice: str = await future
+            choice: str = await asyncio.wait_for(future, timeout=300)
+        except asyncio.TimeoutError:
+            self._pending.pop(request_id, None)
+            return _text_response(f"❌ Таймаут запроса разрешения для '{tool_name}' (5 мин).")
         except asyncio.CancelledError:
             self._pending.pop(request_id, None)
-            return _text_response(f"❌ Запрос разрешения для '{tool_name}' отменён.")
+            raise
         finally:
             self._pending.pop(request_id, None)
 

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -8,9 +8,43 @@ Usage::
 
 from __future__ import annotations
 
-from claude_agent_sdk import create_sdk_mcp_server
+import functools
+
+from claude_agent_sdk import SdkMcpTool, create_sdk_mcp_server
 
 from src.agent.tools._registry import _text_response  # noqa: F401
+
+
+def _wrap_with_session_gate(tool: SdkMcpTool) -> SdkMcpTool:
+    """Wrap a SdkMcpTool with a session-level permission check.
+
+    If the tool is disabled in DB settings for all phones (db_permissions[tool_name] == False)
+    and a PermissionGate is active, shows an interactive dialog instead of blocking silently.
+    Phone-level checks are handled separately inside require_phone_permission().
+    """
+    tool_name = tool.name
+    original_handler = tool.handler
+
+    @functools.wraps(original_handler)
+    async def wrapped_handler(*args, **kwargs):
+        from src.agent.permission_gate import get_gate, get_request_context
+
+        gate = get_gate()
+        if gate is not None:
+            ctx = get_request_context()
+            if ctx is not None and not ctx.db_permissions.get(tool_name, True):
+                result = await gate.check(tool_name, kwargs.get("phone", ""))
+                if result is not None:
+                    return result
+        return await original_handler(*args, **kwargs)
+
+    return SdkMcpTool(
+        name=tool.name,
+        description=tool.description,
+        input_schema=tool.input_schema,
+        handler=wrapped_handler,
+        annotations=tool.annotations,
+    )
 
 
 def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
@@ -71,7 +105,8 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
         settings,
         agent_threads,
     ]:
-        all_tools.extend(module.register(db, client_pool, embedding_service, **extras))
+        for tool_obj in module.register(db, client_pool, embedding_service, **extras):
+            all_tools.append(_wrap_with_session_gate(tool_obj))
 
     return create_sdk_mcp_server(
         name="telegram_db",

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -73,7 +73,8 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
 
     If db has no phone permissions configured, returns None (all phones allowed).
     If phone is in allowed list for this tool, returns None (proceed).
-    Otherwise returns a message with list of allowed phones so agent can retry.
+    Otherwise: if a PermissionGate is active (TUI/web mode), shows an interactive
+    permission dialog instead of a plain error.  Falls back to text error if no gate.
     """
     try:
         from src.agent.tools.permissions import TOOL_PERMISSIONS_SETTING
@@ -96,7 +97,13 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
         return None
     if phone in allowed_phones:
         return None  # phone is allowed
-    # Phone not allowed — return list of allowed phones so agent can retry
+    # Phone not allowed — try permission gate first
+    from src.agent.permission_gate import get_gate
+
+    gate = get_gate()
+    if gate is not None:
+        return await gate.check(tool_name, phone)
+    # No gate (one-shot CLI mode) — return text error with allowed phones
     phones_str = ", ".join(allowed_phones)
     if not phone:
         msg = (

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -14,8 +14,9 @@ from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.reactive import reactive
+from textual.screen import ModalScreen
 from textual.widget import Widget
-from textual.widgets import Button, Footer, Header, Label, Markdown, Static, TextArea
+from textual.widgets import Button, Footer, Header, Label, ListItem, ListView, Markdown, Static, TextArea
 from textual.worker import WorkerState
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ class ThreadItem(Widget):
         super().__init__()
         self.thread_id = thread_id
         self._title = title
+        self.tooltip = "Ctrl+D — удалить тред"
         if active:
             self.add_class("active")
 
@@ -159,6 +161,92 @@ class ThreadSidebar(Container):
             item.set_active(item.thread_id == thread_id)
 
 
+class PermissionDialog(ModalScreen):
+    """Bottom-docked permission request menu in Claude Code style.
+
+    Shows when the agent needs access to a restricted tool.
+    Returns "once", "session", or "deny" via self.dismiss().
+    """
+
+    DEFAULT_CSS = """
+    PermissionDialog {
+        align: center bottom;
+    }
+    #permission-box {
+        background: $surface;
+        border: solid $primary;
+        width: 70;
+        height: auto;
+        padding: 1 2;
+        dock: bottom;
+    }
+    #permission-header {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+    #permission-tool {
+        color: $accent;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    #permission-list {
+        height: auto;
+        margin-bottom: 1;
+    }
+    #permission-hint {
+        color: $text-muted;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "deny", "Отмена"),
+        Binding("1", "choose_once", show=False),
+        Binding("2", "choose_session", show=False),
+        Binding("3", "choose_deny", show=False),
+    ]
+
+    def __init__(self, tool_name: str, phone: str) -> None:
+        super().__init__()
+        self._tool_name = tool_name
+        self._phone = phone
+
+    def compose(self) -> ComposeResult:
+        phone_part = f" ({self._phone})" if self._phone else ""
+        with Container(id="permission-box"):
+            yield Label("Агент хочет использовать:", id="permission-header")
+            yield Label(f"{self._tool_name}{phone_part}", id="permission-tool")
+            with ListView(id="permission-list"):
+                yield ListItem(Label("> 1. Разрешить один раз"), id="item-once")
+                yield ListItem(Label("  2. Разрешить в этой сессии"), id="item-session")
+                yield ListItem(Label("  3. Запретить"), id="item-deny")
+            yield Label("Esc · ↑↓ навигация · Enter выбор", id="permission-hint")
+
+    def on_mount(self) -> None:
+        self.query_one(ListView).focus()
+
+    @on(ListView.Selected)
+    def on_list_selected(self, event: ListView.Selected) -> None:
+        item_id = event.item.id
+        if item_id == "item-once":
+            self.dismiss("once")
+        elif item_id == "item-session":
+            self.dismiss("session")
+        else:
+            self.dismiss("deny")
+
+    def action_deny(self) -> None:
+        self.dismiss("deny")
+
+    def action_choose_once(self) -> None:
+        self.dismiss("once")
+
+    def action_choose_session(self) -> None:
+        self.dismiss("session")
+
+    def action_choose_deny(self) -> None:
+        self.dismiss("deny")
+
+
 class AgentTuiApp(App):
     """Interactive TUI chat with agent."""
 
@@ -230,6 +318,11 @@ class AgentTuiApp(App):
         self.config = config
         self.agent_manager = agent_manager
         self._stream_worker = None
+        # Activate interactive permission dialogs for TUI mode
+        self.agent_manager.enable_permission_gate()
+
+    def on_unmount(self) -> None:
+        self.agent_manager.disable_permission_gate()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -352,11 +445,19 @@ class AgentTuiApp(App):
         messages_container = self.query_one("#messages", VerticalScroll)
         full_text = ""
         try:
-            async for chunk in self.agent_manager.chat_stream(thread_id, message, model=model):
+            async for chunk in self.agent_manager.chat_stream(
+                thread_id, message, model=model, session_id="tui"
+            ):
                 raw = chunk.removeprefix("data: ").strip()
                 try:
                     payload = json.loads(raw)
                 except json.JSONDecodeError:
+                    continue
+                if payload.get("type") == "permission_request":
+                    # Show interactive permission menu; tool handler is awaiting the Future
+                    dialog = PermissionDialog(payload["tool"], payload.get("phone", ""))
+                    choice = await self.push_screen_wait(dialog)
+                    self.agent_manager.permission_gate.resolve(payload["request_id"], choice)
                     continue
                 if "text" in payload:
                     full_text += payload["text"]

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -97,6 +97,7 @@ class ClientPool:
         self._dialogs_fetched: set[str] = set()
         self._dialogs_cache: dict[tuple[str, str], DialogCacheEntry] = {}
         self._dialogs_cache_ttl_sec = 60.0
+        self._dialogs_db_cache_ttl_sec = 3600.0  # 1 hour; stale DB cache triggers fresh Telegram fetch
         self._premium_flood_wait_until: dict[str, datetime] = {}
 
     def is_dialogs_fetched(self, phone: str) -> bool:
@@ -119,6 +120,17 @@ class ClientPool:
         full_dialogs = await self._db.repos.dialog_cache.list_dialogs(phone)
         if not full_dialogs:
             return None
+        cached_at = await self._db.repos.dialog_cache.get_cached_at(phone)
+        if cached_at is not None:
+            age_sec = (datetime.now(timezone.utc) - cached_at).total_seconds()
+            if age_sec > self._dialogs_db_cache_ttl_sec:
+                logger.info(
+                    "_get_db_cached_dialogs: stale cache for %s age=%.0fs > ttl=%.0fs, forcing refresh",
+                    phone,
+                    age_sec,
+                    self._dialogs_db_cache_ttl_sec,
+                )
+                return None
         if mode == "channels_only":
             filtered = [
                 dict(dialog)

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -182,6 +182,24 @@ async def inject_context(request: Request, thread_id: int):
     return JSONResponse({"content": content})
 
 
+@router.post("/threads/{thread_id}/permission/{request_id}")
+async def resolve_permission(request: Request, thread_id: int, request_id: str):
+    """Resolve a pending permission request from the agent.
+
+    Called by the browser after the user picks a choice in the permission dialog.
+    Body: {"choice": "once"|"session"|"deny"}
+    """
+    body = await request.json()
+    choice = body.get("choice", "deny")
+    if choice not in ("once", "session", "deny"):
+        raise HTTPException(status_code=400, detail="Invalid choice")
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is None:
+        raise HTTPException(status_code=503, detail="AgentManager not initialized")
+    ok = agent_manager.permission_gate.resolve(request_id, choice)
+    return JSONResponse({"ok": ok})
+
+
 @router.post("/threads/{thread_id}/stop")
 async def stop_chat(request: Request, thread_id: int):
     db = deps.get_db(request)
@@ -235,8 +253,11 @@ async def chat(request: Request, thread_id: int):
     if thread["title"] == "Новый тред":
         await db.rename_agent_thread(thread_id, message[:60])
 
+    # Use HTTP session cookie as session_id so per-user overrides are isolated
+    session_id = request.cookies.get("session", "web")
+
     async def generate():
-        async for chunk in agent_manager.chat_stream(thread_id, message, model=model):
+        async for chunk in agent_manager.chat_stream(thread_id, message, model=model, session_id=session_id):
             try:
                 data_str = chunk.removeprefix("data: ").strip()
                 data = json.loads(data_str)

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -82,6 +82,10 @@ async def create_thread(request: Request):
 async def delete_thread(request: Request, thread_id: int):
     db = deps.get_db(request)
     await db.delete_agent_thread(thread_id)
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is not None and agent_manager.permission_gate is not None:
+        session_id = request.cookies.get("session", "web")
+        agent_manager.permission_gate.clear_session(session_id, thread_id)
     return {"ok": True}
 
 

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -697,15 +697,21 @@
     }
 
     // Permission request dialog — menu style with keyboard shortcuts (1/2/3 + Enter)
+    function escapeHtml(s) {
+        var d = document.createElement('div');
+        d.textContent = s;
+        return d.innerHTML;
+    }
+
     function showPermissionDialog(toolName, phone) {
         return new Promise(function(resolve) {
-            var phoneStr = phone ? ' (' + phone + ')' : '';
+            var phoneStr = phone ? ' (' + escapeHtml(phone) + ')' : '';
             var modal = document.createElement('div');
             modal.id = 'permission-modal';
             modal.innerHTML =
                 '<div id="permission-box">' +
                 '<div class="perm-header">Агент хочет использовать:</div>' +
-                '<div class="perm-tool">' + toolName + phoneStr + '</div>' +
+                '<div class="perm-tool">' + escapeHtml(toolName) + phoneStr + '</div>' +
                 '<div class="perm-menu">' +
                 '<div class="perm-item" data-choice="once" tabindex="0"><span class="perm-cursor">&gt;</span> 1. Разрешить один раз</div>' +
                 '<div class="perm-item" data-choice="session" tabindex="0">  2. Разрешить в этой сессии</div>' +
@@ -908,11 +914,22 @@
                         var data = JSON.parse(jsonStr);
                         if (data.type === 'permission_request') {
                             var choice = await showPermissionDialog(data.tool, data.phone || '');
-                            await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
-                                method: 'POST',
-                                headers: {'Content-Type': 'application/json'},
-                                body: JSON.stringify({choice: choice})
-                            });
+                            try {
+                                await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
+                                    method: 'POST',
+                                    headers: {'Content-Type': 'application/json'},
+                                    body: JSON.stringify({choice: choice})
+                                });
+                            } catch (fetchErr) {
+                                console.error('Permission POST failed, sending deny:', fetchErr);
+                                try {
+                                    await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
+                                        method: 'POST',
+                                        headers: {'Content-Type': 'application/json'},
+                                        body: JSON.stringify({choice: 'deny'})
+                                    });
+                                } catch (_) { /* server-side timeout will handle it */ }
+                            }
                         } else if (data.error) {
                             aiBubble.className = 'message-error';
                             aiBubble.textContent = data.error;

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -445,6 +445,37 @@
         text-align: left;
     }
 }
+
+/* Permission request dialog */
+#permission-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 2000;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 1rem;
+}
+#permission-box {
+    background: var(--bs-dark-bg-subtle, #1e1e2e);
+    border: 1px solid var(--bs-primary);
+    border-radius: 6px;
+    padding: 1rem 1.5rem;
+    min-width: 360px;
+    max-width: 520px;
+    font-family: var(--bs-font-monospace, monospace);
+}
+.perm-header { color: var(--bs-secondary-color); margin-bottom: 0.25rem; font-size: 0.85rem; }
+.perm-tool { color: var(--bs-info); font-weight: 600; margin-bottom: 0.75rem; }
+.perm-item {
+    padding: 0.2rem 0;
+    cursor: pointer;
+    white-space: pre;
+    color: var(--bs-body-color);
+}
+.perm-item.perm-selected { color: var(--bs-primary); }
+.perm-hint { margin-top: 0.75rem; color: var(--bs-secondary-color); font-size: 0.8rem; }
 </style>
 {% endblock %}
 
@@ -665,6 +696,60 @@
         return marked.parse(text || '');
     }
 
+    // Permission request dialog — menu style with keyboard shortcuts (1/2/3 + Enter)
+    function showPermissionDialog(toolName, phone) {
+        return new Promise(function(resolve) {
+            var phoneStr = phone ? ' (' + phone + ')' : '';
+            var modal = document.createElement('div');
+            modal.id = 'permission-modal';
+            modal.innerHTML =
+                '<div id="permission-box">' +
+                '<div class="perm-header">Агент хочет использовать:</div>' +
+                '<div class="perm-tool">' + toolName + phoneStr + '</div>' +
+                '<div class="perm-menu">' +
+                '<div class="perm-item" data-choice="once" tabindex="0"><span class="perm-cursor">&gt;</span> 1. Разрешить один раз</div>' +
+                '<div class="perm-item" data-choice="session" tabindex="0">  2. Разрешить в этой сессии</div>' +
+                '<div class="perm-item" data-choice="deny" tabindex="0">  3. Запретить</div>' +
+                '</div>' +
+                '<div class="perm-hint">↑↓ навигация &nbsp;·&nbsp; Enter выбор &nbsp;·&nbsp; Esc = Запретить</div>' +
+                '</div>';
+            document.body.appendChild(modal);
+
+            var items = modal.querySelectorAll('.perm-item');
+            var selected = 0;
+
+            function highlight() {
+                items.forEach(function(el, i) {
+                    el.querySelector('.perm-cursor').textContent = i === selected ? '>' : ' ';
+                    el.classList.toggle('perm-selected', i === selected);
+                });
+            }
+
+            function pick(choice) {
+                document.body.removeChild(modal);
+                document.removeEventListener('keydown', onKey);
+                resolve(choice);
+            }
+
+            function onKey(e) {
+                if (e.key === 'ArrowUp' || e.key === 'k') { selected = (selected + 2) % 3; highlight(); e.preventDefault(); }
+                else if (e.key === 'ArrowDown' || e.key === 'j') { selected = (selected + 1) % 3; highlight(); e.preventDefault(); }
+                else if (e.key === 'Enter') { pick(items[selected].dataset.choice); e.preventDefault(); }
+                else if (e.key === 'Escape') { pick('deny'); e.preventDefault(); }
+                else if (e.key === '1') pick('once');
+                else if (e.key === '2') pick('session');
+                else if (e.key === '3') pick('deny');
+            }
+
+            items.forEach(function(el, i) {
+                el.addEventListener('click', function() { pick(el.dataset.choice); });
+            });
+
+            document.addEventListener('keydown', onKey);
+            highlight();
+        });
+    }
+
     // Render existing assistant messages loaded from DB
     document.querySelectorAll('[data-md]').forEach(function(el) {
         el.innerHTML = renderMd(el.textContent);
@@ -821,7 +906,14 @@
                     var jsonStr = line.slice(5).trim();
                     try {
                         var data = JSON.parse(jsonStr);
-                        if (data.error) {
+                        if (data.type === 'permission_request') {
+                            var choice = await showPermissionDialog(data.tool, data.phone || '');
+                            await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
+                                method: 'POST',
+                                headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({choice: choice})
+                            });
+                        } else if (data.error) {
                             aiBubble.className = 'message-error';
                             aiBubble.textContent = data.error;
                             fullText = data.error;

--- a/tests/test_coverage_90_push.py
+++ b/tests/test_coverage_90_push.py
@@ -472,12 +472,14 @@ class TestClientPoolProperties:
         pool = ClientPool.__new__(ClientPool)
         pool._dialogs_cache = {}
         pool._dialogs_cache_ttl_sec = 300
+        pool._dialogs_db_cache_ttl_sec = 3600.0
         pool._db = MagicMock()
         pool._db.repos = MagicMock()
         pool._db.repos.dialog_cache = MagicMock()
         pool._db.repos.dialog_cache.list_dialogs = AsyncMock(
             return_value=[{"id": 1, "channel_type": "channel"}, {"id": 2, "channel_type": "dm"}]
         )
+        pool._db.repos.dialog_cache.get_cached_at = AsyncMock(return_value=datetime.now(timezone.utc))
         result = await pool._get_db_cached_dialogs("+1", "full")
         assert result is not None
         assert len(result) == 2
@@ -489,12 +491,14 @@ class TestClientPoolProperties:
         pool = ClientPool.__new__(ClientPool)
         pool._dialogs_cache = {}
         pool._dialogs_cache_ttl_sec = 300
+        pool._dialogs_db_cache_ttl_sec = 3600.0
         pool._db = MagicMock()
         pool._db.repos = MagicMock()
         pool._db.repos.dialog_cache = MagicMock()
         pool._db.repos.dialog_cache.list_dialogs = AsyncMock(
             return_value=[{"id": 1, "channel_type": "channel"}, {"id": 2, "channel_type": "dm"}]
         )
+        pool._db.repos.dialog_cache.get_cached_at = AsyncMock(return_value=datetime.now(timezone.utc))
         result = await pool._get_db_cached_dialogs("+1", "channels_only")
         assert result is not None
         assert len(result) == 1  # dm filtered out

--- a/tests/test_my_telegram.py
+++ b/tests/test_my_telegram.py
@@ -82,6 +82,7 @@ def _bind_dialog_cache_methods(pool):
 
     pool._dialogs_cache = {}
     pool._dialogs_cache_ttl_sec = 60.0
+    pool._dialogs_db_cache_ttl_sec = 3600.0
     pool.invalidate_dialogs_cache = ClientPool.invalidate_dialogs_cache.__get__(pool, ClientPool)
     pool._get_cached_dialogs = ClientPool._get_cached_dialogs.__get__(pool, ClientPool)
     pool._get_db_cached_dialogs = ClientPool._get_db_cached_dialogs.__get__(pool, ClientPool)


### PR DESCRIPTION
## Summary

- **PermissionGate** — новый класс (`src/agent/permission_gate.py`) перехватывает вызовы заблокированных инструментов и показывает интерактивное меню вместо текстовой ошибки LLM
- **TUI**: Textual `ModalScreen` с меню снизу экрана (стиль Claude Code) — клавиши 1/2/3, стрелки, Enter, Esc; сессионные разрешения хранятся в памяти per `(session_id, thread_id)`
- **Web**: JS-оверлей с тем же меню; браузер POSTит выбор на новый endpoint `POST /agent/threads/{id}/permission/{request_id}`
- **Fix**: ContextVar токен создаётся и сбрасывается внутри `_run_backend` таска (исправляет `ValueError: token created in a different context`)
- **UX**: tooltip «Ctrl+D — удалить тред» на элементах сайдбара

## Test plan

- [ ] TUI: `python -m src.main agent chat` → отключить инструмент в Settings → попросить агента использовать его → появляется меню → «Разрешить один раз» → агент выполняет, следующий вызов снова спрашивает → «Разрешить в сессии» → больше не спрашивает в этом треде → переключить тред → снова спрашивает
- [ ] Web: аналогичный сценарий в `/agent`
- [ ] Без gate (CLI one-shot): поведение не изменилось, текстовая ошибка LLM
- [ ] `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — нет регрессий

🤖 Generated with [Claude Code](https://claude.com/claude-code)