### PR TITLE
fix(filters): check stats before filtering to avoid strange symbols

### DIFF
--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -115,8 +115,13 @@ async def hard_delete_selected(request: Request):
 
 
 @router.post("/filter/analyze")
-async def analyze_channels(request: Request):
+async def analyze_channels(request: Request, with_stats: bool = False):
     db = deps.get_db(request)
+
+    if with_stats:
+        svc = deps.collection_service(request)
+        await svc.collect_all_stats()
+
     analyzer = ChannelAnalyzer(db)
     report = await analyzer.analyze_all()
     await analyzer.apply_filters(report)
@@ -160,6 +165,21 @@ async def apply_filters(request: Request):
 
     count = await analyzer.apply_filters(report)
     return RedirectResponse(url=f"/channels?msg=filter_applied&count={count}", status_code=303)
+
+
+@router.get("/filter/has-stats")
+async def has_stats(request: Request):
+    db = deps.get_db(request)
+    channels = await db.get_channels_with_counts(active_only=True, include_filtered=False)
+    if not channels:
+        return {"has_stats": True}
+
+    stats_map = await db.get_latest_stats_for_all()
+    for ch in channels:
+        if ch.channel_id not in stats_map:
+            return {"has_stats": False}
+
+    return {"has_stats": True}
 
 
 @router.post("/filter/precheck")

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -115,13 +115,8 @@ async def hard_delete_selected(request: Request):
 
 
 @router.post("/filter/analyze")
-async def analyze_channels(request: Request, with_stats: bool = False):
+async def analyze_channels(request: Request):
     db = deps.get_db(request)
-
-    if with_stats:
-        svc = deps.collection_service(request)
-        await svc.collect_all_stats()
-
     analyzer = ChannelAnalyzer(db)
     report = await analyzer.analyze_all()
     await analyzer.apply_filters(report)
@@ -170,7 +165,7 @@ async def apply_filters(request: Request):
 @router.get("/filter/has-stats")
 async def has_stats(request: Request):
     db = deps.get_db(request)
-    channels = await db.get_channels_with_counts(active_only=True, include_filtered=False)
+    channels = await db.get_channels(active_only=True, include_filtered=False)
     if not channels:
         return {"has_stats": True}
 

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -4,7 +4,7 @@
 <h1>Очистка каналов</h1>
 
 <div class="d-flex gap-2 flex-wrap mb-3">
-    <button type="button" class="btn btn-primary btn-sm" onclick="refreshFilters()">Обновить фильтры</button>
+    <button type="button" class="btn btn-primary btn-sm" onclick="refreshFilters(this)">Обновить фильтры</button>
     <form method="post" action="/channels/filter/precheck" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Предпроверка подписчиков</button>
     </form>
@@ -90,10 +90,15 @@
     </form>
     {% endif %}
 </div>
+{% else %}
+<p class="text-muted">Нет отфильтрованных каналов. Нажмите "Обновить фильтры" для анализа.</p>
+{% endif %}
 
 <script>
 (function() {
     var selectAll = document.getElementById('select-all');
+    if (!selectAll) return;
+
     var checkboxes = document.querySelectorAll('.ch-check');
     var countSpans = document.querySelectorAll('.selected-count');
     var actionBtns = document.querySelectorAll('.action-btn');
@@ -105,7 +110,6 @@
     }
 
     function syncHiddenInputs() {
-        // Copy checked PKs into each form as hidden inputs
         document.querySelectorAll('.synced-pk').forEach(function(el) { el.remove(); });
         var pks = getCheckedPks();
         document.querySelectorAll('#purge-form, #hard-delete-form').forEach(function(form) {
@@ -136,22 +140,29 @@
     });
 })();
 
-async function refreshFilters() {
+async function refreshFilters(button) {
+    setAsyncButtonBusy(button, true, 'Обновляю...');
     try {
         var resp = await fetch('/channels/filter/has-stats');
-        var data = await resp.json();
+        if (!resp.ok) throw new Error('stats probe failed');
 
+        var data = await resp.json();
+        var actionUrl = '/channels/filter/analyze';
         if (!data.has_stats) {
             if (!confirm('У некоторых каналов нет статистики. Сначала собрать статистику?')) {
+                setAsyncButtonBusy(button, false);
                 return;
             }
-            await fetch('/channels/filter/analyze?with_stats=1', {method: 'POST'});
-        } else {
-            await fetch('/channels/filter/analyze', {method: 'POST'});
+            actionUrl = '/channels/stats/all';
         }
-        window.location.reload();
+
+        var actionResp = await fetch(actionUrl, {method: 'POST'});
+        if (!actionResp.ok) throw new Error('refresh action failed');
+        window.location = actionResp.url || window.location.href;
     } catch (e) {
         console.error('Failed to refresh filters:', e);
+        setAsyncButtonBusy(button, false);
+        alert('Не удалось обновить фильтры. Попробуйте еще раз.');
     }
 }
 
@@ -165,8 +176,4 @@ function confirmHardDelete() {
     return confirm('ПОЛНОСТЬЮ удалить ' + count + ' канал(ов) из базы данных? Это действие необратимо.');
 }
 </script>
-
-{% else %}
-<p class="text-muted">Нет отфильтрованных каналов. Нажмите "Обновить фильтры" для анализа.</p>
-{% endif %}
 {% endblock %}

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -148,16 +148,21 @@ async function refreshFilters(button) {
 
         var data = await resp.json();
         var actionUrl = '/channels/filter/analyze';
+        var queueStatsOnly = false;
         if (!data.has_stats) {
-            if (!confirm('У некоторых каналов нет статистики. Сначала собрать статистику?')) {
+            if (!confirm('У некоторых каналов нет статистики. Сейчас запустится только сбор статистики. После завершения вернитесь и снова нажмите \"Обновить фильтры\". Продолжить?')) {
                 setAsyncButtonBusy(button, false);
                 return;
             }
             actionUrl = '/channels/stats/all';
+            queueStatsOnly = true;
         }
 
         var actionResp = await fetch(actionUrl, {method: 'POST'});
         if (!actionResp.ok) throw new Error('refresh action failed');
+        if (queueStatsOnly) {
+            alert('Сбор статистики запущен. После завершения вернитесь на эту страницу и снова обновите фильтры.');
+        }
         window.location = actionResp.url || window.location.href;
     } catch (e) {
         console.error('Failed to refresh filters:', e);

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -4,9 +4,7 @@
 <h1>Очистка каналов</h1>
 
 <div class="d-flex gap-2 flex-wrap mb-3">
-    <form method="post" action="/channels/filter/analyze" class="d-inline" data-busy>
-        <button type="submit" class="btn btn-primary btn-sm">Обновить фильтры</button>
-    </form>
+    <button type="button" class="btn btn-primary btn-sm" onclick="refreshFilters()">Обновить фильтры</button>
     <form method="post" action="/channels/filter/precheck" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Предпроверка подписчиков</button>
     </form>
@@ -137,6 +135,25 @@
         cb.addEventListener('change', updateCount);
     });
 })();
+
+async function refreshFilters() {
+    try {
+        var resp = await fetch('/channels/filter/has-stats');
+        var data = await resp.json();
+
+        if (!data.has_stats) {
+            if (!confirm('У некоторых каналов нет статистики. Сначала собрать статистику?')) {
+                return;
+            }
+            await fetch('/channels/filter/analyze?with_stats=1', {method: 'POST'});
+        } else {
+            await fetch('/channels/filter/analyze', {method: 'POST'});
+        }
+        window.location.reload();
+    } catch (e) {
+        console.error('Failed to refresh filters:', e);
+    }
+}
 
 function confirmPurge() {
     var count = document.querySelectorAll('.ch-check:checked').length;

--- a/tests/routes/test_filter_routes.py
+++ b/tests/routes/test_filter_routes.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.models import ChannelStats
 from src.services.filter_deletion_service import PurgeResult
 from tests.routes.conftest import _add_channel, _add_filtered_channel, _enable_dev_mode
 
@@ -28,6 +29,8 @@ async def test_filter_manage_renders_empty(client):
     """Test filter manage page renders empty."""
     resp = await client.get("/channels/filter/manage")
     assert resp.status_code == 200
+    assert 'onclick="refreshFilters(this)"' in resp.text
+    assert "async function refreshFilters(button)" in resp.text
 
 
 @pytest.mark.asyncio
@@ -160,6 +163,59 @@ async def test_analyze_redirects(client):
         resp = await client.post("/channels/filter/analyze", follow_redirects=False)
         assert resp.status_code == 303
         assert "/channels/filter/manage" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_ignores_with_stats_query(client):
+    """Test analyze route no longer runs stats collection inline."""
+    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+        from src.filters.models import FilterReport
+        mock_instance = mock_analyzer.return_value
+        mock_instance.analyze_all = AsyncMock(
+            return_value=FilterReport(results=[], total_channels=0, filtered_count=0)
+        )
+        mock_instance.apply_filters = AsyncMock(return_value=0)
+        with patch("src.web.routes.filter.deps.collection_service") as mock_collection:
+            resp = await client.post("/channels/filter/analyze?with_stats=1", follow_redirects=False)
+
+        assert resp.status_code == 303
+        mock_collection.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_has_stats_true_when_no_active_channels(client, db):
+    """Test has-stats returns true when there are no active channels to inspect."""
+    channel = await db.get_channel_by_channel_id(100)
+    assert channel is not None and channel.id is not None
+    await db.set_channel_active(channel.id, False)
+
+    resp = await client.get("/channels/filter/has-stats")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"has_stats": True}
+
+
+@pytest.mark.asyncio
+async def test_has_stats_false_when_active_channel_lacks_stats(client):
+    """Test has-stats returns false when any active channel has no stats yet."""
+    resp = await client.get("/channels/filter/has-stats")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"has_stats": False}
+
+
+@pytest.mark.asyncio
+async def test_has_stats_true_when_all_active_channels_have_stats(client, db):
+    """Test has-stats returns true when every active channel already has stats."""
+    await db.save_channel_stats(ChannelStats(channel_id=100, subscriber_count=1))
+    extra_channel_id = 101
+    await _add_channel(db, channel_id=extra_channel_id, title="Has Stats")
+    await db.save_channel_stats(ChannelStats(channel_id=extra_channel_id, subscriber_count=2))
+
+    resp = await client.get("/channels/filter/has-stats")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"has_stats": True}
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_filter_routes.py
+++ b/tests/routes/test_filter_routes.py
@@ -31,6 +31,7 @@ async def test_filter_manage_renders_empty(client):
     assert resp.status_code == 200
     assert 'onclick="refreshFilters(this)"' in resp.text
     assert "async function refreshFilters(button)" in resp.text
+    assert "Сейчас запустится только сбор статистики." in resp.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add GET `/channels/filter/has-stats` endpoint to check whether active channels already have statistics
- Replace the filter refresh form with JavaScript that probes stats first and keeps `refreshFilters()` available even in the empty state
- If stats are missing, queue the existing `/channels/stats/all` flow and clearly tell the user to return and rerun filters after stats finish
- Keep `/channels/filter/analyze` focused on filter analysis only, without inline stats collection inside the HTTP request

## Test plan
1. Start server: `python -m src.main serve`
2. Add a channel without collecting stats
3. Open `/channels/filter/manage`
4. Click "Обновить фильтры" → confirm dialog explains that only stats collection runs now
5. Confirm → stats collection is queued and the user is redirected to `/channels`
6. After stats finish, return to `/channels/filter/manage` and click "Обновить фильтры" again
7. With stats present, filters apply immediately without the confirm dialog

Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
