### PR TITLE
refactor(web): reduce duplication in Jinja templates and inline JS

### DIFF
--- a/src/web/static/_busy_button.js
+++ b/src/web/static/_busy_button.js
@@ -1,0 +1,26 @@
+document.addEventListener('submit', function(e) {
+    if (e.defaultPrevented) return;
+    var form = e.target;
+    if (!form.hasAttribute('data-busy')) return;
+    var btn = e.submitter || form.querySelector('button[type="submit"]');
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
+});
+
+window.setAsyncButtonBusy = function(button, busy, busyLabel) {
+    if (!button) return;
+    if (!button.dataset.defaultLabel) {
+        button.dataset.defaultLabel = button.innerHTML;
+    }
+    if (busy) {
+        button.disabled = true;
+        button.innerHTML =
+            '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>' +
+            (busyLabel || '\u0412\u044b\u043f\u043e\u043b\u043d\u044f\u0435\u0442\u0441\u044f...');
+        return;
+    }
+    button.disabled = false;
+    button.innerHTML = button.dataset.defaultLabel;
+};

--- a/src/web/static/_theme_init.js
+++ b/src/web/static/_theme_init.js
@@ -1,0 +1,1 @@
+(function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t)})();

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -16,6 +16,17 @@ from src.web.paths import TEMPLATES_DIR
 
 logger = logging.getLogger(__name__)
 
+FILTER_FLAG_EMOJI = {
+    "low_uniqueness": ("📴", "Низкая уникальность контента"),
+    "low_subscriber_ratio": ("📊", "Мало подписчиков"),
+    "low_subscriber_manual": ("✋", "Мало подписчиков (абс.)"),
+    "manual": ("🚫", "Ручная фильтрация"),
+    "cross_channel_spam": ("📢", "Кросс-канальный спам"),
+    "non_cyrillic": ("🌐", "Не кириллический контент"),
+    "chat_noise": ("💬", "Шум чата"),
+    "username_changed": ("💡", "Сменил юзернейм"),
+}
+
 PACKAGE_NAME = "tg-agent"
 PROJECT_ROOT = TEMPLATES_DIR.parent.parent.parent
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
@@ -114,5 +125,6 @@ def configure_template_globals(
 ) -> Jinja2Templates:
     templates.env.globals["agent_available"] = _agent_available_for_request
     templates.env.globals["app_version"] = get_app_version()
+    templates.env.globals["filter_flag_emoji"] = FILTER_FLAG_EMOJI
     templates.env.filters["local_dt"] = local_dt_filter
     return templates

--- a/src/web/templates/_macros.html
+++ b/src/web/templates/_macros.html
@@ -33,7 +33,7 @@
 <span id="collect-btn-{{ prefix }}{{ ch.id }}">
     <form action="/channels/{{ ch.id }}/collect" method="post"
           hx-post="/channels/{{ ch.id }}/collect"
-          hx-target="#collect-btn-{{ prefix }}{{ ch.id }}"
+          hx-target="#collect-btn-{{ ch.id }}"
           hx-swap="outerHTML"
           hx-disabled-elt="find button"
           class="d-inline">

--- a/src/web/templates/_macros.html
+++ b/src/web/templates/_macros.html
@@ -1,0 +1,54 @@
+{# Reusable Jinja macros for TG Agent templates. #}
+
+{% macro filter_flags(flags_str, margin='') %}
+{% if flags_str %}
+    {% for flag in flags_str.split(',') %}
+        {% set f = flag.strip() %}
+        {% if f in filter_flag_emoji %}
+            <span title="{{ filter_flag_emoji[f][1] }}" style="cursor:default;font-size:1.1em;{{ margin }}">{{ filter_flag_emoji[f][0] }}</span>
+        {% else %}
+            <span title="{{ f }}" style="cursor:default;{{ margin }}">🚫</span>
+        {% endif %}
+    {% endfor %}
+{% else %}
+    <span title="Отфильтрован" style="cursor:default">🚫</span>
+{% endif %}
+{% endmacro %}
+
+
+{% macro channel_actions(ch, prefix='') %}
+{% if ch.message_count > 0 %}
+<a href="/search?channel_id={{ ch.channel_id }}&mode=local" class="btn btn-outline-secondary btn-sm emoji-btn" title="Смотреть сообщения">&#128196;</a>
+{% endif %}
+{% if ch.is_filtered %}
+<form method="post" action="/channels/{{ ch.id }}/filter-toggle" class="d-inline" data-busy>
+    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Вернуть">&#128257;</button>
+</form>
+{% if ch.message_count > 0 %}
+<form method="post" action="/channels/{{ ch.channel_id }}/purge-messages" class="d-inline" data-busy onsubmit="return confirm('Удалить {{ ch.message_count }} сообщений из этого канала?')">
+    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Очистить сообщения">&#129529;</button>
+</form>
+{% endif %}
+{% endif %}
+<span id="collect-btn-{{ prefix }}{{ ch.id }}">
+    <form action="/channels/{{ ch.id }}/collect" method="post"
+          hx-post="/channels/{{ ch.id }}/collect"
+          hx-target="#collect-btn-{{ prefix }}{{ ch.id }}"
+          hx-swap="outerHTML"
+          hx-disabled-elt="find button"
+          class="d-inline">
+        <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Загрузить">&#11015;&#65039;</button>
+    </form>
+</span>
+<form method="post" action="/channels/{{ ch.id }}/stats" class="d-inline" data-busy>
+    <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Обновить статистику">&#128202;</button>
+</form>
+<form method="post" action="/channels/{{ ch.id }}/toggle" class="d-inline" data-busy>
+    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="{{ 'Отключить' if ch.is_active else 'Включить' }}">
+        {{ "⏏️" if ch.is_active else "▶️" }}
+    </button>
+</form>
+<form method="post" action="/channels/{{ ch.id }}/delete" class="d-inline" data-busy onsubmit="return confirm('Вы уверены, что хотите удалить этот канал?')">
+    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Удалить">&#128465;&#65039;</button>
+</form>
+{% endmacro %}

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -9,9 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
     <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
-    <script>
-    (function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t)})();
-    </script>
+    <script src="/static/_theme_init.js"></script>
     {% block head_scripts %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -60,6 +58,7 @@
         <small>TG Agent v{{ app_version }}</small>
     </footer>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="/static/_busy_button.js"></script>
 <script>
 (function() {
     var msgs = {
@@ -241,17 +240,6 @@
             a.classList.add("active");
         }
     });
-    // Unified busy-button handler: add data-busy to any <form> for auto spinner
-    document.addEventListener('submit', function(e) {
-        if (e.defaultPrevented) return;
-        var form = e.target;
-        if (!form.hasAttribute('data-busy')) return;
-        var btn = e.submitter || form.querySelector('button[type="submit"]');
-        if (!btn || btn.disabled) return;
-        btn.disabled = true;
-        var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
-    });
     // Local date conversion: replace .local-dt[data-utc] spans with browser-local time.
     // Initial textContent is a server-side UTC fallback; JS replaces it once the page loads.
     function convertLocalDates(root) {
@@ -270,22 +258,6 @@
     }
     document.addEventListener('DOMContentLoaded', function() { convertLocalDates(); });
     document.body.addEventListener('htmx:afterSwap', function(e) { convertLocalDates(e.detail.target); });
-    // Reusable spinner helper for fetch-based (non-form) buttons
-    window.setAsyncButtonBusy = function(button, busy, busyLabel) {
-        if (!button) return;
-        if (!button.dataset.defaultLabel) {
-            button.dataset.defaultLabel = button.innerHTML;
-        }
-        if (busy) {
-            button.disabled = true;
-            button.innerHTML =
-                '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>' +
-                (busyLabel || 'Выполняется...');
-            return;
-        }
-        button.disabled = false;
-        button.innerHTML = button.dataset.defaultLabel;
-    };
 })();
 </script>
 </body>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import filter_flags, channel_actions %}
 {% block title %}Каналы — TG Agent{% endblock %}
 {% block content %}
 <h1>Каналы</h1>
@@ -95,67 +96,13 @@
             <td>{{ "%.0f"|format(st.avg_forwards) if st and st.avg_forwards is not none else "—" }}</td>
             <td>
                 {% if ch.is_filtered %}
-                    {% set flag_emoji = {
-                        "low_uniqueness": ("📴", "Низкая уникальность контента"),
-                        "low_subscriber_ratio": ("📊", "Мало подписчиков"),
-                        "low_subscriber_manual": ("✋", "Мало подписчиков (абс.)"),
-                        "manual": ("🚫", "Ручная фильтрация"),
-                        "cross_channel_spam": ("📢", "Кросс-канальный спам"),
-                        "non_cyrillic": ("🌐", "Не кириллический контент"),
-                        "chat_noise": ("💬", "Шум чата"),
-                        "username_changed": ("💡", "Сменил юзернейм")
-                    } %}
-                    {% if ch.filter_flags %}
-                        {% for flag in ch.filter_flags.split(',') %}
-                            {% set f = flag.strip() %}
-                            {% if f in flag_emoji %}
-                                <span title="{{ flag_emoji[f][1] }}" style="cursor:default;font-size:1.1em">{{ flag_emoji[f][0] }}</span>
-                            {% else %}
-                                <span title="{{ f }}" style="cursor:default">🚫</span>
-                            {% endif %}
-                        {% endfor %}
-                    {% else %}
-                        <span title="Отфильтрован" style="cursor:default">🚫</span>
-                    {% endif %}
+                    {{ filter_flags(ch.filter_flags) }}
                 {% else %}
                     —
                 {% endif %}
             </td>
             <td class="text-nowrap">
-                {% if ch.message_count > 0 %}
-                <a href="/search?channel_id={{ ch.channel_id }}&mode=local" class="btn btn-outline-secondary btn-sm emoji-btn" title="Смотреть сообщения">&#128196;</a>
-                {% endif %}
-                {% if ch.is_filtered %}
-                <form method="post" action="/channels/{{ ch.id }}/filter-toggle" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Вернуть">&#128257;</button>
-                </form>
-                {% if ch.message_count > 0 %}
-                <form method="post" action="/channels/{{ ch.channel_id }}/purge-messages" class="d-inline" data-busy onsubmit="return confirm('Удалить {{ ch.message_count }} сообщений из этого канала?')">
-                    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Очистить сообщения">&#129529;</button>
-                </form>
-                {% endif %}
-                {% endif %}
-                <span id="collect-btn-{{ ch.id }}">
-                    <form action="/channels/{{ ch.id }}/collect" method="post"
-                          hx-post="/channels/{{ ch.id }}/collect"
-                          hx-target="#collect-btn-{{ ch.id }}"
-                          hx-swap="outerHTML"
-                          hx-disabled-elt="find button"
-                          class="d-inline">
-                        <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Загрузить">&#11015;&#65039;</button>
-                    </form>
-                </span>
-                <form method="post" action="/channels/{{ ch.id }}/stats" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Обновить статистику">&#128202;</button>
-                </form>
-                <form method="post" action="/channels/{{ ch.id }}/toggle" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="{{ 'Отключить' if ch.is_active else 'Включить' }}">
-                        {{ "⏏️" if ch.is_active else "▶️" }}
-                    </button>
-                </form>
-                <form method="post" action="/channels/{{ ch.id }}/delete" class="d-inline" data-busy onsubmit="return confirm('Вы уверены, что хотите удалить этот канал?')">
-                    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Удалить">&#128465;&#65039;</button>
-                </form>
+                {{ channel_actions(ch) }}
             </td>
         </tr>
         {% endfor %}
@@ -201,40 +148,7 @@
                 </div>
             </div>
             <div class="card-actions">
-                {% if ch.message_count > 0 %}
-                <a href="/search?channel_id={{ ch.channel_id }}&mode=local" class="btn btn-outline-secondary btn-sm emoji-btn" title="Смотреть сообщения">&#128196;</a>
-                {% endif %}
-                {% if ch.is_filtered %}
-                <form method="post" action="/channels/{{ ch.id }}/filter-toggle" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="Вернуть">&#128257;</button>
-                </form>
-                {% if ch.message_count > 0 %}
-                <form method="post" action="/channels/{{ ch.channel_id }}/purge-messages" class="d-inline" data-busy onsubmit="return confirm('Удалить {{ ch.message_count }} сообщений из этого канала?')">
-                    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Очистить сообщения">&#129529;</button>
-                </form>
-                {% endif %}
-                {% endif %}
-                <span id="collect-btn-m-{{ ch.id }}">
-                    <form action="/channels/{{ ch.id }}/collect" method="post"
-                          hx-post="/channels/{{ ch.id }}/collect"
-                          hx-target="#collect-btn-m-{{ ch.id }}"
-                          hx-swap="outerHTML"
-                          hx-disabled-elt="find button"
-                          class="d-inline">
-                        <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Загрузить">&#11015;&#65039;</button>
-                    </form>
-                </span>
-                <form method="post" action="/channels/{{ ch.id }}/stats" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-primary btn-sm emoji-btn" title="Обновить статистику">&#128202;</button>
-                </form>
-                <form method="post" action="/channels/{{ ch.id }}/toggle" class="d-inline" data-busy>
-                    <button type="submit" class="btn btn-outline-secondary btn-sm emoji-btn" title="{{ 'Отключить' if ch.is_active else 'Включить' }}">
-                        {{ "⏏️" if ch.is_active else "▶️" }}
-                    </button>
-                </form>
-                <form method="post" action="/channels/{{ ch.id }}/delete" class="d-inline" data-busy onsubmit="return confirm('Вы уверены, что хотите удалить этот канал?')">
-                    <button type="submit" class="btn btn-outline-danger btn-sm emoji-btn" title="Удалить">&#128465;&#65039;</button>
-                </form>
+                {{ channel_actions(ch, prefix="m-") }}
             </div>
         </div>
     </div>

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import filter_flags %}
 {% block title %}Очистка — TG Agent{% endblock %}
 {% block content %}
 <h1>Очистка каналов</h1>
@@ -34,16 +35,6 @@
         </tr>
     </thead>
     <tbody>
-        {% set flag_emoji = {
-            "low_uniqueness": ("📴", "Низкая уникальность контента"),
-            "low_subscriber_ratio": ("📊", "Мало подписчиков"),
-            "low_subscriber_manual": ("✋", "Мало подписчиков (абс.)"),
-            "manual": ("🚫", "Ручная фильтрация"),
-            "cross_channel_spam": ("📢", "Кросс-канальный спам"),
-            "non_cyrillic": ("🌐", "Не кириллический контент"),
-            "chat_noise": ("💬", "Шум чата"),
-            "username_changed": ("💡", "Сменил юзернейм")
-        } %}
         {% for ch in channels %}
         <tr class="table-danger">
             <td>
@@ -55,18 +46,7 @@
             <td class="d-none d-sm-table-cell">{% if ch.username %}@{{ ch.username }}{% else %}-{% endif %}</td>
             <td class="d-none d-sm-table-cell">{{ ch.message_count }}</td>
             <td>
-                {% if ch.filter_flags %}
-                    {% for flag in ch.filter_flags.split(',') %}
-                        {% set f = flag.strip() %}
-                        {% if f in flag_emoji %}
-                            <span title="{{ flag_emoji[f][1] }}" style="margin-right:0.25rem;cursor:default;font-size:1.1em">{{ flag_emoji[f][0] }}</span>
-                        {% else %}
-                            <span title="{{ f }}" style="cursor:default">🚫</span>
-                        {% endif %}
-                    {% endfor %}
-                {% else %}
-                    <span title="Отфильтрован" style="cursor:default">🚫</span>
-                {% endif %}
+                {{ filter_flags(ch.filter_flags, margin='margin-right:0.25rem;') }}
             </td>
         </tr>
         {% endfor %}

--- a/src/web/templates/web_login.html
+++ b/src/web/templates/web_login.html
@@ -6,9 +6,7 @@
     <title>Вход — TG Agent</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
-    <script>
-    (function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-bs-theme',t)})();
-    </script>
+    <script src="/static/_theme_init.js"></script>
 </head>
 <body>
     <div class="d-flex justify-content-center align-items-center min-vh-100">
@@ -40,17 +38,6 @@
             </div>
         </div>
     </div>
-<script>
-document.addEventListener('submit', function(e) {
-    if (e.defaultPrevented) return;
-    var form = e.target;
-    if (!form.hasAttribute('data-busy')) return;
-    var btn = e.submitter || form.querySelector('button[type="submit"]');
-    if (!btn || btn.disabled) return;
-    btn.disabled = true;
-    var label = btn.getAttribute('data-busy-label') || btn.textContent.trim();
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> ' + label;
-});
-</script>
+<script src="/static/_busy_button.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extract `flag_emoji` dict into `FILTER_FLAG_EMOJI` constant in `template_globals.py` and register as Jinja global
- Create `_macros.html` with `filter_flags()` and `channel_actions()` macros, replacing duplicated flag rendering and desktop/mobile action button blocks
- Move shared inline JS (theme init, busy-button handler, `setAsyncButtonBusy`) into `_theme_init.js` and `_busy_button.js` static files

Closes #357

## Test plan
- [x] `ruff check src/` — no errors
- [x] `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — 4587 passed
- [x] `pytest tests/ -v -m aiosqlite_serial` — 684 passed
- [ ] Manual: channels page (desktop + mobile) renders flag emojis and action buttons correctly
- [ ] Manual: filter manage page renders flags with spacing
- [ ] Manual: login page theme init and busy-spinner work

🤖 Generated with [Claude Code](https://claude.com/claude-code)