### PR TITLE
feat(agent): real-time tool call visibility & debug status line

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -1000,11 +1000,11 @@ class DeepagentsBackend:
                 await tracker.on_status(f"Пробую провайдер {cfg.provider}...")
             attempt += 1
             try:
+                agent_start = time.monotonic()
                 await tracker.on_first_event()
                 agent_label = f"{cfg.provider}/{cfg.selected_model or '?'}"
                 await tracker.on_tool_start("agent", 0)
 
-                agent_start = time.monotonic()
                 full_text = await asyncio.to_thread(
                     self._run_agent,
                     prompt,

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -334,6 +334,14 @@ class ClaudeSdkBackend:
                 # claude_agent_sdk raises RuntimeError with this text; no specific exception type
                 if attempt == 0 and "Control request timeout" in str(exc):
                     logger.warning("Agent init timeout, retrying (thread %d)", thread_id)
+                    if tracker._current_tool is not None:
+                        await tracker._put({
+                            "type": "tool_end",
+                            "tool": tracker._current_tool,
+                            "duration": 0,
+                            "is_error": True,
+                            "summary": "timeout",
+                        })
                     last_err = exc
                     continue
                 last_err = exc

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -1469,6 +1469,14 @@ class AgentManager:
                 del self._active_tasks[thread_id]
 
         task.add_done_callback(_cleanup)
+
+        # Immediate feedback before backend connects (can take 10-30s)
+        init_payload = json.dumps(
+            {"type": "status", "text": f"Подключение к {backend_name}..."},
+            ensure_ascii=False,
+        )
+        yield f"data: {init_payload}\n\n"
+
         try:
             while True:
                 item = await queue.get()

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -1042,6 +1042,14 @@ class DeepagentsBackend:
                 await queue.put(f"data: {done_payload}\n\n")
                 return
             except Exception as exc:
+                agent_duration = round(time.monotonic() - agent_start, 1)
+                await tracker._put({
+                    "type": "tool_end",
+                    "tool": "agent",
+                    "duration": agent_duration,
+                    "is_error": True,
+                    "summary": str(exc),
+                })
                 errors.append(f"{cfg.provider}: {exc}")
                 logger.warning("Deepagents provider failed (%s): %s", cfg.provider, exc)
         self._init_error = (

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -8,11 +8,20 @@ import shutil
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, TypeVar
 
-from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, StreamEvent, TextBlock, query
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    StreamEvent,
+    TextBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    query,
+)
 
 from src.agent.models import CLAUDE_MODEL_IDS
 from src.agent.prompt_template import (
@@ -58,6 +67,86 @@ _DEEPAGENTS_PROBE_PROMPT = (
 )
 _DEEPAGENTS_PROBE_TIMEOUT_SECONDS = 45.0
 _ToolResult = TypeVar("_ToolResult")
+
+
+def _summarize_tool_args(args: dict) -> str:
+    if not args:
+        return ""
+    first_key = next(iter(args))
+    first_val = str(args[first_key])
+    if len(first_val) > 60:
+        first_val = first_val[:57] + "..."
+    if len(args) > 1:
+        return f"{first_key}={first_val!r} (+{len(args) - 1})"
+    return f"{first_key}={first_val!r}"
+
+
+def _truncate(text: str, limit: int = 120) -> str:
+    return text[:limit - 3] + "..." if len(text) > limit else text
+
+
+@dataclass
+class _ToolTracker:
+    queue: asyncio.Queue
+    _current_tool: str | None = field(default=None, init=False)
+    _current_index: int | None = field(default=None, init=False)
+    _tool_start_time: float = field(default=0.0, init=False)
+    _input_chunks: list[str] = field(default_factory=list, init=False)
+    _thinking_sent: bool = field(default=False, init=False)
+    _tool_id_to_name: dict[str, str] = field(default_factory=dict, init=False)
+
+    async def _put(self, payload: dict) -> None:
+        await self.queue.put(f"data: {json.dumps(payload, ensure_ascii=False)}\n\n")
+        await asyncio.sleep(0)
+
+    async def on_first_event(self) -> None:
+        if not self._thinking_sent:
+            self._thinking_sent = True
+            await self._put({"type": "thinking"})
+
+    async def on_tool_start(self, name: str, index: int, tool_use_id: str = "") -> None:
+        self._current_tool = name
+        self._current_index = index
+        self._input_chunks = []
+        self._tool_start_time = time.monotonic()
+        if tool_use_id:
+            self._tool_id_to_name[tool_use_id] = name
+        await self._put({"type": "tool_start", "tool": name})
+
+    def accumulate_input(self, chunk: str) -> None:
+        self._input_chunks.append(chunk)
+
+    async def on_block_stop(self, index: int) -> None:
+        if self._current_tool is not None and self._current_index == index:
+            duration = round(time.monotonic() - self._tool_start_time, 1)
+            args_raw = "".join(self._input_chunks)
+            try:
+                args = json.loads(args_raw) if args_raw else {}
+            except json.JSONDecodeError:
+                args = {}
+            summary = _summarize_tool_args(args)
+            await self._put({
+                "type": "tool_end",
+                "tool": self._current_tool,
+                "duration": duration,
+                "is_error": False,
+                "summary": summary,
+            })
+            self._current_tool = None
+            self._current_index = None
+
+    async def on_tool_result(self, tool_use_id: str, content: str | None, is_error: bool) -> None:
+        tool_name = self._tool_id_to_name.get(tool_use_id, "tool")
+        summary = _truncate(content or "", 120) if content else ""
+        await self._put({
+            "type": "tool_result",
+            "tool": tool_name,
+            "is_error": is_error,
+            "summary": summary,
+        })
+
+    async def on_status(self, text: str) -> None:
+        await self._put({"type": "status", "text": text})
 
 
 @dataclass(slots=True)
@@ -172,6 +261,10 @@ class ClaudeSdkBackend:
 
         last_err: Exception | None = None
         for attempt in range(2):
+            if attempt > 0:
+                tracker_retry = _ToolTracker(queue=queue)
+                await tracker_retry.on_status("Повтор подключения к Claude...")
+            tracker = _ToolTracker(queue=queue)
             draining = False
             full_text = ""
             streamed = False
@@ -182,26 +275,52 @@ class ClaudeSdkBackend:
                     try:
                         if isinstance(msg, StreamEvent):
                             event = msg.event
-                            if (
-                                event.get("type") == "content_block_delta"
-                                and event.get("delta", {}).get("type") == "text_delta"
-                            ):
-                                text_chunk = event["delta"].get("text", "")
-                                if text_chunk:
-                                    full_text += text_chunk
-                                    streamed = True
-                                    chunk_payload = json.dumps({"text": text_chunk}, ensure_ascii=False)
-                                    await queue.put(f"data: {chunk_payload}\n\n")
-                                    await asyncio.sleep(0)
-                        elif isinstance(msg, AssistantMessage):
-                            if not streamed:
-                                for block in msg.content:
-                                    if isinstance(block, TextBlock):
-                                        full_text += block.text
+                            event_type = event.get("type")
+                            await tracker.on_first_event()
+
+                            if event_type == "content_block_start":
+                                block = event.get("content_block", {})
+                                if block.get("type") == "tool_use":
+                                    await tracker.on_tool_start(
+                                        block.get("name", "unknown"),
+                                        event.get("index", 0),
+                                        tool_use_id=block.get("id", ""),
+                                    )
+
+                            elif event_type == "content_block_delta":
+                                delta = event.get("delta", {})
+                                delta_type = delta.get("type")
+                                if delta_type == "text_delta":
+                                    text_chunk = delta.get("text", "")
+                                    if text_chunk:
+                                        full_text += text_chunk
+                                        streamed = True
                                         chunk_payload = json.dumps(
-                                            {"text": block.text}, ensure_ascii=False
+                                            {"text": text_chunk}, ensure_ascii=False
                                         )
                                         await queue.put(f"data: {chunk_payload}\n\n")
+                                        await asyncio.sleep(0)
+                                elif delta_type == "input_json_delta":
+                                    tracker.accumulate_input(delta.get("partial_json", ""))
+
+                            elif event_type == "content_block_stop":
+                                await tracker.on_block_stop(event.get("index", 0))
+
+                        elif isinstance(msg, AssistantMessage):
+                            for block in msg.content:
+                                if isinstance(block, TextBlock) and not streamed:
+                                    full_text += block.text
+                                    chunk_payload = json.dumps(
+                                        {"text": block.text}, ensure_ascii=False
+                                    )
+                                    await queue.put(f"data: {chunk_payload}\n\n")
+                                elif isinstance(block, ToolUseBlock):
+                                    tracker._tool_id_to_name[block.id] = block.name
+                                elif isinstance(block, ToolResultBlock):
+                                    content = block.content if isinstance(block.content, str) else ""
+                                    await tracker.on_tool_result(
+                                        block.tool_use_id, content, bool(block.is_error)
+                                    )
                         elif isinstance(msg, ResultMessage):
                             done_payload = json.dumps(
                                 {"done": True, "full_text": full_text, "backend": "claude"},
@@ -869,13 +988,23 @@ class DeepagentsBackend:
             enabled_count, len(permissions),
         )
 
+        tracker = _ToolTracker(queue=queue)
         errors: list[str] = []
+        attempt = 0
         for cfg in await self._candidate_configs():
             validation_error = self._validation_error(cfg)
             if validation_error:
                 errors.append(f"{cfg.provider}: {validation_error}")
                 continue
+            if attempt > 0:
+                await tracker.on_status(f"Пробую провайдер {cfg.provider}...")
+            attempt += 1
             try:
+                await tracker.on_first_event()
+                agent_label = f"{cfg.provider}/{cfg.selected_model or '?'}"
+                await tracker.on_tool_start("agent", 0)
+
+                agent_start = time.monotonic()
                 full_text = await asyncio.to_thread(
                     self._run_agent,
                     prompt,
@@ -884,6 +1013,16 @@ class DeepagentsBackend:
                     system_prompt=system_prompt,
                     permissions=permissions,
                 )
+
+                agent_duration = round(time.monotonic() - agent_start, 1)
+                await tracker._put({
+                    "type": "tool_end",
+                    "tool": "agent",
+                    "duration": agent_duration,
+                    "is_error": False,
+                    "summary": agent_label,
+                })
+
                 self._init_error = None
                 if not full_text:
                     logger.debug("Deepagents returned empty response for provider=%s", cfg.provider)

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -96,6 +96,8 @@ class StreamingMessage(Static):
         self._render_timer: asyncio.TimerHandle | None = None
         self._pending_render = False
         self._loading = True
+        self._status_label: str = ""
+        self._tool_start_time: float = 0.0
 
     def compose(self) -> ComposeResult:
         import time as _time
@@ -117,9 +119,20 @@ class StreamingMessage(Static):
             return
         import time as _time
 
-        elapsed = int(_time.monotonic() - self._start_time)
+        if self._tool_start_time > 0:
+            elapsed = round(_time.monotonic() - self._tool_start_time, 1)
+            text = f"🔧 {self._status_label}... ({elapsed}s)"
+        else:
+            elapsed = int(_time.monotonic() - self._start_time)
+            text = self._status_label or f"⏳ ({elapsed}s)"
         if self._elapsed_label is not None:
-            self._elapsed_label.update(f"⏳ ({elapsed}s)")
+            self._elapsed_label.update(text)
+
+    def update_status(self, label: str) -> None:
+        self._status_label = label
+        self._tool_start_time = 0.0
+        if self._elapsed_label is not None:
+            self._elapsed_label.update(label)
 
     def _stop_loading(self) -> None:
         self._loading = False
@@ -503,11 +516,32 @@ class AgentTuiApp(App):
                     payload = json.loads(raw)
                 except json.JSONDecodeError:
                     continue
-                if payload.get("type") == "permission_request":
+                event_type = payload.get("type")
+                if event_type == "permission_request":
                     # Show interactive permission menu; tool handler is awaiting the Future
                     dialog = PermissionDialog(payload["tool"], payload.get("phone", ""))
                     choice = await self.push_screen_wait(dialog)
                     self.agent_manager.permission_gate.resolve(payload["request_id"], choice)
+                    continue
+                if event_type == "thinking":
+                    widget.update_status("⏳ Думает...")
+                    continue
+                if event_type == "tool_start":
+                    import time as _time
+
+                    widget._status_label = payload.get("tool", "tool")
+                    widget._tool_start_time = _time.monotonic()
+                    continue
+                if event_type == "tool_end":
+                    tool = payload.get("tool", "tool")
+                    dur = payload.get("duration", 0)
+                    icon = "❌" if payload.get("is_error") else "✅"
+                    widget.update_status(f"🔧 {tool} {icon} ({dur}s)")
+                    continue
+                if event_type == "status":
+                    widget.update_status(f"⏳ {payload.get('text', '')}")
+                    continue
+                if event_type in ("tool_result",):
                     continue
                 if "text" in payload:
                     full_text += payload["text"]

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -122,9 +122,12 @@ class StreamingMessage(Static):
         if self._tool_start_time > 0:
             elapsed = round(_time.monotonic() - self._tool_start_time, 1)
             text = f"🔧 {self._status_label}... ({elapsed}s)"
+        elif self._status_label:
+            elapsed = int(_time.monotonic() - self._start_time)
+            text = f"{self._status_label} ({elapsed}s)"
         else:
             elapsed = int(_time.monotonic() - self._start_time)
-            text = self._status_label or f"⏳ ({elapsed}s)"
+            text = f"⏳ ({elapsed}s)"
         if self._elapsed_label is not None:
             self._elapsed_label.update(text)
 

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -467,6 +467,47 @@
 }
 .perm-item.perm-selected { color: var(--bs-primary); }
 .perm-hint { margin-top: 0.75rem; color: var(--bs-secondary-color); font-size: 0.8rem; }
+
+/* Tool call visibility */
+.tool-status-line {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+    color: var(--bs-secondary-color);
+    font-style: italic;
+    padding: 0.15rem 0;
+    min-height: 1.4em;
+}
+.tool-status-line.tool-done { color: var(--bs-success-text-emphasis); font-style: normal; }
+
+.tool-log { margin-top: 0.4rem; border-top: 1px dashed var(--bs-border-color); padding-top: 0.35rem; }
+.tool-log summary {
+    cursor: pointer;
+    font-size: 0.78rem;
+    color: var(--bs-secondary-color);
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+.tool-log summary::before { content: "\25b6"; font-size: 0.65rem; transition: transform 0.15s; }
+.tool-log[open] summary::before { transform: rotate(90deg); }
+.tool-log-entry {
+    font-size: 0.78rem;
+    font-family: var(--bs-font-monospace);
+    padding: 0.2rem 0.4rem;
+    margin-top: 0.2rem;
+    border-radius: 4px;
+    background: var(--bs-tertiary-bg);
+    border-left: 2px solid var(--bs-border-color);
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+.tool-log-entry.tool-entry-running { border-left-color: var(--bs-warning); }
+.tool-log-entry.tool-entry-done { border-left-color: var(--bs-success); }
+.tool-log-entry.tool-entry-error { border-left-color: var(--bs-danger); }
 </style>
 {% endblock %}
 
@@ -838,6 +879,124 @@
         bubble.appendChild(btn);
     }
 
+    function createStatusTracker(bubble) {
+        var statusEl = null;
+        var logDetails = null;
+        var logBody = null;
+        var entryCount = 0;
+        var currentEntryEl = null;
+        var timerInterval = null;
+        var timerStart = 0;
+        var destroyed = false;
+
+        function _clearTimer() {
+            if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+        }
+        function _ensureElements() {
+            if (statusEl) return;
+            statusEl = document.createElement('div');
+            statusEl.className = 'tool-status-line';
+            bubble.innerHTML = '';
+            bubble.appendChild(statusEl);
+            logDetails = document.createElement('details');
+            logDetails.className = 'tool-log';
+            var sum = document.createElement('summary');
+            sum.textContent = 'Вызовы инструментов';
+            logDetails.appendChild(sum);
+            logBody = document.createElement('div');
+            logDetails.appendChild(logBody);
+            logDetails.style.display = 'none';
+            bubble.appendChild(logDetails);
+        }
+        function _startTimer(labelFn) {
+            _clearTimer();
+            timerStart = Date.now();
+            statusEl.textContent = labelFn('0.0');
+            timerInterval = setInterval(function() {
+                if (destroyed || !statusEl) { _clearTimer(); return; }
+                var s = ((Date.now() - timerStart) / 1000).toFixed(1);
+                statusEl.textContent = labelFn(s);
+            }, 200);
+        }
+
+        return {
+            start: function() {
+                _ensureElements();
+                _startTimer(function(s) { return '\u23f3 \u0414\u0443\u043c\u0430\u0435\u0442... (' + s + 's)'; });
+            },
+            onThinking: function() {
+                if (destroyed) return;
+                _ensureElements();
+                _clearTimer();
+                statusEl.textContent = '\ud83d\udcac \u0413\u0435\u043d\u0435\u0440\u0438\u0440\u0443\u0435\u0442 \u043e\u0442\u0432\u0435\u0442...';
+                statusEl.className = 'tool-status-line';
+            },
+            onToolStart: function(toolName) {
+                if (destroyed) return;
+                _ensureElements();
+                entryCount++;
+                logDetails.style.display = '';
+                currentEntryEl = document.createElement('div');
+                currentEntryEl.className = 'tool-log-entry tool-entry-running';
+                currentEntryEl.textContent = '\ud83d\udd27 ' + toolName + ' ...';
+                logBody.appendChild(currentEntryEl);
+                _startTimer(function(s) { return '\ud83d\udd27 ' + toolName + '... (' + s + 's)'; });
+            },
+            onToolEnd: function(toolName, duration, isError, summary) {
+                if (destroyed) return;
+                _ensureElements();
+                _clearTimer();
+                var icon = isError ? '\u274c' : '\u2705';
+                statusEl.textContent = '\ud83d\udd27 ' + toolName + ' ' + icon + ' (' + duration + 's)';
+                statusEl.className = 'tool-status-line' + (isError ? '' : ' tool-done');
+                if (currentEntryEl) {
+                    currentEntryEl.className = 'tool-log-entry ' + (isError ? 'tool-entry-error' : 'tool-entry-done');
+                    var txt = icon + ' ' + toolName + ' (' + duration + 's)';
+                    if (summary) txt += ' \u2192 ' + summary;
+                    currentEntryEl.textContent = txt;
+                    currentEntryEl = null;
+                }
+            },
+            onToolResult: function(toolName, isError, summary) {
+                if (destroyed) return;
+                if (!currentEntryEl && logBody) {
+                    var entries = logBody.querySelectorAll('.tool-log-entry');
+                    if (entries.length > 0) {
+                        var last = entries[entries.length - 1];
+                        if (summary) {
+                            var resultLine = document.createElement('div');
+                            resultLine.style.cssText = 'font-size:0.75rem;color:var(--bs-secondary-color);padding-left:0.4rem;margin-top:0.1rem;word-break:break-all;';
+                            resultLine.textContent = (isError ? '\u274c ' : '\u2192 ') + summary;
+                            last.appendChild(resultLine);
+                        }
+                    }
+                }
+            },
+            onStatus: function(text) {
+                if (destroyed) return;
+                _ensureElements();
+                _clearTimer();
+                statusEl.textContent = '\u23f3 ' + text;
+                statusEl.className = 'tool-status-line';
+            },
+            destroyStatusOnly: function() {
+                destroyed = true;
+                _clearTimer();
+                if (statusEl && statusEl.parentNode) { statusEl.parentNode.removeChild(statusEl); statusEl = null; }
+            },
+            destroy: function() {
+                destroyed = true;
+                _clearTimer();
+                if (statusEl && statusEl.parentNode) { statusEl.parentNode.removeChild(statusEl); statusEl = null; }
+                if (logDetails && logDetails.parentNode && entryCount === 0) {
+                    logDetails.parentNode.removeChild(logDetails);
+                    logDetails = null;
+                }
+            },
+            hasToolEntries: function() { return entryCount > 0; }
+        };
+    }
+
     window.sendMessage = async function(textToRetry) {
         if (sending || !threadId) return;
         var inputEl = document.getElementById('chat-input');
@@ -867,17 +1026,8 @@
         var aiBubble = document.createElement('div');
         aiBubble.className = 'message-bubble message-assistant';
         aiBubble.setAttribute('data-pending', 'true');
-        var thinkStart = Date.now();
-        aiBubble.innerHTML = '<span class="typing-indicator">⏳ (0s)</span>';
-        var thinkTimer = setInterval(function() {
-            var el = aiBubble.querySelector('.typing-indicator');
-            if (el) {
-                var sec = Math.floor((Date.now() - thinkStart) / 1000);
-                el.textContent = '⏳ (' + sec + 's)';
-            } else {
-                clearInterval(thinkTimer);
-            }
-        }, 1000);
+        var statusTracker = createStatusTracker(aiBubble);
+        statusTracker.start();
         container.appendChild(aiBubble);
         container.scrollTop = container.scrollHeight;
 
@@ -931,28 +1081,55 @@
                                     });
                                 } catch (_) { /* server-side timeout will handle it */ }
                             }
+                        } else if (data.type === 'thinking') {
+                            statusTracker.onThinking();
+                        } else if (data.type === 'tool_start') {
+                            statusTracker.onToolStart(data.tool || 'tool');
+                        } else if (data.type === 'tool_end') {
+                            statusTracker.onToolEnd(data.tool || 'tool', data.duration || 0, !!data.is_error, data.summary || '');
+                        } else if (data.type === 'tool_result') {
+                            statusTracker.onToolResult(data.tool || 'tool', !!data.is_error, data.summary || '');
+                        } else if (data.type === 'status') {
+                            statusTracker.onStatus(data.text || '');
                         } else if (data.error) {
-                            clearInterval(thinkTimer);
+                            statusTracker.destroy();
                             aiBubble.className = 'message-error';
                             aiBubble.textContent = data.error;
                             fullText = data.error;
                             addRegenerateButton(aiBubble, text, true);
                         } else if (data.text !== undefined) {
-                            clearInterval(thinkTimer);
+                            var textNode = aiBubble.querySelector('.agent-text-content');
+                            if (!textNode) {
+                                textNode = document.createElement('div');
+                                textNode.className = 'agent-text-content';
+                                aiBubble.appendChild(textNode);
+                            }
                             fullText += data.text;
-                            aiBubble.innerHTML = renderMd(fullText);
+                            textNode.innerHTML = renderMd(fullText);
                             container.scrollTop = container.scrollHeight;
                         } else if (data.done) {
                             fullText = data.full_text || fullText;
-                            aiBubble.innerHTML = renderMd(fullText);
+                            if (statusTracker.hasToolEntries()) {
+                                statusTracker.destroyStatusOnly();
+                                var textNode = aiBubble.querySelector('.agent-text-content');
+                                if (!textNode) {
+                                    textNode = document.createElement('div');
+                                    textNode.className = 'agent-text-content';
+                                    aiBubble.appendChild(textNode);
+                                }
+                                textNode.innerHTML = renderMd(fullText);
+                            } else {
+                                statusTracker.destroy();
+                                aiBubble.innerHTML = renderMd(fullText);
+                            }
                             container.scrollTop = container.scrollHeight;
                         }
                     } catch(e) { /* skip bad JSON */ }
                 }
             }
 
-            clearInterval(thinkTimer);
-            if (aiBubble.querySelector('.typing-indicator')) {
+            statusTracker.destroy();
+            if (!fullText && !aiBubble.querySelector('.agent-text-content')) {
                 aiBubble.textContent = 'Нет ответа от агента.';
             }
 
@@ -960,7 +1137,7 @@
             aiBubble.removeAttribute('data-pending');
 
         } catch(err) {
-            clearInterval(thinkTimer);
+            statusTracker.destroy();
             if (err.name === 'AbortError') return;
             aiBubble.className = 'message-error';
             aiBubble.textContent = 'Ошибка соединения: ' + err.message;

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -106,8 +106,8 @@ async def test_chat_stream_stream_events_yield_incremental_chunks(db):
 
     payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
 
-    # Incremental text chunks must be present
-    text_payloads = [p for p in payloads if "text" in p and not p.get("done")]
+    # Incremental text chunks must be present (filter out status/tool events)
+    text_payloads = [p for p in payloads if "text" in p and not p.get("done") and "type" not in p]
     assert len(text_payloads) == 3, f"ожидали 3 текстовых чанка, получили: {text_payloads}"
     assert text_payloads[0]["text"] == "привет"
     assert text_payloads[1]["text"] == " "
@@ -293,8 +293,9 @@ async def test_chat_stream_retry_emits_status_event(db):
 
     payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
     status_events = [p for p in payloads if p.get("type") == "status"]
-    assert len(status_events) >= 1, f"status event not found on retry, payloads: {payloads}"
-    assert "Повтор" in status_events[0]["text"]
+    assert len(status_events) >= 2, f"expected init + retry status events, got: {status_events}"
+    retry_events = [e for e in status_events if "Повтор" in e["text"]]
+    assert retry_events, f"retry status event not found, status_events: {status_events}"
 
 
 @pytest.mark.asyncio
@@ -329,7 +330,7 @@ async def test_chat_stream_text_delta_not_broken_by_tool_tracking(db):
             chunks.append(chunk)
 
     payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
-    text_payloads = [p for p in payloads if "text" in p and not p.get("done")]
+    text_payloads = [p for p in payloads if "text" in p and not p.get("done") and "type" not in p]
     assert len(text_payloads) == 2
     assert text_payloads[0]["text"] == "привет"
     assert text_payloads[1]["text"] == " мир"
@@ -394,6 +395,36 @@ async def test_chat_stream_multiple_tools_sequence(db):
     assert tool_starts[1]["tool"] == "list_channels"
     assert tool_ends[0]["tool"] == "search_messages"
     assert tool_ends[1]["tool"] == "list_channels"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_emits_initial_connection_status(db):
+    """First SSE event is always a status event with backend connection info."""
+    thread_id = await db.create_agent_thread("init-status thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    assert chunks, "должны быть SSE-строки"
+    first_payload = json.loads(chunks[0].removeprefix("data: ").strip())
+    assert first_payload.get("type") == "status", f"first event should be status, got: {first_payload}"
+    assert "Подключение" in first_payload["text"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -155,7 +155,249 @@ async def test_chat_stream_fallback_to_assistant_message_when_no_stream_events(d
 
 
 @pytest.mark.asyncio
-async def test_agent_chat_stream_renders_saved_prompt_template_variables(db):
+async def test_chat_stream_emits_tool_start_and_tool_end_events(db):
+    """StreamEvent content_block_start (tool_use) and content_block_stop emit tool_start/tool_end SSE."""
+    thread_id = await db.create_agent_thread("tool-visibility thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, StreamEvent, TextBlock
+
+    def _make_event(event_dict):
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = event_dict
+        return ev
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="done")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        # tool_use block start at index 0
+        yield _make_event({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "tu_1", "name": "search_messages"},
+        })
+        # partial input
+        yield _make_event({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"query": "test"}'},
+        })
+        # tool block stop
+        yield _make_event({"type": "content_block_stop", "index": 0})
+        # text block
+        yield _make_event({
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "result"},
+        })
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    types = [p.get("type") for p in payloads if "type" in p]
+
+    assert "thinking" in types, f"thinking event not found in {types}"
+    assert "tool_start" in types, f"tool_start event not found in {types}"
+    assert "tool_end" in types, f"tool_end event not found in {types}"
+
+    tool_start = next(p for p in payloads if p.get("type") == "tool_start")
+    assert tool_start["tool"] == "search_messages"
+
+    tool_end = next(p for p in payloads if p.get("type") == "tool_end")
+    assert tool_end["tool"] == "search_messages"
+    assert "duration" in tool_end
+    assert tool_end["is_error"] is False
+    assert "query" in tool_end["summary"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_emits_tool_result_from_assistant_message(db):
+    """ToolResultBlock in AssistantMessage emits tool_result SSE event."""
+    thread_id = await db.create_agent_thread("tool-result thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, StreamEvent, TextBlock, ToolResultBlock, ToolUseBlock
+
+    def _make_event(event_dict):
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = event_dict
+        return ev
+
+    # AssistantMessage with ToolUseBlock + ToolResultBlock
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [
+        ToolUseBlock(id="tu_1", name="list_channels", input={}),
+        ToolResultBlock(tool_use_id="tu_1", content="Found 5 channels", is_error=False),
+        TextBlock(text="Here are the channels"),
+    ]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    tool_results = [p for p in payloads if p.get("type") == "tool_result"]
+
+    assert len(tool_results) >= 1, f"tool_result event not found, payloads: {payloads}"
+    assert tool_results[0]["tool"] == "list_channels"
+    assert tool_results[0]["is_error"] is False
+    assert "Found 5 channels" in tool_results[0]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_retry_emits_status_event(db):
+    """When Claude SDK retries after timeout, a status SSE event is emitted."""
+    thread_id = await db.create_agent_thread("retry thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    call_count = 0
+
+    async def mock_query(prompt, options):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("Control request timeout")
+        assistant_msg = MagicMock(spec=AssistantMessage)
+        assistant_msg.content = [TextBlock(text="ok")]
+        result_msg = MagicMock(spec=ResultMessage)
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    status_events = [p for p in payloads if p.get("type") == "status"]
+    assert len(status_events) >= 1, f"status event not found on retry, payloads: {payloads}"
+    assert "Повтор" in status_events[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_text_delta_not_broken_by_tool_tracking(db):
+    """Existing text streaming still works correctly with tool tracking in place."""
+    thread_id = await db.create_agent_thread("text-delta thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, StreamEvent, TextBlock
+
+    def _stream_event(text):
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}}
+        return ev
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="привет мир")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        yield _stream_event("привет")
+        yield _stream_event(" мир")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    text_payloads = [p for p in payloads if "text" in p and not p.get("done")]
+    assert len(text_payloads) == 2
+    assert text_payloads[0]["text"] == "привет"
+    assert text_payloads[1]["text"] == " мир"
+
+    done_payloads = [p for p in payloads if p.get("done")]
+    assert done_payloads[0]["full_text"] == "привет мир"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_multiple_tools_sequence(db):
+    """Multiple tool calls in sequence emit correct tool_start/tool_end pairs."""
+    thread_id = await db.create_agent_thread("multi-tool thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, StreamEvent, TextBlock
+
+    def _make_event(event_dict):
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = event_dict
+        return ev
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="result")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        # Tool 1
+        yield _make_event({
+            "type": "content_block_start", "index": 0,
+            "content_block": {"type": "tool_use", "id": "tu_1", "name": "search_messages"},
+        })
+        yield _make_event({"type": "content_block_stop", "index": 0})
+        # Tool 2
+        yield _make_event({
+            "type": "content_block_start", "index": 1,
+            "content_block": {"type": "tool_use", "id": "tu_2", "name": "list_channels"},
+        })
+        yield _make_event({"type": "content_block_stop", "index": 1})
+        # Text
+        yield _make_event({
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "result"},
+        })
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    tool_starts = [p for p in payloads if p.get("type") == "tool_start"]
+    tool_ends = [p for p in payloads if p.get("type") == "tool_end"]
+
+    assert len(tool_starts) == 2, f"expected 2 tool_start, got {tool_starts}"
+    assert len(tool_ends) == 2, f"expected 2 tool_end, got {tool_ends}"
+    assert tool_starts[0]["tool"] == "search_messages"
+    assert tool_starts[1]["tool"] == "list_channels"
+    assert tool_ends[0]["tool"] == "search_messages"
+    assert tool_ends[1]["tool"] == "list_channels"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_renders_saved_prompt_template_variables(db):
     await db.set_setting(
         AGENT_PROMPT_TEMPLATE_SETTING,
         "Дата: {date}\nКанал: {channel_title}\nТема: {topic}\nСообщения:\n{source_messages}",

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -26,6 +26,10 @@ def _make_sse_error(msg: str) -> str:
     return f"data: {json.dumps({'error': msg})}\n\n"
 
 
+def _make_sse_event(event_type: str, **kwargs) -> str:
+    return f"data: {json.dumps({'type': event_type, **kwargs})}\n\n"
+
+
 async def _fake_stream(*chunks: str):
     """Async generator yielding SSE chunks."""
     for chunk in chunks:
@@ -66,6 +70,45 @@ def test_streaming_message_finalize_changes_class():
     widget.finalize()
     assert "assistant-bubble" in widget.classes
     assert "streaming-bubble" not in widget.classes
+
+
+def test_streaming_message_update_status():
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._elapsed_label = MagicMock()
+    widget.update_status("🔧 search_messages ✅ (1.2s)")
+    assert widget._status_label == "🔧 search_messages ✅ (1.2s)"
+    assert widget._tool_start_time == 0.0
+    widget._elapsed_label.update.assert_called_with("🔧 search_messages ✅ (1.2s)")
+
+
+def test_streaming_message_tick_elapsed_with_tool():
+    import time as _time
+
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._elapsed_label = MagicMock()
+    widget._loading = True
+    widget._status_label = "search_messages"
+    widget._tool_start_time = _time.monotonic()
+    widget._tick_elapsed()
+    call_arg = widget._elapsed_label.update.call_args[0][0]
+    assert "🔧 search_messages..." in call_arg
+
+
+def test_streaming_message_tick_elapsed_with_status_label():
+    from src.cli.commands.agent_tui import StreamingMessage
+
+    widget = StreamingMessage()
+    widget._elapsed_label = MagicMock()
+    widget._loading = True
+    widget._start_time = 100.0
+    widget._status_label = "⏳ Думает..."
+    widget._tool_start_time = 0.0
+    widget._tick_elapsed()
+    widget._elapsed_label.update.assert_called_with("⏳ Думает...")
 
 
 def test_streaming_message_set_error_changes_class():
@@ -688,3 +731,31 @@ class TestAgentChatParser:
         args = parser.parse_args(["agent", "chat", "-p", "hi", "--thread-id", "5"])
         assert args.prompt == "hi"
         assert args.thread_id == 5
+
+
+@pytest.mark.asyncio
+async def test_tui_stream_shows_tool_status(db, app_factory):
+    """Tool SSE events update the streaming widget status label."""
+    config = AppConfig()
+    chunks = [
+        _make_sse_event("thinking"),
+        _make_sse_event("tool_start", tool="search_messages"),
+        _make_sse_event("tool_end", tool="search_messages", duration=1.5, is_error=False, summary="query='test'"),
+        _make_sse_chunk("result"),
+        _make_sse_done("result"),
+    ]
+    mgr = _make_manager(*chunks)
+
+    from src.cli.commands.agent_tui import AgentTuiApp
+
+    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        from textual.widgets import TextArea
+
+        input_area = app.query_one("#input", TextArea)
+        input_area.load_text("test")
+        await pilot.click("#send-btn")
+        await pilot.pause(0.3)
+
+    mgr.chat_stream.assert_called_once()

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -99,16 +99,20 @@ def test_streaming_message_tick_elapsed_with_tool():
 
 
 def test_streaming_message_tick_elapsed_with_status_label():
+    import time as _time
+
     from src.cli.commands.agent_tui import StreamingMessage
 
     widget = StreamingMessage()
     widget._elapsed_label = MagicMock()
     widget._loading = True
-    widget._start_time = 100.0
+    widget._start_time = _time.monotonic() - 5.0
     widget._status_label = "⏳ Думает..."
     widget._tool_start_time = 0.0
     widget._tick_elapsed()
-    widget._elapsed_label.update.assert_called_with("⏳ Думает...")
+    call_arg = widget._elapsed_label.update.call_args[0][0]
+    assert "⏳ Думает..." in call_arg
+    assert "(5s)" in call_arg
 
 
 def test_streaming_message_set_error_changes_class():


### PR DESCRIPTION
## Summary

Closes #307

- **Backend**: `_ToolTracker` dataclass intercepts Claude SDK `StreamEvent` tool_use blocks and `AssistantMessage` `ToolResultBlock`s, emitting new SSE event types (`tool_start`, `tool_end`, `tool_result`, `thinking`, `status`). DeepAgents backend wraps `asyncio.to_thread()` with the same events. Retry attempts emit `status` events for visibility.
- **Frontend**: `createStatusTracker()` replaces the old `⏳ (0s)` typing indicator with a live status line (`🔧 search_messages... (2.4s)`) and a collapsible `<details>` tool log that persists in the assistant bubble after completion.
- **Tests**: 5 new tests covering tool_start/tool_end emission, tool_result from AssistantMessage, retry status events, text streaming regression, and multi-tool sequences.

## Test plan

- [ ] `ruff check src/ tests/ conftest.py` — lint passes
- [ ] `pytest tests/test_agent.py -v -n auto` — all 78 tests pass (5 new)
- [ ] Manual: Claude backend — send message, verify `⏳ Думает...` → `🔧 tool_name...` → `✅` → text
- [ ] Manual: DeepAgents backend — verify `🔧 agent... (Xs)` status during blocking call
- [ ] Manual: Click "Вызовы инструментов" to expand tool log
- [ ] Manual: Stop button removes pending bubble cleanly
- [ ] Dark mode: all CSS uses `var(--bs-*)` variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)