### PR TITLE
fix: #330 code review follow-up — migration guard, backfill created_at, test fix

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -743,11 +743,16 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
 
     # Fix forward_from_channel_id normalization (issue #381)
     # Old code stored -PeerChannel.channel_id; correct value is positive channel_id.
-    await db.execute(
-        "UPDATE messages SET forward_from_channel_id = ABS(forward_from_channel_id) "
-        "WHERE forward_from_channel_id < 0"
-    )
-    await db.commit()
+    cur = await db.execute("SELECT value FROM settings WHERE key = '_migration_fwd_abs_v1' LIMIT 1")
+    if not await cur.fetchone():
+        await db.execute(
+            "UPDATE messages SET forward_from_channel_id = ABS(forward_from_channel_id) "
+            "WHERE forward_from_channel_id < 0"
+        )
+        await db.execute(
+            "INSERT OR IGNORE INTO settings (key, value) VALUES ('_migration_fwd_abs_v1', '1')"
+        )
+        await db.commit()
 
     return fts_available
 

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -200,6 +200,15 @@ class ChannelsRepository:
         )
         await self._db.commit()
 
+    async def update_channel_created_at(self, channel_id: int, created_at) -> None:
+        """Set created_at only if currently NULL (backfill from entity.date)."""
+        iso = created_at.isoformat() if hasattr(created_at, "isoformat") else created_at
+        await self._db.execute(
+            "UPDATE channels SET created_at = ? WHERE channel_id = ? AND created_at IS NULL",
+            (iso, channel_id),
+        )
+        await self._db.commit()
+
     async def get_forum_topics(self, channel_id: int) -> list[dict]:
         cur = await self._db.execute(
             "SELECT topic_id, title FROM forum_topics WHERE channel_id = ? ORDER BY topic_id",

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1022,6 +1022,13 @@ class Collector:
                 )
                 await self._db.save_channel_stats(stats)
 
+                # Backfill channel creation date from entity if missing
+                entity_created = getattr(entity, "date", None)
+                if entity_created is not None:
+                    await self._db.repos.channels.update_channel_created_at(
+                        channel.channel_id, entity_created
+                    )
+
                 # Update channel_type if missing
                 if channel.channel_type is None:
                     channel_type, _deactivate = self._pool._classify_entity(entity)

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -454,10 +454,9 @@ async def test_unpin_message_missing_fields(client):
 
 @pytest.mark.asyncio
 async def test_participants_missing_params(client):
-    """Test participants with missing params returns error or empty."""
+    """Test participants with missing params returns 400."""
     resp = await client.get("/dialogs/participants")
-    # May return 400 or redirect
-    assert resp.status_code in (200, 303, 400, 422)
+    assert resp.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add idempotency guard (`_migration_fwd_abs_v1`) to `forward_from_channel_id` ABS migration — prevents full table scan on every startup
- Implement `update_channel_created_at()` repo method and call it from `_collect_channel_stats` to backfill `channels.created_at` from `entity.date`
- Narrow `test_participants_missing_params` assertion from `in (200, 303, 400, 422)` to exact `== 400`

## Related issues
Follow-up fixes from code review of #330:
- #381 (migration guard)
- #382 (backfill created_at)
- #384 (test quality)

## Test plan
- [ ] `pytest tests/routes/test_dialogs_routes.py::test_participants_missing_params -v` — passes with exact 400
- [ ] `pytest tests/repositories/test_channel_stats_repository.py -v` — no regression
- [ ] `pytest tests/test_channel_analytics_service.py tests/test_forward_citations_repo.py -v` — all pass
- [ ] `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)