### PR TITLE
fix(pipelines): add Anthropic and Z.AI adapters to provider system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ coverage.json
 # Tasks
 tasks/
 site/
+docs/superpowers/

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -188,6 +188,48 @@ def make_huggingface_adapter(
     return provider
 
 
+def make_anthropic_adapter(
+    api_key: str, base_url: Optional[str] = None
+) -> Callable[..., Awaitable[str]]:
+    """Anthropic Messages API adapter (works with Z.AI and other compatible endpoints)."""
+    base = (base_url or "https://api.anthropic.com/v1").rstrip("/")
+    endpoint = f"{base}/messages"
+
+    async def provider(
+        prompt: str = "",
+        model: Optional[str] = None,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> str:
+        headers = {
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        payload = {
+            "model": model or "claude-sonnet-4-20250514",
+            "max_tokens": int(max_tokens or 256),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if temperature:
+            payload["temperature"] = float(temperature)
+        timeout = aiohttp.ClientTimeout(total=60)
+        async with aiohttp.ClientSession() as session:
+            async with session.post(endpoint, json=payload, headers=headers, timeout=timeout) as resp:
+                text = await resp.text()
+                if resp.status != 200:
+                    raise RuntimeError(f"Anthropic error {resp.status}: {text}")
+                data = await resp.json()
+                try:
+                    return data["content"][0]["text"]
+                except Exception:
+                    return str(data)
+
+    return provider
+
+
 def make_generic_http_adapter(
     base_url: str, api_key: Optional[str] = None, api_key_header: str = "Authorization"
 ) -> Callable[..., Awaitable[str]]:

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -209,11 +209,11 @@ def make_anthropic_adapter(
             "anthropic-version": "2023-06-01",
         }
         payload = {
-            "model": model or "claude-sonnet-4-20250514",
+            "model": model or "claude-sonnet-4-6",
             "max_tokens": int(max_tokens or 256),
             "messages": [{"role": "user", "content": prompt}],
         }
-        if temperature:
+        if temperature is not None:
             payload["temperature"] = float(temperature)
         timeout = aiohttp.ClientTimeout(total=60)
         async with aiohttp.ClientSession() as session:

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -211,6 +211,7 @@ class AgentProviderService:
     def _build_adapter_for_config(self, cfg: Any) -> Callable[..., Awaitable[str]] | None:
         """Map a ProviderRuntimeConfig to a provider adapter callable."""
         from src.services.provider_adapters import (
+            make_anthropic_adapter,
             make_cohere_adapter,
             make_huggingface_adapter,
             make_ollama_adapter,
@@ -239,10 +240,14 @@ class AgentProviderService:
             return make_huggingface_adapter(api_key, base_url=base_url or None)
 
         if provider == "anthropic":
-            # Anthropic requires a different request schema (messages API)
-            # than what make_generic_http_adapter provides (prompt-based).
-            logger.debug("Skipping db provider %s: incompatible request schema", provider)
-            return None
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            return make_anthropic_adapter(api_key, base_url=base_url or None)
+
+        if provider == "zai":
+            from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL
+
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            return make_anthropic_adapter(api_key, base_url=base_url or ZAI_DEFAULT_BASE_URL)
 
         if provider == "google_genai":
             # Google GenAI also needs a different request schema.

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -343,9 +343,9 @@ async def test_get_provider_status_list_invalid_secrets(mock_db, mock_config):
 async def test_get_provider_status_list_no_adapter(mock_db, mock_config):
     """get_provider_status_list returns no_adapter for unsupported providers."""
     mock_cfg = MagicMock()
-    mock_cfg.provider = "anthropic"
+    mock_cfg.provider = "google_genai"
     mock_cfg.enabled = True
-    mock_cfg.secret_fields = {"api_key": "sk-ant-test"}
+    mock_cfg.secret_fields = {"api_key": "test-key"}
     mock_cfg.plain_fields = {}
     mock_cfg.last_validation_error = ""
 
@@ -361,7 +361,7 @@ async def test_get_provider_status_list_no_adapter(mock_db, mock_config):
 
     assert len(statuses) == 1
     assert statuses[0]["status"] == "no_adapter"
-    assert "anthropic" in statuses[0]["reason"]
+    assert "google_genai" in statuses[0]["reason"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #385

- Adds `make_anthropic_adapter()` with proper Anthropic Messages API schema (`x-api-key`, `anthropic-version`, `messages` payload)
- Wires `anthropic` and `zai` providers in `_build_adapter_for_config()` — previously both were skipped, causing a false "LLM provider not configured" banner
- Updates `test_get_provider_status_list_no_adapter` to test `google_genai` as the no-adapter case instead of `anthropic`

## Test plan

- [ ] Verify `pytest tests/test_provider_service_db_load.py` passes
- [ ] Set `ANTHROPIC_API_KEY` and confirm provider status shows "active" in UI
- [ ] Set `ZAI_API_KEY` + `ZAI_BASE_URL` and confirm Z.AI provider works
- [ ] Confirm "LLM-провайдер не настроен" banner no longer appears with Anthropic/Z.AI configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)