### PR TITLE
fix(pipelines): disable LLM sections when no provider is configured (#333)

### DIFF
--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -116,6 +116,10 @@ class AgentProviderService:
                 logger.debug("Failed to register %s adapter", adapter_name, exc_info=True)
 
 
+    def has_providers(self) -> bool:
+        """Return True if any real (non-default) provider is registered."""
+        return any(name != "default" for name in self._registry)
+
     def register_provider(self, name: str, func: Callable[..., Awaitable[str]]) -> None:
         self._registry[name] = func
 

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -209,6 +209,10 @@ async def delete_pipeline(request: Request, pipeline_id: int):
 
 @router.post("/{pipeline_id}/run")
 async def run_pipeline(request: Request, pipeline_id: int):
+    from src.services.provider_service import AgentProviderService
+
+    if not AgentProviderService(deps.get_db(request)).has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
     svc = deps.pipeline_service(request)
     pipeline = await svc.get(pipeline_id)
     if pipeline is None:
@@ -255,6 +259,8 @@ async def generate_stream(
     from src.services.provider_service import AgentProviderService
 
     provider_service = AgentProviderService(db)
+    if not provider_service.has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService
@@ -323,6 +329,8 @@ async def generate_pipeline(
     from src.services.provider_service import AgentProviderService
 
     provider_service = AgentProviderService(db)
+    if not provider_service.has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -522,6 +522,10 @@ async def import_pipeline(
 @router.post("/{pipeline_id}/ai-edit")
 async def ai_edit_pipeline(request: Request, pipeline_id: int):
     """Accept JSON body: {"instruction": "..."}. Returns updated pipeline_json."""
+    from src.services.provider_service import AgentProviderService
+
+    if not AgentProviderService(deps.get_db(request)).has_providers():
+        return JSONResponse(content={"ok": False, "error": "LLM not configured"}, status_code=400)
     svc: PipelineService = deps.pipeline_service(request)
     db = deps.get_db(request)
     try:

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -46,6 +46,8 @@ def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
 
 
 async def _page_context(request: Request) -> dict:
+    from src.services.provider_service import AgentProviderService
+
     svc = deps.pipeline_service(request)
     channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
     accounts = await deps.get_account_bundle(request).list_accounts()
@@ -82,6 +84,7 @@ async def _page_context(request: Request) -> dict:
         "publish_modes": list(PipelinePublishMode),
         "generation_backends": list(PipelineGenerationBackend),
         "next_runs": next_runs,
+        "llm_configured": AgentProviderService(deps.get_db(request)).has_providers(),
     }
 
 

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -41,9 +41,16 @@
     </div>
 </div>
 
+{% if not llm_configured %}
+<div class="alert alert-warning" role="alert">
+    LLM-провайдер не настроен — генерация контента недоступна. Настройте провайдер в <a href="/settings" class="alert-link">Настройки → Провайдеры</a>.
+</div>
+{% endif %}
+
 <div class="card mb-4">
     <div class="card-header fw-semibold">Новый pipeline</div>
     <div class="card-body">
+    {% if llm_configured %}
         <form method="post" action="/pipelines/add{% if selected_phone %}?phone={{ selected_phone|urlencode }}{% endif %}" data-busy>
             <div class="row g-3 mb-3">
                 <div class="col-12 col-lg-6">
@@ -136,6 +143,9 @@
             </div>
             <button type="submit" class="btn btn-primary">Создать pipeline</button>
         </form>
+    {% else %}
+        <p class="text-muted mb-0">Настройте LLM провайдер для создания пайплайнов.</p>
+    {% endif %}
     </div>
 </div>
 
@@ -188,16 +198,16 @@
                     {% if not pipeline.pipeline_json %}
                     <button type="button" class="btn btn-outline-secondary btn-sm" onclick="togglePipelineEdit({{ pipeline.id }})">Редактировать</button>
                     {% endif %}
-                    <a class="btn btn-outline-primary btn-sm" href="/pipelines/{{ pipeline.id }}/generate">Generate</a>
+                    <a class="btn btn-outline-primary btn-sm{% if not llm_configured %} disabled{% endif %}" href="/pipelines/{{ pipeline.id }}/generate" {% if not llm_configured %}aria-disabled="true" title="Настройте LLM провайдер"{% endif %}>Generate</a>
                     <form method="post" action="/pipelines/{{ pipeline.id }}/run" class="d-inline" data-busy>
-                        <button type="submit" class="btn btn-outline-success btn-sm">Run now</button>
+                        <button type="submit" class="btn btn-outline-success btn-sm" {% if not llm_configured %}disabled title="Настройте LLM провайдер"{% endif %}>Run now</button>
                     </form>
                     <form method="post" action="/pipelines/{{ pipeline.id }}/toggle" class="d-inline" data-busy>
                         <button type="submit" class="btn btn-outline-secondary btn-sm">{{ "Выключить" if pipeline.is_active else "Включить" }}</button>
                     </form>
                     <a class="btn btn-outline-dark btn-sm" href="/pipelines/{{ pipeline.id }}/export" title="Экспорт JSON">JSON</a>
                     {% if pipeline.pipeline_json %}
-                    <button type="button" class="btn btn-outline-info btn-sm" onclick="toggleAiEdit({{ pipeline.id }})" title="Редактировать через AI">AI</button>
+                    <button type="button" class="btn btn-outline-info btn-sm" {% if llm_configured %}onclick="toggleAiEdit({{ pipeline.id }})"{% else %}disabled{% endif %} title="{% if llm_configured %}Редактировать через AI{% else %}Настройте LLM провайдер{% endif %}">AI</button>
                     {% endif %}
                     <form method="post" action="/pipelines/{{ pipeline.id }}/delete{% if selected_phone %}?phone={{ selected_phone|urlencode }}{% endif %}" class="d-inline" data-busy onsubmit="return confirm('Удалить pipeline?')">
                         <button type="submit" class="btn btn-outline-danger btn-sm">Удалить</button>

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -43,7 +43,7 @@
 
 {% if not llm_configured %}
 <div class="alert alert-warning" role="alert">
-    LLM-провайдер не настроен — генерация контента недоступна. Настройте провайдер в <a href="/settings" class="alert-link">Настройки → Провайдеры</a>.
+    LLM-провайдер не настроен — генерация контента недоступна. Установите переменную окружения с ключом API (например, <code>OPENAI_API_KEY</code>, <code>COHERE_API_KEY</code>) и перезапустите сервер.
 </div>
 {% endif %}
 

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -106,7 +106,10 @@ async def test_edit_pipeline(client):
 @pytest.mark.asyncio
 async def test_run_pipeline_not_found(client):
     """Test run pipeline with invalid ID."""
-    resp = await client.post("/pipelines/999999/run", follow_redirects=False)
+    from unittest.mock import patch
+
+    with patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True):
+        resp = await client.post("/pipelines/999999/run", follow_redirects=False)
     assert resp.status_code == 303
     assert "error=pipeline_invalid" in resp.headers["location"]
 
@@ -118,15 +121,16 @@ async def test_run_pipeline_enqueues(client):
 
     await client.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
-        mock_svc.return_value.get = AsyncMock(
-            return_value=MagicMock(id=1, is_active=True)
-        )
-        with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
-            mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
-            resp = await client.post("/pipelines/1/run", follow_redirects=False)
-            assert resp.status_code == 303
-            assert "msg=pipeline_run_enqueued" in resp.headers["location"]
+    with patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True):
+        with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+            mock_svc.return_value.get = AsyncMock(
+                return_value=MagicMock(id=1, is_active=True)
+            )
+            with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+                mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
+                resp = await client.post("/pipelines/1/run", follow_redirects=False)
+                assert resp.status_code == 303
+                assert "msg=pipeline_run_enqueued" in resp.headers["location"]
 
 
 @pytest.mark.asyncio
@@ -136,17 +140,18 @@ async def test_run_pipeline_failure(client):
 
     await client.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
-        mock_svc.return_value.get = AsyncMock(
-            return_value=MagicMock(id=1, is_active=True)
-        )
-        with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
-            mock_enq.return_value.enqueue_pipeline_run = AsyncMock(
-                side_effect=Exception("Queue error")
+    with patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True):
+        with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+            mock_svc.return_value.get = AsyncMock(
+                return_value=MagicMock(id=1, is_active=True)
             )
-            resp = await client.post("/pipelines/1/run", follow_redirects=False)
-            assert resp.status_code == 303
-            assert "error=pipeline_run_failed" in resp.headers["location"]
+            with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+                mock_enq.return_value.enqueue_pipeline_run = AsyncMock(
+                    side_effect=Exception("Queue error")
+                )
+                resp = await client.post("/pipelines/1/run", follow_redirects=False)
+                assert resp.status_code == 303
+                assert "error=pipeline_run_failed" in resp.headers["location"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -87,6 +87,10 @@ async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
         "src.services.generation_service.GenerationService.generate",
         fake_generate,
     )
+    monkeypatch.setattr(
+        "src.services.provider_service.AgentProviderService.has_providers",
+        lambda self: True,
+    )
 
     # Trigger generation (non-streaming path)
     gen_resp = await pipeline_client.post(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -52,8 +52,19 @@ async def pipeline_client(tmp_path, real_pool_harness_factory):
     await built_db.close()
 
 
+_LLM_ENV_VARS = [
+    "OPENAI_API_KEY", "COHERE_API_KEY", "CONTEXT7_API_KEY", "CTX7_API_KEY",
+    "OLLAMA_BASE", "OLLAMA_URL", "HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN",
+    "FIREWORKS_BASE", "FIREWORKS_API_BASE", "FIREWORKS_API_KEY",
+    "DEEPSEEK_BASE", "DEEPSEEK_API_BASE", "DEEPSEEK_API_KEY",
+    "TOGETHER_BASE", "TOGETHER_API_BASE", "TOGETHER_API_KEY",
+]
+
+
 @pytest.mark.asyncio
-async def test_pipelines_page_renders(pipeline_client):
+async def test_pipelines_page_renders(pipeline_client, monkeypatch):
+    for var in _LLM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
     resp = await pipeline_client.get("/pipelines/")
     assert resp.status_code == 200
     assert "Пайплайны контента" in resp.text

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -57,7 +57,9 @@ async def test_pipelines_page_renders(pipeline_client):
     resp = await pipeline_client.get("/pipelines/")
     assert resp.status_code == 200
     assert "Пайплайны контента" in resp.text
-    assert "Source A" in resp.text
+    # When no LLM provider is configured, a warning banner is shown and the
+    # "New pipeline" form is hidden (so channel names like "Source A" are not in the DOM).
+    assert "LLM-провайдер не настроен" in resp.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Show a warning banner on `/pipelines/` when no LLM provider is registered, with a link to Settings → Providers
- Hide the "New pipeline" form when LLM is not configured (replaced with a hint message)
- Disable Generate, Run now, and AI buttons per pipeline row with explanatory tooltips
- Add `has_providers()` method to `AgentProviderService` to encapsulate the check

## Test plan

- [ ] No LLM env vars set → warning banner visible, form hidden, action buttons disabled
- [ ] `OPENAI_API_KEY` set → no banner, form visible, buttons enabled
- [ ] `pytest tests/test_pipelines.py` — both tests pass
- [ ] `python3 -m ruff check src/ tests/` — no lint errors

Closes #333

🤖 Generated with [Claude Code](https://claude.ai/claude-code)