### PR TITLE
fix(agent): enable streaming text output in TUI and Web

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -178,7 +178,7 @@ class ClaudeSdkBackend:
                                 event.get("type") == "content_block_delta"
                                 and event.get("delta", {}).get("type") == "text_delta"
                             ):
-                                text_chunk = event["delta"]["text"]
+                                text_chunk = event["delta"].get("text", "")
                                 full_text += text_chunk
                                 streamed = True
                                 chunk_payload = json.dumps({"text": text_chunk}, ensure_ascii=False)

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, TypeVar
 
-from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, TextBlock, query
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, StreamEvent, TextBlock, query
 
 from src.agent.models import CLAUDE_MODEL_IDS
 from src.agent.prompt_template import (
@@ -158,6 +158,7 @@ class ClaudeSdkBackend:
             allowed_tools=allowed,
             cli_path=cli_path or None,
             stderr=_on_stderr,
+            include_partial_messages=True,
             **extra,
         )
 
@@ -165,19 +166,32 @@ class ClaudeSdkBackend:
         for attempt in range(2):
             draining = False
             full_text = ""
+            streamed = False
             try:
                 async for msg in query(prompt=prompt, options=options):
                     if draining:
                         continue
                     try:
-                        if isinstance(msg, AssistantMessage):
-                            for block in msg.content:
-                                if isinstance(block, TextBlock):
-                                    full_text += block.text
-                                    chunk_payload = json.dumps(
-                                        {"text": block.text}, ensure_ascii=False
-                                    )
-                                    await queue.put(f"data: {chunk_payload}\n\n")
+                        if isinstance(msg, StreamEvent):
+                            event = msg.event
+                            if (
+                                event.get("type") == "content_block_delta"
+                                and event.get("delta", {}).get("type") == "text_delta"
+                            ):
+                                text_chunk = event["delta"]["text"]
+                                full_text += text_chunk
+                                streamed = True
+                                chunk_payload = json.dumps({"text": text_chunk}, ensure_ascii=False)
+                                await queue.put(f"data: {chunk_payload}\n\n")
+                        elif isinstance(msg, AssistantMessage):
+                            if not streamed:
+                                for block in msg.content:
+                                    if isinstance(block, TextBlock):
+                                        full_text += block.text
+                                        chunk_payload = json.dumps(
+                                            {"text": block.text}, ensure_ascii=False
+                                        )
+                                        await queue.put(f"data: {chunk_payload}\n\n")
                         elif isinstance(msg, ResultMessage):
                             done_payload = json.dumps(
                                 {"done": True, "full_text": full_text, "backend": "claude"},

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -179,10 +179,11 @@ class ClaudeSdkBackend:
                                 and event.get("delta", {}).get("type") == "text_delta"
                             ):
                                 text_chunk = event["delta"].get("text", "")
-                                full_text += text_chunk
-                                streamed = True
-                                chunk_payload = json.dumps({"text": text_chunk}, ensure_ascii=False)
-                                await queue.put(f"data: {chunk_payload}\n\n")
+                                if text_chunk:
+                                    full_text += text_chunk
+                                    streamed = True
+                                    chunk_payload = json.dumps({"text": text_chunk}, ensure_ascii=False)
+                                    await queue.put(f"data: {chunk_payload}\n\n")
                         elif isinstance(msg, AssistantMessage):
                             if not streamed:
                                 for block in msg.content:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -72,6 +72,89 @@ async def test_agent_chat_stream_mocked(db):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_stream_events_yield_incremental_chunks(db):
+    """StreamEvent content_block_delta/text_delta chunks are forwarded as SSE data."""
+    thread_id = await db.create_agent_thread("stream-event thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, StreamEvent, TextBlock
+
+    # Simulate three incremental text chunks via StreamEvent
+    def _stream_event(text: str) -> MagicMock:
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}}
+        return ev
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="приветмир")]  # full text — should be skipped
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield _stream_event("привет")
+        yield _stream_event(" ")
+        yield _stream_event("мир")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+
+    # Incremental text chunks must be present
+    text_payloads = [p for p in payloads if "text" in p and not p.get("done")]
+    assert len(text_payloads) == 3, f"ожидали 3 текстовых чанка, получили: {text_payloads}"
+    assert text_payloads[0]["text"] == "привет"
+    assert text_payloads[1]["text"] == " "
+    assert text_payloads[2]["text"] == "мир"
+
+    # AssistantMessage text must NOT be duplicated when StreamEvents were received
+    all_text = "".join(p["text"] for p in text_payloads)
+    assert all_text == "привет мир", f"суммарный текст не совпадает: {all_text!r}"
+
+    # Done signal must be present with correct full_text
+    done_payloads = [p for p in payloads if p.get("done")]
+    assert done_payloads, "не найден done-payload"
+    assert done_payloads[0]["full_text"] == "привет мир"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_fallback_to_assistant_message_when_no_stream_events(db):
+    """When no StreamEvents arrive, AssistantMessage text is used as fallback."""
+    thread_id = await db.create_agent_thread("fallback thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="fallback text")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    text_payloads = [p for p in payloads if "text" in p and not p.get("done")]
+    assert any(p["text"] == "fallback text" for p in text_payloads), (
+        f"AssistantMessage текст не найден в чанках: {text_payloads}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_agent_chat_stream_renders_saved_prompt_template_variables(db):
     await db.set_setting(
         AGENT_PROMPT_TEMPLATE_SETTING,


### PR DESCRIPTION
## Summary
* ClaudeSdkBackend now passes `include_partial_messages=True` to `ClaudeAgentOptions`, enabling the CLI to emit `stream_event` deltas
* Added `StreamEvent` handler in `chat_stream()` that forwards `content_block_delta`/`text_delta` chunks as SSE frames in real-time
* `streamed` flag prevents double-emitting when both `StreamEvent` chunks and the final `AssistantMessage` arrive

## Test plan
- [x] `test_chat_stream_stream_events_yield_incremental_chunks` — verifies 3 incremental SSE chunks + no duplication
- [x] `test_chat_stream_fallback_to_assistant_message_when_no_stream_events` — verifies fallback when no StreamEvents
- [x] All 73 existing tests pass
- [ ] Manual: `python -m src.main agent chat` — text appears incrementally

🤖 Generated with [Claude Code](https://claude.com/claude-code)