### PR TITLE
feat(pipelines): extend wizard with LLM action templates (#406)

### DIFF
--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -202,9 +202,16 @@ async def create_wizard_submit(
     svc = deps.pipeline_service(request)
     try:
         graph_data = _json.loads(pipeline_json)
+        # Extract llm_model from first LLM node config for pipeline-level setting
+        llm_model = ""
+        for node in graph_data.get("nodes", []):
+            if node.get("type") in ("llm_generate", "llm_refine", "agent_loop"):
+                llm_model = node.get("config", {}).get("model", "") or ""
+                break
         data = {
             "name": name,
             "prompt_template": ".",
+            "llm_model": llm_model or None,
             "source_ids": source_channel_ids,
             "target_refs": target_refs,
             "generate_interval_minutes": generate_interval_minutes,

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -171,12 +171,15 @@ async def create_wizard_page(request: Request):
     svc = deps.pipeline_service(request)
     accounts = await deps.get_account_bundle(request).list_accounts()
     cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    llm_provider_svc = deps.get_llm_provider_service(request)
+    llm_configured = llm_provider_svc.has_providers()
     return deps.get_templates(request).TemplateResponse(
         request,
         "pipelines/create.html",
         {
             "accounts": accounts,
             "cached_dialogs": cached_dialogs,
+            "llm_configured": llm_configured,
         },
     )
 

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -66,6 +66,53 @@
             </label>
         </div>
     </div>
+    <h5 class="mb-3 mt-4"><i class="bi bi-stars"></i> LLM-действия</h5>
+    <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'rewrite')">
+                <input type="radio" name="pipeline_type" value="rewrite">
+                <div class="card-body text-center">
+                    <i class="bi bi-pencil fs-2 mb-2"></i>
+                    <h6 class="card-title">Рерайт через LLM</h6>
+                    <p class="card-text small text-muted">Переписывает сообщения своими словами через LLM</p>
+                    <span class="badge bg-info text-dark"><i class="bi bi-stars"></i> Требует LLM</span>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'summarize')">
+                <input type="radio" name="pipeline_type" value="summarize">
+                <div class="card-body text-center">
+                    <i class="bi bi-file-text fs-2 mb-2"></i>
+                    <h6 class="card-title">Суммаризация</h6>
+                    <p class="card-text small text-muted">Создаёт краткое содержание постов через LLM</p>
+                    <span class="badge bg-info text-dark"><i class="bi bi-stars"></i> Требует LLM</span>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'translate')">
+                <input type="radio" name="pipeline_type" value="translate">
+                <div class="card-body text-center">
+                    <i class="bi bi-translate fs-2 mb-2"></i>
+                    <h6 class="card-title">Перевод</h6>
+                    <p class="card-text small text-muted">Переводит посты на другой язык через LLM</p>
+                    <span class="badge bg-info text-dark"><i class="bi bi-stars"></i> Требует LLM</span>
+                </div>
+            </label>
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="card wizard-type-card h-100 p-3" onclick="selectType(this, 'content_gen')">
+                <input type="radio" name="pipeline_type" value="content_gen">
+                <div class="card-body text-center">
+                    <i class="bi bi-magic fs-2 mb-2"></i>
+                    <h6 class="card-title">Генерация контента</h6>
+                    <p class="card-text small text-muted">Создаёт новый контент на основе контекста из источников</p>
+                    <span class="badge bg-info text-dark"><i class="bi bi-stars"></i> Требует LLM</span>
+                </div>
+            </label>
+        </div>
+    </div>
 </div>
 
 {# === Step 2: Sources === #}
@@ -237,6 +284,74 @@
         <div class="alert alert-info">
             <i class="bi bi-info-circle"></i> Преднастроенный пайплайн: автоматически удаляет сообщения о присоединении/выходе пользователей из чата.
             Никаких дополнительных настроек не требуется.
+        </div>
+    </div>
+
+    {# -- LLM panels (shared for rewrite/summarize/translate/content_gen) -- #}
+    <div class="action-panel d-none" id="panel-rewrite">
+        {% if not llm_configured %}
+        <div class="alert alert-warning"><i class="bi bi-exclamation-triangle"></i> Ни один LLM-провайдер не настроен. Пайплайн не сможет работать без LLM.</div>
+        {% endif %}
+        <div class="row g-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">LLM модель</label>
+                <input class="form-control" type="text" name="llm_model" placeholder="Например: openai:gpt-4o-mini">
+                <div class="form-text">Формат: provider:model_id. Оставьте пустым для модели по умолчанию.</div>
+            </div>
+        </div>
+        <div class="alert alert-info mt-3">
+            <i class="bi bi-info-circle"></i> Рерайт: переписывает текст сообщения своими словами, сохраняя смысл.
+        </div>
+    </div>
+
+    <div class="action-panel d-none" id="panel-summarize">
+        {% if not llm_configured %}
+        <div class="alert alert-warning"><i class="bi bi-exclamation-triangle"></i> Ни один LLM-провайдер не настроен. Пайплайн не сможет работать без LLM.</div>
+        {% endif %}
+        <div class="row g-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">LLM модель</label>
+                <input class="form-control" type="text" name="llm_model_sum" placeholder="Например: openai:gpt-4o-mini">
+                <div class="form-text">Формат: provider:model_id. Оставьте пустым для модели по умолчанию.</div>
+            </div>
+        </div>
+        <div class="alert alert-info mt-3">
+            <i class="bi bi-info-circle"></i> Суммаризация: создаёт краткое содержание постов из каналов-источников.
+        </div>
+    </div>
+
+    <div class="action-panel d-none" id="panel-translate">
+        {% if not llm_configured %}
+        <div class="alert alert-warning"><i class="bi bi-exclamation-triangle"></i> Ни один LLM-провайдер не настроен. Пайплайн не сможет работать без LLM.</div>
+        {% endif %}
+        <div class="row g-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">LLM модель</label>
+                <input class="form-control" type="text" name="llm_model_tr" placeholder="Например: openai:gpt-4o-mini">
+                <div class="form-text">Формат: provider:model_id. Оставьте пустым для модели по умолчанию.</div>
+            </div>
+            <div class="col-12 col-md-6">
+                <label class="form-label">Целевой язык</label>
+                <input class="form-control" type="text" name="target_language" value="русский">
+            </div>
+        </div>
+    </div>
+
+    <div class="action-panel d-none" id="panel-content_gen">
+        {% if not llm_configured %}
+        <div class="alert alert-warning"><i class="bi bi-exclamation-triangle"></i> Ни один LLM-провайдер не настроен. Пайплайн не сможет работать без LLM.</div>
+        {% endif %}
+        <div class="row g-3">
+            <div class="col-12 col-md-6">
+                <label class="form-label">LLM модель</label>
+                <input class="form-control" type="text" name="llm_model_gen" placeholder="Например: openai:gpt-4o-mini">
+                <div class="form-text">Формат: provider:model_id. Оставьте пустым для модели по умолчанию.</div>
+            </div>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Промпт для генерации</label>
+            <textarea class="form-control" name="gen_prompt" rows="3" placeholder="Напиши пост на основе контекста"></textarea>
+            <div class="form-text">Опишите что должен сгенерировать LLM на основе контекста из источников.</div>
         </div>
     </div>
 </div>
@@ -496,6 +611,40 @@
             edges.push({ from: lastSourceId, to: "filter_1" });
             nodes.push({ id: "delete_1", type: "delete_message", name: "Удаление", config: {}, position: { x: 440, y: 0 } });
             edges.push({ from: "filter_1", to: "delete_1" });
+
+        } else if (pipelineType === "rewrite") {
+            var llmModel = (document.querySelector('[name="llm_model"]') || {}).value || "";
+            nodes.push({ id: "refine_1", type: "llm_refine", name: "Рерайт", config: { prompt: "Перепиши следующий текст своими словами, сохранив смысл:\n\n{text}", model: llmModel }, position: { x: 220, y: 0 } });
+            edges.push({ from: lastSourceId, to: "refine_1" });
+            nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
+            edges.push({ from: "refine_1", to: "publish_1" });
+
+        } else if (pipelineType === "summarize") {
+            var llmModelS = (document.querySelector('[name="llm_model_sum"]') || {}).value || "";
+            nodes.push({ id: "context_1", type: "retrieve_context", name: "Контекст", config: {}, position: { x: 220, y: 0 } });
+            edges.push({ from: lastSourceId, to: "context_1" });
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Суммаризация", config: { prompt_template: "Сделай краткое содержание следующих сообщений:\n\n{context}", model: llmModelS }, position: { x: 330, y: 0 } });
+            edges.push({ from: "context_1", to: "llm_1" });
+            nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
+            edges.push({ from: "llm_1", to: "publish_1" });
+
+        } else if (pipelineType === "translate") {
+            var llmModelT = (document.querySelector('[name="llm_model_tr"]') || {}).value || "";
+            var targetLang = (document.querySelector('[name="target_language"]') || {}).value || "русский";
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Перевод", config: { prompt_template: "Переведи следующий текст на " + targetLang + ":\n\n{text}", model: llmModelT }, position: { x: 220, y: 0 } });
+            edges.push({ from: lastSourceId, to: "llm_1" });
+            nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
+            edges.push({ from: "llm_1", to: "publish_1" });
+
+        } else if (pipelineType === "content_gen") {
+            var llmModelG = (document.querySelector('[name="llm_model_gen"]') || {}).value || "";
+            var genPrompt = (document.querySelector('[name="gen_prompt"]') || {}).value || "Напиши пост на основе контекста";
+            nodes.push({ id: "context_1", type: "retrieve_context", name: "Контекст", config: {}, position: { x: 220, y: 0 } });
+            edges.push({ from: lastSourceId, to: "context_1" });
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Генерация", config: { prompt_template: genPrompt + "\n\n{context}", model: llmModelG }, position: { x: 330, y: 0 } });
+            edges.push({ from: "context_1", to: "llm_1" });
+            nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
+            edges.push({ from: "llm_1", to: "publish_1" });
         }
 
         return { nodes: nodes, edges: edges };
@@ -509,7 +658,7 @@
         var sources = getFormValues("source_channel_ids");
         var flow = graph.nodes.map(function(n) { return n.name; }).join(" → ");
 
-        var typeLabels = { forward: "Пересылка", react: "Авто-реакции", filter_action: "Фильтр + действие", cleanup: "Очистка чата" };
+        var typeLabels = { forward: "Пересылка", react: "Авто-реакции", filter_action: "Фильтр + действие", cleanup: "Очистка чата", rewrite: "Рерайт через LLM", summarize: "Суммаризация", translate: "Перевод", content_gen: "Генерация контента" };
         var dl = document.createElement("dl");
         dl.className = "row mb-0";
         function addRow(dt, ddContent, isCode) {

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -623,7 +623,7 @@
             var llmModelS = (document.querySelector('[name="llm_model_sum"]') || {}).value || "";
             nodes.push({ id: "context_1", type: "retrieve_context", name: "Контекст", config: {}, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "context_1" });
-            nodes.push({ id: "llm_1", type: "llm_generate", name: "Суммаризация", config: { prompt_template: "Сделай краткое содержание следующих сообщений:\n\n{context}", model: llmModelS }, position: { x: 330, y: 0 } });
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Суммаризация", config: { prompt_template: "Сделай краткое содержание следующих сообщений:\n\n{source_messages}", model: llmModelS }, position: { x: 330, y: 0 } });
             edges.push({ from: "context_1", to: "llm_1" });
             nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
             edges.push({ from: "llm_1", to: "publish_1" });
@@ -631,7 +631,7 @@
         } else if (pipelineType === "translate") {
             var llmModelT = (document.querySelector('[name="llm_model_tr"]') || {}).value || "";
             var targetLang = (document.querySelector('[name="target_language"]') || {}).value || "русский";
-            nodes.push({ id: "llm_1", type: "llm_generate", name: "Перевод", config: { prompt_template: "Переведи следующий текст на " + targetLang + ":\n\n{text}", model: llmModelT }, position: { x: 220, y: 0 } });
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Перевод", config: { prompt_template: "Переведи следующий текст на " + targetLang + ":\n\n{source_messages}", model: llmModelT }, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "llm_1" });
             nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
             edges.push({ from: "llm_1", to: "publish_1" });
@@ -639,9 +639,10 @@
         } else if (pipelineType === "content_gen") {
             var llmModelG = (document.querySelector('[name="llm_model_gen"]') || {}).value || "";
             var genPrompt = (document.querySelector('[name="gen_prompt"]') || {}).value || "Напиши пост на основе контекста";
+            var safePrompt = genPrompt.replace(/\{/g, "{{").replace(/\}/g, "}}");
             nodes.push({ id: "context_1", type: "retrieve_context", name: "Контекст", config: {}, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "context_1" });
-            nodes.push({ id: "llm_1", type: "llm_generate", name: "Генерация", config: { prompt_template: genPrompt + "\n\n{context}", model: llmModelG }, position: { x: 330, y: 0 } });
+            nodes.push({ id: "llm_1", type: "llm_generate", name: "Генерация", config: { prompt_template: safePrompt + "\n\n{source_messages}", model: llmModelG }, position: { x: 330, y: 0 } });
             edges.push({ from: "context_1", to: "llm_1" });
             nodes.push({ id: "publish_1", type: "publish", name: "Публикация", config: { targets: [], mode: "moderated" }, position: { x: 440, y: 0 } });
             edges.push({ from: "llm_1", to: "publish_1" });

--- a/tests/test_pipeline_templates_builtin.py
+++ b/tests/test_pipeline_templates_builtin.py
@@ -64,3 +64,53 @@ def test_content_generation_template_exists():
     templates = get_builtin_templates()
     content_templates = [t for t in templates if t.category == "content"]
     assert len(content_templates) >= 2  # text-only and text+image
+
+
+# ------------------------------------------------------------------
+# LLM template structure tests
+# ------------------------------------------------------------------
+
+
+def _find_template(name: str):
+    return next((t for t in get_builtin_templates() if t.name == name), None)
+
+
+def test_rewrite_template_has_llm_refine():
+    tpl = _find_template("Рерайт через LLM")
+    assert tpl is not None
+    node_types = {n.type for n in tpl.template_json.nodes}
+    assert PipelineNodeType.LLM_REFINE in node_types
+    assert PipelineNodeType.PUBLISH in node_types
+    refine_node = next(n for n in tpl.template_json.nodes if n.type == PipelineNodeType.LLM_REFINE)
+    assert refine_node.config.get("prompt")
+
+
+def test_summarize_template_has_retrieve_and_llm():
+    tpl = _find_template("Суммаризация постов")
+    assert tpl is not None
+    node_types = {n.type for n in tpl.template_json.nodes}
+    assert PipelineNodeType.RETRIEVE_CONTEXT in node_types
+    assert PipelineNodeType.LLM_GENERATE in node_types
+    assert PipelineNodeType.PUBLISH in node_types
+    llm_node = next(n for n in tpl.template_json.nodes if n.type == PipelineNodeType.LLM_GENERATE)
+    assert llm_node.config.get("prompt_template")
+
+
+def test_translate_template_has_llm():
+    tpl = _find_template("Перевод постов")
+    assert tpl is not None
+    node_types = {n.type for n in tpl.template_json.nodes}
+    assert PipelineNodeType.LLM_GENERATE in node_types
+    assert PipelineNodeType.PUBLISH in node_types
+    llm_node = next(n for n in tpl.template_json.nodes if n.type == PipelineNodeType.LLM_GENERATE)
+    prompt_text = llm_node.config.get("prompt_template", "").lower()
+    assert "перевод" in prompt_text or "переведи" in prompt_text
+
+
+def test_content_gen_template_has_retrieve_and_llm():
+    tpl = _find_template("Контент-генерация")
+    assert tpl is not None
+    node_types = {n.type for n in tpl.template_json.nodes}
+    assert PipelineNodeType.RETRIEVE_CONTEXT in node_types
+    assert PipelineNodeType.LLM_GENERATE in node_types
+    assert PipelineNodeType.PUBLISH in node_types


### PR DESCRIPTION
## Summary
- Add 4 LLM pipeline type cards to create wizard (rewrite, summarize, translate, content_gen)
- Each LLM type shows model selector, provider warning when no LLM configured
- Extend `buildPipelineGraph()` JS with proper DAG structures for each LLM type
- Add `llm_configured` flag to wizard page context from `AgentProviderService.has_providers()`
- Add structure tests for all 4 LLM builtin templates

## Test plan
- [x] `python3 -m pytest tests/test_pipeline_templates_builtin.py -v` — 11/11 passed
- [x] `python3 -m ruff check` — all checks passed
- [ ] Manual: wizard shows 8 type cards (4 simple + 4 LLM), LLM cards have badge, provider warning appears

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)