### PR TITLE
Refactor test infrastructure to close issue 228

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,13 +319,12 @@ def pytest_runtest_setup(item):
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    xdist_group = getattr(pytest.mark, "xdist_group", None)
-    if xdist_group is None:
+    if not config.pluginmanager.hasplugin("xdist"):
         return
 
     for item in items:
         if item.get_closest_marker("aiosqlite_serial"):
-            item.add_marker(xdist_group("aiosqlite_serial"))
+            item.add_marker(pytest.mark.xdist_group("aiosqlite_serial"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -318,10 +318,14 @@ def pytest_runtest_setup(item):
         pytest.fail(message, pytrace=False)
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    xdist_group = getattr(pytest.mark, "xdist_group", None)
+    if xdist_group is None:
+        return
+
     for item in items:
-        if item.get_closest_marker("aiosqlite_serial") and not item.get_closest_marker("xdist_group"):
-            item.add_marker(pytest.mark.xdist_group("aiosqlite_serial"))
+        if item.get_closest_marker("aiosqlite_serial"):
+            item.add_marker(xdist_group("aiosqlite_serial"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/repositories/conftest.py
+++ b/tests/repositories/conftest.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from src.database.repositories.accounts import AccountsRepository
@@ -17,31 +15,59 @@ from src.database.repositories.search_queries import SearchQueriesRepository
 from src.database.repositories.settings import SettingsRepository
 from src.models import Channel
 
-_REPO_FACTORIES = {
-    "test_accounts_repository.py": AccountsRepository,
-    "test_channel_stats_repository.py": ChannelStatsRepository,
-    "test_channels_repository.py": ChannelsRepository,
-    "test_collection_tasks_repository.py": CollectionTasksRepository,
-    "test_filters_repository.py": FilterRepository,
-    "test_messages_repository.py": MessagesRepository,
-    "test_notification_bots_repository.py": NotificationBotsRepository,
-    "test_search_log_repository.py": SearchLogRepository,
-    "test_search_queries_repository.py": SearchQueriesRepository,
-    "test_settings_repository.py": SettingsRepository,
-}
+
+@pytest.fixture
+async def accounts_repo(db):
+    return AccountsRepository(db.db)
 
 
 @pytest.fixture
-async def repo(request, db):
-    """Provide the repository under test for repository modules."""
-    filename = Path(str(request.fspath)).name
+async def channel_stats_repo(db):
+    return ChannelStatsRepository(db.db)
 
-    if filename == "test_content_pipelines_repository.py":
-        await db.add_channel(Channel(channel_id=1001, title="Source A"))
-        await db.add_channel(Channel(channel_id=1002, title="Source B"))
-        return ContentPipelinesRepository(db.db)
 
-    factory = _REPO_FACTORIES.get(filename)
-    if factory is None:
-        raise LookupError(f"No shared repo fixture registered for {filename}")
-    return factory(db.db)
+@pytest.fixture
+async def channels_repo(db):
+    return ChannelsRepository(db.db)
+
+
+@pytest.fixture
+async def collection_tasks_repo(db):
+    return CollectionTasksRepository(db.db)
+
+
+@pytest.fixture
+async def content_pipelines_repo(db):
+    await db.add_channel(Channel(channel_id=1001, title="Source A"))
+    await db.add_channel(Channel(channel_id=1002, title="Source B"))
+    return ContentPipelinesRepository(db.db)
+
+
+@pytest.fixture
+async def filters_repo(db):
+    return FilterRepository(db.db)
+
+
+@pytest.fixture
+async def messages_repo(db):
+    return MessagesRepository(db.db)
+
+
+@pytest.fixture
+async def notification_bots_repo(db):
+    return NotificationBotsRepository(db.db)
+
+
+@pytest.fixture
+async def search_log_repo(db):
+    return SearchLogRepository(db.db)
+
+
+@pytest.fixture
+async def search_queries_repo(db):
+    return SearchQueriesRepository(db.db)
+
+
+@pytest.fixture
+async def settings_repo(db):
+    return SettingsRepository(db.db)

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -31,26 +31,26 @@ def make_account(phone: str, session: str = "session_string_123", **kwargs) -> A
 # add_account tests
 
 
-async def test_add_account_insert(repo):
+async def test_add_account_insert(accounts_repo):
     """Test inserting a new account."""
     account = make_account("+1234567890")
-    pk = await repo.add_account(account)
+    pk = await accounts_repo.add_account(account)
     assert pk > 0
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert len(accounts) == 1
     assert accounts[0].phone == "+1234567890"
 
 
-async def test_add_account_upsert_on_conflict(repo):
+async def test_add_account_upsert_on_conflict(accounts_repo):
     """Test that add_account updates existing account on phone conflict."""
     account1 = make_account("+1234567890", is_active=True)
-    await repo.add_account(account1)
+    await accounts_repo.add_account(account1)
 
     account2 = make_account("+1234567890", is_active=False, is_premium=True)
-    await repo.add_account(account2)
+    await accounts_repo.add_account(account2)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert len(accounts) == 1
     assert accounts[0].is_active is False
     assert accounts[0].is_premium is True
@@ -73,34 +73,34 @@ async def test_add_account_with_cipher_encrypts_session(repo_with_cipher, cipher
 # get_accounts tests
 
 
-async def test_get_accounts_empty(repo):
+async def test_get_accounts_empty(accounts_repo):
     """Test getting accounts when none exist."""
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts == []
 
 
-async def test_get_accounts_active_only(repo):
+async def test_get_accounts_active_only(accounts_repo):
     """Test filtering by active_only."""
-    await repo.add_account(make_account("+1111111111", is_active=True))
-    await repo.add_account(make_account("+2222222222", is_active=False))
-    await repo.add_account(make_account("+3333333333", is_active=True))
+    await accounts_repo.add_account(make_account("+1111111111", is_active=True))
+    await accounts_repo.add_account(make_account("+2222222222", is_active=False))
+    await accounts_repo.add_account(make_account("+3333333333", is_active=True))
 
-    all_accounts = await repo.get_accounts()
+    all_accounts = await accounts_repo.get_accounts()
     assert len(all_accounts) == 3
 
-    active_accounts = await repo.get_accounts(active_only=True)
+    active_accounts = await accounts_repo.get_accounts(active_only=True)
     assert len(active_accounts) == 2
     phones = {a.phone for a in active_accounts}
     assert phones == {"+1111111111", "+3333333333"}
 
 
-async def test_get_accounts_ordering(repo):
+async def test_get_accounts_ordering(accounts_repo):
     """Test that accounts are ordered by is_primary DESC, id ASC."""
-    await repo.add_account(make_account("+1111111111", is_primary=False))
-    await repo.add_account(make_account("+2222222222", is_primary=True))
-    await repo.add_account(make_account("+3333333333", is_primary=False))
+    await accounts_repo.add_account(make_account("+1111111111", is_primary=False))
+    await accounts_repo.add_account(make_account("+2222222222", is_primary=True))
+    await accounts_repo.add_account(make_account("+3333333333", is_primary=False))
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].phone == "+2222222222"  # primary first
     assert accounts[1].phone == "+1111111111"
     assert accounts[2].phone == "+3333333333"
@@ -132,104 +132,104 @@ async def test_get_accounts_handles_plaintext_when_cipher_set(repo_with_cipher):
 # update_account_flood tests
 
 
-async def test_update_account_flood_set(repo):
+async def test_update_account_flood_set(accounts_repo):
     """Test setting flood_wait_until."""
-    await repo.add_account(make_account("+1234567890"))
+    await accounts_repo.add_account(make_account("+1234567890"))
     until = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
-    await repo.update_account_flood("+1234567890", until)
+    await accounts_repo.update_account_flood("+1234567890", until)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].flood_wait_until == until
 
 
-async def test_update_account_flood_clear(repo):
+async def test_update_account_flood_clear(accounts_repo):
     """Test clearing flood_wait_until."""
-    await repo.add_account(make_account("+1234567890"))
+    await accounts_repo.add_account(make_account("+1234567890"))
     until = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
-    await repo.update_account_flood("+1234567890", until)
+    await accounts_repo.update_account_flood("+1234567890", until)
 
     # Clear it
-    await repo.update_account_flood("+1234567890", None)
+    await accounts_repo.update_account_flood("+1234567890", None)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].flood_wait_until is None
 
 
 # update_account_premium tests
 
 
-async def test_update_account_premium_set_true(repo):
+async def test_update_account_premium_set_true(accounts_repo):
     """Test setting is_premium to True."""
-    await repo.add_account(make_account("+1234567890", is_premium=False))
-    await repo.update_account_premium("+1234567890", True)
+    await accounts_repo.add_account(make_account("+1234567890", is_premium=False))
+    await accounts_repo.update_account_premium("+1234567890", True)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].is_premium is True
 
 
-async def test_update_account_premium_set_false(repo):
+async def test_update_account_premium_set_false(accounts_repo):
     """Test setting is_premium to False."""
-    await repo.add_account(make_account("+1234567890", is_premium=True))
-    await repo.update_account_premium("+1234567890", False)
+    await accounts_repo.add_account(make_account("+1234567890", is_premium=True))
+    await accounts_repo.update_account_premium("+1234567890", False)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].is_premium is False
 
 
 # set_account_active tests
 
 
-async def test_set_account_active_deactivate(repo):
+async def test_set_account_active_deactivate(accounts_repo):
     """Test deactivating an account."""
-    await repo.add_account(make_account("+1234567890", is_active=True))
-    accounts = await repo.get_accounts()
+    await accounts_repo.add_account(make_account("+1234567890", is_active=True))
+    accounts = await accounts_repo.get_accounts()
     pk = accounts[0].id
 
-    await repo.set_account_active(pk, False)
+    await accounts_repo.set_account_active(pk, False)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].is_active is False
 
 
-async def test_set_account_active_activate(repo):
+async def test_set_account_active_activate(accounts_repo):
     """Test activating an account."""
-    await repo.add_account(make_account("+1234567890", is_active=False))
-    accounts = await repo.get_accounts()
+    await accounts_repo.add_account(make_account("+1234567890", is_active=False))
+    accounts = await accounts_repo.get_accounts()
     pk = accounts[0].id
 
-    await repo.set_account_active(pk, True)
+    await accounts_repo.set_account_active(pk, True)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert accounts[0].is_active is True
 
 
 # delete_account tests
 
 
-async def test_delete_account(repo):
+async def test_delete_account(accounts_repo):
     """Test deleting an account."""
-    await repo.add_account(make_account("+1234567890"))
-    accounts = await repo.get_accounts()
+    await accounts_repo.add_account(make_account("+1234567890"))
+    accounts = await accounts_repo.get_accounts()
     pk = accounts[0].id
 
-    await repo.delete_account(pk)
+    await accounts_repo.delete_account(pk)
 
-    accounts = await repo.get_accounts()
+    accounts = await accounts_repo.get_accounts()
     assert len(accounts) == 0
 
 
-async def test_delete_account_nonexistent(repo):
+async def test_delete_account_nonexistent(accounts_repo):
     """Test deleting non-existent account does not raise."""
-    await repo.delete_account(999)  # Should not raise
+    await accounts_repo.delete_account(999)  # Should not raise
 
 
 # migrate_sessions tests
 
 
-async def test_migrate_sessions_no_cipher(repo):
+async def test_migrate_sessions_no_cipher(accounts_repo):
     """Test migrate_sessions returns 0 when no cipher is configured."""
-    await repo.add_account(make_account("+1234567890", session="plaintext"))
-    count = await repo.migrate_sessions()
+    await accounts_repo.add_account(make_account("+1234567890", session="plaintext"))
+    count = await accounts_repo.migrate_sessions()
     assert count == 0
 
 

--- a/tests/repositories/test_channel_stats_repository.py
+++ b/tests/repositories/test_channel_stats_repository.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import pytest
-
-from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.models import Channel, ChannelStats
-
 
 
 async def _create_channel(db, channel_id):

--- a/tests/repositories/test_channel_stats_repository.py
+++ b/tests/repositories/test_channel_stats_repository.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
+
+from src.database.repositories.channel_stats import ChannelStatsRepository
 from src.models import Channel, ChannelStats
+
 
 
 async def _create_channel(db, channel_id):
@@ -17,7 +21,7 @@ async def _create_channel(db, channel_id):
     await db.add_channel(channel)
 
 
-async def test_save_channel_stats(db, repo):
+async def test_save_channel_stats(db, channel_stats_repo):
     """Test saving channel stats."""
     await _create_channel(db, -1001234567890)
     stats = ChannelStats(
@@ -27,17 +31,17 @@ async def test_save_channel_stats(db, repo):
         avg_reactions=25.3,
         avg_forwards=10.1,
     )
-    result_id = await repo.save_channel_stats(stats)
+    result_id = await channel_stats_repo.save_channel_stats(stats)
     assert result_id > 0
 
 
-async def test_get_channel_stats_empty(repo):
+async def test_get_channel_stats_empty(channel_stats_repo):
     """Test getting stats for non-existent channel."""
-    result = await repo.get_channel_stats(-1009999999999)
+    result = await channel_stats_repo.get_channel_stats(-1009999999999)
     assert result == []
 
 
-async def test_get_channel_stats(db, repo):
+async def test_get_channel_stats(db, channel_stats_repo):
     """Test getting stats for a channel."""
     channel_id = -1001234567890
     await _create_channel(db, channel_id)
@@ -49,9 +53,9 @@ async def test_get_channel_stats(db, repo):
         avg_reactions=25.3,
         avg_forwards=10.1,
     )
-    await repo.save_channel_stats(stats)
+    await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_channel_stats(channel_id)
+    result = await channel_stats_repo.get_channel_stats(channel_id)
     assert len(result) == 1
 
     retrieved = result[0]
@@ -63,7 +67,7 @@ async def test_get_channel_stats(db, repo):
     assert retrieved.collected_at is not None
 
 
-async def test_get_channel_stats_multiple(db, repo):
+async def test_get_channel_stats_multiple(db, channel_stats_repo):
     """Test getting multiple stats records for a channel."""
     channel_id = -1001234567890
     await _create_channel(db, channel_id)
@@ -77,9 +81,9 @@ async def test_get_channel_stats_multiple(db, repo):
             avg_reactions=25.0,
             avg_forwards=10.0,
         )
-        await repo.save_channel_stats(stats)
+        await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_channel_stats(channel_id, limit=10)
+    result = await channel_stats_repo.get_channel_stats(channel_id, limit=10)
     assert len(result) == 3
 
     # Should be ordered by collected_at DESC
@@ -87,7 +91,7 @@ async def test_get_channel_stats_multiple(db, repo):
     assert result[2].subscriber_count == 10000
 
 
-async def test_get_channel_stats_limit(db, repo):
+async def test_get_channel_stats_limit(db, channel_stats_repo):
     """Test limit parameter in get_channel_stats."""
     channel_id = -1001234567890
     await _create_channel(db, channel_id)
@@ -100,19 +104,19 @@ async def test_get_channel_stats_limit(db, repo):
             avg_reactions=25.0,
             avg_forwards=10.0,
         )
-        await repo.save_channel_stats(stats)
+        await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_channel_stats(channel_id, limit=2)
+    result = await channel_stats_repo.get_channel_stats(channel_id, limit=2)
     assert len(result) == 2
 
 
-async def test_get_latest_stats_for_all_empty(repo):
+async def test_get_latest_stats_for_all_empty(channel_stats_repo):
     """Test getting all latest stats when none exist."""
-    result = await repo.get_latest_stats_for_all()
+    result = await channel_stats_repo.get_latest_stats_for_all()
     assert result == {}
 
 
-async def test_get_latest_stats_for_all(db, repo):
+async def test_get_latest_stats_for_all(db, channel_stats_repo):
     """Test getting latest stats for all channels."""
     # Save stats for multiple channels
     channel_ids = [-1001111111111, -1002222222222, -1003333333333]
@@ -128,9 +132,9 @@ async def test_get_latest_stats_for_all(db, repo):
                 avg_reactions=25.0,
                 avg_forwards=10.0,
             )
-            await repo.save_channel_stats(stats)
+            await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_latest_stats_for_all()
+    result = await channel_stats_repo.get_latest_stats_for_all()
 
     # Should return one entry per channel (the latest)
     assert len(result) == 3
@@ -140,7 +144,7 @@ async def test_get_latest_stats_for_all(db, repo):
         assert result[ch_id].subscriber_count == 10100
 
 
-async def test_save_stats_with_none_values(db, repo):
+async def test_save_stats_with_none_values(db, channel_stats_repo):
     """Test saving stats with None optional values."""
     channel_id = -1001234567890
     await _create_channel(db, channel_id)
@@ -153,17 +157,17 @@ async def test_save_stats_with_none_values(db, repo):
         avg_forwards=None,
     )
 
-    result_id = await repo.save_channel_stats(stats)
+    result_id = await channel_stats_repo.save_channel_stats(stats)
     assert result_id > 0
 
-    retrieved = await repo.get_channel_stats(channel_id)
+    retrieved = await channel_stats_repo.get_channel_stats(channel_id)
     assert len(retrieved) == 1
     assert retrieved[0].avg_views is None
     assert retrieved[0].avg_reactions is None
     assert retrieved[0].avg_forwards is None
 
 
-async def test_get_latest_stats_isolates_channels(db, repo):
+async def test_get_latest_stats_isolates_channels(db, channel_stats_repo):
     """Test that get_latest_stats_for_all correctly isolates per-channel max dates."""
     ch1 = -1001111111111
     ch2 = -1002222222222
@@ -179,7 +183,7 @@ async def test_get_latest_stats_isolates_channels(db, repo):
         avg_reactions=10.0,
         avg_forwards=1.0,
     )
-    await repo.save_channel_stats(stats1_old)
+    await channel_stats_repo.save_channel_stats(stats1_old)
 
     # Channel 2: save once
     stats2 = ChannelStats(
@@ -189,7 +193,7 @@ async def test_get_latest_stats_isolates_channels(db, repo):
         avg_reactions=20.0,
         avg_forwards=2.0,
     )
-    await repo.save_channel_stats(stats2)
+    await channel_stats_repo.save_channel_stats(stats2)
 
     # Channel 1: save newer
     stats1_new = ChannelStats(
@@ -199,16 +203,16 @@ async def test_get_latest_stats_isolates_channels(db, repo):
         avg_reactions=11.0,
         avg_forwards=1.1,
     )
-    await repo.save_channel_stats(stats1_new)
+    await channel_stats_repo.save_channel_stats(stats1_new)
 
-    result = await repo.get_latest_stats_for_all()
+    result = await channel_stats_repo.get_latest_stats_for_all()
     assert len(result) == 2
     # Channel 1 should have newer values
     assert result[ch1].subscriber_count == 1100
     assert result[ch2].subscriber_count == 2000
 
 
-async def test_stats_collected_at_is_datetime(db, repo):
+async def test_stats_collected_at_is_datetime(db, channel_stats_repo):
     """Test that collected_at is properly converted to datetime."""
     channel_id = -1001234567890
     await _create_channel(db, channel_id)
@@ -220,14 +224,14 @@ async def test_stats_collected_at_is_datetime(db, repo):
         avg_reactions=25.0,
         avg_forwards=10.0,
     )
-    await repo.save_channel_stats(stats)
+    await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_channel_stats(channel_id)
+    result = await channel_stats_repo.get_channel_stats(channel_id)
     assert len(result) == 1
     assert isinstance(result[0].collected_at, datetime)
 
 
-async def test_save_stats_returns_id(db, repo):
+async def test_save_stats_returns_id(db, channel_stats_repo):
     """Test that save returns a valid row ID."""
     ch1 = -1001234567890
     ch2 = -1009999999999
@@ -241,7 +245,7 @@ async def test_save_stats_returns_id(db, repo):
         avg_reactions=25.0,
         avg_forwards=10.0,
     )
-    id1 = await repo.save_channel_stats(stats1)
+    id1 = await channel_stats_repo.save_channel_stats(stats1)
 
     stats2 = ChannelStats(
         channel_id=ch2,
@@ -250,14 +254,14 @@ async def test_save_stats_returns_id(db, repo):
         avg_reactions=12.0,
         avg_forwards=5.0,
     )
-    id2 = await repo.save_channel_stats(stats2)
+    id2 = await channel_stats_repo.save_channel_stats(stats2)
 
     assert id1 > 0
     assert id2 > 0
     assert id1 != id2
 
 
-async def test_negative_channel_id(db, repo):
+async def test_negative_channel_id(db, channel_stats_repo):
     """Test handling negative channel IDs (Telegram format)."""
     channel_id = -1001234567890123
     await _create_channel(db, channel_id)
@@ -269,8 +273,8 @@ async def test_negative_channel_id(db, repo):
         avg_reactions=12.5,
         avg_forwards=5.0,
     )
-    await repo.save_channel_stats(stats)
+    await channel_stats_repo.save_channel_stats(stats)
 
-    result = await repo.get_channel_stats(channel_id)
+    result = await channel_stats_repo.get_channel_stats(channel_id)
     assert len(result) == 1
     assert result[0].channel_id == channel_id

--- a/tests/repositories/test_channels_repository.py
+++ b/tests/repositories/test_channels_repository.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
-
-from src.database.repositories.channels import ChannelsRepository
 from src.models import Channel
-
 
 
 def make_channel(channel_id: int, title: str = "Test Channel", **kwargs) -> Channel:

--- a/tests/repositories/test_channels_repository.py
+++ b/tests/repositories/test_channels_repository.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
+from src.database.repositories.channels import ChannelsRepository
 from src.models import Channel
+
 
 
 def make_channel(channel_id: int, title: str = "Test Channel", **kwargs) -> Channel:
@@ -13,32 +17,32 @@ def make_channel(channel_id: int, title: str = "Test Channel", **kwargs) -> Chan
 # add_channel tests
 
 
-async def test_add_channel_insert(repo):
+async def test_add_channel_insert(channels_repo):
     """Test inserting a new channel."""
     channel = make_channel(12345)
-    pk = await repo.add_channel(channel)
+    pk = await channels_repo.add_channel(channel)
     assert pk > 0
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert len(channels) == 1
     assert channels[0].channel_id == 12345
 
 
-async def test_add_channel_upsert_on_conflict(repo):
+async def test_add_channel_upsert_on_conflict(channels_repo):
     """Test that add_channel updates existing channel on channel_id conflict."""
     channel1 = make_channel(12345, title="Original Title", is_active=True)
-    await repo.add_channel(channel1)
+    await channels_repo.add_channel(channel1)
 
     channel2 = make_channel(12345, title="Updated Title", is_active=False)
-    await repo.add_channel(channel2)
+    await channels_repo.add_channel(channel2)
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert len(channels) == 1
     assert channels[0].title == "Updated Title"
     assert channels[0].is_active is False
 
 
-async def test_add_channel_with_all_fields(repo):
+async def test_add_channel_with_all_fields(channels_repo):
     """Test inserting channel with all optional fields."""
     channel = make_channel(
         12345,
@@ -47,9 +51,9 @@ async def test_add_channel_with_all_fields(repo):
         channel_type="supergroup",
         is_active=False,
     )
-    await repo.add_channel(channel)
+    await channels_repo.add_channel(channel)
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert channels[0].username == "testchannel"
     assert channels[0].channel_type == "supergroup"
     assert channels[0].is_active is False
@@ -58,53 +62,53 @@ async def test_add_channel_with_all_fields(repo):
 # get_channels tests
 
 
-async def test_get_channels_empty(repo):
+async def test_get_channels_empty(channels_repo):
     """Test getting channels when none exist."""
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert channels == []
 
 
-async def test_get_channels_active_only(repo):
+async def test_get_channels_active_only(channels_repo):
     """Test filtering by active_only."""
-    await repo.add_channel(make_channel(1, is_active=True))
-    await repo.add_channel(make_channel(2, is_active=False))
-    await repo.add_channel(make_channel(3, is_active=True))
+    await channels_repo.add_channel(make_channel(1, is_active=True))
+    await channels_repo.add_channel(make_channel(2, is_active=False))
+    await channels_repo.add_channel(make_channel(3, is_active=True))
 
-    all_channels = await repo.get_channels()
+    all_channels = await channels_repo.get_channels()
     assert len(all_channels) == 3
 
-    active_channels = await repo.get_channels(active_only=True)
+    active_channels = await channels_repo.get_channels(active_only=True)
     assert len(active_channels) == 2
     ids = {c.channel_id for c in active_channels}
     assert ids == {1, 3}
 
 
-async def test_get_channels_include_filtered(repo):
+async def test_get_channels_include_filtered(channels_repo):
     """Test filtering by include_filtered."""
-    await repo.add_channel(make_channel(1))
-    await repo.add_channel(make_channel(2))
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(2))
 
     # Mark one as filtered
-    channels = await repo.get_channels()
-    await repo.set_channel_filtered(channels[0].id, True)
+    channels = await channels_repo.get_channels()
+    await channels_repo.set_channel_filtered(channels[0].id, True)
 
     # Default includes filtered
-    all_channels = await repo.get_channels()
+    all_channels = await channels_repo.get_channels()
     assert len(all_channels) == 2
 
     # Exclude filtered
-    unfiltered = await repo.get_channels(include_filtered=False)
+    unfiltered = await channels_repo.get_channels(include_filtered=False)
     assert len(unfiltered) == 1
     assert unfiltered[0].channel_id == 2
 
 
-async def test_get_channels_ordering(repo):
+async def test_get_channels_ordering(channels_repo):
     """Test that channels are ordered by id ASC."""
-    await repo.add_channel(make_channel(300))
-    await repo.add_channel(make_channel(100))
-    await repo.add_channel(make_channel(200))
+    await channels_repo.add_channel(make_channel(300))
+    await channels_repo.add_channel(make_channel(100))
+    await channels_repo.add_channel(make_channel(200))
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert channels[0].channel_id == 300  # First inserted = lowest id
     assert channels[1].channel_id == 100
     assert channels[2].channel_id == 200
@@ -113,90 +117,90 @@ async def test_get_channels_ordering(repo):
 # get_channel_by_pk tests
 
 
-async def test_get_channel_by_pk_found(repo):
+async def test_get_channel_by_pk_found(channels_repo):
     """Test getting channel by primary key."""
     channel = make_channel(12345, title="Test")
-    pk = await repo.add_channel(channel)
+    pk = await channels_repo.add_channel(channel)
 
-    result = await repo.get_channel_by_pk(pk)
+    result = await channels_repo.get_channel_by_pk(pk)
     assert result is not None
     assert result.channel_id == 12345
     assert result.title == "Test"
 
 
-async def test_get_channel_by_pk_not_found(repo):
+async def test_get_channel_by_pk_not_found(channels_repo):
     """Test getting non-existent channel by pk returns None."""
-    result = await repo.get_channel_by_pk(999)
+    result = await channels_repo.get_channel_by_pk(999)
     assert result is None
 
 
 # get_channel_by_channel_id tests
 
 
-async def test_get_channel_by_channel_id_found(repo):
+async def test_get_channel_by_channel_id_found(channels_repo):
     """Test getting channel by channel_id."""
-    await repo.add_channel(make_channel(12345, title="Test"))
+    await channels_repo.add_channel(make_channel(12345, title="Test"))
 
-    result = await repo.get_channel_by_channel_id(12345)
+    result = await channels_repo.get_channel_by_channel_id(12345)
     assert result is not None
     assert result.title == "Test"
 
 
-async def test_get_channel_by_channel_id_not_found(repo):
+async def test_get_channel_by_channel_id_not_found(channels_repo):
     """Test getting non-existent channel by channel_id returns None."""
-    result = await repo.get_channel_by_channel_id(999)
+    result = await channels_repo.get_channel_by_channel_id(999)
     assert result is None
 
 
 # get_channels_with_counts tests
 
 
-async def test_get_channels_with_counts_empty(repo):
+async def test_get_channels_with_counts_empty(channels_repo):
     """Test getting channels with counts when none exist."""
-    channels = await repo.get_channels_with_counts()
+    channels = await channels_repo.get_channels_with_counts()
     assert channels == []
 
 
-async def test_get_channels_with_counts_no_messages(repo):
+async def test_get_channels_with_counts_no_messages(channels_repo):
     """Test getting channels with counts when no messages exist."""
-    await repo.add_channel(make_channel(1))
-    await repo.add_channel(make_channel(2))
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(2))
 
-    channels = await repo.get_channels_with_counts()
+    channels = await channels_repo.get_channels_with_counts()
     assert len(channels) == 2
     assert all(c.message_count == 0 for c in channels)
 
 
-async def test_get_channels_with_counts_with_messages(repo):
+async def test_get_channels_with_counts_with_messages(channels_repo):
     """Test getting channels with message counts."""
-    await repo.add_channel(make_channel(1))
-    await repo.add_channel(make_channel(2))
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(2))
 
     # Insert some messages
-    await repo._db.executemany(
+    await channels_repo._db.executemany(
         "INSERT INTO messages (channel_id, message_id, date) VALUES (?, ?, datetime('now'))",
         [(1, 100), (1, 101), (2, 200)],
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    channels = await repo.get_channels_with_counts()
+    channels = await channels_repo.get_channels_with_counts()
     assert len(channels) == 2
     counts = {c.channel_id: c.message_count for c in channels}
     assert counts[1] == 2
     assert counts[2] == 1
 
 
-async def test_get_channels_with_counts_filters(repo):
+async def test_get_channels_with_counts_filters(channels_repo):
     """Test that active_only and include_filtered work with counts."""
-    await repo.add_channel(make_channel(1, is_active=True))
-    await repo.add_channel(make_channel(2, is_active=False))
-    await repo.add_channel(make_channel(3, is_active=True))
+    await channels_repo.add_channel(make_channel(1, is_active=True))
+    await channels_repo.add_channel(make_channel(2, is_active=False))
+    await channels_repo.add_channel(make_channel(3, is_active=True))
 
     # Mark channel 3 as filtered
-    channels = await repo.get_channels()
-    await repo.set_channel_filtered(next(c.id for c in channels if c.channel_id == 3), True)
+    channels = await channels_repo.get_channels()
+    await channels_repo.set_channel_filtered(next(c.id for c in channels if c.channel_id == 3), True)
 
-    result = await repo.get_channels_with_counts(active_only=True, include_filtered=False)
+    result = await channels_repo.get_channels_with_counts(active_only=True, include_filtered=False)
     assert len(result) == 1
     assert result[0].channel_id == 1
 
@@ -204,78 +208,78 @@ async def test_get_channels_with_counts_filters(repo):
 # update_channel_last_id tests
 
 
-async def test_update_channel_last_id(repo):
+async def test_update_channel_last_id(channels_repo):
     """Test updating last_collected_id."""
-    await repo.add_channel(make_channel(12345))
-    await repo.update_channel_last_id(12345, 500)
+    await channels_repo.add_channel(make_channel(12345))
+    await channels_repo.update_channel_last_id(12345, 500)
 
-    channel = await repo.get_channel_by_channel_id(12345)
+    channel = await channels_repo.get_channel_by_channel_id(12345)
     assert channel.last_collected_id == 500
 
 
-async def test_update_channel_last_id_overwrites(repo):
+async def test_update_channel_last_id_overwrites(channels_repo):
     """Test that update_channel_last_id overwrites previous value."""
-    await repo.add_channel(make_channel(12345))
-    await repo.update_channel_last_id(12345, 100)
-    await repo.update_channel_last_id(12345, 200)
+    await channels_repo.add_channel(make_channel(12345))
+    await channels_repo.update_channel_last_id(12345, 100)
+    await channels_repo.update_channel_last_id(12345, 200)
 
-    channel = await repo.get_channel_by_channel_id(12345)
+    channel = await channels_repo.get_channel_by_channel_id(12345)
     assert channel.last_collected_id == 200
 
 
 # set_channel_active tests
 
 
-async def test_set_channel_active_deactivate(repo):
+async def test_set_channel_active_deactivate(channels_repo):
     """Test deactivating a channel."""
-    await repo.add_channel(make_channel(1, is_active=True))
-    channels = await repo.get_channels()
+    await channels_repo.add_channel(make_channel(1, is_active=True))
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
 
-    await repo.set_channel_active(pk, False)
+    await channels_repo.set_channel_active(pk, False)
 
-    channel = await repo.get_channel_by_pk(pk)
+    channel = await channels_repo.get_channel_by_pk(pk)
     assert channel.is_active is False
 
 
-async def test_set_channel_active_activate(repo):
+async def test_set_channel_active_activate(channels_repo):
     """Test activating a channel."""
-    await repo.add_channel(make_channel(1, is_active=False))
-    channels = await repo.get_channels()
+    await channels_repo.add_channel(make_channel(1, is_active=False))
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
 
-    await repo.set_channel_active(pk, True)
+    await channels_repo.set_channel_active(pk, True)
 
-    channel = await repo.get_channel_by_pk(pk)
+    channel = await channels_repo.get_channel_by_pk(pk)
     assert channel.is_active is True
 
 
 # set_channel_filtered tests
 
 
-async def test_set_channel_filtered_true(repo):
+async def test_set_channel_filtered_true(channels_repo):
     """Test marking channel as filtered."""
-    await repo.add_channel(make_channel(1))
-    channels = await repo.get_channels()
+    await channels_repo.add_channel(make_channel(1))
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
 
-    await repo.set_channel_filtered(pk, True)
+    await channels_repo.set_channel_filtered(pk, True)
 
-    channel = await repo.get_channel_by_pk(pk)
+    channel = await channels_repo.get_channel_by_pk(pk)
     assert channel.is_filtered is True
     assert channel.filter_flags == "manual"
 
 
-async def test_set_channel_filtered_false(repo):
+async def test_set_channel_filtered_false(channels_repo):
     """Test unmarking channel as filtered."""
-    await repo.add_channel(make_channel(1))
-    channels = await repo.get_channels()
+    await channels_repo.add_channel(make_channel(1))
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
 
-    await repo.set_channel_filtered(pk, True)
-    await repo.set_channel_filtered(pk, False)
+    await channels_repo.set_channel_filtered(pk, True)
+    await channels_repo.set_channel_filtered(pk, False)
 
-    channel = await repo.get_channel_by_pk(pk)
+    channel = await channels_repo.get_channel_by_pk(pk)
     assert channel.is_filtered is False
     assert channel.filter_flags == ""
 
@@ -283,28 +287,28 @@ async def test_set_channel_filtered_false(repo):
 # set_filtered_bulk tests
 
 
-async def test_set_filtered_bulk_empty(repo):
+async def test_set_filtered_bulk_empty(channels_repo):
     """Test set_filtered_bulk with empty list."""
-    count = await repo.set_filtered_bulk([])
+    count = await channels_repo.set_filtered_bulk([])
     assert count == 0
 
 
-async def test_set_filtered_bulk_multiple(repo):
+async def test_set_filtered_bulk_multiple(channels_repo):
     """Test bulk updating filter flags."""
-    await repo.add_channel(make_channel(1))
-    await repo.add_channel(make_channel(2))
-    await repo.add_channel(make_channel(3))
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(2))
+    await channels_repo.add_channel(make_channel(3))
 
     updates = [
         (1, "low_uniqueness"),
         (2, "cross_channel_spam,non_cyrillic"),
     ]
-    count = await repo.set_filtered_bulk(updates)
+    count = await channels_repo.set_filtered_bulk(updates)
     assert count == 2
 
-    c1 = await repo.get_channel_by_channel_id(1)
-    c2 = await repo.get_channel_by_channel_id(2)
-    c3 = await repo.get_channel_by_channel_id(3)
+    c1 = await channels_repo.get_channel_by_channel_id(1)
+    c2 = await channels_repo.get_channel_by_channel_id(2)
+    c3 = await channels_repo.get_channel_by_channel_id(3)
 
     assert c1.is_filtered is True
     assert c1.filter_flags == "low_uniqueness"
@@ -313,59 +317,59 @@ async def test_set_filtered_bulk_multiple(repo):
     assert c3.is_filtered is False
 
 
-async def test_set_filtered_bulk_nonexistent_channel(repo):
+async def test_set_filtered_bulk_nonexistent_channel(channels_repo):
     """Test that nonexistent channels in bulk update don't affect count."""
     updates = [(999, "test_flag")]
-    count = await repo.set_filtered_bulk(updates)
+    count = await channels_repo.set_filtered_bulk(updates)
     assert count == 0
 
 
 # reset_all_filters tests
 
 
-async def test_reset_all_filters(repo):
+async def test_reset_all_filters(channels_repo):
     """Test resetting all channel filters."""
-    await repo.add_channel(make_channel(1))
-    await repo.add_channel(make_channel(2))
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(2))
 
     # Set filters
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     for c in channels:
-        await repo.set_channel_filtered(c.id, True)
+        await channels_repo.set_channel_filtered(c.id, True)
 
-    count = await repo.reset_all_filters()
+    count = await channels_repo.reset_all_filters()
     assert count == 2
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     assert all(c.is_filtered is False for c in channels)
     assert all(c.filter_flags == "" for c in channels)
 
 
-async def test_reset_all_filters_empty(repo):
+async def test_reset_all_filters_empty(channels_repo):
     """Test resetting filters when no channels exist."""
-    count = await repo.reset_all_filters()
+    count = await channels_repo.reset_all_filters()
     assert count == 0
 
 
 # update_channel_meta tests
 
 
-async def test_update_channel_meta(repo):
+async def test_update_channel_meta(channels_repo):
     """Test updating channel metadata."""
-    await repo.add_channel(make_channel(1, title="Old Title", username="old_name"))
-    await repo.update_channel_meta(1, username="new_name", title="New Title")
+    await channels_repo.add_channel(make_channel(1, title="Old Title", username="old_name"))
+    await channels_repo.update_channel_meta(1, username="new_name", title="New Title")
 
-    channel = await repo.get_channel_by_channel_id(1)
+    channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.title == "New Title"
     assert channel.username == "new_name"
 
 
-async def test_update_channel_meta_null_values(repo):
+async def test_update_channel_meta_null_values(channels_repo):
     """Test updating channel metadata with None values."""
-    await repo.add_channel(make_channel(1, title="Title", username="username"))
-    await repo.update_channel_meta(1, username=None, title=None)
+    await channels_repo.add_channel(make_channel(1, title="Title", username="username"))
+    await channels_repo.update_channel_meta(1, username=None, title=None)
 
-    channel = await repo.get_channel_by_channel_id(1)
+    channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.title is None
     assert channel.username is None
 
@@ -373,28 +377,28 @@ async def test_update_channel_meta_null_values(repo):
 # update_channel_full_meta tests
 
 
-async def test_update_channel_full_meta(repo):
+async def test_update_channel_full_meta(channels_repo):
     """Test updating full channel metadata."""
-    await repo.add_channel(make_channel(1))
-    await repo.update_channel_full_meta(
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.update_channel_full_meta(
         1,
         about="Test description",
         linked_chat_id=12345,
         has_comments=True,
     )
 
-    channel = await repo.get_channel_by_channel_id(1)
+    channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.about == "Test description"
     assert channel.linked_chat_id == 12345
     assert channel.has_comments is True
 
 
-async def test_update_channel_full_meta_null_values(repo):
+async def test_update_channel_full_meta_null_values(channels_repo):
     """Test updating full channel metadata with None values."""
-    await repo.add_channel(make_channel(1, about="Old", linked_chat_id=999, has_comments=True))
-    await repo.update_channel_full_meta(1, about=None, linked_chat_id=None, has_comments=False)
+    await channels_repo.add_channel(make_channel(1, about="Old", linked_chat_id=999, has_comments=True))
+    await channels_repo.update_channel_full_meta(1, about=None, linked_chat_id=None, has_comments=False)
 
-    channel = await repo.get_channel_by_channel_id(1)
+    channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.about is None
     assert channel.linked_chat_id is None
     assert channel.has_comments is False
@@ -403,7 +407,7 @@ async def test_update_channel_full_meta_null_values(repo):
 # add_channel_with_meta_fields tests
 
 
-async def test_add_channel_with_meta_fields(repo):
+async def test_add_channel_with_meta_fields(channels_repo):
     """Test inserting channel with metadata fields."""
     channel = make_channel(
         12345,
@@ -412,16 +416,16 @@ async def test_add_channel_with_meta_fields(repo):
         linked_chat_id=54321,
         has_comments=True,
     )
-    pk = await repo.add_channel(channel)
+    pk = await channels_repo.add_channel(channel)
     assert pk > 0
 
-    result = await repo.get_channel_by_pk(pk)
+    result = await channels_repo.get_channel_by_pk(pk)
     assert result.about == "Channel description"
     assert result.linked_chat_id == 54321
     assert result.has_comments is True
 
 
-async def test_add_channel_upsert_preserves_meta(repo):
+async def test_add_channel_upsert_preserves_meta(channels_repo):
     """Test that upsert updates metadata on conflict."""
     ch1 = make_channel(
         12345,
@@ -430,7 +434,7 @@ async def test_add_channel_upsert_preserves_meta(repo):
         linked_chat_id=111,
         has_comments=False,
     )
-    await repo.add_channel(ch1)
+    await channels_repo.add_channel(ch1)
 
     ch2 = make_channel(
         12345,
@@ -439,21 +443,21 @@ async def test_add_channel_upsert_preserves_meta(repo):
         linked_chat_id=222,
         has_comments=True,
     )
-    await repo.add_channel(ch2)
+    await channels_repo.add_channel(ch2)
 
-    result = await repo.get_channel_by_channel_id(12345)
+    result = await channels_repo.get_channel_by_channel_id(12345)
     assert result.title == "Updated"
     assert result.about == "Updated description"
     assert result.linked_chat_id == 222
     assert result.has_comments is True
 
 
-async def test_map_channel_missing_meta_columns(repo):
+async def test_map_channel_missing_meta_columns(channels_repo):
     """Test that _map_channel degrades gracefully when metadata columns are absent."""
     # Add a channel with full fields
-    await repo.add_channel(make_channel(1, title="Test"))
+    await channels_repo.add_channel(make_channel(1, title="Test"))
     # Simulate old row without metadata columns by selecting specific columns
-    cur = await repo._db.execute(
+    cur = await channels_repo._db.execute(
         "SELECT id, channel_id, title, username, channel_type, is_active,"
         " is_filtered, filter_flags, last_collected_id, added_at"
         " FROM channels WHERE channel_id = 1"
@@ -461,7 +465,7 @@ async def test_map_channel_missing_meta_columns(repo):
     old_row = await cur.fetchone()
 
     # Should not raise, should use defaults for missing metadata columns
-    channel = repo._map_channel(old_row)
+    channel = channels_repo._map_channel(old_row)
     assert channel.channel_id == 1
     assert channel.title == "Test"
     assert channel.about is None
@@ -472,23 +476,23 @@ async def test_map_channel_missing_meta_columns(repo):
 # get_forum_topics tests
 
 
-async def test_get_forum_topics_empty(repo):
+async def test_get_forum_topics_empty(channels_repo):
     """Test getting topics when none exist."""
-    await repo.add_channel(make_channel(1))
-    topics = await repo.get_forum_topics(1)
+    await channels_repo.add_channel(make_channel(1))
+    topics = await channels_repo.get_forum_topics(1)
     assert topics == []
 
 
-async def test_get_forum_topics(repo):
+async def test_get_forum_topics(channels_repo):
     """Test getting forum topics."""
-    await repo.add_channel(make_channel(1))
-    await repo._db.executemany(
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo._db.executemany(
         "INSERT INTO forum_topics (channel_id, topic_id, title) VALUES (?, ?, ?)",
         [(1, 101, "Topic 1"), (1, 102, "Topic 2")],
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    topics = await repo.get_forum_topics(1)
+    topics = await channels_repo.get_forum_topics(1)
     assert len(topics) == 2
     assert topics[0] == {"id": 101, "title": "Topic 1"}
     assert topics[1] == {"id": 102, "title": "Topic 2"}
@@ -497,130 +501,130 @@ async def test_get_forum_topics(repo):
 # upsert_forum_topics tests
 
 
-async def test_upsert_forum_topics_insert(repo):
+async def test_upsert_forum_topics_insert(channels_repo):
     """Test inserting forum topics."""
-    await repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(1))
     topics = [{"id": 101, "title": "Topic A"}, {"id": 102, "title": "Topic B"}]
-    await repo.upsert_forum_topics(1, topics)
+    await channels_repo.upsert_forum_topics(1, topics)
 
-    result = await repo.get_forum_topics(1)
+    result = await channels_repo.get_forum_topics(1)
     assert len(result) == 2
 
 
-async def test_upsert_forum_topics_replace(repo):
+async def test_upsert_forum_topics_replace(channels_repo):
     """Test that upsert replaces existing topics."""
-    await repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(1))
 
     # Insert initial topics
-    await repo.upsert_forum_topics(1, [{"id": 1, "title": "Old"}])
-    assert len(await repo.get_forum_topics(1)) == 1
+    await channels_repo.upsert_forum_topics(1, [{"id": 1, "title": "Old"}])
+    assert len(await channels_repo.get_forum_topics(1)) == 1
 
     # Replace with new topics
-    await repo.upsert_forum_topics(1, [{"id": 2, "title": "New"}])
-    topics = await repo.get_forum_topics(1)
+    await channels_repo.upsert_forum_topics(1, [{"id": 2, "title": "New"}])
+    topics = await channels_repo.get_forum_topics(1)
     assert len(topics) == 1
     assert topics[0]["id"] == 2
 
 
-async def test_upsert_forum_topics_empty_list(repo):
+async def test_upsert_forum_topics_empty_list(channels_repo):
     """Test upserting empty list deletes all topics."""
-    await repo.add_channel(make_channel(1))
-    await repo._db.execute(
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo._db.execute(
         "INSERT INTO forum_topics (channel_id, topic_id, title) VALUES (?, ?, ?)",
         (1, 1, "Topic"),
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    await repo.upsert_forum_topics(1, [])
-    topics = await repo.get_forum_topics(1)
+    await channels_repo.upsert_forum_topics(1, [])
+    topics = await channels_repo.get_forum_topics(1)
     assert topics == []
 
 
 # delete_channel tests
 
 
-async def test_delete_channel(repo):
+async def test_delete_channel(channels_repo):
     """Test deleting a channel."""
-    await repo.add_channel(make_channel(1))
-    channels = await repo.get_channels()
+    await channels_repo.add_channel(make_channel(1))
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
 
-    await repo.delete_channel(pk)
+    await channels_repo.delete_channel(pk)
 
-    result = await repo.get_channel_by_pk(pk)
+    result = await channels_repo.get_channel_by_pk(pk)
     assert result is None
 
 
-async def test_delete_channel_cascades_messages(repo):
+async def test_delete_channel_cascades_messages(channels_repo):
     """Test that deleting channel also deletes messages."""
-    await repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(1))
 
     # Insert messages
-    await repo._db.executemany(
+    await channels_repo._db.executemany(
         "INSERT INTO messages (channel_id, message_id, date) VALUES (?, ?, datetime('now'))",
         [(1, 100), (1, 101)],
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
-    await repo.delete_channel(pk)
+    await channels_repo.delete_channel(pk)
 
     # Verify messages are deleted
-    cur = await repo._db.execute("SELECT COUNT(*) as cnt FROM messages WHERE channel_id = 1")
+    cur = await channels_repo._db.execute("SELECT COUNT(*) as cnt FROM messages WHERE channel_id = 1")
     row = await cur.fetchone()
     assert row["cnt"] == 0
 
 
-async def test_delete_channel_cascades_stats(repo):
+async def test_delete_channel_cascades_stats(channels_repo):
     """Test that deleting channel also deletes channel_stats."""
-    await repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(1))
 
     # Insert stats
-    await repo._db.execute(
+    await channels_repo._db.execute(
         "INSERT INTO channel_stats (channel_id) VALUES (1)",
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
-    await repo.delete_channel(pk)
+    await channels_repo.delete_channel(pk)
 
-    cur = await repo._db.execute("SELECT COUNT(*) as cnt FROM channel_stats WHERE channel_id = 1")
+    cur = await channels_repo._db.execute("SELECT COUNT(*) as cnt FROM channel_stats WHERE channel_id = 1")
     row = await cur.fetchone()
     assert row["cnt"] == 0
 
 
-async def test_delete_channel_cascades_forum_topics(repo):
+async def test_delete_channel_cascades_forum_topics(channels_repo):
     """Test that deleting channel also deletes forum_topics."""
-    await repo.add_channel(make_channel(1))
+    await channels_repo.add_channel(make_channel(1))
 
-    await repo._db.execute(
+    await channels_repo._db.execute(
         "INSERT INTO forum_topics (channel_id, topic_id, title) VALUES (1, 1, 'Topic')",
     )
-    await repo._db.commit()
+    await channels_repo._db.commit()
 
-    channels = await repo.get_channels()
+    channels = await channels_repo.get_channels()
     pk = channels[0].id
-    await repo.delete_channel(pk)
+    await channels_repo.delete_channel(pk)
 
-    cur = await repo._db.execute("SELECT COUNT(*) as cnt FROM forum_topics WHERE channel_id = 1")
+    cur = await channels_repo._db.execute("SELECT COUNT(*) as cnt FROM forum_topics WHERE channel_id = 1")
     row = await cur.fetchone()
     assert row["cnt"] == 0
 
 
-async def test_delete_channel_nonexistent(repo):
+async def test_delete_channel_nonexistent(channels_repo):
     """Test deleting non-existent channel does not raise."""
-    await repo.delete_channel(999)  # Should not raise
+    await channels_repo.delete_channel(999)  # Should not raise
 
 
 # set_channel_type tests
 
 
-async def test_set_channel_type(repo):
+async def test_set_channel_type(channels_repo):
     """Test updating channel type."""
-    await repo.add_channel(make_channel(1, channel_type="channel"))
-    await repo.set_channel_type(1, "supergroup")
+    await channels_repo.add_channel(make_channel(1, channel_type="channel"))
+    await channels_repo.set_channel_type(1, "supergroup")
 
-    channel = await repo.get_channel_by_channel_id(1)
+    channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.channel_type == "supergroup"

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from src.database.repositories.collection_tasks import CollectionTasksRepository
 from src.models import CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
-
-
 
 # _deserialize_payload tests
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from src.database.repositories.collection_tasks import CollectionTasksRepository
 from src.models import CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
+
+
 
 # _deserialize_payload tests
 
@@ -75,15 +79,15 @@ def test_serialize_payload_stats_all():
 # create_collection_task tests
 
 
-async def test_create_collection_task_basic(repo):
+async def test_create_collection_task_basic(collection_tasks_repo):
     """Test creating a basic collection task."""
-    task_id = await repo.create_collection_task(
+    task_id = await collection_tasks_repo.create_collection_task(
         channel_id=12345,
         channel_title="Test Channel",
     )
     assert task_id > 0
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task is not None
     assert task.channel_id == 12345
     assert task.channel_title == "Test Channel"
@@ -91,10 +95,10 @@ async def test_create_collection_task_basic(repo):
     assert task.status == CollectionTaskStatus.PENDING
 
 
-async def test_create_collection_task_with_all_fields(repo):
+async def test_create_collection_task_with_all_fields(collection_tasks_repo):
     """Test creating a task with all optional fields."""
     run_after = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
-    task_id = await repo.create_collection_task(
+    task_id = await collection_tasks_repo.create_collection_task(
         channel_id=12345,
         channel_title="Test",
         channel_username="testchannel",
@@ -103,26 +107,26 @@ async def test_create_collection_task_with_all_fields(repo):
         parent_task_id=99,
     )
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.channel_username == "testchannel"
     assert task.run_after is not None
     assert task.payload == {"custom": "data"}
     assert task.parent_task_id == 99
 
 
-async def test_create_collection_task_run_after_normalization(repo):
+async def test_create_collection_task_run_after_normalization(collection_tasks_repo):
     """Test that run_after is normalized to UTC."""
     # Create datetime with different timezone
     local_tz = timezone(timedelta(hours=3))
     run_after = datetime(2026, 3, 16, 12, 0, 0, tzinfo=local_tz)
 
-    task_id = await repo.create_collection_task(
+    task_id = await collection_tasks_repo.create_collection_task(
         channel_id=1,
         channel_title="Test",
         run_after=run_after,
     )
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     # Should be stored as UTC (9:00 instead of 12:00 +03:00)
     assert task.run_after is not None
     assert task.run_after.hour == 9
@@ -131,120 +135,120 @@ async def test_create_collection_task_run_after_normalization(repo):
 # create_stats_task tests
 
 
-async def test_create_stats_task_basic(repo):
+async def test_create_stats_task_basic(collection_tasks_repo):
     """Test creating a stats task."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2, 3])
-    task_id = await repo.create_stats_task(payload)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.task_type == CollectionTaskType.STATS_ALL
     assert task.channel_title == "Обновление статистики"
     assert isinstance(task.payload, StatsAllTaskPayload)
     assert task.payload.channel_ids == [1, 2, 3]
 
 
-async def test_create_stats_task_with_run_after(repo):
+async def test_create_stats_task_with_run_after(collection_tasks_repo):
     """Test creating a stats task with run_after."""
     run_after = datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc)
     payload = StatsAllTaskPayload(channel_ids=[1, 2, 3])
-    task_id = await repo.create_stats_task(payload, run_after=run_after)
+    task_id = await collection_tasks_repo.create_stats_task(payload, run_after=run_after)
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.run_after is not None
 
 
 # update_collection_task_progress tests
 
 
-async def test_update_collection_task_progress(repo):
+async def test_update_collection_task_progress(collection_tasks_repo):
     """Test updating task progress."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task_progress(task_id, 100)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task_progress(task_id, 100)
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.messages_collected == 100
 
 
 # update_collection_task tests
 
 
-async def test_update_collection_task_to_running(repo):
+async def test_update_collection_task_to_running(collection_tasks_repo):
     """Test updating task to running status."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.RUNNING
     assert task.started_at is not None
 
 
-async def test_update_collection_task_to_completed(repo):
+async def test_update_collection_task_to_completed(collection_tasks_repo):
     """Test updating task to completed status."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
-    await repo.update_collection_task(
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.update_collection_task(
         task_id,
         CollectionTaskStatus.COMPLETED,
         messages_collected=500,
         note="Done",
     )
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.COMPLETED
     assert task.completed_at is not None
     assert task.messages_collected == 500
     assert task.note == "Done"
 
 
-async def test_update_collection_task_to_failed(repo):
+async def test_update_collection_task_to_failed(collection_tasks_repo):
     """Test updating task to failed status."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(
         task_id,
         CollectionTaskStatus.FAILED,
         error="Connection timeout",
     )
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.FAILED
     assert task.error == "Connection timeout"
     assert task.completed_at is not None
 
 
-async def test_update_collection_task_with_string_status(repo):
+async def test_update_collection_task_with_string_status(collection_tasks_repo):
     """Test updating task with string status instead of enum."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(task_id, "running")
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, "running")
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.RUNNING
 
 
 # get_collection_task tests
 
 
-async def test_get_collection_task_not_found(repo):
+async def test_get_collection_task_not_found(collection_tasks_repo):
     """Test getting non-existent task."""
-    task = await repo.get_collection_task(999)
+    task = await collection_tasks_repo.get_collection_task(999)
     assert task is None
 
 
 # get_collection_tasks tests
 
 
-async def test_get_collection_tasks_empty(repo):
+async def test_get_collection_tasks_empty(collection_tasks_repo):
     """Test getting tasks when none exist."""
-    tasks = await repo.get_collection_tasks()
+    tasks = await collection_tasks_repo.get_collection_tasks()
     assert tasks == []
 
 
-async def test_get_collection_tasks_ordered(repo):
+async def test_get_collection_tasks_ordered(collection_tasks_repo):
     """Test that tasks are ordered by id DESC."""
-    id1 = await repo.create_collection_task(1, "First")
-    id2 = await repo.create_collection_task(2, "Second")
-    id3 = await repo.create_collection_task(3, "Third")
+    id1 = await collection_tasks_repo.create_collection_task(1, "First")
+    id2 = await collection_tasks_repo.create_collection_task(2, "Second")
+    id3 = await collection_tasks_repo.create_collection_task(3, "Third")
 
-    tasks = await repo.get_collection_tasks(limit=10)
+    tasks = await collection_tasks_repo.get_collection_tasks(limit=10)
     assert len(tasks) == 3
     # Newest first (id DESC)
     assert tasks[0].id == id3
@@ -252,118 +256,118 @@ async def test_get_collection_tasks_ordered(repo):
     assert tasks[2].id == id1
 
 
-async def test_get_collection_tasks_limit(repo):
+async def test_get_collection_tasks_limit(collection_tasks_repo):
     """Test that limit is respected."""
     for i in range(10):
-        await repo.create_collection_task(i, f"Channel {i}")
+        await collection_tasks_repo.create_collection_task(i, f"Channel {i}")
 
-    tasks = await repo.get_collection_tasks(limit=5)
+    tasks = await collection_tasks_repo.get_collection_tasks(limit=5)
     assert len(tasks) == 5
 
 
 # get_active_collection_tasks_for_channel tests
 
 
-async def test_get_active_collection_tasks_for_channel_empty(repo):
+async def test_get_active_collection_tasks_for_channel_empty(collection_tasks_repo):
     """Test getting active tasks when none exist."""
-    tasks = await repo.get_active_collection_tasks_for_channel(12345)
+    tasks = await collection_tasks_repo.get_active_collection_tasks_for_channel(12345)
     assert tasks == []
 
 
-async def test_get_active_collection_tasks_for_channel(repo):
+async def test_get_active_collection_tasks_for_channel(collection_tasks_repo):
     """Test getting active tasks for a channel."""
     channel_id = 12345
-    task_id1 = await repo.create_collection_task(channel_id, "Test")
-    task_id2 = await repo.create_collection_task(channel_id, "Test")
-    await repo.create_collection_task(99999, "Other")
+    task_id1 = await collection_tasks_repo.create_collection_task(channel_id, "Test")
+    task_id2 = await collection_tasks_repo.create_collection_task(channel_id, "Test")
+    await collection_tasks_repo.create_collection_task(99999, "Other")
 
     # Complete one task
-    await repo.update_collection_task(task_id1, CollectionTaskStatus.COMPLETED)
+    await collection_tasks_repo.update_collection_task(task_id1, CollectionTaskStatus.COMPLETED)
 
-    tasks = await repo.get_active_collection_tasks_for_channel(channel_id)
+    tasks = await collection_tasks_repo.get_active_collection_tasks_for_channel(channel_id)
     assert len(tasks) == 1
     assert tasks[0].id == task_id2
 
 
-async def test_get_active_collection_tasks_excludes_other_types(repo):
+async def test_get_active_collection_tasks_excludes_other_types(collection_tasks_repo):
     """Test that stats tasks are excluded."""
     channel_id = 12345
-    await repo.create_collection_task(channel_id, "Test")
-    await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[channel_id]))
+    await collection_tasks_repo.create_collection_task(channel_id, "Test")
+    await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[channel_id]))
 
-    tasks = await repo.get_active_collection_tasks_for_channel(channel_id)
+    tasks = await collection_tasks_repo.get_active_collection_tasks_for_channel(channel_id)
     assert len(tasks) == 1  # Only the channel_collect task
 
 
 # get_channel_ids_with_active_tasks tests
 
 
-async def test_get_channel_ids_with_active_tasks(repo):
+async def test_get_channel_ids_with_active_tasks(collection_tasks_repo):
     """Test getting channel IDs with active tasks."""
-    await repo.create_collection_task(1, "Channel 1")
-    await repo.create_collection_task(2, "Channel 2")
-    await repo.create_collection_task(3, "Channel 3")
+    await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    await collection_tasks_repo.create_collection_task(2, "Channel 2")
+    await collection_tasks_repo.create_collection_task(3, "Channel 3")
 
     # Complete task for channel 3
-    task_id = (await repo.get_collection_tasks())[0].id
-    await repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
+    task_id = (await collection_tasks_repo.get_collection_tasks())[0].id
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
 
-    ids = await repo.get_channel_ids_with_active_tasks()
+    ids = await collection_tasks_repo.get_channel_ids_with_active_tasks()
     assert ids == {1, 2}
 
 
-async def test_get_channel_ids_with_active_tasks_empty(repo):
+async def test_get_channel_ids_with_active_tasks_empty(collection_tasks_repo):
     """Test getting channel IDs when no active tasks."""
-    ids = await repo.get_channel_ids_with_active_tasks()
+    ids = await collection_tasks_repo.get_channel_ids_with_active_tasks()
     assert ids == set()
 
 
 # get_active_stats_task tests
 
 
-async def test_get_active_stats_task_none(repo):
+async def test_get_active_stats_task_none(collection_tasks_repo):
     """Test getting active stats task when none exists."""
-    task = await repo.get_active_stats_task()
+    task = await collection_tasks_repo.get_active_stats_task()
     assert task is None
 
 
-async def test_get_active_stats_task(repo):
+async def test_get_active_stats_task(collection_tasks_repo):
     """Test getting active stats task."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    task_id = await repo.create_stats_task(payload)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
 
-    task = await repo.get_active_stats_task()
+    task = await collection_tasks_repo.get_active_stats_task()
     assert task is not None
     assert task.id == task_id
 
 
-async def test_get_active_stats_task_excludes_completed(repo):
+async def test_get_active_stats_task_excludes_completed(collection_tasks_repo):
     """Test that completed stats tasks are not returned."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    task_id = await repo.create_stats_task(payload)
-    await repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
 
-    task = await repo.get_active_stats_task()
+    task = await collection_tasks_repo.get_active_stats_task()
     assert task is None
 
 
 # claim_next_due_generic_task tests
 
 
-async def test_claim_next_due_stats_task_none_available(repo):
+async def test_claim_next_due_stats_task_none_available(collection_tasks_repo):
     """Test claiming when no stats tasks available."""
     now = datetime.now(tz=timezone.utc)
-    task = await repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+    task = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
     assert task is None
 
 
-async def test_claim_next_due_stats_task_success(repo):
+async def test_claim_next_due_stats_task_success(collection_tasks_repo):
     """Test successfully claiming a stats task."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    task_id = await repo.create_stats_task(payload)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
 
     now = datetime.now(tz=timezone.utc)
-    claimed = await repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
 
     assert claimed is not None
     assert claimed.id == task_id
@@ -371,58 +375,58 @@ async def test_claim_next_due_stats_task_success(repo):
     assert claimed.started_at is not None
 
 
-async def test_claim_next_due_stats_task_respects_run_after(repo):
+async def test_claim_next_due_stats_task_respects_run_after(collection_tasks_repo):
     """Test that run_after is respected."""
     now = datetime.now(tz=timezone.utc)
     future = now + timedelta(hours=1)
 
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    await repo.create_stats_task(payload, run_after=future)
+    await collection_tasks_repo.create_stats_task(payload, run_after=future)
 
-    claimed = await repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
     assert claimed is None
 
 
-async def test_claim_next_due_stats_task_run_after_passed(repo):
+async def test_claim_next_due_stats_task_run_after_passed(collection_tasks_repo):
     """Test claiming task when run_after has passed."""
     now = datetime.now(tz=timezone.utc)
     past = now - timedelta(hours=1)
 
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    task_id = await repo.create_stats_task(payload, run_after=past)
+    task_id = await collection_tasks_repo.create_stats_task(payload, run_after=past)
 
-    claimed = await repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
     assert claimed is not None
     assert claimed.id == task_id
 
 
-async def test_claim_next_due_stats_task_skips_running(repo):
+async def test_claim_next_due_stats_task_skips_running(collection_tasks_repo):
     """Test that running tasks are not claimed."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
-    task_id = await repo.create_stats_task(payload)
-    await repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
 
     now = datetime.now(tz=timezone.utc)
-    claimed = await repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
     assert claimed is None
 
 
 # create_stats_continuation_task tests
 
 
-async def test_create_stats_continuation_task(repo):
+async def test_create_stats_continuation_task(collection_tasks_repo):
     """Test creating a continuation task."""
-    parent_id = await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1, 2]))
+    parent_id = await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1, 2]))
     run_after = datetime.now(tz=timezone.utc) + timedelta(minutes=5)
 
     payload = StatsAllTaskPayload(channel_ids=[1, 2, 3], next_index=10)
-    child_id = await repo.create_stats_continuation_task(
+    child_id = await collection_tasks_repo.create_stats_continuation_task(
         payload=payload,
         run_after=run_after,
         parent_task_id=parent_id,
     )
 
-    task = await repo.get_collection_task(child_id)
+    task = await collection_tasks_repo.get_collection_task(child_id)
     assert task.parent_task_id == parent_id
     assert task.payload.next_index == 10
 
@@ -430,14 +434,14 @@ async def test_create_stats_continuation_task(repo):
 # get_pending_channel_tasks tests
 
 
-async def test_get_pending_channel_tasks(repo):
+async def test_get_pending_channel_tasks(collection_tasks_repo):
     """Test getting pending channel tasks."""
-    id1 = await repo.create_collection_task(1, "Channel 1")
-    id2 = await repo.create_collection_task(2, "Channel 2")
-    await repo.update_collection_task(id1, CollectionTaskStatus.RUNNING)
-    await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
+    id1 = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    id2 = await collection_tasks_repo.create_collection_task(2, "Channel 2")
+    await collection_tasks_repo.update_collection_task(id1, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
 
-    tasks = await repo.get_pending_channel_tasks()
+    tasks = await collection_tasks_repo.get_pending_channel_tasks()
     assert len(tasks) == 1
     assert tasks[0].id == id2
 
@@ -445,155 +449,155 @@ async def test_get_pending_channel_tasks(repo):
 # fail_running_collection_tasks_on_startup tests
 
 
-async def test_fail_running_collection_tasks_on_startup(repo):
+async def test_fail_running_collection_tasks_on_startup(collection_tasks_repo):
     """Test failing running collection tasks."""
-    id1 = await repo.create_collection_task(1, "Channel 1")
-    id2 = await repo.create_collection_task(2, "Channel 2")
-    await repo.update_collection_task(id1, CollectionTaskStatus.RUNNING)
-    await repo.update_collection_task(id2, CollectionTaskStatus.PENDING)
+    id1 = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    id2 = await collection_tasks_repo.create_collection_task(2, "Channel 2")
+    await collection_tasks_repo.update_collection_task(id1, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.update_collection_task(id2, CollectionTaskStatus.PENDING)
 
-    count = await repo.fail_running_collection_tasks_on_startup()
+    count = await collection_tasks_repo.fail_running_collection_tasks_on_startup()
     assert count == 1
 
-    task1 = await repo.get_collection_task(id1)
+    task1 = await collection_tasks_repo.get_collection_task(id1)
     assert task1.status == CollectionTaskStatus.FAILED
     assert task1.completed_at is not None
 
-    task2 = await repo.get_collection_task(id2)
+    task2 = await collection_tasks_repo.get_collection_task(id2)
     assert task2.status == CollectionTaskStatus.PENDING
 
 
-async def test_fail_running_collection_tasks_excludes_stats(repo):
+async def test_fail_running_collection_tasks_excludes_stats(collection_tasks_repo):
     """Test that stats tasks are not affected."""
-    stats_id = await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
-    await repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
+    stats_id = await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
+    await collection_tasks_repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
 
-    count = await repo.fail_running_collection_tasks_on_startup()
+    count = await collection_tasks_repo.fail_running_collection_tasks_on_startup()
     assert count == 0
 
-    task = await repo.get_collection_task(stats_id)
+    task = await collection_tasks_repo.get_collection_task(stats_id)
     assert task.status == CollectionTaskStatus.RUNNING
 
 
 # requeue_running_generic_tasks_on_startup tests
 
 
-async def test_requeue_running_stats_tasks_on_startup(repo):
+async def test_requeue_running_stats_tasks_on_startup(collection_tasks_repo):
     """Test requeueing running stats tasks."""
-    stats_id = await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
-    await repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
+    stats_id = await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
+    await collection_tasks_repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
 
     now = datetime.now(tz=timezone.utc)
     handled = [CollectionTaskType.STATS_ALL.value]
-    count = await repo.requeue_running_generic_tasks_on_startup(now, handled)
+    count = await collection_tasks_repo.requeue_running_generic_tasks_on_startup(now, handled)
     assert count == 1
 
-    task = await repo.get_collection_task(stats_id)
+    task = await collection_tasks_repo.get_collection_task(stats_id)
     assert task.status == CollectionTaskStatus.PENDING
     assert task.started_at is None
 
 
-async def test_requeue_running_stats_tasks_excludes_channel_collect(repo):
+async def test_requeue_running_stats_tasks_excludes_channel_collect(collection_tasks_repo):
     """Test that channel collect tasks are not affected."""
-    channel_id = await repo.create_collection_task(1, "Channel")
-    await repo.update_collection_task(channel_id, CollectionTaskStatus.RUNNING)
+    channel_id = await collection_tasks_repo.create_collection_task(1, "Channel")
+    await collection_tasks_repo.update_collection_task(channel_id, CollectionTaskStatus.RUNNING)
 
     now = datetime.now(tz=timezone.utc)
     handled = [CollectionTaskType.STATS_ALL.value]
-    count = await repo.requeue_running_generic_tasks_on_startup(now, handled)
+    count = await collection_tasks_repo.requeue_running_generic_tasks_on_startup(now, handled)
     assert count == 0
 
 
-async def test_requeue_running_stats_tasks_sets_run_after(repo):
+async def test_requeue_running_stats_tasks_sets_run_after(collection_tasks_repo):
     """Test that run_after is set if not already set."""
-    stats_id = await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
-    await repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
+    stats_id = await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1]))
+    await collection_tasks_repo.update_collection_task(stats_id, CollectionTaskStatus.RUNNING)
 
     now = datetime.now(tz=timezone.utc)
     handled = [CollectionTaskType.STATS_ALL.value]
-    await repo.requeue_running_generic_tasks_on_startup(now, handled)
+    await collection_tasks_repo.requeue_running_generic_tasks_on_startup(now, handled)
 
-    task = await repo.get_collection_task(stats_id)
+    task = await collection_tasks_repo.get_collection_task(stats_id)
     assert task.run_after is not None
 
 
 # cancel_collection_task tests
 
 
-async def test_cancel_collection_task_pending(repo):
+async def test_cancel_collection_task_pending(collection_tasks_repo):
     """Test cancelling a pending task."""
-    task_id = await repo.create_collection_task(1, "Test")
-    result = await repo.cancel_collection_task(task_id)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    result = await collection_tasks_repo.cancel_collection_task(task_id)
     assert result is True
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.CANCELLED
     assert task.completed_at is not None
 
 
-async def test_cancel_collection_task_running(repo):
+async def test_cancel_collection_task_running(collection_tasks_repo):
     """Test cancelling a running task."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
-    result = await repo.cancel_collection_task(task_id)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    result = await collection_tasks_repo.cancel_collection_task(task_id)
     assert result is True
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.status == CollectionTaskStatus.CANCELLED
 
 
-async def test_cancel_collection_task_completed(repo):
+async def test_cancel_collection_task_completed(collection_tasks_repo):
     """Test cancelling a completed task fails."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
-    result = await repo.cancel_collection_task(task_id)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.COMPLETED)
+    result = await collection_tasks_repo.cancel_collection_task(task_id)
     assert result is False
 
 
-async def test_cancel_collection_task_with_note(repo):
+async def test_cancel_collection_task_with_note(collection_tasks_repo):
     """Test cancelling with a note."""
-    task_id = await repo.create_collection_task(1, "Test")
-    await repo.cancel_collection_task(task_id, note="User requested")
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.cancel_collection_task(task_id, note="User requested")
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert task.note == "User requested"
 
 
-async def test_cancel_collection_task_not_found(repo):
+async def test_cancel_collection_task_not_found(collection_tasks_repo):
     """Test cancelling non-existent task."""
-    result = await repo.cancel_collection_task(999)
+    result = await collection_tasks_repo.cancel_collection_task(999)
     assert result is False
 
 
-async def test_delete_pending_channel_tasks_only_removes_pending_channel_collect(repo):
-    pending_id = await repo.create_collection_task(1, "Pending")
+async def test_delete_pending_channel_tasks_only_removes_pending_channel_collect(collection_tasks_repo):
+    pending_id = await collection_tasks_repo.create_collection_task(1, "Pending")
 
-    running_id = await repo.create_collection_task(2, "Running")
-    await repo.update_collection_task(running_id, CollectionTaskStatus.RUNNING)
+    running_id = await collection_tasks_repo.create_collection_task(2, "Running")
+    await collection_tasks_repo.update_collection_task(running_id, CollectionTaskStatus.RUNNING)
 
-    completed_id = await repo.create_collection_task(3, "Completed")
-    await repo.update_collection_task(completed_id, CollectionTaskStatus.COMPLETED)
+    completed_id = await collection_tasks_repo.create_collection_task(3, "Completed")
+    await collection_tasks_repo.update_collection_task(completed_id, CollectionTaskStatus.COMPLETED)
 
-    stats_id = await repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1, 2]))
+    stats_id = await collection_tasks_repo.create_stats_task(StatsAllTaskPayload(channel_ids=[1, 2]))
 
-    deleted = await repo.delete_pending_channel_tasks()
+    deleted = await collection_tasks_repo.delete_pending_channel_tasks()
 
     assert deleted == 1
-    assert await repo.get_collection_task(pending_id) is None
-    assert (await repo.get_collection_task(running_id)).status == CollectionTaskStatus.RUNNING
-    assert (await repo.get_collection_task(completed_id)).status == CollectionTaskStatus.COMPLETED
-    assert (await repo.get_collection_task(stats_id)).task_type == CollectionTaskType.STATS_ALL
+    assert await collection_tasks_repo.get_collection_task(pending_id) is None
+    assert (await collection_tasks_repo.get_collection_task(running_id)).status == CollectionTaskStatus.RUNNING
+    assert (await collection_tasks_repo.get_collection_task(completed_id)).status == CollectionTaskStatus.COMPLETED
+    assert (await collection_tasks_repo.get_collection_task(stats_id)).task_type == CollectionTaskType.STATS_ALL
 
 
 # _to_task tests
 
 
-async def test_to_task_deserializes_payload(repo):
+async def test_to_task_deserializes_payload(collection_tasks_repo):
     """Test that _to_task properly deserializes payload."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2, 3], next_index=5)
-    task_id = await repo.create_stats_task(payload)
+    task_id = await collection_tasks_repo.create_stats_task(payload)
 
-    task = await repo.get_collection_task(task_id)
+    task = await collection_tasks_repo.get_collection_task(task_id)
     assert isinstance(task.payload, StatsAllTaskPayload)
     assert task.payload.channel_ids == [1, 2, 3]
     assert task.payload.next_index == 5

--- a/tests/repositories/test_content_pipelines_repository.py
+++ b/tests/repositories/test_content_pipelines_repository.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import pytest
-
-from src.database.repositories.content_pipelines import ContentPipelinesRepository
-from src.models import Channel, ContentPipeline, PipelineTarget
-
+from src.models import ContentPipeline, PipelineTarget
 
 
 def make_pipeline(**kwargs) -> ContentPipeline:

--- a/tests/repositories/test_content_pipelines_repository.py
+++ b/tests/repositories/test_content_pipelines_repository.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from src.models import ContentPipeline, PipelineTarget
+import pytest
+
+from src.database.repositories.content_pipelines import ContentPipelinesRepository
+from src.models import Channel, ContentPipeline, PipelineTarget
+
 
 
 def make_pipeline(**kwargs) -> ContentPipeline:
@@ -12,8 +16,8 @@ def make_pipeline(**kwargs) -> ContentPipeline:
     return ContentPipeline(**defaults)
 
 
-async def test_add_and_read_with_relations(repo):
-    pipeline_id = await repo.add(
+async def test_add_and_read_with_relations(content_pipelines_repo):
+    pipeline_id = await content_pipelines_repo.add(
         make_pipeline(),
         [1001, 1002],
         [
@@ -34,18 +38,18 @@ async def test_add_and_read_with_relations(repo):
         ],
     )
 
-    pipeline = await repo.get_by_id(pipeline_id)
+    pipeline = await content_pipelines_repo.get_by_id(pipeline_id)
     assert pipeline is not None
     assert pipeline.name == "Digest"
 
-    sources = await repo.list_sources(pipeline_id)
-    targets = await repo.list_targets(pipeline_id)
+    sources = await content_pipelines_repo.list_sources(pipeline_id)
+    targets = await content_pipelines_repo.list_targets(pipeline_id)
     assert [source.channel_id for source in sources] == [1001, 1002]
     assert [(target.phone, target.dialog_id) for target in targets] == [("+100", 77), ("+100", 88)]
 
 
-async def test_update_replaces_sources_and_targets(repo):
-    pipeline_id = await repo.add(
+async def test_update_replaces_sources_and_targets(content_pipelines_repo):
+    pipeline_id = await content_pipelines_repo.add(
         make_pipeline(),
         [1001],
         [
@@ -59,7 +63,7 @@ async def test_update_replaces_sources_and_targets(repo):
         ],
     )
 
-    ok = await repo.update(
+    ok = await content_pipelines_repo.update(
         pipeline_id,
         make_pipeline(name="Updated", generate_interval_minutes=15),
         [1002],
@@ -75,17 +79,17 @@ async def test_update_replaces_sources_and_targets(repo):
     )
 
     assert ok is True
-    pipeline = await repo.get_by_id(pipeline_id)
+    pipeline = await content_pipelines_repo.get_by_id(pipeline_id)
     assert pipeline is not None
     assert pipeline.name == "Updated"
     assert pipeline.generate_interval_minutes == 15
-    assert [source.channel_id for source in await repo.list_sources(pipeline_id)] == [1002]
-    targets = await repo.list_targets(pipeline_id)
+    assert [source.channel_id for source in await content_pipelines_repo.list_sources(pipeline_id)] == [1002]
+    targets = await content_pipelines_repo.list_targets(pipeline_id)
     assert [(target.phone, target.dialog_id) for target in targets] == [("+200", 99)]
 
 
-async def test_delete_cascades_relations(repo):
-    pipeline_id = await repo.add(
+async def test_delete_cascades_relations(content_pipelines_repo):
+    pipeline_id = await content_pipelines_repo.add(
         make_pipeline(),
         [1001],
         [
@@ -99,8 +103,8 @@ async def test_delete_cascades_relations(repo):
         ],
     )
 
-    await repo.delete(pipeline_id)
+    await content_pipelines_repo.delete(pipeline_id)
 
-    assert await repo.get_by_id(pipeline_id) is None
-    assert await repo.list_sources(pipeline_id) == []
-    assert await repo.list_targets(pipeline_id) == []
+    assert await content_pipelines_repo.get_by_id(pipeline_id) is None
+    assert await content_pipelines_repo.list_sources(pipeline_id) == []
+    assert await content_pipelines_repo.list_targets(pipeline_id) == []

--- a/tests/repositories/test_filters_repository.py
+++ b/tests/repositories/test_filters_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from src.database.repositories.channels import ChannelsRepository
-from src.database.repositories.filters import _has_cyrillic_udf
+from src.database.repositories.filters import FilterRepository, _has_cyrillic_udf
 from src.models import Channel
 
 _INSERT_MSG = (
@@ -25,6 +25,9 @@ _INSERT_STATS_NULL = (
     "INSERT INTO channel_stats (channel_id, subscriber_count, collected_at)"
     " VALUES (?, NULL, datetime('now'))"
 )
+
+
+
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""
@@ -73,72 +76,72 @@ def test_has_cyrillic_udf_yo():
 # fetch_channels_for_analysis tests
 
 
-async def test_fetch_channels_for_analysis_empty(repo, channels_repo):
+async def test_fetch_channels_for_analysis_empty(filters_repo, channels_repo):
     """Test fetching when no channels exist."""
-    result = await repo.fetch_channels_for_analysis()
+    result = await filters_repo.fetch_channels_for_analysis()
     assert result == []
 
 
-async def test_fetch_channels_for_analysis_basic(repo, channels_repo):
+async def test_fetch_channels_for_analysis_basic(filters_repo, channels_repo):
     """Test fetching channels for analysis."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Channel 1"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Channel 2"))
 
-    result = await repo.fetch_channels_for_analysis()
+    result = await filters_repo.fetch_channels_for_analysis()
     assert len(result) == 2
     assert result[0]["title"] == "Channel 1"
     assert result[1]["title"] == "Channel 2"
 
 
-async def test_fetch_channels_for_analysis_with_messages(repo, channels_repo):
+async def test_fetch_channels_for_analysis_with_messages(filters_repo, channels_repo):
     """Test that message_count is included."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
     # Insert messages
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG_NO_TEXT,
         [(1, 100), (1, 101), (1, 102)],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_channels_for_analysis()
+    result = await filters_repo.fetch_channels_for_analysis()
     assert len(result) == 1
     assert result[0]["message_count"] == 3
 
 
-async def test_fetch_channels_for_analysis_by_id(repo, channels_repo):
+async def test_fetch_channels_for_analysis_by_id(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Channel 1"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Channel 2"))
 
-    result = await repo.fetch_channels_for_analysis(channel_id=1)
+    result = await filters_repo.fetch_channels_for_analysis(channel_id=1)
     assert len(result) == 1
     assert result[0]["channel_id"] == 1
 
 
-async def test_fetch_channels_for_analysis_nonexistent_id(repo, channels_repo):
+async def test_fetch_channels_for_analysis_nonexistent_id(filters_repo, channels_repo):
     """Test filtering by non-existent channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Channel 1"))
 
-    result = await repo.fetch_channels_for_analysis(channel_id=999)
+    result = await filters_repo.fetch_channels_for_analysis(channel_id=999)
     assert result == []
 
 
 # fetch_uniqueness_map tests
 
 
-async def test_fetch_uniqueness_map_empty(repo):
+async def test_fetch_uniqueness_map_empty(filters_repo):
     """Test uniqueness map with no messages."""
-    result = await repo.fetch_uniqueness_map()
+    result = await filters_repo.fetch_uniqueness_map()
     assert result == {}
 
 
-async def test_fetch_uniqueness_map_basic(repo, channels_repo):
+async def test_fetch_uniqueness_map_basic(filters_repo, channels_repo):
     """Test basic uniqueness calculation."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
     # Insert messages with different prefixes
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "First message here"),
@@ -146,9 +149,9 @@ async def test_fetch_uniqueness_map_basic(repo, channels_repo):
             (1, 102, "Different content"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_uniqueness_map()
+    result = await filters_repo.fetch_uniqueness_map()
     assert 1 in result
     total, unique = result[1]
     assert total == 3
@@ -158,35 +161,35 @@ async def test_fetch_uniqueness_map_basic(repo, channels_repo):
     assert unique == 3
 
 
-async def test_fetch_uniqueness_map_excludes_null_text(repo, channels_repo):
+async def test_fetch_uniqueness_map_excludes_null_text(filters_repo, channels_repo):
     """Test that NULL text is excluded."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Valid text"),
             (1, 101, None),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_uniqueness_map()
+    result = await filters_repo.fetch_uniqueness_map()
     assert result[1][0] == 1  # Only 1 message counted
 
 
-async def test_fetch_uniqueness_map_by_channel(repo, channels_repo):
+async def test_fetch_uniqueness_map_by_channel(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [(1, 100, "Message from channel 1"), (2, 100, "Message from channel 2")],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_uniqueness_map(channel_id=1)
+    result = await filters_repo.fetch_uniqueness_map(channel_id=1)
     assert 1 in result
     assert 2 not in result
 
@@ -194,32 +197,32 @@ async def test_fetch_uniqueness_map_by_channel(repo, channels_repo):
 # fetch_subscriber_map tests
 
 
-async def test_fetch_subscriber_map_empty(repo):
+async def test_fetch_subscriber_map_empty(filters_repo):
     """Test subscriber map with no stats."""
-    result = await repo.fetch_subscriber_map()
+    result = await filters_repo.fetch_subscriber_map()
     assert result == {}
 
 
-async def test_fetch_subscriber_map_basic(repo, channels_repo):
+async def test_fetch_subscriber_map_basic(filters_repo, channels_repo):
     """Test basic subscriber map."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.execute(
+    await filters_repo._db.execute(
         _INSERT_STATS,
         (1, 1000),
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_subscriber_map()
+    result = await filters_repo.fetch_subscriber_map()
     assert result[1] == 1000
 
 
-async def test_fetch_subscriber_map_latest_only(repo, channels_repo):
+async def test_fetch_subscriber_map_latest_only(filters_repo, channels_repo):
     """Test that only the latest subscriber count is returned."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
     # Insert multiple stats with different timestamps
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_STATS_TS,
         [
             (1, 1000, "2026-03-10 12:00:00"),
@@ -227,55 +230,55 @@ async def test_fetch_subscriber_map_latest_only(repo, channels_repo):
             (1, 1200, "2026-03-12 12:00:00"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_subscriber_map()
+    result = await filters_repo.fetch_subscriber_map()
     assert result[1] == 1500  # Latest
 
 
-async def test_fetch_subscriber_map_excludes_null(repo, channels_repo):
+async def test_fetch_subscriber_map_excludes_null(filters_repo, channels_repo):
     """Test that NULL subscriber_count is excluded."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.execute(
+    await filters_repo._db.execute(
         _INSERT_STATS_NULL,
         (1,),
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_subscriber_map()
+    result = await filters_repo.fetch_subscriber_map()
     assert 1 not in result
 
 
-async def test_fetch_subscriber_map_by_channel(repo, channels_repo):
+async def test_fetch_subscriber_map_by_channel(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_STATS,
         [(1, 1000), (2, 2000)],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_subscriber_map(channel_id=1)
+    result = await filters_repo.fetch_subscriber_map(channel_id=1)
     assert result == {1: 1000}
 
 
 # fetch_short_message_map tests
 
 
-async def test_fetch_short_message_map_empty(repo):
+async def test_fetch_short_message_map_empty(filters_repo):
     """Test short message map with no messages."""
-    result = await repo.fetch_short_message_map()
+    result = await filters_repo.fetch_short_message_map()
     assert result == {}
 
 
-async def test_fetch_short_message_map_basic(repo, channels_repo):
+async def test_fetch_short_message_map_basic(filters_repo, channels_repo):
     """Test basic short message counting."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Short"),  # 5 chars <= 10
@@ -283,45 +286,45 @@ async def test_fetch_short_message_map_basic(repo, channels_repo):
             (1, 102, "Tiny"),  # 4 chars <= 10
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_short_message_map()
+    result = await filters_repo.fetch_short_message_map()
     total, short = result[1]
     assert total == 3
     assert short == 2
 
 
-async def test_fetch_short_message_map_null_text(repo, channels_repo):
+async def test_fetch_short_message_map_null_text(filters_repo, channels_repo):
     """Test handling of NULL text."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Short"),
             (1, 101, None),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_short_message_map()
+    result = await filters_repo.fetch_short_message_map()
     total, short = result[1]
     assert total == 2
     assert short == 1  # NULL is not counted as short
 
 
-async def test_fetch_short_message_map_by_channel(repo, channels_repo):
+async def test_fetch_short_message_map_by_channel(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [(1, 100, "Short"), (2, 100, "Short")],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_short_message_map(channel_id=1)
+    result = await filters_repo.fetch_short_message_map(channel_id=1)
     assert 1 in result
     assert 2 not in result
 
@@ -329,54 +332,54 @@ async def test_fetch_short_message_map_by_channel(repo, channels_repo):
 # count_matching_prefixes_in_other_channels tests
 
 
-async def test_count_matching_prefixes_empty_list(repo):
+async def test_count_matching_prefixes_empty_list(filters_repo):
     """Test with empty prefixes list."""
-    result = await repo.count_matching_prefixes_in_other_channels(1, [])
+    result = await filters_repo.count_matching_prefixes_in_other_channels(1, [])
     assert result == 0
 
 
-async def test_count_matching_prefixes_no_matches(repo, channels_repo):
+async def test_count_matching_prefixes_no_matches(filters_repo, channels_repo):
     """Test with no matching prefixes."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [(2, 100, "Completely different text")],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.count_matching_prefixes_in_other_channels(
+    result = await filters_repo.count_matching_prefixes_in_other_channels(
         1, ["This is a specific prefix that won't match"]
     )
     assert result == 0
 
 
-async def test_count_matching_prefixes_with_matches(repo, channels_repo):
+async def test_count_matching_prefixes_with_matches(filters_repo, channels_repo):
     """Test with matching prefixes."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
     prefix = "Same prefix message"
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, prefix),
             (2, 100, prefix),  # Same prefix in other channel
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.count_matching_prefixes_in_other_channels(1, [prefix])
+    result = await filters_repo.count_matching_prefixes_in_other_channels(1, [prefix])
     assert result == 1
 
 
-async def test_count_matching_prefixes_multiple(repo, channels_repo):
+async def test_count_matching_prefixes_multiple(filters_repo, channels_repo):
     """Test with multiple matching prefixes."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (2, 100, "Prefix one message"),
@@ -384,9 +387,9 @@ async def test_count_matching_prefixes_multiple(repo, channels_repo):
             (2, 102, "Prefix one message"),  # Duplicate prefix, counted once
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.count_matching_prefixes_in_other_channels(
+    result = await filters_repo.count_matching_prefixes_in_other_channels(
         1, ["Prefix one message", "Prefix two message"]
     )
     assert result == 2
@@ -395,39 +398,39 @@ async def test_count_matching_prefixes_multiple(repo, channels_repo):
 # fetch_cross_dupe_map tests
 
 
-async def test_fetch_cross_dupe_map_empty(repo):
+async def test_fetch_cross_dupe_map_empty(filters_repo):
     """Test cross dupe map with no messages."""
-    result = await repo.fetch_cross_dupe_map()
+    result = await filters_repo.fetch_cross_dupe_map()
     assert result == {}
 
 
-async def test_fetch_cross_dupe_map_no_dupes(repo, channels_repo):
+async def test_fetch_cross_dupe_map_no_dupes(filters_repo, channels_repo):
     """Test with no cross-channel duplicates."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Unique message one"),
             (1, 101, "Unique message two"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cross_dupe_map()
+    result = await filters_repo.fetch_cross_dupe_map()
     total, duped = result[1]
     assert total == 2
     assert duped == 0
 
 
-async def test_fetch_cross_dupe_map_with_dupes(repo, channels_repo):
+async def test_fetch_cross_dupe_map_with_dupes(filters_repo, channels_repo):
     """Test with cross-channel duplicates."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
     # Same message in both channels (longer than 10 chars)
     shared_text = "This is a shared message between channels"
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, shared_text),
@@ -435,47 +438,47 @@ async def test_fetch_cross_dupe_map_with_dupes(repo, channels_repo):
             (1, 101, "Unique to channel 1"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cross_dupe_map()
+    result = await filters_repo.fetch_cross_dupe_map()
     total, duped = result[1]
     assert total == 2  # 2 unique prefixes in channel 1
     assert duped == 1  # 1 is duplicated in another channel
 
 
-async def test_fetch_cross_dupe_map_excludes_short(repo, channels_repo):
+async def test_fetch_cross_dupe_map_excludes_short(filters_repo, channels_repo):
     """Test that short messages (<=10 chars) are excluded."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Short"),  # <= 10 chars, excluded
             (2, 100, "Short"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cross_dupe_map()
+    result = await filters_repo.fetch_cross_dupe_map()
     assert result == {}  # No messages > 10 chars
 
 
-async def test_fetch_cross_dupe_map_by_channel(repo, channels_repo):
+async def test_fetch_cross_dupe_map_by_channel(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Long message from channel 1"),
             (2, 100, "Long message from channel 2"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cross_dupe_map(channel_id=1)
+    result = await filters_repo.fetch_cross_dupe_map(channel_id=1)
     assert 1 in result
     assert 2 not in result
 
@@ -483,17 +486,17 @@ async def test_fetch_cross_dupe_map_by_channel(repo, channels_repo):
 # fetch_cyrillic_map tests
 
 
-async def test_fetch_cyrillic_map_empty(repo):
+async def test_fetch_cyrillic_map_empty(filters_repo):
     """Test cyrillic map with no messages."""
-    result = await repo.fetch_cyrillic_map()
+    result = await filters_repo.fetch_cyrillic_map()
     assert result == {}
 
 
-async def test_fetch_cyrillic_map_basic(repo, channels_repo):
+async def test_fetch_cyrillic_map_basic(filters_repo, channels_repo):
     """Test basic cyrillic counting."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "English text"),
@@ -501,19 +504,19 @@ async def test_fetch_cyrillic_map_basic(repo, channels_repo):
             (1, 102, "Mixed text с русским"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cyrillic_map()
+    result = await filters_repo.fetch_cyrillic_map()
     total, cyr = result[1]
     assert total == 3
     assert cyr == 2  # 2 messages have cyrillic
 
 
-async def test_fetch_cyrillic_map_excludes_null_empty(repo, channels_repo):
+async def test_fetch_cyrillic_map_excludes_null_empty(filters_repo, channels_repo):
     """Test that NULL and empty text are excluded."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Valid text"),
@@ -521,46 +524,46 @@ async def test_fetch_cyrillic_map_excludes_null_empty(repo, channels_repo):
             (1, 102, ""),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cyrillic_map()
+    result = await filters_repo.fetch_cyrillic_map()
     total, cyr = result[1]
     assert total == 1  # Only non-null, non-empty counted
 
 
-async def test_fetch_cyrillic_map_by_channel(repo, channels_repo):
+async def test_fetch_cyrillic_map_by_channel(filters_repo, channels_repo):
     """Test filtering by channel_id."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
     await channels_repo.add_channel(Channel(channel_id=2, title="Test 2"))
 
-    await repo._db.executemany(
+    await filters_repo._db.executemany(
         _INSERT_MSG,
         [
             (1, 100, "Текст на русском"),
             (2, 100, "English text"),
         ],
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
-    result = await repo.fetch_cyrillic_map(channel_id=1)
+    result = await filters_repo.fetch_cyrillic_map(channel_id=1)
     assert 1 in result
     assert 2 not in result
 
 
-async def test_fetch_cyrillic_map_udf_registered(repo, channels_repo):
+async def test_fetch_cyrillic_map_udf_registered(filters_repo, channels_repo):
     """Test that UDF is registered on first call."""
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
 
-    await repo._db.execute(
+    await filters_repo._db.execute(
         _INSERT_MSG,
         (1, 100, "Test"),
     )
-    await repo._db.commit()
+    await filters_repo._db.commit()
 
     # First call should register UDF
-    result1 = await repo.fetch_cyrillic_map()
-    assert repo._udf_registered is True
+    result1 = await filters_repo.fetch_cyrillic_map()
+    assert filters_repo._udf_registered is True
 
     # Second call should use already registered UDF
-    result2 = await repo.fetch_cyrillic_map()
+    result2 = await filters_repo.fetch_cyrillic_map()
     assert result1 == result2

--- a/tests/repositories/test_filters_repository.py
+++ b/tests/repositories/test_filters_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from src.database.repositories.channels import ChannelsRepository
-from src.database.repositories.filters import FilterRepository, _has_cyrillic_udf
+from src.database.repositories.filters import _has_cyrillic_udf
 from src.models import Channel
 
 _INSERT_MSG = (

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -11,6 +11,7 @@ from src.database.repositories.messages import MessagesRepository, _normalize_da
 from src.models import Message, SearchQuery
 
 
+
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""
@@ -37,29 +38,29 @@ def make_message(
 # insert_message tests
 
 
-async def test_insert_message_success(repo):
+async def test_insert_message_success(messages_repo):
     """Test inserting a message successfully."""
     msg = make_message(1, 100, "Hello world")
-    result = await repo.insert_message(msg)
+    result = await messages_repo.insert_message(msg)
     assert result is True
 
 
-async def test_insert_message_duplicate_ignored(repo):
+async def test_insert_message_duplicate_ignored(messages_repo):
     """Test that duplicate messages are ignored."""
     msg = make_message(1, 100, "First")
-    await repo.insert_message(msg)
+    await messages_repo.insert_message(msg)
 
     msg2 = make_message(1, 100, "Second")  # Same channel_id + message_id
-    result = await repo.insert_message(msg2)
+    result = await messages_repo.insert_message(msg2)
     assert result is False
 
     # Verify only one message exists
-    messages, total = await repo.search_messages()
+    messages, total = await messages_repo.search_messages()
     assert total == 1
     assert messages[0].text == "First"
 
 
-async def test_insert_message_with_all_fields(repo):
+async def test_insert_message_with_all_fields(messages_repo):
     """Test inserting message with all optional fields."""
     msg = Message(
         channel_id=1,
@@ -71,10 +72,10 @@ async def test_insert_message_with_all_fields(repo):
         topic_id=5,
         date=datetime(2026, 3, 16, 12, 0, 0),
     )
-    result = await repo.insert_message(msg)
+    result = await messages_repo.insert_message(msg)
     assert result is True
 
-    messages, _ = await repo.search_messages()
+    messages, _ = await messages_repo.search_messages()
     assert messages[0].sender_id == 12345
     assert messages[0].sender_name == "John Doe"
     assert messages[0].media_type == "photo"
@@ -84,39 +85,39 @@ async def test_insert_message_with_all_fields(repo):
 # insert_messages_batch tests
 
 
-async def test_insert_messages_batch_empty(repo):
+async def test_insert_messages_batch_empty(messages_repo):
     """Test batch insert with empty list."""
-    count = await repo.insert_messages_batch([])
+    count = await messages_repo.insert_messages_batch([])
     assert count == 0
 
 
-async def test_insert_messages_batch_multiple(repo):
+async def test_insert_messages_batch_multiple(messages_repo):
     """Test batch inserting multiple messages."""
     messages = [
         make_message(1, 100, "Message 1"),
         make_message(1, 101, "Message 2"),
         make_message(2, 100, "Message 3"),
     ]
-    count = await repo.insert_messages_batch(messages)
+    count = await messages_repo.insert_messages_batch(messages)
     assert count == 3
 
-    _, total = await repo.search_messages()
+    _, total = await messages_repo.search_messages()
     assert total == 3
 
 
-async def test_insert_messages_batch_with_duplicates(repo):
+async def test_insert_messages_batch_with_duplicates(messages_repo):
     """Test batch insert ignores duplicates."""
     # Insert first batch
-    await repo.insert_messages_batch([make_message(1, 100, "Original")])
+    await messages_repo.insert_messages_batch([make_message(1, 100, "Original")])
 
     # Insert batch with duplicate
     messages = [
         make_message(1, 100, "Duplicate"),  # This should be ignored
         make_message(1, 101, "New"),
     ]
-    await repo.insert_messages_batch(messages)
+    await messages_repo.insert_messages_batch(messages)
 
-    messages_list, total = await repo.search_messages()
+    messages_list, total = await messages_repo.search_messages()
     assert total == 2
     texts = {m.text for m in messages_list}
     assert "Original" in texts
@@ -173,30 +174,30 @@ def test_normalize_date_to_module_function():
 # search_messages tests
 
 
-async def test_search_messages_empty(repo):
+async def test_search_messages_empty(messages_repo):
     """Test searching when no messages exist."""
-    messages, total = await repo.search_messages()
+    messages, total = await messages_repo.search_messages()
     assert messages == []
     assert total == 0
 
 
-async def test_search_messages_all(repo):
+async def test_search_messages_all(messages_repo):
     """Test getting all messages."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "First"),
             make_message(1, 101, "Second"),
         ]
     )
 
-    messages, total = await repo.search_messages()
+    messages, total = await messages_repo.search_messages()
     assert len(messages) == 2
     assert total == 2
 
 
-async def test_search_messages_by_channel(repo):
+async def test_search_messages_by_channel(messages_repo):
     """Test filtering by channel_id."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Channel 1"),
             make_message(2, 100, "Channel 2"),
@@ -204,15 +205,15 @@ async def test_search_messages_by_channel(repo):
         ]
     )
 
-    messages, total = await repo.search_messages(channel_id=1)
+    messages, total = await messages_repo.search_messages(channel_id=1)
     assert len(messages) == 2
     assert total == 2
     assert all(m.channel_id == 1 for m in messages)
 
 
-async def test_search_messages_by_topic(repo):
+async def test_search_messages_by_topic(messages_repo):
     """Test filtering by topic_id."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "No topic", topic_id=None),
             make_message(1, 101, "Topic 5", topic_id=5),
@@ -220,29 +221,29 @@ async def test_search_messages_by_topic(repo):
         ]
     )
 
-    messages, total = await repo.search_messages(topic_id=5)
+    messages, total = await messages_repo.search_messages(topic_id=5)
     assert len(messages) == 1
     assert total == 1
     assert messages[0].topic_id == 5
 
 
-async def test_search_messages_by_date_from(repo):
+async def test_search_messages_by_date_from(messages_repo):
     """Test filtering by date_from."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Old", date=datetime(2026, 3, 10)),
             make_message(1, 101, "New", date=datetime(2026, 3, 16)),
         ]
     )
 
-    messages, total = await repo.search_messages(date_from="2026-03-15")
+    messages, total = await messages_repo.search_messages(date_from="2026-03-15")
     assert len(messages) == 1
     assert messages[0].text == "New"
 
 
-async def test_search_messages_by_date_to(repo):
+async def test_search_messages_by_date_to(messages_repo):
     """Test filtering by date_to (inclusive)."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Old", date=datetime(2026, 3, 10)),
             make_message(1, 101, "New", date=datetime(2026, 3, 16)),
@@ -250,14 +251,14 @@ async def test_search_messages_by_date_to(repo):
     )
 
     # Should include messages up to 2026-03-10
-    messages, total = await repo.search_messages(date_to="2026-03-10")
+    messages, total = await messages_repo.search_messages(date_to="2026-03-10")
     assert len(messages) == 1
     assert messages[0].text == "Old"
 
 
-async def test_search_messages_by_date_range(repo):
+async def test_search_messages_by_date_range(messages_repo):
     """Test filtering by date range."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Before", date=datetime(2026, 3, 5)),
             make_message(1, 101, "In range", date=datetime(2026, 3, 10)),
@@ -265,51 +266,51 @@ async def test_search_messages_by_date_range(repo):
         ]
     )
 
-    messages, total = await repo.search_messages(date_from="2026-03-08", date_to="2026-03-15")
+    messages, total = await messages_repo.search_messages(date_from="2026-03-08", date_to="2026-03-15")
     assert len(messages) == 1
     assert messages[0].text == "In range"
 
 
-async def test_search_messages_by_min_length(repo):
+async def test_search_messages_by_min_length(messages_repo):
     """Test filtering by min_length."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Short"),
             make_message(1, 101, "This is a longer message"),
         ]
     )
 
-    messages, total = await repo.search_messages(min_length=10)
+    messages, total = await messages_repo.search_messages(min_length=10)
     assert len(messages) == 1
     assert messages[0].text == "This is a longer message"
 
 
-async def test_search_messages_by_max_length(repo):
+async def test_search_messages_by_max_length(messages_repo):
     """Test filtering by max_length."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Short"),
             make_message(1, 101, "This is a longer message"),
         ]
     )
 
-    messages, total = await repo.search_messages(max_length=10)
+    messages, total = await messages_repo.search_messages(max_length=10)
     assert len(messages) == 1
     assert messages[0].text == "Short"
 
 
-async def test_search_messages_pagination(repo):
+async def test_search_messages_pagination(messages_repo):
     """Test pagination with limit and offset."""
     for i in range(10):
-        await repo.insert_message(make_message(1, 100 + i, f"Message {i}"))
+        await messages_repo.insert_message(make_message(1, 100 + i, f"Message {i}"))
 
     # First page
-    messages, total = await repo.search_messages(limit=3, offset=0)
+    messages, total = await messages_repo.search_messages(limit=3, offset=0)
     assert len(messages) == 3
     assert total == 10
 
     # Second page
-    messages2, _ = await repo.search_messages(limit=3, offset=3)
+    messages2, _ = await messages_repo.search_messages(limit=3, offset=3)
     assert len(messages2) == 3
 
     # Verify different messages
@@ -318,7 +319,7 @@ async def test_search_messages_pagination(repo):
     assert ids1.isdisjoint(ids2)
 
 
-async def test_search_messages_excludes_filtered_channels(repo, channels_repo):
+async def test_search_messages_excludes_filtered_channels(messages_repo, channels_repo):
     """Test that messages from filtered channels are excluded."""
     from src.models import Channel
 
@@ -330,21 +331,21 @@ async def test_search_messages_excludes_filtered_channels(repo, channels_repo):
     filtered_pk = next(c.id for c in channels if c.channel_id == 2)
     await channels_repo.set_channel_filtered(filtered_pk, True)
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "From unfiltered"),
             make_message(2, 100, "From filtered"),
         ]
     )
 
-    messages, total = await repo.search_messages()
+    messages, total = await messages_repo.search_messages()
     assert total == 1
     assert messages[0].channel_id == 1
 
 
-async def test_search_messages_fts(repo):
+async def test_search_messages_fts(messages_repo):
     """Test FTS search."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),
             make_message(1, 101, "Goodbye universe"),
@@ -352,14 +353,14 @@ async def test_search_messages_fts(repo):
         ]
     )
 
-    messages, total = await repo.search_messages(query="hello", is_fts=True)
+    messages, total = await messages_repo.search_messages(query="hello", is_fts=True)
     assert total == 2
     assert all("hello" in m.text.lower() for m in messages)
 
 
-async def test_search_messages_plain_search(repo):
+async def test_search_messages_plain_search(messages_repo):
     """Test plain text search (non-FTS)."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),
             make_message(1, 101, "Goodbye universe"),
@@ -367,7 +368,7 @@ async def test_search_messages_plain_search(repo):
     )
 
     # Plain search should still work via FTS with quoting
-    messages, total = await repo.search_messages(query="Hello", is_fts=False)
+    messages, total = await messages_repo.search_messages(query="Hello", is_fts=False)
     assert total == 1
 
 
@@ -395,11 +396,11 @@ def test_build_fts_match_escapes_quotes():
 # count_fts_matches_for_query tests
 
 
-async def test_count_fts_matches_for_query(repo):
+async def test_count_fts_matches_for_query(messages_repo):
     """Test counting FTS matches for a search query."""
     sq = SearchQuery(query="hello", is_fts=True)
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),
             make_message(1, 101, "Hello there"),
@@ -407,51 +408,51 @@ async def test_count_fts_matches_for_query(repo):
         ]
     )
 
-    count = await repo.count_fts_matches_for_query(sq)
+    count = await messages_repo.count_fts_matches_for_query(sq)
     assert count == 2
 
 
-async def test_count_fts_matches_for_query_with_max_length(repo):
+async def test_count_fts_matches_for_query_with_max_length(messages_repo):
     """Test counting FTS matches with max_length filter."""
     sq = SearchQuery(query="hello", is_fts=True, max_length=15)
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),  # 11 chars
             make_message(1, 101, "Hello there, this is a very long message"),  # Too long
         ]
     )
 
-    count = await repo.count_fts_matches_for_query(sq)
+    count = await messages_repo.count_fts_matches_for_query(sq)
     assert count == 1
 
 
-async def test_count_fts_matches_for_query_with_exclude_patterns(repo):
+async def test_count_fts_matches_for_query_with_exclude_patterns(messages_repo):
     """Test counting FTS matches with exclude patterns."""
     sq = SearchQuery(query="hello", is_fts=True, exclude_patterns="spam")
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),
             make_message(1, 101, "Hello spam message"),
         ]
     )
 
-    count = await repo.count_fts_matches_for_query(sq)
+    count = await messages_repo.count_fts_matches_for_query(sq)
     assert count == 1
 
 
 # get_fts_daily_stats_for_query tests
 
 
-async def test_get_fts_daily_stats_for_query(repo):
+async def test_get_fts_daily_stats_for_query(messages_repo):
     """Test getting daily FTS stats for a query."""
     sq = SearchQuery(query="test", is_fts=True)
 
     today = datetime.now(timezone.utc)
     yesterday = today - timedelta(days=1)
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "test message", date=today),
             make_message(1, 101, "test again", date=today),
@@ -459,7 +460,7 @@ async def test_get_fts_daily_stats_for_query(repo):
         ]
     )
 
-    stats = await repo.get_fts_daily_stats_for_query(sq, days=7)
+    stats = await messages_repo.get_fts_daily_stats_for_query(sq, days=7)
     assert len(stats) >= 1
     assert all(hasattr(s, "day") and hasattr(s, "count") for s in stats)
 
@@ -467,36 +468,36 @@ async def test_get_fts_daily_stats_for_query(repo):
 # get_fts_daily_stats_batch tests
 
 
-async def test_get_fts_daily_stats_batch(repo):
+async def test_get_fts_daily_stats_batch(messages_repo):
     """Test batch FTS daily stats."""
     sq1 = SearchQuery(id=1, query="hello", is_fts=True)
     sq2 = SearchQuery(id=2, query="world", is_fts=True)
 
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Hello world"),
             make_message(1, 101, "Hello again"),
         ]
     )
 
-    result = await repo.get_fts_daily_stats_batch([sq1, sq2], days=7)
+    result = await messages_repo.get_fts_daily_stats_batch([sq1, sq2], days=7)
 
     assert 1 in result
     assert 2 in result
 
 
-async def test_get_fts_daily_stats_batch_empty(repo):
+async def test_get_fts_daily_stats_batch_empty(messages_repo):
     """Test batch FTS stats with empty list."""
-    result = await repo.get_fts_daily_stats_batch([], days=7)
+    result = await messages_repo.get_fts_daily_stats_batch([], days=7)
     assert result == {}
 
 
 # delete_messages_for_channel tests
 
 
-async def test_delete_messages_for_channel(repo):
+async def test_delete_messages_for_channel(messages_repo):
     """Test deleting all messages for a channel."""
-    await repo.insert_messages_batch(
+    await messages_repo.insert_messages_batch(
         [
             make_message(1, 100, "Channel 1"),
             make_message(1, 101, "Channel 1"),
@@ -504,47 +505,47 @@ async def test_delete_messages_for_channel(repo):
         ]
     )
 
-    count = await repo.delete_messages_for_channel(1)
+    count = await messages_repo.delete_messages_for_channel(1)
     assert count == 2
 
-    _, total = await repo.search_messages()
+    _, total = await messages_repo.search_messages()
     assert total == 1
 
 
-async def test_delete_messages_for_channel_nonexistent(repo):
+async def test_delete_messages_for_channel_nonexistent(messages_repo):
     """Test deleting messages for non-existent channel."""
-    count = await repo.delete_messages_for_channel(999)
+    count = await messages_repo.delete_messages_for_channel(999)
     assert count == 0
 
 
 # get_stats tests
 
 
-async def test_get_stats(repo, channels_repo):
+async def test_get_stats(messages_repo, channels_repo):
     """Test getting database stats."""
     from src.database.repositories.accounts import AccountsRepository
     from src.database.repositories.search_queries import SearchQueriesRepository
     from src.models import Account, Channel
 
-    accounts_repo = AccountsRepository(repo._db)
-    queries_repo = SearchQueriesRepository(repo._db)
+    accounts_repo = AccountsRepository(messages_repo._db)
+    queries_repo = SearchQueriesRepository(messages_repo._db)
 
     # Add some data
     await accounts_repo.add_account(Account(phone="+123", session_string="s1"))
     await channels_repo.add_channel(Channel(channel_id=1, title="Test"))
-    await repo.insert_message(make_message(1, 100, "Test"))
+    await messages_repo.insert_message(make_message(1, 100, "Test"))
     await queries_repo.add(SearchQuery(query="test"))
 
-    stats = await repo.get_stats()
+    stats = await messages_repo.get_stats()
     assert stats["accounts"] == 1
     assert stats["channels"] == 1
     assert stats["messages"] == 1
     assert stats["search_queries"] == 1
 
 
-async def test_get_stats_empty(repo):
+async def test_get_stats_empty(messages_repo):
     """Test getting stats from empty database."""
-    stats = await repo.get_stats()
+    stats = await messages_repo.get_stats()
     assert stats["accounts"] == 0
     assert stats["channels"] == 0
     assert stats["messages"] == 0

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -11,7 +11,6 @@ from src.database.repositories.messages import MessagesRepository, _normalize_da
 from src.models import Message, SearchQuery
 
 
-
 @pytest.fixture
 async def channels_repo(db):
     """Create channels repository instance."""

--- a/tests/repositories/test_notification_bots_repository.py
+++ b/tests/repositories/test_notification_bots_repository.py
@@ -6,9 +6,7 @@ from datetime import datetime
 
 import pytest
 
-from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.models import NotificationBot
-
 
 
 @pytest.fixture

--- a/tests/repositories/test_notification_bots_repository.py
+++ b/tests/repositories/test_notification_bots_repository.py
@@ -6,7 +6,9 @@ from datetime import datetime
 
 import pytest
 
+from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.models import NotificationBot
+
 
 
 @pytest.fixture
@@ -21,17 +23,17 @@ def sample_bot():
     )
 
 
-async def test_get_bot_not_found(repo):
+async def test_get_bot_not_found(notification_bots_repo):
     """Test getting non-existent bot returns None."""
-    result = await repo.get_bot(999999999)
+    result = await notification_bots_repo.get_bot(999999999)
     assert result is None
 
 
-async def test_save_and_get_bot(repo, sample_bot):
+async def test_save_and_get_bot(notification_bots_repo, sample_bot):
     """Test saving and retrieving a bot."""
-    await repo.save_bot(sample_bot)
+    await notification_bots_repo.save_bot(sample_bot)
 
-    result = await repo.get_bot(sample_bot.tg_user_id)
+    result = await notification_bots_repo.get_bot(sample_bot.tg_user_id)
     assert result is not None
     assert result.tg_user_id == sample_bot.tg_user_id
     assert result.tg_username == sample_bot.tg_username
@@ -40,9 +42,9 @@ async def test_save_and_get_bot(repo, sample_bot):
     assert result.bot_token == sample_bot.bot_token
 
 
-async def test_save_bot_upsert(repo, sample_bot):
+async def test_save_bot_upsert(notification_bots_repo, sample_bot):
     """Test that save_bot updates existing bot."""
-    await repo.save_bot(sample_bot)
+    await notification_bots_repo.save_bot(sample_bot)
 
     # Update bot
     updated_bot = NotificationBot(
@@ -52,9 +54,9 @@ async def test_save_bot_upsert(repo, sample_bot):
         bot_username="updated_bot",
         bot_token="new_token",
     )
-    await repo.save_bot(updated_bot)
+    await notification_bots_repo.save_bot(updated_bot)
 
-    result = await repo.get_bot(sample_bot.tg_user_id)
+    result = await notification_bots_repo.get_bot(sample_bot.tg_user_id)
     assert result is not None
     assert result.tg_username == "updated_user"
     assert result.bot_id == 111111111
@@ -62,33 +64,33 @@ async def test_save_bot_upsert(repo, sample_bot):
     assert result.bot_token == "new_token"
 
 
-async def test_delete_bot(repo, sample_bot):
+async def test_delete_bot(notification_bots_repo, sample_bot):
     """Test deleting a bot."""
-    await repo.save_bot(sample_bot)
-    await repo.delete_bot(sample_bot.tg_user_id)
+    await notification_bots_repo.save_bot(sample_bot)
+    await notification_bots_repo.delete_bot(sample_bot.tg_user_id)
 
-    result = await repo.get_bot(sample_bot.tg_user_id)
+    result = await notification_bots_repo.get_bot(sample_bot.tg_user_id)
     assert result is None
 
 
-async def test_delete_nonexistent_bot(repo):
+async def test_delete_nonexistent_bot(notification_bots_repo):
     """Test deleting non-existent bot doesn't raise."""
     # Should not raise
-    await repo.delete_bot(999999999)
+    await notification_bots_repo.delete_bot(999999999)
 
 
-async def test_row_to_model_with_valid_created_at(repo, sample_bot):
+async def test_row_to_model_with_valid_created_at(notification_bots_repo, sample_bot):
     """Test that _row_to_model parses created_at correctly."""
-    await repo.save_bot(sample_bot)
+    await notification_bots_repo.save_bot(sample_bot)
 
-    result = await repo.get_bot(sample_bot.tg_user_id)
+    result = await notification_bots_repo.get_bot(sample_bot.tg_user_id)
     assert result is not None
     # created_at should be set by DB
     assert result.created_at is not None
     assert isinstance(result.created_at, datetime)
 
 
-async def test_row_to_model_with_none_fields(repo):
+async def test_row_to_model_with_none_fields(notification_bots_repo):
     """Test bot with None optional fields."""
     bot = NotificationBot(
         tg_user_id=555555555,
@@ -97,15 +99,15 @@ async def test_row_to_model_with_none_fields(repo):
         bot_username="minimal_bot",
         bot_token="token123",
     )
-    await repo.save_bot(bot)
+    await notification_bots_repo.save_bot(bot)
 
-    result = await repo.get_bot(555555555)
+    result = await notification_bots_repo.get_bot(555555555)
     assert result is not None
     assert result.tg_username is None
     assert result.bot_id is None
 
 
-async def test_multiple_bots(repo):
+async def test_multiple_bots(notification_bots_repo):
     """Test storing multiple bots for different users."""
     bots = [
         NotificationBot(
@@ -125,9 +127,9 @@ async def test_multiple_bots(repo):
     ]
 
     for bot in bots:
-        await repo.save_bot(bot)
+        await notification_bots_repo.save_bot(bot)
 
     for bot in bots:
-        result = await repo.get_bot(bot.tg_user_id)
+        result = await notification_bots_repo.get_bot(bot.tg_user_id)
         assert result is not None
         assert result.bot_username == bot.bot_username

--- a/tests/repositories/test_search_log_repository.py
+++ b/tests/repositories/test_search_log_repository.py
@@ -2,29 +2,34 @@
 
 from __future__ import annotations
 
+import pytest
 
-async def test_log_search(repo):
+from src.database.repositories.search_log import SearchLogRepository
+
+
+
+async def test_log_search(search_log_repo):
     """Test logging a search."""
-    await repo.log_search("+1234567890", "test query", 10)
+    await search_log_repo.log_search("+1234567890", "test query", 10)
 
-    result = await repo.get_recent_searches(limit=1)
+    result = await search_log_repo.get_recent_searches(limit=1)
     assert len(result) == 1
     assert result[0]["query"] == "test query"
     assert result[0]["results_count"] == 10
 
 
-async def test_get_recent_searches_empty(repo):
+async def test_get_recent_searches_empty(search_log_repo):
     """Test getting searches when none exist."""
-    result = await repo.get_recent_searches()
+    result = await search_log_repo.get_recent_searches()
     assert result == []
 
 
-async def test_get_recent_searches(repo):
+async def test_get_recent_searches(search_log_repo):
     """Test getting recent searches."""
-    await repo.log_search("+1111111111", "query1", 5)
-    await repo.log_search("+2222222222", "query2", 10)
+    await search_log_repo.log_search("+1111111111", "query1", 5)
+    await search_log_repo.log_search("+2222222222", "query2", 10)
 
-    result = await repo.get_recent_searches()
+    result = await search_log_repo.get_recent_searches()
     assert len(result) == 2
 
     # Should be ordered by id DESC
@@ -32,23 +37,23 @@ async def test_get_recent_searches(repo):
     assert result[1]["query"] == "query1"
 
 
-async def test_get_recent_searches_limit(repo):
+async def test_get_recent_searches_limit(search_log_repo):
     """Test limit parameter."""
     for i in range(30):
-        await repo.log_search("+1234567890", f"query{i}", i)
+        await search_log_repo.log_search("+1234567890", f"query{i}", i)
 
-    result = await repo.get_recent_searches(limit=10)
+    result = await search_log_repo.get_recent_searches(limit=10)
     assert len(result) == 10
 
     # Should get most recent
     assert result[0]["query"] == "query29"
 
 
-async def test_search_log_fields(repo):
+async def test_search_log_fields(search_log_repo):
     """Test that all fields are returned correctly."""
-    await repo.log_search("+1234567890", "test query", 42)
+    await search_log_repo.log_search("+1234567890", "test query", 42)
 
-    result = await repo.get_recent_searches(limit=1)
+    result = await search_log_repo.get_recent_searches(limit=1)
     assert len(result) == 1
 
     entry = result[0]
@@ -59,9 +64,9 @@ async def test_search_log_fields(repo):
     assert "created_at" in entry
 
 
-async def test_search_log_zero_results(repo):
+async def test_search_log_zero_results(search_log_repo):
     """Test logging search with zero results."""
-    await repo.log_search("+1234567890", "nonexistent", 0)
+    await search_log_repo.log_search("+1234567890", "nonexistent", 0)
 
-    result = await repo.get_recent_searches(limit=1)
+    result = await search_log_repo.get_recent_searches(limit=1)
     assert result[0]["results_count"] == 0

--- a/tests/repositories/test_search_log_repository.py
+++ b/tests/repositories/test_search_log_repository.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-from src.database.repositories.search_log import SearchLogRepository
-
-
 
 async def test_log_search(search_log_repo):
     """Test logging a search."""

--- a/tests/repositories/test_search_queries_repository.py
+++ b/tests/repositories/test_search_queries_repository.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
-from src.database.repositories.search_queries import SearchQueriesRepository
 from src.models import SearchQuery
-
 
 
 def make_query(query: str = "test query", **kwargs) -> SearchQuery:

--- a/tests/repositories/test_search_queries_repository.py
+++ b/tests/repositories/test_search_queries_repository.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
+from src.database.repositories.search_queries import SearchQueriesRepository
 from src.models import SearchQuery
+
 
 
 def make_query(query: str = "test query", **kwargs) -> SearchQuery:
@@ -24,18 +28,18 @@ def make_query(query: str = "test query", **kwargs) -> SearchQuery:
 # add tests
 
 
-async def test_add_basic(repo):
+async def test_add_basic(search_queries_repo):
     """Test adding a basic search query."""
     sq = make_query("hello world")
-    pk = await repo.add(sq)
+    pk = await search_queries_repo.add(sq)
     assert pk > 0
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result is not None
     assert result.query == "hello world"
 
 
-async def test_add_with_all_fields(repo):
+async def test_add_with_all_fields(search_queries_repo):
     """Test adding query with all fields."""
     sq = SearchQuery(
         query="test",
@@ -48,9 +52,9 @@ async def test_add_with_all_fields(repo):
         exclude_patterns="spam\njunk",
         max_length=500,
     )
-    pk = await repo.add(sq)
+    pk = await search_queries_repo.add(sq)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result.is_regex is True
     assert result.is_active is False
     assert result.notify_on_collect is True
@@ -63,42 +67,42 @@ async def test_add_with_all_fields(repo):
 # get_all tests
 
 
-async def test_get_all_empty(repo):
+async def test_get_all_empty(search_queries_repo):
     """Test getting all queries when none exist."""
-    result = await repo.get_all()
+    result = await search_queries_repo.get_all()
     assert result == []
 
 
-async def test_get_all_multiple(repo):
+async def test_get_all_multiple(search_queries_repo):
     """Test getting all queries."""
-    await repo.add(make_query("query1"))
-    await repo.add(make_query("query2"))
-    await repo.add(make_query("query3"))
+    await search_queries_repo.add(make_query("query1"))
+    await search_queries_repo.add(make_query("query2"))
+    await search_queries_repo.add(make_query("query3"))
 
-    result = await repo.get_all()
+    result = await search_queries_repo.get_all()
     assert len(result) == 3
     queries = {q.query for q in result}
     assert queries == {"query1", "query2", "query3"}
 
 
-async def test_get_all_active_only(repo):
+async def test_get_all_active_only(search_queries_repo):
     """Test getting only active queries."""
-    await repo.add(make_query("active1", is_active=True))
-    await repo.add(make_query("inactive", is_active=False))
-    await repo.add(make_query("active2", is_active=True))
+    await search_queries_repo.add(make_query("active1", is_active=True))
+    await search_queries_repo.add(make_query("inactive", is_active=False))
+    await search_queries_repo.add(make_query("active2", is_active=True))
 
-    result = await repo.get_all(active_only=True)
+    result = await search_queries_repo.get_all(active_only=True)
     assert len(result) == 2
     assert all(q.is_active for q in result)
 
 
-async def test_get_all_ordered_by_id(repo):
+async def test_get_all_ordered_by_id(search_queries_repo):
     """Test that queries are ordered by id."""
-    id1 = await repo.add(make_query("first"))
-    id2 = await repo.add(make_query("second"))
-    id3 = await repo.add(make_query("third"))
+    id1 = await search_queries_repo.add(make_query("first"))
+    id2 = await search_queries_repo.add(make_query("second"))
+    id3 = await search_queries_repo.add(make_query("third"))
 
-    result = await repo.get_all()
+    result = await search_queries_repo.get_all()
     assert result[0].id == id1
     assert result[1].id == id2
     assert result[2].id == id3
@@ -107,112 +111,112 @@ async def test_get_all_ordered_by_id(repo):
 # get_by_id tests
 
 
-async def test_get_by_id_found(repo):
+async def test_get_by_id_found(search_queries_repo):
     """Test getting query by id."""
     sq = make_query("test query")
-    pk = await repo.add(sq)
+    pk = await search_queries_repo.add(sq)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result is not None
     assert result.query == "test query"
 
 
-async def test_get_by_id_not_found(repo):
+async def test_get_by_id_not_found(search_queries_repo):
     """Test getting non-existent query."""
-    result = await repo.get_by_id(999)
+    result = await search_queries_repo.get_by_id(999)
     assert result is None
 
 
 # set_active tests
 
 
-async def test_set_active_true(repo):
+async def test_set_active_true(search_queries_repo):
     """Test activating a query."""
-    pk = await repo.add(make_query("test", is_active=False))
-    await repo.set_active(pk, True)
+    pk = await search_queries_repo.add(make_query("test", is_active=False))
+    await search_queries_repo.set_active(pk, True)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result.is_active is True
 
 
-async def test_set_active_false(repo):
+async def test_set_active_false(search_queries_repo):
     """Test deactivating a query."""
-    pk = await repo.add(make_query("test", is_active=True))
-    await repo.set_active(pk, False)
+    pk = await search_queries_repo.add(make_query("test", is_active=True))
+    await search_queries_repo.set_active(pk, False)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result.is_active is False
 
 
 # update tests
 
 
-async def test_update_query(repo):
+async def test_update_query(search_queries_repo):
     """Test updating a query."""
-    pk = await repo.add(make_query("old query"))
+    pk = await search_queries_repo.add(make_query("old query"))
 
     updated = make_query("new query", is_regex=True, interval_minutes=120)
-    await repo.update(pk, updated)
+    await search_queries_repo.update(pk, updated)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result.query == "new query"
     assert result.is_regex is True
     assert result.interval_minutes == 120
 
 
-async def test_update_preserves_id(repo):
+async def test_update_preserves_id(search_queries_repo):
     """Test that update preserves the original id."""
-    pk = await repo.add(make_query("test"))
-    await repo.update(pk, make_query("updated"))
+    pk = await search_queries_repo.add(make_query("test"))
+    await search_queries_repo.update(pk, make_query("updated"))
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result.id == pk
 
 
 # delete tests
 
 
-async def test_delete(repo):
+async def test_delete(search_queries_repo):
     """Test deleting a query."""
-    pk = await repo.add(make_query("test"))
-    await repo.delete(pk)
+    pk = await search_queries_repo.add(make_query("test"))
+    await search_queries_repo.delete(pk)
 
-    result = await repo.get_by_id(pk)
+    result = await search_queries_repo.get_by_id(pk)
     assert result is None
 
 
-async def test_delete_cascades_stats(repo):
+async def test_delete_cascades_stats(search_queries_repo):
     """Test that deleting a query also deletes its stats."""
-    pk = await repo.add(make_query("test"))
-    await repo.record_stat(pk, 10)
+    pk = await search_queries_repo.add(make_query("test"))
+    await search_queries_repo.record_stat(pk, 10)
 
-    await repo.delete(pk)
+    await search_queries_repo.delete(pk)
 
     # Verify stats are gone
-    stats = await repo.get_daily_stats(pk)
+    stats = await search_queries_repo.get_daily_stats(pk)
     assert stats == []
 
 
 # record_stat tests
 
 
-async def test_record_stat(repo):
+async def test_record_stat(search_queries_repo):
     """Test recording a stat."""
-    pk = await repo.add(make_query("test"))
-    await repo.record_stat(pk, 42)
+    pk = await search_queries_repo.add(make_query("test"))
+    await search_queries_repo.record_stat(pk, 42)
 
-    stats = await repo.get_daily_stats(pk, days=1)
+    stats = await search_queries_repo.get_daily_stats(pk, days=1)
     assert len(stats) == 1
     assert stats[0].count == 42
 
 
-async def test_record_stat_replaces_same_day(repo):
+async def test_record_stat_replaces_same_day(search_queries_repo):
     """Test that recording stat for same day replaces previous."""
-    pk = await repo.add(make_query("test"))
-    await repo.record_stat(pk, 10)
-    await repo.record_stat(pk, 20)  # Should replace
+    pk = await search_queries_repo.add(make_query("test"))
+    await search_queries_repo.record_stat(pk, 10)
+    await search_queries_repo.record_stat(pk, 20)  # Should replace
 
-    stats = await repo.get_daily_stats(pk, days=1)
+    stats = await search_queries_repo.get_daily_stats(pk, days=1)
     assert len(stats) == 1
     assert stats[0].count == 20
 
@@ -220,23 +224,23 @@ async def test_record_stat_replaces_same_day(repo):
 # get_daily_stats tests
 
 
-async def test_get_daily_stats_empty(repo):
+async def test_get_daily_stats_empty(search_queries_repo):
     """Test getting daily stats when none exist."""
-    pk = await repo.add(make_query("test"))
-    stats = await repo.get_daily_stats(pk)
+    pk = await search_queries_repo.add(make_query("test"))
+    stats = await search_queries_repo.get_daily_stats(pk)
     assert stats == []
 
 
-async def test_get_daily_stats_multiple_days(repo):
+async def test_get_daily_stats_multiple_days(search_queries_repo):
     """Test getting stats across multiple days."""
-    pk = await repo.add(make_query("test"))
+    pk = await search_queries_repo.add(make_query("test"))
 
     # Insert stats for different days using relative dates
     now = datetime.now(tz=timezone.utc)
     day0 = (now - timedelta(days=2)).strftime("%Y-%m-%d 12:00:00")
     day1 = (now - timedelta(days=1)).strftime("%Y-%m-%d 12:00:00")
     day2 = now.strftime("%Y-%m-%d 12:00:00")
-    await repo._db.executemany(
+    await search_queries_repo._db.executemany(
         "INSERT INTO search_query_stats (query_id, match_count, recorded_at) VALUES (?, ?, ?)",
         [
             (pk, 10, day0),
@@ -244,30 +248,30 @@ async def test_get_daily_stats_multiple_days(repo):
             (pk, 30, day2),
         ],
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    stats = await repo.get_daily_stats(pk, days=7)
+    stats = await search_queries_repo.get_daily_stats(pk, days=7)
     assert len(stats) == 3
     counts = {s.count for s in stats}
     assert counts == {10, 20, 30}
 
 
-async def test_get_daily_stats_aggregates_by_day(repo):
+async def test_get_daily_stats_aggregates_by_day(search_queries_repo):
     """Test that stats are aggregated by day."""
-    pk = await repo.add(make_query("test"))
+    pk = await search_queries_repo.add(make_query("test"))
 
     # Insert multiple stats for same day
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-    await repo._db.executemany(
+    await search_queries_repo._db.executemany(
         "INSERT INTO search_query_stats (query_id, match_count, recorded_at) VALUES (?, ?, ?)",
         [
             (pk, 10, f"{today} 10:00:00"),
             (pk, 20, f"{today} 15:00:00"),
         ],
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    stats = await repo.get_daily_stats(pk, days=7)
+    stats = await search_queries_repo.get_daily_stats(pk, days=7)
     assert len(stats) == 1
     assert stats[0].count == 30  # Sum of both
 
@@ -275,28 +279,28 @@ async def test_get_daily_stats_aggregates_by_day(repo):
 # get_stats_for_all tests
 
 
-async def test_get_stats_for_all_empty(repo):
+async def test_get_stats_for_all_empty(search_queries_repo):
     """Test getting all stats when none exist."""
-    stats = await repo.get_stats_for_all()
+    stats = await search_queries_repo.get_stats_for_all()
     assert stats == {}
 
 
-async def test_get_stats_for_all_multiple_queries(repo):
+async def test_get_stats_for_all_multiple_queries(search_queries_repo):
     """Test getting stats for multiple queries."""
-    pk1 = await repo.add(make_query("query1"))
-    pk2 = await repo.add(make_query("query2"))
+    pk1 = await search_queries_repo.add(make_query("query1"))
+    pk2 = await search_queries_repo.add(make_query("query2"))
 
     today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d 12:00:00")
-    await repo._db.executemany(
+    await search_queries_repo._db.executemany(
         "INSERT INTO search_query_stats (query_id, match_count, recorded_at) VALUES (?, ?, ?)",
         [
             (pk1, 10, today),
             (pk2, 20, today),
         ],
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    stats = await repo.get_stats_for_all(days=7)
+    stats = await search_queries_repo.get_stats_for_all(days=7)
     assert pk1 in stats
     assert pk2 in stats
     assert stats[pk1][0].count == 10
@@ -306,22 +310,22 @@ async def test_get_stats_for_all_multiple_queries(repo):
 # get_last_recorded_at tests
 
 
-async def test_get_last_recorded_at_none(repo):
+async def test_get_last_recorded_at_none(search_queries_repo):
     """Test getting last recorded time when no stats exist."""
-    pk = await repo.add(make_query("test"))
-    result = await repo.get_last_recorded_at(pk)
+    pk = await search_queries_repo.add(make_query("test"))
+    result = await search_queries_repo.get_last_recorded_at(pk)
     assert result is None
 
 
-async def test_get_last_recorded_at(repo):
+async def test_get_last_recorded_at(search_queries_repo):
     """Test getting last recorded time."""
-    pk = await repo.add(make_query("test"))
+    pk = await search_queries_repo.add(make_query("test"))
 
     now = datetime.now(tz=timezone.utc)
     ts_old = (now - timedelta(days=2)).strftime("%Y-%m-%d 12:00:00")
     ts_latest = now.strftime("%Y-%m-%d 18:00:00")
     ts_mid = (now - timedelta(days=1)).strftime("%Y-%m-%d 10:00:00")
-    await repo._db.executemany(
+    await search_queries_repo._db.executemany(
         "INSERT INTO search_query_stats (query_id, match_count, recorded_at) VALUES (?, ?, ?)",
         [
             (pk, 10, ts_old),
@@ -329,39 +333,39 @@ async def test_get_last_recorded_at(repo):
             (pk, 30, ts_mid),
         ],
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    result = await repo.get_last_recorded_at(pk)
+    result = await search_queries_repo.get_last_recorded_at(pk)
     assert result == ts_latest
 
 
 # get_last_recorded_at_all tests
 
 
-async def test_get_last_recorded_at_all_empty(repo):
+async def test_get_last_recorded_at_all_empty(search_queries_repo):
     """Test getting all last recorded times when no stats exist."""
-    result = await repo.get_last_recorded_at_all()
+    result = await search_queries_repo.get_last_recorded_at_all()
     assert result == {}
 
 
-async def test_get_last_recorded_at_all(repo):
+async def test_get_last_recorded_at_all(search_queries_repo):
     """Test getting last recorded times for all queries."""
-    pk1 = await repo.add(make_query("query1"))
-    pk2 = await repo.add(make_query("query2"))
+    pk1 = await search_queries_repo.add(make_query("query1"))
+    pk2 = await search_queries_repo.add(make_query("query2"))
 
     now = datetime.now(tz=timezone.utc)
     ts1 = (now - timedelta(days=1)).strftime("%Y-%m-%d 12:00:00")
     ts2 = now.strftime("%Y-%m-%d 18:00:00")
-    await repo._db.executemany(
+    await search_queries_repo._db.executemany(
         "INSERT INTO search_query_stats (query_id, match_count, recorded_at) VALUES (?, ?, ?)",
         [
             (pk1, 10, ts1),
             (pk2, 20, ts2),
         ],
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    result = await repo.get_last_recorded_at_all()
+    result = await search_queries_repo.get_last_recorded_at_all()
     assert result[pk1] == ts1
     assert result[pk2] == ts2
 
@@ -369,66 +373,66 @@ async def test_get_last_recorded_at_all(repo):
 # get_notification_queries tests
 
 
-async def test_get_notification_queries_empty(repo):
+async def test_get_notification_queries_empty(search_queries_repo):
     """Test getting notification queries when none exist."""
-    result = await repo.get_notification_queries()
+    result = await search_queries_repo.get_notification_queries()
     assert result == []
 
 
-async def test_get_notification_queries(repo):
+async def test_get_notification_queries(search_queries_repo):
     """Test getting queries with notify_on_collect."""
-    await repo.add(make_query("notify1", notify_on_collect=True))
-    await repo.add(make_query("no_notify", notify_on_collect=False))
-    await repo.add(make_query("notify2", notify_on_collect=True))
+    await search_queries_repo.add(make_query("notify1", notify_on_collect=True))
+    await search_queries_repo.add(make_query("no_notify", notify_on_collect=False))
+    await search_queries_repo.add(make_query("notify2", notify_on_collect=True))
 
-    result = await repo.get_notification_queries()
+    result = await search_queries_repo.get_notification_queries()
     assert len(result) == 2
     queries = {q.query for q in result}
     assert queries == {"notify1", "notify2"}
 
 
-async def test_get_notification_queries_active_only(repo):
+async def test_get_notification_queries_active_only(search_queries_repo):
     """Test that notification queries can filter by active."""
-    await repo.add(make_query("active_notify", notify_on_collect=True, is_active=True))
-    await repo.add(make_query("inactive_notify", notify_on_collect=True, is_active=False))
+    await search_queries_repo.add(make_query("active_notify", notify_on_collect=True, is_active=True))
+    await search_queries_repo.add(make_query("inactive_notify", notify_on_collect=True, is_active=False))
 
-    result = await repo.get_notification_queries(active_only=True)
+    result = await search_queries_repo.get_notification_queries(active_only=True)
     assert len(result) == 1
     assert result[0].query == "active_notify"
 
 
-async def test_get_notification_queries_all(repo):
+async def test_get_notification_queries_all(search_queries_repo):
     """Test getting all notification queries including inactive."""
-    await repo.add(make_query("active_notify", notify_on_collect=True, is_active=True))
-    await repo.add(make_query("inactive_notify", notify_on_collect=True, is_active=False))
+    await search_queries_repo.add(make_query("active_notify", notify_on_collect=True, is_active=True))
+    await search_queries_repo.add(make_query("inactive_notify", notify_on_collect=True, is_active=False))
 
-    result = await repo.get_notification_queries(active_only=False)
+    result = await search_queries_repo.get_notification_queries(active_only=False)
     assert len(result) == 2
 
 
 # _row_to_model tests
 
 
-async def test_row_to_model_handles_null_is_fts(repo):
+async def test_row_to_model_handles_null_is_fts(search_queries_repo):
     """Test that null is_fts is handled correctly."""
     # Directly insert with null is_fts
-    await repo._db.execute(
+    await search_queries_repo._db.execute(
         "INSERT INTO search_queries"
         " (query, name, is_regex, is_fts, is_active,"
         " notify_on_collect, track_stats, interval_minutes)"
         " VALUES (?, ?, ?, NULL, ?, ?, ?, ?)",
         ("test", "test", 0, 1, 0, 1, 60),
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    result = await repo.get_all()
+    result = await search_queries_repo.get_all()
     assert len(result) == 1
     assert result[0].is_fts is False  # NULL -> False
 
 
-async def test_row_to_model_handles_null_exclude_patterns(repo):
+async def test_row_to_model_handles_null_exclude_patterns(search_queries_repo):
     """Test that null exclude_patterns is handled correctly."""
-    await repo._db.execute(
+    await search_queries_repo._db.execute(
         "INSERT INTO search_queries"
         " (query, name, is_regex, is_fts, is_active,"
         " notify_on_collect, track_stats, interval_minutes,"
@@ -436,16 +440,16 @@ async def test_row_to_model_handles_null_exclude_patterns(repo):
         " VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)",
         ("test", "test", 0, 0, 1, 0, 1, 60),
     )
-    await repo._db.commit()
+    await search_queries_repo._db.commit()
 
-    result = await repo.get_all()
+    result = await search_queries_repo.get_all()
     assert len(result) == 1
     assert result[0].exclude_patterns == ""
 
 
-async def test_row_to_model_created_at(repo):
+async def test_row_to_model_created_at(search_queries_repo):
     """Test that created_at is properly parsed."""
-    pk = await repo.add(make_query("test"))
-    result = await repo.get_by_id(pk)
+    pk = await search_queries_repo.add(make_query("test"))
+    result = await search_queries_repo.get_by_id(pk)
     assert result.created_at is not None
     assert isinstance(result.created_at, datetime)

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -2,51 +2,56 @@
 
 from __future__ import annotations
 
+import pytest
 
-async def test_get_setting_not_found(repo):
+from src.database.repositories.settings import SettingsRepository
+
+
+
+async def test_get_setting_not_found(settings_repo):
     """Test getting non-existent setting returns None."""
-    result = await repo.get_setting("nonexistent_key")
+    result = await settings_repo.get_setting("nonexistent_key")
     assert result is None
 
 
-async def test_set_and_get_setting(repo):
+async def test_set_and_get_setting(settings_repo):
     """Test setting and getting a value."""
-    await repo.set_setting("test_key", "test_value")
-    result = await repo.get_setting("test_key")
+    await settings_repo.set_setting("test_key", "test_value")
+    result = await settings_repo.get_setting("test_key")
     assert result == "test_value"
 
 
-async def test_set_setting_upsert(repo):
+async def test_set_setting_upsert(settings_repo):
     """Test that set_setting updates existing value."""
-    await repo.set_setting("key1", "value1")
-    await repo.set_setting("key1", "value2")
-    result = await repo.get_setting("key1")
+    await settings_repo.set_setting("key1", "value1")
+    await settings_repo.set_setting("key1", "value2")
+    result = await settings_repo.get_setting("key1")
     assert result == "value2"
 
 
-async def test_set_setting_empty_string(repo):
+async def test_set_setting_empty_string(settings_repo):
     """Test setting empty string value."""
-    await repo.set_setting("empty_key", "")
-    result = await repo.get_setting("empty_key")
+    await settings_repo.set_setting("empty_key", "")
+    result = await settings_repo.get_setting("empty_key")
     assert result == ""
 
 
-async def test_set_setting_unicode(repo):
+async def test_set_setting_unicode(settings_repo):
     """Test setting unicode value."""
-    await repo.set_setting("unicode_key", "Значение на русском 🎉")
-    result = await repo.get_setting("unicode_key")
+    await settings_repo.set_setting("unicode_key", "Значение на русском 🎉")
+    result = await settings_repo.get_setting("unicode_key")
     assert result == "Значение на русском 🎉"
 
 
-async def test_set_setting_long_value(repo):
+async def test_set_setting_long_value(settings_repo):
     """Test setting long value."""
     long_value = "x" * 10000
-    await repo.set_setting("long_key", long_value)
-    result = await repo.get_setting("long_key")
+    await settings_repo.set_setting("long_key", long_value)
+    result = await settings_repo.get_setting("long_key")
     assert result == long_value
 
 
-async def test_roundtrip_multiple_settings(repo):
+async def test_roundtrip_multiple_settings(settings_repo):
     """Test multiple settings roundtrip."""
     settings = {
         "key1": "value1",
@@ -54,17 +59,17 @@ async def test_roundtrip_multiple_settings(repo):
         "key3": "value3",
     }
     for k, v in settings.items():
-        await repo.set_setting(k, v)
+        await settings_repo.set_setting(k, v)
 
     for k, v in settings.items():
-        result = await repo.get_setting(k)
+        result = await settings_repo.get_setting(k)
         assert result == v
 
 
-async def test_get_setting_case_sensitive(repo):
+async def test_get_setting_case_sensitive(settings_repo):
     """Test that keys are case-sensitive."""
-    await repo.set_setting("TestKey", "value1")
-    await repo.set_setting("testkey", "value2")
+    await settings_repo.set_setting("TestKey", "value1")
+    await settings_repo.set_setting("testkey", "value2")
 
-    assert await repo.get_setting("TestKey") == "value1"
-    assert await repo.get_setting("testkey") == "value2"
+    assert await settings_repo.get_setting("TestKey") == "value1"
+    assert await settings_repo.get_setting("testkey") == "value2"

--- a/tests/repositories/test_settings_repository.py
+++ b/tests/repositories/test_settings_repository.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-from src.database.repositories.settings import SettingsRepository
-
-
 
 async def test_get_setting_not_found(settings_repo):
     """Test getting non-existent setting returns None."""

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked auth."""

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked auth."""
@@ -39,7 +38,6 @@ async def client(base_app):
     ) as c:
         yield c
 
-
 @pytest.fixture
 async def client_unconfigured(base_app):
     """Create test client with unconfigured auth."""
@@ -62,6 +60,7 @@ async def client_unconfigured(base_app):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
+
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -37,7 +37,6 @@ async def client(base_app):
     ) as c:
         yield c
 
-
 @pytest.fixture
 async def client_no_buffer(base_app):
     """Create test client without log buffer."""
@@ -64,6 +63,7 @@ async def client_no_buffer(base_app):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
+
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -48,7 +48,6 @@ async def client(base_app):
         ]
     )
     pool_mock.leave_channels = AsyncMock(return_value={-100111: True, -100222: True})
-
     await db.add_account(Account(phone="+9876543210", session_string="test_session2"))
 
     transport = ASGITransport(app=app)
@@ -60,6 +59,7 @@ async def client(base_app):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
+
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient

--- a/tests/routes/test_import_channels_routes.py
+++ b/tests/routes/test_import_channels_routes.py
@@ -10,7 +10,6 @@ from httpx import ASGITransport, AsyncClient
 
 from src.models import Channel
 
-
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked pool."""
@@ -46,7 +45,6 @@ async def client(base_app):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
-
 
 @pytest.fixture
 async def client_no_resolve(client):

--- a/tests/routes/test_import_channels_routes.py
+++ b/tests/routes/test_import_channels_routes.py
@@ -10,6 +10,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.models import Channel
 
+
 @pytest.fixture
 async def client(base_app):
     """Create test client with mocked pool."""

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -10,6 +10,8 @@ from httpx import ASGITransport, AsyncClient
 
 from src.database import Database
 from src.models import (
+    Account,
+    Channel,
     ContentPipeline,
     PipelineGenerationBackend,
     PipelinePublishMode,
@@ -20,7 +22,8 @@ from src.services.publish_service import PublishResult
 
 @pytest.fixture
 async def client(base_app):
-    app, _, pool_mock = base_app
+    app, db, pool_mock = base_app
+
     pool_mock.clients = {"+1234567890": MagicMock()}
     pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
 
@@ -34,6 +37,7 @@ async def client(base_app):
     ) as c:
         c._transport_app = app
         yield c
+
 
 
 async def _create_pipeline(db: Database, *, publish_mode: PipelinePublishMode) -> int:

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -10,8 +10,6 @@ from httpx import ASGITransport, AsyncClient
 
 from src.database import Database
 from src.models import (
-    Account,
-    Channel,
     ContentPipeline,
     PipelineGenerationBackend,
     PipelinePublishMode,

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -23,6 +23,7 @@ _ADD_DATA = {
 @pytest.fixture
 async def client(base_app):
     app, db, pool_mock = base_app
+
     pool_mock.clients = {"+1234567890": MagicMock()}
     pool_mock.get_dialogs_for_phone = AsyncMock(return_value=[])
     await db.repos.dialog_cache.replace_dialogs(
@@ -39,6 +40,7 @@ async def client(base_app):
         headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
     ) as c:
         yield c
+
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -38,6 +38,7 @@ async def client(base_app):
         yield c
 
 
+
 @pytest.mark.asyncio
 async def test_scheduler_page(client):
     """Test scheduler page renders."""

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -400,7 +400,7 @@ async def test_collect_all_stats(db):
     assert result["errors"] == 0
 
 
-def test_cli_channel_stats_no_args(capsys):
+def test_cli_channel_stats_no_args(cli_init_patch, capsys):
     """Calling `channel stats` without identifier or --all should not crash."""
     import argparse
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -421,16 +421,11 @@ def test_cli_channel_stats_no_args(capsys):
     mock_pool.clients = {"phone": True}
     mock_pool.disconnect_all = AsyncMock()
 
-    async def fake_init_db(config_path):
-        from src.config import AppConfig
-
-        return AppConfig(), mock_db
-
     async def fake_init_pool(config, db):
         return config, mock_pool
 
     with (
-        patch("src.main._init_db", fake_init_db),
+        cli_init_patch(mock_db, "src.main._init_db"),
         patch("src.main._init_pool", fake_init_pool),
     ):
         cmd_channel(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from tests.helpers import cli_add_channel as _add_channel
 from tests.helpers import cli_ns as _ns
 
 NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+pytestmark = pytest.mark.aiosqlite_serial
 
 
 @pytest.fixture
@@ -473,7 +474,12 @@ class TestCLISearch:
 
 
 class TestCLIAgentDbProviders:
-    def test_chat_refreshes_db_backed_provider_cache_before_initialize(self, cli_env, cli_init_patch, capsys):
+    def test_chat_refreshes_db_backed_provider_cache_before_initialize(
+        self,
+        cli_env,
+        cli_init_patch,
+        capsys,
+    ):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.cli.commands.agent import run
         from src.services.agent_provider_service import AgentProviderService
@@ -1196,7 +1202,12 @@ class TestCLIAgent:
         assert "model reply" in out
         assert captured_opts.get("model") == "claude-haiku-4-5-20251001"
 
-    def test_test_escaping_uses_runtime_config_for_db_providers(self, cli_db, cli_init_patch, capsys):
+    def test_test_escaping_uses_runtime_config_for_db_providers(
+        self,
+        cli_db,
+        cli_init_patch,
+        capsys,
+    ):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.cli.commands.agent import run
         from src.services.agent_provider_service import AgentProviderService

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -13,6 +13,8 @@ from src.config import AppConfig
 from src.models import Channel, ChannelStats, CollectionTaskStatus
 from src.telegram.flood_wait import FloodWaitInfo
 
+pytestmark = pytest.mark.aiosqlite_serial
+
 
 def _ns(**kwargs) -> argparse.Namespace:
     defaults = {"config": "config.yaml"}

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -32,6 +32,12 @@ def _chan(channel_id, title, username="", ch_type="channel", deactivate=False):
     }
 
 
+def _ensure_db_open(db):
+    """Re-open cli_db if the CLI command closed its connection."""
+    if db._connection.db is None:
+        asyncio.run(db.initialize())
+
+
 @pytest.fixture
 def cli_env(cli_db, cli_init_patch):
     with cli_init_patch(
@@ -39,7 +45,6 @@ def cli_env(cli_db, cli_init_patch):
         "src.cli.commands.channel.runtime.init_db",
         "src.cli.commands.test.runtime.init_db",
         config=AppConfig(),
-        fresh_database=True,
     ):
         yield cli_db
 
@@ -85,6 +90,7 @@ class TestCLIChannelExtended:
         assert "Added channel: New Channel (12345)" in out
 
         # Verify it was added to DB
+        _ensure_db_open(db)
         ch = asyncio.run(db.get_channel_by_channel_id(12345))
         assert ch is not None
         assert ch.title == "New Channel"
@@ -104,6 +110,7 @@ class TestCLIChannelExtended:
         out = capsys.readouterr().out
         assert "WARN: deactivated, type=scam" in out
 
+        _ensure_db_open(db)
         ch = asyncio.run(db.get_channel_by_channel_id(67890))
         assert ch is not None
         assert ch.is_active is False
@@ -231,6 +238,7 @@ class TestCLIChannelExtended:
         assert "OK: T1 → supergroup" in out
         assert "DEACTIVATED (scam): T2" in out
 
+        _ensure_db_open(db)
         ch1 = asyncio.run(db.get_channel_by_channel_id(101))
         assert ch1.channel_type == "supergroup"
         ch2 = asyncio.run(db.get_channel_by_channel_id(102))
@@ -352,6 +360,7 @@ class TestCLIChannelExtended:
         assert "Collected 42 messages" in out
 
         # Verify task status
+        _ensure_db_open(db)
         tasks = asyncio.run(db.get_collection_tasks(limit=1))
         assert tasks[0].status == CollectionTaskStatus.COMPLETED
         assert tasks[0].messages_collected == 42
@@ -462,6 +471,7 @@ class TestCLIChannelExtended:
                         identifier=str(ch_id),
                     )
                 )
+        _ensure_db_open(db)
         tasks = asyncio.run(db.get_collection_tasks(limit=1))
         assert tasks[0].status == CollectionTaskStatus.FAILED
         assert "collect fail" in tasks[0].error

--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -12,6 +12,8 @@ from src.config import AppConfig
 from src.database import Database
 from src.models import Channel, NotificationBot
 
+pytestmark = pytest.mark.aiosqlite_serial
+
 
 @pytest.fixture
 def cli_env_with_pool(cli_env):

--- a/tests/test_cli_filter.py
+++ b/tests/test_cli_filter.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from src.database import Database
 from src.models import Account, Channel
 

--- a/tests/test_cli_filter.py
+++ b/tests/test_cli_filter.py
@@ -5,8 +5,11 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from src.database import Database
 from src.models import Account, Channel
+
+pytestmark = pytest.mark.aiosqlite_serial
 
 _FILTER_INIT_DB_TARGET = "src.cli.commands.filter.runtime.init_db"
 
@@ -73,8 +76,6 @@ def test_filter_analyze(tmp_path, cli_init_patch, capsys):
     asyncio.run(db.initialize())
     asyncio.run(db.add_account(Account(phone="+100", session_string="sess")))
     asyncio.run(db.add_channel(Channel(channel_id=1001, title="Test Channel")))
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -99,8 +100,6 @@ def test_filter_apply(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_apply.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -122,8 +121,6 @@ def test_filter_precheck(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_precheck.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -143,8 +140,6 @@ def test_filter_reset(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_reset.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -164,8 +159,6 @@ def test_filter_purge_all(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_purge.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -189,8 +182,6 @@ def test_filter_purge_by_pks(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_purge_pks.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -214,8 +205,6 @@ def test_filter_purge_invalid_pks(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_purge_invalid.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -230,8 +219,6 @@ def test_filter_hard_delete_requires_dev_mode(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "filter_hard_delete_dev.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
-
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         from src.cli.commands.filter import run
 
@@ -247,6 +234,7 @@ def test_filter_no_action(cli_init_patch, capsys):
 
     db = MagicMock()
     db.close = AsyncMock()
+
     with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
         run(_ns(filter_action=None))
 

--- a/tests/test_cli_photo_loader.py
+++ b/tests/test_cli_photo_loader.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from src.database import Database
 from src.models import Account
 

--- a/tests/test_cli_photo_loader.py
+++ b/tests/test_cli_photo_loader.py
@@ -5,8 +5,11 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from src.database import Database
 from src.models import Account
+
+pytestmark = pytest.mark.aiosqlite_serial
 
 _PHOTO_LOADER_INIT_DB_TARGET = "src.cli.commands.photo_loader.runtime.init_db"
 
@@ -84,7 +87,6 @@ def test_dialogs_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -142,7 +144,6 @@ def test_send_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -185,7 +186,6 @@ def test_schedule_send_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -229,7 +229,6 @@ def test_batch_create_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -274,7 +273,6 @@ def test_batch_list_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -313,7 +311,6 @@ def test_auto_create_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -355,7 +352,6 @@ def test_auto_list_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -399,7 +395,6 @@ def test_auto_toggle_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -433,7 +428,6 @@ def test_auto_toggle_not_found(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -462,7 +456,6 @@ def test_run_due_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -495,7 +488,6 @@ def test_auto_delete_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -524,7 +516,6 @@ def test_batch_cancel_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -553,7 +544,6 @@ def test_auto_update_action(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _setup_photo_db(db)
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -35,8 +35,6 @@ from tests.helpers import (
     make_test_config,
 )
 
-pytestmark = pytest.mark.aiosqlite_serial
-
 
 def _photo_dialog_from_spec(spec: dict) -> MagicMock:
     entity = SimpleNamespace(
@@ -762,6 +760,7 @@ def test_photo_loader_cli_parser():
     assert args.mode == "album"
 
 
+@pytest.mark.aiosqlite_serial
 def test_photo_loader_cli_send_command(tmp_path, cli_init_patch, capsys):
     image = tmp_path / "one.jpg"
     image.write_bytes(b"x")

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -35,6 +35,8 @@ from tests.helpers import (
     make_test_config,
 )
 
+pytestmark = pytest.mark.aiosqlite_serial
+
 
 def _photo_dialog_from_spec(spec: dict) -> MagicMock:
     entity = SimpleNamespace(
@@ -778,7 +780,7 @@ def test_photo_loader_cli_send_command(tmp_path, cli_init_patch, capsys):
         return TelegramAuth(0, ""), fake_pool
 
     with (
-        cli_init_patch(db, "src.cli.runtime.init_db"),
+        cli_init_patch(db, "src.cli.runtime.init_db", config=AppConfig()),
         patch("src.cli.runtime.init_pool", side_effect=fake_init_pool),
     ):
         from src.cli.commands.photo_loader import run

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from src.database import Database
 from src.models import (
     Account,
@@ -16,10 +17,9 @@ from src.models import (
 )
 from src.services.publish_service import PublishResult
 
-_PIPELINE_INIT_DB_TARGETS = (
-    "src.cli.runtime.init_db",
-    "src.cli.commands.pipeline.runtime.init_db",
-)
+pytestmark = pytest.mark.aiosqlite_serial
+
+_PIPELINE_INIT_DB_TARGETS = ("src.cli.runtime.init_db", "src.cli.commands.pipeline.runtime.init_db")
 
 
 def _ns(**kwargs) -> argparse.Namespace:
@@ -51,7 +51,6 @@ def test_pipeline_add_and_list(tmp_path, cli_init_patch, capsys):
     db = Database(db_path)
     asyncio.run(db.initialize())
     _add_pipeline_prereqs(db)
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -82,7 +81,6 @@ def test_pipeline_show_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_not_found.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -119,7 +117,6 @@ def test_pipeline_queue_approve_reject_and_publish(tmp_path, cli_init_patch, cap
     )
     run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated draft for CLI"))
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -165,7 +162,6 @@ def test_pipeline_publish_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_publish_not_found.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -201,7 +197,6 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, cli_init_patch, capsys
             ],
         )
     )
-    asyncio.run(db.close())
 
     class FakeContentGenerationService:
         def __init__(self, db, engine, agent_manager=None, **kwargs):
@@ -267,7 +262,6 @@ def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, cli_ini
             ],
         )
     )
-    asyncio.run(db.close())
 
     captured = {}
 
@@ -340,7 +334,6 @@ def test_pipeline_runs_and_run_show(tmp_path, cli_init_patch, capsys):
     )
     run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated draft for CLI"))
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -384,7 +377,6 @@ def test_pipeline_show_found(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -423,7 +415,6 @@ def test_pipeline_edit_found(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -454,7 +445,6 @@ def test_pipeline_edit_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_edit_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -506,7 +496,6 @@ def test_pipeline_toggle_found(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -522,7 +511,6 @@ def test_pipeline_toggle_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_toggle_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -558,7 +546,6 @@ def test_pipeline_delete(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -595,7 +582,6 @@ def test_pipeline_run_with_preview(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     class FakeGenerationService:
         def __init__(self, engine, provider_callable=None):
@@ -633,7 +619,6 @@ def test_pipeline_run_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_run_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -671,7 +656,6 @@ def test_pipeline_runs_with_status_filter(tmp_path, cli_init_patch, capsys):
     )
     run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Test output"))
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -688,7 +672,6 @@ def test_pipeline_runs_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_runs_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -724,7 +707,6 @@ def test_pipeline_queue_empty(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -740,7 +722,6 @@ def test_pipeline_queue_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_queue_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -778,7 +759,6 @@ def test_pipeline_publish_no_clients(tmp_path, cli_init_patch, capsys):
     )
     run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
     asyncio.run(db.repos.generation_runs.save_result(run_id, "Generated text"))
-    asyncio.run(db.close())
 
     async def fake_init_pool(_config, _db):
         pool = MagicMock()
@@ -803,7 +783,6 @@ def test_pipeline_run_show_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_runshow_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -819,7 +798,6 @@ def test_pipeline_approve_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_approve_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -835,7 +813,6 @@ def test_pipeline_reject_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_reject_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -851,7 +828,6 @@ def test_pipeline_generate_not_found(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_generate_nf.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run
@@ -887,7 +863,6 @@ def test_pipeline_generate_exception(tmp_path, cli_init_patch, capsys):
             ],
         )
     )
-    asyncio.run(db.close())
 
     class FakeContentGenerationService:
         def __init__(self, *args, **kwargs):
@@ -913,7 +888,6 @@ def test_pipeline_list_empty(tmp_path, cli_init_patch, capsys):
     db_path = str(tmp_path / "cli_pipeline_list_empty.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
-    asyncio.run(db.close())
 
     with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
         from src.cli.commands.pipeline import run

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -5,6 +5,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from src.database import Database
 from src.models import (
     Account,


### PR DESCRIPTION
Closes #228

## Summary
- Refactor test infrastructure: add shared `cli_init_patch` fixture and route `aiosqlite_serial` tests into a single xdist group
- Replace ad hoc CLI `fake_init_db` patches with the shared helper in affected test modules
- Add named repository fixtures in `tests/repositories/conftest.py` and switch repository tests away from the generic `repo` fixture
- Move targeted route tests to shared `base_app` setup instead of rebuilding app state per file
- Add ~400+ new tests covering pipeline nodes/handlers, CLI commands (provider/settings/translate/main), services (unified_dispatcher, content_generation, pipeline_service, image_generation, task_enqueuer), web routes (rss, images), repositories (generated_images, pipeline_templates, photo_loader), db connection, migrations, and web timing

## Testing
- `python3 -m pytest tests -q -m 'not aiosqlite_serial' -n auto`
- `python3 -m pytest tests -q -m aiosqlite_serial`

🤖 Generated with [Claude Code](https://claude.com/claude-code)