### PR TITLE
fix: centralize data dir creation & improve TUI logging

### DIFF
--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -53,11 +53,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             result = await svc.generate(model=model, text=prompt)
             if result and (result.startswith("https://") or result.startswith("http://")):
                 import hashlib
+                from urllib.parse import urlparse
 
                 import httpx
-
-                DATA_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
-                from urllib.parse import urlparse
 
                 url_path = urlparse(result).path
                 _, dot, suffix = url_path.rpartition(".")

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -280,7 +280,6 @@ def register(db, client_pool, embedding_service, **kwargs):
             if msg is None:
                 return _text_response(f"Сообщение #{message_id} не найдено.")
             output_dir = pathlib.Path(__file__).resolve().parents[3] / "data" / "downloads"
-            output_dir.mkdir(parents=True, exist_ok=True)
             path = await client.download_media(msg, file=str(output_dir))
             if not path:
                 return _text_response("В сообщении нет медиа.")

--- a/src/cli/commands/agent_tui.tcss
+++ b/src/cli/commands/agent_tui.tcss
@@ -85,6 +85,11 @@ ThreadItem Label {
     border-title-color: $warning;
 }
 
+.activity-log {
+    color: #666666;
+    margin-bottom: 0;
+}
+
 #input-bar {
     height: auto;
     max-height: 8;

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -30,12 +30,13 @@ from src.cli.commands import settings as settings_cmd
 from src.cli.commands import test as test_cmd
 from src.cli.commands import translate as translate_cmd
 from src.cli.parser import build_parser
-from src.cli.runtime import setup_logging
+from src.cli.runtime import ensure_data_dirs, setup_logging
 
 
 def main() -> None:
     load_dotenv()
     setup_logging()
+    ensure_data_dirs()
 
     parser = build_parser()
     args = parser.parse_args()

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -30,13 +30,13 @@ def ensure_data_dirs() -> None:
         (_DATA_ROOT / sub).mkdir(parents=True, exist_ok=True)
 
 
-def redirect_logging_to_file(path: str | Path = _TUI_LOG_PATH) -> logging.Handler | None:
-    """Replace console handler with file handler for TUI mode. Returns removed handler."""
+def redirect_logging_to_file(path: str | Path = _TUI_LOG_PATH) -> list[logging.Handler]:
+    """Replace console handlers with file handler for TUI mode. Returns removed handlers."""
     root = logging.getLogger()
-    removed = None
+    removed: list[logging.Handler] = []
     for h in root.handlers[:]:
         if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
-            removed = h
+            removed.append(h)
             root.removeHandler(h)
     fh = logging.FileHandler(str(path), encoding="utf-8")
     fh.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
@@ -44,15 +44,18 @@ def redirect_logging_to_file(path: str | Path = _TUI_LOG_PATH) -> logging.Handle
     return removed
 
 
-def restore_logging(removed_handler: logging.Handler | None) -> None:
-    """Restore console handler after TUI exits."""
+def restore_logging(removed_handlers: list[logging.Handler] | logging.Handler | None) -> None:
+    """Restore console handlers after TUI exits."""
     root = logging.getLogger()
     for h in root.handlers[:]:
         if isinstance(h, logging.FileHandler):
             h.close()
             root.removeHandler(h)
-    if removed_handler:
-        root.addHandler(removed_handler)
+    if isinstance(removed_handlers, list):
+        for h in removed_handlers:
+            root.addHandler(h)
+    elif removed_handlers:
+        root.addHandler(removed_handlers)
 
 
 async def init_db(config_path: str):

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1,20 +1,58 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from src.config import load_config, resolve_session_encryption_secret
 from src.database import Database
 from src.settings_utils import parse_int_setting
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
+from src.web.paths import PROJECT_ROOT
+
+_DATA_ROOT = PROJECT_ROOT / "data"
+_LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+_TUI_LOG_PATH = _DATA_ROOT / "agent_tui.log"
 
 
 def setup_logging() -> None:
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        format=_LOG_FORMAT,
+        datefmt=_LOG_DATEFMT,
     )
+
+
+def ensure_data_dirs() -> None:
+    """Create all data subdirectories once at startup."""
+    for sub in ("image", "images", "downloads", "photo_uploads", "telegram_sessions"):
+        (_DATA_ROOT / sub).mkdir(parents=True, exist_ok=True)
+
+
+def redirect_logging_to_file(path: str | Path = _TUI_LOG_PATH) -> logging.Handler | None:
+    """Replace console handler with file handler for TUI mode. Returns removed handler."""
+    root = logging.getLogger()
+    removed = None
+    for h in root.handlers[:]:
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+            removed = h
+            root.removeHandler(h)
+    fh = logging.FileHandler(str(path), encoding="utf-8")
+    fh.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+    root.addHandler(fh)
+    return removed
+
+
+def restore_logging(removed_handler: logging.Handler | None) -> None:
+    """Restore console handler after TUI exits."""
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        if isinstance(h, logging.FileHandler):
+            h.close()
+            root.removeHandler(h)
+    if removed_handler:
+        root.addHandler(removed_handler)
 
 
 async def init_db(config_path: str):
@@ -25,30 +63,6 @@ async def init_db(config_path: str):
     )
     await db.initialize()
     return config, db
-
-
-def redirect_logging_to_file() -> list[logging.Handler]:
-    """Move all root logger handlers to a file handler for TUI mode.
-
-    Returns the removed handlers so they can be restored later.
-    """
-    root = logging.getLogger()
-    removed = list(root.handlers)
-    for h in removed:
-        root.removeHandler(h)
-    fh = logging.FileHandler("agent_tui.log", encoding="utf-8")
-    fh.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
-    root.addHandler(fh)
-    return removed
-
-
-def restore_logging(handlers: list[logging.Handler]) -> None:
-    """Restore previously removed handlers and remove the file handler."""
-    root = logging.getLogger()
-    for h in list(root.handlers):
-        root.removeHandler(h)
-    for h in handlers:
-        root.addHandler(h)
 
 
 async def init_pool(config, db: Database):

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -75,7 +75,8 @@ class DBConnection:
         self.db: aiosqlite.Connection | None = None
 
     async def connect(self) -> aiosqlite.Connection:
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        if self._db_path != ":memory:":
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
         self.db = await aiosqlite.connect(self._db_path, timeout=10.0, isolation_level=None)
         self.db.row_factory = aiosqlite.Row
         await self.db.execute("PRAGMA journal_mode=WAL")

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -646,7 +646,6 @@ class AgentProviderService:
             "generated_by": f"tg-agent {self._app_version()}",
             "providers": providers_payload,
         }
-        export_path.parent.mkdir(parents=True, exist_ok=True)
         export_path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -296,7 +296,6 @@ def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/image
                     )
                 image_bytes = await resp.read()
                 out = Path(output_dir)
-                out.mkdir(parents=True, exist_ok=True)
                 filename = f"{uuid.uuid4().hex}.png"
                 filepath = out / filename
                 filepath.write_bytes(image_bytes)

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -51,7 +51,7 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         if "static" not in mount_names:
             app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     # Serve generated images from data/image/
-    if "data-image" not in {r.name for r in app.routes}:
+    if DATA_IMAGE_DIR.exists() and "data-image" not in {r.name for r in app.routes}:
         app.mount("/data/image", StaticFiles(directory=str(DATA_IMAGE_DIR)), name="data-image")
 
 

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -51,7 +51,6 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         if "static" not in mount_names:
             app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     # Serve generated images from data/image/
-    DATA_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
     if "data-image" not in {r.name for r in app.routes}:
         app.mount("/data/image", StaticFiles(directory=str(DATA_IMAGE_DIR)), name="data-image")
 

--- a/src/web/routes/my_telegram.py
+++ b/src/web/routes/my_telegram.py
@@ -360,7 +360,6 @@ async def download_media(request: Request):
                 url=f"/my-telegram/?phone={quote(phone, safe='')}&error=message_not_found", status_code=303
             )
         output_dir = pathlib.Path(__file__).resolve().parents[3] / "data" / "downloads"
-        output_dir.mkdir(parents=True, exist_ok=True)
         path = await client.download_media(msg, file=str(output_dir))
         if not path:
             return RedirectResponse(

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -28,12 +28,7 @@ def _redirect(phone: str, code: str, error: bool = False) -> RedirectResponse:
     )
 
 
-def _ensure_upload_root() -> None:
-    UPLOAD_ROOT.mkdir(parents=True, exist_ok=True)
-
-
 async def _persist_uploads(files: list[UploadFile], folder_name: str) -> list[str]:
-    _ensure_upload_root()
     target_dir = UPLOAD_ROOT / folder_name
     target_dir.mkdir(parents=True, exist_ok=True)
     stored: list[str] = []

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -72,15 +72,17 @@ def test_streaming_message_finalize_changes_class():
     assert "streaming-bubble" not in widget.classes
 
 
-def test_streaming_message_update_status():
+def test_streaming_message_set_pending_status():
     from src.cli.commands.agent_tui import StreamingMessage
 
     widget = StreamingMessage()
     widget._elapsed_label = MagicMock()
-    widget.set_pending_status("🔧 search_messages ✅ (1.2s)")
-    assert widget._status_label == "🔧 search_messages ✅ (1.2s)"
+    widget._activity_log = MagicMock()
+    widget.set_pending_status("Жду ответ Claude API")
+    assert widget._status_label == "Жду ответ Claude API"
+    assert widget._pending_status == "Жду ответ Claude API"
     assert widget._tool_start_time == 0.0
-    widget._elapsed_label.update.assert_called_with("⏳ 🔧 search_messages ✅ (1.2s)")
+    widget._elapsed_label.update.assert_called_with("⏳ Жду ответ Claude API")
 
 
 def test_streaming_message_tick_elapsed_with_tool():
@@ -490,6 +492,36 @@ class TestAgentChatOneShotMode:
         finally:
             conn.close()
         assert any(r["role"] == "user" and r["content"] == "hi" for r in rows)
+
+    def test_one_shot_prints_status_to_stderr(self, cli_env, capsys, monkeypatch):
+        """Status events are printed to stderr, not stdout, in one-shot mode."""
+        from unittest.mock import patch as _patch
+
+        from src.cli.commands.agent import run
+        from tests.helpers import cli_ns as _ns
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        async def fake_init_db(_path):
+            return AppConfig(), cli_env
+
+        async def fake_chat_stream(*_a, **_kw):
+            yield 'data: {"type": "status", "text": "Создание клиента"}\n\n'
+            yield 'data: {"type": "status", "text": "Запрос к API"}\n\n'
+            yield 'data: {"text": "reply text"}\n\n'
+            yield 'data: {"done": true, "full_text": "reply text"}\n\n'
+
+        with (
+            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            _patch("src.agent.manager.AgentManager.chat_stream", fake_chat_stream),
+        ):
+            run(_ns(agent_action="chat", prompt="test", thread_id=None, model=None))
+
+        captured = capsys.readouterr()
+        assert "reply text" in captured.out
+        # Status events must NOT leak into stdout
+        assert "Создание клиента" not in captured.out
+        assert "Запрос к API" not in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Centralize mkdir** — replace 8 scattered `mkdir(parents=True, exist_ok=True)` calls with a single `ensure_data_dirs()` at startup in `src/cli/runtime.py`
- **TUI logging** — add `redirect_logging_to_file()`/`restore_logging()` with proper constants and `data/agent_tui.log` path; deduplicate functions from #312
- **DB fix** — skip `mkdir` for `:memory:` databases in `DBConnection.connect()`

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/test_agent_tui.py tests/test_agent.py` — 125 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)