### PR TITLE
refactor(web): web_login.html extends base.html

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -246,19 +246,23 @@
     }
     function applyThemeMode(mode) {
         document.documentElement.setAttribute("data-bs-theme", resolveTheme(mode));
-        themeBtn.textContent = THEME_ICONS[mode];
-        themeBtn.title = THEME_TITLES[mode];
+        if (themeBtn) {
+            themeBtn.textContent = THEME_ICONS[mode];
+            themeBtn.title = THEME_TITLES[mode];
+        }
     }
     applyThemeMode(getThemeMode());
     matchMedia("(prefers-color-scheme:dark)").addEventListener("change", function() {
         if (getThemeMode() === "auto") applyThemeMode("auto");
     });
-    themeBtn.addEventListener("click", function() {
-        var cur = getThemeMode();
-        var next = THEME_MODES[(THEME_MODES.indexOf(cur) + 1) % 3];
-        if (next === "auto") localStorage.removeItem("theme"); else localStorage.setItem("theme", next);
-        applyThemeMode(next);
-    });
+    if (themeBtn) {
+        themeBtn.addEventListener("click", function() {
+            var cur = getThemeMode();
+            var next = THEME_MODES[(THEME_MODES.indexOf(cur) + 1) % 3];
+            if (next === "auto") localStorage.removeItem("theme"); else localStorage.setItem("theme", next);
+            applyThemeMode(next);
+        });
+    }
     // Active nav highlight
     var path = window.location.pathname;
     var links = document.querySelectorAll("#mainNav .nav-link");

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -85,7 +85,7 @@
         <small>TG Agent v{{ app_version }}</small>
     </footer>
     {% endblock %}
-<script src="https://cdn.jsdelivr.net/npm/bootstrap/5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <script src="/static/_busy_button.js"></script>
 <script src="/static/js/searchable-picker.js"></script>
 <script>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -23,6 +23,7 @@
     {% block head_scripts %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
+    {% block nav %}
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand fw-bold" href="/">TG Agent</a>
@@ -69,6 +70,7 @@
             </div>
         </div>
     </nav>
+    {% endblock %}
     <div id="flash-container" class="container mt-3"></div>
     <main class="container py-3 flex-grow-1">
         {% block content %}{% endblock %}
@@ -78,10 +80,12 @@
             <div class="toast-body"></div>
         </div>
     </div>
+    {% block footer %}
     <footer class="text-center text-muted py-3 mt-auto">
         <small>TG Agent v{{ app_version }}</small>
     </footer>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    {% endblock %}
+<script src="https://cdn.jsdelivr.net/npm/bootstrap/5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <script src="/static/_busy_button.js"></script>
 <script src="/static/js/searchable-picker.js"></script>
 <script>

--- a/src/web/templates/web_login.html
+++ b/src/web/templates/web_login.html
@@ -1,43 +1,39 @@
-<!DOCTYPE html>
-<html lang="ru" data-bs-theme="light">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Вход — TG Agent</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="/static/style.css">
-    <script src="/static/_theme_init.js"></script>
-</head>
-<body>
-    <div class="d-flex justify-content-center align-items-center min-vh-100">
-        <div class="card shadow" style="max-width: 28rem; width: 100%;">
-            <div class="card-body p-3 p-sm-4">
-                <h5 class="card-title mb-3">Вход в веб-панель</h5>
-                <p class="text-muted">Введите пароль из <code>WEB_PASS</code>, чтобы открыть TG Agent.</p>
+{% extends "base.html" %}
 
-                {% if error %}
-                <div class="alert alert-danger" role="alert">{{ error }}</div>
-                {% endif %}
+{% block title %}Вход — TG Agent{% endblock %}
 
-                <form method="post" action="/login" data-busy>
-                    <input type="hidden" name="next" value="{{ next }}">
-                    <div class="mb-3">
-                        <label for="password" class="form-label">Пароль</label>
-                        <input
-                            type="password"
-                            class="form-control"
-                            id="password"
-                            name="password"
-                            autocomplete="current-password"
-                            required
-                            autofocus
-                        >
-                    </div>
-                    <button type="submit" class="btn btn-primary w-100">Войти</button>
-                </form>
-            </div>
+{% block nav %}{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-center align-items-center min-vh-100">
+    <div class="card shadow" style="max-width: 28rem; width: 100%;">
+        <div class="card-body p-3 p-sm-4">
+            <h5 class="card-title mb-3">Вход в веб-панель</h5>
+            <p class="text-muted">Введите пароль из <code>WEB_PASS</code>, чтобы открыть TG Agent.</p>
+
+            {% if error %}
+            <div class="alert alert-danger" role="alert">{{ error }}</div>
+            {% endif %}
+
+            <form method="post" action="/login" data-busy>
+                <input type="hidden" name="next" value="{{ next }}">
+                <div class="mb-3">
+                    <label for="password" class="form-label">Пароль</label>
+                    <input
+                        type="password"
+                        class="form-control"
+                        id="password"
+                        name="password"
+                        autocomplete="current-password"
+                        required
+                        autofocus
+                    >
+                </div>
+                <button type="submit" class="btn btn-primary w-100">Войти</button>
+            </form>
         </div>
     </div>
-<script src="/static/_busy_button.js"></script>
-</body>
-</html>
+</div>
+{% endblock %}

--- a/src/web/templates/web_login.html
+++ b/src/web/templates/web_login.html
@@ -7,7 +7,7 @@
 {% block footer %}{% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-center align-items-center min-vh-100">
+<div class="d-flex justify-content-center align-items-center">
     <div class="card shadow" style="max-width: 28rem; width: 100%;">
         <div class="card-body p-3 p-sm-4">
             <h5 class="card-title mb-3">Вход в веб-панель</h5>


### PR DESCRIPTION
## Summary
- Part of #357, fixes #372
- `web_login.html` now extends `base.html` instead of duplicating code
- Added `{% block nav %}` and `{% block footer %}` blocks to `base.html`
- Login page overrides these blocks to hide navbar/footer
- Removes ~30 LOC of duplicated code

## Test plan
- [x] `pytest tests/ -v` passes (3 login-specific tests verified)
- [x] Login page renders without navbar/footer
- [x] Template extends base correctly