### PR TITLE
feat(channels): add button to browse collected posts per channel

### DIFF
--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -71,7 +71,28 @@ async def _render_search_page(
     service = deps.search_service(request)
     channels = await db.get_channels()
 
-    if q:
+    # Browse mode: channel_id without query shows latest messages from that channel
+    if not q and channel_id_int and mode in {"local", "semantic", "hybrid"}:
+        try:
+            result = await service.search(
+                mode="local",
+                query="",
+                limit=limit,
+                channel_id=channel_id_int,
+                date_from=None,
+                date_to=None,
+                offset=offset,
+                is_fts=False,
+            )
+        except Exception as exc:
+            logger.exception("Browse mode failed: channel_id=%s", channel_id_int)
+            result = SearchResult(
+                messages=[],
+                total=0,
+                query="",
+                error=f"Ошибка загрузки сообщений: {exc}",
+            )
+    elif q:
         if channel_id_error and mode in {"local", "semantic", "hybrid", "channel"}:
             result = SearchResult(messages=[], total=0, query=q, error=channel_id_error)
         else:
@@ -108,6 +129,12 @@ async def _render_search_page(
     if result and result.total > 0:
         total_pages = (result.total + limit - 1) // limit
 
+    # Browse mode: viewing channel messages without search query
+    browse_mode = bool(not q and channel_id_int and mode in {"local", "semantic", "hybrid"})
+    selected_channel = None
+    if browse_mode and channel_id_int:
+        selected_channel = next((ch for ch in channels if ch.channel_id == channel_id_int), None)
+
     return deps.get_templates(request).TemplateResponse(
         request,
         "search.html",
@@ -124,6 +151,8 @@ async def _render_search_page(
             "total_pages": total_pages,
             "ai_enabled": ai_enabled,
             "search_quota": search_quota,
+            "browse_mode": browse_mode,
+            "selected_channel": selected_channel,
         },
     )
 

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -122,6 +122,9 @@
                 {% endif %}
             </td>
             <td class="text-nowrap">
+                {% if ch.message_count > 0 %}
+                <a href="/search?channel_id={{ ch.channel_id }}&mode=local" class="btn btn-outline-secondary btn-sm emoji-btn" title="Смотреть сообщения">&#128196;</a>
+                {% endif %}
                 {% if ch.is_filtered %}
                 <form method="post" action="/channels/{{ ch.id }}/filter-toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Вернуть">&#128257;</button>
@@ -198,6 +201,9 @@
                 </div>
             </div>
             <div class="card-actions">
+                {% if ch.message_count > 0 %}
+                <a href="/search?channel_id={{ ch.channel_id }}&mode=local" class="btn btn-outline-secondary btn-sm emoji-btn" title="Смотреть сообщения">&#128196;</a>
+                {% endif %}
                 {% if ch.is_filtered %}
                 <form method="post" action="/channels/{{ ch.id }}/filter-toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Вернуть">&#128257;</button>

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -92,7 +92,11 @@
 {% endif %}
 
 {% if not result.error %}
+{% if browse_mode and selected_channel %}
+<p>Сообщения из канала <strong>{{ selected_channel.title or selected_channel.username or selected_channel.channel_id }}</strong>: {{ result.total }}</p>
+{% else %}
 <p>Найдено: <strong>{{ result.total }}</strong> сообщений по запросу «{{ result.query }}»</p>
+{% endif %}
 {% endif %}
 
 {% if result.messages %}


### PR DESCRIPTION
## Summary
- Add browse mode: `/search?channel_id=X&mode=local` without query shows latest messages from selected channel
- Add 📄 button in channels list for channels with collected messages (both desktop and mobile views)
- Show channel name in search summary when browsing (instead of "found X messages by query")

## Test plan
- [ ] Open `/channels` page
- [ ] Verify 📄 button appears next to channels with `message_count > 0`
- [ ] Click the button → should open search page showing latest messages from that channel
- [ ] Verify mobile view also has the button

Fixes #332