### PR TITLE
fix(web): pre-render templates to prevent "No response returned" in middleware stack

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -290,15 +290,13 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
             )
 
         try:
-            return app.state.templates.TemplateResponse(
-                request,
-                "error.html",
-                {
-                    "status_code": 500,
-                    "detail": "An unexpected error occurred. See /debug/ for details.",
-                },
-                status_code=500,
-            )
+            tpl = app.state.templates.env.get_template("error.html")
+            body = tpl.render({
+                "request": request,
+                "status_code": 500,
+                "detail": "An unexpected error occurred. See /debug/ for details.",
+            })
+            return HTMLResponse(body, status_code=500)
         except Exception:
             return HTMLResponse("Internal Server Error", status_code=500)
 

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -110,6 +110,16 @@ async def scheduler_page(
     status: str = Query("all"),
     limit: int = Query(50),
 ):
+    try:
+        return await _scheduler_page_inner(request, page, status, limit)
+    except Exception:
+        logger.exception("scheduler_page failed")
+        raise
+
+
+async def _scheduler_page_inner(
+    request: Request, page: int, status: str, limit: int
+) -> HTMLResponse:
     sched = deps.get_scheduler(request)
     db = deps.get_db(request)
     msg = request.query_params.get("msg")
@@ -154,28 +164,29 @@ async def scheduler_page(
 
     scheduler_jobs = await _build_jobs_context(sched, db)
 
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "scheduler.html",
-        {
-            "is_running": sched.is_running,
-            "interval_minutes": sched.interval_minutes,
-            "msg": msg,
-            "tasks": tasks,
-            "has_active_tasks": has_active_tasks,
-            "page": page,
-            "total_pages": total_pages,
-            "all_count": all_count,
-            "active_count": active_count,
-            "completed_count": completed_count,
-            "status_filter": status_filter,
-            "limit": limit,
-            "search_log": search_log,
-            "bot_configured": bot_configured,
-            "pending_collect_count": pending_collect_count,
-            "scheduler_jobs": scheduler_jobs,
-        },
-    )
+    context = {
+        "is_running": sched.is_running,
+        "interval_minutes": sched.interval_minutes,
+        "msg": msg,
+        "tasks": tasks,
+        "has_active_tasks": has_active_tasks,
+        "page": page,
+        "total_pages": total_pages,
+        "all_count": all_count,
+        "active_count": active_count,
+        "completed_count": completed_count,
+        "status_filter": status_filter,
+        "limit": limit,
+        "search_log": search_log,
+        "bot_configured": bot_configured,
+        "pending_collect_count": pending_collect_count,
+        "scheduler_jobs": scheduler_jobs,
+    }
+
+    templates = deps.get_templates(request)
+    tpl = templates.env.get_template("scheduler.html")
+    body = tpl.render({**context, "request": request})
+    return HTMLResponse(body)
 
 
 @router.post("/jobs/{job_id}/toggle")

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.models import CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
+from src.models import Channel, CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
 
 
 @pytest.fixture
@@ -455,6 +455,47 @@ async def test_scheduler_page_with_cancelled_task(client):
 
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_trigger_then_get_scheduler_with_pending_tasks(client):
+    """Trigger collect-all then follow redirect to scheduler page with pending tasks.
+
+    Reproduces the 500 'No response returned' scenario where the scheduler
+    page fails to render when pending tasks exist after triggering collection.
+    """
+    db = client._transport.app.state.db
+
+    # Seed several channels so enqueue_all_channels creates tasks
+    for i in range(3):
+        await db.add_channel(Channel(
+            channel_id=-(1001000000 + i),
+            title=f"Channel {i}",
+            username=f"ch{i}",
+            channel_type="channel",
+        ))
+
+    # Trigger collection (follow redirect to GET /scheduler/?msg=...)
+    resp = await client.post("/scheduler/trigger")
+    assert resp.status_code == 200
+    assert "Планировщик" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_page_with_many_pending_tasks(client):
+    """Scheduler page renders correctly with many pending tasks."""
+    db = client._transport.app.state.db
+
+    for i in range(10):
+        await db.create_collection_task(
+            channel_id=-(1001000000 + i),
+            channel_title=f"Channel {i}",
+            channel_username=f"ch{i}",
+        )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    assert "Channel 0" in resp.text
 
 
 # ── Dry-run notification tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pre-render scheduler template synchronously in handler so Jinja2 errors surface before the ASGI response phase, preventing `RuntimeError("No response returned.")` from 5-layer `BaseHTTPMiddleware` stack
- Add try/except diagnostic logging in `scheduler_page` to capture the real exception before middleware masks it
- Pre-render `error.html` in `unhandled_exception_handler` to prevent double-swallow when the error page itself fails to render
- Add 2 regression tests covering the trigger-collection→redirect→render flow

Temporary workaround until full ASGI middleware migration in #393.

## Test plan

- [x] All 45 scheduler tests pass
- [x] Lint clean (`ruff check`)
- [ ] Manual: Start scheduler → Collect all channels → page renders without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #393