### PR TITLE
fix(pipelines): detect LLM providers configured via DB settings

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -217,13 +217,17 @@ def run(args: argparse.Namespace) -> None:
                     from src.agent.manager import AgentManager
 
                     agent_manager = AgentManager(db, config)
+                from src.services.provider_service import AgentProviderService
                 from src.services.quality_scoring_service import QualityScoringService
 
+                provider_svc = AgentProviderService(db, config)
+                await provider_svc.load_db_providers()
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
                     agent_manager=agent_manager,
                     quality_service=QualityScoringService(db),
+                    provider_service=provider_svc,
                 )
                 try:
                     run = await gen_svc.generate(

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -35,6 +35,7 @@ class ContentGenerationService:
         notification_service: "DraftNotificationService | None" = None,
         quality_service: "QualityScoringService | None" = None,
         client_pool: Any | None = None,
+        provider_service: Any | None = None,
     ) -> None:
         self._db = db
         self._search = search_engine
@@ -43,6 +44,7 @@ class ContentGenerationService:
         self._notification_service = notification_service
         self._quality_service = quality_service
         self._client_pool = client_pool
+        self._provider_service = provider_service
 
     async def generate(
         self,
@@ -175,10 +177,8 @@ class ContentGenerationService:
     ) -> dict[str, Any]:
         """Execute the pipeline using the node-based DAG executor."""
         from src.services.pipeline_executor import PipelineExecutor
-        from src.services.provider_service import AgentProviderService
 
-        provider_service = AgentProviderService(self._db)
-        provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+        provider_callable = self._get_provider_callable(pipeline.llm_model)
 
         default_image_model = await self._db.get_setting("default_image_model") or ""
 
@@ -213,10 +213,7 @@ class ContentGenerationService:
         temperature: float,
     ) -> dict[str, Any]:
         """Run RAG-based generation using GenerationService."""
-        from src.services.provider_service import AgentProviderService
-
-        provider_service = AgentProviderService(self._db)
-        provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+        provider_callable = self._get_provider_callable(pipeline.llm_model)
 
         gen = GenerationService(self._search, provider_callable=provider_callable)
 
@@ -279,10 +276,7 @@ class ContentGenerationService:
         temperature: float,
     ) -> str:
         """Apply each refinement step sequentially, replacing {text} with current output."""
-        from src.services.provider_service import AgentProviderService
-
-        provider_service = AgentProviderService(self._db)
-        provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+        provider_callable = self._get_provider_callable(pipeline.llm_model)
 
         for step in pipeline.refinement_steps:
             step_prompt = step.get("prompt", "")
@@ -326,3 +320,11 @@ class ContentGenerationService:
             )
             return None
         return await self._image_service.generate(model or pipeline.image_model, text)
+
+    def _get_provider_callable(self, model: str | None) -> Any:
+        """Resolve provider callable — prefer injected shared service, fall back to local."""
+        if self._provider_service is not None:
+            return self._provider_service.get_provider_callable(model)
+        from src.services.provider_service import AgentProviderService
+
+        return AgentProviderService(self._db).get_provider_callable(model)

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -8,6 +8,18 @@ import aiohttp
 
 logger = logging.getLogger(__name__)
 
+# Base URLs for OpenAI-compatible providers (shared with agent_provider_service.py).
+_OPENAI_STYLE_BASE_URLS: Dict[str, str] = {
+    "openai": "https://api.openai.com/v1",
+    "groq": "https://api.groq.com/openai/v1",
+    "deepseek": "https://api.deepseek.com/v1",
+    "xai": "https://api.x.ai/v1",
+    "perplexity": "https://api.perplexity.ai",
+    "together": "https://api.together.xyz/v1",
+    "fireworks": "https://api.fireworks.ai/inference/v1",
+    "mistralai": "https://api.mistral.ai/v1",
+}
+
 
 class AgentProviderService:
     """Simple provider registry for generation providers.
@@ -25,14 +37,22 @@ class AgentProviderService:
     OPENAI_API_KEY is present in the environment, a basic OpenAI chat provider is
     registered under the name 'openai' and will be used when model names like
     'gpt-3.5-turbo' are passed.
+
+    DB-backed providers are loaded via ``load_db_providers()`` and complement
+    env-based ones.
     """
 
-    def __init__(self, db: Optional[object] = None) -> None:
+    def __init__(self, db: Optional[object] = None, config: Optional[object] = None) -> None:
         self.db = db
+        self._config = config
         self._registry: Dict[str, Callable[..., Awaitable[str]]] = {}
+        self._db_provider_names: set[str] = set()
         # register default provider
         self.register_provider("default", self._default_provider)
+        self._register_env_providers()
 
+    def _register_env_providers(self) -> None:
+        """Register providers from environment variables (original behaviour)."""
         # optional OpenAI provider (HTTP REST, minimal)
         openai_key = os.environ.get("OPENAI_API_KEY")
         if openai_key:
@@ -115,6 +135,141 @@ class AgentProviderService:
             except Exception:
                 logger.debug("Failed to register %s adapter", adapter_name, exc_info=True)
 
+    # ------------------------------------------------------------------
+    # DB-backed provider loading
+    # ------------------------------------------------------------------
+
+    async def load_db_providers(self) -> int:
+        """Load ProviderRuntimeConfig-s from DB and register them as adapters.
+
+        Returns the number of newly registered providers.
+        """
+        if self.db is None or self._config is None:
+            return 0
+        # Lazy import to avoid circular dependency
+        from src.services.agent_provider_service import AgentProviderService as DbProviderService
+
+        try:
+            db_svc = DbProviderService(self.db, self._config)
+            configs = await db_svc.load_provider_configs()
+        except Exception:
+            logger.debug("Failed to load db provider configs", exc_info=True)
+            return 0
+
+        added = 0
+        for cfg in configs:
+            if not cfg.enabled:
+                continue
+            if not self._has_valid_secrets(cfg):
+                logger.debug("Skipping db provider %s: empty secrets", cfg.provider)
+                continue
+            adapter = self._build_adapter_for_config(cfg)
+            if adapter is None:
+                logger.debug("Skipping db provider %s: no adapter mapping", cfg.provider)
+                continue
+            name = cfg.provider
+            if name not in self._registry:
+                self.register_provider(name, adapter)
+                self._db_provider_names.add(name)
+                added += 1
+        return added
+
+    async def reload_db_providers(self) -> int:
+        """Remove DB-sourced providers and reload from DB."""
+        for name in self._db_provider_names:
+            self._registry.pop(name, None)
+        self._db_provider_names.clear()
+        return await self.load_db_providers()
+
+    @staticmethod
+    def _has_valid_secrets(cfg: Any) -> bool:
+        secrets = getattr(cfg, "secret_fields", None) or {}
+        return any((v or "").strip() for v in secrets.values())
+
+    def _build_adapter_for_config(self, cfg: Any) -> Callable[..., Awaitable[str]] | None:
+        """Map a ProviderRuntimeConfig to a provider adapter callable."""
+        from src.services.provider_adapters import (
+            make_cohere_adapter,
+            make_generic_http_adapter,
+            make_huggingface_adapter,
+            make_ollama_adapter,
+        )
+
+        provider = cfg.provider
+        api_key = (cfg.secret_fields.get("api_key", "") or "").strip()
+
+        # OpenAI-compatible providers
+        if provider in _OPENAI_STYLE_BASE_URLS:
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            if not base_url:
+                base_url = _OPENAI_STYLE_BASE_URLS[provider]
+            return self._make_openai_compat_provider(base_url, api_key)
+
+        if provider == "cohere":
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            return make_cohere_adapter(api_key, base_url=base_url or None)
+
+        if provider == "ollama":
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            return make_ollama_adapter(base_url=base_url or None, api_key=api_key or None)
+
+        if provider == "huggingface":
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            return make_huggingface_adapter(api_key, base_url=base_url or None)
+
+        if provider == "anthropic":
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            endpoint = f"{base_url.rstrip('/')}/messages" if base_url else "https://api.anthropic.com/v1/messages"
+            return make_generic_http_adapter(endpoint, api_key, api_key_header="x-api-key")
+
+        if provider == "google_genai":
+            return make_generic_http_adapter(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                api_key,
+                api_key_header="x-goog-api-key",
+            )
+
+        return None
+
+    @staticmethod
+    def _make_openai_compat_provider(
+        base_url: str, api_key: str
+    ) -> Callable[..., Awaitable[str]]:
+        """Create an OpenAI-compatible chat completion provider."""
+        endpoint = f"{base_url.rstrip('/')}/chat/completions"
+
+        async def _provider(
+            prompt: str = "",
+            model: Optional[str] = None,
+            max_tokens: int = 256,
+            temperature: float = 0.0,
+            stream: bool = False,
+            **kwargs: Any,
+        ) -> str:
+            headers = {"Content-Type": "application/json"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            payload = {
+                "model": model or "gpt-3.5-turbo",
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": int(max_tokens or 256),
+                "temperature": float(temperature or 0.0),
+            }
+            timeout = aiohttp.ClientTimeout(total=60)
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    endpoint, json=payload, headers=headers, timeout=timeout
+                ) as resp:
+                    text = await resp.text()
+                    if resp.status != 200:
+                        raise RuntimeError(f"Provider error {resp.status}: {text}")
+                    data = await resp.json()
+                    try:
+                        return data["choices"][0]["message"]["content"]
+                    except Exception:
+                        return str(data)
+
+        return _provider
 
     def has_providers(self) -> bool:
         """Return True if any real (non-default) provider is registered."""

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -163,15 +163,18 @@ class AgentProviderService:
             if not self._has_valid_secrets(cfg):
                 logger.debug("Skipping db provider %s: empty secrets", cfg.provider)
                 continue
-            adapter = self._build_adapter_for_config(cfg)
-            if adapter is None:
-                logger.debug("Skipping db provider %s: no adapter mapping", cfg.provider)
-                continue
-            name = cfg.provider
-            if name not in self._registry:
-                self.register_provider(name, adapter)
-                self._db_provider_names.add(name)
-                added += 1
+            try:
+                adapter = self._build_adapter_for_config(cfg)
+                if adapter is None:
+                    logger.debug("Skipping db provider %s: no adapter mapping", cfg.provider)
+                    continue
+                name = cfg.provider
+                if name not in self._registry:
+                    self.register_provider(name, adapter)
+                    self._db_provider_names.add(name)
+                    added += 1
+            except Exception:
+                logger.warning("Failed to register db provider %s", cfg.provider, exc_info=True)
         return added
 
     async def reload_db_providers(self) -> int:
@@ -190,7 +193,6 @@ class AgentProviderService:
         """Map a ProviderRuntimeConfig to a provider adapter callable."""
         from src.services.provider_adapters import (
             make_cohere_adapter,
-            make_generic_http_adapter,
             make_huggingface_adapter,
             make_ollama_adapter,
         )
@@ -218,16 +220,15 @@ class AgentProviderService:
             return make_huggingface_adapter(api_key, base_url=base_url or None)
 
         if provider == "anthropic":
-            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
-            endpoint = f"{base_url.rstrip('/')}/messages" if base_url else "https://api.anthropic.com/v1/messages"
-            return make_generic_http_adapter(endpoint, api_key, api_key_header="x-api-key")
+            # Anthropic requires a different request schema (messages API)
+            # than what make_generic_http_adapter provides (prompt-based).
+            logger.debug("Skipping db provider %s: incompatible request schema", provider)
+            return None
 
         if provider == "google_genai":
-            return make_generic_http_adapter(
-                "https://generativelanguage.googleapis.com/v1beta/models",
-                api_key,
-                api_key_header="x-goog-api-key",
-            )
+            # Google GenAI also needs a different request schema.
+            logger.debug("Skipping db provider %s: incompatible request schema", provider)
+            return None
 
         return None
 

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -178,10 +178,19 @@ class AgentProviderService:
         return added
 
     async def reload_db_providers(self) -> int:
-        """Remove DB-sourced providers and reload from DB."""
-        for name in self._db_provider_names:
-            self._registry.pop(name, None)
+        """Remove DB-sourced providers and reload from DB.
+
+        Loads new providers first, then removes only the old names that
+        were not re-registered — avoiding a brief empty-registry window.
+        """
+        old_names = set(self._db_provider_names)
         self._db_provider_names.clear()
+        # Allow load_db_providers to re-register names (they won't be
+        # skipped since we cleared _db_provider_names, but the registry
+        # entries from the previous load must be removed first so the
+        # `if name not in self._registry` check lets them through).
+        for name in old_names:
+            self._registry.pop(name, None)
         return await self.load_db_providers()
 
     @staticmethod

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -139,7 +139,7 @@ class AgentProviderService:
     # DB-backed provider loading
     # ------------------------------------------------------------------
 
-    async def load_db_providers(self) -> int:
+    async def load_db_providers(self, _reloading_names: set[str] | None = None) -> int:
         """Load ProviderRuntimeConfig-s from DB and register them as adapters.
 
         Returns the number of newly registered providers.
@@ -157,6 +157,7 @@ class AgentProviderService:
             return 0
 
         added = 0
+        reloading_names = _reloading_names or set()
         for cfg in configs:
             if not cfg.enabled:
                 continue
@@ -169,7 +170,9 @@ class AgentProviderService:
                     logger.debug("Skipping db provider %s: no adapter mapping", cfg.provider)
                     continue
                 name = cfg.provider
-                if name not in self._registry:
+                # Register if new; overwrite if previously DB-sourced
+                # (env-registered providers are never overwritten by DB loads).
+                if name not in self._registry or name in reloading_names:
                     self.register_provider(name, adapter)
                     self._db_provider_names.add(name)
                     added += 1
@@ -180,18 +183,16 @@ class AgentProviderService:
     async def reload_db_providers(self) -> int:
         """Remove DB-sourced providers and reload from DB.
 
-        Loads new providers first, then removes only the old names that
-        were not re-registered — avoiding a brief empty-registry window.
+        Keeps existing providers live during the DB round-trip so
+        has_providers() never returns False during a reload.
         """
         old_names = set(self._db_provider_names)
         self._db_provider_names.clear()
-        # Allow load_db_providers to re-register names (they won't be
-        # skipped since we cleared _db_provider_names, but the registry
-        # entries from the previous load must be removed first so the
-        # `if name not in self._registry` check lets them through).
-        for name in old_names:
+        added = await self.load_db_providers(_reloading_names=old_names)
+        # Remove only names that were NOT re-registered
+        for name in old_names - self._db_provider_names:
             self._registry.pop(name, None)
-        return await self.load_db_providers()
+        return added
 
     @staticmethod
     def _has_valid_secrets(cfg: Any) -> bool:

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -63,6 +63,7 @@ class UnifiedDispatcher:
         client_pool: object | None = None,
         notifier: "Notifier | None" = None,
         config: object | None = None,
+        llm_provider_service: object | None = None,
     ):
 
         self._collector = collector
@@ -80,6 +81,7 @@ class UnifiedDispatcher:
         self._client_pool = client_pool
         self._notifier = notifier
         self._config = config
+        self._llm_provider_service = llm_provider_service
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
 
@@ -494,10 +496,12 @@ class UnifiedDispatcher:
             quality_service = QualityScoringService(db)
 
             image_service = await self._build_image_service()
-            from src.services.provider_service import AgentProviderService
+            provider_service = self._llm_provider_service
+            if provider_service is None:
+                from src.services.provider_service import AgentProviderService
 
-            provider_service = AgentProviderService(db, self._config)
-            await provider_service.load_db_providers()
+                provider_service = AgentProviderService(db, self._config)
+                await provider_service.load_db_providers()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
@@ -582,10 +586,12 @@ class UnifiedDispatcher:
             quality_service = QualityScoringService(db)
 
             image_service = await self._build_image_service()
-            from src.services.provider_service import AgentProviderService
+            provider_service = self._llm_provider_service
+            if provider_service is None:
+                from src.services.provider_service import AgentProviderService
 
-            provider_service = AgentProviderService(db, self._config)
-            await provider_service.load_db_providers()
+                provider_service = AgentProviderService(db, self._config)
+                await provider_service.load_db_providers()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -494,6 +494,10 @@ class UnifiedDispatcher:
             quality_service = QualityScoringService(db)
 
             image_service = await self._build_image_service()
+            from src.services.provider_service import AgentProviderService
+
+            provider_service = AgentProviderService(db, self._config)
+            await provider_service.load_db_providers()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
@@ -501,6 +505,7 @@ class UnifiedDispatcher:
                 notification_service=notification_service,
                 quality_service=quality_service,
                 client_pool=self._client_pool,
+                provider_service=provider_service,
             )
             try:
                 run = await gen.generate(
@@ -577,6 +582,10 @@ class UnifiedDispatcher:
             quality_service = QualityScoringService(db)
 
             image_service = await self._build_image_service()
+            from src.services.provider_service import AgentProviderService
+
+            provider_service = AgentProviderService(db, self._config)
+            await provider_service.load_db_providers()
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
@@ -584,6 +593,7 @@ class UnifiedDispatcher:
                 notification_service=notification_service,
                 quality_service=quality_service,
                 client_pool=self._client_pool,
+                provider_service=provider_service,
             )
             run = await gen.generate(pipeline=pipeline, model=pipeline.llm_model)
 

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -46,6 +46,7 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         app.state.photo_task_service = container.photo_task_service
         app.state.photo_auto_upload_service = container.photo_auto_upload_service
         app.state.session_secret = container.session_secret
+        app.state.llm_provider_service = container.llm_provider_service
         app.state.timing_buffer = container.timing_buffer
     elif not hasattr(app.state, "templates"):
         app.state.templates = configure_template_globals(

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -181,7 +181,6 @@ async def build_container_with_templates(
     )
     agent_manager = AgentManager(db, config, client_pool=pool, scheduler_manager=scheduler)
 
-    from src.services.provider_service import AgentProviderService
     from src.services.translation_service import TranslationService
 
     translation_provider_service = llm_provider_service

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -151,6 +151,12 @@ async def build_container_with_templates(
 
     collection_service = CollectionService(channel_bundle, collector, collection_queue)
     task_enqueuer = TaskEnqueuer(db, collection_service)
+
+    from src.services.provider_service import AgentProviderService
+
+    llm_provider_service = AgentProviderService(db, config)
+    await llm_provider_service.load_db_providers()
+
     unified_dispatcher = UnifiedDispatcher(
         collector,
         channel_bundle,
@@ -164,6 +170,7 @@ async def build_container_with_templates(
         client_pool=pool,
         notifier=notifier,
         config=config,
+        llm_provider_service=llm_provider_service,
     )
     scheduler = SchedulerManager(
         config.scheduler,
@@ -177,8 +184,6 @@ async def build_container_with_templates(
     from src.services.provider_service import AgentProviderService
     from src.services.translation_service import TranslationService
 
-    llm_provider_service = AgentProviderService(db, config)
-    await llm_provider_service.load_db_providers()
     translation_provider_service = llm_provider_service
     translation_service = TranslationService(db, provider_service=translation_provider_service)
 

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -177,7 +177,9 @@ async def build_container_with_templates(
     from src.services.provider_service import AgentProviderService
     from src.services.translation_service import TranslationService
 
-    translation_provider_service = AgentProviderService(db)
+    llm_provider_service = AgentProviderService(db, config)
+    await llm_provider_service.load_db_providers()
+    translation_provider_service = llm_provider_service
     translation_service = TranslationService(db, provider_service=translation_provider_service)
 
     _templates = configure_template_globals(
@@ -222,6 +224,7 @@ async def build_container_with_templates(
         bg_tasks=set(),
         agent_manager=agent_manager,
         translation_service=translation_service,
+        llm_provider_service=llm_provider_service,
         shutting_down=False,
     )
 

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -28,6 +28,7 @@ from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTaskService
+from src.services.provider_service import AgentProviderService
 from src.services.task_enqueuer import TaskEnqueuer
 from src.services.translation_service import TranslationService
 from src.services.unified_dispatcher import UnifiedDispatcher
@@ -74,4 +75,5 @@ class AppContainer:
     bg_tasks: set[asyncio.Task]
     agent_manager: AgentManager | None = None
     translation_service: TranslationService | None = None
+    llm_provider_service: AgentProviderService | None = None
     shutting_down: bool = False

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -33,6 +33,7 @@ from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTaskService
 from src.services.pipeline_service import PipelineService
+from src.services.provider_service import AgentProviderService
 from src.services.search_query_service import SearchQueryService
 from src.services.search_service import SearchService
 from src.services.task_enqueuer import TaskEnqueuer
@@ -258,6 +259,13 @@ def is_shutting_down(request: Request) -> bool:
 
 def get_agent_manager(request: Request) -> AgentManager | None:
     return get_container(request).agent_manager
+
+
+def get_llm_provider_service(request: Request) -> AgentProviderService:
+    svc = getattr(request.app.state, "llm_provider_service", None)
+    if svc is not None:
+        return svc
+    return get_container(request).llm_provider_service or AgentProviderService()
 
 
 def channel_service(request: Request) -> ChannelService:

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -46,8 +46,6 @@ def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
 
 
 async def _page_context(request: Request) -> dict:
-    from src.services.provider_service import AgentProviderService
-
     svc = deps.pipeline_service(request)
     channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
     accounts = await deps.get_account_bundle(request).list_accounts()
@@ -84,7 +82,7 @@ async def _page_context(request: Request) -> dict:
         "publish_modes": list(PipelinePublishMode),
         "generation_backends": list(PipelineGenerationBackend),
         "next_runs": next_runs,
-        "llm_configured": AgentProviderService(deps.get_db(request)).has_providers(),
+        "llm_configured": deps.get_llm_provider_service(request).has_providers(),
     }
 
 
@@ -209,9 +207,7 @@ async def delete_pipeline(request: Request, pipeline_id: int):
 
 @router.post("/{pipeline_id}/run")
 async def run_pipeline(request: Request, pipeline_id: int):
-    from src.services.provider_service import AgentProviderService
-
-    if not AgentProviderService(deps.get_db(request)).has_providers():
+    if not deps.get_llm_provider_service(request).has_providers():
         return _pipeline_redirect("llm_not_configured", error=True)
     svc = deps.pipeline_service(request)
     pipeline = await svc.get(pipeline_id)
@@ -256,9 +252,7 @@ async def generate_stream(
     db = deps.get_db(request)
     engine = deps.get_search_engine(request)
 
-    from src.services.provider_service import AgentProviderService
-
-    provider_service = AgentProviderService(db)
+    provider_service = deps.get_llm_provider_service(request)
     if not provider_service.has_providers():
         return _pipeline_redirect("llm_not_configured", error=True)
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
@@ -326,9 +320,7 @@ async def generate_pipeline(
     db = deps.get_db(request)
     engine = deps.get_search_engine(request)
 
-    from src.services.provider_service import AgentProviderService
-
-    provider_service = AgentProviderService(db)
+    provider_service = deps.get_llm_provider_service(request)
     if not provider_service.has_providers():
         return _pipeline_redirect("llm_not_configured", error=True)
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
@@ -522,9 +514,7 @@ async def import_pipeline(
 @router.post("/{pipeline_id}/ai-edit")
 async def ai_edit_pipeline(request: Request, pipeline_id: int):
     """Accept JSON body: {"instruction": "..."}. Returns updated pipeline_json."""
-    from src.services.provider_service import AgentProviderService
-
-    if not AgentProviderService(deps.get_db(request)).has_providers():
+    if not deps.get_llm_provider_service(request).has_providers():
         return JSONResponse(content={"ok": False, "error": "LLM not configured"}, status_code=400)
     svc: PipelineService = deps.pipeline_service(request)
     db = deps.get_db(request)

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -73,6 +73,16 @@ def _agent_provider_service(request: Request) -> AgentProviderService:
     return AgentProviderService(deps.get_db(request), request.app.state.config)
 
 
+async def _reload_llm_providers(request: Request) -> None:
+    """Reload the shared LLM provider service from DB after settings change."""
+    svc = getattr(request.app.state, "llm_provider_service", None)
+    if svc is not None:
+        try:
+            await svc.reload_db_providers()
+        except Exception:
+            logger.warning("Failed to reload LLM providers from DB", exc_info=True)
+
+
 async def _semantic_settings_context(request: Request) -> dict[str, object]:
     db = deps.get_db(request)
     last_embedded_id = parse_int_setting(
@@ -710,6 +720,7 @@ async def add_agent_provider(request: Request):
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is not None:
         await agent_manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
     return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
 
 
@@ -753,6 +764,7 @@ async def save_agent_providers(request: Request):
     await service.save_provider_configs(validated)
     if is_persistent_manager:
         await manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
     return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
 
 
@@ -774,6 +786,7 @@ async def delete_agent_provider(request: Request, provider_name: str):
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is not None:
         await agent_manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
     return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
 
 

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -43,7 +43,7 @@
 
 {% if not llm_configured %}
 <div class="alert alert-warning" role="alert">
-    LLM-провайдер не настроен — генерация контента недоступна. Установите переменную окружения с ключом API (например, <code>OPENAI_API_KEY</code>, <code>COHERE_API_KEY</code>) и перезапустите сервер.
+    LLM-провайдер не настроен — генерация контента недоступна. Добавьте провайдера в <a href="/settings">Настройках</a> или задайте переменную окружения с ключом API (например, <code>OPENAI_API_KEY</code>, <code>COHERE_API_KEY</code>).
 </div>
 {% endif %}
 

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -16,6 +16,7 @@ from src.models import Account, Channel
 from src.scheduler.service import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
+from src.services.provider_service import AgentProviderService
 from src.telegram.auth import TelegramAuth
 from src.telegram.collector import Collector
 from src.web.app import create_app
@@ -65,6 +66,7 @@ async def base_app(tmp_path):
     app.state.search_engine = SearchEngine(db)
     app.state.ai_search = AISearchEngine(config.llm, db)
     app.state.scheduler = SchedulerManager(config.scheduler)
+    app.state.llm_provider_service = AgentProviderService()
     app.state.session_secret = "test_secret_key"
     app.state.shutting_down = False
 

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -185,19 +185,21 @@ async def test_generate_stream_success(client):
         yield {"delta": "Hello", "generated_text": None, "citations": []}
         yield {"delta": " world", "generated_text": "Hello world", "citations": []}
 
-    with patch("src.services.provider_service.AgentProviderService") as mock_provider_service:
-        mock_provider_instance = MagicMock()
-        mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
-        mock_provider_service.return_value = mock_provider_instance
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.has_providers = MagicMock(return_value=True)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
 
-        with patch("src.services.generation_service.GenerationService") as mock_gen:
-            mock_instance = MagicMock()
-            mock_instance.generate_stream = fake_stream
-            mock_gen.return_value = mock_instance
+    app = client._transport.app  # type: ignore
+    app.state.llm_provider_service = mock_provider_instance
 
-            resp = await client.get("/pipelines/1/generate-stream")
-            assert resp.status_code == 200
-            assert "text/event-stream" in resp.headers["content-type"]
+    with patch("src.services.generation_service.GenerationService") as mock_gen:
+        mock_instance = MagicMock()
+        mock_instance.generate_stream = fake_stream
+        mock_gen.return_value = mock_instance
+
+        resp = await client.get("/pipelines/1/generate-stream")
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
 
 
 @pytest.mark.asyncio
@@ -215,23 +217,25 @@ async def test_generate_pipeline_success(client):
 
     await client.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.services.provider_service.AgentProviderService") as mock_provider_service:
-        mock_provider_instance = MagicMock()
-        mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
-        mock_provider_service.return_value = mock_provider_instance
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.has_providers = MagicMock(return_value=True)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
 
-        with patch("src.services.generation_service.GenerationService") as mock_gen:
-            mock_instance = MagicMock()
-            mock_instance.generate = AsyncMock(
-                return_value={"generated_text": "Test output", "citations": []}
-            )
-            mock_gen.return_value = mock_instance
+    app = client._transport.app  # type: ignore
+    app.state.llm_provider_service = mock_provider_instance
 
-            resp = await client.post(
-                "/pipelines/1/generate",
-                data={"model": "", "max_tokens": "256", "temperature": "0.0"},
-            )
-            assert resp.status_code == 200
+    with patch("src.services.generation_service.GenerationService") as mock_gen:
+        mock_instance = MagicMock()
+        mock_instance.generate = AsyncMock(
+            return_value={"generated_text": "Test output", "citations": []}
+        )
+        mock_gen.return_value = mock_instance
+
+        resp = await client.post(
+            "/pipelines/1/generate",
+            data={"model": "", "max_tokens": "256", "temperature": "0.0"},
+        )
+        assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -241,22 +245,24 @@ async def test_generate_pipeline_failure(client):
 
     await client.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.services.provider_service.AgentProviderService") as mock_provider_service:
-        mock_provider_instance = MagicMock()
-        mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
-        mock_provider_service.return_value = mock_provider_instance
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.has_providers = MagicMock(return_value=True)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
 
-        with patch("src.services.generation_service.GenerationService") as mock_gen:
-            mock_instance = MagicMock()
-            mock_instance.generate = AsyncMock(side_effect=Exception("Generation error"))
-            mock_gen.return_value = mock_instance
+    app = client._transport.app  # type: ignore
+    app.state.llm_provider_service = mock_provider_instance
 
-            resp = await client.post(
-                "/pipelines/1/generate",
-                data={"model": "", "max_tokens": "256", "temperature": "0.0"},
-            )
-            assert resp.status_code == 200
-            assert "Generation failed" in resp.text
+    with patch("src.services.generation_service.GenerationService") as mock_gen:
+        mock_instance = MagicMock()
+        mock_instance.generate = AsyncMock(side_effect=Exception("Generation error"))
+        mock_gen.return_value = mock_instance
+
+        resp = await client.post(
+            "/pipelines/1/generate",
+            data={"model": "", "max_tokens": "256", "temperature": "0.0"},
+        )
+        assert resp.status_code == 200
+        assert "Generation failed" in resp.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -1,0 +1,232 @@
+"""Tests for AgentProviderService.load_db_providers (env-only service)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.provider_service import AgentProviderService
+
+
+@pytest.fixture
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_config():
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_no_db_or_config():
+    """Returns 0 when db or config is None."""
+    svc = AgentProviderService(db=None, config=None)
+    assert await svc.load_db_providers() == 0
+
+    svc2 = AgentProviderService(db=MagicMock(), config=None)
+    assert await svc2.load_db_providers() == 0
+
+    svc3 = AgentProviderService(db=None, config=MagicMock())
+    assert await svc3.load_db_providers() == 0
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_registers_openai(mock_db, mock_config):
+    """OpenAI-style provider from DB is registered as adapter."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "sk-test-key-123"}
+    mock_cfg.plain_fields = {"base_url": ""}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 1
+    assert svc.has_providers()
+    assert "openai" in svc._registry
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_skips_empty_secrets(mock_db, mock_config):
+    """Provider with empty secrets is skipped."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": ""}
+    mock_cfg.plain_fields = {}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 0
+    assert not svc.has_providers()
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_skips_disabled(mock_db, mock_config):
+    """Disabled provider is skipped."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "cohere"
+    mock_cfg.enabled = False
+    mock_cfg.secret_fields = {"api_key": "test-key"}
+    mock_cfg.plain_fields = {}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 0
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_skips_duplicate(mock_db, mock_config):
+    """Provider already in registry (from env) is not duplicated."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "test-key"}
+    mock_cfg.plain_fields = {}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        # Pre-register 'openai' as if from env
+        svc.register_provider("openai", svc._default_provider)
+        added = await svc.load_db_providers()
+
+    assert added == 0
+
+
+@pytest.mark.asyncio
+async def test_reload_db_providers_clears_and_reloads(mock_db, mock_config):
+    """reload clears db providers and reloads."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "groq"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "gsk-test"}
+    mock_cfg.plain_fields = {}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        await svc.load_db_providers()
+        assert "groq" in svc._registry
+
+        # Now reload — simulate empty config (provider removed)
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[])
+        added = await svc.reload_db_providers()
+
+    assert added == 0
+    assert "groq" not in svc._registry
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_cohere_adapter(mock_db, mock_config):
+    """Cohere provider gets make_cohere_adapter."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "cohere"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "cohere-test-key"}
+    mock_cfg.plain_fields = {"base_url": ""}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 1
+    assert "cohere" in svc._registry
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_ollama_adapter(mock_db, mock_config):
+    """Ollama provider with no api_key has empty secrets -> skipped."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "ollama"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": ""}
+    mock_cfg.plain_fields = {"base_url": "http://localhost:11434"}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    # No api_key = empty secrets -> skipped
+    assert added == 0
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_handles_exception(mock_db, mock_config):
+    """Exception during load_provider_configs returns 0 gracefully."""
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(side_effect=Exception("DB error"))
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 0
+
+
+def test_has_valid_secrets():
+    """_has_valid_secrets checks non-empty secret values."""
+    cfg = MagicMock()
+    cfg.secret_fields = {"api_key": "valid-key"}
+    assert AgentProviderService._has_valid_secrets(cfg) is True
+
+    cfg2 = MagicMock()
+    cfg2.secret_fields = {"api_key": ""}
+    assert AgentProviderService._has_valid_secrets(cfg2) is False
+
+    cfg3 = MagicMock()
+    cfg3.secret_fields = {}
+    assert AgentProviderService._has_valid_secrets(cfg3) is False
+
+    cfg4 = MagicMock(spec=[])  # no secret_fields attr
+    assert AgentProviderService._has_valid_secrets(cfg4) is False


### PR DESCRIPTION
## Summary

- Fixes `/pipelines/` page incorrectly showing "LLM provider not configured" banner when providers are configured via DB settings (UI `/settings`) instead of env vars
- Adds `load_db_providers()` / `reload_db_providers()` to `AgentProviderService` in `provider_service.py` to detect DB-backed providers at startup
- Creates shared `llm_provider_service` singleton in DI (`AppContainer`, `deps`, `assembly`, `bootstrap`) used by all pipeline routes and `ContentGenerationService`
- Updates `settings.py` routes to reload providers after every save/add/delete action
- Updates pipeline banner text to mention `/settings` as an alternative to env vars

## Test plan

- [x] All 684+ existing tests pass (parallel + serial)
- [x] 10 new isolated tests for `load_db_providers()` in `test_provider_service_db_load.py`
- [x] Updated pipeline route tests to mock shared provider service
- [x] `ruff check` passes clean

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)