### PR TITLE
fix(agent): auto-approve CLI tool permissions & improve error visibility

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -578,6 +578,7 @@ class ClaudeSdkBackend:
             streamed = False
             t0 = time.monotonic()
             first_event_logged = False
+            _api_request_count[0] = 0
             try:
                 aiter = query(prompt=_as_prompt_stream(prompt), options=options).__aiter__()
                 try:

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -432,6 +432,8 @@ class ClaudeSdkBackend:
         # "Думает..." status when Claude API is processing for a long time.
         _api_request_ts: list[float] = [0.0]
         _api_request_count: list[int] = [0]
+        # Last rate limit status — included in timeout error message for diagnostics.
+        _last_rate_limit: list[str] = [""]
 
         # Stable stage keywords from claude-cli bootstrap sequence.
         # Checked case-insensitively; first match wins.
@@ -628,9 +630,11 @@ class ClaudeSdkBackend:
                             "Idle timeout %ds fired after %.1fs total (thread %d)",
                             cfg.idle_timeout, time.monotonic() - t0, thread_id,
                         )
+                        reason = "Возможно, соединение потеряно."
+                        if _last_rate_limit[0]:
+                            reason = f"Последний rate limit: {_last_rate_limit[0]}."
                         raise TimeoutError(
-                            f"Стрим Claude замолчал на {cfg.idle_timeout}с. "
-                            "Возможно, соединение потеряно."
+                            f"Стрим Claude замолчал на {cfg.idle_timeout}с. {reason}"
                         )
 
                     if not first_event_logged:
@@ -655,7 +659,17 @@ class ClaudeSdkBackend:
                             parts = [f"Rate limit: {rl_status}"]
                             if utilization is not None:
                                 parts.append(f"{utilization:.0%}")
-                            await tracker.on_status(", ".join(parts))
+                            rl_text = ", ".join(parts)
+                            _last_rate_limit[0] = rl_text
+                            if rl_status == "rejected":
+                                # Hard reject — surface as warning, not just status
+                                warn_payload = json.dumps(
+                                    {"type": "warning", "text": f"⛔ {rl_text}. API отклоняет запросы."},
+                                    ensure_ascii=False,
+                                )
+                                await queue.put(f"data: {warn_payload}\n\n")
+                            else:
+                                await tracker.on_status(rl_text)
                         elif isinstance(msg, StreamEvent):
                             event = msg.event
                             event_type = event.get("type")

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -19,13 +19,16 @@ from claude_agent_sdk import (
     ClaudeSDKError,
     CLIConnectionError,
     CLINotFoundError,
+    PermissionResultAllow,
     ProcessError,
     RateLimitEvent,
     ResultMessage,
     StreamEvent,
     TextBlock,
+    ToolPermissionContext,
     ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
     query,
 )
 
@@ -348,6 +351,20 @@ async def _as_prompt_stream(text: str) -> AsyncIterator[dict]:
     }
 
 
+async def _auto_approve_tool(
+    tool_name: str, tool_input: dict, context: ToolPermissionContext,
+) -> PermissionResultAllow:
+    """Auto-approve all CLI tool permission requests.
+
+    Claude CLI sends can_use_tool control requests for tools that access the
+    network (read_messages, send_message, etc.).  Without this callback the
+    SDK raises "canUseTool callback is not provided" and the tool silently
+    fails with "Tool permission stream closed before response received".
+    We manage permissions through our own PermissionGate instead.
+    """
+    return PermissionResultAllow()
+
+
 class ClaudeSdkBackend:
     def __init__(self, db: Database, config: AppConfig, client_pool=None, scheduler_manager=None) -> None:
         self._db = db
@@ -414,6 +431,7 @@ class ClaudeSdkBackend:
         # Timestamp of the last [api:request] stderr event — used to show
         # "Думает..." status when Claude API is processing for a long time.
         _api_request_ts: list[float] = [0.0]
+        _api_request_count: list[int] = [0]
 
         # Stable stage keywords from claude-cli bootstrap sequence.
         # Checked case-insensitively; first match wins.
@@ -422,8 +440,8 @@ class ClaudeSdkBackend:
             _prompt_short += "…"
         # stderr stage labels — none extend timeouts (_last_activity is updated
         # only when real SDK events arrive: text deltas, tool results, etc.)
+        # NOTE: [api:request] label is dynamic (includes counter), handled separately.
         _stage_map: list[tuple[str, str]] = [
-            ("[api:request]", f"Жду ответ Claude API: «{_prompt_short}»"),
             ("creating client", "Создание клиента"),
             ("installplugins", "Установка плагинов"),
             ("refreshed marketplace", "Обновление плагинов"),
@@ -460,6 +478,19 @@ class ClaudeSdkBackend:
             # Emit connection progress to TUI/web queue.
             # _on_stderr is called from an anyio task in the same event loop,
             # so put_nowait on asyncio.Queue is safe here.
+            # [api:request] is handled separately — each occurrence is unique
+            # (counter incremented) so it must not be deduped.
+            if "[api:request]" in _lower:
+                _api_request_count[0] += 1
+                _api_request_ts[0] = time.monotonic()
+                label = f"Жду ответ Claude API #{_api_request_count[0]}: «{_prompt_short}»"
+                payload = json.dumps({"type": "status", "text": label}, ensure_ascii=False)
+                try:
+                    queue.put_nowait(f"data: {payload}\n\n")
+                except Exception:
+                    pass
+                return  # skip stage_map + error checks for api:request
+
             label: str | None = None
             for keyword, stage in _stage_map:
                 if keyword in _lower:
@@ -467,8 +498,6 @@ class ClaudeSdkBackend:
                     break
             if label and label != _last_emitted[0]:
                 _last_emitted[0] = label
-                if "[api:request]" in _lower:
-                    _api_request_ts[0] = time.monotonic()
                 payload = json.dumps({"type": "status", "text": label}, ensure_ascii=False)
                 try:
                     queue.put_nowait(f"data: {payload}\n\n")
@@ -532,6 +561,7 @@ class ClaudeSdkBackend:
             cli_path=cli_path or None,
             stderr=_on_stderr,
             include_partial_messages=True,
+            can_use_tool=_auto_approve_tool,
             extra_args={"debug-to-stderr": None},
             **extra,
         )
@@ -693,6 +723,9 @@ class ClaudeSdkBackend:
                                     await tracker.on_tool_result(
                                         block.tool_use_id, content, bool(block.is_error)
                                     )
+                        elif isinstance(msg, UserMessage):
+                            # Tool results sent back to Claude — real progress.
+                            _last_activity[0] = time.monotonic()
                         elif isinstance(msg, ResultMessage):
                             done_data: dict = {
                                 "done": True,
@@ -716,6 +749,11 @@ class ClaudeSdkBackend:
                                 done_data["session_id"] = _sid
                             done_payload = json.dumps(done_data, ensure_ascii=False)
                             await queue.put(f"data: {done_payload}\n\n")
+                        else:
+                            logger.warning(
+                                "Unhandled SDK message type: %s (thread %d)",
+                                type(msg).__name__, thread_id,
+                            )
                     except asyncio.CancelledError:
                         draining = True
                 finally:

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -656,11 +656,12 @@ class ClaudeSdkBackend:
                                 "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
                                 thread_id, rl_status, resets, utilization,
                             )
-                            parts = [f"Rate limit: {rl_status}"]
+                            rl_parts = [rl_status]
                             if utilization is not None:
-                                parts.append(f"{utilization:.0%}")
-                            rl_text = ", ".join(parts)
-                            _last_rate_limit[0] = rl_text
+                                rl_parts.append(f"{utilization:.0%}")
+                            rl_summary = ", ".join(rl_parts)
+                            rl_text = f"Rate limit: {rl_summary}"
+                            _last_rate_limit[0] = rl_summary
                             if rl_status == "rejected":
                                 # Hard reject — surface as warning, not just status
                                 warn_payload = json.dumps(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -522,6 +522,82 @@ async def test_stderr_stage_keywords_not_duplicated_as_warnings(db):
 
 
 @pytest.mark.asyncio
+async def test_stderr_api_request_counter_not_deduped(db):
+    """Each [api:request] event gets a unique counter, not deduped."""
+    from claude_agent_sdk import ResultMessage, TextBlock, AssistantMessage
+
+    thread_id = await db.create_agent_thread("api-counter thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="ok")]
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    async def mock_query(prompt, options):
+        if options.stderr:
+            options.stderr("2026-03-30T01:28:36.000Z [INFO] [api:request] POST /messages")
+            options.stderr("2026-03-30T01:28:40.000Z [INFO] [api:request] POST /messages")
+            options.stderr("2026-03-30T01:28:50.000Z [INFO] [api:request] POST /messages")
+        yield assistant_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    api_statuses = [
+        p for p in payloads
+        if p.get("type") == "status" and "API #" in p.get("text", "")
+    ]
+
+    assert len(api_statuses) == 3, f"Expected 3 API request statuses, got {api_statuses}"
+    assert "API #1" in api_statuses[0]["text"]
+    assert "API #2" in api_statuses[1]["text"]
+    assert "API #3" in api_statuses[2]["text"]
+
+
+@pytest.mark.asyncio
+async def test_user_message_does_not_break_stream(db):
+    """UserMessage (tool results sent to Claude) should not break the stream."""
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, UserMessage
+
+    thread_id = await db.create_agent_thread("user-message thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    assistant_msg = MagicMock(spec=AssistantMessage)
+    assistant_msg.content = [TextBlock(text="hello")]
+    user_msg = MagicMock(spec=UserMessage)
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    async def mock_query(prompt, options):
+        yield assistant_msg
+        yield user_msg
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    chunks = []
+    with patch("src.agent.manager.query", mock_query):
+        async for chunk in mgr.chat_stream(thread_id, "test"):
+            chunks.append(chunk)
+
+    payloads = [json.loads(c.removeprefix("data: ").strip()) for c in chunks]
+    texts = [p.get("text", "") for p in payloads if "text" in p and "type" not in p]
+    assert any("hello" in t for t in texts), f"Text should flow through: {texts}"
+    assert any(p.get("done") for p in payloads), "Stream should complete with done"
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_emits_tool_result_from_assistant_message(db):
     """ToolResultBlock in AssistantMessage emits tool_result SSE event."""
     thread_id = await db.create_agent_thread("tool-result thread")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -307,6 +307,43 @@ async def test_chat_stream_passes_prompt_as_async_iterable(db):
 
 
 @pytest.mark.asyncio
+async def test_chat_stream_options_have_can_use_tool(db):
+    """ClaudeAgentOptions must include can_use_tool to auto-approve CLI permissions.
+
+    Without it, CLI sends can_use_tool control requests for network tools
+    (read_messages, etc.) and the SDK raises "canUseTool callback is not provided",
+    causing tools to fail with "Tool permission stream closed".
+    """
+    from claude_agent_sdk import ResultMessage
+
+    thread_id = await db.create_agent_thread("can-use-tool thread")
+    await db.save_agent_message(thread_id, "user", "test")
+
+    result_msg = MagicMock(spec=ResultMessage)
+    result_msg.usage = {}
+    result_msg.model_usage = {}
+
+    captured_options = None
+
+    async def mock_query(prompt, options):
+        nonlocal captured_options
+        captured_options = options
+        yield result_msg
+
+    mgr = AgentManager(db)
+    mgr.initialize()
+
+    with patch("src.agent.manager.query", mock_query):
+        async for _ in mgr.chat_stream(thread_id, "test"):
+            pass
+
+    assert captured_options is not None, "query() was never called"
+    assert captured_options.can_use_tool is not None, (
+        "can_use_tool must be set to auto-approve CLI permission requests"
+    )
+
+
+@pytest.mark.asyncio
 async def test_chat_stream_closes_sdk_generator(db):
     """aiter.aclose() must be called to kill the Claude CLI subprocess."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock


### PR DESCRIPTION
## Summary

- **`can_use_tool` auto-approve**: Claude CLI v2.1.88 sends `can_use_tool` control requests for network tools (read_messages, send_message, etc.). Without a callback, the SDK raises "canUseTool callback is not provided" → tools fail silently with "Tool permission stream closed before response received". Added `_auto_approve_tool` callback that auto-approves all tool calls (our own PermissionGate handles permissions separately).

- **`UserMessage` handling**: SDK yields `UserMessage` after tool results are sent back to Claude. Previously ignored → `_last_activity` not updated → idle timeout starts counting too early. Now updates `_last_activity`.

- **API request counter**: `[api:request]` events were deduplicated (same label). Third API request (after tool call) was invisible. Now each API request gets a unique counter: "API #1", "API #2", "API #3".

- **Unhandled message logging**: Unknown SDK message types logged at warning level for diagnostics.

## Root cause trace

Session data showed:
```
tool_result: "Tool permission stream closed before response received"
tool_result: "Stream closed"
```
Tools appeared as ✅ in TUI but actually returned errors to Claude.

## Test plan

- [x] `ruff check` passes
- [x] 102 tests pass (`pytest tests/test_agent.py tests/test_agent_errors.py -n auto`)
- [x] `test_chat_stream_options_have_can_use_tool` — verifies `can_use_tool` is set
- [ ] Live: `python -m src.main agent chat` → "Получи последние 10 сообщений из чата 1877929309"

🤖 Generated with [Claude Code](https://claude.com/claude-code)