### PR TITLE
test: expand coverage for services, parsers, and flood wait handling

### DIFF
--- a/src/parsers.py
+++ b/src/parsers.py
@@ -9,7 +9,7 @@ _TME_LINK_RE = re.compile(
     r"^(?:https?://)?t\.me/\+?([a-zA-Z][a-zA-Z0-9_]{3,31})(?:/\d+)?$"
 )
 
-# Bare username pattern (without @) — 5-32 chars, starts with letter.
+# Bare username pattern (without @) — 4-32 chars, starts with letter.
 _BARE_USERNAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{3,31}$")
 
 
@@ -57,7 +57,7 @@ def normalize_identifier(raw: str) -> tuple[str, str]:
 _IDENTIFIER_RE = re.compile(
     r"https?://t\.me/[^\s\"'<>,;)]+"  # full t.me link
     r"|(?<![a-zA-Z0-9/])t\.me/[^\s\"'<>,;)]+"  # bare t.me/ (negative lookbehind)
-    r"|@[a-zA-Z][a-zA-Z0-9_]{3,31}"  # @username (5-32 chars total)
+    r"|@[a-zA-Z][a-zA-Z0-9_]{3,31}"  # @username (4-32 chars total)
     r"|-1\d{9,}",  # negative Telegram ID (-100...)
 )
 

--- a/tests/test_ab_testing_service.py
+++ b/tests/test_ab_testing_service.py
@@ -108,3 +108,78 @@ async def test_ab_testing_service_generate_variants_includes_base_text(db, monke
 
     assert variants[0] == "base text"
     assert len(variants) == 3
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_select_variant_invalid_index(db):
+    """Invalid index raises ValueError."""
+    repo = db.repos.generation_runs
+    service = ABTestingService(db)
+    run_id = await repo.create_run(42, "prompt")
+    await repo.save_result(run_id, "base")
+    await service.save_variants(run_id, ["base", "variant"])
+
+    with pytest.raises(ValueError, match="Invalid variant index"):
+        await service.select_variant(run_id, 5)
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_select_variant_missing_run(db):
+    """Missing run raises ValueError."""
+    service = ABTestingService(db)
+
+    with pytest.raises(ValueError, match="Run 999 not found"):
+        await service.select_variant(999, 0)
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_get_variants_missing_run(db):
+    """get_variants returns None for missing run."""
+    service = ABTestingService(db)
+
+    result = await service.get_variants(999)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_get_variants_no_variants_returns_base(db):
+    """get_variants returns generated_text when no variants stored."""
+    repo = db.repos.generation_runs
+    service = ABTestingService(db)
+    run_id = await repo.create_run(42, "prompt")
+    await repo.save_result(run_id, "base text only")
+
+    result = await service.get_variants(run_id)
+
+    assert result is not None
+    assert len(result.variants) == 1
+    assert result.variants[0].text == "base text only"
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_auto_select_single_variant_returns_zero(db):
+    """Auto-select with single variant returns 0."""
+    repo = db.repos.generation_runs
+    service = ABTestingService(db)
+    run_id = await repo.create_run(42, "prompt")
+    await repo.save_result(run_id, "only one")
+    # No variants saved, means only just generated_text
+
+    best_index = await service.auto_select_best(run_id)
+
+    assert best_index == 0
+
+
+@pytest.mark.asyncio
+async def test_ab_testing_service_auto_select_without_scoring_picks_longest(db):
+    """Auto-select without scoring picks longest text."""
+    repo = db.repos.generation_runs
+    service = ABTestingService(db)
+    run_id = await repo.create_run(42, "prompt")
+    await repo.save_result(run_id, "short")
+    await service.save_variants(run_id, ["short", "medium length", "the longest one here"])
+
+    best_index = await service.auto_select_best(run_id, scoring_service=None)
+
+    assert best_index == 2  # Index of "the longest one here"

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -277,9 +277,14 @@ async def test_execute_with_recovery_fatal_error_with_fallback():
 
 
 @pytest.mark.asyncio
-async def test_circuit_breaker_recovery_timeout_transition():
+async def test_circuit_breaker_recovery_timeout_transition(monkeypatch):
     """Circuit breaker transitions from open to half_open after recovery timeout."""
-    import asyncio
+    current_time = {"value": 100.0}
+
+    monkeypatch.setattr(
+        "src.services.error_recovery_service.time.time",
+        lambda: current_time["value"],
+    )
 
     breaker = CircuitBreaker(
         CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.1, half_open_max_calls=1)
@@ -287,8 +292,7 @@ async def test_circuit_breaker_recovery_timeout_transition():
 
     await breaker.record_failure()  # Opens circuit
 
-    # Wait for recovery timeout to pass
-    await asyncio.sleep(0.15)
+    current_time["value"] += 0.15
 
     allowed, state = await breaker.can_execute()
     assert allowed is True
@@ -296,16 +300,21 @@ async def test_circuit_breaker_recovery_timeout_transition():
 
 
 @pytest.mark.asyncio
-async def test_circuit_breaker_half_open_failure_reopens():
+async def test_circuit_breaker_half_open_failure_reopens(monkeypatch):
     """Failure in half_open state transitions back to open."""
-    import asyncio
+    current_time = {"value": 100.0}
+
+    monkeypatch.setattr(
+        "src.services.error_recovery_service.time.time",
+        lambda: current_time["value"],
+    )
 
     breaker = CircuitBreaker(
         CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.1, half_open_max_calls=1)
     )
 
     await breaker.record_failure()  # Opens circuit
-    await asyncio.sleep(0.15)
+    current_time["value"] += 0.15
     allowed, state = await breaker.can_execute()
     assert allowed is True
     assert state == "half_open"
@@ -316,4 +325,3 @@ async def test_circuit_breaker_half_open_failure_reopens():
     allowed, state = await breaker.can_execute()
     assert allowed is False
     assert state == "open"
-

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -221,3 +221,99 @@ async def test_retry_policy_with_jitter():
     # Test that delay calculation works
     delay = service._calculate_delay(0)
     assert delay >= 0  # With jitter, delay can vary
+
+
+# === New tests for improved coverage ===
+
+
+@pytest.mark.asyncio
+async def test_error_history_trims_at_max():
+    """Error history is trimmed to _max_history=100 entries."""
+    service = ErrorRecoveryService()
+
+    # Add 150 errors to exceed max
+    for i in range(150):
+        service._record_error(RuntimeError(f"error {i}"), ErrorCategory.TRANSIENT)
+
+    assert len(service._error_history) == 100
+
+
+@pytest.mark.asyncio
+async def test_execute_with_recovery_fatal_error_no_retries():
+    """Fatal errors raise immediately without retries."""
+    service = ErrorRecoveryService(
+        retry_policy=RetryPolicy(max_retries=3, jitter=False)
+    )
+
+    call_count = 0
+
+    async def fatal():
+        nonlocal call_count
+        call_count += 1
+        raise PermissionError("unauthorized access")  # "unauthorized" is in FATAL_ERRORS
+
+    with pytest.raises(PermissionError, match="unauthorized access"):
+        await service.execute_with_recovery(fatal)
+
+    assert call_count == 1  # No retries
+
+
+@pytest.mark.asyncio
+async def test_execute_with_recovery_fatal_error_with_fallback():
+    """Fatal error with fallback returns fallback value."""
+    service = ErrorRecoveryService(
+        retry_policy=RetryPolicy(max_retries=3, jitter=False)
+    )
+
+    async def fallback():
+        return "fallback-value"
+
+    async def fatal():
+        raise PermissionError("forbidden access")  # "forbidden" is in FATAL_ERRORS
+
+    result = await service.execute_with_recovery(fatal, fallback=fallback)
+
+    assert result == "fallback-value"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_recovery_timeout_transition():
+    """Circuit breaker transitions from open to half_open after recovery timeout."""
+    import asyncio
+
+    breaker = CircuitBreaker(
+        CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.1, half_open_max_calls=1)
+    )
+
+    await breaker.record_failure()  # Opens circuit
+
+    # Wait for recovery timeout to pass
+    await asyncio.sleep(0.15)
+
+    allowed, state = await breaker.can_execute()
+    assert allowed is True
+    assert state == "half_open"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_half_open_failure_reopens():
+    """Failure in half_open state transitions back to open."""
+    import asyncio
+
+    breaker = CircuitBreaker(
+        CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.1, half_open_max_calls=1)
+    )
+
+    await breaker.record_failure()  # Opens circuit
+    await asyncio.sleep(0.15)
+    allowed, state = await breaker.can_execute()
+    assert allowed is True
+    assert state == "half_open"
+
+    # Failure in half_open should reopen
+    await breaker.record_failure()
+
+    allowed, state = await breaker.can_execute()
+    assert allowed is False
+    assert state == "open"
+

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock
 import pytest
 from telethon.errors import FloodWaitError
 
-from src.telegram.flood_wait import HandledFloodWaitError, handle_flood_wait, run_with_flood_wait
+from src.telegram.flood_wait import (
+    HandledFloodWaitError,
+    format_flood_wait_detail,
+    handle_flood_wait,
+    run_with_flood_wait,
+)
 
 
 @pytest.mark.asyncio
@@ -61,3 +66,104 @@ async def test_run_with_flood_wait_raises_handled_error_with_info():
     assert exc_info.value.info.wait_seconds == 17
     assert "Flood wait 17s" in exc_info.value.info.detail
     pool.report_flood.assert_awaited_once_with("+7999", 17)
+
+
+# === format_flood_wait_detail tests ===
+
+
+def test_format_flood_wait_detail_without_phone():
+    """Detail string without phone."""
+    from datetime import datetime, timezone
+
+    next_time = datetime(2024, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+    detail = format_flood_wait_detail(
+        wait_seconds=30,
+        next_available_at_utc=next_time,
+    )
+
+    assert "Flood wait 30s" in detail
+    assert "2024-03-15T12:00:00" in detail
+    assert "UTC" in detail
+    assert "for " not in detail  # No phone
+
+
+def test_format_flood_wait_detail_with_phone():
+    """Detail string includes phone."""
+    from datetime import datetime, timezone
+
+    next_time = datetime(2024, 3, 15, 14, 30, 0, tzinfo=timezone.utc)
+    detail = format_flood_wait_detail(
+        wait_seconds=45,
+        next_available_at_utc=next_time,
+        phone="+1234567890",
+    )
+
+    assert "Flood wait 45s" in detail
+    assert "for +1234567890" in detail
+
+
+# === handle_flood_wait edge cases ===
+
+
+@pytest.mark.asyncio
+async def test_handle_flood_wait_zero_seconds_clamped_to_one():
+    """Zero seconds is clamped to 1."""
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 0
+
+    info = await handle_flood_wait(
+        err,
+        operation="test_op",
+    )
+
+    assert info.wait_seconds == 1  # Clamped
+
+
+@pytest.mark.asyncio
+async def test_handle_flood_wait_none_seconds_clamped_to_one():
+    """None seconds is clamped to 1."""
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = None
+
+    info = await handle_flood_wait(
+        err,
+        operation="test_op",
+    )
+
+    assert info.wait_seconds == 1  # Clamped
+
+
+@pytest.mark.asyncio
+async def test_handle_flood_wait_without_pool():
+    """No pool means no report_flood call."""
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 10
+
+    info = await handle_flood_wait(
+        err,
+        operation="test_op",
+        phone="+7000",
+        pool=None,
+    )
+
+    assert info.wait_seconds == 10
+
+
+@pytest.mark.asyncio
+async def test_run_with_flood_wait_with_timeout():
+    """Timeout parameter is forwarded to wait_for."""
+    import asyncio
+
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 5
+
+    async def _raise_after_delay():
+        await asyncio.sleep(0.1)
+        raise err
+
+    with pytest.raises(HandledFloodWaitError):
+        await run_with_flood_wait(
+            _raise_after_delay(),
+            operation="test_op",
+            timeout=0.5,
+        )

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -150,20 +150,21 @@ async def test_handle_flood_wait_without_pool():
 
 
 @pytest.mark.asyncio
-async def test_run_with_flood_wait_with_timeout():
-    """Timeout parameter is forwarded to wait_for."""
-    import asyncio
+async def test_run_with_flood_wait_with_timeout(monkeypatch):
+    """Timeout parameter is forwarded to asyncio.wait_for."""
+    captured: dict[str, float] = {}
 
-    err = FloodWaitError(request=None, capture=0)
-    err.seconds = 5
+    async def fake_wait_for(awaitable, timeout):
+        captured["timeout"] = timeout
+        return await awaitable
 
-    async def _raise_after_delay():
-        await asyncio.sleep(0.1)
-        raise err
+    monkeypatch.setattr("src.telegram.flood_wait.asyncio.wait_for", fake_wait_for)
 
-    with pytest.raises(HandledFloodWaitError):
-        await run_with_flood_wait(
-            _raise_after_delay(),
-            operation="test_op",
-            timeout=0.5,
-        )
+    result = await run_with_flood_wait(
+        AsyncMock(return_value="ok")(),
+        operation="test_op",
+        timeout=0.5,
+    )
+
+    assert result == "ok"
+    assert captured == {"timeout": 0.5}

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -1,0 +1,304 @@
+"""Tests for src/services/notification_matcher.py"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models import Message, SearchQuery
+from src.services.notification_matcher import (
+    NotificationMatcher,
+    _fts_query_matches,
+    _make_message_link,
+)
+
+
+def make_message(
+    text: str,
+    channel_id: int = -1001234567890,
+    message_id: int = 123,
+    channel_username: str | None = None,
+) -> Message:
+    return Message(
+        channel_id=channel_id,
+        message_id=message_id,
+        text=text,
+        channel_username=channel_username,
+        date="2024-01-01T00:00:00",
+    )
+
+
+def make_query(
+    query: str,
+    sq_id: int = 1,
+    is_regex: bool = False,
+    is_fts: bool = False,
+    exclude_patterns: str = "",
+    max_length: int | None = None,
+) -> SearchQuery:
+    return SearchQuery(
+        id=sq_id,
+        query=query,
+        is_regex=is_regex,
+        is_fts=is_fts,
+        exclude_patterns=exclude_patterns,
+        max_length=max_length,
+    )
+
+
+# === match_and_notify tests ===
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_empty_messages():
+    """Empty message list returns {}."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    result = await matcher.match_and_notify([], [make_query("test")])
+
+    assert result == {}
+    notifier.notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_empty_queries():
+    """Empty query list returns {}."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    result = await matcher.match_and_notify([make_message("test")], [])
+
+    assert result == {}
+    notifier.notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_plain_text_match():
+    """Plain text query matches message text."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("Hello world example")]
+    queries = [make_query("world")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+    notifier.notify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_case_insensitive():
+    """Matching is case-insensitive."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("HELLO WORLD")]
+    queries = [make_query("hello")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_regex_query():
+    """Regex query matches via re.search."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("Order #12345 confirmed")]
+    queries = [make_query(r"order #\d+", is_regex=True)]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_regex_error_falls_through():
+    """Invalid regex in query does not crash."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("some text")]
+    # Invalid regex pattern
+    queries = [make_query(r"[invalid(", is_regex=True)]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {}  # No match due to regex error
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_fts_query_and():
+    """FTS5 AND logic - both terms required."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    # Only message with both terms should match
+    messages = [
+        make_message("apple only"),
+        make_message("banana only"),
+        make_message("apple and banana together"),
+    ]
+    queries = [make_query("apple AND banana", is_fts=True)]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}  # Only one message matched
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_fts_query_or():
+    """FTS5 OR logic - any term matches."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("apple fruit"),
+        make_message("banana fruit"),
+        make_message("orange fruit"),
+    ]
+    # Explicit OR between terms
+    queries = [make_query("apple OR banana", is_fts=True)]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    # apple and banana should match (2 messages)
+    assert result.get(1, 0) == 2
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_excludes_by_pattern():
+    """Messages matching exclude patterns are skipped."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("hello spam world"),
+        make_message("hello good world"),
+    ]
+    queries = [make_query("hello", exclude_patterns="spam")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}  # Only non-spam message
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_max_length_filter():
+    """Messages at/above max_length are skipped."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    short_text = "hello world"
+    long_text = "hello world " * 20
+
+    messages = [
+        make_message(short_text),
+        make_message(long_text),
+    ]
+    queries = [make_query("hello", max_length=50)]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    # Only short message should match
+    assert result == {1: 1}
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_message_no_text():
+    """Messages with None text are skipped."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("valid text"), Message(channel_id=-100, message_id=1, text=None, date="2024")]
+    queries = [make_query("valid")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_counts_multiple_matches():
+    """One query matching multiple messages counts correctly."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("hello one", message_id=1),
+        make_message("hello two", message_id=2),
+        make_message("hello three", message_id=3),
+    ]
+    queries = [make_query("hello")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 3}
+    # Should send notification with count
+    call_args = notifier.notify.call_args[0][0]
+    assert "3 times" in call_args
+
+
+@pytest.mark.asyncio
+async def test_match_and_notify_multiple_queries():
+    """Multiple queries each produce separate counts."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("apple fruit"),
+        make_message("banana fruit"),
+    ]
+    queries = [
+        make_query("apple", sq_id=1),
+        make_query("banana", sq_id=2),
+    ]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1, 2: 1}
+
+
+# === _make_message_link tests ===
+
+
+def test_make_message_link_with_username():
+    """t.me/{username}/{message_id} when channel_username is set."""
+    msg = make_message("test", channel_username="mychannel", message_id=456)
+    link = _make_message_link(msg)
+
+    assert link == "https://t.me/mychannel/456"
+
+
+def test_make_message_link_without_username():
+    """t.me/c/{bare_id}/{message_id} when no channel_username."""
+    msg = make_message("test", channel_id=-1001234567890, message_id=789)
+    link = _make_message_link(msg)
+
+    # -1001234567890 -> bare_id = 1234567890 (strip -100 prefix)
+    assert link == "https://t.me/c/1234567890/789"
+
+
+# === _fts_query_matches pure function tests ===
+
+
+def test_fts_query_matches_single_term():
+    """Single term matching."""
+    assert _fts_query_matches("hello", "hello world") is True
+    assert _fts_query_matches("goodbye", "hello world") is False
+
+
+def test_fts_query_matches_and():
+    """AND logic requires all parts."""
+    assert _fts_query_matches("hello AND world", "hello world") is True
+    assert _fts_query_matches("hello AND goodbye", "hello world") is False
+
+
+def test_fts_query_matches_case_insensitive():
+    """FTS matching is case-insensitive."""
+    assert _fts_query_matches("HELLO", "hello world") is True

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -300,7 +300,7 @@ class TestNormalizeIdentifier:
         assert kind == "username"
 
     def test_bare_username_short(self):
-        # Too short (3 chars) doesn't match bare username pattern (needs 5+ chars)
+        # Too short (3 chars) doesn't match bare username pattern (needs 4+ chars)
         value, kind = normalize_identifier("abc")
         assert kind == "unknown"
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from src.parsers import deduplicate_identifiers, extract_identifiers, parse_file, parse_identifiers
+from src.parsers import (
+    deduplicate_identifiers,
+    extract_identifiers,
+    normalize_identifier,
+    parse_file,
+    parse_identifiers,
+)
 
 
 class TestParseIdentifiers:
@@ -243,3 +249,77 @@ class TestDeduplicateIdentifiers:
         identifiers = ["@ch1", "@ch2", "@ch3"]
         result = deduplicate_identifiers(identifiers)
         assert result == identifiers
+
+
+class TestNormalizeIdentifier:
+    """Tests for normalize_identifier function."""
+
+    def test_at_username(self):
+        value, kind = normalize_identifier("@TestChannel")
+        assert value == "testchannel"
+        assert kind == "username"
+
+    def test_at_username_upper(self):
+        value, kind = normalize_identifier("@TESTCHANNEL")
+        assert value == "testchannel"
+        assert kind == "username"
+
+    def test_tme_link_https(self):
+        value, kind = normalize_identifier("https://t.me/channel1")
+        assert value == "channel1"
+        assert kind == "username"
+
+    def test_tme_link_bare(self):
+        value, kind = normalize_identifier("t.me/channel1")
+        assert value == "channel1"
+        assert kind == "username"
+
+    def test_tme_link_with_post(self):
+        value, kind = normalize_identifier("t.me/channel/123")
+        assert value == "channel"
+        assert kind == "username"
+
+    def test_tme_link_https_with_post(self):
+        value, kind = normalize_identifier("https://t.me/channel/456")
+        assert value == "channel"
+        assert kind == "username"
+
+    def test_numeric_id_negative(self):
+        value, kind = normalize_identifier("-1001234567890")
+        assert value == "-1001234567890"
+        assert kind == "numeric_id"
+
+    def test_numeric_id_positive(self):
+        value, kind = normalize_identifier("123456789")
+        assert value == "123456789"
+        assert kind == "numeric_id"
+
+    def test_bare_username(self):
+        value, kind = normalize_identifier("testchan")
+        assert value == "testchan"
+        assert kind == "username"
+
+    def test_bare_username_short(self):
+        # Too short (3 chars) doesn't match bare username pattern (needs 5+ chars)
+        value, kind = normalize_identifier("abc")
+        assert kind == "unknown"
+
+    def test_empty_string(self):
+        value, kind = normalize_identifier("")
+        assert value == ""
+        assert kind == "unknown"
+
+    def test_whitespace_only(self):
+        value, kind = normalize_identifier("   ")
+        assert value == ""
+        assert kind == "unknown"
+
+    def test_unknown_identifier(self):
+        value, kind = normalize_identifier("garbage!%^&*")
+        assert value == "garbage!%^&*"
+        assert kind == "unknown"
+
+    def test_strips_whitespace(self):
+        value, kind = normalize_identifier("  @TestChannel  ")
+        assert value == "testchannel"
+        assert kind == "username"

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -9,6 +9,7 @@ from src.services.production_limits_service import (
     CostTracker,
     ProductionLimitsService,
     RateLimitConfig,
+    RateLimiter,
 )
 
 
@@ -74,3 +75,100 @@ async def test_execute_with_retry_respects_daily_cost_cap():
 
     with pytest.raises(RuntimeError, match="Daily cost cap exceeded"):
         await service.execute_with_retry(ok, tokens=500, max_retries=0)
+
+
+# === RateLimiter unit tests ===
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_allows_under_limits():
+    """Requests under all limits succeed."""
+    limiter = RateLimiter(RateLimitConfig(requests_per_minute=10, tokens_per_minute=1000))
+
+    for _ in range(5):
+        allowed, wait_time = await limiter.check_and_acquire(tokens=100, is_image=False)
+        assert allowed is True
+        assert wait_time == 0.0
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_blocks_over_request_limit():
+    """Requests over requests_per_minute limit are blocked."""
+    limiter = RateLimiter(RateLimitConfig(requests_per_minute=3, tokens_per_minute=1000))
+
+    for _ in range(3):
+        await limiter.check_and_acquire(tokens=100, is_image=False)
+
+    # 4th request should be blocked
+    allowed, wait_time = await limiter.check_and_acquire(tokens=100, is_image=False)
+    assert allowed is False
+    assert wait_time > 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_blocks_over_token_limit():
+    """Requests over tokens_per_minute limit are blocked."""
+    limiter = RateLimiter(RateLimitConfig(requests_per_minute=10, tokens_per_minute=500))
+
+    # First request uses 400 tokens (under limit)
+    allowed, _ = await limiter.check_and_acquire(tokens=400, is_image=False)
+    assert allowed is True
+
+    # Second request uses 200 tokens (total 600, over limit)
+    allowed, wait_time = await limiter.check_and_acquire(tokens=200, is_image=False)
+    assert allowed is False
+    assert wait_time > 0
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_tracks_images():
+    """Image requests increment image_count."""
+    limiter = RateLimiter(RateLimitConfig(requests_per_minute=10))
+
+    await limiter.check_and_acquire(tokens=100, is_image=True)
+    await limiter.check_and_acquire(tokens=100, is_image=True)
+
+    usage = limiter.get_usage()
+    assert usage["minute"]["images"] == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_get_usage_structure():
+    """get_usage returns correct structure."""
+    limiter = RateLimiter(RateLimitConfig(requests_per_minute=60, tokens_per_minute=1000, tokens_per_day=10000))
+
+    usage = limiter.get_usage()
+
+    assert "minute" in usage
+    assert "day" in usage
+    assert usage["minute"]["limit_requests"] == 60
+    assert usage["minute"]["limit_tokens"] == 1000
+    assert usage["day"]["limit_tokens"] == 10000
+
+
+# === CostTracker unit tests ===
+
+
+@pytest.mark.asyncio
+async def test_cost_tracker_estimate_cost_tokens():
+    """Token cost estimation: (tokens/1000) * cost_per_1k."""
+    tracker = CostTracker(CostConfig(cost_per_1k_tokens=2.0))
+
+    cost = await tracker.estimate_cost(tokens=500, is_image=False)
+    assert cost == 1.0  # 500/1000 * 2.0
+
+    cost = await tracker.estimate_cost(tokens=1500, is_image=False)
+    assert cost == 3.0  # 1500/1000 * 2.0
+
+
+@pytest.mark.asyncio
+async def test_cost_tracker_estimate_cost_image():
+    """Image cost estimation returns fixed cost_per_image."""
+    tracker = CostTracker(CostConfig(cost_per_image=0.5))
+
+    cost = await tracker.estimate_cost(tokens=0, is_image=True)
+    assert cost == 0.5
+
+    # Tokens ignored for images
+    cost = await tracker.estimate_cost(tokens=1000, is_image=True)
+    assert cost == 0.5

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -210,3 +210,117 @@ async def test_publish_service_client_unavailable():
     assert results[0].success is False
     assert "No client" in results[0].error
     assert pool.released == []
+
+
+# === Additional tests for image, timeout, edge cases ===
+
+
+@pytest.mark.asyncio
+async def test_publish_service_with_image_url():
+    """Publishes via send_file when run has image_url."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+    pool = FakeClientPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Content with image",
+        image_url="https://example.com/image.jpg",
+        moderation_status="approved",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert len(results) == 1
+    assert results[0].success is True
+    # Verify send_file was called with the image URL
+    client = await pool.get_client_by_phone("+1234567890")
+    assert client is not None
+
+
+@pytest.mark.asyncio
+async def test_publish_service_whitespace_text():
+    """Empty/whitespace generated_text is skipped."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+    pool = FakeClientPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="   \n\t  ",  # Whitespace only
+        moderation_status="approved",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "No generated text" in results[0].error
+
+
+@pytest.mark.asyncio
+async def test_publish_service_entity_resolution_fail():
+    """Entity resolution failure produces error result."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+
+    class FailingEntityPool(FakeClientPool):
+        async def resolve_dialog_entity(self, session, phone, dialog_id, dialog_type):
+            return None  # Entity resolution fails
+
+    pool = FailingEntityPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "Could not resolve" in results[0].error
+
+
+@pytest.mark.asyncio
+async def test_publish_service_timeout():
+    """asyncio.TimeoutError produces 'Timeout' error."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+
+    import asyncio
+
+    class TimeoutPool(FakeClientPool):
+        async def get_client_by_phone(self, phone):
+            raise asyncio.TimeoutError()
+
+    pool = TimeoutPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "Timeout" in results[0].error

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -45,12 +45,14 @@ class FakeGenerationRunsRepo:
 class FakeClientPool:
     def __init__(self, should_succeed=True):
         self._should_succeed = should_succeed
+        self._clients = {}
         self.released = []
 
     async def get_client_by_phone(self, phone):
         if not self._should_succeed:
             return None
-        return (FakeClient(), phone)
+        client = self._clients.setdefault(phone, FakeClient())
+        return (client, phone)
 
     async def release_client(self, phone):
         self.released.append(phone)
@@ -60,6 +62,10 @@ class FakeClientPool:
 
 
 class FakeClient:
+    def __init__(self):
+        self.sent_files = []
+        self.sent_messages = []
+
     @property
     def raw_client(self):
         return FakeRawClient()
@@ -71,9 +77,24 @@ class FakeClient:
         return peer
 
     async def send_file(self, entity, files, caption=None, schedule=None):
+        self.sent_files.append(
+            {
+                "entity": entity,
+                "files": files,
+                "caption": caption,
+                "schedule": schedule,
+            }
+        )
         return FakeMessage()
 
     async def send_message(self, entity, text, **kwargs):
+        self.sent_messages.append(
+            {
+                "entity": entity,
+                "text": text,
+                "kwargs": kwargs,
+            }
+        )
         return FakeMessage()
 
 
@@ -237,9 +258,18 @@ async def test_publish_service_with_image_url():
 
     assert len(results) == 1
     assert results[0].success is True
-    # Verify send_file was called with the image URL
-    client = await pool.get_client_by_phone("+1234567890")
-    assert client is not None
+    client_result = await pool.get_client_by_phone("+1234567890")
+    assert client_result is not None
+    client, _phone = client_result
+    assert client.sent_files == [
+        {
+            "entity": {"phone": "+1234567890", "dialog_id": -1001234567890, "dialog_type": None},
+            "files": run.image_url,
+            "caption": run.generated_text,
+            "schedule": None,
+        }
+    ]
+    assert client.sent_messages == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -1,0 +1,301 @@
+"""Tests for src/services/search_query_service.py"""
+
+from __future__ import annotations
+
+from datetime import date as date_cls
+from datetime import timedelta
+
+import pytest
+
+from src.models import SearchQuery, SearchQueryDailyStat
+from src.services.search_query_service import SearchQueryService
+
+
+class FakeBundle:
+    """Fake SearchQueryBundle for testing."""
+
+    def __init__(self):
+        self._queries: dict[int, SearchQuery] = {}
+        self._next_id = 1
+        self._stats: dict[int, list[SearchQueryDailyStat]] = {}
+        self._last_recorded: dict[int, str] = {}
+
+    async def add(self, sq: SearchQuery) -> int:
+        sq_id = self._next_id
+        self._next_id += 1
+        sq.id = sq_id
+        self._queries[sq_id] = sq
+        return sq_id
+
+    async def get_all(self, active_only: bool = False) -> list[SearchQuery]:
+        queries = list(self._queries.values())
+        if active_only:
+            queries = [q for q in queries if q.is_active]
+        return queries
+
+    async def get_by_id(self, sq_id: int) -> SearchQuery | None:
+        return self._queries.get(sq_id)
+
+    async def set_active(self, sq_id: int, active: bool) -> None:
+        if sq_id in self._queries:
+            self._queries[sq_id].is_active = active
+
+    async def update(self, sq_id: int, sq: SearchQuery) -> None:
+        sq.id = sq_id
+        self._queries[sq_id] = sq
+
+    async def delete(self, sq_id: int) -> None:
+        self._queries.pop(sq_id, None)
+
+    async def record_stat(self, sq_id: int, count: int) -> None:
+        pass
+
+    async def get_fts_daily_stats_for_query(
+        self, sq: SearchQuery, days: int = 30
+    ) -> list[SearchQueryDailyStat]:
+        return self._stats.get(sq.id or 0, [])
+
+    async def get_fts_daily_stats_batch(
+        self, queries: list[SearchQuery], days: int = 30
+    ) -> dict[int, list[SearchQueryDailyStat]]:
+        return {q.id: self._stats.get(q.id or 0, []) for q in queries if q.id}
+
+    async def get_last_recorded_at_all(self) -> dict[int, str]:
+        return self._last_recorded.copy()
+
+    async def get_daily_stats(
+        self, sq_id: int, days: int = 30
+    ) -> list[SearchQueryDailyStat]:
+        return self._stats.get(sq_id, [])
+
+    def set_stats(self, sq_id: int, stats: list[SearchQueryDailyStat]) -> None:
+        self._stats[sq_id] = stats
+
+
+@pytest.fixture
+def bundle():
+    return FakeBundle()
+
+
+@pytest.fixture
+def service(bundle):
+    return SearchQueryService(bundle)
+
+
+# === add/list/get tests ===
+
+
+@pytest.mark.asyncio
+async def test_add_creates_search_query(service, bundle):
+    """Add delegates to bundle.add() with correct fields."""
+    sq_id = await service.add(
+        query="test query",
+        interval_minutes=30,
+        is_regex=True,
+        is_fts=False,
+        notify_on_collect=True,
+        track_stats=True,
+        exclude_patterns="spam",
+        max_length=500,
+    )
+
+    assert sq_id == 1
+    stored = await bundle.get_by_id(sq_id)
+    assert stored is not None
+    assert stored.query == "test query"
+    assert stored.interval_minutes == 30
+    assert stored.is_regex is True
+    assert stored.notify_on_collect is True
+    assert stored.exclude_patterns == "spam"
+    assert stored.max_length == 500
+
+
+@pytest.mark.asyncio
+async def test_list_returns_all_queries(service, bundle):
+    """List delegates to bundle.get_all()."""
+    await service.add("query1")
+    await service.add("query2")
+
+    result = await service.list()
+
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_active_only(service, bundle):
+    """List with active_only filters inactive queries."""
+    id1 = await service.add("active query")
+    id2 = await service.add("inactive query")
+    await bundle.set_active(id2, False)
+
+    result = await service.list(active_only=True)
+
+    assert len(result) == 1
+    assert result[0].id == id1
+
+
+@pytest.mark.asyncio
+async def test_get_returns_query_by_id(service, bundle):
+    """Get delegates to bundle.get_by_id()."""
+    sq_id = await service.add("test")
+
+    result = await service.get(sq_id)
+
+    assert result is not None
+    assert result.query == "test"
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_returns_none(service):
+    """Get returns None for nonexistent query."""
+    result = await service.get(999)
+
+    assert result is None
+
+
+# === toggle tests ===
+
+
+@pytest.mark.asyncio
+async def test_toggle_switches_active_state(service, bundle):
+    """Toggle switches is_active on existing query."""
+    sq_id = await service.add("test", is_regex=False)
+
+    await service.toggle(sq_id)
+
+    stored = await bundle.get_by_id(sq_id)
+    assert stored is not None
+    assert stored.is_active is False  # Started as True, toggled to False
+
+
+@pytest.mark.asyncio
+async def test_toggle_nonexistent_does_nothing(service):
+    """Toggle is a no-op when query not found."""
+    # Should not raise
+    await service.toggle(999)
+
+
+# === update tests ===
+
+
+@pytest.mark.asyncio
+async def test_update_modifies_query(service, bundle):
+    """Update delegates to bundle.update() preserving is_active."""
+    sq_id = await service.add("old query")
+    await bundle.set_active(sq_id, False)  # Make it inactive
+
+    result = await service.update(
+        sq_id,
+        query="new query",
+        interval_minutes=120,
+        is_regex=True,
+        is_fts=False,
+        notify_on_collect=False,
+        track_stats=False,
+        exclude_patterns="",
+        max_length=None,
+    )
+
+    assert result is True
+    stored = await bundle.get_by_id(sq_id)
+    assert stored is not None
+    assert stored.query == "new query"
+    assert stored.interval_minutes == 120
+    assert stored.is_active is False  # Preserved
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent_returns_false(service):
+    """Update returns False when query not found."""
+    result = await service.update(
+        999,
+        query="new query",
+        interval_minutes=60,
+    )
+
+    assert result is False
+
+
+# === run_once tests ===
+
+
+@pytest.mark.asyncio
+async def test_run_once_regex_query_returns_zero(service, bundle):
+    """Regex queries return 0 (not FTS-countable)."""
+    sq_id = await service.add("test", is_regex=True)
+
+    result = await service.run_once(sq_id)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_run_once_fts_query_with_stats(service, bundle):
+    """FTS query records stats when track_stats=True."""
+    sq_id = await service.add("test", is_fts=True, track_stats=True)
+    today = date_cls.today().isoformat()
+    bundle.set_stats(sq_id, [SearchQueryDailyStat(day=today, count=5)])
+
+    result = await service.run_once(sq_id)
+
+    assert result == 5
+
+
+# === _fill_missing_days static method tests ===
+
+
+def test_fill_missing_days_empty_stats():
+    """Empty stats generates full days+1 empty entries."""
+    result = SearchQueryService._fill_missing_days([], days=7)
+
+    assert len(result) == 8  # 7 days + today
+    for stat in result:
+        assert stat.count == 0
+
+
+def test_fill_missing_days_fills_gaps():
+    """Existing days preserved, missing days filled with 0."""
+    today = date_cls.today()
+    day3 = (today - timedelta(days=3)).isoformat()
+    day1 = (today - timedelta(days=1)).isoformat()
+
+    existing = [
+        SearchQueryDailyStat(day=day3, count=10),
+        SearchQueryDailyStat(day=day1, count=5),
+    ]
+
+    result = SearchQueryService._fill_missing_days(existing, days=5)
+
+    assert len(result) == 6  # 5 days + today
+    # Check that existing values are preserved
+    by_day = {s.day: s.count for s in result}
+    assert by_day[day3] == 10
+    assert by_day[day1] == 5
+    # Check that missing days are filled
+    day2 = (today - timedelta(days=2)).isoformat()
+    assert by_day[day2] == 0
+
+
+def test_fill_missing_days_none_stats():
+    """None stats returns empty list."""
+    result = SearchQueryService._fill_missing_days(None, days=7)
+
+    assert result == []
+
+
+# === get_with_stats tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_with_stats_excludes_regex_from_fts(service, bundle):
+    """Regex queries are excluded from FTS stats batch."""
+    await service.add("regex.*", is_regex=True, track_stats=True)
+    await service.add("fts query", is_fts=True, track_stats=True)
+
+    result = await service.get_with_stats(days=7)
+
+    assert len(result) == 2
+    # Both should have daily_stats (empty for regex, potentially populated for FTS)
+    for item in result:
+        assert "daily_stats" in item
+        assert "total_30d" in item

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -19,6 +19,7 @@ class FakeBundle:
         self._next_id = 1
         self._stats: dict[int, list[SearchQueryDailyStat]] = {}
         self._last_recorded: dict[int, str] = {}
+        self.record_stat_calls: list[tuple[int, int]] = []
 
     async def add(self, sq: SearchQuery) -> int:
         sq_id = self._next_id
@@ -48,7 +49,7 @@ class FakeBundle:
         self._queries.pop(sq_id, None)
 
     async def record_stat(self, sq_id: int, count: int) -> None:
-        pass
+        self.record_stat_calls.append((sq_id, count))
 
     async def get_fts_daily_stats_for_query(
         self, sq: SearchQuery, days: int = 30
@@ -239,6 +240,7 @@ async def test_run_once_fts_query_with_stats(service, bundle):
     result = await service.run_once(sq_id)
 
     assert result == 5
+    assert bundle.record_stat_calls == [(sq_id, 5)]
 
 
 # === _fill_missing_days static method tests ===

--- a/tests/test_task_enqueuer.py
+++ b/tests/test_task_enqueuer.py
@@ -6,8 +6,88 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import CollectionTaskType, PipelineRunTaskPayload, SqStatsTaskPayload
+from src.models import (
+    CollectionTaskType,
+    ContentGenerateTaskPayload,
+    ContentPublishTaskPayload,
+    PipelineRunTaskPayload,
+    SqStatsTaskPayload,
+)
 from src.services.task_enqueuer import TaskEnqueuer
+
+# === enqueue_content_generate tests ===
+
+
+@pytest.mark.asyncio
+async def test_enqueue_content_generate_creates_task(task_enqueuer, mock_db):
+    """Creates CONTENT_GENERATE task when no active task exists."""
+    mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
+    mock_db.repos.tasks.create_generic_task = AsyncMock(return_value=101)
+
+    result = await task_enqueuer.enqueue_content_generate(pipeline_id=5)
+
+    mock_db.repos.tasks.has_active_task.assert_called_once_with(
+        CollectionTaskType.CONTENT_GENERATE,
+        payload_filter_key="pipeline_id",
+        payload_filter_value=5,
+    )
+    mock_db.repos.tasks.create_generic_task.assert_called_once()
+    args, kwargs = mock_db.repos.tasks.create_generic_task.call_args
+    assert args[0] == CollectionTaskType.CONTENT_GENERATE
+    assert "Content generate #5" in kwargs.get("title", "")
+    payload = kwargs.get("payload")
+    assert isinstance(payload, ContentGenerateTaskPayload)
+    assert payload.pipeline_id == 5
+    assert result == 101
+
+
+@pytest.mark.asyncio
+async def test_enqueue_content_generate_skips_if_active(task_enqueuer, mock_db):
+    """Skips creation if active task for same pipeline exists."""
+    mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)
+
+    result = await task_enqueuer.enqueue_content_generate(pipeline_id=5)
+
+    mock_db.repos.tasks.create_generic_task.assert_not_called()
+    assert result is None
+
+
+# === enqueue_content_publish tests ===
+
+
+@pytest.mark.asyncio
+async def test_enqueue_content_publish_creates_task(task_enqueuer, mock_db):
+    """Creates CONTENT_PUBLISH task when no active task exists."""
+    mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
+    mock_db.repos.tasks.create_generic_task = AsyncMock(return_value=202)
+
+    result = await task_enqueuer.enqueue_content_publish()
+
+    mock_db.repos.tasks.has_active_task.assert_called_once_with(
+        CollectionTaskType.CONTENT_PUBLISH
+    )
+    mock_db.repos.tasks.create_generic_task.assert_called_once()
+    args, kwargs = mock_db.repos.tasks.create_generic_task.call_args
+    assert args[0] == CollectionTaskType.CONTENT_PUBLISH
+    assert "Content publish" in kwargs.get("title", "")
+    payload = kwargs.get("payload")
+    assert isinstance(payload, ContentPublishTaskPayload)
+    assert result == 202
+
+
+@pytest.mark.asyncio
+async def test_enqueue_content_publish_with_pipeline_id(task_enqueuer, mock_db):
+    """Creates CONTENT_PUBLISH task with pipeline_id in payload."""
+    mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
+    mock_db.repos.tasks.create_generic_task = AsyncMock(return_value=203)
+
+    result = await task_enqueuer.enqueue_content_publish(pipeline_id=7)
+
+    args, kwargs = mock_db.repos.tasks.create_generic_task.call_args
+    payload = kwargs.get("payload")
+    assert isinstance(payload, ContentPublishTaskPayload)
+    assert payload.pipeline_id == 7
+    assert result == 203
 
 
 @pytest.fixture

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,0 +1,71 @@
+"""Tests for src/telegram/utils.py"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.telegram.utils import normalize_utc
+
+
+@pytest.mark.asyncio
+async def test_normalize_utc_none_returns_none():
+    """None input returns None."""
+    assert normalize_utc(None) is None
+
+
+@pytest.mark.asyncio
+async def test_normalize_utc_naive_treated_as_utc():
+    """Naive datetime gets UTC tzinfo."""
+    naive = datetime(2024, 3, 15, 10, 30, 45)
+    result = normalize_utc(naive)
+
+    assert result is not None
+    assert result.tzinfo == timezone.utc
+    assert result.year == 2024
+    assert result.month == 3
+    assert result.day == 15
+    assert result.hour == 10
+    assert result.minute == 30
+    assert result.second == 45
+
+
+@pytest.mark.asyncio
+async def test_normalize_utc_aware_converted():
+    """Non-UTC timezone converted to UTC."""
+    # Create datetime in UTC+5
+    tz_plus5 = timezone(timedelta(hours=5))
+    aware = datetime(2024, 3, 15, 15, 30, 45, tzinfo=tz_plus5)
+    result = normalize_utc(aware)
+
+    assert result is not None
+    assert result.tzinfo == timezone.utc
+    # 15:30 UTC+5 = 10:30 UTC
+    assert result.hour == 10
+    assert result.minute == 30
+
+
+@pytest.mark.asyncio
+async def test_normalize_utc_already_utc():
+    """Already-UTC datetime returned as-is."""
+    utc_dt = datetime(2024, 3, 15, 10, 30, 45, tzinfo=timezone.utc)
+    result = normalize_utc(utc_dt)
+
+    assert result == utc_dt
+
+
+@pytest.mark.asyncio
+async def test_normalize_utc_preserves_values():
+    """Time components unchanged after conversion from naive."""
+    naive = datetime(2024, 12, 31, 23, 59, 59, 999999)
+    result = normalize_utc(naive)
+
+    assert result is not None
+    assert result.year == 2024
+    assert result.month == 12
+    assert result.day == 31
+    assert result.hour == 23
+    assert result.minute == 59
+    assert result.second == 59
+    assert result.microsecond == 999999


### PR DESCRIPTION
## Summary
- Adds edge-case tests for ABTestingService (invalid index, missing run, auto-select logic)
- Adds tests for ErrorRecoveryService (history trimming, fatal errors with/without fallback, circuit breaker state transitions)
- Adds tests for flood wait formatting (`format_flood_wait_detail`), zero/None seconds clamping, timeout forwarding
- Adds `TestNormalizeIdentifier` covering @username, t.me links, numeric IDs, edge cases
- Adds RateLimiter and CostTracker unit tests (request/token limits, image tracking, cost estimation)
- Adds PublishService tests (image URL publish, whitespace skip, entity resolution failure, timeout)
- Adds TaskEnqueuer tests for `enqueue_content_generate` and `enqueue_content_publish` flows
- Adds new test files: `test_notification_matcher.py`, `test_search_query_service.py`, `test_telegram_utils.py`

## Test plan
- [ ] Run `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — all new tests pass
- [ ] Run `pytest tests/ -v -m aiosqlite_serial` — serial tests pass
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)