### PR TITLE
fix(agent): surface stderr errors/warnings to user

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -438,15 +438,24 @@ class ClaudeSdkBackend:
             # claude-cli stderr format: "2026-03-30T01:28:36.888Z [DEBUG] ..."
             # Level tag is NOT at the start — check anywhere in the line.
             _lower = line.lower()
+            is_error = False
             if "[debug]" in _lower or "[trace]" in _lower:
                 debug_lines.append(line)
                 logger.debug("claude-cli debug: %s", line)
             elif "[warn" in _lower:
                 debug_lines.append(line)
-                logger.debug("claude-cli warn: %s", line)
+                logger.warning("claude-cli warn: %s", line)
+                is_error = True
+            elif "[error]" in _lower or _lower.startswith("error"):
+                stderr_lines.append(line)
+                logger.error("claude-cli error: %s", line)
+                is_error = True
             else:
                 stderr_lines.append(line)
                 logger.warning("claude-cli stderr: %s", line)
+                # Treat untagged stderr as potential errors (e.g. "Error: Invalid URL")
+                if "error" in _lower:
+                    is_error = True
 
             # Emit connection progress to TUI/web queue.
             # _on_stderr is called from an anyio task in the same event loop,
@@ -465,6 +474,25 @@ class ClaudeSdkBackend:
                     queue.put_nowait(f"data: {payload}\n\n")
                 except Exception:
                     pass
+
+            # Surface errors/warnings to user — don't swallow them silently.
+            if is_error and not label:
+                # Strip timestamp prefix (ISO format) for cleaner display
+                display = line.strip()
+                if len(display) > 25 and display[10] == "T" and display[23] == "Z":
+                    display = display[25:].strip()
+                # Remove level tags for cleaner output
+                for tag in ("[WARN]", "[warn]", "[ERROR]", "[error]"):
+                    display = display.replace(tag, "").strip()
+                if display:
+                    warn_payload = json.dumps(
+                        {"type": "warning", "text": display},
+                        ensure_ascii=False,
+                    )
+                    try:
+                        queue.put_nowait(f"data: {warn_payload}\n\n")
+                    except Exception:
+                        pass
 
         cli_path = shutil.which("claude")
         logger.info("claude-cli path: %s", cli_path)

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -550,7 +550,8 @@ class ClaudeSdkBackend:
             first_event_logged = False
             try:
                 aiter = query(prompt=_as_prompt_stream(prompt), options=options).__aiter__()
-                while True:
+                try:
+                  while True:
                     if not first_event_logged:
                         iter_timeout = cfg.first_event_timeout
                         iter_label = "Ожидание ответа Claude"
@@ -717,6 +718,9 @@ class ClaudeSdkBackend:
                             await queue.put(f"data: {done_payload}\n\n")
                     except asyncio.CancelledError:
                         draining = True
+                finally:
+                    with suppress(Exception):
+                        await aiter.aclose()
                 return
 
             except TimeoutError as exc:

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -609,6 +609,9 @@ class AgentTuiApp(App):
                         summary = payload.get("summary", "")
                         widget._append_log(f"    ❌ {tool}: {summary}")
                     continue
+                if event_type == "warning":
+                    widget._append_log(f"  ⚠️ {payload.get('text', '')}")
+                    continue
                 if event_type == "status":
                     widget.set_pending_status(payload.get("text", ""))
                     continue

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -1089,6 +1089,8 @@
                             statusTracker.onToolEnd(data.tool || 'tool', data.duration || 0, !!data.is_error, data.summary || '');
                         } else if (data.type === 'tool_result') {
                             statusTracker.onToolResult(data.tool || 'tool', !!data.is_error, data.summary || '');
+                        } else if (data.type === 'warning') {
+                            statusTracker.onToolResult('⚠️ ' + (data.text || ''), true, '');
                         } else if (data.type === 'status' || data.type === 'countdown') {
                             statusTracker.onStatus(data.text || '');
                         } else if (data.error) {

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -972,6 +972,15 @@
                     }
                 }
             },
+            onWarning: function(text) {
+                if (destroyed) return;
+                _ensureElements();
+                logDetails.style.display = '';
+                var warnLine = document.createElement('div');
+                warnLine.className = 'tool-log-entry tool-entry-error';
+                warnLine.textContent = '\u26a0\ufe0f ' + text;
+                logBody.appendChild(warnLine);
+            },
             onStatus: function(text) {
                 if (destroyed) return;
                 _ensureElements();
@@ -1090,7 +1099,7 @@
                         } else if (data.type === 'tool_result') {
                             statusTracker.onToolResult(data.tool || 'tool', !!data.is_error, data.summary || '');
                         } else if (data.type === 'warning') {
-                            statusTracker.onToolResult('', true, '⚠️ ' + (data.text || ''));
+                            statusTracker.onWarning(data.text || '');
                         } else if (data.type === 'status' || data.type === 'countdown') {
                             statusTracker.onStatus(data.text || '');
                         } else if (data.error) {

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -1090,7 +1090,7 @@
                         } else if (data.type === 'tool_result') {
                             statusTracker.onToolResult(data.tool || 'tool', !!data.is_error, data.summary || '');
                         } else if (data.type === 'warning') {
-                            statusTracker.onToolResult('⚠️ ' + (data.text || ''), true, '');
+                            statusTracker.onToolResult('', true, '⚠️ ' + (data.text || ''));
                         } else if (data.type === 'status' || data.type === 'countdown') {
                             statusTracker.onStatus(data.text || '');
                         } else if (data.error) {

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -307,6 +307,122 @@ async def test_chat_stream_passes_prompt_as_async_iterable(db):
 
 
 @pytest.mark.asyncio
+async def test_stderr_errors_surfaced_as_warnings(db):
+    """Errors from claude-cli stderr are emitted as warning events to the user."""
+    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+
+    thread_id = await db.create_agent_thread("stderr-warning thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    async def mock_query(prompt, options):
+        # Simulate stderr errors from claude-cli
+        if options.stderr:
+            options.stderr("2026-03-30T01:28:36.888Z [ERROR] Invalid URL")
+            options.stderr("Error: connection refused")
+            options.stderr("2026-03-30T01:28:37.000Z [WARN] rate limit approaching")
+            options.stderr("2026-03-30T01:28:37.100Z [DEBUG] normal debug line")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    warnings = [p for p in payloads if p.get("type") == "warning"]
+
+    assert len(warnings) >= 2, f"Expected at least 2 warnings, got {warnings}"
+    warning_texts = [w["text"] for w in warnings]
+    # [ERROR] tagged line should surface
+    assert any("Invalid URL" in t for t in warning_texts), f"Missing 'Invalid URL' in {warning_texts}"
+    # Untagged "Error:" line should surface
+    assert any("connection refused" in t for t in warning_texts), f"Missing 'connection refused' in {warning_texts}"
+
+
+@pytest.mark.asyncio
+async def test_stderr_debug_lines_not_surfaced(db):
+    """DEBUG/TRACE stderr lines must NOT be shown to the user."""
+    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+
+    thread_id = await db.create_agent_thread("stderr-debug thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    async def mock_query(prompt, options):
+        if options.stderr:
+            options.stderr("2026-03-30T01:28:36.888Z [DEBUG] some debug info")
+            options.stderr("2026-03-30T01:28:36.888Z [TRACE] trace data")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    warnings = [p for p in payloads if p.get("type") == "warning"]
+    assert len(warnings) == 0, f"DEBUG/TRACE should not produce warnings: {warnings}"
+
+
+@pytest.mark.asyncio
+async def test_stderr_stage_keywords_not_duplicated_as_warnings(db):
+    """stderr lines matching stage keywords should emit status, not warning."""
+    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+
+    thread_id = await db.create_agent_thread("stderr-stage thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    async def mock_query(prompt, options):
+        if options.stderr:
+            # "rate limit event" matches _stage_map → should be status, not warning
+            options.stderr("rate limit event [WARN] utilization 82%")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    warnings = [p for p in payloads if p.get("type") == "warning"]
+    statuses = [p for p in payloads if p.get("type") == "status"]
+
+    assert len(warnings) == 0, f"Stage keywords should not produce warnings: {warnings}"
+    assert any("Rate limit" in s.get("text", "") for s in statuses), (
+        f"Stage keyword should produce status event: {statuses}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_emits_tool_result_from_assistant_message(db):
     """ToolResultBlock in AssistantMessage emits tool_result SSE event."""
     thread_id = await db.create_agent_thread("tool-result thread")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -307,6 +307,68 @@ async def test_chat_stream_passes_prompt_as_async_iterable(db):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_closes_sdk_generator(db):
+    """aiter.aclose() must be called to kill the Claude CLI subprocess."""
+    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+
+    thread_id = await db.create_agent_thread("aclose thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    aclose_called = False
+
+    async def mock_query(prompt, options):
+        nonlocal aclose_called
+        try:
+            yield assistant_msg
+            yield result_msg
+        finally:
+            aclose_called = True
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    with patch("src.agent.manager.query", mock_query):
+        async for _ in mgr.chat_stream(thread_id, "test"):
+            pass
+
+    assert aclose_called, "aiter.aclose() was never called — subprocess may leak"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_closes_sdk_generator_on_timeout(db):
+    """aiter.aclose() must be called even when timeout fires."""
+    thread_id = await db.create_agent_thread("aclose-timeout thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    aclose_called = False
+
+    async def mock_query(prompt, options):
+        nonlocal aclose_called
+        try:
+            # Never yield anything — will trigger first_event_timeout
+            await asyncio.sleep(9999)
+            yield  # make it a generator
+        finally:
+            aclose_called = True
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+    mgr._config.agent.first_event_timeout = 1  # 1s for fast test
+
+    with patch("src.agent.manager.query", mock_query):
+        async for _ in mgr.chat_stream(thread_id, "test"):
+            pass
+
+    assert aclose_called, "aiter.aclose() not called on timeout — subprocess may leak"
+
+
+@pytest.mark.asyncio
 async def test_stderr_errors_surfaced_as_warnings(db):
     """Errors from claude-cli stderr are emitted as warning events to the user."""
     from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -309,7 +309,7 @@ async def test_chat_stream_passes_prompt_as_async_iterable(db):
 @pytest.mark.asyncio
 async def test_chat_stream_closes_sdk_generator(db):
     """aiter.aclose() must be called to kill the Claude CLI subprocess."""
-    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
     thread_id = await db.create_agent_thread("aclose thread")
     await db.save_agent_message(thread_id, "user", "test")
@@ -371,7 +371,7 @@ async def test_chat_stream_closes_sdk_generator_on_timeout(db):
 @pytest.mark.asyncio
 async def test_stderr_errors_surfaced_as_warnings(db):
     """Errors from claude-cli stderr are emitted as warning events to the user."""
-    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
     thread_id = await db.create_agent_thread("stderr-warning thread")
     await db.save_agent_message(thread_id, "user", "test")
@@ -414,7 +414,7 @@ async def test_stderr_errors_surfaced_as_warnings(db):
 @pytest.mark.asyncio
 async def test_stderr_debug_lines_not_surfaced(db):
     """DEBUG/TRACE stderr lines must NOT be shown to the user."""
-    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
     thread_id = await db.create_agent_thread("stderr-debug thread")
     await db.save_agent_message(thread_id, "user", "test")
@@ -448,7 +448,7 @@ async def test_stderr_debug_lines_not_surfaced(db):
 @pytest.mark.asyncio
 async def test_stderr_stage_keywords_not_duplicated_as_warnings(db):
     """stderr lines matching stage keywords should emit status, not warning."""
-    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
     thread_id = await db.create_agent_thread("stderr-stage thread")
     await db.save_agent_message(thread_id, "user", "test")


### PR DESCRIPTION
## Summary

- claude-cli errors (e.g. `Error: Invalid URL`) were silently logged but never shown to the user
- Now errors and warnings from stderr emit `{"type": "warning"}` events to the queue
- TUI: displayed as `⚠️` entries in tool log
- Web: displayed in the tool result area
- `[WARN]` lines now logged at `warning` level (was `debug`)
- `[ERROR]` lines logged at `error` level
- Stage keywords (rate limit, etc.) emit `status` only, not duplicated as `warning`

## Test plan

- [x] `test_stderr_errors_surfaced_as_warnings` — `[ERROR]` and `Error:` → warning event
- [x] `test_stderr_debug_lines_not_surfaced` — `[DEBUG]`/`[TRACE]` not shown
- [x] `test_stderr_stage_keywords_not_duplicated_as_warnings` — stage keywords → status only
- [x] 99 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)