### PR TITLE
fix(pipelines): resolve LLM provider banner regression (#360)

### DIFF
--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -1003,6 +1003,11 @@ class AgentProviderService:
             if not raw:
                 continue
             if self._cipher is None:
+                if raw:
+                    raise ValueError(
+                        "SESSION_ENCRYPTION_KEY is not configured; "
+                        "cannot decrypt saved provider secrets."
+                    )
                 values[spec_field.name] = ""
                 continue
             values[spec_field.name] = self._cipher.decrypt(raw)

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -1003,13 +1003,10 @@ class AgentProviderService:
             if not raw:
                 continue
             if self._cipher is None:
-                if raw:
-                    raise ValueError(
-                        "SESSION_ENCRYPTION_KEY is not configured; "
-                        "cannot decrypt saved provider secrets."
-                    )
-                values[spec_field.name] = ""
-                continue
+                raise ValueError(
+                    "SESSION_ENCRYPTION_KEY is not configured; "
+                    "cannot decrypt saved provider secrets."
+                )
             values[spec_field.name] = self._cipher.decrypt(raw)
         return values
 

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -160,7 +160,7 @@ class AgentProviderService:
         reloading_names = _reloading_names or set()
         for cfg in configs:
             if not cfg.enabled:
-                logger.warning("Skipping db provider %s: disabled", cfg.provider)
+                logger.debug("Skipping db provider %s: disabled", cfg.provider)
                 continue
             if not self._has_valid_secrets(cfg):
                 logger.warning("Skipping db provider %s: empty/invalid secrets", cfg.provider)
@@ -309,6 +309,7 @@ class AgentProviderService:
             db_svc = DbProviderService(self.db, self._config)
             configs = await db_svc.load_provider_configs()
         except Exception:
+            logger.warning("Failed to load provider statuses from DB", exc_info=True)
             return []
 
         statuses: list[dict[str, str]] = []

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -160,14 +160,15 @@ class AgentProviderService:
         reloading_names = _reloading_names or set()
         for cfg in configs:
             if not cfg.enabled:
+                logger.warning("Skipping db provider %s: disabled", cfg.provider)
                 continue
             if not self._has_valid_secrets(cfg):
-                logger.debug("Skipping db provider %s: empty secrets", cfg.provider)
+                logger.warning("Skipping db provider %s: empty/invalid secrets", cfg.provider)
                 continue
             try:
                 adapter = self._build_adapter_for_config(cfg)
                 if adapter is None:
-                    logger.debug("Skipping db provider %s: no adapter mapping", cfg.provider)
+                    logger.warning("Skipping db provider %s: no adapter mapping", cfg.provider)
                     continue
                 name = cfg.provider
                 # Register if new; overwrite if previously DB-sourced
@@ -194,10 +195,18 @@ class AgentProviderService:
             self._registry.pop(name, None)
         return added
 
-    @staticmethod
-    def _has_valid_secrets(cfg: Any) -> bool:
+    def _has_valid_secrets(self, cfg: Any) -> bool:
         secrets = getattr(cfg, "secret_fields", None) or {}
-        return any((v or "").strip() for v in secrets.values())
+        if any((v or "").strip() for v in secrets.values()):
+            return True
+        # Providers where ALL secret fields are optional (e.g. Ollama)
+        # are valid even without secrets.
+        from src.agent.provider_registry import provider_spec
+
+        spec = provider_spec(getattr(cfg, "provider", ""))
+        if spec is not None and spec.secret_fields and all(not f.required for f in spec.secret_fields):
+            return True
+        return False
 
     def _build_adapter_for_config(self, cfg: Any) -> Callable[..., Awaitable[str]] | None:
         """Map a ProviderRuntimeConfig to a provider adapter callable."""
@@ -285,6 +294,44 @@ class AgentProviderService:
     def has_providers(self) -> bool:
         """Return True if any real (non-default) provider is registered."""
         return any(name != "default" for name in self._registry)
+
+    async def get_provider_status_list(self) -> list[dict[str, str]]:
+        """Return per-provider diagnostic status for UI display.
+
+        Each entry: {"provider": str, "status": str, "reason": str}.
+        Statuses: active, disabled, invalid_secrets, no_adapter.
+        """
+        if self.db is None or self._config is None:
+            return []
+        from src.services.agent_provider_service import AgentProviderService as DbProviderService
+
+        try:
+            db_svc = DbProviderService(self.db, self._config)
+            configs = await db_svc.load_provider_configs()
+        except Exception:
+            return []
+
+        statuses: list[dict[str, str]] = []
+        for cfg in configs:
+            if cfg.provider in self._registry and cfg.provider != "default":
+                statuses.append({"provider": cfg.provider, "status": "active", "reason": ""})
+            elif not cfg.enabled:
+                statuses.append({"provider": cfg.provider, "status": "disabled", "reason": "Провайдер отключён."})
+            elif not self._has_valid_secrets(cfg):
+                reason = cfg.last_validation_error or "API-ключ или секрет пуст."
+                statuses.append({"provider": cfg.provider, "status": "invalid_secrets", "reason": reason})
+            else:
+                adapter = self._build_adapter_for_config(cfg)
+                if adapter is None:
+                    reason = f"Адаптер для {cfg.provider} ещё не реализован."
+                    statuses.append({"provider": cfg.provider, "status": "no_adapter", "reason": reason})
+                else:
+                    statuses.append({
+                        "provider": cfg.provider,
+                        "status": "unknown_skip",
+                        "reason": "Провайдер пропущен по неизвестной причине.",
+                    })
+        return statuses
 
     def register_provider(self, name: str, func: Callable[..., Awaitable[str]]) -> None:
         self._registry[name] = func

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -72,7 +72,7 @@ async def _page_context(request: Request) -> dict:
             next_runs[pipeline.id] = nr.isoformat() if nr else None
     except Exception:
         next_runs = {}
-    return {
+    ctx = {
         "items": items,
         "channels": channels,
         "accounts": accounts,
@@ -83,8 +83,11 @@ async def _page_context(request: Request) -> dict:
         "generation_backends": list(PipelineGenerationBackend),
         "next_runs": next_runs,
         "llm_configured": deps.get_llm_provider_service(request).has_providers(),
-        "llm_provider_statuses": await deps.get_llm_provider_service(request).get_provider_status_list(),
     }
+    # Only query DB for provider statuses when the banner is visible
+    if not ctx["llm_configured"]:
+        ctx["llm_provider_statuses"] = await deps.get_llm_provider_service(request).get_provider_status_list()
+    return ctx
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -83,6 +83,7 @@ async def _page_context(request: Request) -> dict:
         "generation_backends": list(PipelineGenerationBackend),
         "next_runs": next_runs,
         "llm_configured": deps.get_llm_provider_service(request).has_providers(),
+        "llm_provider_statuses": await deps.get_llm_provider_service(request).get_provider_status_list(),
     }
 
 

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -43,7 +43,14 @@
 
 {% if not llm_configured %}
 <div class="alert alert-warning" role="alert">
-    LLM-провайдер не настроен — генерация контента недоступна. Добавьте провайдера в <a href="/settings">Настройках</a> или задайте переменную окружения с ключом API (например, <code>OPENAI_API_KEY</code>, <code>COHERE_API_KEY</code>).
+    <strong>LLM-провайдер не настроен</strong> — генерация контента недоступна. Добавьте провайдера в <a href="/settings">Настройках</a> или задайте переменную окружения с ключом API (например, <code>OPENAI_API_KEY</code>, <code>COHERE_API_KEY</code>).
+    {% if llm_provider_statuses %}
+    <ul class="mb-0 mt-2">
+        {% for ps in llm_provider_statuses %}
+        <li><strong>{{ ps.provider }}</strong>: {{ ps.reason }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
 </div>
 {% endif %}
 

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -1180,14 +1180,16 @@ class TestAgentProviderServiceExtended:
         assert result["model"] == "test"
 
     async def test_decrypt_no_cipher(self, db):
+        import pytest
+
         from src.services.agent_provider_service import AgentProviderService, provider_spec
         config = AppConfig()
         svc = AgentProviderService(db, config)
         svc._cipher = None
         spec = provider_spec("openai")
         if spec and spec.secret_fields:
-            result = svc._decrypt_secret_fields({"api_key": "secret"}, spec)
-            assert result.get("api_key") == ""
+            with pytest.raises(ValueError, match="SESSION_ENCRYPTION_KEY"):
+                svc._decrypt_secret_fields({"api_key": "secret"}, spec)
 
     async def test_app_version(self, db):
         from src.services.agent_provider_service import AgentProviderService

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -1,6 +1,7 @@
 """Tests for AgentProviderService.load_db_providers (env-only service)."""
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -57,7 +58,7 @@ async def test_load_db_providers_registers_openai(mock_db, mock_config):
 
 @pytest.mark.asyncio
 async def test_load_db_providers_skips_empty_secrets(mock_db, mock_config):
-    """Provider with empty secrets is skipped."""
+    """Provider with empty secrets (all required) is skipped."""
     mock_cfg = MagicMock()
     mock_cfg.provider = "openai"
     mock_cfg.enabled = True
@@ -176,8 +177,31 @@ async def test_load_db_providers_cohere_adapter(mock_db, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_load_db_providers_ollama_adapter(mock_db, mock_config):
-    """Ollama provider with no api_key has empty secrets -> skipped."""
+async def test_load_db_providers_ollama_adapter_with_key(mock_db, mock_config):
+    """Ollama provider with api_key is registered."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "ollama"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "ollama-key"}
+    mock_cfg.plain_fields = {"base_url": "http://localhost:11434"}
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        added = await svc.load_db_providers()
+
+    assert added == 1
+    assert "ollama" in svc._registry
+
+
+@pytest.mark.asyncio
+async def test_load_db_providers_ollama_without_api_key(mock_db, mock_config):
+    """Ollama with no api_key should be valid since api_key is optional."""
     mock_cfg = MagicMock()
     mock_cfg.provider = "ollama"
     mock_cfg.enabled = True
@@ -194,8 +218,9 @@ async def test_load_db_providers_ollama_adapter(mock_db, mock_config):
         svc = AgentProviderService(db=mock_db, config=mock_config)
         added = await svc.load_db_providers()
 
-    # No api_key = empty secrets -> skipped
-    assert added == 0
+    assert added == 1
+    assert svc.has_providers()
+    assert "ollama" in svc._registry
 
 
 @pytest.mark.asyncio
@@ -216,17 +241,171 @@ async def test_load_db_providers_handles_exception(mock_db, mock_config):
 
 def test_has_valid_secrets():
     """_has_valid_secrets checks non-empty secret values."""
+    svc = AgentProviderService()
     cfg = MagicMock()
+    cfg.provider = "openai"
     cfg.secret_fields = {"api_key": "valid-key"}
-    assert AgentProviderService._has_valid_secrets(cfg) is True
+    assert svc._has_valid_secrets(cfg) is True
 
     cfg2 = MagicMock()
+    cfg2.provider = "openai"
     cfg2.secret_fields = {"api_key": ""}
-    assert AgentProviderService._has_valid_secrets(cfg2) is False
+    assert svc._has_valid_secrets(cfg2) is False
 
     cfg3 = MagicMock()
+    cfg3.provider = "openai"
     cfg3.secret_fields = {}
-    assert AgentProviderService._has_valid_secrets(cfg3) is False
+    assert svc._has_valid_secrets(cfg3) is False
 
     cfg4 = MagicMock(spec=[])  # no secret_fields attr
-    assert AgentProviderService._has_valid_secrets(cfg4) is False
+    cfg4.provider = "openai"
+    assert svc._has_valid_secrets(cfg4) is False
+
+
+def test_has_valid_secrets_allows_all_optional():
+    """Providers where all secret fields are optional (like Ollama) should be valid."""
+    svc = AgentProviderService()
+    cfg = MagicMock()
+    cfg.provider = "ollama"
+    cfg.secret_fields = {"api_key": ""}
+    assert svc._has_valid_secrets(cfg) is True
+
+
+def test_has_valid_secrets_huggingface_without_key():
+    """HuggingFace api_key is also optional, should be valid without it."""
+    svc = AgentProviderService()
+    cfg = MagicMock()
+    cfg.provider = "huggingface"
+    cfg.secret_fields = {"api_key": ""}
+    assert svc._has_valid_secrets(cfg) is True
+
+
+def test_has_valid_secrets_requires_secrets_for_required_providers():
+    """Providers with required secret fields still need a non-empty value."""
+    svc = AgentProviderService()
+    cfg = MagicMock()
+    cfg.provider = "deepseek"
+    cfg.secret_fields = {"api_key": ""}
+    assert svc._has_valid_secrets(cfg) is False
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_disabled(mock_db, mock_config):
+    """get_provider_status_list returns disabled status."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = False
+    mock_cfg.secret_fields = {"api_key": "sk-test"}
+    mock_cfg.plain_fields = {}
+    mock_cfg.last_validation_error = ""
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        statuses = await svc.get_provider_status_list()
+
+    assert len(statuses) == 1
+    assert statuses[0]["provider"] == "openai"
+    assert statuses[0]["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_invalid_secrets(mock_db, mock_config):
+    """get_provider_status_list returns invalid_secrets with reason."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": ""}
+    mock_cfg.plain_fields = {}
+    mock_cfg.last_validation_error = "SESSION_ENCRYPTION_KEY is not configured"
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        statuses = await svc.get_provider_status_list()
+
+    assert len(statuses) == 1
+    assert statuses[0]["status"] == "invalid_secrets"
+    assert "SESSION_ENCRYPTION_KEY" in statuses[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_no_adapter(mock_db, mock_config):
+    """get_provider_status_list returns no_adapter for unsupported providers."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "anthropic"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "sk-ant-test"}
+    mock_cfg.plain_fields = {}
+    mock_cfg.last_validation_error = ""
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        statuses = await svc.get_provider_status_list()
+
+    assert len(statuses) == 1
+    assert statuses[0]["status"] == "no_adapter"
+    assert "anthropic" in statuses[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_active(mock_db, mock_config):
+    """get_provider_status_list returns active for registered providers."""
+    mock_cfg = MagicMock()
+    mock_cfg.provider = "openai"
+    mock_cfg.enabled = True
+    mock_cfg.secret_fields = {"api_key": "sk-test"}
+    mock_cfg.plain_fields = {"base_url": ""}
+    mock_cfg.last_validation_error = ""
+
+    with patch(
+        "src.services.agent_provider_service.AgentProviderService"
+    ) as mock_db_svc_cls:
+        mock_db_svc = MagicMock()
+        mock_db_svc.load_provider_configs = AsyncMock(return_value=[mock_cfg])
+        mock_db_svc_cls.return_value = mock_db_svc
+
+        svc = AgentProviderService(db=mock_db, config=mock_config)
+        await svc.load_db_providers()
+        statuses = await svc.get_provider_status_list()
+
+    assert len(statuses) == 1
+    assert statuses[0]["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_no_db():
+    """Returns empty list when no DB configured."""
+    svc = AgentProviderService(db=None, config=None)
+    assert await svc.get_provider_status_list() == []
+
+
+def test_env_provider_makes_has_providers_true():
+    """When env provider exists, has_providers() is True even if DB load fails."""
+    env_key = "OPENAI_API_KEY"
+    original = os.environ.get(env_key)
+    try:
+        os.environ[env_key] = "test-key-for-banner-test"
+        svc = AgentProviderService(db=MagicMock(), config=MagicMock())
+        assert svc.has_providers()
+    finally:
+        if original is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = original


### PR DESCRIPTION
## Summary
- Fix 4 silent skip paths in provider loading chain that caused the "LLM-провайдер не настроен" banner to show when API keys are saved in DB
- `_decrypt_secret_fields` now raises `ValueError` when `SESSION_ENCRYPTION_KEY` is missing but encrypted data exists, instead of silently returning empty strings
- `_has_valid_secrets` respects `ProviderSpec.required` flag, allowing providers with optional secrets (Ollama, HuggingFace) to validate without an API key
- New `get_provider_status_list()` method returns per-provider diagnostics (disabled/invalid_secrets/no_adapter/active)
- Pipeline banner now shows specific skip reasons when DB configs exist but all providers are skipped
- Skip reasons elevated from `debug` to `warning` level in `load_db_providers`

## Test plan
- [x] 20 tests in `test_provider_service_db_load.py` pass (Ollama without key, optional secrets, provider statuses, env providers)
- [x] Updated `test_decrypt_no_cipher` in `test_coverage_final.py` to expect `ValueError`
- [x] Full parallel test suite: 4607 passed, 0 failed
- [x] `ruff check` clean on all changed files

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)