### PR TITLE
refactor(web): add status_dot and task_status_badge macros

### DIFF
--- a/src/web/templates/_macros_ui.html
+++ b/src/web/templates/_macros_ui.html
@@ -1,0 +1,42 @@
+{# UI utility macros: status_dot, task_status_badge, task_status_text. #}
+{% from "_macros.html" import icon %}
+
+{% macro status_dot(ch) %}
+{% if ch.is_filtered %}<span class="badge-filtered" title="Отфильтрован">&#9679;</span>
+{% elif ch.is_active %}<span class="badge-active">{{ icon("active") }}</span>
+{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}
+{% endmacro %}
+
+{% macro task_status_badge(task) %}
+{% if task.status == 'running' %}
+    <span class="spinner-border spinner-border-sm" role="status"></span>
+{% elif task.status == 'completed' %}
+    <span class="badge text-bg-success">OK</span>
+{% elif task.status == 'failed' %}
+    <span class="badge text-bg-danger">Ошибка</span>
+{% elif task.status == 'cancelled' %}
+    <span class="badge text-bg-secondary">Отменена</span>
+{% else %}
+    <span class="badge text-bg-warning">Ожидание</span>
+{% endif %}
+{% endmacro %}
+
+{% macro task_status_text(task) %}
+{% if task.status == 'running' %}
+    <span class="spinner-border spinner-border-sm" role="status"></span> Выполняется
+{% elif task.status == 'completed' %}
+    Завершено
+    {% if task.note %}<br><small class="text-muted">{{ task.note }}</small>{% endif %}
+{% elif task.status == 'failed' %}
+    <span class="badge text-bg-danger">Ошибка</span>
+    {% if task.error %}<br><small>{{ task.error[:100] }}</small>{% endif %}
+{% elif task.status == 'cancelled' %}
+    Отменена
+{% else %}
+    {% if task.run_after %}
+        Ожидание до {{ task.run_after|local_dt }}
+    {% else %}
+        Ожидание
+    {% endif %}
+{% endif %}
+{% endmacro %}

--- a/src/web/templates/_macros_ui.html
+++ b/src/web/templates/_macros_ui.html
@@ -1,5 +1,18 @@
-{# UI utility macros: status_dot, task_status_badge, task_status_text. #}
+{# UI utility macros: empty_state, card, status_dot, task_status_badge, task_status_text. #}
 {% from "_macros.html" import icon %}
+
+{% macro empty_state(text, icon_name=None, class='') %}
+<p class="text-muted {{ class }}">
+  {% if icon_name %}<i class="bi bi-{{ icon_name }} me-1"></i>{% endif %}{{ text }}
+</p>
+{% endmacro %}
+
+{% macro card(title) %}
+<div class="card mb-3">
+  <div class="card-header fw-semibold">{{ title }}</div>
+  <div class="card-body">{{ caller() }}</div>
+</div>
+{% endmacro %}
 
 {% macro status_dot(ch) %}
 {% if ch.is_filtered %}<span class="badge-filtered" title="Отфильтрован">&#9679;</span>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_macros.html" import icon, filter_flags, channel_actions %}
+{% from "_macros_ui.html" import status_dot %}
 {% block title %}Каналы — TG Agent{% endblock %}
 {% block content %}
 <h1>Каналы</h1>
@@ -70,9 +71,7 @@
             <td><small>{% if ch.about %}{{ ch.about[:60] }}{% if ch.about|length > 60 %}…{% endif %}{% else %}—{% endif %}</small></td>
             <td>{% if ch.channel_type == "channel" %}{% if not ch.username %}Канал <span title="Приватный">{{ icon("private") }}</span>{% else %}Канал{% endif %}{% elif ch.channel_type == "supergroup" %}{% if not ch.username %}Супергруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Супергруппа{% endif %}{% elif ch.channel_type == "gigagroup" %}{% if not ch.username %}Гигагруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Гигагруппа{% endif %}{% elif ch.channel_type == "group" %}{% if not ch.username %}Группа <span title="Приватная">{{ icon("private") }}</span>{% else %}Группа{% endif %}{% elif ch.channel_type == "forum" %}{% if not ch.username %}Форум <span title="Приватный">{{ icon("private") }}</span>{% else %}Форум{% endif %}{% elif ch.channel_type == "monoforum" %}Монофорум{% elif ch.channel_type == "restricted" %}<span class="text-danger">Ограничен</span>{% elif ch.channel_type == "scam" %}<span class="text-danger">Скам {{ icon("warning") }}</span>{% elif ch.channel_type == "fake" %}<span class="text-danger">Фейк {{ icon("warning") }}</span>{% elif ch.channel_type == "unavailable" %}<span class="text-muted">Недоступен</span>{% else %}<span class="text-muted">Непроверен</span>{% endif %}{% if ch.has_comments %} <span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}</td>
             <td>
-              {% if ch.is_filtered %}<span class="badge-filtered" title="Отфильтрован">&#9679;</span>
-              {% elif ch.is_active %}<span class="badge-active">{{ icon("active") }}</span>
-              {% else %}<span class="badge-inactive">&#9679;</span>{% endif %}
+              {{ status_dot(ch) }}
             </td>
             <td>{{ ch.message_count }}</td>
             <td>
@@ -119,9 +118,7 @@
             <div class="d-flex justify-content-between align-items-start">
                 <div class="min-w-0 flex-fill">
                     <div class="d-flex align-items-center gap-1 mb-1">
-                        {% if ch.is_filtered %}<span class="badge-filtered">&#9679;</span>
-                        {% elif ch.is_active %}<span class="badge-active">{{ icon("active") }}</span>
-                        {% else %}<span class="badge-inactive">&#9679;</span>{% endif %}
+                        {{ status_dot(ch) }}
                         <strong class="text-truncate">{{ ch.title or "—" }}</strong>
                         {% if ch.has_comments %}<span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}
                     </div>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_macros.html" import icon %}
+{% from "_macros_ui.html" import task_status_badge, task_status_text %}
 {% block title %}Планировщик — TG Agent{% endblock %}
 {% block content %}
 <h1>Планировщик</h1>
@@ -222,23 +223,7 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if t.status == 'running' %}
-                            <span class="spinner-border spinner-border-sm" role="status"></span> Выполняется
-                        {% elif t.status == 'completed' %}
-                            Завершено
-                            {% if t.note %}<br><small class="text-muted">{{ t.note }}</small>{% endif %}
-                        {% elif t.status == 'failed' %}
-                            <span class="badge text-bg-danger">Ошибка</span>
-                            {% if t.error %}<br><small>{{ t.error[:100] }}</small>{% endif %}
-                        {% elif t.status == 'cancelled' %}
-                            Отменена
-                        {% else %}
-                            {% if t.run_after %}
-                                Ожидание до {{ t.run_after|local_dt }}
-                            {% else %}
-                                Ожидание
-                            {% endif %}
-                        {% endif %}
+                        {{ task_status_text(t) }}
                     </td>
                     <td>
                         {% if t.task_type == 'stats_all' and t.payload and t.payload.channel_ids %}
@@ -277,17 +262,7 @@
                             {% if t.channel_username %}<br><small class="text-muted">@{{ t.channel_username }}</small>{% endif %}
                         </div>
                         <span>
-                            {% if t.status == 'running' %}
-                                <span class="spinner-border spinner-border-sm" role="status"></span>
-                            {% elif t.status == 'completed' %}
-                                <span class="badge text-bg-success">OK</span>
-                            {% elif t.status == 'failed' %}
-                                <span class="badge text-bg-danger">Ошибка</span>
-                            {% elif t.status == 'cancelled' %}
-                                <span class="badge text-bg-secondary">Отменена</span>
-                            {% else %}
-                                <span class="badge text-bg-warning">Ожидание</span>
-                            {% endif %}
+                            {{ task_status_badge(t) }}
                         </span>
                     </div>
                     <small class="text-muted">


### PR DESCRIPTION
## Summary
Closes #371

- Created `_macros_ui.html` with `status_dot(ch)`, `task_status_badge(task)`, and `task_status_text(task)` macros
- Replaced duplicated status dot logic in `channels.html` (desktop table + mobile cards)
- Replaced duplicated 5-branch task status ladder in `scheduler.html` (desktop text version + mobile badge version)
- ~34 lines of duplicated template code consolidated into reusable macros

**Note:** This PR should be merged after #419 (PR #370) which also creates `_macros_ui.html`. If merged independently, the file is self-contained.

## Test plan
- [x] `ruff check` passes
- [x] 4868 tests pass (1 pre-existing date-sensitive failure unrelated to changes)
- [ ] Visual check: status dots render correctly on /channels (desktop + mobile)
- [ ] Visual check: task status badges/text render correctly on /scheduler (desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)