### PR TITLE
fix(telegram): add grace period in disconnect_all to prevent Task destroyed warnings

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -508,6 +508,7 @@ class ClientPool:
         return set(self._premium_flood_wait_until)
 
     async def disconnect_all(self) -> None:
+        had_clients = bool(self.clients)
         for phone in list(self.clients):
             try:
                 await asyncio.wait_for(self.remove_client(phone), timeout=5.0)
@@ -520,7 +521,8 @@ class ClientPool:
             except Exception:
                 logger.debug("Error disconnecting %s", phone, exc_info=True)
         # Allow Telethon internal tasks (_send_loop, _recv_loop) to finish
-        await asyncio.sleep(0.25)
+        if had_clients:
+            await asyncio.sleep(0.25)
 
     @staticmethod
     def _normalize_runtime_config(

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -519,6 +519,8 @@ class ClientPool:
                 self._dialogs_fetched.discard(phone)
             except Exception:
                 logger.debug("Error disconnecting %s", phone, exc_info=True)
+        # Allow Telethon internal tasks (_send_loop, _recv_loop) to finish
+        await asyncio.sleep(0.25)
 
     @staticmethod
     def _normalize_runtime_config(


### PR DESCRIPTION
## Summary
- Add `await asyncio.sleep(0.25)` at the end of `ClientPool.disconnect_all()` to give the event loop time to drain Telethon's internal tasks (`_send_loop`, `_recv_loop`) before `asyncio.run()` closes
- Eliminates `Task was destroyed but it is pending!` and `RuntimeError: coroutine ignored GeneratorExit` errors on exit from `agent chat` and other CLI commands

## Test plan
- [x] `ruff check src/telegram/client_pool.py` — passed
- [x] `pytest tests/ -v -k "client_pool or pool" -n auto` — 244 passed
- [ ] Manual: `python -m src.main agent chat` → send message → Ctrl+Q → no "Task was destroyed" in stderr/logs

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)