### PR TITLE
feat(logging): rotate logs to data/app.log, wire debug page to file

### DIFF
--- a/src/cli/commands/debug.py
+++ b/src/cli/commands/debug.py
@@ -6,6 +6,7 @@ import os
 import resource
 
 from src.cli import runtime
+from src.cli.runtime import APP_LOG_PATH
 
 
 def run(args: argparse.Namespace) -> None:
@@ -14,21 +15,14 @@ def run(args: argparse.Namespace) -> None:
         try:
             if args.debug_action == "logs":
                 limit = args.limit
-                log_path = os.path.join(os.path.dirname(os.path.abspath("config.yaml")), "app.log")
-                if not os.path.exists(log_path):
-                    # Try common locations
-                    for candidate in ["app.log", "/tmp/tg_content_factory.log"]:
-                        if os.path.exists(candidate):
-                            log_path = candidate
-                            break
-                if os.path.exists(log_path):
-                    with open(log_path, encoding="utf-8", errors="replace") as f:
+                if APP_LOG_PATH.exists():
+                    with open(APP_LOG_PATH, encoding="utf-8", errors="replace") as f:
                         lines = f.readlines()
                     for line in lines[-limit:]:
                         print(line, end="")
                 else:
-                    print(f"No log file found at {log_path}")
-                    print("Tip: logs are typically written to stdout in this project.")
+                    print(f"No log file found at {APP_LOG_PATH}")
+                    print("Tip: start the server first — logs are written to data/app.log.")
 
             elif args.debug_action == "memory":
                 usage = resource.getrusage(resource.RUSAGE_SELF)

--- a/src/cli/commands/debug.py
+++ b/src/cli/commands/debug.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import os
 import resource
+from collections import deque
 
 from src.cli import runtime
 from src.cli.runtime import APP_LOG_PATH
@@ -17,8 +18,8 @@ def run(args: argparse.Namespace) -> None:
                 limit = args.limit
                 if APP_LOG_PATH.exists():
                     with open(APP_LOG_PATH, encoding="utf-8", errors="replace") as f:
-                        lines = f.readlines()
-                    for line in lines[-limit:]:
+                        tail = deque(f, maxlen=limit)
+                    for line in tail:
                         print(line, end="")
                 else:
                     print(f"No log file found at {APP_LOG_PATH}")

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -24,6 +24,10 @@ def setup_logging() -> None:
         format=_LOG_FORMAT,
         datefmt=_LOG_DATEFMT,
     )
+    root = logging.getLogger()
+    for h in root.handlers:
+        if isinstance(h, RotatingFileHandler) and getattr(h, "baseFilename", None) == str(APP_LOG_PATH):
+            return
     _DATA_ROOT.mkdir(parents=True, exist_ok=True)
     rfh = RotatingFileHandler(
         str(APP_LOG_PATH),
@@ -32,7 +36,7 @@ def setup_logging() -> None:
         encoding="utf-8",
     )
     rfh.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
-    logging.getLogger().addHandler(rfh)
+    root.addHandler(rfh)
 
 
 def ensure_data_dirs() -> None:

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from src.config import load_config, resolve_session_encryption_secret
@@ -14,6 +15,7 @@ _DATA_ROOT = PROJECT_ROOT / "data"
 _LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 _LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 _TUI_LOG_PATH = _DATA_ROOT / "agent_tui.log"
+APP_LOG_PATH = _DATA_ROOT / "app.log"
 
 
 def setup_logging() -> None:
@@ -22,6 +24,15 @@ def setup_logging() -> None:
         format=_LOG_FORMAT,
         datefmt=_LOG_DATEFMT,
     )
+    _DATA_ROOT.mkdir(parents=True, exist_ok=True)
+    rfh = RotatingFileHandler(
+        str(APP_LOG_PATH),
+        maxBytes=10 * 1024 * 1024,
+        backupCount=3,
+        encoding="utf-8",
+    )
+    rfh.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATEFMT))
+    logging.getLogger().addHandler(rfh)
 
 
 def ensure_data_dirs() -> None:
@@ -48,7 +59,8 @@ def restore_logging(removed_handlers: list[logging.Handler] | logging.Handler | 
     """Restore console handlers after TUI exits."""
     root = logging.getLogger()
     for h in root.handlers[:]:
-        if isinstance(h, logging.FileHandler):
+        # Remove only plain FileHandlers (TUI log), not RotatingFileHandler (app.log)
+        if type(h) is logging.FileHandler:
             h.close()
             root.removeHandler(h)
     if isinstance(removed_handlers, list):

--- a/src/web/routes/debug.py
+++ b/src/web/routes/debug.py
@@ -2,27 +2,55 @@ from __future__ import annotations
 
 import gc
 import platform
+import re
 import resource
+from collections import deque
+from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.cli.runtime import APP_LOG_PATH
 from src.web import deps
 
 router = APIRouter()
 
+_LOG_RE = re.compile(
+    r"^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+"
+    r"\[(?P<level>\w+)]\s+"
+    r"(?P<logger>\S+?):\s+"
+    r"(?P<message>.*)$",
+)
+
+
+def _read_log_tail(path: Path | None = None, max_lines: int = 500) -> list[dict]:
+    if path is None:
+        path = APP_LOG_PATH
+    if not path.exists():
+        return []
+    lines: deque[str] = deque(maxlen=max_lines)
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            lines.append(line)
+    records: list[dict] = []
+    for line in lines:
+        m = _LOG_RE.match(line.rstrip())
+        if m:
+            records.append(m.groupdict())
+        elif records:
+            records[-1]["message"] += "\n" + line.rstrip()
+    return records
+
 
 @router.get("/", response_class=HTMLResponse)
 async def debug_page(request: Request):
-    log_buffer = deps.get_log_buffer(request)
-    records = log_buffer.get_records() if log_buffer is not None else []
+    records = _read_log_tail()
     return deps.get_templates(request).TemplateResponse(request, "debug.html", {"records": records})
 
 
 @router.get("/logs", response_class=HTMLResponse)
 async def debug_logs_partial(request: Request):
-    log_buffer = deps.get_log_buffer(request)
-    records = log_buffer.get_records() if log_buffer is not None else []
+    records = _read_log_tail()
     return deps.get_templates(request).TemplateResponse(
         request, "_debug_logs.html", {"records": records}
     )

--- a/src/web/routes/debug.py
+++ b/src/web/routes/debug.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import gc
 import platform
 import re
@@ -28,10 +29,13 @@ def _read_log_tail(path: Path | None = None, max_lines: int = 500) -> list[dict]
         path = APP_LOG_PATH
     if not path.exists():
         return []
-    lines: deque[str] = deque(maxlen=max_lines)
-    with open(path, encoding="utf-8", errors="replace") as f:
-        for line in f:
-            lines.append(line)
+    try:
+        lines: deque[str] = deque(maxlen=max_lines)
+        with open(path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                lines.append(line)
+    except OSError:
+        return []
     records: list[dict] = []
     for line in lines:
         m = _LOG_RE.match(line.rstrip())
@@ -44,13 +48,15 @@ def _read_log_tail(path: Path | None = None, max_lines: int = 500) -> list[dict]
 
 @router.get("/", response_class=HTMLResponse)
 async def debug_page(request: Request):
-    records = _read_log_tail()
+    loop = asyncio.get_running_loop()
+    records = await loop.run_in_executor(None, _read_log_tail)
     return deps.get_templates(request).TemplateResponse(request, "debug.html", {"records": records})
 
 
 @router.get("/logs", response_class=HTMLResponse)
 async def debug_logs_partial(request: Request):
-    records = _read_log_tail()
+    loop = asyncio.get_running_loop()
+    records = await loop.run_in_executor(None, _read_log_tail)
     return deps.get_templates(request).TemplateResponse(
         request, "_debug_logs.html", {"records": records}
     )

--- a/src/web/templates/pipelines/edit.html
+++ b/src/web/templates/pipelines/edit.html
@@ -161,42 +161,6 @@
 
     <button type="submit" class="btn btn-primary me-2"><i class="bi bi-check-lg"></i> Сохранить</button>
     <a href="/pipelines" class="btn btn-secondary">Отмена</a>
-
-    <span class="ms-3 d-inline-flex align-items-center gap-2">
-        <input type="number" id="edit-since-value" value="24" min="1"
-               class="form-control form-control-sm" style="width:64px">
-        <select id="edit-since-unit" class="form-select form-select-sm" style="width:72px">
-            <option value="m">мин</option>
-            <option value="h" selected>ч</option>
-            <option value="d">д</option>
-        </select>
-    </span>
-    <form method="post" action="/pipelines/{{ pipeline.id }}/run" class="d-inline" id="edit-run-form">
-        <input type="hidden" name="since_value" id="edit-run-since-value">
-        <input type="hidden" name="since_unit" id="edit-run-since-unit">
-        <button type="submit" class="btn btn-outline-primary btn-sm"
-                onclick="syncEditRunParams()">&#x25BA; Запустить</button>
-    </form>
-    <button type="button" class="btn btn-outline-warning btn-sm"
-            onclick="editDryRunCount({{ pipeline.id }})">&#x1F9EA; Тест</button>
-
-    <script>
-    function syncEditRunParams() {
-        document.getElementById("edit-run-since-value").value =
-            document.getElementById("edit-since-value").value;
-        document.getElementById("edit-run-since-unit").value =
-            document.getElementById("edit-since-unit").value;
-    }
-    function editDryRunCount(id) {
-        var sv = document.getElementById("edit-since-value").value;
-        var su = document.getElementById("edit-since-unit").value;
-        fetch("/pipelines/" + id + "/dry-run-count?since_value=" + sv + "&since_unit=" + su)
-            .then(function(r) { return r.json(); })
-            .then(function(d) {
-                showToast("Тест: " + d.total + " сообщений, " + d.after_filter + " пройдут обработку");
-            }).catch(function() { showToast("Ошибка при подсчёте"); });
-    }
-    </script>
 </form>
 
 {% if is_dag %}

--- a/src/web/templates/pipelines/edit.html
+++ b/src/web/templates/pipelines/edit.html
@@ -161,6 +161,42 @@
 
     <button type="submit" class="btn btn-primary me-2"><i class="bi bi-check-lg"></i> Сохранить</button>
     <a href="/pipelines" class="btn btn-secondary">Отмена</a>
+
+    <span class="ms-3 d-inline-flex align-items-center gap-2">
+        <input type="number" id="edit-since-value" value="24" min="1"
+               class="form-control form-control-sm" style="width:64px">
+        <select id="edit-since-unit" class="form-select form-select-sm" style="width:72px">
+            <option value="m">мин</option>
+            <option value="h" selected>ч</option>
+            <option value="d">д</option>
+        </select>
+    </span>
+    <form method="post" action="/pipelines/{{ pipeline.id }}/run" class="d-inline" id="edit-run-form">
+        <input type="hidden" name="since_value" id="edit-run-since-value">
+        <input type="hidden" name="since_unit" id="edit-run-since-unit">
+        <button type="submit" class="btn btn-outline-primary btn-sm"
+                onclick="syncEditRunParams()">&#x25BA; Запустить</button>
+    </form>
+    <button type="button" class="btn btn-outline-warning btn-sm"
+            onclick="editDryRunCount({{ pipeline.id }})">&#x1F9EA; Тест</button>
+
+    <script>
+    function syncEditRunParams() {
+        document.getElementById("edit-run-since-value").value =
+            document.getElementById("edit-since-value").value;
+        document.getElementById("edit-run-since-unit").value =
+            document.getElementById("edit-since-unit").value;
+    }
+    function editDryRunCount(id) {
+        var sv = document.getElementById("edit-since-value").value;
+        var su = document.getElementById("edit-since-unit").value;
+        fetch("/pipelines/" + id + "/dry-run-count?since_value=" + sv + "&since_unit=" + su)
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                showToast("Тест: " + d.total + " сообщений, " + d.after_filter + " пройдут обработку");
+            }).catch(function() { showToast("Ошибка при подсчёте"); });
+    }
+    </script>
 </form>
 
 {% if is_dag %}

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -8,11 +8,12 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.web.log_handler import LogBuffer
+from src.web.routes.debug import _read_log_tail
 
 
 @pytest.fixture
 async def client(base_app):
-    """Create test client with log buffer."""
+    """Create test client."""
     app, _, pool = base_app
 
     async def _resolve_channel(identifier):
@@ -37,34 +38,59 @@ async def client(base_app):
     ) as c:
         yield c
 
-@pytest.fixture
-async def client_no_buffer(base_app):
-    """Create test client without log buffer."""
-    app, _, pool = base_app
 
-    async def _resolve_channel(identifier):
-        return {
-            "channel_id": -1001234567890,
-            "title": "Test Channel",
-            "username": "testchannel",
-            "channel_type": "channel",
-        }
+# ─── _read_log_tail unit tests ───────────────────────────────────────
 
-    pool.clients = {}
-    pool.resolve_channel = _resolve_channel
-    app.state.log_buffer = None  # No buffer
-
-    transport = ASGITransport(app=app)
-    auth_header = base64.b64encode(b":testpass").decode()
-    async with AsyncClient(
-        transport=transport,
-        base_url="http://test",
-        follow_redirects=True,
-        headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
-    ) as c:
-        yield c
+def test_read_log_tail_missing_file(tmp_path):
+    """Returns empty list when log file does not exist."""
+    assert _read_log_tail(tmp_path / "nonexistent.log") == []
 
 
+def test_read_log_tail_parses_records(tmp_path):
+    """Parses standard log lines into dicts."""
+    log = tmp_path / "app.log"
+    log.write_text(
+        "2024-01-01 12:00:00 [INFO] myapp.service: Started\n"
+        "2024-01-01 12:00:01 [WARNING] myapp.db: Slow query\n",
+        encoding="utf-8",
+    )
+    records = _read_log_tail(log)
+    assert len(records) == 2
+    assert records[0] == {
+        "time": "2024-01-01 12:00:00", "level": "INFO",
+        "logger": "myapp.service", "message": "Started",
+    }
+    assert records[1]["level"] == "WARNING"
+    assert records[1]["logger"] == "myapp.db"
+
+
+def test_read_log_tail_multiline(tmp_path):
+    """Continuation lines are merged into the previous record."""
+    log = tmp_path / "app.log"
+    log.write_text(
+        "2024-01-01 12:00:00 [ERROR] app: Something failed\n"
+        "Traceback (most recent call last):\n"
+        "  File foo.py, line 1\n"
+        "ValueError: bad value\n",
+        encoding="utf-8",
+    )
+    records = _read_log_tail(log)
+    assert len(records) == 1
+    assert "Traceback" in records[0]["message"]
+    assert "ValueError" in records[0]["message"]
+
+
+def test_read_log_tail_respects_max_lines(tmp_path):
+    """Only the last max_lines lines are considered."""
+    log = tmp_path / "app.log"
+    lines = [f"2024-01-01 12:00:{i:02d} [INFO] app: msg {i}\n" for i in range(10)]
+    log.write_text("".join(lines), encoding="utf-8")
+    records = _read_log_tail(log, max_lines=3)
+    assert len(records) == 3
+    assert "msg 9" in records[-1]["message"]
+
+
+# ─── route smoke tests ───────────────────────────────────────────────
 
 @pytest.mark.asyncio
 async def test_debug_page_renders(client):
@@ -75,28 +101,24 @@ async def test_debug_page_renders(client):
 
 
 @pytest.mark.asyncio
-async def test_debug_page_with_records(client):
-    """Test debug page shows log records."""
-    # Add some log records
-    import logging
-
-    logger = logging.getLogger("test_debug")
-    handler = client._transport.app.state.log_buffer
-    handler.setFormatter(logging.Formatter())
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-
-    logger.info("Test message 1")
-    logger.warning("Test warning message")
-
+async def test_debug_page_reads_from_file(client, tmp_path, monkeypatch):
+    """Debug page shows records read from log file."""
+    log = tmp_path / "app.log"
+    log.write_text(
+        "2024-01-01 12:00:00 [INFO] test.logger: Hello from file\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("src.web.routes.debug.APP_LOG_PATH", log)
     resp = await client.get("/debug/")
     assert resp.status_code == 200
+    assert "Hello from file" in resp.text
 
 
 @pytest.mark.asyncio
-async def test_debug_page_without_buffer(client_no_buffer):
-    """Test debug page when no log buffer configured."""
-    resp = await client_no_buffer.get("/debug/")
+async def test_debug_page_empty_when_no_file(client, tmp_path, monkeypatch):
+    """Debug page renders without error when log file is absent."""
+    monkeypatch.setattr("src.web.routes.debug.APP_LOG_PATH", tmp_path / "missing.log")
+    resp = await client.get("/debug/")
     assert resp.status_code == 200
 
 
@@ -108,9 +130,10 @@ async def test_debug_logs_partial(client):
 
 
 @pytest.mark.asyncio
-async def test_debug_logs_partial_without_buffer(client_no_buffer):
-    """Test debug logs partial when no buffer configured."""
-    resp = await client_no_buffer.get("/debug/logs")
+async def test_debug_page_empty_buffer(client):
+    """Kept for compatibility — debug page renders when buffer is empty."""
+    client._transport.app.state.log_buffer._records.clear()
+    resp = await client.get("/debug/")
     assert resp.status_code == 200
 
 
@@ -203,16 +226,6 @@ async def test_log_buffer_exception():
     assert "ValueError" in records[0]["message"]
 
 
-@pytest.mark.asyncio
-async def test_debug_page_empty_buffer(client):
-    """Test debug page with empty log buffer."""
-    # Clear buffer
-    client._transport.app.state.log_buffer._records.clear()
-
-    resp = await client.get("/debug/")
-    assert resp.status_code == 200
-
-
 # ─── timing endpoint tests ──────────────────────────────────────────
 
 
@@ -224,23 +237,9 @@ async def test_debug_timing_page(client):
 
 
 @pytest.mark.asyncio
-async def test_debug_timing_page_without_buffer(client_no_buffer):
-    """Test timing page when no timing buffer configured."""
-    resp = await client_no_buffer.get("/debug/timing")
-    assert resp.status_code == 200
-
-
-@pytest.mark.asyncio
 async def test_debug_timing_rows(client):
     """Test timing rows partial."""
     resp = await client.get("/debug/timing/rows")
-    assert resp.status_code == 200
-
-
-@pytest.mark.asyncio
-async def test_debug_timing_rows_without_buffer(client_no_buffer):
-    """Test timing rows without buffer."""
-    resp = await client_no_buffer.get("/debug/timing/rows")
     assert resp.status_code == 200
 
 

--- a/tests/test_cli_runtime_extra.py
+++ b/tests/test_cli_runtime_extra.py
@@ -95,9 +95,9 @@ class TestRedirectLogging:
 
             # Console handler should be back
             assert console in root.handlers
-            # File handler should be gone
-            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
-            assert len(file_handlers) == 0
+            # Plain TUI FileHandler should be gone; RotatingFileHandler (app.log) may remain
+            plain_file_handlers = [h for h in root.handlers if type(h) is logging.FileHandler]
+            assert len(plain_file_handlers) == 0
         finally:
             root.handlers = original_handlers
 


### PR DESCRIPTION
## Summary

- Adds `RotatingFileHandler` (10 MB, 3 backups) to `setup_logging()` — all console output is now mirrored to `data/app.log`
- Debug page (`/debug/`, `/debug/logs`) reads last 500 lines from file instead of in-memory `LogBuffer`; multiline entries (stack traces) are merged into one record
- `restore_logging` fixed to use exact type check so `RotatingFileHandler` survives TUI-mode log redirection cycles
- CLI `debug logs` now uses the canonical `APP_LOG_PATH` constant instead of a fragile `os.path.abspath("config.yaml")` guess

## Test plan

- [x] `pytest tests/routes/test_debug_routes.py` — 17 passed (4 new unit tests for `_read_log_tail`, integration smoke via `monkeypatch`)
- [x] `pytest tests/test_cli_runtime_extra.py` — 10 passed (updated `test_restore_logging` assertion)
- [x] Full parallel suite: 4870 passed, 0 failed
- [x] Full serial suite: 695 passed, 0 failed
- [x] `ruff check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)