### PR TITLE
feat(agent): atomic configurable timeouts with countdown & graceful shutdown

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -206,28 +206,34 @@ async def _await_with_countdown(
     """Await *coro* with periodic countdown status updates pushed to *queue*."""
     task = asyncio.ensure_future(coro)
     start = time.monotonic()
-    while True:
-        elapsed = time.monotonic() - start
-        remaining = timeout - elapsed
-        if remaining <= 0:
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
-            raise asyncio.TimeoutError()
-        wait_time = min(countdown_interval, remaining)
-        done, _ = await asyncio.wait({task}, timeout=wait_time)
-        if done:
-            return task.result()
-        remaining_int = int(timeout - (time.monotonic() - start))
-        if remaining_int > 0:
-            payload = json.dumps(
-                {"type": "countdown", "text": f"{label} ({remaining_int}с до таймаута)"},
-                ensure_ascii=False,
-            )
-            try:
-                queue.put_nowait(f"data: {payload}\n\n")
-            except Exception:
-                pass
+    try:
+        while True:
+            elapsed = time.monotonic() - start
+            remaining = timeout - elapsed
+            if remaining <= 0:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+                raise asyncio.TimeoutError()
+            wait_time = min(countdown_interval, remaining)
+            done, _ = await asyncio.wait({task}, timeout=wait_time)
+            if done:
+                return task.result()
+            remaining_int = int(timeout - (time.monotonic() - start))
+            if remaining_int > 0:
+                payload = json.dumps(
+                    {"type": "countdown", "text": f"{label} ({remaining_int}с до таймаута)"},
+                    ensure_ascii=False,
+                )
+                try:
+                    queue.put_nowait(f"data: {payload}\n\n")
+                except Exception:
+                    pass
+    except asyncio.CancelledError:
+        task.cancel()
+        with suppress(asyncio.CancelledError, Exception):
+            await task
+        raise
 
 
 class ClaudeSdkBackend:
@@ -284,7 +290,6 @@ class ClaudeSdkBackend:
 
         stderr_lines: list[str] = []
         debug_lines: list[str] = []
-        _stderr_count = [0]  # mutable counter for closure
 
         # Stable stage keywords from claude-cli bootstrap sequence.
         # Checked case-insensitively; first match wins.
@@ -320,7 +325,6 @@ class ClaudeSdkBackend:
             # Emit connection progress to TUI/web queue.
             # _on_stderr is called from an anyio task in the same event loop,
             # so put_nowait on asyncio.Queue is safe here.
-            _stderr_count[0] += 1
             label: str | None = None
             for keyword, stage in _stage_map:
                 if keyword in _lower:

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -90,6 +90,35 @@ def _truncate(text: str, limit: int = 120) -> str:
     return text[:limit - 3] + "..." if len(text) > limit else text
 
 
+def _diagnose_connection(cli_path: str | None, stderr_lines: list[str]) -> str:
+    """Build a concrete diagnostic message by checking environment and stderr."""
+    problems: list[str] = []
+
+    if not cli_path:
+        problems.append("Claude CLI не найден в PATH")
+
+    has_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+    has_oauth = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"))
+    if not has_key and not has_oauth:
+        problems.append("Ни ANTHROPIC_API_KEY, ни CLAUDE_CODE_OAUTH_TOKEN не заданы")
+
+    stderr_lower = " ".join(stderr_lines[-5:]).lower() if stderr_lines else ""
+    if "invalid" in stderr_lower and "key" in stderr_lower:
+        problems.append("API ключ невалиден (см. stderr)")
+    if "rate limit" in stderr_lower or "429" in stderr_lower:
+        problems.append("Сработал rate limit на API")
+    if "network" in stderr_lower or "dns" in stderr_lower or "econnrefused" in stderr_lower:
+        problems.append("Проблема с сетевым подключением")
+    if "permission" in stderr_lower or "403" in stderr_lower:
+        problems.append("Нет прав доступа к API (403)")
+    if "401" in stderr_lower or "unauthorized" in stderr_lower:
+        problems.append("API ключ отклонён (401)")
+
+    if problems:
+        return "Диагностика: " + "; ".join(problems) + "."
+    return "Проверьте подключение к сети и API ключ."
+
+
 @dataclass
 class _ToolTracker:
     queue: asyncio.Queue
@@ -167,6 +196,40 @@ class AgentRuntimeStatus:
     error: str | None = None
 
 
+async def _await_with_countdown(
+    coro: Awaitable,
+    timeout: float,
+    queue: asyncio.Queue,
+    label: str,
+    countdown_interval: int = 10,
+) -> Any:
+    """Await *coro* with periodic countdown status updates pushed to *queue*."""
+    task = asyncio.ensure_future(coro)
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        remaining = timeout - elapsed
+        if remaining <= 0:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            raise asyncio.TimeoutError()
+        wait_time = min(countdown_interval, remaining)
+        done, _ = await asyncio.wait({task}, timeout=wait_time)
+        if done:
+            return task.result()
+        remaining_int = int(timeout - (time.monotonic() - start))
+        if remaining_int > 0:
+            payload = json.dumps(
+                {"type": "countdown", "text": f"{label} ({remaining_int}с до таймаута)"},
+                ensure_ascii=False,
+            )
+            try:
+                queue.put_nowait(f"data: {payload}\n\n")
+            except Exception:
+                pass
+
+
 class ClaudeSdkBackend:
     def __init__(self, db: Database, config: AppConfig, client_pool=None, scheduler_manager=None) -> None:
         self._db = db
@@ -184,7 +247,8 @@ class ClaudeSdkBackend:
             return
         from src.agent.tools import make_mcp_server
 
-        os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "300000")
+        timeout_ms = str(self._config.agent.stream_close_timeout * 1000)
+        os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", timeout_ms)
         self._server = make_mcp_server(
             self._db, client_pool=self._client_pool, scheduler_manager=self._scheduler_manager,
             config=self._config,
@@ -210,6 +274,7 @@ class ClaudeSdkBackend:
         history_msgs: list[dict] | None = None,
     ) -> None:
         self._ensure_initialized()
+        original_prompt = prompt
         if history_msgs:
             prompt = _embed_history_in_prompt(history_msgs, prompt)
         resolved_model = model or self._config.agent.model.strip() or os.environ.get("AGENT_MODEL")
@@ -219,16 +284,55 @@ class ClaudeSdkBackend:
 
         stderr_lines: list[str] = []
         debug_lines: list[str] = []
+        _stderr_count = [0]  # mutable counter for closure
+
+        # Stable stage keywords from claude-cli bootstrap sequence.
+        # Checked case-insensitively; first match wins.
+        _prompt_short = original_prompt[:100].replace("\n", " ")
+        if len(original_prompt) > 100:
+            _prompt_short += "…"
+        _stage_map: list[tuple[str, str]] = [
+            ("[api:request]", f"Жду ответ Claude API: «{_prompt_short}»"),
+            ("creating client", "Создание клиента"),
+            ("installplugins", "Установка плагинов"),
+            ("refreshed marketplace", "Обновление плагинов"),
+            ("hooks:", "Загрузка хуков"),
+            ("lsp server", "LSP"),
+            ("settings changed", "Применение настроек"),
+            ("rate limit event", "Rate limit"),
+        ]
+        _last_emitted: list[str] = [""]
 
         def _on_stderr(line: str) -> None:
-            # debug-to-stderr produces verbose transport logs; keep them separate
-            # so user-facing error details show real errors, not debug noise.
-            if line.startswith(("[DEBUG]", "[TRACE]", "DEBUG", "TRACE")):
+            # claude-cli stderr format: "2026-03-30T01:28:36.888Z [DEBUG] ..."
+            # Level tag is NOT at the start — check anywhere in the line.
+            _lower = line.lower()
+            if "[debug]" in _lower or "[trace]" in _lower:
                 debug_lines.append(line)
                 logger.debug("claude-cli debug: %s", line)
+            elif "[warn" in _lower:
+                debug_lines.append(line)
+                logger.debug("claude-cli warn: %s", line)
             else:
                 stderr_lines.append(line)
                 logger.warning("claude-cli stderr: %s", line)
+
+            # Emit connection progress to TUI/web queue.
+            # _on_stderr is called from an anyio task in the same event loop,
+            # so put_nowait on asyncio.Queue is safe here.
+            _stderr_count[0] += 1
+            label: str | None = None
+            for keyword, stage in _stage_map:
+                if keyword in _lower:
+                    label = stage
+                    break
+            if label and label != _last_emitted[0]:
+                _last_emitted[0] = label
+                payload = json.dumps({"type": "status", "text": label}, ensure_ascii=False)
+                try:
+                    queue.put_nowait(f"data: {payload}\n\n")
+                except Exception:
+                    pass
 
         cli_path = shutil.which("claude")
         logger.info("claude-cli path: %s", cli_path)
@@ -272,6 +376,7 @@ class ClaudeSdkBackend:
             **extra,
         )
 
+        cfg = self._config.agent
         last_err: Exception | None = None
         for attempt in range(2):
             if attempt > 0:
@@ -284,12 +389,60 @@ class ClaudeSdkBackend:
             t0 = time.monotonic()
             first_event_logged = False
             try:
-                async for msg in query(prompt=prompt, options=options):
+                aiter = query(prompt=prompt, options=options).__aiter__()
+                while True:
                     if not first_event_logged:
-                        elapsed = time.monotonic() - t0
+                        iter_timeout = cfg.first_event_timeout
+                        iter_label = "Ожидание ответа Claude"
+                    else:
+                        iter_timeout = cfg.idle_timeout
+                        iter_label = "Ожидание данных от Claude"
+
+                    elapsed = time.monotonic() - t0
+                    remaining_total = cfg.total_timeout - elapsed
+                    if remaining_total <= 0:
+                        logger.error(
+                            "Total timeout %ds exceeded after %.1fs (thread %d)",
+                            cfg.total_timeout, elapsed, thread_id,
+                        )
+                        raise TimeoutError(
+                            f"Общий таймаут запроса ({cfg.total_timeout}с)"
+                        )
+                    effective_timeout = min(iter_timeout, remaining_total)
+
+                    try:
+                        msg = await _await_with_countdown(
+                            aiter.__anext__(),
+                            timeout=effective_timeout,
+                            queue=queue,
+                            label=iter_label,
+                        )
+                    except StopAsyncIteration:
+                        break
+                    except asyncio.TimeoutError:
+                        if not first_event_logged:
+                            logger.error(
+                                "First event timeout %ds fired after %.1fs (thread %d)",
+                                cfg.first_event_timeout, time.monotonic() - t0, thread_id,
+                            )
+                            diag = _diagnose_connection(cli_path, stderr_lines)
+                            raise TimeoutError(
+                                f"Claude не ответил за {cfg.first_event_timeout}с. {diag}"
+                            )
+                        logger.error(
+                            "Idle timeout %ds fired after %.1fs total (thread %d)",
+                            cfg.idle_timeout, time.monotonic() - t0, thread_id,
+                        )
+                        raise TimeoutError(
+                            f"Стрим Claude замолчал на {cfg.idle_timeout}с. "
+                            "Возможно, соединение потеряно."
+                        )
+
+                    if not first_event_logged:
+                        elapsed_fe = time.monotonic() - t0
                         logger.info(
                             "First SDK event after %.1fs (thread %d, attempt %d): %s",
-                            elapsed, thread_id, attempt + 1, type(msg).__name__,
+                            elapsed_fe, thread_id, attempt + 1, type(msg).__name__,
                         )
                         first_event_logged = True
                     if draining:
@@ -364,6 +517,20 @@ class ClaudeSdkBackend:
                             await queue.put(f"data: {done_payload}\n\n")
                     except asyncio.CancelledError:
                         draining = True
+                return
+
+            except TimeoutError as exc:
+                elapsed = time.monotonic() - t0
+                logger.error(
+                    "Agent timeout after %.1fs (thread %d): %s", elapsed, thread_id, exc,
+                )
+                stderr_summary = "\n".join(stderr_lines[-10:]) if stderr_lines else None
+                err_payload = json.dumps(
+                    {"error": str(exc), "details": stderr_summary},
+                    ensure_ascii=False,
+                )
+                await queue.put(f"data: {err_payload}\n\n")
+                await queue.put(None)
                 return
 
             except CLINotFoundError as exc:
@@ -1538,6 +1705,7 @@ class AgentManager:
                 thread_id=thread_id,
                 queue=queue,
                 db_permissions=_db_perms,
+                permission_timeout=self._config.agent.permission_timeout,
             )
 
         async def _run_backend(
@@ -1636,6 +1804,7 @@ class AgentManager:
         self._active_tasks.clear()
         for task in tasks:
             task.cancel()
-        for task in tasks:
-            with suppress(asyncio.CancelledError):
-                await task
+        if tasks:
+            _, pending = await asyncio.wait(tasks, timeout=5.0)
+            for task in pending:
+                logger.debug("Agent task did not finish within timeout: %s", task.get_name())

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -35,6 +35,7 @@ class AgentRequestContext:
     thread_id: int
     queue: asyncio.Queue              # SSE queue for this request
     db_permissions: dict[str, bool]   # from load_tool_permissions_union at call time
+    permission_timeout: int = 120     # seconds to wait for user response
 
 
 _request_ctx: ContextVar[AgentRequestContext | None] = ContextVar(
@@ -121,22 +122,29 @@ class PermissionGate:
         future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
 
+        timeout = ctx.permission_timeout
         event = json.dumps(
             {
                 "type": "permission_request",
                 "request_id": request_id,
                 "tool": tool_name,
                 "phone": phone,
+                "timeout": timeout,
             },
             ensure_ascii=False,
         )
         await ctx.queue.put(f"data: {event}\n\n")
 
         try:
-            choice: str = await asyncio.wait_for(future, timeout=300)
+            choice: str = await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
             self._pending.pop(request_id, None)
-            return _text_response(f"❌ Таймаут запроса разрешения для '{tool_name}' (5 мин).")
+            logger.warning(
+                "Permission timeout %ds fired for tool '%s' (thread %d, session %s)",
+                timeout, tool_name, ctx.thread_id, ctx.session_id,
+            )
+            mins = timeout // 60
+            return _text_response(f"❌ Таймаут запроса разрешения для '{tool_name}' ({mins} мин).")
         except asyncio.CancelledError:
             self._pending.pop(request_id, None)
             raise

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import logging
+import sys
 
 from src.cli import runtime
 
@@ -115,15 +116,40 @@ def run(args: argparse.Namespace) -> None:
                     await db.save_agent_message(thread_id, "user", args.prompt)
 
                     model = getattr(args, "model", None)
-                    print("Агент: ", end="", flush=True)
                     full_text = ""
+                    text_started = False
                     async for chunk in mgr.chat_stream(thread_id, args.prompt, model=model):
                         raw = chunk.removeprefix("data: ").strip()
                         try:
                             payload = json.loads(raw)
                         except Exception:
                             continue
+                        event_type = payload.get("type")
+                        if event_type == "status":
+                            if not text_started:
+                                print(f"⏳ {payload.get('text', '')}",
+                                      file=sys.stderr, flush=True)
+                            continue
+                        if event_type == "tool_start":
+                            print(f"🔧 {payload.get('tool', 'tool')}...",
+                                  file=sys.stderr, flush=True)
+                            continue
+                        if event_type == "tool_end":
+                            tool = payload.get("tool", "tool")
+                            dur = payload.get("duration", 0)
+                            icon = "❌" if payload.get("is_error") else "✅"
+                            summary = payload.get("summary", "")
+                            line = f"  {icon} {tool} ({dur}s)"
+                            if summary:
+                                line += f" — {summary}"
+                            print(line, file=sys.stderr, flush=True)
+                            continue
+                        if event_type in ("thinking", "tool_result"):
+                            continue
                         if "text" in payload:
+                            if not text_started:
+                                print("Агент: ", end="", flush=True)
+                                text_started = True
                             print(payload["text"], end="", flush=True)
                             full_text += payload.get("text", "")
                         if payload.get("done"):
@@ -137,11 +163,16 @@ def run(args: argparse.Namespace) -> None:
                     if full_text:
                         await db.save_agent_message(thread_id, "assistant", full_text)
                 else:
-                    # Interactive TUI mode
+                    # Interactive TUI mode — redirect logs to file
                     from src.cli.commands.agent_tui import AgentTuiApp
+                    from src.cli.runtime import redirect_logging_to_file, restore_logging
 
-                    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
-                    await app.run_async()
+                    removed = redirect_logging_to_file()
+                    try:
+                        app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+                        await app.run_async()
+                    finally:
+                        restore_logging(removed)
 
             elif action == "thread-rename":
                 await db.rename_agent_thread(args.thread_id, args.title[:100])
@@ -203,11 +234,23 @@ def run(args: argparse.Namespace) -> None:
                 await _test_escaping(db, config)
         finally:
             if mgr is not None:
-                await mgr.close_all()
+                try:
+                    await mgr.close_all()
+                except Exception:
+                    logger.debug("Failed to close agent manager", exc_info=True)
             if pool is not None:
-                await pool.disconnect_all()
+                try:
+                    await pool.disconnect_all()
+                except Exception:
+                    logger.debug("Failed to disconnect pool", exc_info=True)
             if auth is not None:
-                await auth.cleanup()
-            await db.close()
+                try:
+                    await auth.cleanup()
+                except Exception:
+                    logger.debug("Failed to cleanup auth", exc_info=True)
+            try:
+                await db.close()
+            except Exception:
+                logger.debug("Failed to close database", exc_info=True)
 
     asyncio.run(_run())

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -613,8 +613,6 @@ class AgentTuiApp(App):
                 if event_type == "countdown":
                     widget.replace_pending_status(payload.get("text", ""))
                     continue
-                if event_type in ("tool_result",):
-                    continue
                 if "text" in payload:
                     full_text += payload["text"]
                     widget.append_text(payload["text"])

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -91,6 +91,10 @@ class StreamingMessage(Static):
         self._content = ""
         self._md: Markdown | None = None
         self._elapsed_label: Label | None = None
+        self._activity_log: Static | None = None
+        self._log_lines: list[str] = []
+        self._pending_status: str = ""
+        self._last_log_time: float = 0.0
         self._tick_timer = None
         self._start_time: float = 0.0
         self._render_timer: asyncio.TimerHandle | None = None
@@ -103,6 +107,9 @@ class StreamingMessage(Static):
         import time as _time
 
         self._start_time = _time.monotonic()
+        log = Static("", classes="activity-log")
+        self._activity_log = log
+        yield log
         label = Label("⏳ (0s)")
         self._elapsed_label = label
         yield label
@@ -131,11 +138,53 @@ class StreamingMessage(Static):
         if self._elapsed_label is not None:
             self._elapsed_label.update(text)
 
-    def update_status(self, label: str) -> None:
+    def _flush_pending(self) -> None:
+        """Complete the pending status into the log with elapsed time."""
+        import time as _time
+
+        if self._pending_status:
+            now = _time.monotonic()
+            elapsed = round(now - self._last_log_time, 1) if self._last_log_time else 0
+            self._log_lines.append(f"  {self._pending_status} ({elapsed}s)")
+            self._last_log_time = now
+            self._pending_status = ""
+
+    def _append_log(self, line: str) -> None:
+        """Add a completed line to the activity log."""
+        self._flush_pending()
+        self._log_lines.append(line)
+        if self._activity_log is not None:
+            self._activity_log.update("\n".join(self._log_lines))
+
+    def set_pending_status(self, label: str) -> None:
+        """Set a pending status — shown only in elapsed label, added to log when next event arrives."""
+        import time as _time
+
+        # Skip duplicate
+        if label == self._pending_status:
+            return
+        self._flush_pending()
+        self._pending_status = label
+        self._last_log_time = _time.monotonic()
+        # Update elapsed label (ticking timer shows this)
         self._status_label = label
         self._tool_start_time = 0.0
         if self._elapsed_label is not None:
-            self._elapsed_label.update(label)
+            self._elapsed_label.update(f"⏳ {label}")
+        if self._activity_log is not None:
+            self._activity_log.update("\n".join(self._log_lines))
+
+    def replace_pending_status(self, label: str) -> None:
+        """Replace pending status text WITHOUT flushing old one to log.
+
+        Used by countdown events to update the elapsed label in-place
+        instead of creating a new log line for each tick.
+        """
+        self._pending_status = label
+        self._status_label = label
+        self._tool_start_time = 0.0
+        if self._elapsed_label is not None:
+            self._elapsed_label.update(f"⏳ {label}")
 
     def _stop_loading(self) -> None:
         self._loading = False
@@ -144,6 +193,10 @@ class StreamingMessage(Static):
             self._tick_timer = None
         if self._elapsed_label is not None:
             self._elapsed_label.display = False
+        # Finalize pending status into log
+        self._flush_pending()
+        if self._activity_log is not None and self._log_lines:
+            self._activity_log.update("\n".join(self._log_lines))
         if self._md is not None:
             self._md.display = True
 
@@ -527,22 +580,38 @@ class AgentTuiApp(App):
                     self.agent_manager.permission_gate.resolve(payload["request_id"], choice)
                     continue
                 if event_type == "thinking":
-                    widget.update_status("⏳ Думает...")
+                    widget.set_pending_status("Думает...")
                     continue
                 if event_type == "tool_start":
                     import time as _time
 
-                    widget._status_label = payload.get("tool", "tool")
+                    tool_name = payload.get("tool", "tool")
+                    widget._flush_pending()
+                    widget._append_log(f"  🔧 {tool_name}...")
+                    widget._status_label = tool_name
                     widget._tool_start_time = _time.monotonic()
                     continue
                 if event_type == "tool_end":
                     tool = payload.get("tool", "tool")
                     dur = payload.get("duration", 0)
                     icon = "❌" if payload.get("is_error") else "✅"
-                    widget.update_status(f"🔧 {tool} {icon} ({dur}s)")
+                    summary = payload.get("summary", "")
+                    log_line = f"    {icon} {tool} ({dur}s)"
+                    if summary:
+                        log_line += f" — {summary}"
+                    widget._append_log(log_line)
+                    continue
+                if event_type == "tool_result":
+                    if payload.get("is_error"):
+                        tool = payload.get("tool", "tool")
+                        summary = payload.get("summary", "")
+                        widget._append_log(f"    ❌ {tool}: {summary}")
                     continue
                 if event_type == "status":
-                    widget.update_status(f"⏳ {payload.get('text', '')}")
+                    widget.set_pending_status(payload.get("text", ""))
+                    continue
+                if event_type == "countdown":
+                    widget.replace_pending_status(payload.get("text", ""))
                     continue
                 if event_type in ("tool_result",):
                     continue

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -27,6 +27,30 @@ async def init_db(config_path: str):
     return config, db
 
 
+def redirect_logging_to_file() -> list[logging.Handler]:
+    """Move all root logger handlers to a file handler for TUI mode.
+
+    Returns the removed handlers so they can be restored later.
+    """
+    root = logging.getLogger()
+    removed = list(root.handlers)
+    for h in removed:
+        root.removeHandler(h)
+    fh = logging.FileHandler("agent_tui.log", encoding="utf-8")
+    fh.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    root.addHandler(fh)
+    return removed
+
+
+def restore_logging(handlers: list[logging.Handler]) -> None:
+    """Restore previously removed handlers and remove the file handler."""
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in handlers:
+        root.addHandler(h)
+
+
 async def init_pool(config, db: Database):
     api_id = config.telegram.api_id
     api_hash = config.telegram.api_hash

--- a/src/config.py
+++ b/src/config.py
@@ -50,6 +50,11 @@ class AgentConfig(BaseModel):
     model: str = ""
     fallback_model: str = ""
     fallback_api_key: str = ""
+    stream_close_timeout: int = 60
+    first_event_timeout: int = 90
+    idle_timeout: int = 90
+    permission_timeout: int = 120
+    total_timeout: int = 600
 
 
 class SecurityConfig(BaseModel):

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -509,7 +509,14 @@ class ClientPool:
 
     async def disconnect_all(self) -> None:
         for phone in list(self.clients):
-            await self.remove_client(phone)
+            try:
+                await asyncio.wait_for(self.remove_client(phone), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("Timeout disconnecting %s, forcing cleanup", phone)
+                self.clients.pop(phone, None)
+                self._in_use.discard(phone)
+            except Exception:
+                logger.debug("Error disconnecting %s", phone, exc_info=True)
 
     @staticmethod
     def _normalize_runtime_config(

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -515,6 +515,8 @@ class ClientPool:
                 logger.warning("Timeout disconnecting %s, forcing cleanup", phone)
                 self.clients.pop(phone, None)
                 self._in_use.discard(phone)
+                self._active_leases.pop(phone, None)
+                self._dialogs_fetched.discard(phone)
             except Exception:
                 logger.debug("Error disconnecting %s", phone, exc_info=True)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -428,6 +428,43 @@ async def test_chat_stream_emits_initial_connection_status(db):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_emits_stderr_stage_status(db):
+    """Stderr lines with stage keywords emit status events to the stream."""
+    thread_id = await db.create_agent_thread("stderr-status")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+
+    async def mock_query(prompt, options):
+        # Simulate stderr callback as claude-cli would
+        if options.stderr:
+            options.stderr("2026-03-30T01:28:36.888Z [DEBUG] [API:request] Creating client")
+            options.stderr("2026-03-30T01:28:37.000Z [DEBUG] Hooks: Found 0 hooks")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks if c.startswith("data:")]
+    status_events = [p for p in payloads if p.get("type") == "status"]
+    status_texts = [s["text"] for s in status_events]
+    # Initial "Подключение" status
+    assert any("Подключение" in t for t in status_texts), f"missing initial status: {status_texts}"
+    # Stderr-derived stage status from [API:request] keyword
+    assert any("API" in t for t in status_texts), f"missing stderr-derived status: {status_texts}"
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_renders_saved_prompt_template_variables(db):
     await db.set_setting(
         AGENT_PROMPT_TEMPLATE_SETTING,
@@ -1307,3 +1344,171 @@ async def test_runtime_status_selected_backend_deepagents_override(db, monkeypat
     assert status.claude_available is True
     assert status.selected_backend == "deepagents"
     assert status.using_override is True
+
+
+# ---------------------------------------------------------------------------
+# Atomic timeout tests
+# ---------------------------------------------------------------------------
+
+
+def test_agent_config_timeout_defaults():
+    """AgentConfig has correct default timeout values."""
+    config = AppConfig()
+    assert config.agent.stream_close_timeout == 60
+    assert config.agent.first_event_timeout == 90
+    assert config.agent.idle_timeout == 90
+    assert config.agent.permission_timeout == 120
+    assert config.agent.total_timeout == 600
+
+
+@pytest.mark.asyncio
+async def test_await_with_countdown_normal():
+    """_await_with_countdown returns result when coro completes within timeout."""
+    from src.agent.manager import _await_with_countdown
+
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def fast_coro():
+        return 42
+
+    result = await _await_with_countdown(fast_coro(), timeout=5, queue=queue, label="test")
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_await_with_countdown_timeout_fires():
+    """_await_with_countdown raises TimeoutError when coro exceeds timeout."""
+    from src.agent.manager import _await_with_countdown
+
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def slow_coro():
+        await asyncio.sleep(100)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await _await_with_countdown(slow_coro(), timeout=0.2, queue=queue, label="test", countdown_interval=1)
+
+
+@pytest.mark.asyncio
+async def test_await_with_countdown_emits_status():
+    """_await_with_countdown pushes countdown status events to queue."""
+    from src.agent.manager import _await_with_countdown
+
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def slow_coro():
+        await asyncio.sleep(100)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await _await_with_countdown(
+            slow_coro(), timeout=3.0, queue=queue, label="Ожидание", countdown_interval=0.5,
+        )
+
+    items = []
+    while not queue.empty():
+        items.append(queue.get_nowait())
+
+    countdown_items = [i for i in items if "countdown" in i and "до таймаута" in i]
+    assert len(countdown_items) >= 1, f"ожидали хотя бы один countdown event, получили: {items}"
+
+
+@pytest.mark.asyncio
+async def test_first_event_timeout_fires(db):
+    """When query() yields no events, first_event_timeout triggers with error."""
+    thread_id = await db.create_agent_thread("timeout thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    async def stalling_query(prompt, options):
+        await asyncio.sleep(100)
+        # Never yields — simulates stalled connection
+        if False:
+            yield  # noqa: F841 — make it an async generator
+
+    config = AppConfig()
+    config.agent.first_event_timeout = 1
+    config.agent.idle_timeout = 1
+    config.agent.total_timeout = 5
+
+    mgr = AgentManager(db, config=config)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", stalling_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks if c.startswith("data: ")]
+    errors = [p for p in payloads if "error" in p]
+    assert errors, f"ожидали ошибку таймаута, получили: {payloads}"
+    assert "90" not in errors[0]["error"], "должен использовать конфиг first_event_timeout=1, не дефолт 90"
+
+
+@pytest.mark.asyncio
+async def test_idle_timeout_fires(db):
+    """When query() stops yielding mid-stream, idle_timeout triggers."""
+    thread_id = await db.create_agent_thread("idle-timeout thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    from claude_agent_sdk import StreamEvent
+
+    def _stream_event(text: str) -> MagicMock:
+        ev = MagicMock(spec=StreamEvent)
+        ev.event = {"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}}
+        return ev
+
+    async def stalling_after_first(prompt, options):
+        yield _stream_event("hello")
+        await asyncio.sleep(100)  # stalls after first event
+
+    config = AppConfig()
+    config.agent.first_event_timeout = 5
+    config.agent.idle_timeout = 1
+    config.agent.total_timeout = 10
+
+    mgr = AgentManager(db, config=config)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", stalling_after_first):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks if c.startswith("data: ")]
+    errors = [p for p in payloads if "error" in p]
+    assert errors, f"ожидали ошибку idle таймаута, получили: {payloads}"
+    assert "замолчал" in errors[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_permission_timeout_from_config(db):
+    """permission_timeout from AgentConfig is passed to AgentRequestContext."""
+    from src.agent.permission_gate import AgentRequestContext
+
+    config = AppConfig()
+    config.agent.permission_timeout = 77
+
+    ctx = AgentRequestContext(
+        session_id="test",
+        thread_id=1,
+        queue=asyncio.Queue(),
+        db_permissions={},
+        permission_timeout=config.agent.permission_timeout,
+    )
+    assert ctx.permission_timeout == 77
+
+
+@pytest.mark.asyncio
+async def test_stream_close_timeout_from_config(db, monkeypatch):
+    """stream_close_timeout from config is used for CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var."""
+    monkeypatch.delenv("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", raising=False)
+    config = AppConfig()
+    config.agent.stream_close_timeout = 42
+
+    from src.agent.manager import ClaudeSdkBackend
+
+    backend = ClaudeSdkBackend(db, config)
+    with patch("src.agent.tools.make_mcp_server", return_value=MagicMock()):
+        backend.initialize()
+
+    import os
+    assert os.environ.get("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT") == "42000"

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -77,10 +77,10 @@ def test_streaming_message_update_status():
 
     widget = StreamingMessage()
     widget._elapsed_label = MagicMock()
-    widget.update_status("🔧 search_messages ✅ (1.2s)")
+    widget.set_pending_status("🔧 search_messages ✅ (1.2s)")
     assert widget._status_label == "🔧 search_messages ✅ (1.2s)"
     assert widget._tool_start_time == 0.0
-    widget._elapsed_label.update.assert_called_with("🔧 search_messages ✅ (1.2s)")
+    widget._elapsed_label.update.assert_called_with("⏳ 🔧 search_messages ✅ (1.2s)")
 
 
 def test_streaming_message_tick_elapsed_with_tool():


### PR DESCRIPTION
## Summary

- **5 atomic timeouts** replace monolithic 300s `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`: `stream_close_timeout` (60s), `first_event_timeout` (90s), `idle_timeout` (90s), `permission_timeout` (120s), `total_timeout` (600s) — all configurable via `config.yaml`
- **Live countdown** in TUI via new `"countdown"` SSE event type + `replace_pending_status()` — updates one line in-place instead of spamming 4-5 log entries
- **Connection diagnostics** — `_diagnose_connection()` checks API key, CLI path, stderr for concrete error messages on timeout
- **Graceful shutdown** — cascade-safe cleanup in `agent.py`, per-client 5s timeout in `disconnect_all()`, batch `asyncio.wait()` in `close_all()`
- Filed external issues: anthropics/claude-agent-sdk-python#776 (cancel scope RuntimeError), anthropics/claude-code#40844 (lock acquisition stderr noise)

## Test plan

- [x] `ruff check` passes
- [x] `pytest tests/test_agent.py` — 88 tests pass (8 new timeout tests)
- [x] `pytest tests/test_agent_tui.py` — 32 tests pass
- [x] `pytest tests/test_cli.py` — passes
- [x] `pytest tests/test_config.py` — passes
- [ ] Manual: Agent TUI shows countdown updating in-place, error appears in ~90s not 300s
- [ ] Manual: CLI `agent chat` exits cleanly without "Task was destroyed" errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)