### PR TITLE
Refactor duplicated test fixtures and CLI DB patching

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Collection, Mapping
@@ -66,6 +67,27 @@ def cli_env(cli_db):
 
     with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
         yield cli_db
+
+
+@pytest.fixture
+def cli_init_patch():
+    """Patch one or more CLI init_db targets to return the provided database."""
+
+    @contextmanager
+    def _patch(db, *targets: str, config: AppConfig | None = None):
+        runtime_config = config or AppConfig()
+
+        async def fake_init_db(_config_path: str):
+            if isinstance(db, Database):
+                await db.initialize()
+            return runtime_config, db
+
+        with ExitStack() as stack:
+            for target in targets:
+                stack.enter_context(patch(target, side_effect=fake_init_db))
+            yield runtime_config, db
+
+    return _patch
 
 
 @pytest.fixture
@@ -285,6 +307,12 @@ def pytest_runtest_setup(item):
         pytest.skip(message)
     if action == "fail":
         pytest.fail(message, pytrace=False)
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if item.get_closest_marker("aiosqlite_serial") and not item.get_closest_marker("xdist_group"):
+            item.add_marker(pytest.mark.xdist_group("aiosqlite_serial"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,11 +74,20 @@ def cli_init_patch():
     """Patch one or more CLI init_db targets to return the provided database."""
 
     @contextmanager
-    def _patch(db, *targets: str, config: AppConfig | None = None):
+    def _patch(
+        db,
+        *targets: str,
+        config: AppConfig | None = None,
+        fresh_database: bool = False,
+    ):
         runtime_config = config or AppConfig()
 
         async def fake_init_db(_config_path: str):
-            if isinstance(db, Database):
+            if isinstance(db, Database) and fresh_database:
+                cmd_db = Database(db._db_path, session_encryption_secret=db._session_encryption_secret)
+                await cmd_db.initialize()
+                return runtime_config, cmd_db
+            if isinstance(db, Database) and db._connection.db is None:
                 await db.initialize()
             return runtime_config, db
 

--- a/tests/repositories/conftest.py
+++ b/tests/repositories/conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.database.repositories.accounts import AccountsRepository
+from src.database.repositories.channel_stats import ChannelStatsRepository
+from src.database.repositories.channels import ChannelsRepository
+from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.database.repositories.content_pipelines import ContentPipelinesRepository
+from src.database.repositories.filters import FilterRepository
+from src.database.repositories.messages import MessagesRepository
+from src.database.repositories.notification_bots import NotificationBotsRepository
+from src.database.repositories.search_log import SearchLogRepository
+from src.database.repositories.search_queries import SearchQueriesRepository
+from src.database.repositories.settings import SettingsRepository
+from src.models import Channel
+
+
+_REPO_FACTORIES = {
+    "test_accounts_repository.py": AccountsRepository,
+    "test_channel_stats_repository.py": ChannelStatsRepository,
+    "test_channels_repository.py": ChannelsRepository,
+    "test_collection_tasks_repository.py": CollectionTasksRepository,
+    "test_filters_repository.py": FilterRepository,
+    "test_messages_repository.py": MessagesRepository,
+    "test_notification_bots_repository.py": NotificationBotsRepository,
+    "test_search_log_repository.py": SearchLogRepository,
+    "test_search_queries_repository.py": SearchQueriesRepository,
+    "test_settings_repository.py": SettingsRepository,
+}
+
+
+@pytest.fixture
+async def repo(request, db):
+    """Provide the repository under test for repository modules."""
+    filename = Path(str(request.fspath)).name
+
+    if filename == "test_content_pipelines_repository.py":
+        await db.add_channel(Channel(channel_id=1001, title="Source A"))
+        await db.add_channel(Channel(channel_id=1002, title="Source B"))
+        return ContentPipelinesRepository(db.db)
+
+    factory = _REPO_FACTORIES.get(filename)
+    if factory is None:
+        raise LookupError(f"No shared repo fixture registered for {filename}")
+    return factory(db.db)

--- a/tests/repositories/conftest.py
+++ b/tests/repositories/conftest.py
@@ -17,7 +17,6 @@ from src.database.repositories.search_queries import SearchQueriesRepository
 from src.database.repositories.settings import SettingsRepository
 from src.models import Channel
 
-
 _REPO_FACTORIES = {
     "test_accounts_repository.py": AccountsRepository,
     "test_channel_stats_repository.py": ChannelStatsRepository,

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -9,6 +9,8 @@ import pytest
 from src.database.repositories.accounts import AccountsRepository
 from src.models import Account
 from src.security.session_cipher import SessionCipher
+
+
 @pytest.fixture
 def cipher():
     """Create a SessionCipher for encryption tests."""

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -9,14 +9,6 @@ import pytest
 from src.database.repositories.accounts import AccountsRepository
 from src.models import Account
 from src.security.session_cipher import SessionCipher
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance without cipher."""
-    return AccountsRepository(db.db)
-
-
 @pytest.fixture
 def cipher():
     """Create a SessionCipher for encryption tests."""

--- a/tests/repositories/test_channel_stats_repository.py
+++ b/tests/repositories/test_channel_stats_repository.py
@@ -8,14 +8,6 @@ import pytest
 
 from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.models import Channel, ChannelStats
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return ChannelStatsRepository(db.db)
-
-
 async def _create_channel(db, channel_id):
     """Helper to create a channel for FK constraint."""
     channel = Channel(

--- a/tests/repositories/test_channel_stats_repository.py
+++ b/tests/repositories/test_channel_stats_repository.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import pytest
-
-from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.models import Channel, ChannelStats
+
+
 async def _create_channel(db, channel_id):
     """Helper to create a channel for FK constraint."""
     channel = Channel(

--- a/tests/repositories/test_channels_repository.py
+++ b/tests/repositories/test_channels_repository.py
@@ -6,14 +6,6 @@ import pytest
 
 from src.database.repositories.channels import ChannelsRepository
 from src.models import Channel
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return ChannelsRepository(db.db)
-
-
 def make_channel(channel_id: int, title: str = "Test Channel", **kwargs) -> Channel:
     """Create a test Channel."""
     return Channel(channel_id=channel_id, title=title, **kwargs)

--- a/tests/repositories/test_channels_repository.py
+++ b/tests/repositories/test_channels_repository.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import pytest
-
-from src.database.repositories.channels import ChannelsRepository
 from src.models import Channel
+
+
 def make_channel(channel_id: int, title: str = "Test Channel", **kwargs) -> Channel:
     """Create a test Channel."""
     return Channel(channel_id=channel_id, title=title, **kwargs)

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -8,14 +8,6 @@ import pytest
 
 from src.database.repositories.collection_tasks import CollectionTasksRepository
 from src.models import CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return CollectionTasksRepository(db.db)
-
-
 # _deserialize_payload tests
 
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from src.database.repositories.collection_tasks import CollectionTasksRepository
 from src.models import CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
+
 # _deserialize_payload tests
 
 

--- a/tests/repositories/test_content_pipelines_repository.py
+++ b/tests/repositories/test_content_pipelines_repository.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import pytest
+from src.models import ContentPipeline, PipelineTarget
 
-from src.database.repositories.content_pipelines import ContentPipelinesRepository
-from src.models import Channel, ContentPipeline, PipelineTarget
+
 def make_pipeline(**kwargs) -> ContentPipeline:
     defaults = {
         "name": "Digest",

--- a/tests/repositories/test_content_pipelines_repository.py
+++ b/tests/repositories/test_content_pipelines_repository.py
@@ -4,15 +4,6 @@ import pytest
 
 from src.database.repositories.content_pipelines import ContentPipelinesRepository
 from src.models import Channel, ContentPipeline, PipelineTarget
-
-
-@pytest.fixture
-async def repo(db):
-    await db.add_channel(Channel(channel_id=1001, title="Source A"))
-    await db.add_channel(Channel(channel_id=1002, title="Source B"))
-    return ContentPipelinesRepository(db.db)
-
-
 def make_pipeline(**kwargs) -> ContentPipeline:
     defaults = {
         "name": "Digest",

--- a/tests/repositories/test_filters_repository.py
+++ b/tests/repositories/test_filters_repository.py
@@ -25,14 +25,6 @@ _INSERT_STATS_NULL = (
     "INSERT INTO channel_stats (channel_id, subscriber_count, collected_at)"
     " VALUES (?, NULL, datetime('now'))"
 )
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return FilterRepository(db.db)
-
-
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""

--- a/tests/repositories/test_filters_repository.py
+++ b/tests/repositories/test_filters_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from src.database.repositories.channels import ChannelsRepository
-from src.database.repositories.filters import FilterRepository, _has_cyrillic_udf
+from src.database.repositories.filters import _has_cyrillic_udf
 from src.models import Channel
 
 _INSERT_MSG = (

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -9,6 +9,8 @@ import pytest
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.messages import MessagesRepository, _normalize_date_to
 from src.models import Message, SearchQuery
+
+
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -9,14 +9,6 @@ import pytest
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.messages import MessagesRepository, _normalize_date_to
 from src.models import Message, SearchQuery
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return MessagesRepository(db.db)
-
-
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""

--- a/tests/repositories/test_notification_bots_repository.py
+++ b/tests/repositories/test_notification_bots_repository.py
@@ -6,8 +6,9 @@ from datetime import datetime
 
 import pytest
 
-from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.models import NotificationBot
+
+
 @pytest.fixture
 def sample_bot():
     """Create sample NotificationBot."""

--- a/tests/repositories/test_notification_bots_repository.py
+++ b/tests/repositories/test_notification_bots_repository.py
@@ -8,14 +8,6 @@ import pytest
 
 from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.models import NotificationBot
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return NotificationBotsRepository(db.db)
-
-
 @pytest.fixture
 def sample_bot():
     """Create sample NotificationBot."""

--- a/tests/repositories/test_search_log_repository.py
+++ b/tests/repositories/test_search_log_repository.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 import pytest
 
 from src.database.repositories.search_log import SearchLogRepository
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return SearchLogRepository(db.db)
-
-
 async def test_log_search(repo):
     """Test logging a search."""
     await repo.log_search("+1234567890", "test query", 10)

--- a/tests/repositories/test_search_log_repository.py
+++ b/tests/repositories/test_search_log_repository.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
 
-from src.database.repositories.search_log import SearchLogRepository
 async def test_log_search(repo):
     """Test logging a search."""
     await repo.log_search("+1234567890", "test query", 10)

--- a/tests/repositories/test_search_queries_repository.py
+++ b/tests/repositories/test_search_queries_repository.py
@@ -8,14 +8,6 @@ import pytest
 
 from src.database.repositories.search_queries import SearchQueriesRepository
 from src.models import SearchQuery
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return SearchQueriesRepository(db.db)
-
-
 def make_query(query: str = "test query", **kwargs) -> SearchQuery:
     """Create a test SearchQuery."""
     defaults = {

--- a/tests/repositories/test_search_queries_repository.py
+++ b/tests/repositories/test_search_queries_repository.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
-from src.database.repositories.search_queries import SearchQueriesRepository
 from src.models import SearchQuery
+
+
 def make_query(query: str = "test query", **kwargs) -> SearchQuery:
     """Create a test SearchQuery."""
     defaults = {

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
 
-from src.database.repositories.settings import SettingsRepository
 async def test_get_setting_not_found(repo):
     """Test getting non-existent setting returns None."""
     result = await repo.get_setting("nonexistent_key")

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -5,14 +5,6 @@ from __future__ import annotations
 import pytest
 
 from src.database.repositories.settings import SettingsRepository
-
-
-@pytest.fixture
-async def repo(db):
-    """Create repository instance."""
-    return SettingsRepository(db.db)
-
-
 async def test_get_setting_not_found(repo):
     """Test getting non-existent setting returns None."""
     result = await repo.get_setting("nonexistent_key")

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -9,22 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig
-from src.database import Database
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
-
 
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked auth."""
     app, _, pool = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         return {
             "channel_id": -1001234567890,
             "title": "Test Channel",

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -21,19 +21,9 @@ from src.web.app import create_app
 
 
 @pytest.fixture
-async def client(tmp_path):
+async def client(base_app):
     """Create test client with mocked auth."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, _, pool = base_app
     async def _resolve_channel(self, identifier):
         return {
             "channel_id": -1001234567890,
@@ -42,30 +32,11 @@ async def client(tmp_path):
             "channel_type": "channel",
         }
 
-    # Create mock auth
-    auth = TelegramAuth(12345, "test_hash")
-    app.state.auth = auth
-
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "resolve_channel": _resolve_channel,
-            "add_client": AsyncMock(),
-            "get_client_by_phone": AsyncMock(return_value=None),
-            "release_client": AsyncMock(),
-        },
-    )()
-
-    app.state.notifier = None
-    collector = Collector(app.state.pool, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
+    pool.clients = {}
+    pool.resolve_channel = _resolve_channel
+    pool.add_client = AsyncMock()
+    pool.get_client_by_phone = AsyncMock(return_value=None)
+    pool.release_client = AsyncMock()
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -77,48 +48,19 @@ async def client(tmp_path):
     ) as c:
         yield c
 
-    await app.state.collection_queue.shutdown()
-    await db.close()
-
 
 @pytest.fixture
-async def client_unconfigured(tmp_path):
+async def client_unconfigured(base_app):
     """Create test client with unconfigured auth."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 0  # Unconfigured
-    config.telegram.api_hash = ""
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
-    # Unconfigured auth
+    app, _, pool = base_app
     auth = MagicMock()
     auth.is_configured = False
     app.state.auth = auth
 
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "add_client": AsyncMock(),
-            "get_client_by_phone": AsyncMock(return_value=None),
-            "release_client": AsyncMock(),
-        },
-    )()
-
-    app.state.notifier = None
-    collector = Collector(app.state.pool, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
+    pool.clients = {}
+    pool.add_client = AsyncMock()
+    pool.get_client_by_phone = AsyncMock(return_value=None)
+    pool.release_client = AsyncMock()
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -129,9 +71,6 @@ async def client_unconfigured(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await app.state.collection_queue.shutdown()
-    await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -21,19 +21,9 @@ from src.web.log_handler import LogBuffer
 
 
 @pytest.fixture
-async def client(tmp_path):
+async def client(base_app):
     """Create test client with log buffer."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, _, pool = base_app
     async def _resolve_channel(self, identifier):
         return {
             "channel_id": -1001234567890,
@@ -42,27 +32,9 @@ async def client(tmp_path):
             "channel_type": "channel",
         }
 
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "resolve_channel": _resolve_channel,
-        },
-    )()
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(app.state.pool, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
+    pool.clients = {}
+    pool.resolve_channel = _resolve_channel
     app.state.log_buffer = LogBuffer()
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -73,25 +45,12 @@ async def client(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await app.state.collection_queue.shutdown()
-    await db.close()
 
 
 @pytest.fixture
-async def client_no_buffer(tmp_path):
+async def client_no_buffer(base_app):
     """Create test client without log buffer."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, _, pool = base_app
     async def _resolve_channel(self, identifier):
         return {
             "channel_id": -1001234567890,
@@ -100,27 +59,9 @@ async def client_no_buffer(tmp_path):
             "channel_type": "channel",
         }
 
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "resolve_channel": _resolve_channel,
-        },
-    )()
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(app.state.pool, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
+    pool.clients = {}
+    pool.resolve_channel = _resolve_channel
     app.state.log_buffer = None  # No buffer
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -131,9 +72,6 @@ async def client_no_buffer(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await app.state.collection_queue.shutdown()
-    await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -7,16 +7,6 @@ import base64
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig
-from src.database import Database
-from src.models import Account
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
 from src.web.log_handler import LogBuffer
 
 
@@ -24,7 +14,8 @@ from src.web.log_handler import LogBuffer
 async def client(base_app):
     """Create test client with log buffer."""
     app, _, pool = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         return {
             "channel_id": -1001234567890,
             "title": "Test Channel",
@@ -51,7 +42,8 @@ async def client(base_app):
 async def client_no_buffer(base_app):
     """Create test client without log buffer."""
     app, _, pool = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         return {
             "channel_id": -1001234567890,
             "title": "Test Channel",

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -22,19 +22,9 @@ from src.web.app import create_app
 
 
 @pytest.fixture
-async def client(tmp_path):
+async def client(base_app):
     """Create test client with mocked pool."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, db, pool_mock = base_app
     async def _resolve_channel(self, identifier):
         return {
             "channel_id": -1001234567890,
@@ -43,7 +33,6 @@ async def client(tmp_path):
             "channel_type": "channel",
         }
 
-    pool_mock = MagicMock()
     pool_mock.clients = {
         "+1234567890": SimpleNamespace(is_connected=lambda: True),
         "+9876543210": SimpleNamespace(is_connected=lambda: True),
@@ -67,21 +56,7 @@ async def client(tmp_path):
         ]
     )
     pool_mock.leave_channels = AsyncMock(return_value={-100111: True, -100222: True})
-    app.state.pool = pool_mock
 
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(pool_mock, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
-    app.state.shutting_down = False
-
-    # Add test account
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
     await db.add_account(Account(phone="+9876543210", session_string="test_session2"))
 
     transport = ASGITransport(app=app)
@@ -93,9 +68,6 @@ async def client(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await app.state.collection_queue.shutdown()
-    await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -4,28 +4,20 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig
-from src.database import Database
 from src.models import Account, Channel
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
 
 
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked pool."""
     app, db, pool_mock = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         return {
             "channel_id": -1001234567890,
             "title": "Test Channel",

--- a/tests/routes/test_import_channels_routes.py
+++ b/tests/routes/test_import_channels_routes.py
@@ -21,19 +21,9 @@ from src.web.app import create_app
 
 
 @pytest.fixture
-async def client(tmp_path):
+async def client(base_app):
     """Create test client with mocked pool."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, _, pool = base_app
     async def _resolve_channel(self, identifier):
         # Mock resolve based on identifier
         if identifier.startswith("@"):
@@ -52,26 +42,8 @@ async def client(tmp_path):
             }
         raise RuntimeError(f"Cannot resolve: {identifier}")
 
-    app.state.pool = type(
-        "Pool",
-        (),
-        {
-            "clients": {},
-            "resolve_channel": _resolve_channel,
-        },
-    )()
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(app.state.pool, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
+    pool.clients = {}
+    pool.resolve_channel = _resolve_channel
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -83,9 +55,6 @@ async def client(tmp_path):
     ) as c:
         yield c
 
-    await app.state.collection_queue.shutdown()
-    await db.close()
-
 
 @pytest.fixture
 async def client_no_resolve(client):
@@ -95,6 +64,7 @@ async def client_no_resolve(client):
         raise RuntimeError("no_client")
 
     client._transport.app.state.pool.resolve_channel = _resolve_no_client
+    return client
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_import_channels_routes.py
+++ b/tests/routes/test_import_channels_routes.py
@@ -8,23 +8,15 @@ import io
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig
-from src.database import Database
-from src.models import Account, Channel
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
+from src.models import Channel
 
 
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked pool."""
     app, _, pool = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         # Mock resolve based on identifier
         if identifier.startswith("@"):
             return {
@@ -60,7 +52,7 @@ async def client(base_app):
 async def client_no_resolve(client):
     """Client with resolve that raises no_client error."""
 
-    async def _resolve_no_client(self, identifier):
+    async def _resolve_no_client(identifier):
         raise RuntimeError("no_client")
 
     client._transport.app.state.pool.resolve_channel = _resolve_no_client

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -28,34 +28,10 @@ from src.web.app import create_app
 
 
 @pytest.fixture
-async def client(tmp_path):
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
-    pool_mock = MagicMock()
+async def client(base_app):
+    app, _, pool_mock = base_app
     pool_mock.clients = {"+1234567890": MagicMock()}
     pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
-    app.state.pool = pool_mock
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    app.state.collector = Collector(pool_mock, db, config.scheduler)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
-    app.state.shutting_down = False
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
-    await db.add_channel(Channel(channel_id=100, title="Test Channel"))
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -67,8 +43,6 @@ async def client(tmp_path):
     ) as c:
         c._transport_app = app
         yield c
-
-    await db.close()
 
 
 async def _create_pipeline(db: Database, *, publish_mode: PipelinePublishMode) -> int:

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -8,23 +8,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.config import AppConfig
 from src.database import Database
 from src.models import (
-    Account,
-    Channel,
     ContentPipeline,
     PipelineGenerationBackend,
     PipelinePublishMode,
     PipelineTarget,
 )
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
 from src.services.publish_service import PublishResult
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
 
 
 @pytest.fixture

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -7,16 +7,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.config import AppConfig
-from src.database import Database
-from src.models import Account, Channel
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
-
 _ADD_DATA = {
     "name": "Test Pipeline",
     "prompt_template": "Write a summary",

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -31,35 +31,10 @@ _ADD_DATA = {
 
 
 @pytest.fixture
-async def client(tmp_path):
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
-    pool_mock = MagicMock()
+async def client(base_app):
+    app, db, pool_mock = base_app
     pool_mock.clients = {"+1234567890": MagicMock()}
     pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
-    app.state.pool = pool_mock
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(pool_mock, db, config.scheduler)
-    app.state.collector = collector
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-    app.state.scheduler = SchedulerManager(config.scheduler)
-    app.state.session_secret = "test_secret_key"
-    app.state.shutting_down = False
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
-    await db.add_channel(Channel(channel_id=100, title="Test Channel"))
     await db.repos.dialog_cache.replace_dialogs(
         "+1234567890",
         [{"channel_id": 200, "title": "Test Dialog", "channel_type": "channel"}],
@@ -74,8 +49,6 @@ async def client(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -8,23 +8,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.collection_queue import CollectionQueue
-from src.config import AppConfig
-from src.database import Database
-from src.models import Account, CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
-from src.scheduler.service import SchedulerManager
-from src.search.ai_search import AISearchEngine
-from src.search.engine import SearchEngine
-from src.telegram.auth import TelegramAuth
-from src.telegram.collector import Collector
-from src.web.app import create_app
+from src.models import CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
 
 
 @pytest.fixture
 async def client(base_app):
     """Create test client with scheduler."""
     app, _, pool_mock = base_app
-    async def _resolve_channel(self, identifier):
+
+    async def _resolve_channel(identifier):
         return {
             "channel_id": -1001234567890,
             "title": "Test Channel",

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -21,19 +21,9 @@ from src.web.app import create_app
 
 
 @pytest.fixture
-async def client(tmp_path):
+async def client(base_app):
     """Create test client with scheduler."""
-    config = AppConfig()
-    config.database.path = str(tmp_path / "test.db")
-    config.telegram.api_id = 12345
-    config.telegram.api_hash = "test_hash"
-    config.web.password = "testpass"
-    app = create_app(config)
-
-    db = Database(config.database.path)
-    await db.initialize()
-    app.state.db = db
-
+    app, _, pool_mock = base_app
     async def _resolve_channel(self, identifier):
         return {
             "channel_id": -1001234567890,
@@ -42,25 +32,8 @@ async def client(tmp_path):
             "channel_type": "channel",
         }
 
-    pool_mock = MagicMock()
     pool_mock.clients = {}
     pool_mock.resolve_channel = _resolve_channel
-    app.state.pool = pool_mock
-
-    app.state.auth = TelegramAuth(12345, "test_hash")
-    app.state.notifier = None
-    collector = Collector(pool_mock, db, config.scheduler)
-    app.state.collector = collector
-    app.state.collection_queue = CollectionQueue(collector, db)
-    app.state.search_engine = SearchEngine(db)
-    app.state.ai_search = AISearchEngine(config.llm, db)
-
-    scheduler = SchedulerManager(config.scheduler)
-    app.state.scheduler = scheduler
-    app.state.session_secret = "test_secret_key"
-    app.state.shutting_down = False
-
-    await db.add_account(Account(phone="+1234567890", session_string="test_session"))
 
     transport = ASGITransport(app=app)
     auth_header = base64.b64encode(b":testpass").decode()
@@ -71,9 +44,6 @@ async def client(tmp_path):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
-    await app.state.collection_queue.shutdown()
-    await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -431,7 +431,7 @@ def test_clipboard_reads_from_native_tool(monkeypatch):
 class TestAgentChatOneShotMode:
     """Tests for `agent chat -p <message>` one-shot mode."""
 
-    def _run_chat(self, cli_env, prompt: str, thread_id=None, monkeypatch=None, capsys=None):
+    def _run_chat(self, cli_env, prompt: str, thread_id=None, cli_init_patch=None, monkeypatch=None, capsys=None):
         """Helper: run agent chat in one-shot mode with mocked AgentManager."""
         from unittest.mock import MagicMock
         from unittest.mock import patch as _patch
@@ -453,23 +453,20 @@ class TestAgentChatOneShotMode:
             yield assistant_msg
             yield result_msg
 
-        async def fake_init_db(_path):
-            return AppConfig(), cli_env
-
         with (
-            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            cli_init_patch(cli_env, "src.cli.runtime.init_db"),
             _patch("src.agent.manager.query", mock_query),
         ):
             run(_ns(agent_action="chat", prompt=prompt, thread_id=thread_id, model=None))
 
-    def test_one_shot_prints_response(self, cli_env, capsys, monkeypatch):
-        self._run_chat(cli_env, "hello", monkeypatch=monkeypatch)
+    def test_one_shot_prints_response(self, cli_env, cli_init_patch, capsys, monkeypatch):
+        self._run_chat(cli_env, "hello", cli_init_patch=cli_init_patch, monkeypatch=monkeypatch)
         assert "one-shot reply" in capsys.readouterr().out
 
-    def test_one_shot_creates_thread_if_none(self, cli_env, monkeypatch):
+    def test_one_shot_creates_thread_if_none(self, cli_env, cli_init_patch, monkeypatch):
         import sqlite3
 
-        self._run_chat(cli_env, "hi", monkeypatch=monkeypatch)
+        self._run_chat(cli_env, "hi", cli_init_patch=cli_init_patch, monkeypatch=monkeypatch)
         conn = sqlite3.connect(cli_env._db_path)
         try:
             count = conn.execute("SELECT COUNT(*) FROM agent_threads").fetchone()[0]
@@ -477,11 +474,11 @@ class TestAgentChatOneShotMode:
             conn.close()
         assert count >= 1
 
-    def test_one_shot_uses_existing_thread(self, cli_env, monkeypatch):
+    def test_one_shot_uses_existing_thread(self, cli_env, cli_init_patch, monkeypatch):
         import sqlite3
 
         tid = asyncio.run(cli_env.create_agent_thread("existing"))
-        self._run_chat(cli_env, "hi", thread_id=tid, monkeypatch=monkeypatch)
+        self._run_chat(cli_env, "hi", thread_id=tid, cli_init_patch=cli_init_patch, monkeypatch=monkeypatch)
         # CLI closes the aiosqlite connection, use raw sqlite3 to read state
         conn = sqlite3.connect(cli_env._db_path)
         conn.row_factory = sqlite3.Row
@@ -493,7 +490,7 @@ class TestAgentChatOneShotMode:
             conn.close()
         assert any(r["role"] == "user" and r["content"] == "hi" for r in rows)
 
-    def test_one_shot_prints_status_to_stderr(self, cli_env, capsys, monkeypatch):
+    def test_one_shot_prints_status_to_stderr(self, cli_env, cli_init_patch, capsys, monkeypatch):
         """Status events are printed to stderr, not stdout, in one-shot mode."""
         from unittest.mock import patch as _patch
 
@@ -502,9 +499,6 @@ class TestAgentChatOneShotMode:
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
-        async def fake_init_db(_path):
-            return AppConfig(), cli_env
-
         async def fake_chat_stream(*_a, **_kw):
             yield 'data: {"type": "status", "text": "Создание клиента"}\n\n'
             yield 'data: {"type": "status", "text": "Запрос к API"}\n\n'
@@ -512,7 +506,7 @@ class TestAgentChatOneShotMode:
             yield 'data: {"done": true, "full_text": "reply text"}\n\n'
 
         with (
-            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            cli_init_patch(cli_env, "src.cli.runtime.init_db"),
             _patch("src.agent.manager.AgentManager.chat_stream", fake_chat_stream),
         ):
             run(_ns(agent_action="chat", prompt="test", thread_id=None, model=None))
@@ -532,7 +526,7 @@ class TestAgentChatOneShotMode:
 class TestAgentChatInteractiveMode:
     """Tests that `agent chat` without --prompt launches TUI."""
 
-    def test_no_prompt_launches_tui(self, cli_env, monkeypatch):
+    def test_no_prompt_launches_tui(self, cli_env, cli_init_patch, monkeypatch):
         """When prompt is None, AgentTuiApp.run_async() is called."""
         from unittest.mock import AsyncMock
         from unittest.mock import patch as _patch
@@ -542,13 +536,10 @@ class TestAgentChatInteractiveMode:
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
-        async def fake_init_db(_path):
-            return AppConfig(), cli_env
-
         mock_run_async = AsyncMock()
 
         with (
-            _patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            cli_init_patch(cli_env, "src.cli.runtime.init_db"),
             _patch("src.cli.commands.agent_tui.AgentTuiApp.run_async", mock_run_async),
         ):
             run(_ns(agent_action="chat", prompt=None, thread_id=None, model=None))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -473,7 +473,7 @@ class TestCLISearch:
 
 
 class TestCLIAgentDbProviders:
-    def test_chat_refreshes_db_backed_provider_cache_before_initialize(self, cli_env, capsys):
+    def test_chat_refreshes_db_backed_provider_cache_before_initialize(self, cli_env, cli_init_patch, capsys):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.cli.commands.agent import run
         from src.services.agent_provider_service import AgentProviderService
@@ -497,9 +497,6 @@ class TestCLIAgentDbProviders:
 
         thread_id = asyncio.run(cli_env.create_agent_thread("cli chat"))
 
-        async def fake_init_db(_config_path: str):
-            return config, cli_env
-
         def fake_init_chat_model(*, model, model_provider, **kwargs):
             assert model_provider == "openai"
             assert model == "gpt-4.1-mini"
@@ -509,7 +506,7 @@ class TestCLIAgentDbProviders:
         fake_agent = MagicMock(run=MagicMock(return_value="ok-from-db-provider"))
 
         with (
-            patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            cli_init_patch(cli_env, "src.cli.runtime.init_db", config=config),
             patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
             patch("deepagents.create_deep_agent", return_value=fake_agent),
         ):
@@ -1199,7 +1196,7 @@ class TestCLIAgent:
         assert "model reply" in out
         assert captured_opts.get("model") == "claude-haiku-4-5-20251001"
 
-    def test_test_escaping_uses_runtime_config_for_db_providers(self, cli_db, capsys):
+    def test_test_escaping_uses_runtime_config_for_db_providers(self, cli_db, cli_init_patch, capsys):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.cli.commands.agent import run
         from src.services.agent_provider_service import AgentProviderService
@@ -1221,11 +1218,8 @@ class TestCLIAgent:
             )
         )
 
-        async def fake_init_db(config_path: str):
-            return config, cli_db
-
         with (
-            patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+            cli_init_patch(cli_db, "src.cli.runtime.init_db", config=config),
             patch(
                 "src.agent.manager.DeepagentsBackend._build_agent",
                 return_value=MagicMock(run=MagicMock(return_value="ok")),

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -32,23 +32,12 @@ def _chan(channel_id, title, username="", ch_type="channel", deactivate=False):
 
 
 @pytest.fixture
-def cli_env(cli_db):
-    config = AppConfig()
-
-    async def fake_init_db(config_path: str):
-        cmd_db = Database(cli_db._db_path)
-        await cmd_db.initialize()
-        return config, cmd_db
-
-    with (
-        patch(
-            "src.cli.commands.channel.runtime.init_db",
-            side_effect=fake_init_db,
-        ),
-        patch(
-            "src.cli.commands.test.runtime.init_db",
-            side_effect=fake_init_db,
-        ),
+def cli_env(cli_db, cli_init_patch):
+    with cli_init_patch(
+        cli_db,
+        "src.cli.commands.channel.runtime.init_db",
+        "src.cli.commands.test.runtime.init_db",
+        config=AppConfig(),
     ):
         yield cli_db
 

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -10,7 +10,6 @@ import pydantic.root_model  # noqa: F401
 import pytest
 
 from src.config import AppConfig
-from src.database import Database
 from src.models import Channel, ChannelStats, CollectionTaskStatus
 from src.telegram.flood_wait import FloodWaitInfo
 
@@ -38,6 +37,7 @@ def cli_env(cli_db, cli_init_patch):
         "src.cli.commands.channel.runtime.init_db",
         "src.cli.commands.test.runtime.init_db",
         config=AppConfig(),
+        fresh_database=True,
     ):
         yield cli_db
 

--- a/tests/test_cli_filter.py
+++ b/tests/test_cli_filter.py
@@ -9,6 +9,8 @@ from src.config import AppConfig
 from src.database import Database
 from src.models import Account, Channel
 
+_FILTER_INIT_DB_TARGET = "src.cli.commands.filter.runtime.init_db"
+
 
 def _ns(**kwargs) -> argparse.Namespace:
     defaults = {"config": "config.yaml"}
@@ -65,7 +67,7 @@ def test_print_result_with_purged(capsys):
     assert "Skipped: 1" in out
 
 
-def test_filter_analyze(tmp_path, capsys):
+def test_filter_analyze(tmp_path, cli_init_patch, capsys):
     """Test filter analyze action."""
     db_path = str(tmp_path / "filter_analyze.db")
     db = Database(db_path)
@@ -74,13 +76,7 @@ def test_filter_analyze(tmp_path, capsys):
     asyncio.run(db.add_channel(Channel(channel_id=1001, title="Test Channel")))
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter.ChannelAnalyzer") as mock_analyzer:
@@ -99,20 +95,14 @@ def test_filter_analyze(tmp_path, capsys):
     assert "No channels found" in out
 
 
-def test_filter_apply(tmp_path, capsys):
+def test_filter_apply(tmp_path, cli_init_patch, capsys):
     """Test filter apply action."""
     db_path = str(tmp_path / "filter_apply.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter.ChannelAnalyzer") as mock_analyzer:
@@ -128,20 +118,14 @@ def test_filter_apply(tmp_path, capsys):
     assert "Applied filters: 5" in out
 
 
-def test_filter_precheck(tmp_path, capsys):
+def test_filter_precheck(tmp_path, cli_init_patch, capsys):
     """Test filter precheck action."""
     db_path = str(tmp_path / "filter_precheck.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter.ChannelAnalyzer") as mock_analyzer:
@@ -155,20 +139,14 @@ def test_filter_precheck(tmp_path, capsys):
     assert "Pre-filter applied: 3" in out
 
 
-def test_filter_reset(tmp_path, capsys):
+def test_filter_reset(tmp_path, cli_init_patch, capsys):
     """Test filter reset action."""
     db_path = str(tmp_path / "filter_reset.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter.ChannelAnalyzer") as mock_analyzer:
@@ -182,20 +160,14 @@ def test_filter_reset(tmp_path, capsys):
     assert "All channel filters have been reset" in out
 
 
-def test_filter_purge_all(tmp_path, capsys):
+def test_filter_purge_all(tmp_path, cli_init_patch, capsys):
     """Test filter purge all action."""
     db_path = str(tmp_path / "filter_purge.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter._build_deletion_service") as mock_build:
@@ -213,20 +185,14 @@ def test_filter_purge_all(tmp_path, capsys):
     assert "Purged messages from 2 channels" in out
 
 
-def test_filter_purge_by_pks(tmp_path, capsys):
+def test_filter_purge_by_pks(tmp_path, cli_init_patch, capsys):
     """Test filter purge by PKs action."""
     db_path = str(tmp_path / "filter_purge_pks.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         with patch("src.cli.commands.filter._build_deletion_service") as mock_build:
@@ -244,20 +210,14 @@ def test_filter_purge_by_pks(tmp_path, capsys):
     assert "Purged messages from 1 channel" in out
 
 
-def test_filter_purge_invalid_pks(tmp_path, capsys):
+def test_filter_purge_invalid_pks(tmp_path, cli_init_patch, capsys):
     """Test filter purge with invalid PKs."""
     db_path = str(tmp_path / "filter_purge_invalid.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         run(_ns(filter_action="purge", pks="abc,def"))
@@ -266,20 +226,14 @@ def test_filter_purge_invalid_pks(tmp_path, capsys):
     assert "No valid PKs provided" in out
 
 
-def test_filter_hard_delete_requires_dev_mode(tmp_path, capsys):
+def test_filter_hard_delete_requires_dev_mode(tmp_path, cli_init_patch, capsys):
     """Test filter hard-delete requires dev mode."""
     db_path = str(tmp_path / "filter_hard_delete_dev.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
         run(_ns(filter_action="hard-delete", pks=None, yes=False))
@@ -288,17 +242,13 @@ def test_filter_hard_delete_requires_dev_mode(tmp_path, capsys):
     assert "Hard-delete requires developer mode" in out
 
 
-def test_filter_no_action(capsys):
+def test_filter_no_action(cli_init_patch, capsys):
     """Test filter without action."""
     from src.cli.commands.filter import run
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        db = MagicMock()
-        db.close = AsyncMock()
-        return config, db
-
-    with patch("src.cli.commands.filter.runtime.init_db", side_effect=fake_init_db):
+    db = MagicMock()
+    db.close = AsyncMock()
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         run(_ns(filter_action=None))
 
     out = capsys.readouterr().out

--- a/tests/test_cli_filter.py
+++ b/tests/test_cli_filter.py
@@ -5,7 +5,6 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.config import AppConfig
 from src.database import Database
 from src.models import Account, Channel
 

--- a/tests/test_cli_issue_303.py
+++ b/tests/test_cli_issue_303.py
@@ -92,13 +92,10 @@ def test_dialogs_help_still_uses_dialogs_usage(capsys):
     assert "mark-read" in out
 
 
-def test_dialogs_run_is_primary_entrypoint(cli_db, capsys):
+def test_dialogs_run_is_primary_entrypoint(cli_db, cli_init_patch, capsys):
     pool = MagicMock()
     pool.clients = {"+79001234567": AsyncMock()}
     pool.disconnect_all = AsyncMock()
-
-    async def fake_init_db(_config_path):
-        return AppConfig(), cli_db
 
     async def fake_init_pool(config, db):
         return MagicMock(), pool
@@ -114,7 +111,7 @@ def test_dialogs_run_is_primary_entrypoint(cli_db, capsys):
     ]
 
     with (
-        patch("src.cli.commands.dialogs.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(cli_db, "src.cli.commands.dialogs.runtime.init_db"),
         patch("src.cli.commands.dialogs.runtime.init_pool", side_effect=fake_init_pool),
         patch(
             "src.cli.commands.dialogs.ChannelService.get_my_dialogs",
@@ -131,19 +128,16 @@ def test_dialogs_run_is_primary_entrypoint(cli_db, capsys):
     assert "@primary_dialogs" in out
 
 
-def test_dialogs_legacy_alias_remains_compatible(cli_db, capsys):
+def test_dialogs_legacy_alias_remains_compatible(cli_db, cli_init_patch, capsys):
     pool = MagicMock()
     pool.clients = {"+79001234567": AsyncMock()}
     pool.disconnect_all = AsyncMock()
-
-    async def fake_init_db(_config_path):
-        return AppConfig(), cli_db
 
     async def fake_init_pool(config, db):
         return MagicMock(), pool
 
     with (
-        patch("src.cli.commands.dialogs.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(cli_db, "src.cli.commands.dialogs.runtime.init_db"),
         patch("src.cli.commands.dialogs.runtime.init_pool", side_effect=fake_init_pool),
         patch(
             "src.cli.commands.dialogs.ChannelService.get_my_dialogs",

--- a/tests/test_cli_issue_303.py
+++ b/tests/test_cli_issue_303.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.config import AppConfig
 from tests.helpers import cli_ns
 
 ISSUE_303_PARSE_CASES = {

--- a/tests/test_cli_photo_loader.py
+++ b/tests/test_cli_photo_loader.py
@@ -9,6 +9,8 @@ from src.config import AppConfig
 from src.database import Database
 from src.models import Account
 
+_PHOTO_LOADER_INIT_DB_TARGET = "src.cli.commands.photo_loader.runtime.init_db"
+
 
 def _ns(**kwargs) -> argparse.Namespace:
     defaults = {"config": "config.yaml"}
@@ -77,7 +79,7 @@ def test_parse_schedule_at_without_tz():
     assert dt.tzinfo is not None
 
 
-def test_dialogs_action(tmp_path, capsys):
+def test_dialogs_action(tmp_path, cli_init_patch, capsys):
     """Test dialogs action prints dialog list."""
     db_path = str(tmp_path / "photo_dialogs.db")
     db = Database(db_path)
@@ -85,19 +87,13 @@ def test_dialogs_action(tmp_path, capsys):
     _setup_photo_db(db)
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
         pool.disconnect_all = AsyncMock()
         return MagicMock(), pool
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
     ):
         from src.cli.commands.photo_loader import run
@@ -141,19 +137,13 @@ def _create_fake_services(task_methods=None, auto_methods=None):
     return FakePhotoTaskService, FakePhotoAutoUploadService
 
 
-def test_send_action(tmp_path, capsys):
+def test_send_action(tmp_path, cli_init_patch, capsys):
     """Test send action sends photo immediately."""
     db_path = str(tmp_path / "photo_send.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -168,7 +158,7 @@ def test_send_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -190,19 +180,13 @@ def test_send_action(tmp_path, capsys):
     assert "Sent photo item #1" in out
 
 
-def test_schedule_send_action(tmp_path, capsys):
+def test_schedule_send_action(tmp_path, cli_init_patch, capsys):
     """Test schedule-send action schedules photo."""
     db_path = str(tmp_path / "photo_schedule.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -217,7 +201,7 @@ def test_schedule_send_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -240,19 +224,13 @@ def test_schedule_send_action(tmp_path, capsys):
     assert "Scheduled photo item #2" in out
 
 
-def test_batch_create_action(tmp_path, capsys):
+def test_batch_create_action(tmp_path, cli_init_patch, capsys):
     """Test batch-create action creates photo batch."""
     db_path = str(tmp_path / "photo_batch_create.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -270,7 +248,7 @@ def test_batch_create_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -291,19 +269,13 @@ def test_batch_create_action(tmp_path, capsys):
     assert "Created photo batch #3" in out
 
 
-def test_batch_list_action(tmp_path, capsys):
+def test_batch_list_action(tmp_path, cli_init_patch, capsys):
     """Test batch-list action lists batches."""
     db_path = str(tmp_path / "photo_batch_list.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -322,7 +294,7 @@ def test_batch_list_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -336,19 +308,13 @@ def test_batch_list_action(tmp_path, capsys):
     assert "#2" in out
 
 
-def test_auto_create_action(tmp_path, capsys):
+def test_auto_create_action(tmp_path, cli_init_patch, capsys):
     """Test auto-create action creates auto upload job."""
     db_path = str(tmp_path / "photo_auto_create.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -361,7 +327,7 @@ def test_auto_create_action(tmp_path, capsys):
     fake_task, fake_auto = _create_fake_services(auto_methods={"create_job": AsyncMock(return_value=4)})
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -384,19 +350,13 @@ def test_auto_create_action(tmp_path, capsys):
     assert "Created auto job #4" in out
 
 
-def test_auto_list_action(tmp_path, capsys):
+def test_auto_list_action(tmp_path, cli_init_patch, capsys):
     """Test auto-list action lists auto jobs."""
     db_path = str(tmp_path / "photo_auto_list.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -420,7 +380,7 @@ def test_auto_list_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -434,19 +394,13 @@ def test_auto_list_action(tmp_path, capsys):
     assert "/tmp/photos" in out
 
 
-def test_auto_toggle_action(tmp_path, capsys):
+def test_auto_toggle_action(tmp_path, cli_init_patch, capsys):
     """Test auto-toggle action toggles job active state."""
     db_path = str(tmp_path / "photo_auto_toggle.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -461,7 +415,7 @@ def test_auto_toggle_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -474,19 +428,13 @@ def test_auto_toggle_action(tmp_path, capsys):
     assert "Toggled auto job #1" in out
 
 
-def test_auto_toggle_not_found(tmp_path, capsys):
+def test_auto_toggle_not_found(tmp_path, cli_init_patch, capsys):
     """Test auto-toggle with non-existent job."""
     db_path = str(tmp_path / "photo_auto_toggle_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -496,7 +444,7 @@ def test_auto_toggle_not_found(tmp_path, capsys):
     fake_task, fake_auto = _create_fake_services(auto_methods={"get_job": AsyncMock(return_value=None)})
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -509,19 +457,13 @@ def test_auto_toggle_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_run_due_action(tmp_path, capsys):
+def test_run_due_action(tmp_path, cli_init_patch, capsys):
     """Test run-due action processes due items and jobs."""
     db_path = str(tmp_path / "photo_run_due.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -534,7 +476,7 @@ def test_run_due_action(tmp_path, capsys):
     )
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -548,19 +490,13 @@ def test_run_due_action(tmp_path, capsys):
     assert "auto_jobs=2" in out
 
 
-def test_auto_delete_action(tmp_path, capsys):
+def test_auto_delete_action(tmp_path, cli_init_patch, capsys):
     """Test auto-delete action deletes job."""
     db_path = str(tmp_path / "photo_auto_delete.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -570,7 +506,7 @@ def test_auto_delete_action(tmp_path, capsys):
     fake_task, fake_auto = _create_fake_services(auto_methods={"delete_job": AsyncMock(return_value=None)})
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -583,19 +519,13 @@ def test_auto_delete_action(tmp_path, capsys):
     assert "Deleted auto job #1" in out
 
 
-def test_batch_cancel_action(tmp_path, capsys):
+def test_batch_cancel_action(tmp_path, cli_init_patch, capsys):
     """Test batch-cancel action cancels item."""
     db_path = str(tmp_path / "photo_batch_cancel.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -605,7 +535,7 @@ def test_batch_cancel_action(tmp_path, capsys):
     fake_task, fake_auto = _create_fake_services(task_methods={"cancel_item": AsyncMock(return_value=True)})
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),
@@ -618,19 +548,13 @@ def test_batch_cancel_action(tmp_path, capsys):
     assert "Cancelled" in out
 
 
-def test_auto_update_action(tmp_path, capsys):
+def test_auto_update_action(tmp_path, cli_init_patch, capsys):
     """Test auto-update action updates job."""
     db_path = str(tmp_path / "photo_auto_update.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
     asyncio.run(db.close())
-
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -640,7 +564,7 @@ def test_auto_update_action(tmp_path, capsys):
     fake_task, fake_auto = _create_fake_services(auto_methods={"update_job": AsyncMock(return_value=None)})
 
     with (
-        patch("src.cli.commands.photo_loader.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, _PHOTO_LOADER_INIT_DB_TARGET),
         patch("src.cli.commands.photo_loader.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.photo_loader.PhotoTaskService", fake_task),
         patch("src.cli.commands.photo_loader.PhotoAutoUploadService", fake_auto),

--- a/tests/test_cli_photo_loader.py
+++ b/tests/test_cli_photo_loader.py
@@ -5,7 +5,6 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.config import AppConfig
 from src.database import Database
 from src.models import Account
 

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -760,7 +760,7 @@ def test_photo_loader_cli_parser():
     assert args.mode == "album"
 
 
-def test_photo_loader_cli_send_command(tmp_path, capsys):
+def test_photo_loader_cli_send_command(tmp_path, cli_init_patch, capsys):
     image = tmp_path / "one.jpg"
     image.write_bytes(b"x")
     db = Database(str(tmp_path / "cli.db"))
@@ -777,11 +777,8 @@ def test_photo_loader_cli_send_command(tmp_path, capsys):
 
         return TelegramAuth(0, ""), fake_pool
 
-    async def fake_init_db(config_path):
-        return AppConfig(), db
-
     with (
-        patch("src.cli.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, "src.cli.runtime.init_db"),
         patch("src.cli.runtime.init_pool", side_effect=fake_init_pool),
     ):
         from src.cli.commands.photo_loader import run

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -17,6 +17,11 @@ from src.models import (
 )
 from src.services.publish_service import PublishResult
 
+_PIPELINE_INIT_DB_TARGETS = (
+    "src.cli.runtime.init_db",
+    "src.cli.commands.pipeline.runtime.init_db",
+)
+
 
 def _ns(**kwargs) -> argparse.Namespace:
     defaults = {"config": "config.yaml"}
@@ -42,20 +47,14 @@ def _add_pipeline_prereqs(db: Database) -> None:
     )
 
 
-def test_pipeline_add_and_list(tmp_path, capsys):
+def test_pipeline_add_and_list(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     _add_pipeline_prereqs(db)
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(
@@ -80,19 +79,13 @@ def test_pipeline_add_and_list(tmp_path, capsys):
     assert "Digest" in out
 
 
-def test_pipeline_show_not_found(tmp_path, capsys):
+def test_pipeline_show_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_not_found.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="show", id=999))
@@ -101,7 +94,7 @@ def test_pipeline_show_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_queue_approve_reject_and_publish(tmp_path, capsys):
+def test_pipeline_queue_approve_reject_and_publish(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_actions.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
@@ -129,12 +122,6 @@ def test_pipeline_queue_approve_reject_and_publish(tmp_path, capsys):
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated draft for CLI"))
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
         pool.clients = {"+100": object()}
@@ -150,7 +137,7 @@ def test_pipeline_queue_approve_reject_and_publish(tmp_path, capsys):
             return [PublishResult(success=True, message_id=123)]
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.cli.commands.pipeline.runtime.init_pool", side_effect=fake_init_pool),
         patch("src.cli.commands.pipeline.PublishService", FakePublishService),
     ):
@@ -175,19 +162,13 @@ def test_pipeline_queue_approve_reject_and_publish(tmp_path, capsys):
     assert run_after.moderation_status == "rejected"
 
 
-def test_pipeline_publish_not_found(tmp_path, capsys):
+def test_pipeline_publish_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_publish_not_found.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="publish", run_id=999))
@@ -196,7 +177,7 @@ def test_pipeline_publish_not_found(tmp_path, capsys):
     assert "Run id=999 not found" in out
 
 
-def test_pipeline_generate_prints_draft_preview(tmp_path, capsys):
+def test_pipeline_generate_prints_draft_preview(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_generate.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
@@ -223,12 +204,6 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     class FakeContentGenerationService:
         def __init__(self, db, engine, agent_manager=None, **kwargs):
             self.db = db
@@ -246,7 +221,7 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, capsys):
             )
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.cli.commands.pipeline.ContentGenerationService", FakeContentGenerationService),
     ):
         from src.cli.commands.pipeline import run
@@ -268,7 +243,7 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, capsys):
     assert "Generated draft for CLI" in out
 
 
-def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, capsys):
+def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_generate_deep_agents.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
@@ -295,12 +270,6 @@ def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, capsys)
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     captured = {}
 
     class FakeAgentManager:
@@ -323,7 +292,7 @@ def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, capsys)
             )
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.agent.manager.AgentManager", FakeAgentManager),
         patch("src.cli.commands.pipeline.ContentGenerationService", FakeContentGenerationService),
     ):
@@ -346,7 +315,7 @@ def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, capsys)
     assert "Created generation run id=124" in out
 
 
-def test_pipeline_runs_and_run_show(tmp_path, capsys):
+def test_pipeline_runs_and_run_show(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_runs.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
@@ -374,13 +343,7 @@ def test_pipeline_runs_and_run_show(tmp_path, capsys):
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated draft for CLI"))
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="runs", id=pipeline_id, limit=20, status=None))
@@ -393,7 +356,7 @@ def test_pipeline_runs_and_run_show(tmp_path, capsys):
     assert "Generated draft for CLI" in out
 
 
-def test_pipeline_show_found(tmp_path, capsys):
+def test_pipeline_show_found(tmp_path, cli_init_patch, capsys):
     """Test show action with existing pipeline."""
     db_path = str(tmp_path / "cli_pipeline_show.db")
     db = Database(db_path)
@@ -424,13 +387,7 @@ def test_pipeline_show_found(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="show", id=pipeline_id))
@@ -442,7 +399,7 @@ def test_pipeline_show_found(tmp_path, capsys):
     assert "publish_mode=moderated" in out
 
 
-def test_pipeline_edit_found(tmp_path, capsys):
+def test_pipeline_edit_found(tmp_path, cli_init_patch, capsys):
     """Test edit action with existing pipeline."""
     db_path = str(tmp_path / "cli_pipeline_edit.db")
     db = Database(db_path)
@@ -469,13 +426,7 @@ def test_pipeline_edit_found(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(
@@ -499,20 +450,14 @@ def test_pipeline_edit_found(tmp_path, capsys):
     assert f"Updated pipeline id={pipeline_id}" in out
 
 
-def test_pipeline_edit_not_found(tmp_path, capsys):
+def test_pipeline_edit_not_found(tmp_path, cli_init_patch, capsys):
     """Test edit action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_edit_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(
@@ -536,7 +481,7 @@ def test_pipeline_edit_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_toggle_found(tmp_path, capsys):
+def test_pipeline_toggle_found(tmp_path, cli_init_patch, capsys):
     """Test toggle action with existing pipeline."""
     db_path = str(tmp_path / "cli_pipeline_toggle.db")
     db = Database(db_path)
@@ -564,13 +509,7 @@ def test_pipeline_toggle_found(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="toggle", id=pipeline_id))
@@ -579,20 +518,14 @@ def test_pipeline_toggle_found(tmp_path, capsys):
     assert f"Toggled pipeline id={pipeline_id}" in out
 
 
-def test_pipeline_toggle_not_found(tmp_path, capsys):
+def test_pipeline_toggle_not_found(tmp_path, cli_init_patch, capsys):
     """Test toggle action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_toggle_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="toggle", id=999))
@@ -601,7 +534,7 @@ def test_pipeline_toggle_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_delete(tmp_path, capsys):
+def test_pipeline_delete(tmp_path, cli_init_patch, capsys):
     """Test delete action."""
     db_path = str(tmp_path / "cli_pipeline_delete.db")
     db = Database(db_path)
@@ -628,13 +561,7 @@ def test_pipeline_delete(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="delete", id=pipeline_id))
@@ -643,7 +570,7 @@ def test_pipeline_delete(tmp_path, capsys):
     assert f"Deleted pipeline id={pipeline_id}" in out
 
 
-def test_pipeline_run_with_preview(tmp_path, capsys):
+def test_pipeline_run_with_preview(tmp_path, cli_init_patch, capsys):
     """Test run action with preview flag."""
     db_path = str(tmp_path / "cli_pipeline_run_preview.db")
     db = Database(db_path)
@@ -671,12 +598,6 @@ def test_pipeline_run_with_preview(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     class FakeGenerationService:
         def __init__(self, engine, provider_callable=None):
             pass
@@ -685,7 +606,7 @@ def test_pipeline_run_with_preview(tmp_path, capsys):
             return {"generated_text": "Preview content here", "citations": []}
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.cli.commands.pipeline.GenerationService", FakeGenerationService),
     ):
         from src.cli.commands.pipeline import run
@@ -708,20 +629,14 @@ def test_pipeline_run_with_preview(tmp_path, capsys):
     assert "Preview content here" in out
 
 
-def test_pipeline_run_not_found(tmp_path, capsys):
+def test_pipeline_run_not_found(tmp_path, cli_init_patch, capsys):
     """Test run action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_run_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="run", id=999, limit=10, max_tokens=256, temperature=0.7, preview=False, publish=False))
@@ -730,7 +645,7 @@ def test_pipeline_run_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_runs_with_status_filter(tmp_path, capsys):
+def test_pipeline_runs_with_status_filter(tmp_path, cli_init_patch, capsys):
     """Test runs action with status filter."""
     db_path = str(tmp_path / "cli_pipeline_runs_filter.db")
     db = Database(db_path)
@@ -759,13 +674,7 @@ def test_pipeline_runs_with_status_filter(tmp_path, capsys):
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Test output"))
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="runs", id=pipeline_id, limit=20, status="completed"))
@@ -775,20 +684,14 @@ def test_pipeline_runs_with_status_filter(tmp_path, capsys):
     assert "completed" in out
 
 
-def test_pipeline_runs_not_found(tmp_path, capsys):
+def test_pipeline_runs_not_found(tmp_path, cli_init_patch, capsys):
     """Test runs action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_runs_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="runs", id=999, limit=20, status=None))
@@ -797,7 +700,7 @@ def test_pipeline_runs_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_queue_empty(tmp_path, capsys):
+def test_pipeline_queue_empty(tmp_path, cli_init_patch, capsys):
     """Test queue action when no pending runs."""
     db_path = str(tmp_path / "cli_pipeline_queue_empty.db")
     db = Database(db_path)
@@ -824,13 +727,7 @@ def test_pipeline_queue_empty(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="queue", id=pipeline_id, limit=20))
@@ -839,20 +736,14 @@ def test_pipeline_queue_empty(tmp_path, capsys):
     assert "No pending moderation runs" in out
 
 
-def test_pipeline_queue_not_found(tmp_path, capsys):
+def test_pipeline_queue_not_found(tmp_path, cli_init_patch, capsys):
     """Test queue action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_queue_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="queue", id=999, limit=20))
@@ -861,7 +752,7 @@ def test_pipeline_queue_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_publish_no_clients(tmp_path, capsys):
+def test_pipeline_publish_no_clients(tmp_path, cli_init_patch, capsys):
     """Test publish action when no Telegram clients available."""
     db_path = str(tmp_path / "cli_pipeline_publish_no_clients.db")
     db = Database(db_path)
@@ -890,12 +781,6 @@ def test_pipeline_publish_no_clients(tmp_path, capsys):
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated text"))
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
         pool.clients = {}  # No clients available
@@ -903,7 +788,7 @@ def test_pipeline_publish_no_clients(tmp_path, capsys):
         return MagicMock(), pool
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.cli.commands.pipeline.runtime.init_pool", side_effect=fake_init_pool),
     ):
         from src.cli.commands.pipeline import run
@@ -914,20 +799,14 @@ def test_pipeline_publish_no_clients(tmp_path, capsys):
     assert "Нет доступных аккаунтов" in out
 
 
-def test_pipeline_run_show_not_found(tmp_path, capsys):
+def test_pipeline_run_show_not_found(tmp_path, cli_init_patch, capsys):
     """Test run-show action with non-existent run."""
     db_path = str(tmp_path / "cli_pipeline_runshow_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="run-show", run_id=999))
@@ -936,20 +815,14 @@ def test_pipeline_run_show_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_approve_not_found(tmp_path, capsys):
+def test_pipeline_approve_not_found(tmp_path, cli_init_patch, capsys):
     """Test approve action with non-existent run."""
     db_path = str(tmp_path / "cli_pipeline_approve_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="approve", run_id=999))
@@ -958,20 +831,14 @@ def test_pipeline_approve_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_reject_not_found(tmp_path, capsys):
+def test_pipeline_reject_not_found(tmp_path, cli_init_patch, capsys):
     """Test reject action with non-existent run."""
     db_path = str(tmp_path / "cli_pipeline_reject_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="reject", run_id=999))
@@ -980,20 +847,14 @@ def test_pipeline_reject_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_generate_not_found(tmp_path, capsys):
+def test_pipeline_generate_not_found(tmp_path, cli_init_patch, capsys):
     """Test generate action with non-existent pipeline."""
     db_path = str(tmp_path / "cli_pipeline_generate_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="generate", id=999, model=None, max_tokens=256, temperature=0.7))
@@ -1002,7 +863,7 @@ def test_pipeline_generate_not_found(tmp_path, capsys):
     assert "not found" in out
 
 
-def test_pipeline_generate_exception(tmp_path, capsys):
+def test_pipeline_generate_exception(tmp_path, cli_init_patch, capsys):
     """Test generate action handles exception."""
     db_path = str(tmp_path / "cli_pipeline_generate_exc.db")
     db = Database(db_path)
@@ -1029,12 +890,6 @@ def test_pipeline_generate_exception(tmp_path, capsys):
     )
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
     class FakeContentGenerationService:
         def __init__(self, *args, **kwargs):
             pass
@@ -1043,7 +898,7 @@ def test_pipeline_generate_exception(tmp_path, capsys):
             raise RuntimeError("Generation failed")
 
     with (
-        patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db),
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
         patch("src.cli.commands.pipeline.ContentGenerationService", FakeContentGenerationService),
     ):
         from src.cli.commands.pipeline import run
@@ -1054,20 +909,14 @@ def test_pipeline_generate_exception(tmp_path, capsys):
     assert "Generation failed" in out
 
 
-def test_pipeline_list_empty(tmp_path, capsys):
+def test_pipeline_list_empty(tmp_path, cli_init_patch, capsys):
     """Test list action when no pipelines exist."""
     db_path = str(tmp_path / "cli_pipeline_list_empty.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
     asyncio.run(db.close())
 
-    async def fake_init_db(_config_path: str):
-        config = AppConfig()
-        database = Database(db_path)
-        await database.initialize()
-        return config, database
-
-    with patch("src.cli.commands.pipeline.runtime.init_db", side_effect=fake_init_db):
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
 
         run(_ns(pipeline_action="list"))

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.config import AppConfig
 from src.database import Database
 from src.models import (
     Account,


### PR DESCRIPTION
## Summary
- add shared test helpers in `tests/conftest.py` for CLI `init_db` patching and xdist grouping of `aiosqlite_serial` tests
- add `tests/repositories/conftest.py` and remove duplicated repository `repo` fixtures across repository test modules
- migrate route tests to the shared `base_app` setup instead of repeating manual app/bootstrap wiring
- replace repeated CLI `fake_init_db` blocks in pipeline, photo loader, filter, agent, and dialogs-related tests with the shared fixture

## Testing
- `python3 -m pytest tests/repositories tests/routes/test_auth_routes.py tests/routes/test_debug_routes.py tests/routes/test_dialogs_routes.py tests/routes/test_import_channels_routes.py tests/routes/test_moderation_routes.py tests/routes/test_pipelines_routes.py tests/routes/test_scheduler_routes.py`
- `python3 -m pytest tests/test_cli_filter.py tests/test_cli_photo_loader.py tests/test_pipeline_cli.py tests/test_cli.py -k 'provider or filter or pipeline or photo_loader'`
- `python3 -m pytest -n auto tests/test_cli_filter.py tests/test_cli_photo_loader.py tests/test_pipeline_cli.py`
- `python3 -m pytest --collect-only -q tests/test_migrations.py tests/test_database.py`
- `python3 -m pytest tests/test_cli_issue_303.py tests/test_agent_tui.py -k 'dialogs or one_shot or no_prompt'`