### PR TITLE
feat: milestone v0.2.2 — forward normalization, channel age, docs, tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,10 @@ Each repository has a `_to_<model>(row)` static helper that maps `aiosqlite.Row`
 - **DB migrations**: `_migrate()` in `src/database/migrations.py` uses `PRAGMA table_info` to detect missing columns and issues `ALTER TABLE ADD COLUMN` as needed
 - **Keyword matching**: plain text (case-insensitive substring) and regex (`re.IGNORECASE`)
 - **Channel filters**: `ChannelAnalyzer` checks `low_uniqueness`, `low_subscriber_ratio`, `cross_channel_spam`, `non_cyrillic`, `chat_noise`; filtered channels skipped during collection unless `force=True`
+- **Channel creation date**: `channels.created_at` stores Telegram `entity.date` (channel creation timestamp); captured via `resolve_channel()` and `get_dialogs_for_phone()`; distinct from `added_at` (when added to the system)
 - **Collection service**: `enqueue_channel_by_pk(pk, force)` respects `is_filtered` flag; `enqueue_all_channels()` uses `full=False` for incremental collection
+- **Hour x Weekday Heatmap**: `db.repos.messages.get_hour_weekday_heatmap(channel_id, days)` → `[{hour, weekday, count}]`; weekday 0=Sunday per SQLite `%w`; service wrapper: `ChannelAnalyticsService.get_heatmap()`; CLI: `analytics channel`; Web: `/analytics/channels/api/heatmap`
+- **Cross-Channel Citations**: `db.repos.messages.get_cross_channel_citations(channel_id, days)` → sources by `forward_from_channel_id` with JOIN to channels for title/username enrichment; stored as positive MTProto channel ID
 - **Image adapter convention**: `ImageAdapter = Callable[[str, str], Awaitable[str | None]]` — signature is `(prompt, model_id) → URL/path`; model string format `provider:model_id` (e.g. `together:black-forest-labs/FLUX.1-schnell`); without prefix falls back to first registered adapter
 - **Content pipeline flow**: CONTENT_GENERATE task → `ContentGenerationService.generate()` → LLM text → optional image → `generation_runs` record → if AUTO publish mode, enqueues CONTENT_PUBLISH → `PublishService.publish_run()` sends to target channel
 - **Destructive tool confirmation**: agent tools that delete data require `confirm=true` argument; `require_confirmation()` in `_registry.py` returns a warning response if not confirmed

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -141,6 +141,7 @@ def run(args: argparse.Namespace) -> None:
                         about=meta.get("about") if meta else None,
                         linked_chat_id=meta.get("linked_chat_id") if meta else None,
                         has_comments=meta.get("has_comments", False) if meta else False,
+                        created_at=info.get("created_at"),
                     )
                 )
                 msg = f"Added channel: {info['title']} ({info['channel_id']})"
@@ -219,6 +220,7 @@ def run(args: argparse.Namespace) -> None:
                             username=info["username"],
                             channel_type=info.get("channel_type"),
                             is_active=not deactivate,
+                            created_at=info.get("created_at"),
                         )
                     )
                     existing_ids.add(info["channel_id"])
@@ -407,6 +409,7 @@ def run(args: argparse.Namespace) -> None:
                             username=info.get("username"),
                             channel_type=info.get("channel_type"),
                             is_active=True,
+                            created_at=info.get("created_at"),
                         )
                     )
                     existing_ids.add(info["channel_id"])

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -117,6 +117,9 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     if "has_comments" not in ch_columns:
         await db.execute("ALTER TABLE channels ADD COLUMN has_comments INTEGER DEFAULT 0")
         await db.commit()
+    if "created_at" not in ch_columns:
+        await db.execute("ALTER TABLE channels ADD COLUMN created_at TEXT")
+        await db.commit()
 
     cur = await db.execute("PRAGMA table_info(collection_tasks)")
     task_rows = await cur.fetchall()
@@ -737,6 +740,14 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
             "INSERT OR IGNORE INTO settings (key, value) VALUES ('_migration_reset_prompt_v2', '1')"
         )
         await db.commit()
+
+    # Fix forward_from_channel_id normalization (issue #381)
+    # Old code stored -PeerChannel.channel_id; correct value is positive channel_id.
+    await db.execute(
+        "UPDATE messages SET forward_from_channel_id = ABS(forward_from_channel_id) "
+        "WHERE forward_from_channel_id < 0"
+    )
+    await db.commit()
 
     return fts_available
 

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -14,8 +14,8 @@ class ChannelsRepository:
     async def add_channel(self, channel: Channel) -> int:
         cur = await self._db.execute(
             """INSERT INTO channels (channel_id, title, username, channel_type, is_active,
-                                     about, linked_chat_id, has_comments)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                                     about, linked_chat_id, has_comments, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(channel_id) DO UPDATE
                SET title=excluded.title, username=excluded.username,
                    channel_type=excluded.channel_type,
@@ -23,7 +23,8 @@ class ChannelsRepository:
                    about=COALESCE(excluded.about, channels.about),
                    linked_chat_id=COALESCE(excluded.linked_chat_id, channels.linked_chat_id),
                    has_comments=CASE WHEN COALESCE(excluded.linked_chat_id, channels.linked_chat_id)
-                                          IS NOT NULL THEN 1 ELSE 0 END""",
+                                          IS NOT NULL THEN 1 ELSE 0 END,
+                   created_at=COALESCE(excluded.created_at, channels.created_at)""",
             (
                 channel.channel_id,
                 channel.title,
@@ -33,6 +34,7 @@ class ChannelsRepository:
                 channel.about,
                 channel.linked_chat_id,
                 int(channel.has_comments),
+                channel.created_at.isoformat() if channel.created_at else None,
             ),
         )
         await self._db.commit()
@@ -57,6 +59,11 @@ class ChannelsRepository:
             has_comments=bool(row["has_comments"]) if "has_comments" in keys and row["has_comments"] else False,
             last_collected_id=row["last_collected_id"],
             added_at=datetime.fromisoformat(row["added_at"]) if row["added_at"] else None,
+            created_at=(
+                datetime.fromisoformat(row["created_at"])
+                if "created_at" in keys and row["created_at"]
+                else None
+            ),
             message_count=(
                 row["message_count"]
                 if "message_count" in keys and row["message_count"] is not None

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -1322,9 +1322,14 @@ class MessagesRepository:
     async def get_hour_weekday_heatmap(
         self, channel_id: int, days: int = 30,
     ) -> list[dict]:
-        """Return message counts grouped by hour (0-23) x weekday (0=Mon..6=Sun).
+        """Return message counts grouped by hour (0-23) x weekday (0=Sun..6=Sat).
 
-        Each row has keys: ``hour``, ``weekday``, ``count``.
+        Each row has keys: ``hour`` (0-23), ``weekday`` (0=Sunday per SQLite ``%w``),
+        ``count`` (messages in that slot).
+
+        Uses ``strftime('%H', date)`` for hour and ``strftime('%w', date)`` for weekday.
+        Only includes (hour, weekday) slots with at least one message; absent cells
+        should be treated as 0 when rendering the heatmap grid.
         """
         cur = await self._db.execute(
             """SELECT CAST(strftime('%H', m.date) AS INTEGER) AS hour,

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS channels (
     filter_flags TEXT DEFAULT '',
     about TEXT,
     linked_chat_id INTEGER,
-    has_comments INTEGER DEFAULT 0
+    has_comments INTEGER DEFAULT 0,
+    created_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS messages (

--- a/src/models.py
+++ b/src/models.py
@@ -44,6 +44,7 @@ class Channel(BaseModel):
     has_comments: bool = False
     last_collected_id: int = 0
     added_at: datetime | None = None
+    created_at: datetime | None = None
     message_count: int = 0
     tags: list[str] = []
 

--- a/src/services/channel_analytics_service.py
+++ b/src/services/channel_analytics_service.py
@@ -201,7 +201,12 @@ class ChannelAnalyticsService:
     async def get_heatmap(
         self, channel_id: int, days: int = 30,
     ) -> list[dict]:
-        """Hour x weekday message-count heatmap data."""
+        """Hour x weekday message-count heatmap data.
+
+        Returns ``[{hour, weekday, count}]`` dicts for a 7x24 grid
+        (weekdays on Y, hours on X).  Absent cells = 0.
+        Delegates to :meth:`MessagesRepository.get_hour_weekday_heatmap`.
+        """
         return await self._db.repos.messages.get_hour_weekday_heatmap(channel_id, days)
 
     async def get_cross_channel_citations(

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -51,6 +51,7 @@ class ChannelService:
             about=meta.get("about") if meta else None,
             linked_chat_id=meta.get("linked_chat_id") if meta else None,
             has_comments=meta.get("has_comments", False) if meta else False,
+            created_at=info.get("created_at"),
         )
         await self._channels.add_channel(channel)
         return True
@@ -77,6 +78,7 @@ class ChannelService:
                     username=dialog["username"],
                     channel_type=dialog.get("channel_type"),
                     is_active=not dialog.get("deactivate", False),
+                    created_at=dialog.get("created_at"),
                 )
             )
 

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -774,6 +774,7 @@ class ClientPool:
                     "username": getattr(entity, "username", None),
                     "channel_type": channel_type,
                     "deactivate": deactivate,
+                    "created_at": getattr(entity, "date", None),
                 }
             except asyncio.TimeoutError:
                 logger.warning("resolve_channel: get_entity timed out for '%s'", identifier)
@@ -1068,6 +1069,7 @@ class ClientPool:
                                 "channel_type": channel_type,
                                 "deactivate": deactivate,
                                 "is_own": getattr(entity, "creator", False),
+                                "created_at": getattr(entity, "date", None),
                             }
                         )
                     elif include_dm or mode == "full":
@@ -1085,6 +1087,7 @@ class ClientPool:
                                 "channel_type": "saved" if is_saved else ("bot" if is_bot else "dm"),
                                 "deactivate": False,
                                 "is_own": False,
+                                "created_at": getattr(entity, "date", None),
                             }
                         )
 

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -605,7 +605,7 @@ class Collector:
                         if fwd_from and getattr(fwd_from, "from_id", None):
                             from_id = fwd_from.from_id
                             if hasattr(from_id, "channel_id"):
-                                fwd_from_channel_id = -from_id.channel_id
+                                fwd_from_channel_id = from_id.channel_id
 
                         message = Message(
                             channel_id=channel_id,

--- a/src/web/routes/import_channels.py
+++ b/src/web/routes/import_channels.py
@@ -106,6 +106,7 @@ async def import_channels(
             username=info["username"],
             channel_type=info.get("channel_type"),
             is_active=not deactivate,
+            created_at=info.get("created_at"),
         )
         await db.add_channel(channel)
         existing_ids.add(info["channel_id"])

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -211,3 +211,57 @@ async def test_debug_page_empty_buffer(client):
 
     resp = await client.get("/debug/")
     assert resp.status_code == 200
+
+
+# ─── timing endpoint tests ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_debug_timing_page(client):
+    """Test timing page renders."""
+    resp = await client.get("/debug/timing")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_debug_timing_page_without_buffer(client_no_buffer):
+    """Test timing page when no timing buffer configured."""
+    resp = await client_no_buffer.get("/debug/timing")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_debug_timing_rows(client):
+    """Test timing rows partial."""
+    resp = await client.get("/debug/timing/rows")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_debug_timing_rows_without_buffer(client_no_buffer):
+    """Test timing rows without buffer."""
+    resp = await client_no_buffer.get("/debug/timing/rows")
+    assert resp.status_code == 200
+
+
+# ─── memory endpoint tests ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_debug_memory_returns_json(client):
+    """Test memory endpoint returns JSON with expected keys."""
+    resp = await client.get("/debug/memory")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "rss_mb" in data
+    assert "gc_counts" in data
+    assert "pool" in data
+
+
+@pytest.mark.asyncio
+async def test_debug_memory_pool_info(client):
+    """Test memory endpoint includes pool info."""
+    resp = await client.get("/debug/memory")
+    data = resp.json()
+    assert "connected_clients" in data["pool"]
+    assert "dialogs_cache_entries" in data["pool"]

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -303,3 +303,188 @@ async def test_leave_dialogs_multiple(client):
         follow_redirects=False,
     )
     assert resp.status_code == 303
+
+
+# ─── refresh & cache ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_refresh_dialogs_redirects(client):
+    """Test refresh dialogs redirects back."""
+    resp = await client.post(
+        "/dialogs/refresh",
+        data={"phone": "+1234567890"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "phone=" in resp.headers.get("location", "")
+
+
+@pytest.mark.asyncio
+async def test_refresh_dialogs_missing_phone(client):
+    """Test refresh without phone returns validation error."""
+    resp = await client.post("/dialogs/refresh", follow_redirects=False)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_cache_status_returns_json(client):
+    """Test cache-status endpoint returns JSON list."""
+    db = client._transport.app.state.db
+    await db.repos.dialog_cache.replace_dialogs("+1234567890", [
+        {"channel_id": 100111, "title": "Cached", "username": "cached",
+         "channel_type": "channel", "deactivate": 0, "is_own": 0},
+    ])
+    resp = await client.get("/dialogs/cache-status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.asyncio
+async def test_cache_clear_with_phone(client):
+    """Test cache-clear with phone param."""
+    resp = await client.post(
+        "/dialogs/cache-clear",
+        data={"phone": "+1234567890"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_cache_clear_without_phone(client):
+    """Test cache-clear without phone clears all."""
+    resp = await client.post("/dialogs/cache-clear", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# ─── send / edit / delete messages ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_message_missing_fields(client):
+    """Test send with missing required fields redirects."""
+    resp = await client.post("/dialogs/send", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_send_message_no_client(client):
+    """Test send when native client is unavailable."""
+    pool = client._transport.app.state.pool
+    pool.get_native_client_by_phone = AsyncMock(return_value=None)
+
+    resp = await client.post(
+        "/dialogs/send",
+        data={"phone": "+1234567890", "dialog_id": "-100111", "message": "hi"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_send_message_success(client):
+    """Test successful send message."""
+    native_mock = AsyncMock()
+    native_mock.send_message = AsyncMock(return_value=SimpleNamespace(id=42))
+    pool = client._transport.app.state.pool
+    pool.get_native_client_by_phone = AsyncMock(return_value=native_mock)
+
+    resp = await client.post(
+        "/dialogs/send",
+        data={"phone": "+1234567890", "dialog_id": "-100111", "message": "hello"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_edit_message_missing_fields(client):
+    """Test edit-message with missing fields redirects."""
+    resp = await client.post("/dialogs/edit-message", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_delete_message_missing_fields(client):
+    """Test delete-message with missing fields redirects."""
+    resp = await client.post("/dialogs/delete-message", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_delete_message_invalid_ids(client):
+    """Test delete-message with non-numeric message_ids."""
+    resp = await client.post(
+        "/dialogs/delete-message",
+        data={"phone": "+1234567890", "dialog_id": "-100111", "message_ids": "abc"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_forward_messages_missing_fields(client):
+    """Test forward-messages with missing fields redirects."""
+    resp = await client.post("/dialogs/forward-messages", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# ─── pin / unpin ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pin_message_missing_fields(client):
+    """Test pin-message with missing fields redirects."""
+    resp = await client.post("/dialogs/pin-message", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_unpin_message_missing_fields(client):
+    """Test unpin-message with missing fields redirects."""
+    resp = await client.post("/dialogs/unpin-message", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# ─── participants / archive / unarchive / mark-read ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_participants_missing_params(client):
+    """Test participants with missing params returns error or empty."""
+    resp = await client.get("/dialogs/participants")
+    # May return 400 or redirect
+    assert resp.status_code in (200, 303, 400, 422)
+
+
+@pytest.mark.asyncio
+async def test_archive_dialog_missing_fields(client):
+    """Test archive with missing fields redirects."""
+    resp = await client.post("/dialogs/archive", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_unarchive_dialog_missing_fields(client):
+    """Test unarchive with missing fields redirects."""
+    resp = await client.post("/dialogs/unarchive", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_mark_read_missing_fields(client):
+    """Test mark-read with missing fields redirects."""
+    resp = await client.post("/dialogs/mark-read", follow_redirects=False)
+    assert resp.status_code == 303
+
+
+# ─── create-channel page ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_channel_page_renders(client):
+    """Test create-channel page renders."""
+    resp = await client.get("/dialogs/create-channel")
+    assert resp.status_code == 200

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -422,6 +422,7 @@ async def test_delete_message_invalid_ids(client):
         follow_redirects=False,
     )
     assert resp.status_code == 303
+    assert "error=invalid_ids" in resp.headers["location"]
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -377,7 +377,7 @@ async def test_send_message_no_client(client):
 
     resp = await client.post(
         "/dialogs/send",
-        data={"phone": "+1234567890", "dialog_id": "-100111", "message": "hi"},
+        data={"phone": "+1234567890", "recipient": "-100111", "text": "hi"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
@@ -389,11 +389,11 @@ async def test_send_message_success(client):
     native_mock = AsyncMock()
     native_mock.send_message = AsyncMock(return_value=SimpleNamespace(id=42))
     pool = client._transport.app.state.pool
-    pool.get_native_client_by_phone = AsyncMock(return_value=native_mock)
+    pool.get_native_client_by_phone = AsyncMock(return_value=(native_mock, "+1234567890"))
 
     resp = await client.post(
         "/dialogs/send",
-        data={"phone": "+1234567890", "dialog_id": "-100111", "message": "hello"},
+        data={"phone": "+1234567890", "recipient": "-100111", "text": "hello"},
         follow_redirects=False,
     )
     assert resp.status_code == 303
@@ -418,7 +418,7 @@ async def test_delete_message_invalid_ids(client):
     """Test delete-message with non-numeric message_ids."""
     resp = await client.post(
         "/dialogs/delete-message",
-        data={"phone": "+1234567890", "dialog_id": "-100111", "message_ids": "abc"},
+        data={"phone": "+1234567890", "chat_id": "-100111", "message_ids": "abc"},
         follow_redirects=False,
     )
     assert resp.status_code == 303

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -22,7 +22,7 @@ from src.services.channel_analytics_service import (
 # ─── helpers ───────────────────────────────────────────────────────
 
 
-async def _seed_channel(db, channel_id=-100123, title="Test Channel", username="test_chan"):
+async def _seed_channel(db, channel_id=100123, title="Test Channel", username="test_chan"):
     await db.add_channel(Channel(channel_id=channel_id, title=title, username=username))
     return await db.get_channel_by_channel_id(channel_id)
 
@@ -65,18 +65,18 @@ async def _seed_messages_batch(db, channel_id, messages):
 
 @pytest.mark.asyncio
 async def test_get_active_channels(db):
-    await _seed_channel(db, channel_id=-100111, title="Active 1", username="active1")
-    await _seed_channel(db, channel_id=-100222, title="Active 2", username="active2")
-    ch3 = await _seed_channel(db, channel_id=-100333, title="Filtered", username="filtered_chan")
+    await _seed_channel(db, channel_id=100111, title="Active 1", username="active1")
+    await _seed_channel(db, channel_id=100222, title="Active 2", username="active2")
+    ch3 = await _seed_channel(db, channel_id=100333, title="Filtered", username="filtered_chan")
     await db.set_channel_filtered(ch3.id, True)
 
     svc = ChannelAnalyticsService(db)
     channels = await svc.get_active_channels()
     assert len(channels) == 2
     ids = {c.channel_id for c in channels}
-    assert -100111 in ids
-    assert -100222 in ids
-    assert -100333 not in ids
+    assert 100111 in ids
+    assert 100222 in ids
+    assert 100333 not in ids
     assert all(isinstance(c, ChannelListItem) for c in channels)
 
 
@@ -89,11 +89,11 @@ async def test_get_active_channels_empty(db):
 
 @pytest.mark.asyncio
 async def test_get_channel_overview_basic(db):
-    await _seed_channel(db, channel_id=-100123, title="Overview Chan", username="ov_chan")
+    await _seed_channel(db, channel_id=100123, title="Overview Chan", username="ov_chan")
     svc = ChannelAnalyticsService(db)
-    overview = await svc.get_channel_overview(-100123)
+    overview = await svc.get_channel_overview(100123)
     assert isinstance(overview, ChannelOverview)
-    assert overview.channel_id == -100123
+    assert overview.channel_id == 100123
     assert overview.title == "Overview Chan"
     assert overview.username == "ov_chan"
     assert overview.subscriber_count is None
@@ -106,13 +106,13 @@ async def test_get_channel_overview_basic(db):
 
 @pytest.mark.asyncio
 async def test_get_channel_overview_with_subscribers(db):
-    await _seed_channel(db, channel_id=-100123, title="Sub Chan")
+    await _seed_channel(db, channel_id=100123, title="Sub Chan")
     # Two stats entries for delta calculation
-    await _seed_stats(db, -100123, subscriber_count=1000, avg_views=500.0)
-    await _seed_stats(db, -100123, subscriber_count=1200, avg_views=600.0)
+    await _seed_stats(db, 100123, subscriber_count=1000, avg_views=500.0)
+    await _seed_stats(db, 100123, subscriber_count=1200, avg_views=600.0)
 
     svc = ChannelAnalyticsService(db)
-    overview = await svc.get_channel_overview(-100123)
+    overview = await svc.get_channel_overview(100123)
     assert overview.subscriber_count == 1200
     assert overview.subscriber_delta == 200  # 1200 - 1000
     assert overview.avg_views == 600.0
@@ -122,15 +122,15 @@ async def test_get_channel_overview_with_subscribers(db):
 
 @pytest.mark.asyncio
 async def test_get_channel_overview_with_posts(db):
-    await _seed_channel(db, channel_id=-100123, title="Post Chan")
-    await _seed_stats(db, -100123, subscriber_count=500, avg_views=200.0)
+    await _seed_channel(db, channel_id=100123, title="Post Chan")
+    await _seed_stats(db, 100123, subscriber_count=500, avg_views=200.0)
     now = datetime.now(timezone.utc)
 
     messages = []
     # 5 today
     for i in range(5):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=100 + i,
             text=f"msg {i}",
             views=50 + i * 10,
@@ -141,7 +141,7 @@ async def test_get_channel_overview_with_posts(db):
     # 3 within the last week but more than 1 day ago
     for i in range(3):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=200 + i,
             text=f"week msg {i}",
             views=30 + i,
@@ -151,7 +151,7 @@ async def test_get_channel_overview_with_posts(db):
         ))
     # 1 old message from 35 days ago
     messages.append(Message(
-        channel_id=-100123,
+        channel_id=100123,
         message_id=300,
         text="old msg",
         views=10,
@@ -159,42 +159,42 @@ async def test_get_channel_overview_with_posts(db):
         reply_count=0,
         date=now - timedelta(days=35),
     ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    overview = await svc.get_channel_overview(-100123, days=30)
+    overview = await svc.get_channel_overview(100123, days=30)
     assert overview.total_posts == 9
     assert overview.posts_today == 5
     assert overview.posts_week == 8
     assert overview.posts_month == 8  # 5 today + 3 this week (within 30d)
 
-    overview7 = await svc.get_channel_overview(-100123, days=7)
+    overview7 = await svc.get_channel_overview(100123, days=7)
     assert overview7.posts_month == 8  # 5 today + 3 this week
 
-    overview1 = await svc.get_channel_overview(-100123, days=1)
+    overview1 = await svc.get_channel_overview(100123, days=1)
     assert overview1.posts_month == 5  # 5 within last day
 
 
 @pytest.mark.asyncio
 async def test_get_channel_overview_missing_channel(db):
     svc = ChannelAnalyticsService(db)
-    overview = await svc.get_channel_overview(-999999)
-    assert overview.channel_id == -999999
+    overview = await svc.get_channel_overview(999999)
+    assert overview.channel_id == 999999
     assert overview.title is None
     assert overview.username is None
 
 
 @pytest.mark.asyncio
 async def test_get_subscriber_history(db):
-    await _seed_channel(db, channel_id=-100123, title="Hist Chan")
+    await _seed_channel(db, channel_id=100123, title="Hist Chan")
     for i in range(5):
         await db.save_channel_stats(ChannelStats(
-            channel_id=-100123,
+            channel_id=100123,
             subscriber_count=100 + i * 50,
         ))
 
     svc = ChannelAnalyticsService(db)
-    history = await svc.get_subscriber_history(-100123, days=5)
+    history = await svc.get_subscriber_history(100123, days=5)
     assert len(history) == 5
     # Verify chronological order
     counts = [entry["subscriber_count"] for entry in history]
@@ -204,22 +204,22 @@ async def test_get_subscriber_history(db):
 
 @pytest.mark.asyncio
 async def test_get_views_timeseries(db):
-    await _seed_channel(db, channel_id=-100123, title="Views Chan")
+    await _seed_channel(db, channel_id=100123, title="Views Chan")
     now = datetime.now(timezone.utc)
     messages = []
     for i in range(3):
         ts = now - timedelta(days=i)
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=10 + i,
             text=f"msg {i}",
             views=100 * (i + 1),
             date=ts,
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    ts = await svc.get_views_timeseries(-100123, days=5)
+    ts = await svc.get_views_timeseries(100123, days=5)
     assert len(ts) >= 1
     for entry in ts:
         assert "day" in entry
@@ -229,13 +229,13 @@ async def test_get_views_timeseries(db):
 
 @pytest.mark.asyncio
 async def test_get_post_frequency(db):
-    await _seed_channel(db, channel_id=-100123, title="Freq Chan")
+    await _seed_channel(db, channel_id=100123, title="Freq Chan")
     now = datetime.now(timezone.utc)
     messages = []
     # 3 messages today
     for i in range(3):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=100 + i,
             text=f"today msg {i}",
             views=10,
@@ -244,15 +244,15 @@ async def test_get_post_frequency(db):
     # 2 yesterday
     for i in range(2):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=200 + i,
             text=f"yesterday msg {i}",
             date=now - timedelta(days=1),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    freq = await svc.get_post_frequency(-100123, days=7)
+    freq = await svc.get_post_frequency(100123, days=7)
     assert len(freq) == 2
     today_count = sum(e["count"] for e in freq if e["day"] == now.strftime("%Y-%m-%d"))
     assert today_count == 3
@@ -265,21 +265,21 @@ async def test_get_post_frequency(db):
 
 @pytest.mark.asyncio
 async def test_get_citation_stats(db):
-    await _seed_channel(db, channel_id=-100123, title="Cite Chan")
+    await _seed_channel(db, channel_id=100123, title="Cite Chan")
     messages = []
     for i in range(5):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=100 + i,
             text=f"msg {i}",
             views=100,
             forwards=i * 10,
             date=datetime(2025, 1, 15, 12, 0, 0),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    stats = await svc.get_citation_stats(-100123)
+    stats = await svc.get_citation_stats(100123)
     assert isinstance(stats, CitationStats)
     assert stats.post_count == 5
     assert stats.total_forwards == sum(range(5)) * 10  # 0+10+20+30+40 = 100
@@ -288,12 +288,12 @@ async def test_get_citation_stats(db):
 
 @pytest.mark.asyncio
 async def test_get_err(db):
-    await _seed_channel(db, channel_id=-100123, title="ERR Chan")
-    await _seed_stats(db, -100123, subscriber_count=1000, avg_views=200.0)
+    await _seed_channel(db, channel_id=100123, title="ERR Chan")
+    await _seed_stats(db, 100123, subscriber_count=1000, avg_views=200.0)
     messages = []
     for i in range(5):
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=100 + i,
             text=f"msg {i}",
             views=100,
@@ -301,10 +301,10 @@ async def test_get_err(db):
             reply_count=2,
             date=datetime(2025, 1, 15, 12, 0, 0),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    err = await svc.get_err(-100123)
+    err = await svc.get_err(100123)
     assert isinstance(err, float)
     assert err > 0
     # ERR = total_engagement / (num_posts * subscribers) * 100
@@ -315,19 +315,19 @@ async def test_get_err(db):
 
 @pytest.mark.asyncio
 async def test_get_err_no_subscribers(db):
-    await _seed_channel(db, channel_id=-100123, title="No Sub Chan")
+    await _seed_channel(db, channel_id=100123, title="No Sub Chan")
     svc = ChannelAnalyticsService(db)
-    err = await svc.get_err(-100123)
+    err = await svc.get_err(100123)
     assert err is None
 
 
 @pytest.mark.asyncio
 async def test_get_err24(db):
-    await _seed_channel(db, channel_id=-100123, title="ERR24 Chan")
-    await _seed_stats(db, -100123, subscriber_count=500)
+    await _seed_channel(db, channel_id=100123, title="ERR24 Chan")
+    await _seed_stats(db, 100123, subscriber_count=500)
     now = datetime.now(timezone.utc)
     msg = Message(
-        channel_id=-100123,
+        channel_id=100123,
         message_id=1,
         text="recent msg",
         views=200,
@@ -338,7 +338,7 @@ async def test_get_err24(db):
     await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    err24 = await svc.get_err24(-100123)
+    err24 = await svc.get_err24(100123)
     assert isinstance(err24, float)
     assert err24 > 0
     # engagement = 200 + 10 + 5 = 215; err24 = 215 / (1 * 500) * 100 = 43.0
@@ -347,10 +347,10 @@ async def test_get_err24(db):
 
 @pytest.mark.asyncio
 async def test_get_err24_no_recent_posts(db):
-    await _seed_channel(db, channel_id=-100123, title="Empty ERR24")
-    await _seed_stats(db, -100123, subscriber_count=500)
+    await _seed_channel(db, channel_id=100123, title="Empty ERR24")
+    await _seed_stats(db, 100123, subscriber_count=500)
     msg = Message(
-        channel_id=-100123,
+        channel_id=100123,
         message_id=1,
         text="old msg",
         views=50,
@@ -359,26 +359,26 @@ async def test_get_err24_no_recent_posts(db):
     await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    err24 = await svc.get_err24(-100123)
+    err24 = await svc.get_err24(100123)
     assert err24 is None
 
 
 @pytest.mark.asyncio
 async def test_get_hourly_activity(db):
-    await _seed_channel(db, channel_id=-100123, title="Hourly Chan")
+    await _seed_channel(db, channel_id=100123, title="Hourly Chan")
     now = datetime.now(timezone.utc)
     messages = []
     for hour in [8, 8, 8, 14, 14, 20]:
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=len(messages) + 1,
             text=f"msg at {hour}",
             date=now.replace(hour=hour, minute=0, second=0, microsecond=0),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    activity = await svc.get_hourly_activity(-100123, days=7)
+    activity = await svc.get_hourly_activity(100123, days=7)
     assert len(activity) > 0
     hour_counts = {e["hour"]: e["count"] for e in activity}
     assert hour_counts.get(8) == 3
@@ -388,14 +388,14 @@ async def test_get_hourly_activity(db):
 
 @pytest.mark.asyncio
 async def test_get_ranked_channels_by_err(db):
-    await _seed_channel(db, channel_id=-100111, title="Low ERR", username="low_err")
-    await _seed_channel(db, channel_id=-100222, title="High ERR", username="high_err")
-    await _seed_stats(db, -100111, subscriber_count=1000, avg_views=100.0)
-    await _seed_stats(db, -100222, subscriber_count=1000, avg_views=500.0)
+    await _seed_channel(db, channel_id=100111, title="Low ERR", username="low_err")
+    await _seed_channel(db, channel_id=100222, title="High ERR", username="high_err")
+    await _seed_stats(db, 100111, subscriber_count=1000, avg_views=100.0)
+    await _seed_stats(db, 100222, subscriber_count=1000, avg_views=500.0)
 
     for i in range(3):
         msg = Message(
-            channel_id=-100111,
+            channel_id=100111,
             message_id=100 + i,
             text=f"low msg {i}",
             views=50,
@@ -407,7 +407,7 @@ async def test_get_ranked_channels_by_err(db):
 
     for i in range(3):
         msg = Message(
-            channel_id=-100222,
+            channel_id=100222,
             message_id=200 + i,
             text=f"high msg {i}",
             views=500,
@@ -421,26 +421,26 @@ async def test_get_ranked_channels_by_err(db):
     rankings = await svc.get_ranked_channels(metric="err")
     assert len(rankings) == 2
     assert all(isinstance(r, ChannelRanking) for r in rankings)
-    assert rankings[0].channel_id == -100222
+    assert rankings[0].channel_id == 100222
     assert rankings[0].rank == 1
     assert rankings[0].score > rankings[1].score
-    assert rankings[1].channel_id == -100111
+    assert rankings[1].channel_id == 100111
     assert rankings[1].rank == 2
 
 
 @pytest.mark.asyncio
 async def test_get_ranked_channels_by_subscriber_count(db):
-    await _seed_channel(db, channel_id=-100111, title="Small", username="small")
-    await _seed_channel(db, channel_id=-100222, title="Big", username="big")
-    await _seed_stats(db, -100111, subscriber_count=100)
-    await _seed_stats(db, -100222, subscriber_count=10000)
+    await _seed_channel(db, channel_id=100111, title="Small", username="small")
+    await _seed_channel(db, channel_id=100222, title="Big", username="big")
+    await _seed_stats(db, 100111, subscriber_count=100)
+    await _seed_stats(db, 100222, subscriber_count=10000)
 
     svc = ChannelAnalyticsService(db)
     rankings = await svc.get_ranked_channels(metric="subscriber_count")
     assert len(rankings) == 2
-    assert rankings[0].channel_id == -100222
+    assert rankings[0].channel_id == 100222
     assert rankings[0].score == 10000.0
-    assert rankings[1].channel_id == -100111
+    assert rankings[1].channel_id == 100111
     assert rankings[1].score == 100.0
 
 
@@ -458,17 +458,17 @@ async def test_get_ranked_channels_limit(db):
 
 @pytest.mark.asyncio
 async def test_get_channel_comparison(db):
-    await _seed_channel(db, channel_id=-100111, title="Chan A", username="chan_a")
-    await _seed_channel(db, channel_id=-100222, title="Chan B", username="chan_b")
-    await _seed_stats(db, -100111, subscriber_count=1000)
-    await _seed_stats(db, -100222, subscriber_count=2000)
+    await _seed_channel(db, channel_id=100111, title="Chan A", username="chan_a")
+    await _seed_channel(db, channel_id=100222, title="Chan B", username="chan_b")
+    await _seed_stats(db, 100111, subscriber_count=1000)
+    await _seed_stats(db, 100222, subscriber_count=2000)
 
     svc = ChannelAnalyticsService(db)
-    comparison = await svc.get_channel_comparison([-100111, -100222])
+    comparison = await svc.get_channel_comparison([100111, 100222])
     assert isinstance(comparison, ChannelComparison)
     assert len(comparison.channels) == 2
-    assert comparison.channels[0].channel_id == -100111
-    assert comparison.channels[1].channel_id == -100222
+    assert comparison.channels[0].channel_id == 100111
+    assert comparison.channels[1].channel_id == 100222
     assert comparison.channels[0].subscriber_count == 1000
     assert comparison.channels[1].subscriber_count == 2000
     assert "subscriber_count" in comparison.metrics
@@ -485,8 +485,8 @@ async def test_get_channel_comparison_empty(db):
 
 @pytest.mark.asyncio
 async def test_get_ranked_channels_unknown_metric(db):
-    await _seed_channel(db, channel_id=-100111, title="Unknown Metric Chan")
-    await _seed_stats(db, -100111, subscriber_count=500)
+    await _seed_channel(db, channel_id=100111, title="Unknown Metric Chan")
+    await _seed_stats(db, 100111, subscriber_count=500)
 
     svc = ChannelAnalyticsService(db)
     rankings = await svc.get_ranked_channels(metric="nonexistent_metric")
@@ -497,12 +497,12 @@ async def test_get_ranked_channels_unknown_metric(db):
 @pytest.mark.asyncio
 async def test_overview_to_dict(db):
     """Verify dataclass serialization works for template rendering."""
-    await _seed_channel(db, channel_id=-100123, title="Dict Chan")
+    await _seed_channel(db, channel_id=100123, title="Dict Chan")
     svc = ChannelAnalyticsService(db)
-    overview = await svc.get_channel_overview(-100123)
+    overview = await svc.get_channel_overview(100123)
     d = dataclasses.asdict(overview)
     assert isinstance(d, dict)
-    assert d["channel_id"] == -100123
+    assert d["channel_id"] == 100123
     assert d["title"] == "Dict Chan"
     assert "subscriber_count" in d
     assert "err" in d
@@ -514,22 +514,22 @@ async def test_overview_to_dict(db):
 
 @pytest.mark.asyncio
 async def test_get_heatmap_empty(db):
-    await _seed_channel(db, channel_id=-100123, title="Heatmap Empty")
+    await _seed_channel(db, channel_id=100123, title="Heatmap Empty")
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_heatmap(-100123, days=30)
+    data = await svc.get_heatmap(100123, days=30)
     assert data == []
 
 
 @pytest.mark.asyncio
 async def test_get_heatmap_basic(db):
-    await _seed_channel(db, channel_id=-100123, title="Heatmap Chan")
+    await _seed_channel(db, channel_id=100123, title="Heatmap Chan")
     now = datetime.now(timezone.utc)
     messages = []
     # Monday (weekday 1 via %w = 1)
     mon = now - timedelta(days=now.weekday())
     for h in [8, 9, 10]:
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=len(messages) + 1,
             text=f"mon {h}",
             date=mon.replace(hour=h, minute=0, second=0, microsecond=0),
@@ -538,15 +538,15 @@ async def test_get_heatmap_basic(db):
     wed = mon + timedelta(days=2)
     for h in [14, 14]:
         messages.append(Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=len(messages) + 1,
             text=f"wed {h}",
             date=wed.replace(hour=14, minute=0, second=0, microsecond=0),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_heatmap(-100123, days=30)
+    data = await svc.get_heatmap(100123, days=30)
     assert len(data) > 0
     # All rows have expected keys
     for row in data:
@@ -565,22 +565,22 @@ async def test_get_heatmap_basic(db):
 
 @pytest.mark.asyncio
 async def test_get_heatmap_days_filter(db):
-    await _seed_channel(db, channel_id=-100123, title="Heatmap Days")
+    await _seed_channel(db, channel_id=100123, title="Heatmap Days")
     now = datetime.now(timezone.utc)
     # Recent message
     await db.insert_message(Message(
-        channel_id=-100123, message_id=1, text="recent",
+        channel_id=100123, message_id=1, text="recent",
         date=now - timedelta(hours=1),
     ))
     # Old message outside 7-day window
     await db.insert_message(Message(
-        channel_id=-100123, message_id=2, text="old",
+        channel_id=100123, message_id=2, text="old",
         date=now - timedelta(days=14),
     ))
 
     svc = ChannelAnalyticsService(db)
-    data7 = await svc.get_heatmap(-100123, days=7)
-    data30 = await svc.get_heatmap(-100123, days=30)
+    data7 = await svc.get_heatmap(100123, days=7)
+    data30 = await svc.get_heatmap(100123, days=30)
     total_7 = sum(r["count"] for r in data7)
     total_30 = sum(r["count"] for r in data30)
     assert total_7 == 1
@@ -592,43 +592,43 @@ async def test_get_heatmap_days_filter(db):
 
 @pytest.mark.asyncio
 async def test_get_cross_channel_citations_empty(db):
-    await _seed_channel(db, channel_id=-100123, title="Cite Empty")
+    await _seed_channel(db, channel_id=100123, title="Cite Empty")
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123)
+    data = await svc.get_cross_channel_citations(100123)
     assert data == []
 
 
 @pytest.mark.asyncio
 async def test_get_cross_channel_citations_basic(db):
     # Source channel
-    await _seed_channel(db, channel_id=-100500, title="Source Chan", username="src_chan")
+    await _seed_channel(db, channel_id=100500, title="Source Chan", username="src_chan")
     # Target channel
-    await _seed_channel(db, channel_id=-100123, title="Target Chan", username="tgt_chan")
+    await _seed_channel(db, channel_id=100123, title="Target Chan", username="tgt_chan")
 
     now = datetime.now(timezone.utc)
-    # Messages forwarded from -100500 into -100123
+    # Messages forwarded from 100500 into 100123
     for i in range(3):
         msg = Message(
-            channel_id=-100123,
+            channel_id=100123,
             message_id=100 + i,
             text=f"fwd msg {i}",
             date=now - timedelta(hours=i),
             forwards=0,
         )
-        msg.forward_from_channel_id = -100500
+        msg.forward_from_channel_id = 100500
         await db.insert_message(msg)
     # One regular message (no forward)
     await db.insert_message(Message(
-        channel_id=-100123,
+        channel_id=100123,
         message_id=200,
         text="regular msg",
         date=now,
     ))
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30)
+    data = await svc.get_cross_channel_citations(100123, days=30)
     assert len(data) == 1
-    assert data[0]["source_channel_id"] == -100500
+    assert data[0]["source_channel_id"] == 100500
     assert data[0]["source_title"] == "Source Chan"
     assert data[0]["citation_count"] == 3
     assert data[0]["latest_date"] is not None
@@ -636,50 +636,50 @@ async def test_get_cross_channel_citations_basic(db):
 
 @pytest.mark.asyncio
 async def test_get_cross_channel_citations_multiple_sources(db):
-    await _seed_channel(db, channel_id=-100111, title="Source A", username="src_a")
-    await _seed_channel(db, channel_id=-100222, title="Source B", username="src_b")
-    await _seed_channel(db, channel_id=-100123, title="Target", username="target")
+    await _seed_channel(db, channel_id=100111, title="Source A", username="src_a")
+    await _seed_channel(db, channel_id=100222, title="Source B", username="src_b")
+    await _seed_channel(db, channel_id=100123, title="Target", username="target")
 
     now = datetime.now(timezone.utc)
     for i in range(5):
         msg = Message(
-            channel_id=-100123, message_id=100 + i, text=f"fwd a {i}",
+            channel_id=100123, message_id=100 + i, text=f"fwd a {i}",
             date=now,
         )
-        msg.forward_from_channel_id = -100111
+        msg.forward_from_channel_id = 100111
         await db.insert_message(msg)
     for i in range(2):
         msg = Message(
-            channel_id=-100123, message_id=200 + i, text=f"fwd b {i}",
+            channel_id=100123, message_id=200 + i, text=f"fwd b {i}",
             date=now,
         )
-        msg.forward_from_channel_id = -100222
+        msg.forward_from_channel_id = 100222
         await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30)
+    data = await svc.get_cross_channel_citations(100123, days=30)
     assert len(data) == 2
     # Sorted by citation_count DESC
-    assert data[0]["source_channel_id"] == -100111
+    assert data[0]["source_channel_id"] == 100111
     assert data[0]["citation_count"] == 5
-    assert data[1]["source_channel_id"] == -100222
+    assert data[1]["source_channel_id"] == 100222
     assert data[1]["citation_count"] == 2
 
 
 @pytest.mark.asyncio
 async def test_get_cross_channel_citations_limit(db):
-    await _seed_channel(db, channel_id=-100123, title="Target Limit")
+    await _seed_channel(db, channel_id=100123, title="Target Limit")
     now = datetime.now(timezone.utc)
     for i in range(10):
         msg = Message(
-            channel_id=-100123, message_id=100 + i, text=f"fwd {i}",
+            channel_id=100123, message_id=100 + i, text=f"fwd {i}",
             date=now,
         )
-        msg.forward_from_channel_id = -(200 + i)
+        msg.forward_from_channel_id = 200 + i
         await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30, limit=3)
+    data = await svc.get_cross_channel_citations(100123, days=30, limit=3)
     assert len(data) <= 3
 
 
@@ -688,20 +688,20 @@ async def test_get_cross_channel_citations_limit(db):
 
 @pytest.mark.asyncio
 async def test_repo_hour_weekday_heatmap(db):
-    await _seed_channel(db, channel_id=-100123, title="Repo Heatmap")
+    await _seed_channel(db, channel_id=100123, title="Repo Heatmap")
     now = datetime.now(timezone.utc)
     # Create messages at known hour/weekday
     messages = [
-        Message(channel_id=-100123, message_id=1, text="a",
+        Message(channel_id=100123, message_id=1, text="a",
                 date=now.replace(hour=10, minute=0, second=0, microsecond=0)),
-        Message(channel_id=-100123, message_id=2, text="b",
+        Message(channel_id=100123, message_id=2, text="b",
                 date=now.replace(hour=10, minute=0, second=0, microsecond=0)),
-        Message(channel_id=-100123, message_id=3, text="c",
+        Message(channel_id=100123, message_id=3, text="c",
                 date=now.replace(hour=22, minute=0, second=0, microsecond=0)),
     ]
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
-    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    rows = await db.repos.messages.get_hour_weekday_heatmap(100123, days=7)
     assert len(rows) >= 2  # At least hour 10 and hour 22 entries
     for r in rows:
         assert 0 <= r["hour"] <= 23
@@ -711,13 +711,13 @@ async def test_repo_hour_weekday_heatmap(db):
 
 @pytest.mark.asyncio
 async def test_repo_cross_channel_citations_no_forward(db):
-    await _seed_channel(db, channel_id=-100123, title="No Fwd")
+    await _seed_channel(db, channel_id=100123, title="No Fwd")
     await db.insert_message(Message(
-        channel_id=-100123, message_id=1, text="hello",
+        channel_id=100123, message_id=1, text="hello",
         date=datetime.now(timezone.utc),
     ))
 
-    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
     assert rows == []
 
 
@@ -727,18 +727,18 @@ async def test_repo_cross_channel_citations_no_forward(db):
 @pytest.mark.asyncio
 async def test_api_heatmap_route(db):
     """Verify heatmap service returns list (route requires full app state)."""
-    await _seed_channel(db, channel_id=-100123, title="API Heat")
+    await _seed_channel(db, channel_id=100123, title="API Heat")
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_heatmap(-100123, days=30)
+    data = await svc.get_heatmap(100123, days=30)
     assert isinstance(data, list)
 
 
 @pytest.mark.asyncio
 async def test_api_cross_citations_route(db):
     """Verify cross-citations service returns list (route requires full app state)."""
-    await _seed_channel(db, channel_id=-100123, title="API Cross")
+    await _seed_channel(db, channel_id=100123, title="API Cross")
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30)
+    data = await svc.get_cross_channel_citations(100123, days=30)
     assert isinstance(data, list)
 
 
@@ -748,7 +748,7 @@ async def test_api_cross_citations_route(db):
 @pytest.mark.asyncio
 async def test_heatmap_specific_weekday_hour_values(db):
     """Verify heatmap returns correct weekday (%w) and hour values."""
-    await _seed_channel(db, channel_id=-100123, title="Heatmap Precise")
+    await _seed_channel(db, channel_id=100123, title="Heatmap Precise")
     # Use dates within the last 30 days to ensure they fall in the query window.
     # Find a recent Monday and Wednesday.
     now = datetime.now(timezone.utc)
@@ -759,13 +759,13 @@ async def test_heatmap_specific_weekday_hour_values(db):
     mon_10 = mon.replace(hour=10, minute=30, second=0, microsecond=0)
     wed_22 = wed.replace(hour=22, minute=0, second=0, microsecond=0)
     messages = [
-        Message(channel_id=-100123, message_id=1, text="mon 10:30", date=mon_10),
-        Message(channel_id=-100123, message_id=2, text="wed 22", date=wed_22),
+        Message(channel_id=100123, message_id=1, text="mon 10:30", date=mon_10),
+        Message(channel_id=100123, message_id=2, text="wed 22", date=wed_22),
     ]
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_heatmap(-100123, days=30)
+    data = await svc.get_heatmap(100123, days=30)
 
     # Build a lookup (weekday, hour) -> count
     lookup = {(r["weekday"], r["hour"]): r["count"] for r in data}
@@ -781,19 +781,19 @@ async def test_heatmap_specific_weekday_hour_values(db):
 @pytest.mark.asyncio
 async def test_heatmap_aggregation_multiple_same_slot(db):
     """Multiple messages in the same (weekday, hour) slot aggregate."""
-    await _seed_channel(db, channel_id=-100123, title="Heatmap Agg")
+    await _seed_channel(db, channel_id=100123, title="Heatmap Agg")
     # All messages on same hour of the current day
     now = datetime.now(timezone.utc)
     base = now.replace(hour=14, minute=0, second=0, microsecond=0)
     messages = [
-        Message(channel_id=-100123, message_id=i, text=f"msg {i}",
+        Message(channel_id=100123, message_id=i, text=f"msg {i}",
                 date=base + timedelta(minutes=i * 5))
         for i in range(10)
     ]
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_heatmap(-100123, days=7)
+    data = await svc.get_heatmap(100123, days=7)
     lookup = {(r["weekday"], r["hour"]): r["count"] for r in data}
     # All 10 land in hour 14; weekday depends on today
     today_wd = int(now.strftime("%w"))
@@ -808,29 +808,29 @@ async def test_heatmap_aggregation_multiple_same_slot(db):
 @pytest.mark.asyncio
 async def test_cross_citations_date_filtering(db):
     """Messages outside the days window are excluded from cross-citations."""
-    await _seed_channel(db, channel_id=-100500, title="Source")
-    await _seed_channel(db, channel_id=-100123, title="Target")
+    await _seed_channel(db, channel_id=100500, title="Source")
+    await _seed_channel(db, channel_id=100123, title="Target")
     now = datetime.now(timezone.utc)
 
     # Recent forwarded message
     msg_recent = Message(
-        channel_id=-100123, message_id=1, text="recent fwd",
+        channel_id=100123, message_id=1, text="recent fwd",
         date=now - timedelta(hours=1),
     )
-    msg_recent.forward_from_channel_id = -100500
+    msg_recent.forward_from_channel_id = 100500
     await db.insert_message(msg_recent)
 
     # Old forwarded message (outside 7-day window)
     msg_old = Message(
-        channel_id=-100123, message_id=2, text="old fwd",
+        channel_id=100123, message_id=2, text="old fwd",
         date=now - timedelta(days=30),
     )
-    msg_old.forward_from_channel_id = -100500
+    msg_old.forward_from_channel_id = 100500
     await db.insert_message(msg_old)
 
     svc = ChannelAnalyticsService(db)
-    data_7d = await svc.get_cross_channel_citations(-100123, days=7)
-    data_90d = await svc.get_cross_channel_citations(-100123, days=90)
+    data_7d = await svc.get_cross_channel_citations(100123, days=7)
+    data_90d = await svc.get_cross_channel_citations(100123, days=90)
 
     assert len(data_7d) == 1
     assert data_7d[0]["citation_count"] == 1  # only recent
@@ -842,21 +842,21 @@ async def test_cross_citations_date_filtering(db):
 @pytest.mark.asyncio
 async def test_cross_citations_unknown_source(db):
     """Cross-citations work even when source channel is not in channels table."""
-    await _seed_channel(db, channel_id=-100123, title="Target Only")
+    await _seed_channel(db, channel_id=100123, title="Target Only")
     now = datetime.now(timezone.utc)
 
     # Forward from a channel that doesn't exist in DB
     msg = Message(
-        channel_id=-100123, message_id=1, text="fwd from unknown",
+        channel_id=100123, message_id=1, text="fwd from unknown",
         date=now,
     )
-    msg.forward_from_channel_id = -999999
+    msg.forward_from_channel_id = 999999
     await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30)
+    data = await svc.get_cross_channel_citations(100123, days=30)
     assert len(data) == 1
-    assert data[0]["source_channel_id"] == -999999
+    assert data[0]["source_channel_id"] == 999999
     assert data[0]["source_title"] is None  # no matching channel row
     assert data[0]["source_username"] is None
     assert data[0]["citation_count"] == 1
@@ -865,35 +865,35 @@ async def test_cross_citations_unknown_source(db):
 @pytest.mark.asyncio
 async def test_cross_citations_respects_limit(db):
     """Limit parameter caps the number of returned source channels."""
-    await _seed_channel(db, channel_id=-100123, title="Target")
+    await _seed_channel(db, channel_id=100123, title="Target")
     now = datetime.now(timezone.utc)
     for i in range(15):
         msg = Message(
-            channel_id=-100123, message_id=100 + i,
+            channel_id=100123, message_id=100 + i,
             text=f"fwd {i}", date=now,
         )
-        msg.forward_from_channel_id = -(200 + i)
+        msg.forward_from_channel_id = 200 + i
         await db.insert_message(msg)
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30, limit=5)
+    data = await svc.get_cross_channel_citations(100123, days=30, limit=5)
     assert len(data) == 5
 
 
 @pytest.mark.asyncio
 async def test_cross_citations_only_includes_forwards(db):
     """Regular messages (no forward_from_channel_id) are not counted."""
-    await _seed_channel(db, channel_id=-100123, title="No Fwd Target")
+    await _seed_channel(db, channel_id=100123, title="No Fwd Target")
     now = datetime.now(timezone.utc)
     # 5 regular messages
     for i in range(5):
         await db.insert_message(Message(
-            channel_id=-100123, message_id=100 + i,
+            channel_id=100123, message_id=100 + i,
             text=f"regular {i}", date=now,
         ))
 
     svc = ChannelAnalyticsService(db)
-    data = await svc.get_cross_channel_citations(-100123, days=30)
+    data = await svc.get_cross_channel_citations(100123, days=30)
     assert data == []
 
 
@@ -903,26 +903,26 @@ async def test_cross_citations_only_includes_forwards(db):
 @pytest.mark.asyncio
 async def test_heatmap_service_delegates_to_repo(db):
     """Service get_heatmap delegates correctly and returns repo output."""
-    await _seed_channel(db, channel_id=-100123, title="Delegator")
+    await _seed_channel(db, channel_id=100123, title="Delegator")
     now = datetime.now(timezone.utc)
     await db.insert_message(Message(
-        channel_id=-100123, message_id=1, text="x",
+        channel_id=100123, message_id=1, text="x",
         date=now.replace(hour=15, minute=0, second=0, microsecond=0),
     ))
 
     svc = ChannelAnalyticsService(db)
-    svc_data = await svc.get_heatmap(-100123, days=7)
-    repo_data = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    svc_data = await svc.get_heatmap(100123, days=7)
+    repo_data = await db.repos.messages.get_hour_weekday_heatmap(100123, days=7)
     assert svc_data == repo_data
 
 
 @pytest.mark.asyncio
 async def test_cross_citations_service_delegates_to_repo(db):
     """Service get_cross_channel_citations delegates correctly."""
-    await _seed_channel(db, channel_id=-100123, title="Delegator")
+    await _seed_channel(db, channel_id=100123, title="Delegator")
     svc = ChannelAnalyticsService(db)
-    svc_data = await svc.get_cross_channel_citations(-100123, days=7)
-    repo_data = await db.repos.messages.get_cross_channel_citations(-100123, days=7)
+    svc_data = await svc.get_cross_channel_citations(100123, days=7)
+    repo_data = await db.repos.messages.get_cross_channel_citations(100123, days=7)
     assert svc_data == repo_data
 
 
@@ -932,17 +932,17 @@ async def test_cross_citations_service_delegates_to_repo(db):
 @pytest.mark.asyncio
 async def test_repo_heatmap_all_hours_covered(db):
     """Messages spanning many hours produce correct hour range."""
-    await _seed_channel(db, channel_id=-100123, title="All Hours")
+    await _seed_channel(db, channel_id=100123, title="All Hours")
     now = datetime.now(timezone.utc)
     messages = []
     for h in range(0, 24, 3):  # hours 0, 3, 6, 9, 12, 15, 18, 21
         messages.append(Message(
-            channel_id=-100123, message_id=h + 1, text=f"h{h}",
+            channel_id=100123, message_id=h + 1, text=f"h{h}",
             date=now.replace(hour=h, minute=0, second=0, microsecond=0),
         ))
-    await _seed_messages_batch(db, -100123, messages)
+    await _seed_messages_batch(db, 100123, messages)
 
-    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=7)
+    rows = await db.repos.messages.get_hour_weekday_heatmap(100123, days=7)
     hours_seen = {r["hour"] for r in rows}
     for h in range(0, 24, 3):
         assert h in hours_seen
@@ -951,55 +951,55 @@ async def test_repo_heatmap_all_hours_covered(db):
 @pytest.mark.asyncio
 async def test_repo_heatmap_no_messages_returns_empty(db):
     """Heatmap for a channel with no messages returns empty list."""
-    await _seed_channel(db, channel_id=-100123, title="Empty Heat")
-    rows = await db.repos.messages.get_hour_weekday_heatmap(-100123, days=30)
+    await _seed_channel(db, channel_id=100123, title="Empty Heat")
+    rows = await db.repos.messages.get_hour_weekday_heatmap(100123, days=30)
     assert rows == []
 
 
 @pytest.mark.asyncio
 async def test_repo_cross_citations_multiple_from_same_source(db):
     """Multiple forwarded messages from the same source are aggregated."""
-    await _seed_channel(db, channel_id=-100500, title="Agg Source")
-    await _seed_channel(db, channel_id=-100123, title="Agg Target")
+    await _seed_channel(db, channel_id=100500, title="Agg Source")
+    await _seed_channel(db, channel_id=100123, title="Agg Target")
     now = datetime.now(timezone.utc)
     for i in range(7):
         msg = Message(
-            channel_id=-100123, message_id=100 + i,
+            channel_id=100123, message_id=100 + i,
             text=f"agg fwd {i}", date=now - timedelta(hours=i),
         )
-        msg.forward_from_channel_id = -100500
+        msg.forward_from_channel_id = 100500
         await db.insert_message(msg)
 
-    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
     assert len(rows) == 1
-    assert rows[0]["source_channel_id"] == -100500
+    assert rows[0]["source_channel_id"] == 100500
     assert rows[0]["citation_count"] == 7
 
 
 @pytest.mark.asyncio
 async def test_repo_cross_citations_latest_date(db):
     """latest_date is the most recent forwarded message date."""
-    await _seed_channel(db, channel_id=-100500, title="Src Latest")
-    await _seed_channel(db, channel_id=-100123, title="Tgt Latest")
+    await _seed_channel(db, channel_id=100500, title="Src Latest")
+    await _seed_channel(db, channel_id=100123, title="Tgt Latest")
     now = datetime.now(timezone.utc)
 
     # Older forward
     msg1 = Message(
-        channel_id=-100123, message_id=1, text="old",
+        channel_id=100123, message_id=1, text="old",
         date=now - timedelta(days=5),
     )
-    msg1.forward_from_channel_id = -100500
+    msg1.forward_from_channel_id = 100500
     await db.insert_message(msg1)
 
     # Newer forward
     msg2 = Message(
-        channel_id=-100123, message_id=2, text="new",
+        channel_id=100123, message_id=2, text="new",
         date=now - timedelta(hours=2),
     )
-    msg2.forward_from_channel_id = -100500
+    msg2.forward_from_channel_id = 100500
     await db.insert_message(msg2)
 
-    rows = await db.repos.messages.get_cross_channel_citations(-100123, days=30)
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
     assert len(rows) == 1
     latest = rows[0]["latest_date"]
     assert latest is not None
@@ -1019,16 +1019,16 @@ def test_cli_analytics_channel(cli_db, capsys):
     # Seed data synchronously via the db
     async def _seed():
         await cli_db.add_channel(Channel(
-            channel_id=-100123, title="CLI Channel", username="cli_chan",
+            channel_id=100123, title="CLI Channel", username="cli_chan",
         ))
         await cli_db.save_channel_stats(ChannelStats(
-            channel_id=-100123, subscriber_count=5000, avg_views=300.0,
+            channel_id=100123, subscriber_count=5000, avg_views=300.0,
             avg_reactions=15.0, avg_forwards=8.0,
         ))
         now = datetime.now(timezone.utc)
         for i in range(3):
             msg = Message(
-                channel_id=-100123, message_id=100 + i,
+                channel_id=100123, message_id=100 + i,
                 text=f"cli msg {i}",
                 views=200, forwards=5, reply_count=2,
                 date=now - timedelta(hours=i),
@@ -1036,14 +1036,14 @@ def test_cli_analytics_channel(cli_db, capsys):
             await cli_db.insert_message(msg)
         # Forward from another channel
         await cli_db.add_channel(Channel(
-            channel_id=-100500, title="CLI Source", username="cli_src",
+            channel_id=100500, title="CLI Source", username="cli_src",
         ))
         fwd_msg = Message(
-            channel_id=-100123, message_id=999,
+            channel_id=100123, message_id=999,
             text="forwarded msg", views=100,
             date=now - timedelta(hours=1),
         )
-        fwd_msg.forward_from_channel_id = -100500
+        fwd_msg.forward_from_channel_id = 100500
         await cli_db.insert_message(fwd_msg)
 
     asyncio.run(_seed())
@@ -1057,7 +1057,7 @@ def test_cli_analytics_channel(cli_db, capsys):
         analytics_run(argparse.Namespace(
             config="config.yaml",
             analytics_action="channel",
-            channel_id=-100123,
+            channel_id=100123,
             days=30,
         ))
 
@@ -1084,7 +1084,7 @@ def test_cli_analytics_channel_not_found(cli_db, capsys):
         analytics_run(argparse.Namespace(
             config="config.yaml",
             analytics_action="channel",
-            channel_id=-999999,
+            channel_id=999999,
             days=30,
         ))
 

--- a/tests/test_cli_dialogs.py
+++ b/tests/test_cli_dialogs.py
@@ -1,0 +1,130 @@
+"""Tests for CLI dialogs commands."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.cli.commands.dialogs import run_with_dependencies
+from src.config import AppConfig
+from tests.helpers import cli_ns as _ns
+
+pytestmark = pytest.mark.aiosqlite_serial
+
+
+def _mock_pool():
+    pool = MagicMock()
+    pool.clients = {"+1234567890": MagicMock()}
+    pool.disconnect_all = AsyncMock()
+    pool.get_forum_topics = AsyncMock(return_value=[])
+    pool.get_native_client_by_phone = AsyncMock(return_value=None)
+    pool.get_dialogs_for_phone = AsyncMock(return_value=[
+        {"channel_id": 100111, "title": "My Channel", "username": "mychan",
+         "channel_type": "channel", "already_added": False},
+    ])
+    pool.leave_channels = AsyncMock(return_value={100111: True})
+    return pool
+
+
+def _run(args, pool, cli_db):
+    """Run CLI command with mocked pool."""
+    config = AppConfig()
+
+    async def fake_init_db(_):
+        return config, cli_db
+
+    async def fake_init_pool(_, __):
+        from src.telegram.auth import TelegramAuth
+        return TelegramAuth(0, ""), pool
+
+    with patch("src.cli.commands.dialogs.runtime.init_db", side_effect=fake_init_db), \
+         patch("src.cli.commands.dialogs.runtime.init_pool", side_effect=fake_init_pool):
+        run_with_dependencies(args)
+
+
+def test_cli_dialogs_list(cli_db, capsys):
+    """Test `dialogs list` command prints dialog table."""
+    pool = _mock_pool()
+    _run(_ns(dialogs_action="list", phone="+1234567890"), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "My Channel" in out
+    assert "mychan" in out
+
+
+def test_cli_dialogs_list_no_accounts(cli_db, capsys):
+    """Test `dialogs list` with no connected accounts."""
+    pool = _mock_pool()
+    pool.clients = {}
+    _run(_ns(dialogs_action="list", phone=None), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "No connected accounts" in out
+
+
+def test_cli_dialogs_list_phone_not_connected(cli_db, capsys):
+    """Test `dialogs list` with phone that is not connected."""
+    pool = _mock_pool()
+    _run(_ns(dialogs_action="list", phone="+9999999999"), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "not connected" in out
+
+
+def test_cli_dialogs_refresh(cli_db, capsys):
+    """Test `dialogs refresh` command."""
+    pool = _mock_pool()
+    _run(_ns(dialogs_action="refresh", phone="+1234567890"), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "refreshed" in out.lower()
+
+
+def test_cli_dialogs_refresh_no_accounts(cli_db, capsys):
+    """Test `dialogs refresh` with no connected accounts."""
+    pool = _mock_pool()
+    pool.clients = {}
+    _run(_ns(dialogs_action="refresh", phone=None), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "No connected accounts" in out
+
+
+def test_cli_dialogs_leave(cli_db, capsys):
+    """Test `dialogs leave` with auto-confirm."""
+    pool = _mock_pool()
+    _run(
+        _ns(dialogs_action="leave", phone="+1234567890",
+            dialog_ids=["100111"], yes=True),
+        pool, cli_db,
+    )
+    out = capsys.readouterr().out
+    assert "left" in out
+
+
+def test_cli_dialogs_topics(cli_db, capsys):
+    """Test `dialogs topics` with no topics."""
+    pool = _mock_pool()
+    pool.get_forum_topics = AsyncMock(return_value=[])
+    _run(_ns(dialogs_action="topics", channel_id=100111), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "No forum topics" in out
+
+
+def test_cli_dialogs_topics_with_data(cli_db, capsys):
+    """Test `dialogs topics` returns topic list."""
+    pool = _mock_pool()
+    pool.get_forum_topics = AsyncMock(return_value=[
+        {"id": 1, "title": "General", "icon_emoji_id": None, "date": "2025-01-01"},
+    ])
+    _run(_ns(dialogs_action="topics", channel_id=100111), pool, cli_db)
+    out = capsys.readouterr().out
+    assert "General" in out
+
+
+def test_cli_dialogs_send_no_client(cli_db, capsys):
+    """Test `dialogs send` when client unavailable."""
+    pool = _mock_pool()
+    pool.get_native_client_by_phone = AsyncMock(return_value=None)
+    _run(
+        _ns(dialogs_action="send", phone="+1234567890",
+            recipient="100111", text="hello", yes=True),
+        pool, cli_db,
+    )
+    out = capsys.readouterr().out
+    assert "unavailable" in out.lower()

--- a/tests/test_forward_citations_repo.py
+++ b/tests/test_forward_citations_repo.py
@@ -1,0 +1,152 @@
+"""Repo-level tests for forward_from_channel_id normalization and cross-channel citations."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models import Channel, Message
+
+
+async def _seed(db, channel_id: int, title: str = "Test", username: str | None = None) -> None:
+    await db.add_channel(Channel(channel_id=channel_id, title=title, username=username))
+
+
+async def _fwd_msg(
+    db,
+    target_ch: int,
+    msg_id: int,
+    fwd_from: int,
+    text: str = "fwd",
+    days_ago: int = 0,
+) -> None:
+    msg = Message(
+        channel_id=target_ch,
+        message_id=msg_id,
+        text=text,
+        date=datetime.now(timezone.utc) - timedelta(days=days_ago),
+    )
+    msg.forward_from_channel_id = fwd_from
+    await db.insert_message(msg)
+
+
+async def _plain_msg(db, target_ch: int, msg_id: int, text: str = "plain") -> None:
+    await db.insert_message(
+        Message(
+            channel_id=target_ch,
+            message_id=msg_id,
+            text=text,
+            date=datetime.now(timezone.utc),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_citation_positive_ids(db):
+    """After fix, forward_from_channel_id stores positive values matching channels.channel_id."""
+    await _seed(db, 100500, "Source Chan", "src")
+    await _seed(db, 100123, "Target Chan")
+
+    await _fwd_msg(db, 100123, 1, 100500, "fwd msg")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
+    assert len(rows) == 1
+    assert rows[0]["source_channel_id"] == 100500
+    assert rows[0]["source_title"] == "Source Chan"
+    assert rows[0]["citation_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_citation_multiple_sources(db):
+    """Multiple source channels are correctly identified."""
+    await _seed(db, 100111, "Source A", "a")
+    await _seed(db, 100222, "Source B", "b")
+    await _seed(db, 100123, "Target")
+
+    for i in range(5):
+        await _fwd_msg(db, 100123, 100 + i, 100111, f"fwd a {i}")
+    for i in range(2):
+        await _fwd_msg(db, 100123, 200 + i, 100222, f"fwd b {i}")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
+    assert len(rows) == 2
+    assert rows[0]["source_channel_id"] == 100111
+    assert rows[0]["citation_count"] == 5
+    assert rows[1]["source_channel_id"] == 100222
+    assert rows[1]["citation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_null_source(db):
+    """Messages without forward_from_channel_id are excluded."""
+    await _seed(db, 100123, "Target")
+
+    await _plain_msg(db, 100123, 1, "no forward")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
+    assert len(rows) == 0
+
+
+@pytest.mark.asyncio
+async def test_citation_unknown_source(db):
+    """Forward from unknown channel returns citation with NULL title."""
+    await _seed(db, 100123, "Target")
+
+    await _fwd_msg(db, 100123, 1, 999999, "from unknown")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
+    assert len(rows) == 1
+    assert rows[0]["source_channel_id"] == 999999
+    assert rows[0]["source_title"] is None
+    assert rows[0]["citation_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_citation_limit(db):
+    """Limit parameter works correctly."""
+    await _seed(db, 100123, "Target")
+
+    for i in range(10):
+        await _fwd_msg(db, 100123, 100 + i, 200 + i, f"fwd {i}")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30, limit=3)
+    assert len(rows) == 3
+
+
+@pytest.mark.asyncio
+async def test_citation_date_filtering(db):
+    """Only messages within the date window are included."""
+    await _seed(db, 100500, "Source")
+    await _seed(db, 100123, "Target")
+
+    # Recent forward (within 7 days)
+    await _fwd_msg(db, 100123, 1, 100500, "recent", days_ago=1)
+    # Old forward (outside 7 days)
+    await _fwd_msg(db, 100123, 2, 100500, "old", days_ago=30)
+
+    rows_7d = await db.repos.messages.get_cross_channel_citations(100123, days=7)
+    assert len(rows_7d) == 1
+    assert rows_7d[0]["citation_count"] == 1
+
+    rows_90d = await db.repos.messages.get_cross_channel_citations(100123, days=90)
+    assert len(rows_90d) == 1
+    assert rows_90d[0]["citation_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_citation_ordering(db):
+    """Results ordered by citation_count DESC."""
+    await _seed(db, 100111, "Less")
+    await _seed(db, 100222, "More")
+    await _seed(db, 100123, "Target")
+
+    for i in range(2):
+        await _fwd_msg(db, 100123, 100 + i, 100111, f"few {i}")
+    for i in range(5):
+        await _fwd_msg(db, 100123, 200 + i, 100222, f"many {i}")
+
+    rows = await db.repos.messages.get_cross_channel_citations(100123, days=30)
+    assert rows[0]["source_channel_id"] == 100222
+    assert rows[0]["citation_count"] == 5
+    assert rows[1]["source_channel_id"] == 100111
+    assert rows[1]["citation_count"] == 2


### PR DESCRIPTION
## Summary

- **#381 (CRITICAL)**: Fix `forward_from_channel_id` normalization bug — removed incorrect negation in collector so positive MTProto IDs match `channels.channel_id`, added migration to fix existing rows with `ABS()`
- **#382**: Add `channels.created_at` column with migration, capture `entity.date` from Telethon in `resolve_channel()` and `get_dialogs_for_phone()`, thread through all channel addition flows (CLI add/import/bulk, web import, service layer)
- **#383**: Add heatmap and cross-channel citations references to CLAUDE.md, enhance docstrings on `get_hour_weekday_heatmap()` and `get_heatmap()`
- **#384**: Add test coverage — forward citations repo tests (7), CLI dialogs tests (9), extend dialogs routes tests (+19), extend debug routes tests (+6)

## Test plan

- [x] All 5401 tests pass (4706 parallel + 695 serial)
- [x] `ruff check src/ tests/ conftest.py` — clean
- [x] Migration tested via `test_migrations.py`
- [x] Forward citations tested with positive IDs matching production format

🤖 Generated with [Claude Code](https://claude.com/claude-code)