### PR TITLE
[codex] Log web error redirects and rejected overrides

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -8,6 +8,7 @@ import re
 import secrets
 import time
 from contextlib import asynccontextmanager
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
@@ -145,6 +146,24 @@ class ActionLogMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class ErrorRedirectLogMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if 300 <= response.status_code < 400:
+            location = response.headers.get("location", "")
+            if location:
+                error_code = parse_qs(urlparse(location).query).get("error", [""])[0]
+                if error_code:
+                    logger.warning(
+                        "Web request redirected with error: method=%s path=%s error=%s location=%s",
+                        request.method,
+                        request.url.path,
+                        error_code,
+                        location,
+                    )
+        return response
+
+
 class BasicAuthMiddleware(BaseHTTPMiddleware):
     def __init__(self, app, password: str):
         super().__init__(app)
@@ -257,6 +276,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
         app.add_middleware(BasicAuthMiddleware, password=config.web.password)
     app.add_middleware(OriginCSRFMiddleware)
     app.add_middleware(ActionLogMiddleware)
+    app.add_middleware(ErrorRedirectLogMiddleware)
     app.add_middleware(TimingMiddleware)
 
     @app.exception_handler(Exception)

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -660,6 +660,9 @@ async def save_agent_settings(request: Request):
                 cfg.enabled and not service.validate_provider_config(cfg) for cfg in configs
             )
             if not has_valid:
+                logger.warning(
+                    "Rejected deepagents override in dev mode: no valid provider configs are available"
+                )
                 return RedirectResponse(
                     url="/settings?error=agent_backend_no_valid_providers", status_code=303
                 )
@@ -667,6 +670,9 @@ async def save_agent_settings(request: Request):
             if not (
                 os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
             ):
+                logger.warning(
+                    "Rejected claude override in dev mode: no API credentials are available"
+                )
                 return RedirectResponse(
                     url="/settings?error=agent_backend_claude_unavailable", status_code=303
                 )

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -403,6 +404,26 @@ async def test_save_agent_dev_mode_without_disclaimer(client, db):
     # Dev mode should NOT be enabled without disclaimer
     enabled = await db.get_setting("agent_dev_mode_enabled")
     assert enabled == "0"
+
+
+@pytest.mark.asyncio
+async def test_save_agent_logs_rejected_deepagents_override(client, db, caplog):
+    """Rejected deepagents override should be written to logs."""
+    await db.set_setting("agent_dev_mode_enabled", "1")
+
+    with caplog.at_level(logging.WARNING, logger="src.web.routes.settings"):
+        resp = await client.post(
+            "/settings/save-agent",
+            data={
+                "agent_form_scope": "backend_override",
+                "agent_backend_override": "deepagents",
+            },
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert "error=agent_backend_no_valid_providers" in resp.headers["location"]
+    assert "Rejected deepagents override in dev mode" in caplog.text
 
 
 # === Agent Provider tests ===

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1838,6 +1838,21 @@ async def test_notification_setup_logs_exception(client, monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_error_redirects_are_logged_globally(client, caplog):
+    with caplog.at_level(logging.WARNING, logger="src.web.app"):
+        resp = await client.post(
+            "/settings/save-scheduler",
+            data={"collect_interval_minutes": "abc"},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/settings?error=invalid_value"
+    assert "Web request redirected with error" in caplog.text
+    assert "error=invalid_value" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_csrf_blocks_cross_origin_post(client):
     resp = await client.post(
         "/channels/add",


### PR DESCRIPTION
Closes #334.

## What changed
- add app-level logging for web redirects that carry `?error=...`, so UI-visible redirect failures also appear in server logs and the debug log buffer
- keep explicit warning logs for rejected dev-mode backend overrides in settings
- add regression coverage for the rejected `deepagents` override path and for a generic redirect error path

## Why
The web UI could surface an error code via redirect/flash handling without any corresponding backend log entry. That made `/debug/` incomplete and hid failures outside the browser, especially for rejected `deepagents` override flows.

## Impact
- web redirect errors are now visible in logs even when routes only return `RedirectResponse(...?error=...)`
- existing redirect / flash behavior remains unchanged
- the settings override path still provides route-specific context in addition to the generic app-layer log

## Root cause
A large class of web errors was encoded only in redirect query params and never passed through a consistent logging path.

## Validation
- `python3 -m pytest tests/test_web.py tests/routes/test_settings_routes.py`
