### PR TITLE
fix(pipelines): inject source/target IDs into DAG node config (#405)

### DIFF
--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -430,6 +430,17 @@ class PipelineService:
         )
         pipeline = pipeline.model_copy(update={"pipeline_json": graph})
 
+        # Inject source channel IDs into source nodes and target refs into publish/forward nodes
+        if source_ids:
+            for node in graph.nodes:
+                if node.type == PipelineNodeType.SOURCE and not node.config.get("channel_ids"):
+                    node.config["channel_ids"] = source_ids
+        if target_refs:
+            target_dicts = [{"phone": t.phone, "dialog_id": t.dialog_id} for t in target_refs]
+            for node in graph.nodes:
+                if node.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD) and not node.config.get("targets"):
+                    node.config["targets"] = target_dicts
+
         # Templates are created inactive; sources/targets are optional at creation time
         sources = await self._normalize_sources(source_ids) if source_ids else []
         targets = await self._normalize_targets(target_refs) if target_refs else []

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -432,11 +432,18 @@ class PipelineService:
 
         # Inject source channel IDs into source nodes and target refs into publish/forward nodes
         if source_ids:
+            clean_ids = sorted(set(source_ids))
             for node in graph.nodes:
                 if node.type == PipelineNodeType.SOURCE and not node.config.get("channel_ids"):
-                    node.config["channel_ids"] = source_ids
+                    node.config["channel_ids"] = clean_ids
         if target_refs:
-            target_dicts = [{"phone": t.phone, "dialog_id": t.dialog_id} for t in target_refs]
+            seen: set[tuple[str, int]] = set()
+            target_dicts = []
+            for t in target_refs:
+                key = (t.phone, t.dialog_id)
+                if key not in seen:
+                    seen.add(key)
+                    target_dicts.append({"phone": t.phone, "dialog_id": t.dialog_id})
             for node in graph.nodes:
                 if node.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD) and not node.config.get("targets"):
                     node.config["targets"] = target_dicts

--- a/tests/test_pipeline_templates_builtin.py
+++ b/tests/test_pipeline_templates_builtin.py
@@ -1,7 +1,11 @@
 """Tests for built-in pipeline templates."""
 from __future__ import annotations
 
-from src.models import PipelineNodeType
+import pytest
+
+from src.database.bundles import PipelineBundle
+from src.models import Account, Channel, PipelineNodeType
+from src.services.pipeline_service import PipelineService, PipelineTargetRef
 from src.services.pipeline_templates_builtin import get_builtin_templates
 
 
@@ -64,3 +68,106 @@ def test_content_generation_template_exists():
     templates = get_builtin_templates()
     content_templates = [t for t in templates if t.category == "content"]
     assert len(content_templates) >= 2  # text-only and text+image
+
+
+# ------------------------------------------------------------------
+# Template wiring tests (source/target injection)
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+async def _seeded_db(db):
+    """DB with accounts, channels, and builtin templates seeded."""
+    await db.add_account(Account(phone="+100", session_string="sess"))
+    await db.add_channel(Channel(channel_id=1001, title="Source A"))
+    await db.add_channel(Channel(channel_id=1002, title="Source B"))
+    await db.repos.dialog_cache.replace_dialogs(
+        "+100",
+        [{"channel_id": 77, "title": "Target A", "username": "targeta", "channel_type": "channel"}],
+    )
+    # Seed builtin templates
+    templates = get_builtin_templates()
+    await db.repos.pipeline_templates.ensure_builtins(templates)
+    return db
+
+
+async def _create_from_template(db, template_name, source_ids, target_refs=None):
+    """Helper: create a pipeline from a builtin template by name."""
+    svc = PipelineService(PipelineBundle.from_database(db))
+    tpl = await db.repos.pipeline_templates.get_by_name(template_name)
+    assert tpl is not None, f"Template '{template_name}' not found"
+    return await svc.create_from_template(
+        tpl.id,
+        name=f"Test {template_name}",
+        source_ids=source_ids,
+        target_refs=target_refs or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_forward_template_source_wiring(_seeded_db):
+    db = _seeded_db
+    pipeline_id = await _create_from_template(
+        db, "Пересылка сообщений", [1001, 1002], [PipelineTargetRef(phone="+100", dialog_id=77)]
+    )
+    svc = PipelineService(PipelineBundle.from_database(db))
+    pipeline = await svc.get(pipeline_id)
+    graph = pipeline.pipeline_json
+
+    source_node = next(n for n in graph.nodes if n.type == PipelineNodeType.SOURCE)
+    assert source_node.config["channel_ids"] == [1001, 1002]
+
+    forward_node = next(n for n in graph.nodes if n.type == PipelineNodeType.FORWARD)
+    assert len(forward_node.config.get("targets", [])) == 1
+    assert forward_node.config["targets"][0]["phone"] == "+100"
+    assert forward_node.config["targets"][0]["dialog_id"] == 77
+
+
+@pytest.mark.asyncio
+async def test_react_template_source_wiring(_seeded_db):
+    db = _seeded_db
+    pipeline_id = await _create_from_template(db, "Реакции на сообщения", [1001])
+    svc = PipelineService(PipelineBundle.from_database(db))
+    pipeline = await svc.get(pipeline_id)
+
+    source_node = next(n for n in pipeline.pipeline_json.nodes if n.type == PipelineNodeType.SOURCE)
+    assert source_node.config["channel_ids"] == [1001]
+
+    react_node = next(n for n in pipeline.pipeline_json.nodes if n.type == PipelineNodeType.REACT)
+    assert react_node is not None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_template_source_wiring(_seeded_db):
+    db = _seeded_db
+    pipeline_id = await _create_from_template(db, "Удаление join/leave сообщений", [1001])
+    svc = PipelineService(PipelineBundle.from_database(db))
+    pipeline = await svc.get(pipeline_id)
+    graph = pipeline.pipeline_json
+
+    source_node = next(n for n in graph.nodes if n.type == PipelineNodeType.SOURCE)
+    assert source_node.config["channel_ids"] == [1001]
+
+    filter_node = next(n for n in graph.nodes if n.type == PipelineNodeType.FILTER)
+    assert "service_types" in filter_node.config
+
+    delete_node = next(n for n in graph.nodes if n.type == PipelineNodeType.DELETE_MESSAGE)
+    assert delete_node is not None
+
+
+@pytest.mark.asyncio
+async def test_template_without_targets_no_injection(_seeded_db):
+    """Templates without source_ids should leave source node config empty."""
+    db = _seeded_db
+    svc = PipelineService(PipelineBundle.from_database(db))
+    templates = get_builtin_templates()
+    await db.repos.pipeline_templates.ensure_builtins(templates)
+    tpl = await db.repos.pipeline_templates.get_by_name("Удаление join/leave сообщений")
+    assert tpl is not None
+
+    pipeline_id = await svc.create_from_template(
+        tpl.id, name="No sources", source_ids=[], target_refs=[]
+    )
+    pipeline = await svc.get(pipeline_id)
+    source_node = next(n for n in pipeline.pipeline_json.nodes if n.type == PipelineNodeType.SOURCE)
+    assert source_node.config.get("channel_ids") == []


### PR DESCRIPTION
## Summary
- Fix `create_from_template()` to inject `source_ids` into DAG source nodes' `channel_ids` config
- Fix `create_from_template()` to inject `target_refs` into DAG publish/forward nodes' `targets` config
- Previously these values were only stored in junction tables, leaving executor unable to fetch messages

## Test plan
- [x] `test_forward_template_source_wiring` — verifies source + target injection
- [x] `test_react_template_source_wiring` — verifies source injection for react template
- [x] `test_cleanup_template_source_wiring` — verifies source + filter + delete node structure
- [x] `test_template_without_targets_no_injection` — verifies no injection when no sources provided
- [x] Full pipeline test suite: 128/128 passed

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)