### PR TITLE
feat(agent): upgrade claude-agent-sdk 0.1.50 → 0.1.52

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "numpy==2.4.3",
     "langdetect==1.0.9",
     "textual[syntax]>=1.0.0",
-    "claude-agent-sdk==0.1.50",
+    "claude-agent-sdk==0.1.52",
     "deepagents==0.4.12",
     "langchain==1.2.12",
     "langchain-core==1.2.19",

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -278,6 +278,7 @@ class ClaudeSdkBackend:
         model: str | None,
         queue: asyncio.Queue[str | None],
         history_msgs: list[dict] | None = None,
+        session_id: str = "web",
     ) -> None:
         self._ensure_initialized()
         original_prompt = prompt
@@ -287,6 +288,8 @@ class ClaudeSdkBackend:
         extra: dict = {}
         if resolved_model:
             extra["model"] = resolved_model
+        if session_id:
+            extra["session_id"] = session_id
 
         stderr_lines: list[str] = []
         debug_lines: list[str] = []
@@ -514,10 +517,27 @@ class ClaudeSdkBackend:
                                         block.tool_use_id, content, bool(block.is_error)
                                     )
                         elif isinstance(msg, ResultMessage):
-                            done_payload = json.dumps(
-                                {"done": True, "full_text": full_text, "backend": "claude"},
-                                ensure_ascii=False,
-                            )
+                            done_data: dict = {
+                                "done": True,
+                                "full_text": full_text,
+                                "backend": "claude",
+                            }
+                            _usage = getattr(msg, "usage", None)
+                            if isinstance(_usage, dict):
+                                done_data["usage"] = _usage
+                            _model_usage = getattr(msg, "model_usage", None)
+                            if isinstance(_model_usage, dict):
+                                done_data["model_usage"] = _model_usage
+                            _cost = getattr(msg, "total_cost_usd", None)
+                            if isinstance(_cost, (int, float)):
+                                done_data["total_cost_usd"] = _cost
+                            _turns = getattr(msg, "num_turns", None)
+                            if isinstance(_turns, int) and _turns > 0:
+                                done_data["num_turns"] = _turns
+                            _sid = getattr(msg, "session_id", None)
+                            if isinstance(_sid, str) and _sid:
+                                done_data["session_id"] = _sid
+                            done_payload = json.dumps(done_data, ensure_ascii=False)
                             await queue.put(f"data: {done_payload}\n\n")
                     except asyncio.CancelledError:
                         draining = True
@@ -1719,7 +1739,7 @@ class AgentManager:
             # Set ContextVar here so token is created and reset in the same task context.
             _token = set_request_context(_req_ctx) if _req_ctx is not None else None
             try:
-                await selected_backend.chat_stream(
+                kwargs: dict = dict(
                     thread_id=thread_id,
                     prompt=prompt,
                     system_prompt=system_prompt,
@@ -1728,6 +1748,9 @@ class AgentManager:
                     queue=queue,
                     history_msgs=history_for_backend,
                 )
+                if isinstance(selected_backend, ClaudeSdkBackend):
+                    kwargs["session_id"] = session_id
+                await selected_backend.chat_stream(**kwargs)
             except Exception as exc:
                 logger.exception("Agent chat error for thread %d", thread_id)
                 error_text = str(exc)

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -38,7 +40,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_account",
         "Toggle account active/inactive status. account_id = id from list_accounts.",
-        {"account_id": int},
+        {"account_id": Annotated[int, "ID аккаунта из list_accounts"]},
     )
     async def toggle_account(args):
         account_id = args.get("account_id")
@@ -62,7 +64,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "delete_account",
         "⚠️ DANGEROUS: Delete a Telegram account from the system. "
         "account_id = id from list_accounts. Always ask user for confirmation first.",
-        {"account_id": int, "confirm": bool},
+        {
+            "account_id": Annotated[int, "ID аккаунта из list_accounts"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_account(args):
@@ -104,7 +109,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "clear_flood_status",
         "Clear flood wait restriction for a specific account. Ask user for confirmation first.",
-        {"phone": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def clear_flood_status(args):
         phone, err = await resolve_phone(db, args.get("phone", ""))
@@ -133,7 +141,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_account_info",
         "Get live Telegram account info (name, username, premium status) for connected accounts. "
         "Optionally filter by phone number.",
-        {"phone": str},
+        {"phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"]},
     )
     async def get_account_info(args):
         pool_gate = require_pool(client_pool, "Информация об аккаунтах")

--- a/src/agent/tools/agent_threads.py
+++ b/src/agent/tools/agent_threads.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -26,7 +28,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(list_agent_threads)
 
-    @tool("create_agent_thread", "Create a new agent chat thread", {"title": str})
+    @tool("create_agent_thread", "Create a new agent chat thread", {"title": Annotated[str, "Название треда"]})
     async def create_agent_thread(args):
         try:
             title = args.get("title", "Новый тред")
@@ -41,7 +43,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "delete_agent_thread",
         "⚠️ DANGEROUS: Delete an agent chat thread and all its messages. "
         "Always ask user for confirmation first.",
-        {"thread_id": int, "confirm": bool},
+        {
+            "thread_id": Annotated[int, "ID треда агента"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_agent_thread(args):
@@ -61,7 +66,11 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(delete_agent_thread)
 
-    @tool("rename_agent_thread", "Rename an agent chat thread", {"thread_id": int, "title": str})
+    @tool(
+        "rename_agent_thread",
+        "Rename an agent chat thread",
+        {"thread_id": Annotated[int, "ID треда агента"], "title": Annotated[str, "Название треда"]},
+    )
     async def rename_agent_thread(args):
         thread_id = args.get("thread_id")
         title = args.get("title", "")
@@ -78,7 +87,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_thread_messages",
         "Get messages from an agent chat thread",
-        {"thread_id": int, "limit": int},
+        {
+            "thread_id": Annotated[int, "ID треда агента"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def get_thread_messages(args):
         thread_id = args.get("thread_id")

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response
@@ -34,7 +36,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_pipeline_stats",
         "Get detailed statistics for a specific pipeline or all pipelines",
-        {"pipeline_id": int},
+        {"pipeline_id": Annotated[int, "ID пайплайна для фильтрации"]},
     )
     async def get_pipeline_stats(args):
         try:
@@ -64,7 +66,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_daily_stats",
         "Get daily content generation statistics over a time period",
-        {"days": int, "pipeline_id": int},
+        {
+            "days": Annotated[int, "Количество дней для анализа"],
+            "pipeline_id": Annotated[int, "ID пайплайна для фильтрации"],
+        },
     )
     async def get_daily_stats(args):
         try:
@@ -91,7 +96,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_trending_topics",
         "Get trending topics/keywords from collected messages over the last N days",
-        {"days": int, "limit": int},
+        {
+            "days": Annotated[int, "Количество дней для анализа"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def get_trending_topics(args):
         try:
@@ -115,7 +123,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_trending_channels",
         "Get top channels by message activity over the last N days",
-        {"days": int, "limit": int},
+        {
+            "days": Annotated[int, "Количество дней для анализа"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def get_trending_channels(args):
         try:
@@ -139,7 +150,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_message_velocity",
         "Get message volume over time (messages per day) for the last N days",
-        {"days": int},
+        {"days": Annotated[int, "Количество дней для анализа"]},
     )
     async def get_message_velocity(args):
         try:
@@ -181,7 +192,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_calendar",
         "Get upcoming scheduled content publications",
-        {"limit": int, "pipeline_id": int},
+        {
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "pipeline_id": Annotated[int, "ID пайплайна для фильтрации"],
+        },
     )
     async def get_calendar(args):
         try:
@@ -218,7 +232,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_top_messages",
         "Get top messages ranked by total reactions count. "
         "Optional date filters: date_from, date_to (YYYY-MM-DD).",
-        {"limit": int, "date_from": str, "date_to": str},
+        {
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "date_from": Annotated[str, "Начало периода в формате YYYY-MM-DD"],
+            "date_to": Annotated[str, "Конец периода в формате YYYY-MM-DD"],
+        },
     )
     async def get_top_messages(args):
         try:
@@ -246,7 +264,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_content_type_stats",
         "Get message counts and average reactions grouped by content type (text, photo, video, etc.).",
-        {"date_from": str, "date_to": str},
+        {
+            "date_from": Annotated[str, "Начало периода в формате YYYY-MM-DD"],
+            "date_to": Annotated[str, "Конец периода в формате YYYY-MM-DD"],
+        },
     )
     async def get_content_type_stats(args):
         try:
@@ -274,7 +295,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_hourly_activity",
         "Get message distribution by hour of day (UTC). Shows when channels are most active.",
-        {"date_from": str, "date_to": str},
+        {
+            "date_from": Annotated[str, "Начало периода в формате YYYY-MM-DD"],
+            "date_to": Annotated[str, "Конец периода в формате YYYY-MM-DD"],
+        },
     )
     async def get_hourly_activity(args):
         try:

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -19,7 +21,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "List Telegram channels saved in the local database. Each row includes pk "
         "(DB primary key used by collect_channel/delete_channel/toggle_channel), "
         "channel_id (Telegram numeric ID), title, username, channel_type, and is_filtered status.",
-        {"active_only": bool, "include_filtered": bool},
+        {
+            "active_only": Annotated[bool, "Показывать только активные записи"],
+            "include_filtered": Annotated[bool, "Включить отфильтрованные каналы в результат"],
+        },
     )
     async def list_channels(args):
         active_only = bool(args.get("active_only", False))
@@ -80,7 +85,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Add a Telegram channel to the local database by identifier (t.me link, @username, or numeric ID). "
         "After adding, use list_channels to get the pk, then call collect_channel to start message collection. "
         "Requires confirmation.",
-        {"identifier": str, "confirm": bool},
+        {
+            "identifier": Annotated[str, "Идентификатор канала (t.me ссылка, @username или числовой ID)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def add_channel(args):
         identifier = args.get("identifier")
@@ -110,7 +118,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "delete_channel",
         "DANGEROUS: Permanently delete a channel and all its messages from the DB. "
         "pk = DB primary key — get it from list_channels. Always ask user for confirmation first.",
-        {"pk": int, "confirm": bool},
+        {
+            "pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_channel(args):
@@ -140,7 +151,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_channel",
         "Toggle channel active/inactive status. pk = DB primary key — get it from list_channels.",
-        {"pk": int},
+        {"pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"]},
     )
     async def toggle_channel(args):
         pk = args.get("pk")
@@ -169,7 +180,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "import_channels",
         "Bulk-import channels from a text string (t.me links, @usernames, or numeric IDs, any separator). "
         "After import, use collect_all_channels to start collection. Requires confirmation.",
-        {"text": str, "confirm": bool},
+        {
+            "text": Annotated[str, "Идентификаторы каналов (t.me ссылки, @username, ID через любой разделитель)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def import_channels(args):
         text = args.get("text")
@@ -215,7 +229,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "refresh_channel_types",
         "Refresh channel_type (channel/group/supergroup/unavailable) for all active channels "
         "via Telegram API. Requires a connected Telegram client. Requires confirmation.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def refresh_channel_types(args):
         pool_gate = require_pool(client_pool, "Обновление типов каналов")
@@ -264,7 +278,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Refresh channel metadata (about, linked_chat_id, has_comments) from Telegram. "
         "Pass identifier (channel_id as string, or @username) for one channel, or omit to refresh all. "
         "Requires confirmation.",
-        {"identifier": str, "confirm": bool},
+        {
+            "identifier": Annotated[str, "Идентификатор канала (t.me ссылка, @username или числовой ID)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def refresh_channel_meta(args):
         pool_gate = require_pool(client_pool, "Обновление метаданных каналов")
@@ -357,7 +374,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "create_tag",
         "Create a new channel tag. Requires confirm=true.",
-        {"name": str, "confirm": bool},
+        {
+            "name": Annotated[str, "Название тега"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def create_tag(args):
         name = (args.get("name") or "").strip()
@@ -377,7 +397,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "delete_tag",
         "⚠️ DANGEROUS: Delete a tag and remove it from all channels. Requires confirm=true.",
-        {"name": str, "confirm": bool},
+        {
+            "name": Annotated[str, "Название тега"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_tag(args):
@@ -399,7 +422,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "set_channel_tags",
         "Assign tags to a channel (replaces all existing tags). "
         "pk = DB primary key from list_channels. tags = comma-separated tag names (empty to clear all).",
-        {"pk": int, "tags": str},
+        {
+            "pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"],
+            "tags": Annotated[str, "Теги через запятую (пустая строка — очистить)"],
+        },
     )
     async def set_channel_tags(args):
         pk = args.get("pk")

--- a/src/agent/tools/collection.py
+++ b/src/agent/tools/collection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response, require_pool
@@ -15,7 +17,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Enqueue a single channel for message collection. pk = DB primary key — get it from list_channels. "
         "If the channel is not in the DB yet, first add it with add_channel, then use pk from list_channels. "
         "Use force=true to collect filtered channels.",
-        {"pk": int, "force": bool},
+        {
+            "pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"],
+            "force": Annotated[bool, "Принудительно собрать отфильтрованный канал"],
+        },
     )
     async def collect_channel(args):
         gate = require_pool(client_pool, "Сбор сообщений")
@@ -68,7 +73,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "collect_channel_stats",
         "Enqueue subscriber/views statistics collection for a single channel. "
         "pk = DB primary key — get it from list_channels.",
-        {"pk": int},
+        {"pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"]},
     )
     async def collect_channel_stats(args):
         gate = require_pool(client_pool, "Сбор статистики")

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -43,7 +45,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "apply_filters",
         "⚠️ DANGEROUS: Run analyze_filters and mark flagged channels as filtered (skipped during collection). "
         "Always ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def apply_filters(args):
@@ -66,7 +68,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "reset_filters",
         "⚠️ DANGEROUS: Reset all channel filters — unmark all filtered channels. "
         "Always ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def reset_filters(args):
@@ -87,7 +89,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_channel_filter",
         "Toggle filter status for a specific channel. pk = DB primary key — get it from list_channels.",
-        {"pk": int},
+        {"pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"]},
     )
     async def toggle_channel_filter(args):
         pk = args.get("pk")
@@ -111,7 +113,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ DANGEROUS: Soft-delete messages from filtered channels. "
         "pks = comma-separated DB primary keys from list_channels; "
         "omit to purge all filtered channels. Always ask user for confirmation first.",
-        {"pks": str, "confirm": bool},
+        {
+            "pks": Annotated[str, "ID записей через запятую (первичные ключи из list_channels)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def purge_filtered_channels(args):
@@ -145,7 +150,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ DANGEROUS: Permanently delete channels and ALL their data (irreversible). "
         "pks = comma-separated DB primary keys from list_channels. "
         "Always ask user for confirmation first.",
-        {"pks": str, "confirm": bool},
+        {
+            "pks": Annotated[str, "ID записей через запятую (первичные ключи из list_channels)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def hard_delete_channels(args):
@@ -173,7 +181,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "precheck_filters",
         "⚠️ Pre-filter channels by subscriber ratio (no Telegram API needed). "
         "Marks channels as filtered. Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def precheck_filters(args):
         gate = require_confirmation(

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Annotated
 
 from claude_agent_sdk import tool
 
@@ -39,7 +40,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Generate an image from a text prompt. Model format: 'provider:model_id' "
         "(e.g. 'together:black-forest-labs/FLUX.1-schnell'). "
         "Use list_image_providers to see available providers, list_image_models for models.",
-        {"prompt": str, "model": str},
+        {
+            "prompt": Annotated[str, "Текстовый промпт для генерации изображения"],
+            "model": Annotated[str, "Модель в формате provider:model_id (например together:FLUX.1-schnell)"],
+        },
     )
     async def generate_image(args):
         prompt = args.get("prompt", "")
@@ -99,7 +103,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "list_image_models",
         "Search available image models for a provider. "
         "Get provider name from list_image_providers first. query filters by model name substring.",
-        {"provider": str, "query": str},
+        {
+            "provider": Annotated[str, "Название провайдера из list_image_providers"],
+            "query": Annotated[str, "Подстрока для фильтрации моделей по имени"],
+        },
     )
     async def list_image_models(args):
         provider = args.get("provider", "")
@@ -148,7 +155,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "list_generated_images",
         "List recently generated images stored in the database. "
         "Returns image ID, prompt, model, local file path, and creation date.",
-        {"limit": int},
+        {"limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def list_generated_images(args):
         limit = args.get("limit") or 20

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -22,7 +24,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "send_message",
         "Send a message from a connected account (phone = sender's phone). "
         "recipient accepts @username, phone number, or numeric ID. Ask user for confirmation first.",
-        {"phone": str, "recipient": str, "text": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "recipient": Annotated[str, "Получатель (@username, телефон или числовой ID)"],
+            "text": Annotated[str, "Текст сообщения"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def send_message(args):
         pool_gate = require_pool(client_pool, "Отправка сообщения")
@@ -59,7 +66,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "edit_message",
         "Edit a previously sent message. "
         "chat_id accepts @username, t.me link, numeric ID, or 'me'. Ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "message_id": int, "text": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "message_id": Annotated[int, "ID сообщения в Telegram"],
+            "text": Annotated[str, "Текст сообщения"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def edit_message(args):
         pool_gate = require_pool(client_pool, "Редактирование сообщения")
@@ -98,7 +111,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ DANGEROUS: Delete messages from a Telegram chat. "
         "chat_id accepts @username, numeric ID, or 'me'. "
         "message_ids = comma-separated integers. Always ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "message_ids": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "message_ids": Annotated[str, "ID сообщений через запятую"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_message(args):
@@ -138,7 +156,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "forward_messages",
         "Forward messages from one Telegram chat to another. "
         "Pass comma-separated message IDs. Always ask user for confirmation first.",
-        {"phone": str, "from_chat": str, "to_chat": str, "message_ids": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "from_chat": Annotated[str, "ID чата-источника (@username, числовой ID)"],
+            "to_chat": Annotated[str, "ID чата-получателя (@username, числовой ID)"],
+            "message_ids": Annotated[str, "ID сообщений через запятую"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def forward_messages(args):
         pool_gate = require_pool(client_pool, "Пересылка сообщений")
@@ -181,7 +205,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "pin_message",
         "Pin a message in a Telegram chat. notify=true sends a notification to all members. "
         "chat_id accepts @username, numeric ID, or 'me'. Ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "message_id": int, "notify": bool, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "message_id": Annotated[int, "ID сообщения в Telegram"],
+            "notify": Annotated[bool, "Отправить уведомление участникам"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def pin_message(args):
         pool_gate = require_pool(client_pool, "Закрепление сообщения")
@@ -216,7 +246,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "unpin_message",
         "Unpin a message in a Telegram chat. Omit message_id to unpin all. "
         "Ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "message_id": int, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "message_id": Annotated[int, "ID сообщения в Telegram"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def unpin_message(args):
         pool_gate = require_pool(client_pool, "Открепление сообщения")
@@ -251,7 +286,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "download_media",
         "Download media from a Telegram message. Returns the local file path. "
         "Use chat_id='me' for Saved Messages (Избранное).",
-        {"phone": str, "chat_id": str, "message_id": int},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "message_id": Annotated[int, "ID сообщения в Telegram"],
+        },
     )
     async def download_media(args):
         import pathlib
@@ -296,7 +335,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_participants",
         "Get list of participants in a Telegram group (not broadcast channels). "
         "search filters by name/username substring.",
-        {"phone": str, "chat_id": str, "limit": int, "search": str},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "search": Annotated[str, "Фильтр по имени/username участника"],
+        },
     )
     async def get_participants(args):
         pool_gate = require_pool(client_pool, "Получение участников")
@@ -339,7 +383,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Promote (is_admin=true) or demote (is_admin=false) a user as admin. "
         "user_id accepts @username or numeric ID. title sets a custom admin badge. "
         "Requires admin rights. Ask for confirmation first.",
-        {"phone": str, "chat_id": str, "user_id": str, "is_admin": bool, "title": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "user_id": Annotated[str, "ID пользователя (@username или числовой ID)"],
+            "is_admin": Annotated[bool, "true — назначить админом, false — снять права"],
+            "title": Annotated[str, "Кастомный бейдж администратора"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def edit_admin(args):
         pool_gate = require_pool(client_pool, "Изменение прав администратора")
@@ -384,9 +435,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "until_date = ISO datetime (e.g. '2025-12-31T23:59:59') for temporary restriction. "
         "Ask for confirmation first.",
         {
-            "phone": str, "chat_id": str, "user_id": str,
-            "send_messages": bool, "send_media": bool,
-            "until_date": str, "confirm": bool,
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "user_id": Annotated[str, "ID пользователя (@username или числовой ID)"],
+            "send_messages": Annotated[bool, "Разрешить отправку сообщений"],
+            "send_media": Annotated[bool, "Разрешить отправку медиа"],
+            "until_date": Annotated[str, "Дата окончания ограничения в формате ISO (YYYY-MM-DDTHH:MM:SS)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def edit_permissions(args):
@@ -440,7 +495,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "kick_participant",
         "⚠️ DANGEROUS: Kick a participant from a Telegram chat. "
         "user_id accepts @username or numeric ID. Always ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "user_id": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "user_id": Annotated[str, "ID пользователя (@username или числовой ID)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def kick_participant(args):
@@ -478,7 +538,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_broadcast_stats",
         "Get broadcast statistics (followers, views, reactions) for a Telegram channel. "
         "Requires admin/owner rights on the channel.",
-        {"phone": str, "chat_id": str},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+        },
     )
     async def get_broadcast_stats(args):
         pool_gate = require_pool(client_pool, "Получение статистики")
@@ -532,7 +595,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "archive_chat",
         "Archive a Telegram dialog (move to archive folder). "
         "Ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def archive_chat(args):
         pool_gate = require_pool(client_pool, "Архивирование чата")
@@ -565,7 +632,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "unarchive_chat",
         "Unarchive a Telegram dialog (move back to main folder). "
         "Ask user for confirmation first.",
-        {"phone": str, "chat_id": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def unarchive_chat(args):
         pool_gate = require_pool(client_pool, "Разархивирование чата")
@@ -598,7 +669,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "mark_read",
         "Mark messages as read in a Telegram chat. "
         "max_id marks all messages up to that ID as read; omit to mark all.",
-        {"phone": str, "chat_id": str, "max_id": int},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "max_id": Annotated[int, "Отметить прочитанными до этого ID включительно"],
+        },
     )
     async def mark_read(args):
         pool_gate = require_pool(client_pool, "Отметка сообщений как прочитанных")
@@ -630,7 +705,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Preview last N messages from any Telegram chat/channel (not stored in DB). "
         "chat_id accepts @username, t.me link, numeric ID, or 'me'. "
         "To save messages to DB for search, use add_channel + collect_channel instead.",
-        {"phone": str, "chat_id": str, "limit": int},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "chat_id": Annotated[str, "ID чата (@username, t.me ссылка, числовой ID или me)"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def read_messages(args):
         pool_gate = require_pool(client_pool, "Чтение сообщений")

--- a/src/agent/tools/moderation.py
+++ b/src/agent/tools/moderation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -19,7 +21,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "list_pending_moderation",
         "List generation runs awaiting moderation. Filter by pipeline_id. "
         "Use run_id from results with get_pipeline_run to view full text, then approve_run or reject_run.",
-        {"pipeline_id": int, "limit": int},
+        {
+            "pipeline_id": Annotated[int, "ID пайплайна для фильтрации"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def list_pending_moderation(args):
         try:
@@ -49,7 +54,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "View full details of a specific generation run for moderation review: "
         "generated text, pipeline name, status, quality score. "
         "run_id from list_pending_moderation. Then use approve_run or reject_run.",
-        {"run_id": int},
+        {"run_id": Annotated[int, "ID генерации из list_pipeline_runs"]},
     )
     async def view_moderation_run(args):
         run_id = args.get("run_id")
@@ -82,7 +87,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "approve_run",
         "Approve a generation run for publishing. Then use publish_pipeline_run to publish it. "
         "run_id from list_pending_moderation or list_pipeline_runs.",
-        {"run_id": int},
+        {"run_id": Annotated[int, "ID генерации из list_pipeline_runs"]},
     )
     async def approve_run(args):
         run_id = args.get("run_id")
@@ -102,7 +107,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "reject_run",
         "Reject a generation run. Provide the run_id.",
-        {"run_id": int},
+        {"run_id": Annotated[int, "ID генерации из list_pipeline_runs"]},
     )
     async def reject_run(args):
         run_id = args.get("run_id")
@@ -127,7 +132,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "bulk_approve_runs",
         "Approve multiple generation runs at once. Provide comma-separated run_ids (e.g. '1,2,3'). "
         "Requires confirm=true.",
-        {"run_ids": str, "confirm": bool},
+        {
+            "run_ids": Annotated[str, "ID генераций через запятую (например 1,2,3)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=False),
     )
     async def bulk_approve_runs(args):
@@ -156,7 +164,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "bulk_reject_runs",
         "Reject multiple generation runs at once. Provide comma-separated run_ids (e.g. '1,2,3'). "
         "Requires confirm=true.",
-        {"run_ids": str, "confirm": bool},
+        {
+            "run_ids": Annotated[str, "ID генераций через запятую (например 1,2,3)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=False),
     )
     async def bulk_reject_runs(args):

--- a/src/agent/tools/my_telegram.py
+++ b/src/agent/tools/my_telegram.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -34,7 +36,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         "type — filter: 'channels' (channel), 'groups' (group/supergroup/gigagroup/forum/monoforum), "
         "'chats' (dm/bot/saved), or exact type like 'supergroup', 'dm', 'bot'; "
         "limit — cap results (default: all).",
-        {"phone": str, "search": str, "type": str, "limit": int},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "search": Annotated[str, "Поиск по @username, t.me ссылке, числовому ID или подстроке названия"],
+            "type": Annotated[str, "Фильтр по типу: channels, groups, chats или точный тип (supergroup, dm, bot)"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def search_my_telegram(args):
         pool_gate = require_pool(client_pool, "Поиск диалогов")
@@ -113,7 +120,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "refresh_dialogs",
         "Refresh cached dialog list for an account from Telegram. "
         "Use when messaging tools fail to resolve a numeric chat_id.",
-        {"phone": str},
+        {"phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"]},
     )
     async def refresh_dialogs(args):
         pool_gate = require_pool(client_pool, "Обновление диалогов")
@@ -141,7 +148,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ DANGEROUS: Leave (unsubscribe from) Telegram channels/groups. "
         "dialog_ids = comma-separated Telegram chat IDs (get from search_my_telegram). "
         "Always ask user for confirmation first.",
-        {"phone": str, "dialog_ids": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "dialog_ids": Annotated[str, "Telegram ID диалогов через запятую"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def leave_dialogs(args):
@@ -179,7 +190,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "create_telegram_channel",
         "⚠️ Create a new Telegram channel via a connected account. "
         "Ask user for confirmation first.",
-        {"phone": str, "title": str, "about": str, "username": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "title": Annotated[str, "Название канала"],
+            "about": Annotated[str, "Описание канала"],
+            "username": Annotated[str, "Username канала (без @)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def create_telegram_channel(args):
         pool_gate = require_pool(client_pool, "Создание канала")
@@ -233,7 +250,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_forum_topics",
         "Get forum topics for a supergroup with topics enabled. "
         "channel_id = Telegram numeric ID (from list_channels or search_my_telegram).",
-        {"channel_id": int},
+        {"channel_id": Annotated[int, "Числовой Telegram ID канала"]},
     )
     async def get_forum_topics(args):
         channel_id = args.get("channel_id")
@@ -255,7 +272,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "clear_dialog_cache",
         "⚠️ Clear cached dialog list for an account. Ask user for confirmation first.",
-        {"phone": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def clear_dialog_cache(args):
         phone = normalize_phone(args.get("phone", ""))
@@ -309,7 +329,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "or when search_my_telegram cannot find a dialog by username. "
         "Does NOT require the entity to be in your dialogs. "
         "Params: identifier — @username, t.me/username, or numeric ID; phone — preferred account (optional).",
-        {"identifier": str, "phone": str},
+        {
+            "identifier": Annotated[str, "Идентификатор (@username, t.me ссылка или числовой ID)"],
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+        },
     )
     async def resolve_entity(args):
         pool_gate = require_pool(client_pool, "Resolve entity")

--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -36,7 +38,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "setup_notification_bot",
         "⚠️ Set up a notification bot via BotFather. Requires Telegram client. "
         "Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def setup_notification_bot(args):
         pool_gate = require_pool(client_pool, "Настройка бота уведомлений")
@@ -64,7 +66,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "delete_notification_bot",
         "⚠️ DANGEROUS: Delete the notification bot. Always ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_notification_bot(args):

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -20,7 +22,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "list_photo_batches",
         "List photo upload batches with batch_id, phone, target, status, and item count.",
-        {"limit": int},
+        {"limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def list_photo_batches(args):
         try:
@@ -49,7 +51,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "list_photo_items",
         "List photo batch items with item_id, batch_id, status, and scheduled time. "
         "Use item_id with cancel_photo_item.",
-        {"limit": int},
+        {"limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def list_photo_items(args):
         try:
@@ -80,7 +82,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         "target = dialog_id from list_photo_dialogs (or 'me'). "
         "file_paths = comma-separated server-local paths. mode: album/separate. "
         "Ask for confirmation first.",
-        {"phone": str, "target": str, "file_paths": str, "mode": str, "caption": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "target": Annotated[str, "ID диалога-получателя (из list_photo_dialogs или me)"],
+            "file_paths": Annotated[str, "Пути к файлам через запятую (серверные пути)"],
+            "mode": Annotated[str, "Режим отправки: album или separate"],
+            "caption": Annotated[str, "Подпись к фото"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def send_photos_now(args):
         pool_gate = require_pool(client_pool, "Отправка фото")
@@ -139,8 +148,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "schedule_at = ISO datetime (e.g. '2025-12-31T10:00:00'). "
         "file_paths = comma-separated server-local paths. Ask for confirmation first.",
         {
-            "phone": str, "target": str, "file_paths": str,
-            "schedule_at": str, "mode": str, "caption": str, "confirm": bool,
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "target": Annotated[str, "ID диалога-получателя (из list_photo_dialogs или me)"],
+            "file_paths": Annotated[str, "Пути к файлам через запятую (серверные пути)"],
+            "schedule_at": Annotated[str, "Дата/время отправки в формате ISO (YYYY-MM-DDTHH:MM:SS)"],
+            "mode": Annotated[str, "Режим отправки: album или separate"],
+            "caption": Annotated[str, "Подпись к фото"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def schedule_photos(args):
@@ -189,7 +203,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "cancel_photo_item",
         "⚠️ Cancel a scheduled photo item. item_id from list_photo_items. Ask user for confirmation first.",
-        {"item_id": int, "confirm": bool},
+        {
+            "item_id": Annotated[int, "ID элемента из list_photo_items"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def cancel_photo_item(args):
         item_id = args.get("item_id")
@@ -245,7 +262,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_auto_upload",
         "Toggle an auto-upload job active/paused. job_id from list_auto_uploads.",
-        {"job_id": int},
+        {"job_id": Annotated[int, "ID автозагрузки из list_auto_uploads"]},
     )
     async def toggle_auto_upload(args):
         job_id = args.get("job_id")
@@ -272,7 +289,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "delete_auto_upload",
         "⚠️ DANGEROUS: Delete an auto-upload job. job_id from list_auto_uploads. "
         "Always ask user for confirmation first.",
-        {"job_id": int, "confirm": bool},
+        {
+            "job_id": Annotated[int, "ID автозагрузки из list_auto_uploads"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_auto_upload(args):
@@ -300,7 +320,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ Create a photo batch for sending to a Telegram dialog. "
         "Params: phone, target (dialog_id), file_paths (comma-sep), caption. "
         "Ask user for confirmation first.",
-        {"phone": str, "target": str, "file_paths": str, "caption": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "target": Annotated[str, "ID диалога-получателя (из list_photo_dialogs или me)"],
+            "file_paths": Annotated[str, "Пути к файлам через запятую (серверные пути)"],
+            "caption": Annotated[str, "Подпись к фото"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def create_photo_batch(args):
         pool_gate = require_pool(client_pool, "Создание батча фото")
@@ -347,7 +373,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "run_photo_due",
         "⚠️ Process all due photo items and auto-upload jobs (sends to Telegram). "
         "Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def run_photo_due(args):
         pool_gate = require_pool(client_pool, "Обработка фото")
@@ -379,8 +405,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ Create an auto-upload job to send photos from a server-side folder on a schedule. "
         "target = dialog_id from list_photo_dialogs. mode: album/separate. Ask for confirmation first.",
         {
-            "phone": str, "target": str, "folder_path": str,
-            "interval_minutes": int, "mode": str, "caption": str, "confirm": bool,
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "target": Annotated[str, "ID диалога-получателя (из list_photo_dialogs или me)"],
+            "folder_path": Annotated[str, "Путь к папке на сервере"],
+            "interval_minutes": Annotated[int, "Интервал автозагрузки в минутах"],
+            "mode": Annotated[str, "Режим отправки: album или separate"],
+            "caption": Annotated[str, "Подпись к фото"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def create_auto_upload(args):
@@ -431,8 +462,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ Update an existing auto-upload job settings. job_id from list_auto_uploads. "
         "mode: album/separate. Ask user for confirmation first.",
         {
-            "job_id": int, "folder_path": str, "mode": str,
-            "caption": str, "interval_minutes": int, "is_active": bool, "confirm": bool,
+            "job_id": Annotated[int, "ID автозагрузки из list_auto_uploads"],
+            "folder_path": Annotated[str, "Путь к папке на сервере"],
+            "mode": Annotated[str, "Режим отправки: album или separate"],
+            "caption": Annotated[str, "Подпись к фото"],
+            "interval_minutes": Annotated[int, "Интервал автозагрузки в минутах"],
+            "is_active": Annotated[bool, "Активна ли автозагрузка"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def update_auto_upload(args):
@@ -486,7 +522,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "list_photo_dialogs",
         "List Telegram dialogs available as photo upload targets (channels, groups, chats).",
-        {"phone": str},
+        {"phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"]},
     )
     async def list_photo_dialogs(args):
         pool_gate = require_pool(client_pool, "Список диалогов для фото")
@@ -525,7 +561,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "refresh_photo_dialogs",
         "Refresh the Telegram dialog cache for photo upload targeting. "
         "Use when new channels/groups are not appearing in the list.",
-        {"phone": str, "confirm": bool},
+        {
+            "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def refresh_photo_dialogs(args):
         pool_gate = require_pool(client_pool, "Обновление кэша диалогов")

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Annotated
 
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
@@ -41,7 +42,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "list_pipelines",
         "List all content pipelines with id, name, model, publish_mode (auto/moderated), schedule, "
         "and backend. Use pipeline_id from this list for other pipeline tools.",
-        {"active_only": bool},
+        {"active_only": Annotated[bool, "Показывать только активные"]},
     )
     async def list_pipelines(args):
         try:
@@ -72,7 +73,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_pipeline_detail",
         "Get detailed information about a specific pipeline including sources, targets, and channel names.",
-        {"pipeline_id": int},
+        {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def get_pipeline_detail(args):
         pipeline_id = args.get("pipeline_id")
@@ -111,7 +112,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "List pending and running generation runs across all pipelines (the generation queue). "
         "Shows run_id, pipeline_id, status, and text preview. "
         "Use get_pipeline_run to see full text of a specific run.",
-        {"limit": int},
+        {"limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def get_pipeline_queue(args):
         try:
@@ -135,7 +136,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_refinement_steps",
         "Get the refinement (post-processing) steps for a pipeline. "
         "Each step has a name and a prompt template with {text} placeholder.",
-        {"pipeline_id": int},
+        {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def get_refinement_steps(args):
         pipeline_id = args.get("pipeline_id")
@@ -168,13 +169,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "(from list_channels). target_refs = comma-separated 'phone|dialog_id' pairs. "
         "publish_mode: 'auto' or 'moderated'. Requires confirm=true.",
         {
-            "name": str,
-            "prompt_template": str,
-            "source_channel_ids": str,
-            "target_refs": str,
-            "llm_model": str,
-            "publish_mode": str,
-            "confirm": bool,
+            "name": Annotated[str, "Название пайплайна"],
+            "prompt_template": Annotated[str, "Шаблон промпта для генерации контента"],
+            "source_channel_ids": Annotated[str, "Telegram ID каналов-источников через запятую"],
+            "target_refs": Annotated[str, "Цели публикации через запятую в формате phone|dialog_id"],
+            "llm_model": Annotated[str, "Модель LLM для генерации (например claude-sonnet-4-20250514)"],
+            "publish_mode": Annotated[str, "Режим публикации: auto или moderated"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def add_pipeline(args):
@@ -223,14 +224,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Edit an existing pipeline. All fields are optional except pipeline_id. "
         "source_channel_ids and target_refs are comma-separated strings. Requires confirm=true.",
         {
-            "pipeline_id": int,
-            "name": str,
-            "prompt_template": str,
-            "source_channel_ids": str,
-            "target_refs": str,
-            "llm_model": str,
-            "publish_mode": str,
-            "confirm": bool,
+            "pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"],
+            "name": Annotated[str, "Название пайплайна"],
+            "prompt_template": Annotated[str, "Шаблон промпта для генерации контента"],
+            "source_channel_ids": Annotated[str, "Telegram ID каналов-источников через запятую"],
+            "target_refs": Annotated[str, "Цели публикации через запятую в формате phone|dialog_id"],
+            "llm_model": Annotated[str, "Модель LLM для генерации (например claude-sonnet-4-20250514)"],
+            "publish_mode": Annotated[str, "Режим публикации: auto или moderated"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def edit_pipeline(args):
@@ -296,7 +297,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_pipeline",
         "Toggle pipeline active/inactive status.",
-        {"pipeline_id": int},
+        {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def toggle_pipeline(args):
         pipeline_id = args.get("pipeline_id")
@@ -321,7 +322,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "delete_pipeline",
         "⚠️ DANGEROUS: Delete a content pipeline permanently. Requires confirm=true.",
-        {"pipeline_id": int, "confirm": bool},
+        {
+            "pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_pipeline(args):
@@ -353,7 +357,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Trigger content generation for a pipeline. Returns a preview of the generated text. "
         "If publish_mode=auto, the run is published immediately; "
         "otherwise use approve_run + publish_pipeline_run.",
-        {"pipeline_id": int},
+        {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def run_pipeline(args):
         pipeline_id = args.get("pipeline_id")
@@ -392,7 +396,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "generate_draft",
         "Generate a draft from a query using RAG (returns draft text and citations). "
         "Optionally use a pipeline's prompt template and model.",
-        {"query": str, "pipeline_id": int, "limit": int},
+        {
+            "query": Annotated[str, "Запрос для генерации черновика"],
+            "pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def generate_draft(args):
         query = args.get("query", "")
@@ -436,7 +444,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "List generation runs for a pipeline. "
         "Filter by status (pending/completed/approved/rejected). "
         "Use run_id from results with get_pipeline_run, approve_run, publish_pipeline_run.",
-        {"pipeline_id": int, "limit": int, "status": str},
+        {
+            "pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "status": Annotated[str, "Фильтр по статусу (pending/completed/approved/rejected)"],
+        },
     )
     async def list_pipeline_runs(args):
         pipeline_id = args.get("pipeline_id")
@@ -468,7 +480,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_pipeline_run",
         "Get full details of a specific generation run including generated text, status, and quality score.",
-        {"run_id": int},
+        {"run_id": Annotated[int, "ID генерации из list_pipeline_runs"]},
     )
     async def get_pipeline_run(args):
         run_id = args.get("run_id")
@@ -500,7 +512,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Publish a generation run to its pipeline target channels. "
         "Approve the run first via approve_run. run_id from list_pipeline_runs. "
         "Requires Telegram client and confirm=true.",
-        {"run_id": int, "confirm": bool},
+        {
+            "run_id": Annotated[int, "ID генерации из list_pipeline_runs"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def publish_pipeline_run(args):
         gate = require_pool(client_pool, "Публикация контента")
@@ -543,7 +558,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "⚠️ Set the refinement (post-processing) steps for a pipeline. "
         "steps_json is a JSON array: [{\"name\": \"Step name\", \"prompt\": \"...{text}...\"}]. "
         "Pass an empty array to clear all steps. Requires confirm=true.",
-        {"pipeline_id": int, "steps_json": str, "confirm": bool},
+        {
+            "pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"],
+            "steps_json": Annotated[str, "JSON-массив шагов: [{name, prompt}]"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def set_refinement_steps(args):
         pipeline_id = args.get("pipeline_id")

--- a/src/agent/tools/scheduler.py
+++ b/src/agent/tools/scheduler.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response, require_confirmation, require_pool
@@ -46,7 +48,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "start_scheduler",
         "⚠️ Start the scheduler for periodic message collection. Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def start_scheduler(args):
         pool_gate = require_pool(client_pool, "Запуск планировщика")
@@ -67,7 +69,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "stop_scheduler",
         "⚠️ Stop the scheduler. Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def stop_scheduler(args):
         gate = require_confirmation("остановит планировщик", args)
@@ -85,7 +87,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "trigger_collection",
         "⚠️ Trigger immediate collection run. Ask user for confirmation first.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def trigger_collection(args):
         pool_gate = require_pool(client_pool, "Запуск сбора")
@@ -106,7 +108,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_scheduler_job",
         "Toggle a scheduler job on/off. Get valid job_ids from get_scheduler_status.",
-        {"job_id": str},
+        {"job_id": Annotated[str, "ID задачи планировщика из get_scheduler_status"]},
     )
     async def toggle_scheduler_job(args):
         job_id = args.get("job_id", "")
@@ -131,7 +133,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "set_scheduler_interval",
         "Set the collection interval (in minutes). Currently only 'collect_all' is supported. Range: 1–1440.",
-        {"job_id": str, "minutes": int, "confirm": bool},
+        {
+            "job_id": Annotated[str, "ID задачи планировщика из get_scheduler_status"],
+            "minutes": Annotated[int, "Интервал сбора в минутах (1–1440)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def set_scheduler_interval(args):
         job_id = args.get("job_id", "")
@@ -166,7 +172,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Cancel a collection task by task_id (from get_scheduler_status or DB). "
         "Pending tasks are cancelled immediately; running tasks are marked cancelled "
         "but may continue until the current channel finishes. Requires confirmation.",
-        {"task_id": int, "confirm": bool},
+        {
+            "task_id": Annotated[int, "ID задачи сбора"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def cancel_scheduler_task(args):
         task_id = args.get("task_id")
@@ -192,7 +201,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "clear_pending_tasks",
         "Clear all pending collection tasks from the queue. Requires confirmation.",
-        {"confirm": bool},
+        {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def clear_pending_tasks(args):
         gate = require_confirmation("удалит все ожидающие задачи сбора из очереди", args)

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response, require_pool
@@ -38,13 +40,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "channel_id is the Telegram numeric ID (from list_channels, not pk). "
         "Supports date_from/date_to (YYYY-MM-DD), min_length, max_length filters.",
         {
-            "query": str,
-            "limit": int,
-            "channel_id": int,
-            "date_from": str,
-            "date_to": str,
-            "min_length": int,
-            "max_length": int,
+            "query": Annotated[str, "Поисковый запрос"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "channel_id": Annotated[int, "Числовой Telegram ID канала для фильтрации"],
+            "date_from": Annotated[str, "Начало периода в формате YYYY-MM-DD"],
+            "date_to": Annotated[str, "Конец периода в формате YYYY-MM-DD"],
+            "min_length": Annotated[int, "Минимальная длина текста сообщения в символах"],
+            "max_length": Annotated[int, "Максимальная длина текста сообщения в символах"],
         },
     )
     async def search_messages(args):
@@ -86,7 +88,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "semantic_search",
         "Search collected messages by semantic (embedding) similarity. "
         "Requires messages to be indexed first via index_messages, and an OpenAI/embedding API key configured.",
-        {"query": str, "limit": int},
+        {"query": Annotated[str, "Поисковый запрос"], "limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def semantic_search(args):
         query = args.get("query", "")
@@ -162,7 +164,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "search_telegram",
         "Search messages across all public Telegram channels via Telegram API. Requires a connected "
         "Premium account. Use for discovering content beyond collected channels.",
-        {"query": str, "limit": int},
+        {"query": Annotated[str, "Поисковый запрос"], "limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def search_telegram(args):
         pool_gate = require_pool(client_pool, "Telegram-поиск")
@@ -187,7 +189,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "search_my_chats",
         "Search messages in your own Telegram dialogs (private chats, groups, saved messages) "
         "via Telegram API. Uses the primary connected account.",
-        {"query": str, "limit": int},
+        {"query": Annotated[str, "Поисковый запрос"], "limit": Annotated[int, "Максимальное количество результатов"]},
     )
     async def search_my_chats(args):
         pool_gate = require_pool(client_pool, "Поиск по личным чатам")
@@ -213,7 +215,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Search messages within a specific channel via Telegram API. "
         "channel_id = Telegram numeric ID (from list_channels or search_my_telegram). "
         "Searches live Telegram, not local DB.",
-        {"channel_id": int, "query": str, "limit": int},
+        {
+            "channel_id": Annotated[int, "Числовой Telegram ID канала для фильтрации"],
+            "query": Annotated[str, "Поисковый запрос"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+        },
     )
     async def search_in_channel(args):
         pool_gate = require_pool(client_pool, "Поиск в канале")
@@ -244,13 +250,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Hybrid search combining FTS and semantic similarity on collected local messages. "
         "Semantic part requires prior index_messages call. Supports same filters as search_messages.",
         {
-            "query": str,
-            "limit": int,
-            "channel_id": int,
-            "date_from": str,
-            "date_to": str,
-            "min_length": int,
-            "max_length": int,
+            "query": Annotated[str, "Поисковый запрос"],
+            "limit": Annotated[int, "Максимальное количество результатов"],
+            "channel_id": Annotated[int, "Числовой Telegram ID канала для фильтрации"],
+            "date_from": Annotated[str, "Начало периода в формате YYYY-MM-DD"],
+            "date_to": Annotated[str, "Конец периода в формате YYYY-MM-DD"],
+            "min_length": Annotated[int, "Минимальная длина текста сообщения в символах"],
+            "max_length": Annotated[int, "Максимальная длина текста сообщения в символах"],
         },
     )
     async def search_hybrid(args):

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
@@ -18,7 +20,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "list_search_queries",
         "List saved search queries. Optionally show only active ones.",
-        {"active_only": bool},
+        {"active_only": Annotated[bool, "Показывать только активные запросы"]},
     )
     async def list_search_queries(args):
         try:
@@ -53,7 +55,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "get_search_query",
         "Get full details of a saved search query. sq_id from list_search_queries.",
-        {"sq_id": int},
+        {"sq_id": Annotated[int, "ID поискового запроса из list_search_queries"]},
     )
     async def get_search_query(args):
         sq_id = args.get("sq_id")
@@ -91,15 +93,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         "notify_on_collect=true to send notification on new matches. "
         "track_stats=true to record daily match counts for get_search_query_stats. Requires confirm=true.",
         {
-            "query": str,
-            "interval_minutes": int,
-            "is_regex": bool,
-            "is_fts": bool,
-            "notify_on_collect": bool,
-            "track_stats": bool,
-            "exclude_patterns": str,
-            "max_length": int,
-            "confirm": bool,
+            "query": Annotated[str, "Текст поискового запроса"],
+            "interval_minutes": Annotated[int, "Интервал выполнения запроса в минутах"],
+            "is_regex": Annotated[bool, "Использовать регулярное выражение"],
+            "is_fts": Annotated[bool, "Использовать полнотекстовый поиск FTS5"],
+            "notify_on_collect": Annotated[bool, "Отправлять уведомление при новых совпадениях"],
+            "track_stats": Annotated[bool, "Записывать ежедневную статистику совпадений"],
+            "exclude_patterns": Annotated[str, "Паттерны исключения через запятую"],
+            "max_length": Annotated[int, "Максимальная длина сообщения для совпадения"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def add_search_query(args):
@@ -140,16 +142,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         "edit_search_query",
         "Edit an existing search query. Provide sq_id and fields to change. Requires confirm=true.",
         {
-            "sq_id": int,
-            "query": str,
-            "interval_minutes": int,
-            "is_regex": bool,
-            "is_fts": bool,
-            "notify_on_collect": bool,
-            "track_stats": bool,
-            "exclude_patterns": str,
-            "max_length": int,
-            "confirm": bool,
+            "sq_id": Annotated[int, "ID поискового запроса из list_search_queries"],
+            "query": Annotated[str, "Текст поискового запроса"],
+            "interval_minutes": Annotated[int, "Интервал выполнения запроса в минутах"],
+            "is_regex": Annotated[bool, "Использовать регулярное выражение"],
+            "is_fts": Annotated[bool, "Использовать полнотекстовый поиск FTS5"],
+            "notify_on_collect": Annotated[bool, "Отправлять уведомление при новых совпадениях"],
+            "track_stats": Annotated[bool, "Записывать ежедневную статистику совпадений"],
+            "exclude_patterns": Annotated[str, "Паттерны исключения через запятую"],
+            "max_length": Annotated[int, "Максимальная длина сообщения для совпадения"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
     async def edit_search_query(args):
@@ -196,7 +198,10 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "delete_search_query",
         "⚠️ DANGEROUS: Delete a saved search query. Requires confirm=true.",
-        {"sq_id": int, "confirm": bool},
+        {
+            "sq_id": Annotated[int, "ID поискового запроса из list_search_queries"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_search_query(args):
@@ -224,7 +229,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "toggle_search_query",
         "Toggle a search query active/inactive.",
-        {"sq_id": int},
+        {"sq_id": Annotated[int, "ID поискового запроса из list_search_queries"]},
     )
     async def toggle_search_query(args):
         sq_id = args.get("sq_id")
@@ -248,7 +253,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "run_search_query",
         "Run a search query once and return the number of matches found today.",
-        {"sq_id": int},
+        {"sq_id": Annotated[int, "ID поискового запроса из list_search_queries"]},
     )
     async def run_search_query(args):
         sq_id = args.get("sq_id")
@@ -273,7 +278,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "get_search_query_stats",
         "Get daily match statistics for a search query over the last N days. "
         "Only works if track_stats=true was set when creating the query. sq_id from list_search_queries.",
-        {"sq_id": int, "days": int},
+        {
+            "sq_id": Annotated[int, "ID поискового запроса из list_search_queries"],
+            "days": Annotated[int, "Количество дней для анализа"],
+        },
     )
     async def get_search_query_stats(args):
         sq_id = args.get("sq_id")

--- a/src/agent/tools/settings.py
+++ b/src/agent/tools/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response, require_confirmation
@@ -34,7 +36,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "save_agent_settings",
         "⚠️ Update agent settings. backend values: 'claude-agent-sdk' or 'deepagents'. Ask user for confirmation first.",
-        {"prompt_template": str, "backend": str, "confirm": bool},
+        {
+            "prompt_template": Annotated[str, "Шаблон системного промпта агента"],
+            "backend": Annotated[str, "Бэкенд агента: claude-agent-sdk или deepagents"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def save_agent_settings(args):
         gate = require_confirmation("изменит настройки агента", args)
@@ -56,7 +62,11 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool(
         "save_filter_settings",
         "⚠️ Update channel filter thresholds. Ask user for confirmation first.",
-        {"low_uniqueness_threshold": float, "low_subscriber_ratio_threshold": float, "confirm": bool},
+        {
+            "low_uniqueness_threshold": Annotated[float, "Порог уникальности контента (0.0–1.0)"],
+            "low_subscriber_ratio_threshold": Annotated[float, "Порог соотношения подписчиков (0.0–1.0)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def save_filter_settings(args):
         gate = require_confirmation("изменит пороги фильтров каналов", args)
@@ -77,7 +87,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         "save_scheduler_settings",
         "⚠️ Update scheduler collection interval (1–1440 minutes). "
         "Changes take effect immediately if the scheduler is running. Requires confirm=true.",
-        {"collect_interval_minutes": int, "confirm": bool},
+        {
+            "collect_interval_minutes": Annotated[int, "Интервал сбора в минутах (1–1440)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
     )
     async def save_scheduler_settings(args):
         gate = require_confirmation("изменит интервал планировщика сбора", args)


### PR DESCRIPTION
## Summary

Closes #314

- Bump `claude-agent-sdk` from **0.1.50** to **0.1.52** (includes v0.1.51 bugfixes)
- Pass `session_id` through to `ClaudeAgentOptions` for SDK session tracking
- Add `typing.Annotated` per-parameter descriptions to all **140+** `@tool` definitions across **17** tool files — improves JSON Schema so the LLM better understands each parameter
- Expose `ResultMessage` usage data (`usage`, `model_usage`, `total_cost_usd`, `num_turns`, `session_id`) in the `done` SSE event for context/cost monitoring

### SDK bugfixes included (free with upgrade)
- Python 3.10 `TypedDict` compatibility
- `connect(prompt="...")` no longer silently drops string prompts
- `control_cancel_request` — proper cancellation of in-flight callbacks
- Cross-task cancel scope `RuntimeError` fix
- `SIGKILL` fallback when `SIGTERM` blocks
- Skip non-JSON lines on CLI stdout
- `is_error` flag propagation in MCP tool results

## Test plan
- [x] `ruff check src/ tests/ conftest.py` — all checks passed
- [x] `pytest -m "not aiosqlite_serial" -n auto` — 4107 passed
- [x] `pytest -m aiosqlite_serial` — 509 passed
- [ ] Manual: `python -m src.main agent chat` — verify streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)