### PR TITLE
feat(web): wizard создания пайплайнов + AJAX picker (#387)

### DIFF
--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -229,6 +229,28 @@ class ContentPipelinesRepository:
         )
         return [self._to_target(row) for row in await cur.fetchall()]
 
+    async def batch_sources(self, pipeline_ids: list[int]) -> list[PipelineSource]:
+        """Load sources for multiple pipelines in one query."""
+        if not pipeline_ids:
+            return []
+        placeholders = ",".join("?" * len(pipeline_ids))
+        cur = await self._db.execute(
+            f"SELECT * FROM pipeline_sources WHERE pipeline_id IN ({placeholders}) ORDER BY id",
+            pipeline_ids,
+        )
+        return [self._to_source(row) for row in await cur.fetchall()]
+
+    async def batch_targets(self, pipeline_ids: list[int]) -> list[PipelineTarget]:
+        """Load targets for multiple pipelines in one query."""
+        if not pipeline_ids:
+            return []
+        placeholders = ",".join("?" * len(pipeline_ids))
+        cur = await self._db.execute(
+            f"SELECT * FROM pipeline_targets WHERE pipeline_id IN ({placeholders}) ORDER BY id",
+            pipeline_ids,
+        )
+        return [self._to_target(row) for row in await cur.fetchall()]
+
     async def _replace_sources_no_commit(
         self,
         pipeline_id: int,

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -22,6 +22,14 @@ from src.models import (
 logger = logging.getLogger(__name__)
 
 
+def _group_by_pipeline(items: list) -> dict[int, list]:
+    """Group a list of source/target objects by their pipeline_id."""
+    result: dict[int, list] = {}
+    for item in items:
+        result.setdefault(item.pipeline_id, []).append(item)
+    return result
+
+
 @dataclass(frozen=True)
 class PipelineTargetRef:
     phone: str
@@ -145,12 +153,37 @@ class PipelineService:
 
     async def get_with_relations(self, active_only: bool = False) -> list[dict]:
         pipelines = await self._bundle.get_all(active_only)
-        channels = await self._bundle.list_channels(include_filtered=True)
-        channels_by_id = {channel.channel_id: channel for channel in channels}
-        relation_rows = await asyncio.gather(
-            *[self._get_relation_row(pipeline, channels_by_id) for pipeline in pipelines]
+        if not pipelines:
+            return []
+        pipeline_ids = [p.id for p in pipelines if p.id is not None]
+        channels, all_sources, all_targets = await asyncio.gather(
+            self._bundle.list_channels(include_filtered=True),
+            self._batch_sources(pipeline_ids),
+            self._batch_targets(pipeline_ids),
         )
-        return relation_rows
+        channels_by_id = {channel.channel_id: channel for channel in channels}
+        sources_by_pid = _group_by_pipeline(all_sources)
+        targets_by_pid = _group_by_pipeline(all_targets)
+        return [
+            {
+                "pipeline": p,
+                "sources": sources_by_pid.get(p.id, []),
+                "targets": targets_by_pid.get(p.id, []),
+                "source_ids": [s.channel_id for s in sources_by_pid.get(p.id, [])],
+                "target_refs": [
+                    f"{t.phone}|{t.dialog_id}" for t in targets_by_pid.get(p.id, [])
+                ],
+                "source_titles": [
+                    (
+                        channels_by_id.get(s.channel_id).title or str(s.channel_id)
+                        if channels_by_id.get(s.channel_id)
+                        else str(s.channel_id)
+                    )
+                    for s in sources_by_pid.get(p.id, [])
+                ],
+            }
+            for p in pipelines
+        ]
 
     async def list_cached_dialogs_by_phone(
         self,
@@ -162,31 +195,13 @@ class PipelineService:
         )
         return {account.phone: rows for account, rows in zip(accounts, dialogs, strict=False)}
 
-    async def _get_relation_row(
-        self,
-        pipeline: ContentPipeline,
-        channels_by_id: dict[int, object],
-    ) -> dict:
-        assert pipeline.id is not None
-        sources, targets = await asyncio.gather(
-            self._bundle.list_sources(pipeline.id),
-            self._bundle.list_targets(pipeline.id),
-        )
-        return {
-            "pipeline": pipeline,
-            "sources": sources,
-            "targets": targets,
-            "source_ids": [source.channel_id for source in sources],
-            "target_refs": [f"{target.phone}|{target.dialog_id}" for target in targets],
-            "source_titles": [
-                (
-                    channels_by_id.get(source.channel_id).title or str(source.channel_id)
-                    if channels_by_id.get(source.channel_id)
-                    else str(source.channel_id)
-                )
-                for source in sources
-            ],
-        }
+    async def _batch_sources(self, pipeline_ids: list[int]) -> list[PipelineSource]:
+        """Load sources for all given pipeline IDs in a single query."""
+        return await self._bundle.content_pipelines.batch_sources(pipeline_ids)
+
+    async def _batch_targets(self, pipeline_ids: list[int]) -> list[PipelineTarget]:
+        """Load targets for all given pipeline IDs in a single query."""
+        return await self._bundle.content_pipelines.batch_targets(pipeline_ids)
 
     async def _build_pipeline(
         self,

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -49,10 +49,22 @@ def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
 @router.get("/api/channels/search", response_class=JSONResponse)
 async def api_channels_search(request: Request, q: str = ""):
     """AJAX endpoint for searchable picker — returns up to 50 channels matching *q*."""
+    db = deps.get_db(request)
     query = q.strip()
     if len(query) < 2:
-        return []
-    db = deps.get_db(request)
+        cur = await db.execute(
+            "SELECT channel_id, title, username FROM channels ORDER BY id DESC LIMIT 50",
+        )
+        rows = await cur.fetchall()
+        return [
+            {
+                "value": row["channel_id"],
+                "title": row["title"] or str(row["channel_id"]),
+                "username": row["username"] or "",
+                "group": "channel",
+            }
+            for row in rows
+        ]
     cur = await db.execute(
         """SELECT channel_id, title, username FROM channels
            WHERE (LOWER(title) LIKE ? OR LOWER(username) LIKE ? OR CAST(channel_id AS TEXT) LIKE ?)

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -46,6 +46,31 @@ def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
     return refs
 
 
+@router.get("/api/channels/search", response_class=JSONResponse)
+async def api_channels_search(request: Request, q: str = ""):
+    """AJAX endpoint for searchable picker — returns up to 50 channels matching *q*."""
+    query = q.strip()
+    if len(query) < 2:
+        return []
+    db = deps.get_db(request)
+    cur = await db.execute(
+        """SELECT channel_id, title, username FROM channels
+           WHERE (LOWER(title) LIKE ? OR LOWER(username) LIKE ? OR CAST(channel_id AS TEXT) LIKE ?)
+           ORDER BY channel_id LIMIT 50""",
+        (f"%{query.lower()}%", f"%{query.lower()}%", f"%{query}%"),
+    )
+    rows = await cur.fetchall()
+    return [
+        {
+            "value": row["channel_id"],
+            "title": row["title"] or str(row["channel_id"]),
+            "username": row["username"] or "",
+            "group": "channel",
+        }
+        for row in rows
+    ]
+
+
 async def _page_context(request: Request) -> dict:
     svc = deps.pipeline_service(request)
     channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -152,6 +152,60 @@ async def pipelines_page(request: Request):
     )
 
 
+@router.get("/create", response_class=HTMLResponse)
+async def create_wizard_page(request: Request):
+    svc = deps.pipeline_service(request)
+    accounts = await deps.get_account_bundle(request).list_accounts()
+    cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/create.html",
+        {
+            "accounts": accounts,
+            "cached_dialogs": cached_dialogs,
+        },
+    )
+
+
+@router.post("/create-wizard")
+async def create_wizard_submit(
+    request: Request,
+    name: str = Form(...),
+    pipeline_json: str = Form(...),
+    source_channel_ids: list[int] = Form(default=[]),
+    target_refs: list[str] = Form(default=[]),
+    generate_interval_minutes: int = Form(60),
+    is_active: str = Form(""),
+):
+    import json as _json
+
+    svc = deps.pipeline_service(request)
+    try:
+        graph_data = _json.loads(pipeline_json)
+        data = {
+            "name": name,
+            "prompt_template": ".",
+            "source_ids": source_channel_ids,
+            "target_refs": target_refs,
+            "generate_interval_minutes": generate_interval_minutes,
+            "pipeline_json": graph_data,
+        }
+        pipeline_id = await svc.import_json(data)
+    except PipelineValidationError as exc:
+        return _pipeline_redirect(str(exc), error=True)
+    except Exception as exc:
+        logger.warning("create-wizard failed: %s", exc, exc_info=True)
+        return _pipeline_redirect(f"Ошибка: {exc}", error=True)
+    if is_active:
+        await svc.toggle(pipeline_id)
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return _pipeline_redirect("pipeline_added")
+
+
 @router.post("/add")
 async def add_pipeline(
     request: Request,

--- a/src/web/static/js/searchable-picker.js
+++ b/src/web/static/js/searchable-picker.js
@@ -49,10 +49,10 @@
             });
             // Also include pre-selected that don't have a visible option yet
             preselectedEls.forEach(function (el) {
-                var already = options.some(function (opt) {
-                    return opt.dataset.value === el.value && getCheckbox(opt).checked;
+                var hasVisible = options.some(function (opt) {
+                    return opt.dataset.value === el.value;
                 });
-                if (!already) {
+                if (!hasVisible) {
                     addHiddenInput(el.value);
                 }
             });

--- a/src/web/static/js/searchable-picker.js
+++ b/src/web/static/js/searchable-picker.js
@@ -173,6 +173,7 @@
         function renderAjaxResults(items) {
             if (!listEl) return;
             listEl.innerHTML = "";
+            options = options.filter(function (o) { return o.isConnected; });
             var count = 0;
             (items || []).forEach(function (item) {
                 var label = document.createElement("label");

--- a/src/web/static/js/searchable-picker.js
+++ b/src/web/static/js/searchable-picker.js
@@ -139,10 +139,9 @@
         // ---- AJAX mode ----
         function fetchAjaxResults(query) {
             if (!ajaxUrl || !listEl) return;
+            // Short queries → fetch default batch (top 50) instead of clearing
             if (query.length < 2) {
-                listEl.innerHTML = "";
-                if (emptyEl) emptyEl.classList.add("d-none");
-                return;
+                query = "";
             }
 
             // Check sessionStorage cache
@@ -237,7 +236,12 @@
         });
 
         syncHiddenInputs();
-        if (!ajaxUrl) applyFilters();
+        if (ajaxUrl) {
+            // AJAX mode: load initial batch immediately
+            fetchAjaxResults("");
+        } else {
+            applyFilters();
+        }
     }
 
     document.addEventListener("DOMContentLoaded", function () {

--- a/src/web/static/js/searchable-picker.js
+++ b/src/web/static/js/searchable-picker.js
@@ -1,9 +1,11 @@
 /**
  * Searchable multi-select picker.
  *
- * Usage: add [data-picker-name="field_name"] to a container div.
- * Options are <label data-picker-option data-value="..." data-group="..." data-search-text="...">
- * with an <input type="checkbox"> inside.
+ * Modes:
+ *   Static — add [data-picker-name="field"] + <label data-picker-option ...> elements.
+ *   AJAX   — add [data-picker-name="field" data-picker-url="/api/search?q="].
+ *            Results are fetched on type (>1 char). Pre-selected items via
+ *            <input data-picker-preselected value="..." data-title="...">.
  */
 (function () {
     "use strict";
@@ -11,12 +13,26 @@
     function initPicker(container) {
         var name = container.dataset.pickerName;
         var isMulti = container.dataset.pickerMulti !== "false";
+        var ajaxUrl = container.dataset.pickerUrl || "";
         var searchInput = container.querySelector("[data-picker-search]");
-        var options = Array.from(container.querySelectorAll("[data-picker-option]"));
+        var listEl = container.querySelector(".picker-list");
         var filterButtons = Array.from(container.querySelectorAll("[data-filter]"));
         var emptyEl = container.querySelector("[data-picker-empty]");
         var selectedContainer = container.querySelector(".picker-selected");
         var activeFilter = "all";
+
+        // Track all options: static + dynamically added
+        var options = Array.from(container.querySelectorAll("[data-picker-option]"));
+
+        // Pre-selected items (AJAX mode) — rendered as badges immediately
+        var preselectedEls = Array.from(container.querySelectorAll("[data-picker-preselected]"));
+        var preselectedMap = {}; // value -> title
+        preselectedEls.forEach(function (el) {
+            preselectedMap[el.value] = el.dataset.title || el.value;
+        });
+
+        // AJAX debounce timer
+        var ajaxTimer = null;
 
         function getCheckbox(opt) {
             return opt.querySelector("input[type=checkbox]");
@@ -28,33 +44,69 @@
             });
             options.forEach(function (opt) {
                 if (getCheckbox(opt).checked) {
-                    var inp = document.createElement("input");
-                    inp.type = "hidden";
-                    inp.name = name;
-                    inp.value = opt.dataset.value;
-                    inp.setAttribute("data-picker-hidden", "");
-                    container.appendChild(inp);
+                    addHiddenInput(opt.dataset.value);
+                }
+            });
+            // Also include pre-selected that don't have a visible option yet
+            preselectedEls.forEach(function (el) {
+                var already = options.some(function (opt) {
+                    return opt.dataset.value === el.value && getCheckbox(opt).checked;
+                });
+                if (!already) {
+                    addHiddenInput(el.value);
                 }
             });
             renderBadges();
         }
 
+        function addHiddenInput(value) {
+            var inp = document.createElement("input");
+            inp.type = "hidden";
+            inp.name = name;
+            inp.value = value;
+            inp.setAttribute("data-picker-hidden", "");
+            container.appendChild(inp);
+        }
+
         function renderBadges() {
             if (!selectedContainer) return;
             selectedContainer.innerHTML = "";
+
+            // Badges for checked options
             options.forEach(function (opt) {
                 if (!getCheckbox(opt).checked) return;
-                var badge = document.createElement("span");
-                badge.className = "badge bg-primary me-1 mb-1";
-                badge.style.cursor = "pointer";
-                badge.title = "\u0423\u0431\u0440\u0430\u0442\u044c";
-                badge.textContent = opt.dataset.searchText.split(" ")[0] || opt.dataset.value;
-                badge.addEventListener("click", function () {
-                    getCheckbox(opt).checked = false;
-                    syncHiddenInputs();
-                });
-                selectedContainer.appendChild(badge);
+                addBadge(opt.dataset.searchText.split(" ")[0] || opt.dataset.value, opt);
             });
+            // Badges for pre-selected without visible option
+            preselectedEls.forEach(function (el) {
+                var hasVisible = options.some(function (opt) {
+                    return opt.dataset.value === el.value;
+                });
+                if (hasVisible) return;
+                addBadge(el.dataset.title || el.value, null, el.value);
+            });
+        }
+
+        function addBadge(text, opt, fallbackValue) {
+            var badge = document.createElement("span");
+            badge.className = "badge bg-primary me-1 mb-1";
+            badge.style.cursor = "pointer";
+            badge.title = "\u0423\u0431\u0440\u0430\u0442\u044c";
+            badge.textContent = text;
+            badge.addEventListener("click", function () {
+                if (opt) {
+                    getCheckbox(opt).checked = false;
+                }
+                if (fallbackValue) {
+                    // Remove pre-selected element
+                    preselectedEls = preselectedEls.filter(function (el) {
+                        return el.value !== fallbackValue || (el.parentNode && el.parentNode.removeChild(el), false);
+                    });
+                    delete preselectedMap[fallbackValue];
+                }
+                syncHiddenInputs();
+            });
+            selectedContainer.appendChild(badge);
         }
 
         function applyFilters() {
@@ -70,7 +122,7 @@
             if (emptyEl) emptyEl.classList.toggle("d-none", visibleCount !== 0);
         }
 
-        options.forEach(function (opt) {
+        function bindOptionEvents(opt) {
             getCheckbox(opt).addEventListener("change", function () {
                 if (!isMulti) {
                     options.forEach(function (other) {
@@ -79,7 +131,100 @@
                 }
                 syncHiddenInputs();
             });
-        });
+        }
+
+        // Bind events for initial static options
+        options.forEach(bindOptionEvents);
+
+        // ---- AJAX mode ----
+        function fetchAjaxResults(query) {
+            if (!ajaxUrl || !listEl) return;
+            if (query.length < 2) {
+                listEl.innerHTML = "";
+                if (emptyEl) emptyEl.classList.add("d-none");
+                return;
+            }
+
+            // Check sessionStorage cache
+            var cacheKey = "picker:" + ajaxUrl + query;
+            try {
+                var cached = sessionStorage.getItem(cacheKey);
+                if (cached) {
+                    renderAjaxResults(JSON.parse(cached));
+                    return;
+                }
+            } catch (e) { /* ignore */ }
+
+            fetch(ajaxUrl + encodeURIComponent(query), {
+                headers: {"Accept": "application/json", "X-Requested-With": "XMLHttpRequest"}
+            })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                try { sessionStorage.setItem(cacheKey, JSON.stringify(data)); } catch (e) { /* ignore */ }
+                renderAjaxResults(data);
+            })
+            .catch(function () {
+                if (emptyEl) {
+                    emptyEl.textContent = "\u041e\u0448\u0438\u0431\u043a\u0430 \u0437\u0430\u0433\u0440\u0443\u0437\u043a\u0438";
+                    emptyEl.classList.remove("d-none");
+                }
+            });
+        }
+
+        function renderAjaxResults(items) {
+            if (!listEl) return;
+            listEl.innerHTML = "";
+            var count = 0;
+            (items || []).forEach(function (item) {
+                var label = document.createElement("label");
+                label.className = "list-group-item list-group-item-action d-flex align-items-center gap-2";
+                label.setAttribute("data-picker-option", "");
+                label.setAttribute("data-value", item.value);
+                label.setAttribute("data-group", item.group || "");
+                label.setAttribute("data-search-text", (item.title + " " + (item.username || "")).toLowerCase());
+
+                var cb = document.createElement("input");
+                cb.type = "checkbox";
+                cb.className = "form-check-input mt-0";
+                // Pre-check if this value was pre-selected
+                if (preselectedMap[item.value]) {
+                    cb.checked = true;
+                }
+                label.appendChild(cb);
+
+                var span = document.createElement("span");
+                span.textContent = item.title;
+                label.appendChild(span);
+
+                if (item.username) {
+                    var small = document.createElement("small");
+                    small.className = "text-muted";
+                    small.textContent = "@" + item.username;
+                    span.appendChild(document.createTextNode(" "));
+                    span.appendChild(small);
+                }
+
+                listEl.appendChild(label);
+                options.push(label);
+                bindOptionEvents(label);
+                count++;
+            });
+            if (emptyEl) emptyEl.classList.toggle("d-none", count !== 0);
+            syncHiddenInputs();
+        }
+
+        if (searchInput) {
+            if (ajaxUrl) {
+                searchInput.addEventListener("input", function () {
+                    clearTimeout(ajaxTimer);
+                    ajaxTimer = setTimeout(function () {
+                        fetchAjaxResults(searchInput.value.trim());
+                    }, 200);
+                });
+            } else {
+                searchInput.addEventListener("input", applyFilters);
+            }
+        }
 
         filterButtons.forEach(function (btn) {
             btn.addEventListener("click", function () {
@@ -91,10 +236,8 @@
             });
         });
 
-        if (searchInput) searchInput.addEventListener("input", applyFilters);
-
         syncHiddenInputs();
-        applyFilters();
+        if (!ajaxUrl) applyFilters();
     }
 
     document.addEventListener("DOMContentLoaded", function () {

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -262,3 +262,50 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
 
     .card-body { padding: 0.75rem; }
 }
+
+/* Pipeline creation wizard */
+.wizard-stepper .nav-pills .nav-link {
+    border-radius: 0;
+    font-size: 0.85rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--bs-border-color);
+    color: var(--bs-secondary-color);
+}
+.wizard-stepper .nav-pills .nav-link.active {
+    background-color: var(--bs-primary);
+    color: #fff;
+}
+.wizard-stepper .nav-pills .nav-link.completed {
+    background-color: var(--bs-success-bg-subtle);
+    color: var(--bs-success);
+    border-color: var(--bs-success);
+}
+.wizard-stepper .nav-pills .nav-link.disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+.wizard-step { display: none; }
+.wizard-step.active { display: block; }
+
+/* Wizard type cards */
+.wizard-type-card {
+    cursor: pointer;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.wizard-type-card:hover {
+    border-color: var(--bs-primary);
+}
+.wizard-type-card.selected {
+    border-color: var(--bs-primary);
+    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25);
+}
+.wizard-type-card input[type="radio"] {
+    display: none;
+}
+
+@media (max-width: 575.98px) {
+    .wizard-stepper .nav-pills .nav-link {
+        font-size: 0.7rem;
+        padding: 0.35rem 0.4rem;
+    }
+}

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -120,25 +120,14 @@
                     </div>
                 </div>
 
-                {# Source channels — searchable picker #}
+                {# Source channels — AJAX searchable picker #}
                 <div class="row g-3 mb-3">
                     <div class="col-12 col-lg-6">
                         <label class="form-label">Каналы-источники</label>
-                        <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true">
+                        <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true" data-picker-url="/pipelines/api/channels/search?q=">
                             <div class="picker-selected"></div>
-                            <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск канала..." data-picker-search>
-                            <div class="list-group picker-list">
-                                {% for channel in channels %}
-                                <label class="list-group-item list-group-item-action d-flex align-items-center gap-2"
-                                       data-picker-option
-                                       data-value="{{ channel.channel_id }}"
-                                       data-group="channel"
-                                       data-search-text="{{ ((channel.title or '') ~ ' ' ~ (channel.username or '') ~ ' ' ~ channel.channel_id)|lower }}">
-                                    <input type="checkbox" class="form-check-input mt-0">
-                                    <span>{{ channel.title or channel.channel_id }}{% if channel.username %} <small class="text-muted">@{{ channel.username }}</small>{% endif %}</span>
-                                </label>
-                                {% endfor %}
-                            </div>
+                            <input type="search" class="form-control form-control-sm mb-1" placeholder="Введите название или ID канала (мин. 2 символа)..." data-picker-search>
+                            <div class="list-group picker-list"></div>
                             <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
                         </div>
                     </div>

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -5,6 +5,7 @@
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Пайплайны контента</h1>
     <div class="d-flex gap-2">
+        <a class="btn btn-success btn-sm" href="/pipelines/create">+ Мастер</a>
         <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#importModal">Импорт JSON</button>
         <a class="btn btn-outline-primary btn-sm" href="/pipelines/templates">Шаблоны</a>
     </div>
@@ -126,7 +127,7 @@
                         <label class="form-label">Каналы-источники</label>
                         <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true" data-picker-url="/pipelines/api/channels/search?q=">
                             <div class="picker-selected"></div>
-                            <input type="search" class="form-control form-control-sm mb-1" placeholder="Введите название или ID канала (мин. 2 символа)..." data-picker-search>
+                            <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск каналов..." data-picker-search>
                             <div class="list-group picker-list"></div>
                             <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
                         </div>

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -1,0 +1,516 @@
+{% extends "base.html" %}
+{% block title %}Создать пайплайн — TG Agent{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Создать пайплайн</h1>
+    <a class="btn btn-secondary btn-sm" href="/pipelines">&larr; Назад</a>
+</div>
+
+{# Stepper nav #}
+<nav class="wizard-stepper mb-4">
+    <div class="nav nav-pills nav-justified">
+        <a class="nav-link active" data-step="1">1. Тип</a>
+        <a class="nav-link disabled" data-step="2">2. Источники</a>
+        <a class="nav-link disabled" data-step="3">3. Действие</a>
+        <a class="nav-link disabled" data-step="4">4. Расписание</a>
+        <a class="nav-link disabled" data-step="5">5. Проверка</a>
+    </div>
+</nav>
+
+<form id="wizard-form" method="post" action="/pipelines/create-wizard" data-busy>
+
+{# === Step 1: Pipeline Type === #}
+<div class="wizard-step active" id="step-1">
+    <h5 class="mb-3">Выберите тип пайплайна</h5>
+    <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'forward')">
+                <input type="radio" name="pipeline_type" value="forward">
+                <div class="card-body text-center">
+                    <div class="fs-2 mb-2">&#x1F517;</div>
+                    <h6 class="card-title">Пересылка сообщений</h6>
+                    <p class="card-text small text-muted">Пересылает сообщения из источников в целевые каналы/чаты</p>
+                    <code class="small">ИСТОЧНИК → ПЕРЕСЫЛКА</code>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'react')">
+                <input type="radio" name="pipeline_type" value="react">
+                <div class="card-body text-center">
+                    <div class="fs-2 mb-2">👍</div>
+                    <h6 class="card-title">Авто-реакции</h6>
+                    <p class="card-text small text-muted">Ставит emoji-реакции на сообщения с случайной задержкой</p>
+                    <code class="small">ИСТОЧНИК → ЗАДЕРЖКА → РЕАКЦИЯ</code>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'filter_action')">
+                <input type="radio" name="pipeline_type" value="filter_action">
+                <div class="card-body text-center">
+                    <div class="fs-2 mb-2">&#x1F3AF;</div>
+                    <h6 class="card-title">Фильтр + действие</h6>
+                    <p class="card-text small text-muted">Фильтрует по ключевым словам или regex, затем пересылает/реагирует/удаляет</p>
+                    <code class="small">ИСТОЧНИК → ФИЛЬТР → ДЕЙСТВИЕ</code>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'cleanup')">
+                <input type="radio" name="pipeline_type" value="cleanup">
+                <div class="card-body text-center">
+                    <div class="fs-2 mb-2">&#x1F5D1;</div>
+                    <h6 class="card-title">Очистка чата</h6>
+                    <p class="card-text small text-muted">Удаляет служебные сообщения (присоединение/выход из чата)</p>
+                    <code class="small">ИСТОЧНИК → ФИЛЬТР → УДАЛЕНИЕ</code>
+                </div>
+            </label>
+        </div>
+    </div>
+</div>
+
+{# === Step 2: Sources === #}
+<div class="wizard-step" id="step-2">
+    <h5 class="mb-3">Каналы-источники</h5>
+    <p class="text-muted">Выберите каналы, из которых будут поступать сообщения.</p>
+    <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true" data-picker-url="/pipelines/api/channels/search?q=">
+        <div class="picker-selected"></div>
+        <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск каналов..." data-picker-search>
+        <div class="list-group picker-list"></div>
+        <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
+    </div>
+</div>
+
+{# === Step 3: Action Config === #}
+<div class="wizard-step" id="step-3">
+
+    {# -- Forward panel -- #}
+    <div class="action-panel d-none" id="panel-forward">
+        <h5 class="mb-3">Целевые диалоги</h5>
+        <p class="text-muted">Выберите каналы/чаты, куда будут пересылаться сообщения.</p>
+        <div class="searchable-picker" data-picker-name="target_refs" data-picker-multi="true">
+            <div class="picker-selected"></div>
+            <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск диалога..." data-picker-search>
+            <div class="btn-group btn-group-sm mb-1" data-picker-filters>
+                <button type="button" class="btn btn-outline-secondary active" data-filter="all">Все</button>
+                <button type="button" class="btn btn-outline-secondary" data-filter="channel">Каналы</button>
+                <button type="button" class="btn btn-outline-secondary" data-filter="group">Группы</button>
+                <button type="button" class="btn btn-outline-secondary" data-filter="dm">Личные</button>
+            </div>
+            <div class="list-group picker-list">
+                {% for account in accounts %}
+                {% set dialogs = cached_dialogs.get(account.phone, []) %}
+                {% for dialog in dialogs %}
+                {% set ref = account.phone ~ "|" ~ dialog.channel_id %}
+                {% set dtype = dialog.channel_type %}
+                {% set dgroup = "dm" if dtype == "dm" else ("channel" if dtype in ("channel", "monoforum") else "group") %}
+                <label class="list-group-item list-group-item-action d-flex align-items-center gap-2"
+                       data-picker-option
+                       data-value="{{ ref }}"
+                       data-group="{{ dgroup }}"
+                       data-search-text="{{ ((dialog.title or '') ~ ' ' ~ dtype ~ ' ' ~ account.phone)|lower }}">
+                    <input type="checkbox" class="form-check-input mt-0">
+                    <span>{{ dialog.title or dialog.channel_id }}</span>
+                    <small class="text-muted ms-auto">{{ dtype }}</small>
+                </label>
+                {% endfor %}
+                {% endfor %}
+            </div>
+            <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
+        </div>
+    </div>
+
+    {# -- React panel -- #}
+    <div class="action-panel d-none" id="panel-react">
+        <h5 class="mb-3">Реакции</h5>
+        <div class="row g-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">Emoji реакция</label>
+                <input class="form-control" type="text" name="react_emoji" maxlength="10" placeholder="👍" value="👍">
+                <div class="form-text">Одиночный emoji или список через запятую для случайного выбора</div>
+            </div>
+        </div>
+        <h6 class="mt-4 mb-2">Задержка (опционально)</h6>
+        <div class="row g-3">
+            <div class="col-6 col-md-3">
+                <label class="form-label">Мин (сек)</label>
+                <input class="form-control" type="number" name="delay_min" min="0" value="5">
+            </div>
+            <div class="col-6 col-md-3">
+                <label class="form-label">Макс (сек)</label>
+                <input class="form-control" type="number" name="delay_max" min="0" value="60">
+            </div>
+        </div>
+    </div>
+
+    {# -- Filter+Action panel -- #}
+    <div class="action-panel d-none" id="panel-filter_action">
+        <h5 class="mb-3">Фильтрация</h5>
+        <div class="row g-3 mb-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">Тип фильтра</label>
+                <select class="form-select" name="filter_type" onchange="toggleFilterSubpanel()">
+                    <option value="keywords">По ключевым словам</option>
+                    <option value="regex">По регулярному выражению</option>
+                    <option value="service_message">Служебные сообщения</option>
+                    <option value="anonymous_sender">Анонимные сообщения</option>
+                </select>
+            </div>
+        </div>
+
+        <div id="filter-keywords" class="mb-3">
+            <label class="form-label">Ключевые слова (по одному на строку)</label>
+            <textarea class="form-control" name="filter_keywords" rows="3" placeholder="crypto&#10;buy now&#10;free money"></textarea>
+        </div>
+        <div id="filter-regex" class="mb-3 d-none">
+            <label class="form-label">Регулярное выражение</label>
+            <input class="form-control" type="text" name="filter_pattern" placeholder="https?://\S+">
+        </div>
+        <div id="filter-service" class="mb-3 d-none">
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="filter_joined" value="1" checked>
+                <label class="form-check-label">user_joined</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="filter_left" value="1" checked>
+                <label class="form-check-label">user_left</label>
+            </div>
+        </div>
+        <div id="filter-anonymous" class="mb-3 d-none">
+            <p class="text-muted">Будут отфильтрованы все сообщения от анонимных отправителей.</p>
+        </div>
+
+        <h5 class="mt-4 mb-3">Действие с отфильтрованными</h5>
+        <div class="row g-3 mb-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">Тип действия</label>
+                <select class="form-select" name="action_type" onchange="toggleActionSubpanel()">
+                    <option value="forward">Переслать</option>
+                    <option value="react">Поставить реакцию</option>
+                    <option value="delete_message">Удалить</option>
+                </select>
+            </div>
+        </div>
+
+        <div id="action-forward" class="mb-3">
+            <label class="form-label">Целевые диалоги</label>
+            <div class="searchable-picker" data-picker-name="filter_target_refs" data-picker-multi="true">
+                <div class="picker-selected"></div>
+                <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск диалога..." data-picker-search>
+                <div class="btn-group btn-group-sm mb-1" data-picker-filters>
+                    <button type="button" class="btn btn-outline-secondary active" data-filter="all">Все</button>
+                    <button type="button" class="btn btn-outline-secondary" data-filter="channel">Каналы</button>
+                    <button type="button" class="btn btn-outline-secondary" data-filter="group">Группы</button>
+                </div>
+                <div class="list-group picker-list">
+                    {% for account in accounts %}
+                    {% set dialogs = cached_dialogs.get(account.phone, []) %}
+                    {% for dialog in dialogs %}
+                    {% set ref = account.phone ~ "|" ~ dialog.channel_id %}
+                    {% set dtype = dialog.channel_type %}
+                    {% set dgroup = "dm" if dtype == "dm" else ("channel" if dtype in ("channel", "monoforum") else "group") %}
+                    <label class="list-group-item list-group-item-action d-flex align-items-center gap-2"
+                           data-picker-option
+                           data-value="{{ ref }}"
+                           data-group="{{ dgroup }}"
+                           data-search-text="{{ ((dialog.title or '') ~ ' ' ~ dtype ~ ' ' ~ account.phone)|lower }}">
+                        <input type="checkbox" class="form-check-input mt-0">
+                        <span>{{ dialog.title or dialog.channel_id }}</span>
+                        <small class="text-muted ms-auto">{{ dtype }}</small>
+                    </label>
+                    {% endfor %}
+                    {% endfor %}
+                </div>
+                <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
+            </div>
+        </div>
+        <div id="action-react" class="mb-3 d-none">
+            <label class="form-label">Emoji</label>
+            <input class="form-control" type="text" name="action_react_emoji" maxlength="10" value="👍">
+        </div>
+        <div id="action-delete" class="mb-3 d-none">
+            <p class="text-muted">Отфильтрованные сообщения будут удалены.</p>
+        </div>
+    </div>
+
+    {# -- Cleanup panel -- #}
+    <div class="action-panel d-none" id="panel-cleanup">
+        <div class="alert alert-info">
+            Преднастроенный пайплайн: автоматически удаляет сообщения о присоединении/выходе пользователей из чата.
+            Никаких дополнительных настроек не требуется.
+        </div>
+    </div>
+</div>
+
+{# === Step 4: Schedule === #}
+<div class="wizard-step" id="step-4">
+    <h5 class="mb-3">Расписание</h5>
+    <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <label class="form-label">Название пайплайна</label>
+            <input class="form-control" type="text" name="name" required placeholder="Мой пайплайн">
+        </div>
+        <div class="col-6 col-md-3">
+            <label class="form-label">Интервал (мин)</label>
+            <input class="form-control" type="number" name="generate_interval_minutes" min="1" value="60">
+        </div>
+    </div>
+    <div class="form-check mt-3">
+        <input class="form-check-input" type="checkbox" name="is_active" value="true" id="wizard-active" checked>
+        <label class="form-check-label" for="wizard-active">Активен сразу после создания</label>
+    </div>
+</div>
+
+{# === Step 5: Review === #}
+<div class="wizard-step" id="step-5">
+    <h5 class="mb-3">Проверка</h5>
+    <div id="wizard-review" class="card">
+        <div class="card-body">
+            <div id="review-content"></div>
+        </div>
+    </div>
+</div>
+
+{# Navigation buttons #}
+<div class="d-flex justify-content-between mt-4">
+    <button type="button" class="btn btn-secondary" id="btn-back" onclick="goBack()" style="display:none">
+        &larr; Назад
+    </button>
+    <div class="ms-auto">
+        <button type="button" class="btn btn-primary" id="btn-next" onclick="goNext()">
+            Далее &rarr;
+        </button>
+        <button type="submit" class="btn btn-success d-none" id="btn-submit">
+            &#x2714; Создать
+        </button>
+    </div>
+</div>
+
+<input type="hidden" name="pipeline_json" id="pipeline_json_input">
+</form>
+
+<script>
+(function() {
+    "use strict";
+    var currentStep = 1;
+    var pipelineType = null;
+    var totalSteps = 5;
+
+    window.selectType = function(card, type) {
+        document.querySelectorAll(".wizard-type-card").forEach(function(c) {
+            c.classList.remove("selected");
+        });
+        card.classList.add("selected");
+        card.querySelector('input[type="radio"]').checked = true;
+        pipelineType = type;
+    };
+
+    window.toggleFilterSubpanel = function() {
+        var ft = document.querySelector('[name="filter_type"]').value;
+        ["keywords", "regex", "service", "anonymous"].forEach(function(t) {
+            var el = document.getElementById("filter-" + t);
+            if (el) el.classList.toggle("d-none", t !== ft);
+        });
+    };
+
+    window.toggleActionSubpanel = function() {
+        var at = document.querySelector('[name="action_type"]').value;
+        ["forward", "react", "delete"].forEach(function(t) {
+            var el = document.getElementById("action-" + t);
+            if (el) el.classList.toggle("d-none", t !== at);
+        });
+    };
+
+    function validateStep(step) {
+        if (step === 1) {
+            if (!pipelineType) { alert("Выберите тип пайплайна"); return false; }
+        } else if (step === 2) {
+            var src = document.querySelectorAll('[name="source_channel_ids"]');
+            if (src.length === 0) { alert("Выберите хотя бы один канал-источник"); return false; }
+        } else if (step === 3) {
+            if (pipelineType === 'forward') {
+                var tgts = document.querySelectorAll('[name="target_refs"]');
+                if (tgts.length === 0) { alert("Выберите хотя бы один целевой диалог"); return false; }
+            } else if (pipelineType === 'filter_action') {
+                var at = document.querySelector('[name="action_type"]').value;
+                if (at === 'forward') {
+                    var ft = document.querySelectorAll('[name="filter_target_refs"]');
+                    if (ft.length === 0) { alert("Выберите целевые диалоги для пересылки"); return false; }
+                }
+            }
+        } else if (step === 4) {
+            var n = document.querySelector('[name="name"]').value.trim();
+            if (!n) { alert("Введите название пайплайна"); return false; }
+        }
+        return true;
+    }
+
+    window.goNext = function() {
+        if (!validateStep(currentStep)) return;
+        if (currentStep === 1) {
+            configureActionPanel();
+        }
+        if (currentStep === 4) {
+            renderReview();
+        }
+        showStep(currentStep + 1);
+    };
+
+    window.goBack = function() {
+        showStep(currentStep - 1);
+    };
+
+    function showStep(n) {
+        if (n < 1 || n > totalSteps) return;
+        document.querySelectorAll(".wizard-step").forEach(function(s) { s.classList.remove("active"); });
+        document.getElementById("step-" + n).classList.add("active");
+        // Update stepper nav
+        document.querySelectorAll(".wizard-stepper .nav-link").forEach(function(link) {
+            var s = parseInt(link.dataset.step);
+            link.classList.remove("active", "completed", "disabled");
+            if (s === n) link.classList.add("active");
+            else if (s < n) link.classList.add("completed");
+            else link.classList.add("disabled");
+        });
+        // Toggle buttons
+        document.getElementById("btn-back").style.display = n > 1 ? "" : "none";
+        if (n === totalSteps) {
+            document.getElementById("btn-next").classList.add("d-none");
+            document.getElementById("btn-submit").classList.remove("d-none");
+        } else {
+            document.getElementById("btn-next").classList.remove("d-none");
+            document.getElementById("btn-submit").classList.add("d-none");
+        }
+        currentStep = n;
+    }
+
+    function configureActionPanel() {
+        document.querySelectorAll(".action-panel").forEach(function(p) { p.classList.add("d-none"); });
+        var panel = document.getElementById("panel-" + pipelineType);
+        if (panel) panel.classList.remove("d-none");
+    }
+
+    function getFormValues(name) {
+        return Array.from(document.querySelectorAll('[name="' + name + '"]')).map(function(el) { return el.value; });
+    }
+
+    function parseTargetRefs(name) {
+        name = name || "target_refs";
+        return getFormValues(name).map(function(ref) {
+            var parts = ref.split("|");
+            return { phone: parts[0], dialog_id: parseInt(parts[1]) };
+        });
+    }
+
+    function buildPipelineGraph() {
+        var sourceIds = getFormValues("source_channel_ids").map(Number);
+        var nodes = [];
+        var edges = [];
+
+        nodes.push({ id: "source_1", type: "source", name: "Источники", config: { channel_ids: sourceIds }, position: { x: 0, y: 0 } });
+
+        if (pipelineType === "forward") {
+            var targets = parseTargetRefs();
+            nodes.push({ id: "forward_1", type: "forward", name: "Пересылка", config: { targets: targets }, position: { x: 220, y: 0 } });
+            edges.push({ from: "source_1", to: "forward_1" });
+
+        } else if (pipelineType === "react") {
+            var emojiRaw = document.querySelector('[name="react_emoji"]').value.trim();
+            var reactConfig;
+            if (emojiRaw.indexOf(",") !== -1) {
+                reactConfig = { random_emojis: emojiRaw.split(",").map(function(e) { return e.trim(); }).filter(Boolean) };
+            } else {
+                reactConfig = { emoji: emojiRaw || "👍" };
+            }
+            var delayMin = parseFloat(document.querySelector('[name="delay_min"]').value) || 0;
+            var delayMax = parseFloat(document.querySelector('[name="delay_max"]').value) || 0;
+            var lastId = "source_1";
+            if (delayMin > 0 || delayMax > 0) {
+                nodes.push({ id: "delay_1", type: "delay", name: "Задержка", config: { min_seconds: delayMin, max_seconds: delayMax }, position: { x: 220, y: 0 } });
+                edges.push({ from: "source_1", to: "delay_1" });
+                lastId = "delay_1";
+            }
+            nodes.push({ id: "react_1", type: "react", name: "Реакция", config: reactConfig, position: { x: lastId === "delay_1" ? 440 : 220, y: 0 } });
+            edges.push({ from: lastId, to: "react_1" });
+
+        } else if (pipelineType === "filter_action") {
+            var ft = document.querySelector('[name="filter_type"]').value;
+            var filterConfig;
+            if (ft === "keywords") {
+                filterConfig = { type: "keywords", keywords: document.querySelector('[name="filter_keywords"]').value.split("\n").map(function(k) { return k.trim(); }).filter(Boolean) };
+            } else if (ft === "regex") {
+                filterConfig = { type: "regex", pattern: document.querySelector('[name="filter_pattern"]').value };
+            } else if (ft === "service_message") {
+                var stypes = [];
+                if (document.querySelector('[name="filter_joined"]').checked) stypes.push("user_joined");
+                if (document.querySelector('[name="filter_left"]').checked) stypes.push("user_left");
+                filterConfig = { type: "service_message", service_types: stypes };
+            } else {
+                filterConfig = { type: "anonymous_sender" };
+            }
+            nodes.push({ id: "filter_1", type: "filter", name: "Фильтр", config: filterConfig, position: { x: 220, y: 0 } });
+            edges.push({ from: "source_1", to: "filter_1" });
+
+            var at = document.querySelector('[name="action_type"]').value;
+            var actionConfig = {};
+            var actionType = at;
+            var actionName = "";
+            if (at === "forward") {
+                actionConfig = { targets: parseTargetRefs("filter_target_refs") };
+                actionName = "Пересылка";
+            } else if (at === "react") {
+                actionConfig = { emoji: document.querySelector('[name="action_react_emoji"]').value || "👍" };
+                actionName = "Реакция";
+            } else {
+                actionName = "Удаление";
+            }
+            nodes.push({ id: "action_1", type: actionType, name: actionName, config: actionConfig, position: { x: 440, y: 0 } });
+            edges.push({ from: "filter_1", to: "action_1" });
+
+        } else if (pipelineType === "cleanup") {
+            nodes.push({ id: "filter_1", type: "filter", name: "Фильтр join/leave", config: { type: "service_message", service_types: ["user_joined", "user_left"] }, position: { x: 220, y: 0 } });
+            edges.push({ from: "source_1", to: "filter_1" });
+            nodes.push({ id: "delete_1", type: "delete_message", name: "Удаление", config: {}, position: { x: 440, y: 0 } });
+            edges.push({ from: "filter_1", to: "delete_1" });
+        }
+
+        return { nodes: nodes, edges: edges };
+    }
+
+    function renderReview() {
+        var graph = buildPipelineGraph();
+        document.getElementById("pipeline_json_input").value = JSON.stringify(graph);
+        var name = document.querySelector('[name="name"]').value || "Без названия";
+        var interval = document.querySelector('[name="generate_interval_minutes"]').value;
+        var sources = getFormValues("source_channel_ids");
+        var flow = graph.nodes.map(function(n) { return n.name; }).join(" → ");
+
+        var typeLabels = { forward: "Пересылка", react: "Авто-реакции", filter_action: "Фильтр + действие", cleanup: "Очистка чата" };
+        var html = '<dl class="row mb-0">';
+        html += '<dt class="col-sm-4">Название</dt><dd class="col-sm-8">' + name + '</dd>';
+        html += '<dt class="col-sm-4">Тип</dt><dd class="col-sm-8">' + (typeLabels[pipelineType] || pipelineType) + '</dd>';
+        html += '<dt class="col-sm-4">Источники</dt><dd class="col-sm-8">' + sources.length + ' каналов</dd>';
+        html += '<dt class="col-sm-4">Цепочка</dt><dd class="col-sm-8"><code>' + flow + '</code></dd>';
+        html += '<dt class="col-sm-4">Интервал</dt><dd class="col-sm-8">' + interval + ' мин</dd>';
+        html += '</dl>';
+        document.getElementById("review-content").innerHTML = html;
+    }
+
+    // Form submit: copy target_refs for filter_action forward into main target_refs
+    var form = document.getElementById("wizard-form");
+    form.addEventListener("submit", function(e) {
+        // For filter_action with forward: copy filter_target_refs as target_refs
+        if (pipelineType === "filter_action" && document.querySelector('[name="action_type"]').value === "forward") {
+            getFormValues("filter_target_refs").forEach(function(val) {
+                var inp = document.createElement("input");
+                inp.type = "hidden";
+                inp.name = "target_refs";
+                inp.value = val;
+                form.appendChild(inp);
+            });
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -308,17 +308,21 @@
 
     window.toggleFilterSubpanel = function() {
         var ft = document.querySelector('[name="filter_type"]').value;
+        var panelMap = { service_message: "service", anonymous_sender: "anonymous" };
+        var panelKey = panelMap[ft] || ft;
         ["keywords", "regex", "service", "anonymous"].forEach(function(t) {
             var el = document.getElementById("filter-" + t);
-            if (el) el.classList.toggle("d-none", t !== ft);
+            if (el) el.classList.toggle("d-none", t !== panelKey);
         });
     };
 
     window.toggleActionSubpanel = function() {
         var at = document.querySelector('[name="action_type"]').value;
+        var panelMap = { delete_message: "delete" };
+        var panelKey = panelMap[at] || at;
         ["forward", "react", "delete"].forEach(function(t) {
             var el = document.getElementById("action-" + t);
-            if (el) el.classList.toggle("d-none", t !== at);
+            if (el) el.classList.toggle("d-none", t !== panelKey);
         });
     };
 
@@ -487,14 +491,27 @@
         var flow = graph.nodes.map(function(n) { return n.name; }).join(" → ");
 
         var typeLabels = { forward: "Пересылка", react: "Авто-реакции", filter_action: "Фильтр + действие", cleanup: "Очистка чата" };
-        var html = '<dl class="row mb-0">';
-        html += '<dt class="col-sm-4">Название</dt><dd class="col-sm-8">' + name + '</dd>';
-        html += '<dt class="col-sm-4">Тип</dt><dd class="col-sm-8">' + (typeLabels[pipelineType] || pipelineType) + '</dd>';
-        html += '<dt class="col-sm-4">Источники</dt><dd class="col-sm-8">' + sources.length + ' каналов</dd>';
-        html += '<dt class="col-sm-4">Цепочка</dt><dd class="col-sm-8"><code>' + flow + '</code></dd>';
-        html += '<dt class="col-sm-4">Интервал</dt><dd class="col-sm-8">' + interval + ' мин</dd>';
-        html += '</dl>';
-        document.getElementById("review-content").innerHTML = html;
+        var dl = document.createElement("dl");
+        dl.className = "row mb-0";
+        function addRow(dt, ddContent, isCode) {
+            var dtEl = document.createElement("dt");
+            dtEl.className = "col-sm-4";
+            dtEl.textContent = dt;
+            var ddEl = document.createElement("dd");
+            ddEl.className = "col-sm-8";
+            if (isCode) { var c = document.createElement("code"); c.textContent = ddContent; ddEl.appendChild(c); }
+            else { ddEl.textContent = ddContent; }
+            dl.appendChild(dtEl);
+            dl.appendChild(ddEl);
+        }
+        addRow("Название", name);
+        addRow("Тип", typeLabels[pipelineType] || pipelineType);
+        addRow("Источники", sources.length + " каналов");
+        addRow("Цепочка", flow, true);
+        addRow("Интервал", interval + " мин");
+        var reviewEl = document.getElementById("review-content");
+        reviewEl.innerHTML = "";
+        reviewEl.appendChild(dl);
     }
 
     // Form submit: copy target_refs for filter_action forward into main target_refs

--- a/src/web/templates/pipelines/edit.html
+++ b/src/web/templates/pipelines/edit.html
@@ -63,27 +63,19 @@
         </div>
     </div>
 
-    {# Source channels — searchable picker #}
+    {# Source channels — AJAX searchable picker #}
     <div class="row g-3 mb-3">
         <div class="col-12 col-lg-6">
             <label class="form-label">Каналы-источники</label>
-            <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true">
+            <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true" data-picker-url="/pipelines/api/channels/search?q=">
                 <div class="picker-selected"></div>
-                <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск канала..." data-picker-search>
-                <div class="list-group picker-list">
-                    {% for channel in channels %}
-                    <label class="list-group-item list-group-item-action d-flex align-items-center gap-2"
-                           data-picker-option
-                           data-value="{{ channel.channel_id }}"
-                           data-group="channel"
-                           data-search-text="{{ ((channel.title or '') ~ ' ' ~ (channel.username or '') ~ ' ' ~ channel.channel_id)|lower }}">
-                        <input type="checkbox" class="form-check-input mt-0"
-                               {{ "checked" if channel.channel_id in source_ids }}>
-                        <span>{{ channel.title or channel.channel_id }}{% if channel.username %} <small class="text-muted">@{{ channel.username }}</small>{% endif %}</span>
-                    </label>
-                    {% endfor %}
-                </div>
+                <input type="search" class="form-control form-control-sm mb-1" placeholder="Введите название или ID канала (мин. 2 символа)..." data-picker-search>
+                <div class="list-group picker-list"></div>
                 <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
+                {# Pre-selected sources — rendered as hidden inputs + badges #}
+                {% for sid in source_ids %}
+                <input type="hidden" data-picker-preselected value="{{ sid }}" data-title="Канал {{ sid }}">
+                {% endfor %}
             </div>
         </div>
 

--- a/src/web/templates/pipelines/templates.html
+++ b/src/web/templates/pipelines/templates.html
@@ -79,24 +79,13 @@
                             <input class="form-control" type="number" name="generate_interval_minutes" min="1" value="60">
                         </div>
 
-                        {# Source channels #}
+                        {# Source channels — AJAX searchable picker #}
                         <div class="mb-3">
                             <label class="form-label">Каналы-источники</label>
-                            <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true">
+                            <div class="searchable-picker" data-picker-name="source_channel_ids" data-picker-multi="true" data-picker-url="/pipelines/api/channels/search?q=">
                                 <div class="picker-selected"></div>
-                                <input type="search" class="form-control form-control-sm mb-1" placeholder="Поиск канала..." data-picker-search>
-                                <div class="list-group picker-list">
-                                    {% for channel in channels %}
-                                    <label class="list-group-item list-group-item-action d-flex align-items-center gap-2"
-                                           data-picker-option
-                                           data-value="{{ channel.channel_id }}"
-                                           data-group="channel"
-                                           data-search-text="{{ ((channel.title or '') ~ ' ' ~ (channel.username or '') ~ ' ' ~ channel.channel_id)|lower }}">
-                                        <input type="checkbox" class="form-check-input mt-0">
-                                        <span>{{ channel.title or channel.channel_id }}{% if channel.username %} <small class="text-muted">@{{ channel.username }}</small>{% endif %}</span>
-                                    </label>
-                                    {% endfor %}
-                                </div>
+                                <input type="search" class="form-control form-control-sm mb-1" placeholder="Введите название или ID канала (мин. 2 символа)..." data-picker-search>
+                                <div class="list-group picker-list"></div>
                                 <small class="text-muted d-none" data-picker-empty>Ничего не найдено</small>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- AJAX searchable picker для каналов-источников — загружает каналы по запросу вместо рендера 2000+ DOM-элементов
- Batch SQL для relations пайплайнов — 3 запроса вместо N+1 (101+ → 3)
- Пошаговый wizard создания пайплайнов без LLM: пересылка, авто-реакции, фильтр+действие, очистка чата
- Кнопка "+ Мастер" на странице пайплайнов → /pipelines/create

## Test plan
- [x] 4710 тестов пройдено, 0 упавших
- [x] ruff check чисто
- [ ] Открыть /pipelines — проверить AJAX picker загружает каналы при вводе
- [ ] Открыть /pipelines/create — пройти wizard для каждого из 4 типов
- [ ] Проверить что созданный пайплайн корректно сохраняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)