### PR TITLE
feat: add Z.AI provider support

### DIFF
--- a/docs/plans/zai-provider-support.md
+++ b/docs/plans/zai-provider-support.md
@@ -1,0 +1,31 @@
+# z.ai Provider Support
+
+## Summary
+Add Z.AI as a new LLM provider option for the deepagents backend. Z.AI provides an Anthropic-compatible API endpoint that works with langchain-anthropic.
+
+## Changes
+
+### 1. src/agent/provider_registry.py
+- Added `ProviderSpec` for z.ai provider
+- Static models: `glm-5`, `glm-5-turbo`, `glm-4.7`
+- Secret field: `api_key` (required)
+- Plain field: `base_url` (placeholder: `https://api.z.ai/api/anthropic`)
+
+### 2. src/services/agent_provider_service.py
+- Added `zai` to `_OPENAI_STYLE_DEFAULT_BASE_URLS` dict
+- Added `_fetch_zai_models` method for dynamic model fetching
+- Added z.ai case in `_fetch_live_models` method
+
+### 3. src/agent/manager.py
+- Added import of `_OPENAI_STYLE_DEFAULT_BASE_URLS` from agent_provider_service
+- Added z.ai case in `_build_agent` to initialize ChatAnthropic with custom `anthropic_api_url`
+
+## Usage
+
+1. Add Z.AI provider in Settings UI or via CLI
+2. Configure API key (and optionally base URL, defaults to https://api.z.ai/api/anthropic)
+3. Select model (glm-5, glm-5-turbo, or glm-4.7)
+4. Start chat with the agent
+
+## Related Issue
+- Closes #339

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -40,11 +40,10 @@ from src.agent.prompt_template import (
     build_prompt_template_context,
     render_prompt_template,
 )
-from src.agent.provider_registry import ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
 from src.config import AppConfig
 from src.database import Database
 from src.services.agent_provider_service import (
-    _OPENAI_STYLE_DEFAULT_BASE_URLS,
     AgentProviderService,
     ProviderModelCacheEntry,
     ProviderModelCompatibilityRecord,
@@ -1194,6 +1193,7 @@ class DeepagentsBackend:
                 "иначе deepagents переиспользует Claude SDK credentials."
             )
             raise RuntimeError(self._init_error)
+        model_provider = provider
         extra: dict[str, object] = {
             key: value for key, value in cfg.plain_fields.items() if value.strip()
         }
@@ -1209,16 +1209,11 @@ class DeepagentsBackend:
         else:
             extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
 
-        # z.ai uses Anthropic-compatible API with custom base_url
         if provider == "zai":
-            from langchain_anthropic import ChatAnthropic
-
-            base_url = cfg.plain_fields.get("base_url", "").strip() or _OPENAI_STYLE_DEFAULT_BASE_URLS["zai"]
-            model = ChatAnthropic(
-                model=resolved_model_name,
-                anthropic_api_url=base_url,
-                api_key=cfg.secret_fields.get("api_key", ""),
-            )
+            model_provider = "anthropic"
+            base_url = cfg.plain_fields.get("base_url", "").strip() or ZAI_DEFAULT_BASE_URL
+            extra.pop("base_url", None)
+            extra["anthropic_api_url"] = base_url
         self._init_attempted_model = cfg.model_name
 
         # ReAct fallback for Ollama models without native function calling
@@ -1251,10 +1246,16 @@ class DeepagentsBackend:
         try:
             from langchain.chat_models import init_chat_model
 
-            model = init_chat_model(model=resolved_model_name, model_provider=provider, **extra)
+            model = init_chat_model(
+                model=resolved_model_name,
+                model_provider=model_provider,
+                **extra,
+            )
         except ImportError as exc:
             package = (
-                f"langchain-{provider.replace('_', '-')}" if provider else "langchain provider"
+                f"langchain-{model_provider.replace('_', '-')}"
+                if model_provider
+                else "langchain provider"
             )
             self._init_error = (
                 f"Не установлена интеграция для provider '{provider}'. "

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -44,6 +44,7 @@ from src.agent.provider_registry import ProviderRuntimeConfig
 from src.config import AppConfig
 from src.database import Database
 from src.services.agent_provider_service import (
+    _OPENAI_STYLE_DEFAULT_BASE_URLS,
     AgentProviderService,
     ProviderModelCacheEntry,
     ProviderModelCompatibilityRecord,
@@ -1207,6 +1208,17 @@ class DeepagentsBackend:
                 extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
         else:
             extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
+
+        # z.ai uses Anthropic-compatible API with custom base_url
+        if provider == "zai":
+            from langchain_anthropic import ChatAnthropic
+
+            base_url = cfg.plain_fields.get("base_url", "").strip() or _OPENAI_STYLE_DEFAULT_BASE_URLS["zai"]
+            model = ChatAnthropic(
+                model=resolved_model_name,
+                anthropic_api_url=base_url,
+                api_key=cfg.secret_fields.get("api_key", ""),
+            )
         self._init_attempted_model = cfg.model_name
 
         # ReAct fallback for Ollama models without native function calling

--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -257,6 +257,14 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         static_models=("sonar", "sonar-pro", "sonar-reasoning"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
     ),
+    "zai": ProviderSpec(
+        name="zai",
+        display_name="Z.AI",
+        package_name="langchain-anthropic",
+        static_models=("glm-5", "glm-5-turbo", "glm-4.7"),
+        secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        plain_fields=(_field("base_url", "Base URL", placeholder="https://api.z.ai/api/anthropic"),),
+    ),
 }
 
 PROVIDER_ORDER = tuple(PROVIDER_SPECS.keys())

--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 
 from src.agent.models import CLAUDE_MODELS
 
+ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/anthropic"
+
 
 @dataclass(frozen=True, slots=True)
 class ProviderFieldSpec:
@@ -263,7 +265,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-anthropic",
         static_models=("glm-5", "glm-5-turbo", "glm-4.7"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
-        plain_fields=(_field("base_url", "Base URL", placeholder="https://api.z.ai/api/anthropic"),),
+        plain_fields=(_field("base_url", "Base URL", placeholder=ZAI_DEFAULT_BASE_URL),),
     ),
 }
 

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -17,6 +17,7 @@ import aiohttp
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
     PROVIDER_SPECS,
+    ZAI_DEFAULT_BASE_URL,
     ProviderRuntimeConfig,
     ProviderSpec,
     provider_spec,
@@ -46,7 +47,6 @@ _OPENAI_STYLE_DEFAULT_BASE_URLS = {
     "together": "https://api.together.xyz/v1",
     "fireworks": "https://api.fireworks.ai/inference/v1",
     "mistralai": "https://api.mistral.ai/v1",
-    "zai": "https://api.z.ai/api/anthropic",
 }
 _NON_CANONICAL_EXPORT_PROVIDERS = {
     "azure_openai",
@@ -663,6 +663,12 @@ class AgentProviderService:
             if api_key and base_url == "https://ollama.com":
                 return "ollama://cloud"
             return None
+        if provider == "zai":
+            base_url = cfg.plain_fields.get("base_url", "").strip()
+            normalized = self._normalize_urlish(base_url or ZAI_DEFAULT_BASE_URL)
+            if normalized == ZAI_DEFAULT_BASE_URL:
+                return normalized
+            return None
         if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
             base_url = cfg.plain_fields.get("base_url", "").strip()
             default_base_url = _OPENAI_STYLE_DEFAULT_BASE_URLS[provider]
@@ -692,6 +698,12 @@ class AgentProviderService:
         cfg: ProviderRuntimeConfig | None,
     ) -> list[str]:
         provider = spec.name
+        if provider == "zai":
+            assert cfg is not None
+            return await self._fetch_zai_models(
+                cfg.plain_fields.get("base_url", ""),
+                cfg.secret_fields.get("api_key", ""),
+            )
         if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
             assert cfg is not None
             base_url = (
@@ -717,12 +729,6 @@ class AgentProviderService:
         if provider == "huggingface":
             api_key = cfg.secret_fields.get("api_key", "") if cfg else ""
             return await self._fetch_huggingface_models(api_key)
-        if provider == "zai":
-            assert cfg is not None
-            return await self._fetch_zai_models(
-                cfg.plain_fields.get("base_url", ""),
-                cfg.secret_fields.get("api_key", ""),
-            )
         raise RuntimeError("live model fetch adapter is not available for this provider yet")
 
     async def _fetch_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
@@ -796,7 +802,7 @@ class AgentProviderService:
     async def _fetch_zai_models(
         self, base_url: str, api_key: str
     ) -> list[str]:
-        base_url = base_url.strip() or _OPENAI_STYLE_DEFAULT_BASE_URLS["zai"]
+        base_url = base_url.strip() or ZAI_DEFAULT_BASE_URL
         headers = {
             "x-api-key": api_key,
             "anthropic-version": "2023-06-01",
@@ -888,6 +894,9 @@ class AgentProviderService:
                     value,
                     secret_fields.get("api_key", ""),
                 )
+                continue
+            if key == "base_url" and provider_name == "zai":
+                normalized[key] = self._normalize_urlish(value or ZAI_DEFAULT_BASE_URL)
                 continue
             if key == "base_url" and provider_name in _OPENAI_STYLE_DEFAULT_BASE_URLS:
                 normalized[key] = self._normalize_urlish(

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -46,6 +46,7 @@ _OPENAI_STYLE_DEFAULT_BASE_URLS = {
     "together": "https://api.together.xyz/v1",
     "fireworks": "https://api.fireworks.ai/inference/v1",
     "mistralai": "https://api.mistral.ai/v1",
+    "zai": "https://api.z.ai/api/anthropic",
 }
 _NON_CANONICAL_EXPORT_PROVIDERS = {
     "azure_openai",
@@ -716,6 +717,12 @@ class AgentProviderService:
         if provider == "huggingface":
             api_key = cfg.secret_fields.get("api_key", "") if cfg else ""
             return await self._fetch_huggingface_models(api_key)
+        if provider == "zai":
+            assert cfg is not None
+            return await self._fetch_zai_models(
+                cfg.plain_fields.get("base_url", ""),
+                cfg.secret_fields.get("api_key", ""),
+            )
         raise RuntimeError("live model fetch adapter is not available for this provider yet")
 
     async def _fetch_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
@@ -785,6 +792,23 @@ class AgentProviderService:
             headers=headers,
         )
         return [str(item.get("id", "")).strip() for item in payload if item.get("id")]
+
+    async def _fetch_zai_models(
+        self, base_url: str, api_key: str
+    ) -> list[str]:
+        base_url = base_url.strip() or _OPENAI_STYLE_DEFAULT_BASE_URLS["zai"]
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        payload = await self._fetch_json(
+            base_url.rstrip("/") + "/models", headers=headers
+        )
+        return [
+            str(item.get("id", "")).strip()
+            for item in payload.get("data", [])
+            if item.get("id")
+        ]
 
     def _build_model_option(
         self,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import date, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,7 +16,7 @@ from src.agent.prompt_template import (
     PromptTemplateError,
     validate_prompt_template,
 )
-from src.agent.provider_registry import ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
 from src.agent.tools import make_mcp_server
 from src.config import AppConfig
 from src.models import Message
@@ -1657,6 +1658,47 @@ def test_build_agent_langchain_import_error_blames_correct_provider(db, monkeypa
             mgr._deepagents_backend._build_agent(cfg, record_last_used=False)
 
     assert "ollama" in mgr._deepagents_backend._init_error
+
+
+def test_build_agent_zai_uses_anthropic_init_chat_model(db):
+    """Z.AI should reuse the Anthropic integration with a custom API URL."""
+    config = AppConfig()
+    config.agent.fallback_model = "openai:gpt-4.1-mini"
+    mgr = AgentManager(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5",
+        plain_fields={"base_url": ZAI_DEFAULT_BASE_URL},
+        secret_fields={"api_key": "zai-key"},
+    )
+
+    captured: dict[str, object] = {}
+    fake_model = SimpleNamespace(name="zai-model")
+
+    def fake_init_chat_model(*, model, model_provider, **kwargs):
+        captured["model"] = model
+        captured["provider"] = model_provider
+        captured["kwargs"] = kwargs
+        return fake_model
+
+    def fake_create_agent(model, tools, system_prompt):
+        assert model is fake_model
+        return MagicMock(run=MagicMock(return_value="ok-zai"))
+
+    with (
+        patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
+        patch("deepagents.create_deep_agent", side_effect=fake_create_agent),
+    ):
+        agent = mgr._deepagents_backend._build_agent(cfg, record_last_used=False)
+
+    assert agent is not None
+    assert captured["model"] == "glm-5"
+    assert captured["provider"] == "anthropic"
+    assert captured["kwargs"]["api_key"] == "zai-key"
+    assert captured["kwargs"]["anthropic_api_url"] == ZAI_DEFAULT_BASE_URL
 
 
 def test_build_agent_tools_import_error_shows_details(db, monkeypatch):

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agent.manager import AgentManager
-from src.agent.provider_registry import ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig, provider_spec
 from src.config import AppConfig
 from src.services.agent_provider_service import (
     MODEL_CACHE_SETTINGS_KEY,
@@ -879,6 +879,42 @@ async def test_fetch_live_models_success_updates_cache(db, monkeypatch):
 
     assert "gpt-4.1" in models
     assert "gpt-4.1-mini" in models
+
+
+@pytest.mark.asyncio
+async def test_fetch_live_models_zai_uses_anthropic_headers(db, monkeypatch):
+    """Z.AI live model fetch uses Anthropic-compatible headers and endpoint."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5",
+        secret_fields={"api_key": "zai-key"},
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _fake_fetch_json(url, headers=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return {"data": [{"id": "glm-5"}]}
+
+    monkeypatch.setattr(service, "_fetch_json", _fake_fetch_json)
+
+    spec = provider_spec("zai")
+    assert spec is not None
+    models = await service._fetch_live_models(spec, cfg)
+
+    assert models == ["glm-5"]
+    assert captured["url"] == ZAI_DEFAULT_BASE_URL + "/models"
+    assert captured["headers"] == {
+        "x-api-key": "zai-key",
+        "anthropic-version": "2023-06-01",
+    }
 
 
 # === save_provider_configs encryption tests ===


### PR DESCRIPTION
## Summary
- Add Z.AI as LLM provider option for the deepagents backend
- Z.AI provides an Anthropic-compatible API endpoint

## Changes
- `src/agent/provider_registry.py`: ProviderSpec for z.ai
- `src/services/agent_provider_service.py`: default URL, fetch models
- `src/agent/manager.py`: ChatAnthropic initialization with custom base_url
- `docs/plans/zai-provider-support.md`: plan documentation

## Usage
1. Add Z.AI provider in Settings UI
2. Configure API key
3. Select model (glm-5, glm-5-turbo, glm-4.7)
4. Start chat with the agent

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)