### PR TITLE
feat(analytics): per-channel statistics dashboard (#330)

### DIFF
--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -220,6 +220,80 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Top {limit} emojis (last {days} days):\n")
                     for emoji, count in counter.most_common(limit):
                         print(f"  {emoji}  {count}")
+
+            elif action == "channel":
+                from src.services.channel_analytics_service import ChannelAnalyticsService
+
+                channel_id = args.channel_id
+                days = getattr(args, "days", 30)
+                svc = ChannelAnalyticsService(db)
+                ov = await svc.get_channel_overview(channel_id, days=days)
+                if ov.title is None:
+                    print(f"Channel {channel_id} not found.")
+                    return
+                print(f"Channel: {ov.title or ov.username or channel_id}")
+                print(f"Username: {ov.username or '-'}")
+                print(f"Subscribers: {ov.subscriber_count if ov.subscriber_count is not None else '-'}")
+                if ov.subscriber_delta_week is not None:
+                    print(f"  Delta week: {'+' if ov.subscriber_delta_week >= 0 else ''}{ov.subscriber_delta_week}")
+                if ov.subscriber_delta_month is not None:
+                    print(f"  Delta month: {'+' if ov.subscriber_delta_month >= 0 else ''}{ov.subscriber_delta_month}")
+                print(f"ERR: {ov.err:.2f}%" if ov.err is not None else "ERR: -")
+                print(f"ERR24: {ov.err24:.2f}%" if ov.err24 is not None else "ERR24: -")
+                print(f"Posts total: {ov.total_posts}")
+                print(f"  today / week / period({days}d): {ov.posts_today} / {ov.posts_week} / {ov.posts_month}")
+                print(f"Avg views: {ov.avg_views if ov.avg_views is not None else '-'}")
+                print(f"Avg forwards: {ov.avg_forwards if ov.avg_forwards is not None else '-'}")
+                print(f"Avg reactions: {ov.avg_reactions if ov.avg_reactions is not None else '-'}")
+
+                # Citation stats
+                cit = await svc.get_citation_stats(channel_id)
+                print("\nCitations (forwards):")
+                print(f"  Total: {cit.total_forwards}  Posts: {cit.post_count}  Avg/post: {cit.avg_forwards}")
+
+                # Cross-channel citations
+                cross = await svc.get_cross_channel_citations(channel_id, days=days, limit=10)
+                if cross:
+                    print(f"\nCross-channel citations (last {days}d):")
+                    fmt = "  {:<30} {:<10} {}"
+                    print(fmt.format("Source", "Citations", "Last date"))
+                    for row in cross:
+                        name = row["source_title"] or row["source_username"] or str(row["source_channel_id"])
+                        print(fmt.format(name[:30], str(row["citation_count"]), (row["latest_date"] or "")[:10]))
+                else:
+                    print(f"\nNo cross-channel citations in last {days}d.")
+
+                # Heatmap (compact text representation)
+                heatmap = await svc.get_heatmap(channel_id, days=days)
+                if heatmap:
+                    print(f"\nHeatmap (hour x weekday, last {days}d):")
+                    # SQLite %w: 0=Sun; reorder to Mon-first
+                    wd_order = [1, 2, 3, 4, 5, 6, 0]
+                    wd_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+                    heat_map = {}
+                    max_cnt = 1
+                    for r in heatmap:
+                        heat_map[(r["weekday"], r["hour"])] = r["count"]
+                        if r["count"] > max_cnt:
+                            max_cnt = r["count"]
+                    header = "       " + " ".join(f"{h:02d}" for h in range(24))
+                    print(header)
+                    for idx, wd in enumerate(wd_order):
+                        cells = []
+                        for h in range(24):
+                            cnt = heat_map.get((wd, h), 0)
+                            pct = cnt / max_cnt if max_cnt else 0
+                            if cnt == 0:
+                                cells.append("  .")
+                            elif pct < 0.33:
+                                cells.append("  -")
+                            elif pct < 0.66:
+                                cells.append("  +")
+                            else:
+                                cells.append("  *")
+                        print(f"  {wd_labels[idx]:>3}  " + " ".join(cells))
+                else:
+                    print(f"\nNo heatmap data for last {days}d.")
         finally:
             await db.close()
 

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -803,6 +803,10 @@ def build_parser() -> argparse.ArgumentParser:
     analytics_emojis.add_argument("--days", type=int, default=7, help="Number of days (default: 7)")
     analytics_emojis.add_argument("--limit", type=int, default=20)
 
+    analytics_channel = analytics_sub.add_parser("channel", help="Per-channel statistics overview")
+    analytics_channel.add_argument("channel_id", type=int, help="Telegram channel_id (negative int)")
+    analytics_channel.add_argument("--days", type=int, default=30, help="Time window in days (default: 30)")
+
     # ── provider ──
     provider_parser = sub.add_parser("provider", help="LLM provider management")
     provider_sub = provider_parser.add_subparsers(dest="provider_action")

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -704,6 +704,20 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     await _migrate_tool_permission_key(db, "list_dialogs", legacy_dialog_search_key)
     await _migrate_tool_permission_key(db, legacy_dialog_search_key, "search_dialogs")
 
+    # forward_from_channel_id on messages for cross-channel citation tracking (issue #330)
+    cur = await db.execute("PRAGMA table_info(messages)")
+    msg2_columns = {row["name"] for row in await cur.fetchall()}
+    if "forward_from_channel_id" not in msg2_columns:
+        await db.execute(
+            "ALTER TABLE messages ADD COLUMN forward_from_channel_id INTEGER"
+        )
+        await db.commit()
+    await db.execute("""
+        CREATE INDEX IF NOT EXISTS idx_messages_fwd_from_channel
+        ON messages(forward_from_channel_id) WHERE forward_from_channel_id IS NOT NULL
+    """)
+    await db.commit()
+
     # Reset agent prompt template to new default (AI Telegram client) — one-time migration
     cur = await db.execute("SELECT value FROM settings WHERE key = '_migration_reset_prompt_v2'")
     if not await cur.fetchone():

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -123,3 +123,27 @@ class ChannelStatsRepository:
             elif rn == 2:
                 previous[r["channel_id"]] = r["subscriber_count"]
         return latest, previous
+
+    async def get_subscriber_history(
+        self, channel_id: int, days: int = 30
+    ) -> list[dict]:
+        """Return subscriber_count time series for a channel over the last N days."""
+        cur = await self._db.execute(
+            "SELECT collected_at, subscriber_count "
+            "FROM channel_stats "
+            "WHERE channel_id = ? AND collected_at >= datetime('now', ?) "
+            "ORDER BY collected_at ASC",
+            (channel_id, f"-{days} days"),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_subscriber_count_at(self, channel_id: int, days_ago: int) -> int | None:
+        """Get the subscriber count closest to N days ago for a channel."""
+        cur = await self._db.execute(
+            "SELECT subscriber_count FROM channel_stats "
+            "WHERE channel_id = ? AND collected_at <= datetime('now', ?) "
+            "ORDER BY collected_at DESC LIMIT 1",
+            (channel_id, f"-{days_ago} days"),
+        )
+        row = await cur.fetchone()
+        return row["subscriber_count"] if row else None

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -132,7 +132,7 @@ class ChannelStatsRepository:
             "SELECT collected_at, subscriber_count "
             "FROM channel_stats "
             "WHERE channel_id = ? AND collected_at >= datetime('now', ?) "
-            "ORDER BY collected_at ASC",
+            "ORDER BY collected_at ASC, id ASC",
             (channel_id, f"-{days} days"),
         )
         return [dict(r) for r in await cur.fetchall()]
@@ -142,7 +142,7 @@ class ChannelStatsRepository:
         cur = await self._db.execute(
             "SELECT subscriber_count FROM channel_stats "
             "WHERE channel_id = ? AND collected_at <= datetime('now', ?) "
-            "ORDER BY collected_at DESC LIMIT 1",
+            "ORDER BY collected_at DESC, id DESC LIMIT 1",
             (channel_id, f"-{days_ago} days"),
         )
         row = await cur.fetchone()

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -1221,3 +1221,95 @@ class MessagesRepository:
         if updated:
             await self._db.commit()
         return updated
+
+    async def get_views_timeseries(
+        self, channel_id: int, days: int = 30
+    ) -> list[dict]:
+        """Daily average views and message count for a channel."""
+        cur = await self._db.execute(
+            """SELECT date(m.date) AS day,
+                      COUNT(*) AS message_count,
+                      COALESCE(AVG(m.views), 0) AS avg_views
+               FROM messages m
+               WHERE m.channel_id = ? AND m.date >= datetime('now', ?)
+               GROUP BY day
+               ORDER BY day ASC""",
+            (channel_id, f"-{days} days"),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_post_frequency(
+        self, channel_id: int, days: int = 30
+    ) -> list[dict]:
+        """Daily post count for a channel."""
+        cur = await self._db.execute(
+            """SELECT date(m.date) AS day, COUNT(*) AS count
+               FROM messages m
+               WHERE m.channel_id = ? AND m.date >= datetime('now', ?)
+               GROUP BY day
+               ORDER BY day ASC""",
+            (channel_id, f"-{days} days"),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_channel_message_count(
+        self, channel_id: int, days: int | None = None
+    ) -> int:
+        """Count messages for a channel, optionally within last N days."""
+        if days is not None:
+            cur = await self._db.execute(
+                "SELECT COUNT(*) AS cnt FROM messages "
+                "WHERE channel_id = ? AND date >= datetime('now', ?)",
+                (channel_id, f"-{days} days"),
+            )
+        else:
+            cur = await self._db.execute(
+                "SELECT COUNT(*) AS cnt FROM messages WHERE channel_id = ?",
+                (channel_id,),
+            )
+        row = await cur.fetchone()
+        return row["cnt"] if row else 0
+
+    async def get_err_data(
+        self, channel_id: int, last_n: int = 20
+    ) -> list[dict]:
+        """Get engagement data for ERR calculation (last N posts)."""
+        cur = await self._db.execute(
+            """SELECT m.views, m.forwards, m.reply_count,
+                      COALESCE((SELECT SUM(mr.count) FROM message_reactions mr
+                                WHERE mr.channel_id = m.channel_id
+                                AND mr.message_id = m.message_id), 0) AS total_reactions
+               FROM messages m
+               WHERE m.channel_id = ?
+               ORDER BY m.date DESC
+               LIMIT ?""",
+            (channel_id, last_n),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_err24_data(self, channel_id: int) -> list[dict]:
+        """Get engagement data for ERR24 (posts from last 24h)."""
+        cur = await self._db.execute(
+            """SELECT m.views, m.forwards, m.reply_count,
+                      COALESCE((SELECT SUM(mr.count) FROM message_reactions mr
+                                WHERE mr.channel_id = m.channel_id
+                                AND mr.message_id = m.message_id), 0) AS total_reactions
+               FROM messages m
+               WHERE m.channel_id = ? AND m.date >= datetime('now', '-1 day')
+               ORDER BY m.date DESC""",
+            (channel_id,),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_citation_stats(self, channel_id: int) -> dict:
+        """Get forward-based citation stats for a channel."""
+        cur = await self._db.execute(
+            """SELECT COALESCE(SUM(m.forwards), 0) AS total_forwards,
+                      COUNT(*) AS post_count,
+                      COALESCE(AVG(m.forwards), 0) AS avg_forwards
+               FROM messages m
+               WHERE m.channel_id = ?""",
+            (channel_id,),
+        )
+        row = await cur.fetchone()
+        return dict(row) if row else {"total_forwards": 0, "post_count": 0, "avg_forwards": 0}

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -1311,7 +1311,7 @@ class MessagesRepository:
         cur = await self._db.execute(
             """SELECT COALESCE(SUM(m.forwards), 0) AS total_forwards,
                       COUNT(*) AS post_count,
-                      COALESCE(AVG(m.forwards), 0) AS avg_forwards
+                      COALESCE(AVG(COALESCE(m.forwards, 0)), 0) AS avg_forwards
                FROM messages m
                WHERE m.channel_id = ?""",
             (channel_id,),

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -108,8 +108,9 @@ class MessagesRepository:
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
                     text, media_type, topic_id, reactions_json,
-                    views, forwards, reply_count, date, detected_lang)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    views, forwards, reply_count, date, detected_lang,
+                    forward_from_channel_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     msg.channel_id,
                     msg.message_id,
@@ -124,6 +125,7 @@ class MessagesRepository:
                     msg.reply_count,
                     msg.date.isoformat(),
                     msg.detected_lang,
+                    getattr(msg, "forward_from_channel_id", None),
                 ),
             )
             await self._db.commit()
@@ -179,6 +181,7 @@ class MessagesRepository:
                 m.reply_count,
                 m.date.isoformat(),
                 m.detected_lang,
+                getattr(m, "forward_from_channel_id", None),
             )
             for m in messages
         ]
@@ -187,8 +190,9 @@ class MessagesRepository:
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
                     text, media_type, topic_id, reactions_json,
-                    views, forwards, reply_count, date, detected_lang)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    views, forwards, reply_count, date, detected_lang,
+                    forward_from_channel_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 data,
             )
             await self._db.commit()
@@ -699,6 +703,7 @@ class MessagesRepository:
                 detected_lang=r["detected_lang"] if "detected_lang" in r.keys() else None,
                 translation_en=r["translation_en"] if "translation_en" in r.keys() else None,
                 translation_custom=r["translation_custom"] if "translation_custom" in r.keys() else None,
+                forward_from_channel_id=r["forward_from_channel_id"] if "forward_from_channel_id" in r.keys() else None,
                 channel_title=r["channel_title"],
                 channel_username=r["channel_username"],
             )
@@ -1313,3 +1318,48 @@ class MessagesRepository:
         )
         row = await cur.fetchone()
         return dict(row) if row else {"total_forwards": 0, "post_count": 0, "avg_forwards": 0}
+
+    async def get_hour_weekday_heatmap(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Return message counts grouped by hour (0-23) x weekday (0=Mon..6=Sun).
+
+        Each row has keys: ``hour``, ``weekday``, ``count``.
+        """
+        cur = await self._db.execute(
+            """SELECT CAST(strftime('%H', m.date) AS INTEGER) AS hour,
+                      CAST(strftime('%w', m.date) AS INTEGER) AS weekday,
+                      COUNT(*) AS count
+               FROM messages m
+               WHERE m.channel_id = ? AND m.date >= datetime('now', ?)
+               GROUP BY hour, weekday
+               ORDER BY weekday, hour""",
+            (channel_id, f"-{days} days"),
+        )
+        return [dict(r) for r in await cur.fetchall()]
+
+    async def get_cross_channel_citations(
+        self, channel_id: int, days: int = 30, limit: int = 20,
+    ) -> list[dict]:
+        """Return channels whose messages are forwarded into *channel_id*.
+
+        Each row: ``source_channel_id``, ``source_title``, ``source_username``,
+        ``citation_count``, ``latest_date``.
+        """
+        cur = await self._db.execute(
+            """SELECT m.forward_from_channel_id AS source_channel_id,
+                      c.title AS source_title,
+                      c.username AS source_username,
+                      COUNT(*) AS citation_count,
+                      MAX(m.date) AS latest_date
+               FROM messages m
+               LEFT JOIN channels c ON c.channel_id = m.forward_from_channel_id
+               WHERE m.channel_id = ?
+                 AND m.forward_from_channel_id IS NOT NULL
+                 AND m.date >= datetime('now', ?)
+               GROUP BY m.forward_from_channel_id
+               ORDER BY citation_count DESC
+               LIMIT ?""",
+            (channel_id, f"-{days} days", limit),
+        )
+        return [dict(r) for r in await cur.fetchall()]

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS messages (
     reply_count INTEGER,
     date TEXT NOT NULL,
     collected_at TEXT DEFAULT (datetime('now')),
+    forward_from_channel_id INTEGER,
     UNIQUE(channel_id, message_id)
 );
 

--- a/src/models.py
+++ b/src/models.py
@@ -66,6 +66,7 @@ class Message(BaseModel):
     detected_lang: str | None = None
     translation_en: str | None = None
     translation_custom: str | None = None
+    forward_from_channel_id: int | None = None
     channel_title: str | None = None
     channel_username: str | None = None
 

--- a/src/services/channel_analytics_service.py
+++ b/src/services/channel_analytics_service.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from src.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChannelOverview:
+    """Summary card for a single channel."""
+
+    channel_id: int
+    title: str | None
+    username: str | None
+    subscriber_count: int | None = None
+    subscriber_delta: int | None = None
+    subscriber_delta_week: int | None = None
+    subscriber_delta_month: int | None = None
+    err: float | None = None
+    err24: float | None = None
+    total_posts: int = 0
+    posts_today: int = 0
+    posts_week: int = 0
+    posts_month: int = 0
+    avg_views: float | None = None
+    avg_forwards: float | None = None
+    avg_reactions: float | None = None
+
+
+@dataclass
+class CitationStats:
+    """Forward-based citation statistics for a channel."""
+
+    total_forwards: int = 0
+    post_count: int = 0
+    avg_forwards: float = 0.0
+
+
+@dataclass
+class ChannelListItem:
+    """Minimal channel descriptor for list views."""
+
+    channel_id: int
+    title: str | None
+    username: str | None
+
+
+@dataclass
+class ChannelRanking:
+    """A single channel's position in a ranked comparison."""
+
+    channel_id: int
+    title: str | None
+    username: str | None
+    rank: int
+    score: float
+    subscriber_count: int | None = None
+    posts_period: int = 0
+    avg_views_period: float | None = None
+
+
+@dataclass
+class ChannelComparison:
+    """Side-by-side metrics for multiple channels."""
+
+    channels: list[ChannelOverview] = field(default_factory=list)
+    metrics: list[str] = field(default_factory=lambda: [
+        "subscriber_count",
+        "err",
+        "err24",
+        "avg_views",
+        "avg_forwards",
+        "avg_reactions",
+        "posts_today",
+        "posts_week",
+        "posts_month",
+    ])
+
+
+class ChannelAnalyticsService:
+    """Per-channel analytics -- subscribers, ERR, reach, post frequency, citation.
+
+    All public methods accept a ``days`` parameter (default 30) so callers can
+    control the time window for time-series and aggregated metrics.
+    """
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    # ── public API ──────────────────────────────────────────────────
+
+    async def get_active_channels(self) -> list[ChannelListItem]:
+        """List active, non-filtered channels as lightweight items."""
+        channels = await self._db.get_channels(active_only=True, include_filtered=False)
+        return [
+            ChannelListItem(
+                channel_id=ch.channel_id,
+                title=ch.title,
+                username=ch.username,
+            )
+            for ch in channels
+        ]
+
+    async def get_channel_overview(
+        self,
+        channel_id: int,
+        days: int = 30,
+    ) -> ChannelOverview:
+        """Build the summary card for a single channel.
+
+        Args:
+            channel_id: Telegram channel_id to analyze.
+            days: Time window (in days) for time-series lookups.
+
+        Returns:
+            A ChannelOverview dataclass with all computed metrics.
+        """
+        ch = await self._db.get_channel_by_channel_id(channel_id)
+        overview = ChannelOverview(
+            channel_id=channel_id,
+            title=ch.title if ch else None,
+            username=ch.username if ch else None,
+        )
+
+        # Subscriber data from channel_stats
+        stats_history = await self._db.get_channel_stats(channel_id, limit=60)
+        if stats_history:
+            latest = stats_history[0]
+            overview.subscriber_count = latest.subscriber_count
+            overview.avg_views = latest.avg_views
+            overview.avg_forwards = latest.avg_forwards
+            overview.avg_reactions = latest.avg_reactions
+
+            # Delta vs previous collection
+            if len(stats_history) > 1 and latest.subscriber_count is not None:
+                prev = stats_history[1].subscriber_count
+                if prev is not None:
+                    overview.subscriber_delta = latest.subscriber_count - prev
+
+        # Week/month deltas from historical stats
+        week_ago_count = await self._db.repos.channel_stats.get_subscriber_count_at(
+            channel_id, days_ago=7,
+        )
+        month_ago_count = await self._db.repos.channel_stats.get_subscriber_count_at(
+            channel_id, days_ago=30,
+        )
+        if overview.subscriber_count is not None:
+            if week_ago_count is not None:
+                overview.subscriber_delta_week = overview.subscriber_count - week_ago_count
+            if month_ago_count is not None:
+                overview.subscriber_delta_month = overview.subscriber_count - month_ago_count
+
+        # Post counts -- posts_month uses the days parameter
+        overview.total_posts = await self._db.repos.messages.get_channel_message_count(channel_id)
+        overview.posts_today = await self._db.repos.messages.get_channel_message_count(
+            channel_id, days=1,
+        )
+        overview.posts_week = await self._db.repos.messages.get_channel_message_count(
+            channel_id, days=7,
+        )
+        overview.posts_month = await self._db.repos.messages.get_channel_message_count(
+            channel_id, days=days,
+        )
+
+        # ERR calculations
+        overview.err = await self._calc_err(channel_id, last_n=20)
+        overview.err24 = await self._calc_err24(channel_id)
+
+        return overview
+
+    async def get_subscriber_history(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Subscriber count time series for *days* lookback."""
+        return await self._db.repos.channel_stats.get_subscriber_history(channel_id, days)
+
+    async def get_views_timeseries(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Daily average views and message count for a channel."""
+        return await self._db.repos.messages.get_views_timeseries(channel_id, days)
+
+    async def get_post_frequency(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Daily post count for a channel."""
+        return await self._db.repos.messages.get_post_frequency(channel_id, days)
+
+    async def get_citation_stats(self, channel_id: int) -> CitationStats:
+        """Forward-based citation statistics."""
+        raw = await self._db.repos.messages.get_citation_stats(channel_id)
+        return CitationStats(
+            total_forwards=int(raw.get("total_forwards", 0)),
+            post_count=int(raw.get("post_count", 0)),
+            avg_forwards=round(float(raw.get("avg_forwards", 0)), 1),
+        )
+
+    async def get_err(self, channel_id: int) -> float | None:
+        """Engagement Rate per Reach for the last 20 posts."""
+        return await self._calc_err(channel_id, last_n=20)
+
+    async def get_err24(self, channel_id: int) -> float | None:
+        """Engagement Rate per Reach for posts from the last 24 hours."""
+        return await self._calc_err24(channel_id)
+
+    async def get_hourly_activity(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Message count by hour of day for a channel."""
+        rows = await self._db.execute_fetchall(
+            """SELECT CAST(strftime('%H', m.date) AS INTEGER) AS hour,
+                      COUNT(*) AS count
+               FROM messages m
+               WHERE m.channel_id = ? AND m.date >= datetime('now', ?)
+               GROUP BY hour
+               ORDER BY hour""",
+            (channel_id, f"-{days} days"),
+        )
+        return [dict(r) for r in rows]
+
+    async def get_ranked_channels(
+        self,
+        metric: str = "err",
+        days: int = 30,
+        limit: int = 20,
+    ) -> list[ChannelRanking]:
+        """Rank active channels by a given metric.
+
+        Supported metrics: ``err``, ``subscriber_count``, ``avg_views``,
+        ``posts_period`` (post count in the last *days* days).
+
+        Returns:
+            List of :class:`ChannelRanking` sorted descending by score.
+        """
+        channels = await self.get_active_channels()
+        rankings: list[ChannelRanking] = []
+
+        for item in channels:
+            cid = item.channel_id
+            overview = await self.get_channel_overview(cid, days=days)
+
+            if metric == "err":
+                score = overview.err or 0.0
+            elif metric == "subscriber_count":
+                score = float(overview.subscriber_count or 0)
+            elif metric == "avg_views":
+                score = overview.avg_views or 0.0
+            elif metric == "posts_period":
+                score = float(overview.posts_month)
+            else:
+                logger.warning("Unknown ranking metric %r, defaulting to err", metric)
+                score = overview.err or 0.0
+
+            rankings.append(ChannelRanking(
+                channel_id=cid,
+                title=item.title,
+                username=item.username,
+                rank=0,  # assigned below after sort
+                score=round(score, 4),
+                subscriber_count=overview.subscriber_count,
+                posts_period=overview.posts_month,
+                avg_views_period=overview.avg_views,
+            ))
+
+        rankings.sort(key=lambda r: r.score, reverse=True)
+        for i, r in enumerate(rankings, start=1):
+            r.rank = i
+
+        return rankings[:limit]
+
+    async def get_channel_comparison(
+        self,
+        channel_ids: list[int],
+        days: int = 30,
+    ) -> ChannelComparison:
+        """Compare overview metrics for a set of channels side by side."""
+        overviews: list[ChannelOverview] = []
+        for cid in channel_ids:
+            overview = await self.get_channel_overview(cid, days=days)
+            overviews.append(overview)
+        return ChannelComparison(channels=overviews)
+
+    # -- private helpers -----------------------------------------------------
+
+    async def _get_subscriber_count(self, channel_id: int) -> int | None:
+        stats = await self._db.get_channel_stats(channel_id, limit=1)
+        if stats and stats[0].subscriber_count is not None:
+            return stats[0].subscriber_count
+        return None
+
+    async def _calc_err(self, channel_id: int, last_n: int = 20) -> float | None:
+        sub_count = await self._get_subscriber_count(channel_id)
+        if not sub_count:
+            return None
+        rows = await self._db.repos.messages.get_err_data(channel_id, last_n)
+        if not rows:
+            return None
+        total_engagement = sum(
+            (r.get("views") or 0)
+            + (r.get("forwards") or 0)
+            + (r.get("reply_count") or 0)
+            + r.get("total_reactions", 0)
+            for r in rows
+        )
+        return round(total_engagement / (len(rows) * sub_count) * 100, 2)
+
+    async def _calc_err24(self, channel_id: int) -> float | None:
+        sub_count = await self._get_subscriber_count(channel_id)
+        if not sub_count:
+            return None
+        rows = await self._db.repos.messages.get_err24_data(channel_id)
+        if not rows:
+            return None
+        total_engagement = sum(
+            (r.get("views") or 0)
+            + (r.get("forwards") or 0)
+            + (r.get("reply_count") or 0)
+            + r.get("total_reactions", 0)
+            for r in rows
+        )
+        return round(total_engagement / (len(rows) * sub_count) * 100, 2)

--- a/src/services/channel_analytics_service.py
+++ b/src/services/channel_analytics_service.py
@@ -198,6 +198,20 @@ class ChannelAnalyticsService:
             avg_forwards=round(float(raw.get("avg_forwards", 0)), 1),
         )
 
+    async def get_heatmap(
+        self, channel_id: int, days: int = 30,
+    ) -> list[dict]:
+        """Hour x weekday message-count heatmap data."""
+        return await self._db.repos.messages.get_hour_weekday_heatmap(channel_id, days)
+
+    async def get_cross_channel_citations(
+        self, channel_id: int, days: int = 30, limit: int = 20,
+    ) -> list[dict]:
+        """Cross-channel citation index via forward_from_channel_id."""
+        return await self._db.repos.messages.get_cross_channel_citations(
+            channel_id, days, limit,
+        )
+
     async def get_err(self, channel_id: int) -> float | None:
         """Engagement Rate per Reach for the last 20 posts."""
         return await self._calc_err(channel_id, last_n=20)

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -599,6 +599,14 @@ class Collector:
                             )
                         elif reply_to:
                             pass
+                        # Extract forward source channel for cross-channel citation tracking
+                        fwd_from_channel_id = None
+                        fwd_from = getattr(msg, "fwd_from", None)
+                        if fwd_from and getattr(fwd_from, "from_id", None):
+                            from_id = fwd_from.from_id
+                            if hasattr(from_id, "channel_id"):
+                                fwd_from_channel_id = -from_id.channel_id
+
                         message = Message(
                             channel_id=channel_id,
                             message_id=msg.id,
@@ -617,6 +625,7 @@ class Collector:
                                 if msg.date and msg.date.tzinfo is None
                                 else msg.date
                             ),
+                            forward_from_channel_id=fwd_from_channel_id,
                         )
                         messages_batch.append(message)
 

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import dataclasses
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.services.channel_analytics_service import ChannelAnalyticsService
 from src.services.content_analytics_service import ContentAnalyticsService
 from src.services.trend_service import TrendService
 from src.web import deps
@@ -106,3 +109,72 @@ async def trends_page(request: Request, days: int = 7):
             "days": days,
         },
     )
+
+
+# ── Channel analytics ────────────────────────────────────────────
+
+
+@router.get("/channels", response_class=HTMLResponse)
+async def channel_analytics_page(request: Request, channel_id: int = 0, days: int = 30):
+    """Render per-channel analytics dashboard."""
+    days = days if days in (7, 14, 30, 90) else 30
+    db = deps.get_db(request)
+    svc = ChannelAnalyticsService(db)
+    channels = await svc.get_active_channels()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "analytics/channels.html",
+        {
+            "channels": [dataclasses.asdict(c) for c in channels],
+            "selected_channel_id": channel_id,
+            "days": days,
+        },
+    )
+
+
+def _svc(request: Request) -> ChannelAnalyticsService:
+    return ChannelAnalyticsService(deps.get_db(request))
+
+
+@router.get("/channels/api/overview")
+async def api_channel_overview(request: Request, channel_id: int):
+    overview = await _svc(request).get_channel_overview(channel_id)
+    return JSONResponse(dataclasses.asdict(overview))
+
+
+@router.get("/channels/api/subscribers")
+async def api_subscriber_history(request: Request, channel_id: int, days: int = 30):
+    data = await _svc(request).get_subscriber_history(channel_id, days)
+    return JSONResponse(data)
+
+
+@router.get("/channels/api/views")
+async def api_views_timeseries(request: Request, channel_id: int, days: int = 30):
+    data = await _svc(request).get_views_timeseries(channel_id, days)
+    return JSONResponse(data)
+
+
+@router.get("/channels/api/frequency")
+async def api_post_frequency(request: Request, channel_id: int, days: int = 30):
+    data = await _svc(request).get_post_frequency(channel_id, days)
+    return JSONResponse(data)
+
+
+@router.get("/channels/api/err")
+async def api_err(request: Request, channel_id: int):
+    svc = _svc(request)
+    err = await svc.get_err(channel_id)
+    err24 = await svc.get_err24(channel_id)
+    return JSONResponse({"err": err, "err24": err24})
+
+
+@router.get("/channels/api/hourly")
+async def api_hourly_activity(request: Request, channel_id: int, days: int = 30):
+    data = await _svc(request).get_hourly_activity(channel_id, days)
+    return JSONResponse(data)
+
+
+@router.get("/channels/api/citation")
+async def api_citation_stats(request: Request, channel_id: int):
+    stats = await _svc(request).get_citation_stats(channel_id)
+    return JSONResponse(dataclasses.asdict(stats))

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -178,3 +178,17 @@ async def api_hourly_activity(request: Request, channel_id: int, days: int = 30)
 async def api_citation_stats(request: Request, channel_id: int):
     stats = await _svc(request).get_citation_stats(channel_id)
     return JSONResponse(dataclasses.asdict(stats))
+
+
+@router.get("/channels/api/heatmap")
+async def api_heatmap(request: Request, channel_id: int, days: int = 30):
+    data = await _svc(request).get_heatmap(channel_id, days)
+    return JSONResponse(data)
+
+
+@router.get("/channels/api/cross-citations")
+async def api_cross_citations(
+    request: Request, channel_id: int, days: int = 30, limit: int = 20,
+):
+    data = await _svc(request).get_cross_channel_citations(channel_id, days, limit)
+    return JSONResponse(data)

--- a/src/web/templates/analytics.html
+++ b/src/web/templates/analytics.html
@@ -2,7 +2,13 @@
 {% block title %}Аналитика — TG Agent{% endblock %}
 {% block content %}
 {% macro msg_text(text, max_len=100) %}{{ (text or '')[:max_len] }}{{ '…' if text and text|length > max_len else '' }}{% endmacro %}
-<h1>Аналитика сообщений</h1>
+<h1 class="h3">Аналитика сообщений</h1>
+<div class="btn-group btn-group-sm mb-3" role="group">
+  <a href="/analytics" class="btn btn-outline-secondary active">Сообщения</a>
+  <a href="/analytics/channels" class="btn btn-outline-secondary">Каналы</a>
+  <a href="/analytics/trends" class="btn btn-outline-secondary">Тренды</a>
+  <a href="/analytics/content" class="btn btn-outline-secondary">Контент</a>
+</div>
 
 <form method="get" action="/analytics" class="mb-4" data-busy>
     <div class="row g-3 align-items-end">

--- a/src/web/templates/analytics/channels.html
+++ b/src/web/templates/analytics/channels.html
@@ -197,8 +197,7 @@
 
   function fmtDelta(d) {
     if (d == null) return '';
-    var s = Number(d).toLocaleString('ru-RU', {signDisplay: 'exceptZero'});
-    return d > 0 ? '+' + s : s;
+    return Number(d).toLocaleString('ru-RU', {signDisplay: 'exceptZero'});
   }
 
   async function loadChannel(cid) {
@@ -389,6 +388,7 @@
   document.getElementById('channel-select').addEventListener('change', function() {
     var val = parseInt(this.value);
     if (val) {
+      channelId = val;
       var url = new URL(window.location);
       url.searchParams.set('channel_id', val);
       url.searchParams.set('days', days);

--- a/src/web/templates/analytics/channels.html
+++ b/src/web/templates/analytics/channels.html
@@ -1,0 +1,281 @@
+{% extends "base.html" %}
+{% block title %}Статистика каналов — TG Agent{% endblock %}
+{% block head_scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+{% endblock %}
+{% block content %}
+<h1 class="h3 mb-3">Статистика каналов</h1>
+
+{% macro analytics_tabs(active) %}
+<div class="btn-group btn-group-sm mb-3" role="group">
+  <a href="/analytics" class="btn btn-outline-secondary{% if active == 'messages' %} active{% endif %}">Сообщения</a>
+  <a href="/analytics/channels" class="btn btn-outline-secondary{% if active == 'channels' %} active{% endif %}">Каналы</a>
+  <a href="/analytics/trends" class="btn btn-outline-secondary{% if active == 'trends' %} active{% endif %}">Тренды</a>
+  <a href="/analytics/content" class="btn btn-outline-secondary{% if active == 'content' %} active{% endif %}">Контент</a>
+</div>
+{% endmacro %}
+{{ analytics_tabs('channels') }}
+
+<div class="row g-3 mb-3">
+  <div class="col-md-5">
+    <select id="channel-select" class="form-select">
+      <option value="">— выберите канал —</option>
+      {% for ch in channels %}
+      <option value="{{ ch.channel_id }}" {% if ch.channel_id == selected_channel_id %}selected{% endif %}>
+        {{ ch.title or ch.username or ch.channel_id }}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-3">
+    <div class="btn-group btn-group-sm" role="group" id="period-btns">
+      <button class="btn btn-outline-secondary{% if days == 7 %} active{% endif %}" data-days="7">7д</button>
+      <button class="btn btn-outline-secondary{% if days == 14 %} active{% endif %}" data-days="14">14д</button>
+      <button class="btn btn-outline-secondary{% if days == 30 %} active{% endif %}" data-days="30">30д</button>
+      <button class="btn btn-outline-secondary{% if days == 90 %} active{% endif %}" data-days="90">90д</button>
+    </div>
+  </div>
+</div>
+
+<div id="channel-data" style="display:none">
+  <div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <div class="text-muted small">Подписчики</div>
+          <h4 id="ov-subs">—</h4>
+          <small id="ov-subs-delta" class="text-muted"></small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <div class="text-muted small">ERR / ERR24</div>
+          <h4 id="ov-err">—</h4>
+          <small class="text-muted">Engagement Rate</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <div class="text-muted small">Посты</div>
+          <h4 id="ov-posts">—</h4>
+          <small id="ov-posts-detail" class="text-muted"></small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-3">
+      <div class="card text-center h-100">
+        <div class="card-body">
+          <div class="text-muted small">Ср. просмотры</div>
+          <h4 id="ov-views">—</h4>
+          <small id="ov-views-detail" class="text-muted"></small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4 mb-4">
+    <div class="col-12 col-lg-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Подписчики</div>
+        <div class="card-body"><canvas id="chart-subs"></canvas></div>
+      </div>
+    </div>
+    <div class="col-12 col-lg-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Просмотры (средние)</div>
+        <div class="card-body"><canvas id="chart-views"></canvas></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4 mb-4">
+    <div class="col-12 col-lg-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Частота постов</div>
+        <div class="card-body"><canvas id="chart-freq"></canvas></div>
+      </div>
+    </div>
+    <div class="col-12 col-lg-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Активность по часам (UTC)</div>
+        <div class="card-body"><canvas id="chart-hourly"></canvas></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4 mb-4">
+    <div class="col-12 col-md-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Цитируемость (форварды)</div>
+        <div class="card-body">
+          <div class="row text-center">
+            <div class="col-4">
+              <div class="text-muted small">Всего</div>
+              <h5 id="cit-total">—</h5>
+            </div>
+            <div class="col-4">
+              <div class="text-muted small">Постов</div>
+              <h5 id="cit-posts">—</h5>
+            </div>
+            <div class="col-4">
+              <div class="text-muted small">Ср. / пост</div>
+              <h5 id="cit-avg">—</h5>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="no-channel" class="text-muted py-5 text-center">
+  Выберите канал для отображения статистики.
+</div>
+
+<script>
+(function() {
+  var channelId = {{ selected_channel_id | default(0) }};
+  var days = {{ days | default(30) }};
+  var baseUrl = '/analytics/channels/api';
+
+  var charts = {};
+  var defaultOptions = {
+    responsive: true,
+    maintainAspectRatio: true,
+    plugins: { legend: { display: false } },
+    scales: { x: { grid: { display: false } }, y: { beginAtZero: true } }
+  };
+
+  function destroyCharts() {
+    Object.keys(charts).forEach(function(k) {
+      if (charts[k]) charts[k].destroy();
+      delete charts[k];
+    });
+  }
+
+  function makeChart(id, type, labels, datasets, opts) {
+    var ctx = document.getElementById(id);
+    if (!ctx) return null;
+    var c = new Chart(ctx, {
+      type: type,
+      data: { labels: labels, datasets: datasets },
+      options: Object.assign({}, defaultOptions, opts || {})
+    });
+    charts[id] = c;
+    return c;
+  }
+
+  function fmt(n) {
+    if (n == null) return '—';
+    return Number(n).toLocaleString('ru-RU');
+  }
+
+  function fmtDelta(d) {
+    if (d == null) return '';
+    var s = Number(d).toLocaleString('ru-RU', {signDisplay: 'exceptZero'});
+    return d > 0 ? '+' + s : s;
+  }
+
+  async function loadChannel(cid) {
+    destroyCharts();
+    if (!cid) {
+      document.getElementById('channel-data').style.display = 'none';
+      document.getElementById('no-channel').style.display = '';
+      return;
+    }
+    document.getElementById('channel-data').style.display = '';
+    document.getElementById('no-channel').style.display = 'none';
+
+    // Overview
+    var ov = await fetch(baseUrl + '/overview?channel_id=' + cid).then(function(r) { return r.json(); });
+    document.getElementById('ov-subs').textContent = fmt(ov.subscriber_count);
+    var deltaEl = document.getElementById('ov-subs-delta');
+    if (ov.subscriber_delta_week != null) {
+      deltaEl.textContent = 'нед: ' + fmtDelta(ov.subscriber_delta_week) + ' / мес: ' + fmtDelta(ov.subscriber_delta_month);
+      deltaEl.className = 'text-muted';
+    } else if (ov.subscriber_delta != null) {
+      deltaEl.textContent = fmtDelta(ov.subscriber_delta);
+      deltaEl.className = ov.subscriber_delta >= 0 ? 'text-success' : 'text-danger';
+    } else {
+      deltaEl.textContent = '';
+    }
+    document.getElementById('ov-err').textContent =
+      (ov.err != null ? ov.err.toFixed(2) + '%' : '—') + ' / ' +
+      (ov.err24 != null ? ov.err24.toFixed(2) + '%' : '—');
+    document.getElementById('ov-posts').textContent = fmt(ov.total_posts);
+    document.getElementById('ov-posts-detail').textContent =
+      'сег: ' + (ov.posts_today || 0) + ' / нед: ' + (ov.posts_week || 0) + ' / пер: ' + (ov.posts_month || 0);
+    document.getElementById('ov-views').textContent = ov.avg_views != null ? fmt(Math.round(ov.avg_views)) : '—';
+    document.getElementById('ov-views-detail').textContent =
+      'фор: ' + (ov.avg_forwards != null ? ov.avg_forwards.toFixed(1) : '—') +
+      ' / реакт: ' + (ov.avg_reactions != null ? ov.avg_reactions.toFixed(1) : '—');
+
+    // Charts
+    var subs = await fetch(baseUrl + '/subscribers?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    makeChart('chart-subs', 'line',
+      subs.map(function(r) { return r.collected_at ? r.collected_at.slice(0, 10) : ''; }),
+      [{ data: subs.map(function(r) { return r.subscriber_count; }), borderColor: '#0d6efd', tension: 0.3, fill: false }]
+    );
+
+    var views = await fetch(baseUrl + '/views?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    makeChart('chart-views', 'line',
+      views.map(function(r) { return r.day; }),
+      [{ label: 'Ср. просмотры', data: views.map(function(r) { return Math.round(r.avg_views); }), borderColor: '#198754', tension: 0.3, fill: false }]
+    );
+
+    var freq = await fetch(baseUrl + '/frequency?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    makeChart('chart-freq', 'bar',
+      freq.map(function(r) { return r.day; }),
+      [{ label: 'Постов', data: freq.map(function(r) { return r.count; }), backgroundColor: '#6f42c1' }]
+    );
+
+    var hourly = await fetch(baseUrl + '/hourly?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    var allHours = [];
+    for (var h = 0; h < 24; h++) allHours.push(h);
+    var hourData = allHours.map(function(h) {
+      var found = hourly.find(function(r) { return r.hour === h; });
+      return found ? found.count : 0;
+    });
+    makeChart('chart-hourly', 'bar',
+      allHours.map(function(h) { return String(h).padStart(2, '0') + ':00'; }),
+      [{ label: 'Сообщений', data: hourData, backgroundColor: '#fd7e14' }]
+    );
+
+    // Citation
+    var cit = await fetch(baseUrl + '/citation?channel_id=' + cid).then(function(r) { return r.json(); });
+    document.getElementById('cit-total').textContent = fmt(cit.total_forwards);
+    document.getElementById('cit-posts').textContent = fmt(cit.post_count);
+    document.getElementById('cit-avg').textContent = cit.avg_forwards.toFixed(1);
+  }
+
+  // Channel select
+  document.getElementById('channel-select').addEventListener('change', function() {
+    var val = parseInt(this.value);
+    if (val) {
+      var url = new URL(window.location);
+      url.searchParams.set('channel_id', val);
+      url.searchParams.set('days', days);
+      window.history.replaceState(null, '', url);
+    }
+    loadChannel(val);
+  });
+
+  // Period buttons
+  document.querySelectorAll('#period-btns button').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('#period-btns button').forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      days = parseInt(btn.dataset.days);
+      if (channelId) loadChannel(channelId);
+    });
+  });
+
+  // Auto-load if channel_id is set
+  if (channelId) loadChannel(channelId);
+})();
+</script>
+{% endblock %}

--- a/src/web/templates/analytics/channels.html
+++ b/src/web/templates/analytics/channels.html
@@ -129,6 +129,27 @@
         </div>
       </div>
     </div>
+    <div class="col-12 col-md-6">
+      <div class="card">
+        <div class="card-header fw-semibold">Кросс-канальные цитирования</div>
+        <div class="card-body" style="max-height:260px;overflow-y:auto">
+          <table class="table table-sm table-hover mb-0" id="cross-cite-table">
+            <thead><tr><th>Источник</th><th>Цитат</th><th>Последняя</th></tr></thead>
+            <tbody></tbody>
+          </table>
+          <div id="cross-cite-empty" class="text-muted small text-center py-2">Нет данных</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-4 mb-4">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header fw-semibold">Тепловая карта: час × день недели (UTC)</div>
+        <div class="card-body" style="overflow-x:auto"><canvas id="chart-heatmap" height="260"></canvas></div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -250,6 +271,118 @@
     document.getElementById('cit-total').textContent = fmt(cit.total_forwards);
     document.getElementById('cit-posts').textContent = fmt(cit.post_count);
     document.getElementById('cit-avg').textContent = cit.avg_forwards.toFixed(1);
+
+    // Cross-channel citations
+    var crossCite = await fetch(baseUrl + '/cross-citations?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    var tbody = document.querySelector('#cross-cite-table tbody');
+    var emptyEl = document.getElementById('cross-cite-empty');
+    tbody.innerHTML = '';
+    if (crossCite.length) {
+      emptyEl.style.display = 'none';
+      crossCite.forEach(function(row) {
+        var name = row.source_title || row.source_username || row.source_channel_id;
+        var tr = document.createElement('tr');
+        tr.innerHTML = '<td>' + name + '</td><td>' + row.citation_count + '</td><td>' + (row.latest_date || '').slice(0, 10) + '</td>';
+        tbody.appendChild(tr);
+      });
+    } else {
+      emptyEl.style.display = '';
+    }
+
+    // Heatmap (hour x weekday) -- matrix-style bubble chart
+    var heatmap = await fetch(baseUrl + '/heatmap?channel_id=' + cid + '&days=' + days).then(function(r) { return r.json(); });
+    var weekdays = ['Пн','Вт','Ср','Чт','Пт','Сб','Вс'];
+    // SQLite %w: 0=Sun; convert to Mon=0..Sun=6 for display
+    var wdOrder = [1,2,3,4,5,6,0]; // display index 0..6 -> actual %w values
+    var heatMap = {}; // key: "wd-hr" -> count
+    var maxCount = 1;
+    heatmap.forEach(function(r) {
+      heatMap[r.weekday + '-' + r.hour] = r.count;
+      if (r.count > maxCount) maxCount = r.count;
+    });
+    var heatCtx = document.getElementById('chart-heatmap');
+    if (heatCtx) {
+      // Build single dataset with one bubble per cell
+      var bubbleData = [];
+      for (var di = 0; di < 7; di++) {
+        for (var h = 0; h < 24; h++) {
+          var wd = wdOrder[di];
+          var cnt = heatMap[wd + '-' + h] || 0;
+          var pct = cnt / maxCount;
+          // Color gradient: light-blue (low) -> orange (mid) -> dark-red (high)
+          var cr, cg, cb;
+          if (pct < 0.5) {
+            cr = Math.round(200 + pct * 110);
+            cg = Math.round(220 - pct * 100);
+            cb = Math.round(240 - pct * 280);
+          } else {
+            cr = Math.round(255);
+            cg = Math.round(170 - (pct - 0.5) * 300);
+            cb = Math.round(100 - (pct - 0.5) * 200);
+          }
+          cr = Math.max(0, Math.min(255, cr));
+          cg = Math.max(0, Math.min(255, cg));
+          cb = Math.max(0, Math.min(255, cb));
+          bubbleData.push({
+            x: h,
+            y: 6 - di,  // Invert so Mon is at top
+            r: cnt > 0 ? Math.max(3, Math.round(Math.sqrt(cnt / maxCount) * 14)) : 2,
+            _count: cnt,
+            _weekday: weekdays[di],
+            _hour: String(h).padStart(2, '0') + ':00',
+            _color: 'rgba(' + cr + ',' + cg + ',' + cb + ',' + (cnt > 0 ? '0.9' : '0.2') + ')'
+          });
+        }
+      }
+      var heatChart = new Chart(heatCtx, {
+        type: 'bubble',
+        data: {
+          datasets: [{
+            data: bubbleData,
+            backgroundColor: bubbleData.map(function(d) { return d._color; }),
+            borderColor: 'rgba(0,0,0,0.15)',
+            borderWidth: 1
+          }]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: function(ctx) {
+                  var d = ctx.raw;
+                  return d._weekday + ' ' + d._hour + ': ' + d._count + ' сообщ.';
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              min: -0.5, max: 23.5,
+              ticks: {
+                callback: function(val) { return typeof val === 'number' && val >= 0 && val <= 23 ? String(val).padStart(2, '0') + ':00' : ''; },
+                stepSize: 1
+              },
+              grid: { display: false },
+              title: { display: true, text: 'Час (UTC)' }
+            },
+            y: {
+              min: -0.5, max: 6.5,
+              reverse: true,
+              ticks: {
+                callback: function(val) { return typeof val === 'number' && val >= 0 && val <= 6 ? weekdays[val] : ''; },
+                stepSize: 1
+              },
+              grid: { display: false },
+              title: { display: false }
+            }
+          }
+        }
+      });
+      charts['chart-heatmap'] = heatChart;
+    }
   }
 
   // Channel select

--- a/src/web/templates/analytics/content.html
+++ b/src/web/templates/analytics/content.html
@@ -4,7 +4,14 @@
 
 {% block content %}
 <div class="container-fluid">
-    <h1 class="h3 mb-4">Content Analytics</h1>
+    <h1 class="h3 mb-3">Content Analytics</h1>
+
+    <div class="btn-group btn-group-sm mb-3" role="group">
+      <a href="/analytics" class="btn btn-outline-secondary">Сообщения</a>
+      <a href="/analytics/channels" class="btn btn-outline-secondary">Каналы</a>
+      <a href="/analytics/trends" class="btn btn-outline-secondary">Тренды</a>
+      <a href="/analytics/content" class="btn btn-outline-secondary active">Контент</a>
+    </div>
 
     <div class="row mb-4">
         <div class="col-md-3">

--- a/src/web/templates/analytics/trends.html
+++ b/src/web/templates/analytics/trends.html
@@ -1,9 +1,13 @@
 {% extends "base.html" %}
 {% block title %}Тренды — TG Agent{% endblock %}
 {% block content %}
-<div class="d-flex align-items-center gap-3 mb-3">
-    <h1 class="mb-0">Тренды</h1>
-    <a href="/analytics" class="btn btn-outline-secondary btn-sm">← Аналитика</a>
+<h1 class="h3 mb-3">Тренды</h1>
+
+<div class="btn-group btn-group-sm mb-3" role="group">
+  <a href="/analytics" class="btn btn-outline-secondary">Сообщения</a>
+  <a href="/analytics/channels" class="btn btn-outline-secondary">Каналы</a>
+  <a href="/analytics/trends" class="btn btn-outline-secondary active">Тренды</a>
+  <a href="/analytics/content" class="btn btn-outline-secondary">Контент</a>
 </div>
 
 <div class="mb-3">

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models import Channel, ChannelStats, Message
+from src.services.channel_analytics_service import (
+    ChannelAnalyticsService,
+    ChannelComparison,
+    ChannelListItem,
+    ChannelOverview,
+    ChannelRanking,
+    CitationStats,
+)
+
+# ─── helpers ───────────────────────────────────────────────────────
+
+
+async def _seed_channel(db, channel_id=-100123, title="Test Channel", username="test_chan"):
+    await db.add_channel(Channel(channel_id=channel_id, title=title, username=username))
+    return await db.get_channel_by_channel_id(channel_id)
+
+
+async def _seed_stats(db, channel_id, subscriber_count=1000, avg_views=500.0,
+                      avg_reactions=25.0, avg_forwards=10.0):
+    stats = ChannelStats(
+        channel_id=channel_id,
+        subscriber_count=subscriber_count,
+        avg_views=avg_views,
+        avg_reactions=avg_reactions,
+        avg_forwards=avg_forwards,
+    )
+    await db.save_channel_stats(stats)
+    return stats
+
+
+async def _seed_message(db, channel_id, msg_id=1, text="hello", views=100,
+                        forwards=5, reply_count=2,
+                        date_str="2025-01-15T12:00:00+00:00"):
+    msg = Message(
+        channel_id=channel_id,
+        message_id=msg_id,
+        text=text,
+        views=views,
+        forwards=forwards,
+        reply_count=reply_count,
+        date=datetime.fromisoformat(date_str),
+    )
+    await db.insert_message(msg)
+    return msg
+
+
+async def _seed_messages_batch(db, channel_id, messages):
+    return await db.insert_messages_batch(messages) or len(messages) or 0
+
+
+# ─── tests ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_active_channels(db):
+    await _seed_channel(db, channel_id=-100111, title="Active 1", username="active1")
+    await _seed_channel(db, channel_id=-100222, title="Active 2", username="active2")
+    ch3 = await _seed_channel(db, channel_id=-100333, title="Filtered", username="filtered_chan")
+    await db.set_channel_filtered(ch3.id, True)
+
+    svc = ChannelAnalyticsService(db)
+    channels = await svc.get_active_channels()
+    assert len(channels) == 2
+    ids = {c.channel_id for c in channels}
+    assert -100111 in ids
+    assert -100222 in ids
+    assert -100333 not in ids
+    assert all(isinstance(c, ChannelListItem) for c in channels)
+
+
+@pytest.mark.asyncio
+async def test_get_active_channels_empty(db):
+    svc = ChannelAnalyticsService(db)
+    channels = await svc.get_active_channels()
+    assert channels == []
+
+
+@pytest.mark.asyncio
+async def test_get_channel_overview_basic(db):
+    await _seed_channel(db, channel_id=-100123, title="Overview Chan", username="ov_chan")
+    svc = ChannelAnalyticsService(db)
+    overview = await svc.get_channel_overview(-100123)
+    assert isinstance(overview, ChannelOverview)
+    assert overview.channel_id == -100123
+    assert overview.title == "Overview Chan"
+    assert overview.username == "ov_chan"
+    assert overview.subscriber_count is None
+    assert overview.total_posts == 0
+    assert overview.posts_today == 0
+    assert overview.posts_month == 0
+    assert overview.err is None
+    assert overview.err24 is None
+
+
+@pytest.mark.asyncio
+async def test_get_channel_overview_with_subscribers(db):
+    await _seed_channel(db, channel_id=-100123, title="Sub Chan")
+    # Two stats entries for delta calculation
+    await _seed_stats(db, -100123, subscriber_count=1000, avg_views=500.0)
+    await _seed_stats(db, -100123, subscriber_count=1200, avg_views=600.0)
+
+    svc = ChannelAnalyticsService(db)
+    overview = await svc.get_channel_overview(-100123)
+    assert overview.subscriber_count == 1200
+    assert overview.subscriber_delta == 200  # 1200 - 1000
+    assert overview.avg_views == 600.0
+    assert overview.avg_forwards == 10.0
+    assert overview.avg_reactions == 25.0
+
+
+@pytest.mark.asyncio
+async def test_get_channel_overview_with_posts(db):
+    await _seed_channel(db, channel_id=-100123, title="Post Chan")
+    await _seed_stats(db, -100123, subscriber_count=500, avg_views=200.0)
+    now = datetime.now(timezone.utc)
+
+    messages = []
+    # 5 today
+    for i in range(5):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=100 + i,
+            text=f"msg {i}",
+            views=50 + i * 10,
+            forwards=i,
+            reply_count=1,
+            date=now - timedelta(hours=i),
+        ))
+    # 3 within the last week but more than 1 day ago
+    for i in range(3):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=200 + i,
+            text=f"week msg {i}",
+            views=30 + i,
+            forwards=i,
+            reply_count=0,
+            date=now - timedelta(days=5),
+        ))
+    # 1 old message from 35 days ago
+    messages.append(Message(
+        channel_id=-100123,
+        message_id=300,
+        text="old msg",
+        views=10,
+        forwards=0,
+        reply_count=0,
+        date=now - timedelta(days=35),
+    ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    overview = await svc.get_channel_overview(-100123, days=30)
+    assert overview.total_posts == 9
+    assert overview.posts_today == 5
+    assert overview.posts_week == 8
+    assert overview.posts_month == 8  # 5 today + 3 this week (within 30d)
+
+    overview7 = await svc.get_channel_overview(-100123, days=7)
+    assert overview7.posts_month == 8  # 5 today + 3 this week
+
+    overview1 = await svc.get_channel_overview(-100123, days=1)
+    assert overview1.posts_month == 5  # 5 within last day
+
+
+@pytest.mark.asyncio
+async def test_get_channel_overview_missing_channel(db):
+    svc = ChannelAnalyticsService(db)
+    overview = await svc.get_channel_overview(-999999)
+    assert overview.channel_id == -999999
+    assert overview.title is None
+    assert overview.username is None
+
+
+@pytest.mark.asyncio
+async def test_get_subscriber_history(db):
+    await _seed_channel(db, channel_id=-100123, title="Hist Chan")
+    for i in range(5):
+        await db.save_channel_stats(ChannelStats(
+            channel_id=-100123,
+            subscriber_count=100 + i * 50,
+        ))
+
+    svc = ChannelAnalyticsService(db)
+    history = await svc.get_subscriber_history(-100123, days=5)
+    assert len(history) == 5
+    # Verify chronological order
+    counts = [entry["subscriber_count"] for entry in history]
+    assert counts == sorted(counts)
+    assert counts[-1] == 300
+
+
+@pytest.mark.asyncio
+async def test_get_views_timeseries(db):
+    await _seed_channel(db, channel_id=-100123, title="Views Chan")
+    now = datetime.now(timezone.utc)
+    messages = []
+    for i in range(3):
+        ts = now - timedelta(days=i)
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=10 + i,
+            text=f"msg {i}",
+            views=100 * (i + 1),
+            date=ts,
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    ts = await svc.get_views_timeseries(-100123, days=5)
+    assert len(ts) >= 1
+    for entry in ts:
+        assert "day" in entry
+        assert "message_count" in entry
+        assert "avg_views" in entry
+
+
+@pytest.mark.asyncio
+async def test_get_post_frequency(db):
+    await _seed_channel(db, channel_id=-100123, title="Freq Chan")
+    now = datetime.now(timezone.utc)
+    messages = []
+    # 3 messages today
+    for i in range(3):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=100 + i,
+            text=f"today msg {i}",
+            views=10,
+            date=now - timedelta(hours=i),
+        ))
+    # 2 yesterday
+    for i in range(2):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=200 + i,
+            text=f"yesterday msg {i}",
+            date=now - timedelta(days=1),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    freq = await svc.get_post_frequency(-100123, days=7)
+    assert len(freq) == 2
+    today_count = sum(e["count"] for e in freq if e["day"] == now.strftime("%Y-%m-%d"))
+    assert today_count == 3
+    yesterday_count = sum(
+        e["count"] for e in freq
+        if e["day"] == (now - timedelta(days=1)).strftime("%Y-%m-%d")
+    )
+    assert yesterday_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_citation_stats(db):
+    await _seed_channel(db, channel_id=-100123, title="Cite Chan")
+    messages = []
+    for i in range(5):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=100 + i,
+            text=f"msg {i}",
+            views=100,
+            forwards=i * 10,
+            date=datetime(2025, 1, 15, 12, 0, 0),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    stats = await svc.get_citation_stats(-100123)
+    assert isinstance(stats, CitationStats)
+    assert stats.post_count == 5
+    assert stats.total_forwards == sum(range(5)) * 10  # 0+10+20+30+40 = 100
+    assert stats.avg_forwards == 20.0  # 100 / 5
+
+
+@pytest.mark.asyncio
+async def test_get_err(db):
+    await _seed_channel(db, channel_id=-100123, title="ERR Chan")
+    await _seed_stats(db, -100123, subscriber_count=1000, avg_views=200.0)
+    messages = []
+    for i in range(5):
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=100 + i,
+            text=f"msg {i}",
+            views=100,
+            forwards=5,
+            reply_count=2,
+            date=datetime(2025, 1, 15, 12, 0, 0),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    err = await svc.get_err(-100123)
+    assert isinstance(err, float)
+    assert err > 0
+    # ERR = total_engagement / (num_posts * subscribers) * 100
+    # total_engagement = 5 * (100 + 5 + 2) = 535
+    # err = 535 / (5 * 1000) * 100 = 10.7
+    assert abs(err - 10.7) < 0.1
+
+
+@pytest.mark.asyncio
+async def test_get_err_no_subscribers(db):
+    await _seed_channel(db, channel_id=-100123, title="No Sub Chan")
+    svc = ChannelAnalyticsService(db)
+    err = await svc.get_err(-100123)
+    assert err is None
+
+
+@pytest.mark.asyncio
+async def test_get_err24(db):
+    await _seed_channel(db, channel_id=-100123, title="ERR24 Chan")
+    await _seed_stats(db, -100123, subscriber_count=500)
+    now = datetime.now(timezone.utc)
+    msg = Message(
+        channel_id=-100123,
+        message_id=1,
+        text="recent msg",
+        views=200,
+        forwards=10,
+        reply_count=5,
+        date=now - timedelta(hours=1),
+    )
+    await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    err24 = await svc.get_err24(-100123)
+    assert isinstance(err24, float)
+    assert err24 > 0
+    # engagement = 200 + 10 + 5 = 215; err24 = 215 / (1 * 500) * 100 = 43.0
+    assert abs(err24 - 43.0) < 0.1
+
+
+@pytest.mark.asyncio
+async def test_get_err24_no_recent_posts(db):
+    await _seed_channel(db, channel_id=-100123, title="Empty ERR24")
+    await _seed_stats(db, -100123, subscriber_count=500)
+    msg = Message(
+        channel_id=-100123,
+        message_id=1,
+        text="old msg",
+        views=50,
+        date=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    err24 = await svc.get_err24(-100123)
+    assert err24 is None
+
+
+@pytest.mark.asyncio
+async def test_get_hourly_activity(db):
+    await _seed_channel(db, channel_id=-100123, title="Hourly Chan")
+    now = datetime.now(timezone.utc)
+    messages = []
+    for hour in [8, 8, 8, 14, 14, 20]:
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=len(messages) + 1,
+            text=f"msg at {hour}",
+            date=now.replace(hour=hour, minute=0, second=0, microsecond=0),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    activity = await svc.get_hourly_activity(-100123, days=7)
+    assert len(activity) > 0
+    hour_counts = {e["hour"]: e["count"] for e in activity}
+    assert hour_counts.get(8) == 3
+    assert hour_counts.get(14) == 2
+    assert hour_counts.get(20) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_ranked_channels_by_err(db):
+    await _seed_channel(db, channel_id=-100111, title="Low ERR", username="low_err")
+    await _seed_channel(db, channel_id=-100222, title="High ERR", username="high_err")
+    await _seed_stats(db, -100111, subscriber_count=1000, avg_views=100.0)
+    await _seed_stats(db, -100222, subscriber_count=1000, avg_views=500.0)
+
+    for i in range(3):
+        msg = Message(
+            channel_id=-100111,
+            message_id=100 + i,
+            text=f"low msg {i}",
+            views=50,
+            forwards=1,
+            reply_count=0,
+            date=datetime(2025, 1, 15, 12, 0, 0),
+        )
+        await db.insert_message(msg)
+
+    for i in range(3):
+        msg = Message(
+            channel_id=-100222,
+            message_id=200 + i,
+            text=f"high msg {i}",
+            views=500,
+            forwards=20,
+            reply_count=10,
+            date=datetime(2025, 1, 15, 12, 0, 0),
+        )
+        await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    rankings = await svc.get_ranked_channels(metric="err")
+    assert len(rankings) == 2
+    assert all(isinstance(r, ChannelRanking) for r in rankings)
+    assert rankings[0].channel_id == -100222
+    assert rankings[0].rank == 1
+    assert rankings[0].score > rankings[1].score
+    assert rankings[1].channel_id == -100111
+    assert rankings[1].rank == 2
+
+
+@pytest.mark.asyncio
+async def test_get_ranked_channels_by_subscriber_count(db):
+    await _seed_channel(db, channel_id=-100111, title="Small", username="small")
+    await _seed_channel(db, channel_id=-100222, title="Big", username="big")
+    await _seed_stats(db, -100111, subscriber_count=100)
+    await _seed_stats(db, -100222, subscriber_count=10000)
+
+    svc = ChannelAnalyticsService(db)
+    rankings = await svc.get_ranked_channels(metric="subscriber_count")
+    assert len(rankings) == 2
+    assert rankings[0].channel_id == -100222
+    assert rankings[0].score == 10000.0
+    assert rankings[1].channel_id == -100111
+    assert rankings[1].score == 100.0
+
+
+@pytest.mark.asyncio
+async def test_get_ranked_channels_limit(db):
+    for i in range(5):
+        await _seed_channel(db, channel_id=-100100 - i, title=f"Ch {i}")
+        await _seed_stats(db, -100100 - i, subscriber_count=(i + 1) * 100)
+
+    svc = ChannelAnalyticsService(db)
+    rankings = await svc.get_ranked_channels(metric="subscriber_count", limit=3)
+    assert len(rankings) == 3
+    assert all(r.rank <= 3 for r in rankings)
+
+
+@pytest.mark.asyncio
+async def test_get_channel_comparison(db):
+    await _seed_channel(db, channel_id=-100111, title="Chan A", username="chan_a")
+    await _seed_channel(db, channel_id=-100222, title="Chan B", username="chan_b")
+    await _seed_stats(db, -100111, subscriber_count=1000)
+    await _seed_stats(db, -100222, subscriber_count=2000)
+
+    svc = ChannelAnalyticsService(db)
+    comparison = await svc.get_channel_comparison([-100111, -100222])
+    assert isinstance(comparison, ChannelComparison)
+    assert len(comparison.channels) == 2
+    assert comparison.channels[0].channel_id == -100111
+    assert comparison.channels[1].channel_id == -100222
+    assert comparison.channels[0].subscriber_count == 1000
+    assert comparison.channels[1].subscriber_count == 2000
+    assert "subscriber_count" in comparison.metrics
+    assert "err" in comparison.metrics
+
+
+@pytest.mark.asyncio
+async def test_get_channel_comparison_empty(db):
+    svc = ChannelAnalyticsService(db)
+    comparison = await svc.get_channel_comparison([])
+    assert isinstance(comparison, ChannelComparison)
+    assert comparison.channels == []
+
+
+@pytest.mark.asyncio
+async def test_get_ranked_channels_unknown_metric(db):
+    await _seed_channel(db, channel_id=-100111, title="Unknown Metric Chan")
+    await _seed_stats(db, -100111, subscriber_count=500)
+
+    svc = ChannelAnalyticsService(db)
+    rankings = await svc.get_ranked_channels(metric="nonexistent_metric")
+    assert len(rankings) == 1
+    assert rankings[0].score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_overview_to_dict(db):
+    """Verify dataclass serialization works for template rendering."""
+    await _seed_channel(db, channel_id=-100123, title="Dict Chan")
+    svc = ChannelAnalyticsService(db)
+    overview = await svc.get_channel_overview(-100123)
+    d = dataclasses.asdict(overview)
+    assert isinstance(d, dict)
+    assert d["channel_id"] == -100123
+    assert d["title"] == "Dict Chan"
+    assert "subscriber_count" in d
+    assert "err" in d
+    assert "posts_today" in d

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import argparse
+import asyncio
 import dataclasses
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
+from src.config import AppConfig
 from src.models import Channel, ChannelStats, Message
 from src.services.channel_analytics_service import (
     ChannelAnalyticsService,
@@ -503,3 +507,586 @@ async def test_overview_to_dict(db):
     assert "subscriber_count" in d
     assert "err" in d
     assert "posts_today" in d
+
+
+# ── heatmap tests ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_heatmap_empty(db):
+    await _seed_channel(db, channel_id=-100123, title="Heatmap Empty")
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_heatmap(-100123, days=30)
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_get_heatmap_basic(db):
+    await _seed_channel(db, channel_id=-100123, title="Heatmap Chan")
+    now = datetime.now(timezone.utc)
+    messages = []
+    # Monday (weekday 1 via %w = 1)
+    mon = now - timedelta(days=now.weekday())
+    for h in [8, 9, 10]:
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=len(messages) + 1,
+            text=f"mon {h}",
+            date=mon.replace(hour=h, minute=0, second=0, microsecond=0),
+        ))
+    # Wednesday (%w = 3)
+    wed = mon + timedelta(days=2)
+    for h in [14, 14]:
+        messages.append(Message(
+            channel_id=-100123,
+            message_id=len(messages) + 1,
+            text=f"wed {h}",
+            date=wed.replace(hour=14, minute=0, second=0, microsecond=0),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_heatmap(-100123, days=30)
+    assert len(data) > 0
+    # All rows have expected keys
+    for row in data:
+        assert "hour" in row
+        assert "weekday" in row
+        assert "count" in row
+        assert 0 <= row["hour"] <= 23
+        assert 0 <= row["weekday"] <= 6
+
+    # Check actual counts: Monday(%w=1) should have 3 messages at hours 8,9,10
+    # The weekday values depend on the actual date of `mon`, but the data
+    # should aggregate correctly. Just check total messages match.
+    total_count = sum(r["count"] for r in data)
+    assert total_count == 5  # 3 Monday + 2 Wednesday
+
+
+@pytest.mark.asyncio
+async def test_get_heatmap_days_filter(db):
+    await _seed_channel(db, channel_id=-100123, title="Heatmap Days")
+    now = datetime.now(timezone.utc)
+    # Recent message
+    await db.insert_message(Message(
+        channel_id=-100123, message_id=1, text="recent",
+        date=now - timedelta(hours=1),
+    ))
+    # Old message outside 7-day window
+    await db.insert_message(Message(
+        channel_id=-100123, message_id=2, text="old",
+        date=now - timedelta(days=14),
+    ))
+
+    svc = ChannelAnalyticsService(db)
+    data7 = await svc.get_heatmap(-100123, days=7)
+    data30 = await svc.get_heatmap(-100123, days=30)
+    total_7 = sum(r["count"] for r in data7)
+    total_30 = sum(r["count"] for r in data30)
+    assert total_7 == 1
+    assert total_30 == 2
+
+
+# ── cross-channel citation tests ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_cross_channel_citations_empty(db):
+    await _seed_channel(db, channel_id=-100123, title="Cite Empty")
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123)
+    assert data == []
+
+
+@pytest.mark.asyncio
+async def test_get_cross_channel_citations_basic(db):
+    # Source channel
+    await _seed_channel(db, channel_id=-100500, title="Source Chan", username="src_chan")
+    # Target channel
+    await _seed_channel(db, channel_id=-100123, title="Target Chan", username="tgt_chan")
+
+    now = datetime.now(timezone.utc)
+    # Messages forwarded from -100500 into -100123
+    for i in range(3):
+        msg = Message(
+            channel_id=-100123,
+            message_id=100 + i,
+            text=f"fwd msg {i}",
+            date=now - timedelta(hours=i),
+            forwards=0,
+        )
+        msg.forward_from_channel_id = -100500
+        await db.insert_message(msg)
+    # One regular message (no forward)
+    await db.insert_message(Message(
+        channel_id=-100123,
+        message_id=200,
+        text="regular msg",
+        date=now,
+    ))
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30)
+    assert len(data) == 1
+    assert data[0]["source_channel_id"] == -100500
+    assert data[0]["source_title"] == "Source Chan"
+    assert data[0]["citation_count"] == 3
+    assert data[0]["latest_date"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_cross_channel_citations_multiple_sources(db):
+    await _seed_channel(db, channel_id=-100111, title="Source A", username="src_a")
+    await _seed_channel(db, channel_id=-100222, title="Source B", username="src_b")
+    await _seed_channel(db, channel_id=-100123, title="Target", username="target")
+
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        msg = Message(
+            channel_id=-100123, message_id=100 + i, text=f"fwd a {i}",
+            date=now,
+        )
+        msg.forward_from_channel_id = -100111
+        await db.insert_message(msg)
+    for i in range(2):
+        msg = Message(
+            channel_id=-100123, message_id=200 + i, text=f"fwd b {i}",
+            date=now,
+        )
+        msg.forward_from_channel_id = -100222
+        await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30)
+    assert len(data) == 2
+    # Sorted by citation_count DESC
+    assert data[0]["source_channel_id"] == -100111
+    assert data[0]["citation_count"] == 5
+    assert data[1]["source_channel_id"] == -100222
+    assert data[1]["citation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_cross_channel_citations_limit(db):
+    await _seed_channel(db, channel_id=-100123, title="Target Limit")
+    now = datetime.now(timezone.utc)
+    for i in range(10):
+        msg = Message(
+            channel_id=-100123, message_id=100 + i, text=f"fwd {i}",
+            date=now,
+        )
+        msg.forward_from_channel_id = -(200 + i)
+        await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30, limit=3)
+    assert len(data) <= 3
+
+
+# ── repo-level tests for new methods ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_repo_hour_weekday_heatmap(db):
+    await _seed_channel(db, channel_id=-100123, title="Repo Heatmap")
+    now = datetime.now(timezone.utc)
+    # Create messages at known hour/weekday
+    messages = [
+        Message(channel_id=-100123, message_id=1, text="a",
+                date=now.replace(hour=10, minute=0, second=0, microsecond=0)),
+        Message(channel_id=-100123, message_id=2, text="b",
+                date=now.replace(hour=10, minute=0, second=0, microsecond=0)),
+        Message(channel_id=-100123, message_id=3, text="c",
+                date=now.replace(hour=22, minute=0, second=0, microsecond=0)),
+    ]
+    await _seed_messages_batch(db, -100123, messages)
+
+    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    assert len(rows) >= 2  # At least hour 10 and hour 22 entries
+    for r in rows:
+        assert 0 <= r["hour"] <= 23
+        assert 0 <= r["weekday"] <= 6
+        assert r["count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_repo_cross_channel_citations_no_forward(db):
+    await _seed_channel(db, channel_id=-100123, title="No Fwd")
+    await db.insert_message(Message(
+        channel_id=-100123, message_id=1, text="hello",
+        date=datetime.now(timezone.utc),
+    ))
+
+    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    assert rows == []
+
+
+# ── web API route tests ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_heatmap_route(db):
+    """Verify heatmap service returns list (route requires full app state)."""
+    await _seed_channel(db, channel_id=-100123, title="API Heat")
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_heatmap(-100123, days=30)
+    assert isinstance(data, list)
+
+
+@pytest.mark.asyncio
+async def test_api_cross_citations_route(db):
+    """Verify cross-citations service returns list (route requires full app state)."""
+    await _seed_channel(db, channel_id=-100123, title="API Cross")
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30)
+    assert isinstance(data, list)
+
+
+# ── heatmap: weekday / hour precision tests ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_heatmap_specific_weekday_hour_values(db):
+    """Verify heatmap returns correct weekday (%w) and hour values."""
+    await _seed_channel(db, channel_id=-100123, title="Heatmap Precise")
+    # Use dates within the last 30 days to ensure they fall in the query window.
+    # Find a recent Monday and Wednesday.
+    now = datetime.now(timezone.utc)
+    # Monday of the current week
+    mon = now - timedelta(days=now.weekday())
+    # Wednesday of the current week
+    wed = mon + timedelta(days=2)
+    mon_10 = mon.replace(hour=10, minute=30, second=0, microsecond=0)
+    wed_22 = wed.replace(hour=22, minute=0, second=0, microsecond=0)
+    messages = [
+        Message(channel_id=-100123, message_id=1, text="mon 10:30", date=mon_10),
+        Message(channel_id=-100123, message_id=2, text="wed 22", date=wed_22),
+    ]
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_heatmap(-100123, days=30)
+
+    # Build a lookup (weekday, hour) -> count
+    lookup = {(r["weekday"], r["hour"]): r["count"] for r in data}
+
+    # Monday is %w=1, hour=10 (date was Monday so strftime %w = 1)
+    assert lookup.get((1, 10)) == 1
+    # Wednesday is %w=3, hour=22
+    assert lookup.get((3, 22)) == 1
+    # Empty cells should be absent
+    assert (0, 0) not in lookup or lookup.get((0, 0)) is None  # Sunday midnight unlikely
+
+
+@pytest.mark.asyncio
+async def test_heatmap_aggregation_multiple_same_slot(db):
+    """Multiple messages in the same (weekday, hour) slot aggregate."""
+    await _seed_channel(db, channel_id=-100123, title="Heatmap Agg")
+    # All messages on same hour of the current day
+    now = datetime.now(timezone.utc)
+    base = now.replace(hour=14, minute=0, second=0, microsecond=0)
+    messages = [
+        Message(channel_id=-100123, message_id=i, text=f"msg {i}",
+                date=base + timedelta(minutes=i * 5))
+        for i in range(10)
+    ]
+    await _seed_messages_batch(db, -100123, messages)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_heatmap(-100123, days=7)
+    lookup = {(r["weekday"], r["hour"]): r["count"] for r in data}
+    # All 10 land in hour 14; weekday depends on today
+    today_wd = int(now.strftime("%w"))
+    assert lookup.get((today_wd, 14)) == 10
+    # Total messages should be exactly 10
+    assert sum(r["count"] for r in data) == 10
+
+
+# ── cross-channel citation edge cases ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_citations_date_filtering(db):
+    """Messages outside the days window are excluded from cross-citations."""
+    await _seed_channel(db, channel_id=-100500, title="Source")
+    await _seed_channel(db, channel_id=-100123, title="Target")
+    now = datetime.now(timezone.utc)
+
+    # Recent forwarded message
+    msg_recent = Message(
+        channel_id=-100123, message_id=1, text="recent fwd",
+        date=now - timedelta(hours=1),
+    )
+    msg_recent.forward_from_channel_id = -100500
+    await db.insert_message(msg_recent)
+
+    # Old forwarded message (outside 7-day window)
+    msg_old = Message(
+        channel_id=-100123, message_id=2, text="old fwd",
+        date=now - timedelta(days=30),
+    )
+    msg_old.forward_from_channel_id = -100500
+    await db.insert_message(msg_old)
+
+    svc = ChannelAnalyticsService(db)
+    data_7d = await svc.get_cross_channel_citations(-100123, days=7)
+    data_90d = await svc.get_cross_channel_citations(-100123, days=90)
+
+    assert len(data_7d) == 1
+    assert data_7d[0]["citation_count"] == 1  # only recent
+
+    assert len(data_90d) == 1
+    assert data_90d[0]["citation_count"] == 2  # both
+
+
+@pytest.mark.asyncio
+async def test_cross_citations_unknown_source(db):
+    """Cross-citations work even when source channel is not in channels table."""
+    await _seed_channel(db, channel_id=-100123, title="Target Only")
+    now = datetime.now(timezone.utc)
+
+    # Forward from a channel that doesn't exist in DB
+    msg = Message(
+        channel_id=-100123, message_id=1, text="fwd from unknown",
+        date=now,
+    )
+    msg.forward_from_channel_id = -999999
+    await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30)
+    assert len(data) == 1
+    assert data[0]["source_channel_id"] == -999999
+    assert data[0]["source_title"] is None  # no matching channel row
+    assert data[0]["source_username"] is None
+    assert data[0]["citation_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cross_citations_respects_limit(db):
+    """Limit parameter caps the number of returned source channels."""
+    await _seed_channel(db, channel_id=-100123, title="Target")
+    now = datetime.now(timezone.utc)
+    for i in range(15):
+        msg = Message(
+            channel_id=-100123, message_id=100 + i,
+            text=f"fwd {i}", date=now,
+        )
+        msg.forward_from_channel_id = -(200 + i)
+        await db.insert_message(msg)
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30, limit=5)
+    assert len(data) == 5
+
+
+@pytest.mark.asyncio
+async def test_cross_citations_only_includes_forwards(db):
+    """Regular messages (no forward_from_channel_id) are not counted."""
+    await _seed_channel(db, channel_id=-100123, title="No Fwd Target")
+    now = datetime.now(timezone.utc)
+    # 5 regular messages
+    for i in range(5):
+        await db.insert_message(Message(
+            channel_id=-100123, message_id=100 + i,
+            text=f"regular {i}", date=now,
+        ))
+
+    svc = ChannelAnalyticsService(db)
+    data = await svc.get_cross_channel_citations(-100123, days=30)
+    assert data == []
+
+
+# ── service-level heatmap / citation integration ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_heatmap_service_delegates_to_repo(db):
+    """Service get_heatmap delegates correctly and returns repo output."""
+    await _seed_channel(db, channel_id=-100123, title="Delegator")
+    now = datetime.now(timezone.utc)
+    await db.insert_message(Message(
+        channel_id=-100123, message_id=1, text="x",
+        date=now.replace(hour=15, minute=0, second=0, microsecond=0),
+    ))
+
+    svc = ChannelAnalyticsService(db)
+    svc_data = await svc.get_heatmap(-100123, days=7)
+    repo_data = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    assert svc_data == repo_data
+
+
+@pytest.mark.asyncio
+async def test_cross_citations_service_delegates_to_repo(db):
+    """Service get_cross_channel_citations delegates correctly."""
+    await _seed_channel(db, channel_id=-100123, title="Delegator")
+    svc = ChannelAnalyticsService(db)
+    svc_data = await svc.get_cross_channel_citations(-100123, days=7)
+    repo_data = await db.repos.messages.get_cross_channel_citations(-100123, days=7)
+    assert svc_data == repo_data
+
+
+# ── repo-level heatmap edge cases ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_repo_heatmap_all_hours_covered(db):
+    """Messages spanning many hours produce correct hour range."""
+    await _seed_channel(db, channel_id=-100123, title="All Hours")
+    now = datetime.now(timezone.utc)
+    messages = []
+    for h in range(0, 24, 3):  # hours 0, 3, 6, 9, 12, 15, 18, 21
+        messages.append(Message(
+            channel_id=-100123, message_id=h + 1, text=f"h{h}",
+            date=now.replace(hour=h, minute=0, second=0, microsecond=0),
+        ))
+    await _seed_messages_batch(db, -100123, messages)
+
+    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    hours_seen = {r["hour"] for r in rows}
+    for h in range(0, 24, 3):
+        assert h in hours_seen
+
+
+@pytest.mark.asyncio
+async def test_repo_heatmap_no_messages_returns_empty(db):
+    """Heatmap for a channel with no messages returns empty list."""
+    await _seed_channel(db, channel_id=-100123, title="Empty Heat")
+    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=30)
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_repo_cross_citations_multiple_from_same_source(db):
+    """Multiple forwarded messages from the same source are aggregated."""
+    await _seed_channel(db, channel_id=-100500, title="Agg Source")
+    await _seed_channel(db, channel_id=-100123, title="Agg Target")
+    now = datetime.now(timezone.utc)
+    for i in range(7):
+        msg = Message(
+            channel_id=-100123, message_id=100 + i,
+            text=f"agg fwd {i}", date=now - timedelta(hours=i),
+        )
+        msg.forward_from_channel_id = -100500
+        await db.insert_message(msg)
+
+    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    assert len(rows) == 1
+    assert rows[0]["source_channel_id"] == -100500
+    assert rows[0]["citation_count"] == 7
+
+
+@pytest.mark.asyncio
+async def test_repo_cross_citations_latest_date(db):
+    """latest_date is the most recent forwarded message date."""
+    await _seed_channel(db, channel_id=-100500, title="Src Latest")
+    await _seed_channel(db, channel_id=-100123, title="Tgt Latest")
+    now = datetime.now(timezone.utc)
+
+    # Older forward
+    msg1 = Message(
+        channel_id=-100123, message_id=1, text="old",
+        date=now - timedelta(days=5),
+    )
+    msg1.forward_from_channel_id = -100500
+    await db.insert_message(msg1)
+
+    # Newer forward
+    msg2 = Message(
+        channel_id=-100123, message_id=2, text="new",
+        date=now - timedelta(hours=2),
+    )
+    msg2.forward_from_channel_id = -100500
+    await db.insert_message(msg2)
+
+    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    assert len(rows) == 1
+    latest = rows[0]["latest_date"]
+    assert latest is not None
+    # The latest_date should be closer to now than 5 days ago
+    latest_dt = datetime.fromisoformat(latest)
+    assert (now - latest_dt).total_seconds() < 86400  # within 24h
+
+
+# ── CLI analytics channel command test ────────────────────────────────
+
+
+@pytest.mark.aiosqlite_serial
+def test_cli_analytics_channel(cli_db, capsys):
+    """End-to-end test for `analytics channel <channel_id>` CLI command."""
+    from src.cli.commands.analytics import run as analytics_run
+
+    # Seed data synchronously via the db
+    async def _seed():
+        await cli_db.add_channel(Channel(
+            channel_id=-100123, title="CLI Channel", username="cli_chan",
+        ))
+        await cli_db.save_channel_stats(ChannelStats(
+            channel_id=-100123, subscriber_count=5000, avg_views=300.0,
+            avg_reactions=15.0, avg_forwards=8.0,
+        ))
+        now = datetime.now(timezone.utc)
+        for i in range(3):
+            msg = Message(
+                channel_id=-100123, message_id=100 + i,
+                text=f"cli msg {i}",
+                views=200, forwards=5, reply_count=2,
+                date=now - timedelta(hours=i),
+            )
+            await cli_db.insert_message(msg)
+        # Forward from another channel
+        await cli_db.add_channel(Channel(
+            channel_id=-100500, title="CLI Source", username="cli_src",
+        ))
+        fwd_msg = Message(
+            channel_id=-100123, message_id=999,
+            text="forwarded msg", views=100,
+            date=now - timedelta(hours=1),
+        )
+        fwd_msg.forward_from_channel_id = -100500
+        await cli_db.insert_message(fwd_msg)
+
+    asyncio.run(_seed())
+
+    config = AppConfig()
+
+    async def fake_init_db(_config_path):
+        return config, cli_db
+
+    with patch("src.cli.commands.analytics.runtime.init_db", side_effect=fake_init_db):
+        analytics_run(argparse.Namespace(
+            config="config.yaml",
+            analytics_action="channel",
+            channel_id=-100123,
+            days=30,
+        ))
+
+    out = capsys.readouterr().out
+    assert "CLI Channel" in out
+    assert "5000" in out
+    assert "ERR:" in out
+    assert "Citations (forwards)" in out
+    assert "CLI Source" in out
+    assert "Heatmap" in out
+
+
+@pytest.mark.aiosqlite_serial
+def test_cli_analytics_channel_not_found(cli_db, capsys):
+    """CLI analytics channel for nonexistent channel prints not found."""
+    from src.cli.commands.analytics import run as analytics_run
+
+    config = AppConfig()
+
+    async def fake_init_db(_config_path):
+        return config, cli_db
+
+    with patch("src.cli.commands.analytics.runtime.init_db", side_effect=fake_init_db):
+        analytics_run(argparse.Namespace(
+            config="config.yaml",
+            analytics_action="channel",
+            channel_id=-999999,
+            days=30,
+        ))
+
+    out = capsys.readouterr().out
+    assert "not found" in out.lower()


### PR DESCRIPTION
## Summary

- Add tgstat-style per-channel analytics dashboard at `/analytics/channels`
- Subscriber tracking with history chart, week/month deltas
- ERR/ERR24 engagement rate calculations
- Views timeseries, post frequency, hourly activity charts (Chart.js)
- Citation/forward statistics
- Nav tabs across all analytics pages (Сообщения | Каналы | Тренды | Контент)

## Changes

| File | Action |
|------|--------|
| `src/database/repositories/channel_stats.py` | +2 methods: `get_subscriber_history`, `get_subscriber_count_at` |
| `src/database/repositories/messages.py` | +6 methods: `get_views_timeseries`, `get_post_frequency`, `get_channel_message_count`, `get_err_data`, `get_err24_data`, `get_citation_stats` |
| `src/services/channel_analytics_service.py` | **New** — `ChannelAnalyticsService` with overview, history, ERR, ranking, comparison |
| `src/web/routes/analytics.py` | +8 routes: HTML page + 7 JSON API endpoints |
| `src/web/templates/analytics/channels.html` | **New** — Chart.js dashboard with 4 charts |
| `src/web/templates/analytics.html` | Nav tabs added |
| `src/web/templates/analytics/trends.html` | Nav tabs added |
| `src/web/templates/analytics/content.html` | Nav tabs added |
| `tests/test_channel_analytics_service.py` | **New** — 22 tests |

## Test plan

- [x] 22 new unit tests pass (`test_channel_analytics_service.py`)
- [x] Full test suite passes (684 parallel + 684 serial)
- [x] `ruff check` clean
- [ ] Manual: open `/analytics/channels`, select channel, verify charts render

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)