### PR TITLE
fix(pool): auto-reconnect disconnected Telegram clients

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -583,6 +583,18 @@ class ClientPool:
         phone = account_lease.account.phone
         # force_native bypasses the persistent pool session — callers need a raw native client
         direct_session = None if force_native else self._direct_session(phone)
+
+        # Auto-reconnect: if the cached session's connection dropped (Stream closed),
+        # attempt to reconnect before using it; fall back to backend on failure.
+        if direct_session is not None and not direct_session.raw_client.is_connected():
+            logger.warning("Client for %s disconnected, attempting auto-reconnect", phone)
+            try:
+                await direct_session.raw_client.connect()
+            except Exception:
+                logger.exception("Auto-reconnect failed for %s, falling back to backend", phone)
+                self.clients.pop(phone, None)
+                direct_session = None
+
         lease: BackendClientLease | None = None
         try:
             if direct_session is not None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -239,6 +239,7 @@ class FakeCliTelethonClient:
         self.flood_sleep_threshold = 60
         self.connect = AsyncMock()
         self.disconnect = AsyncMock()
+        self.is_connected = MagicMock(return_value=True)
         self.is_user_authorized = AsyncMock(return_value=authorized)
         self.get_me = AsyncMock(side_effect=self._get_me)
         self.download_profile_photo = AsyncMock(side_effect=self._download_profile_photo)

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -206,8 +206,8 @@ async def test_acquire_reconnects_disconnected_client(
     await harness.add_account("+70000000001", session_string="s1", is_primary=True)
     await harness.initialize_connected_accounts()
 
-    # Simulate connection drop: is_connected returns False, then True after connect()
-    cli_client.is_connected = MagicMock(side_effect=[False, True])
+    # Simulate connection drop: is_connected() is called once in _acquire_from_lease
+    cli_client.is_connected = MagicMock(return_value=False)
 
     acquired = await harness.pool.get_client_by_phone("+70000000001")
 

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from telethon_cli.errors import CLIError
@@ -191,3 +191,59 @@ async def test_notification_target_uses_real_pool_native_getter(
         assert phone == "+70000000001"
 
     native_client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_acquire_reconnects_disconnected_client(
+    real_pool_harness_factory,
+):
+    """When cached client is disconnected, _acquire_from_lease auto-reconnects it."""
+    harness = real_pool_harness_factory()
+    cli_client = harness.queue_cli_client(
+        phone="+70000000001",
+        client=FakeCliTelethonClient(),
+    )
+    await harness.add_account("+70000000001", session_string="s1", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    # Simulate connection drop: is_connected returns False, then True after connect()
+    cli_client.is_connected = MagicMock(side_effect=[False, True])
+
+    acquired = await harness.pool.get_client_by_phone("+70000000001")
+
+    assert acquired is not None
+    _, phone = acquired
+    assert phone == "+70000000001"
+    cli_client.connect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acquire_falls_back_to_backend_when_reconnect_fails(
+    real_pool_harness_factory,
+):
+    """When auto-reconnect fails, pool falls back to backend router for a fresh client."""
+    harness = real_pool_harness_factory()
+    cli_client = harness.queue_cli_client(
+        phone="+70000000001",
+        client=FakeCliTelethonClient(),
+    )
+    await harness.add_account("+70000000001", session_string="s1", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    # Simulate: disconnected + reconnect raises
+    cli_client.is_connected = MagicMock(return_value=False)
+    cli_client.connect = AsyncMock(side_effect=ConnectionError("reconnect failed"))
+
+    # Queue a fresh client for the backend fallback
+    fresh_client = harness.queue_cli_client(
+        phone="+70000000001",
+        client=FakeCliTelethonClient(),
+    )
+
+    acquired = await harness.pool.get_client_by_phone("+70000000001")
+
+    assert acquired is not None
+    _, phone = acquired
+    assert phone == "+70000000001"
+    # The dead client was evicted from self.clients
+    assert harness.pool.clients["+70000000001"].raw_client is fresh_client


### PR DESCRIPTION
## Summary
- **Root cause**: `ClientPool._direct_session()` returned cached `TelegramTransportSession` without checking `is_connected()`. When the Telegram connection dropped (Stream closed), the pool kept returning the dead client to all callers — agent tools, collection, etc.
- **Fix**: Added `is_connected()` check + auto-reconnect in `_acquire_from_lease()`. If reconnect fails, the dead session is evicted and a fresh client is acquired via backend router.
- **Tests**: 2 new tests — successful reconnect and fallback when reconnect fails. Added `is_connected` mock to `FakeCliTelethonClient`.

## Test plan
- [x] `pytest tests/test_client_pool_runtime.py -v` — 9/9 passed
- [x] `ruff check` — all checks passed
- [x] `python -m src.main messages read @alxz500 --live --limit 100` — live Telegram read works
- [x] Full test suite — 4088 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)