### PR TITLE
fix(web): surface collector flood wait state

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -307,7 +307,16 @@ class CollectionQueue:
                 continue
             force = bool((task.payload or {}).get("force", False))
             full = bool((task.payload or {}).get("full", True))
-            await self._queue.put((task.id, channel, force, full))
+            if task.run_after is not None and task.run_after.timestamp() > time.time():
+                self._schedule_requeue_after_delay(
+                    task_id=task.id,
+                    channel=channel,
+                    force=force,
+                    full=full,
+                    run_after=task.run_after,
+                )
+            else:
+                await self._queue.put((task.id, channel, force, full))
             count += 1
         if count:
             self._ensure_worker()

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -70,6 +70,11 @@ class CollectionQueue:
             else:
                 self._queue.task_done()
                 removed_from_memory += 1
+        # Cancel any delayed requeues (flood-wait timers) so they don't
+        # re-inject deleted task IDs back into the queue.
+        for task in list(self._delayed_requeues):
+            task.cancel()
+        self._delayed_requeues.clear()
         logger.info(
             "Cleared %d pending collection tasks from DB and %d queued items from memory",
             deleted,
@@ -126,9 +131,14 @@ class CollectionQueue:
             if task.run_after is not None:
                 remaining = task.run_after.timestamp() - time.time()
                 if remaining > 0:
-                    self._queue.put_nowait((task_id, channel, force, full))
+                    self._schedule_requeue_after_delay(
+                        task_id=task_id,
+                        channel=channel,
+                        force=force,
+                        full=full,
+                        run_after=task.run_after,
+                    )
                     self._queue.task_done()
-                    await asyncio.sleep(min(remaining, 60.0))
                     continue
 
             # Channel may become filtered after being queued.

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
+from datetime import timedelta, timezone
 
 from src.database import Database
 from src.database.bundles import ChannelBundle
 from src.models import Channel, CollectionTaskStatus
-from src.telegram.collector import Collector
+from src.telegram.collector import (
+    AllCollectionClientsFloodedError,
+    Collector,
+    NoActiveCollectionClientsError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +27,7 @@ class CollectionQueue:
         self._worker: asyncio.Task | None = None
         self._current_task_id: int | None = None
         self._retried_tasks: set[int] = set()
+        self._delayed_requeues: set[asyncio.Task] = set()
 
     async def enqueue(self, channel: Channel, force: bool = False, full: bool = True) -> int | None:
         """Enqueue a channel for collection, atomically skipping duplicates.
@@ -74,6 +81,26 @@ class CollectionQueue:
         if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._run_worker())
 
+    def _schedule_requeue_after_delay(
+        self,
+        *,
+        task_id: int,
+        channel: Channel,
+        force: bool,
+        full: bool,
+        run_after,
+    ) -> None:
+        async def _requeue_later() -> None:
+            remaining = max(0.0, run_after.timestamp() - time.time())
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            self._queue.put_nowait((task_id, channel, force, full))
+            self._ensure_worker()
+
+        task = asyncio.create_task(_requeue_later())
+        self._delayed_requeues.add(task)
+        task.add_done_callback(self._delayed_requeues.discard)
+
     async def _run_worker(self) -> None:
         while True:
             try:
@@ -96,6 +123,13 @@ class CollectionQueue:
             if task and task.status == CollectionTaskStatus.CANCELLED:
                 self._queue.task_done()
                 continue
+            if task.run_after is not None:
+                remaining = task.run_after.timestamp() - time.time()
+                if remaining > 0:
+                    self._queue.put_nowait((task_id, channel, force, full))
+                    self._queue.task_done()
+                    await asyncio.sleep(min(remaining, 60.0))
+                    continue
 
             # Channel may become filtered after being queued.
             fresh_channel = None
@@ -161,6 +195,43 @@ class CollectionQueue:
                         note=note,
                     )
                     logger.info("Collected %d messages from channel %d", count, channel.channel_id)
+            except AllCollectionClientsFloodedError as exc:
+                run_after = exc.next_available_at + timedelta(seconds=5)
+                note = (
+                    "Отложено: все аккаунты во Flood Wait "
+                    f"до {exc.next_available_at.astimezone(timezone.utc).isoformat()}"
+                )
+                self._retried_tasks.discard(task_id)
+                await self._channels.reschedule_collection_task(
+                    task_id,
+                    run_after=run_after,
+                    note=note,
+                )
+                self._schedule_requeue_after_delay(
+                    task_id=task_id,
+                    channel=channel,
+                    force=force,
+                    full=full,
+                    run_after=run_after,
+                )
+                logger.warning(
+                    "Rescheduled collection task %d for channel %d until %s: all clients flooded",
+                    task_id,
+                    channel.channel_id,
+                    run_after.isoformat(),
+                )
+            except NoActiveCollectionClientsError as exc:
+                self._retried_tasks.discard(task_id)
+                await self._channels.update_collection_task(
+                    task_id,
+                    CollectionTaskStatus.FAILED,
+                    error=str(exc)[:500],
+                    note="Нет подключённых активных аккаунтов для сбора.",
+                )
+                logger.error(
+                    "Collection failed for channel %d: no active connected clients",
+                    channel.channel_id,
+                )
             except ConnectionError as exc:
                 requeued = await self._try_reconnect_and_requeue(task_id, channel, full, force, exc)
                 if not requeued:
@@ -248,6 +319,13 @@ class CollectionQueue:
             self._worker.cancel()
             try:
                 await self._worker
+            except asyncio.CancelledError:
+                pass
+        for task in list(self._delayed_requeues):
+            task.cancel()
+        for task in list(self._delayed_requeues):
+            try:
+                await task
             except asyncio.CancelledError:
                 pass
         self._retried_tasks.clear()

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -232,6 +232,7 @@ class ChannelBundle:
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
+        run_after: datetime | None = None,
     ) -> None:
         await self.tasks.update_collection_task(
             task_id,
@@ -239,6 +240,22 @@ class ChannelBundle:
             messages_collected,
             error,
             note,
+            run_after,
+        )
+
+    async def reschedule_collection_task(
+        self,
+        task_id: int,
+        *,
+        run_after: datetime,
+        note: str | None = None,
+        messages_collected: int = 0,
+    ) -> None:
+        await self.tasks.reschedule_collection_task(
+            task_id,
+            run_after=run_after,
+            note=note,
+            messages_collected=messages_collected,
         )
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -624,9 +624,33 @@ class Database:
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
+        run_after: datetime | None = None,
     ) -> None:
         self._require()
-        await self._tasks.update_collection_task(task_id, status, messages_collected, error, note)
+        await self._tasks.update_collection_task(
+            task_id,
+            status,
+            messages_collected,
+            error,
+            note,
+            run_after,
+        )
+
+    async def reschedule_collection_task(
+        self,
+        task_id: int,
+        *,
+        run_after: datetime,
+        note: str | None = None,
+        messages_collected: int = 0,
+    ) -> None:
+        self._require()
+        await self._tasks.reschedule_collection_task(
+            task_id,
+            run_after=run_after,
+            note=note,
+            messages_collected=messages_collected,
+        )
 
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
         self._require()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -241,6 +241,7 @@ class CollectionTasksRepository:
         messages_collected: int | None = None,
         error: str | None = None,
         note: str | None = None,
+        run_after: datetime | None = None,
     ) -> None:
         status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -259,6 +260,40 @@ class CollectionTasksRepository:
         if error is not None:
             sets.append("error = ?")
             params.append(error)
+        if note is not None:
+            sets.append("note = ?")
+            params.append(note)
+        if run_after is not None:
+            sets.append("run_after = ?")
+            params.append(run_after.astimezone(timezone.utc).isoformat())
+        params.append(task_id)
+        await self._db.execute(
+            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
+            tuple(params),
+        )
+        await self._db.commit()
+
+    async def reschedule_collection_task(
+        self,
+        task_id: int,
+        *,
+        run_after: datetime,
+        note: str | None = None,
+        messages_collected: int = 0,
+    ) -> None:
+        sets = [
+            "status = ?",
+            "run_after = ?",
+            "started_at = NULL",
+            "completed_at = NULL",
+            "error = NULL",
+            "messages_collected = ?",
+        ]
+        params: list[Any] = [
+            CollectionTaskStatus.PENDING.value,
+            run_after.astimezone(timezone.utc).isoformat(),
+            messages_collected,
+        ]
         if note is not None:
             sets.append("note = ?")
             params.append(note)
@@ -404,7 +439,7 @@ class CollectionTasksRepository:
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
             "WHERE task_type = ? AND status = ? "
-            "ORDER BY id ASC",
+            "ORDER BY COALESCE(run_after, ''), id ASC",
             (
                 CollectionTaskType.CHANNEL_COLLECT.value,
                 CollectionTaskStatus.PENDING.value,

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -49,7 +49,23 @@ class NoActiveStatsClientsError(RuntimeError):
     """Raised when there are no active connected clients for stats collection."""
 
 
+class NoActiveCollectionClientsError(RuntimeError):
+    """Raised when there are no active connected clients for message collection."""
+
+
 class AllStatsClientsFloodedError(RuntimeError):
+    """Raised when all active connected clients are in flood-wait."""
+
+    def __init__(self, retry_after_sec: int, next_available_at: datetime):
+        super().__init__(
+            "All active clients are flood-waited until "
+            f"{next_available_at.isoformat()} (retry in {retry_after_sec}s)"
+        )
+        self.retry_after_sec = retry_after_sec
+        self.next_available_at = next_available_at
+
+
+class AllCollectionClientsFloodedError(RuntimeError):
     """Raised when all active connected clients are in flood-wait."""
 
     def __init__(self, retry_after_sec: int, next_available_at: datetime):
@@ -80,6 +96,15 @@ class Collector:
         self._lock = asyncio.Lock()
         self._stats_lock = asyncio.Lock()
         self._stats_all_lock = asyncio.Lock()
+        self._last_unavailability_log: tuple[str, str | int | None, datetime | None] | None = None
+
+    async def get_collection_availability(self):
+        availability_fn = getattr(self._pool, "get_stats_availability", None)
+        if callable(availability_fn):
+            result = availability_fn()
+            if asyncio.iscoroutine(result):
+                return await result
+        return await self._fallback_collection_availability()
 
     @property
     def is_running(self) -> bool:
@@ -94,7 +119,77 @@ class Collector:
         return self._config.delay_between_channels_sec
 
     async def get_stats_availability(self):
-        return await self._pool.get_stats_availability()
+        return await self.get_collection_availability()
+
+    async def _fallback_collection_availability(self):
+        connected = bool(getattr(self._pool, "clients", {}))
+        if connected:
+            return type(
+                "Availability",
+                (),
+                {
+                    "state": "available",
+                    "retry_after_sec": None,
+                    "next_available_at_utc": None,
+                },
+            )()
+        return type(
+            "Availability",
+            (),
+            {
+                "state": "no_connected_active",
+                "retry_after_sec": None,
+                "next_available_at_utc": None,
+            },
+        )()
+
+    def _log_collection_unavailability_once(
+        self,
+        *,
+        state: str,
+        retry_after_sec: int | None = None,
+        next_available_at: datetime | None = None,
+    ) -> None:
+        signature = (state, retry_after_sec, next_available_at)
+        if self._last_unavailability_log == signature:
+            logger.debug(
+                "Collection clients still unavailable: state=%s retry_after_sec=%s next_available_at=%s",
+                state,
+                retry_after_sec,
+                next_available_at.isoformat() if next_available_at else None,
+            )
+            return
+        self._last_unavailability_log = signature
+        if state == "all_flooded" and retry_after_sec is not None and next_available_at is not None:
+            logger.error(
+                "No available clients for collection: all active clients are flood-waited until %s "
+                "(retry in %ss)",
+                next_available_at.isoformat(),
+                retry_after_sec,
+            )
+            return
+        logger.error("No available clients for collection: no active connected clients")
+
+    def _reset_collection_unavailability_log(self) -> None:
+        self._last_unavailability_log = None
+
+    async def _raise_collection_unavailability(self) -> None:
+        availability = await self.get_collection_availability()
+        self._log_collection_unavailability_once(
+            state=availability.state,
+            retry_after_sec=availability.retry_after_sec,
+            next_available_at=availability.next_available_at_utc,
+        )
+        if (
+            availability.state == "all_flooded"
+            and availability.retry_after_sec is not None
+            and availability.next_available_at_utc is not None
+        ):
+            raise AllCollectionClientsFloodedError(
+                retry_after_sec=availability.retry_after_sec,
+                next_available_at=availability.next_available_at_utc,
+            )
+        raise NoActiveCollectionClientsError("No active connected clients")
 
     async def cancel(self) -> None:
         self._cancel_event.set()
@@ -328,10 +423,10 @@ class Collector:
 
             result = await self._pool.get_available_client()
             if result is None:
-                logger.error("No available clients for collection")
-                return total_collected
+                await self._raise_collection_unavailability()
 
             session, phone = result
+            self._reset_collection_unavailability_log()
             session = adapt_transport_session(session, disconnect_on_close=False)
             # Populate entity cache when using PeerChannel
             # (StringSession loses cache between restarts).

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -355,6 +355,10 @@ class Collector:
                         stats["channels"] += 1
                         stats["messages"] += collected
                         await asyncio.sleep(self._config.delay_between_channels_sec)
+                    except (AllCollectionClientsFloodedError, NoActiveCollectionClientsError) as e:
+                        logger.error("Stopping collection: %s", e)
+                        stats["errors"] += 1
+                        break
                     except Exception as e:
                         logger.error("Error collecting channel %s: %s", channel.channel_id, e)
                         stats["errors"] += 1

--- a/src/web/routes/dashboard.py
+++ b/src/web/routes/dashboard.py
@@ -42,6 +42,8 @@ async def dashboard(request: Request):
 
     now = datetime.now(tz=timezone.utc)
     flood_wait_count = 0
+    all_connected_flooded = True
+    connected_count = len(deps.get_pool(request).clients)
     for a in accounts:
         if a.flood_wait_until:
             until = a.flood_wait_until
@@ -49,6 +51,17 @@ async def dashboard(request: Request):
                 until = until.replace(tzinfo=timezone.utc)
             if until > now:
                 flood_wait_count += 1
+        if a.is_active and a.phone in deps.get_pool(request).clients:
+            until = a.flood_wait_until
+            if until is None:
+                all_connected_flooded = False
+            else:
+                if until.tzinfo is None:
+                    until = until.replace(tzinfo=timezone.utc)
+                if until <= now:
+                    all_connected_flooded = False
+    if connected_count == 0:
+        all_connected_flooded = False
 
     last_task = await db.repos.tasks.get_last_completed_collect_task()
     active_tasks = await db.repos.tasks.count_collection_tasks("active")
@@ -63,8 +76,9 @@ async def dashboard(request: Request):
             "stats": stats,
             "scheduler_running": scheduler.is_running,
             "scheduler_interval": scheduler.interval_minutes,
-            "accounts_connected": len(deps.get_pool(request).clients),
+            "accounts_connected": connected_count,
             "accounts_flood_wait": flood_wait_count,
+            "collector_attention": all_connected_flooded,
             "last_collect_ago": _time_ago(last_task.completed_at if last_task else None),
             "active_tasks": active_tasks,
             "content_pending": calendar_stats["pending"],

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from datetime import timezone
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -30,6 +30,147 @@ def _job_label(job_id: str) -> str:
     if job_id.startswith("content_generate_"):
         return f"Генерация #{job_id.removeprefix('content_generate_')}"
     return job_id
+
+
+def _format_retry_hint(run_after) -> str:
+    if run_after is None:
+        return ""
+    return run_after.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _compute_load_level(
+    *,
+    interval_minutes: int,
+    active_unfiltered_channels: int,
+    available_accounts_now: int,
+    state: str,
+) -> str:
+    if state in {"all_flooded", "no_clients"}:
+        return "overload"
+    capacity_accounts = max(1, available_accounts_now)
+    pressure = active_unfiltered_channels / capacity_accounts
+    if interval_minutes <= 15 and pressure >= 60:
+        return "overload"
+    if interval_minutes <= 30 and pressure >= 40:
+        return "high"
+    if pressure >= 75:
+        return "high"
+    return "ok"
+
+
+def _collector_health_recommendations(
+    *,
+    state: str,
+    load_level: str,
+    interval_minutes: int,
+    active_unfiltered_channels: int,
+    available_accounts_now: int,
+) -> list[str]:
+    recommendations: list[str] = []
+    if state == "all_flooded":
+        recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
+    if state == "no_clients":
+        recommendations.append("Проверить активность аккаунтов и переподключить хотя бы один рабочий клиент.")
+    if load_level in {"high", "overload"}:
+        recommendations.append(
+            f"Поднять интервал автосбора выше текущих {interval_minutes} мин, чтобы снизить частоту обращений."
+        )
+        recommendations.append(
+            "Сократить число активных отслеживаемых каналов: "
+            f"сейчас активных неотфильтрованных {active_unfiltered_channels}."
+        )
+    if available_accounts_now <= 1:
+        recommendations.append("Добавить ещё Telegram-аккаунты, чтобы распределить нагрузку по чтению.")
+    return recommendations
+
+
+async def _build_collector_health_context(request: Request) -> dict[str, object]:
+    db = deps.get_db(request)
+    pool = deps.get_pool(request)
+    collector = deps.get_collector(request)
+    accounts = await db.get_accounts(active_only=False)
+    connected_phones = set(pool.clients.keys())
+    active_accounts = [acc for acc in accounts if acc.is_active]
+    connected_active_accounts = [acc for acc in active_accounts if acc.phone in connected_phones]
+    now = datetime.now(timezone.utc)
+
+    flooded_accounts = []
+    next_available_at = None
+    for acc in connected_active_accounts:
+        flood_until = acc.flood_wait_until
+        if flood_until is None:
+            continue
+        if flood_until.tzinfo is None:
+            flood_until = flood_until.replace(tzinfo=timezone.utc)
+        if flood_until <= now:
+            continue
+        flooded_accounts.append({"phone": acc.phone, "until": flood_until})
+        if next_available_at is None or flood_until < next_available_at:
+            next_available_at = flood_until
+
+    availability = await collector.get_collection_availability()
+    availability_state = getattr(availability, "state", "no_connected_active")
+    availability_retry_after = getattr(availability, "retry_after_sec", None)
+    availability_next = getattr(availability, "next_available_at_utc", None)
+    if not isinstance(availability_next, datetime):
+        availability_next = None
+    if not isinstance(availability_retry_after, int):
+        availability_retry_after = None
+    available_accounts_now = max(0, len(connected_active_accounts) - len(flooded_accounts))
+    active_unfiltered_channels = len(await db.get_channels(active_only=True, include_filtered=False))
+    recent_tasks = await db.get_collection_tasks(limit=200)
+    recent_zero_collect_count = sum(
+        1
+        for task in recent_tasks
+        if task.task_type.value == "channel_collect"
+        and task.status == "completed"
+        and task.messages_collected == 0
+    )
+    recent_unavailability_events = [
+        task.note or task.error or ""
+        for task in recent_tasks
+        if (task.note and "Flood Wait" in task.note) or (task.error and "No active connected clients" in task.error)
+    ][:5]
+
+    state = "healthy"
+    if not connected_active_accounts:
+        state = "no_clients"
+    elif availability_state == "all_flooded" or available_accounts_now == 0:
+        state = "all_flooded"
+    elif flooded_accounts:
+        state = "degraded"
+
+    interval_minutes = max(1, getattr(deps.get_scheduler(request), "interval_minutes", 60))
+    load_level = _compute_load_level(
+        interval_minutes=interval_minutes,
+        active_unfiltered_channels=active_unfiltered_channels,
+        available_accounts_now=available_accounts_now,
+        state=state,
+    )
+    return {
+        "state": state,
+        "connected_accounts": len(connected_phones),
+        "active_accounts": len(active_accounts),
+        "available_accounts_now": available_accounts_now,
+        "flooded_accounts": flooded_accounts,
+        "flooded_accounts_count": len(flooded_accounts),
+        "next_available_at": next_available_at or availability_next,
+        "retry_after_sec": availability_retry_after,
+        "active_unfiltered_channels": active_unfiltered_channels,
+        "collect_interval_minutes": interval_minutes,
+        "load_level": load_level,
+        "recommendations": _collector_health_recommendations(
+            state=state,
+            load_level=load_level,
+            interval_minutes=interval_minutes,
+            active_unfiltered_channels=active_unfiltered_channels,
+            available_accounts_now=available_accounts_now,
+        ),
+        "recent_zero_collect_count": recent_zero_collect_count,
+        "recent_unavailability_events": recent_unavailability_events,
+        "is_running": collector.is_running,
+        "next_available_label": _format_retry_hint(next_available_at or availability_next),
+    }
 
 
 @router.post("/tasks/{task_id}/cancel")
@@ -163,6 +304,7 @@ async def _scheduler_page_inner(
     ) or bot is not None
 
     scheduler_jobs = await _build_jobs_context(sched, db)
+    collector_health = await _build_collector_health_context(request)
 
     context = {
         "is_running": sched.is_running,
@@ -181,6 +323,7 @@ async def _scheduler_page_inner(
         "bot_configured": bot_configured,
         "pending_collect_count": pending_collect_count,
         "scheduler_jobs": scheduler_jobs,
+        "collector_health": collector_health,
     }
 
     templates = deps.get_templates(request)

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -426,6 +426,38 @@ async def settings_page(request: Request):
                 await db.update_account_flood(_acc.phone, None)
                 _acc.flood_wait_until = None
     connected_phones = set(pool.clients.keys())
+    account_status: dict[str, dict[str, object]] = {}
+    flooded_connected = []
+    for _acc in accounts:
+        connected = _acc.phone in connected_phones
+        if not _acc.is_active:
+            state = "inactive"
+            remaining_seconds = 0
+        elif not connected:
+            state = "disconnected"
+            remaining_seconds = 0
+        elif _acc.flood_wait_until is not None:
+            _flood_until = _acc.flood_wait_until
+            if _flood_until.tzinfo is None:
+                _flood_until = _flood_until.replace(tzinfo=UTC)
+            remaining_seconds = max(0, int((_flood_until - _now).total_seconds()))
+            if remaining_seconds > 0:
+                state = "flood"
+                flooded_connected.append(_flood_until)
+            else:
+                state = "available"
+        else:
+            state = "available"
+            remaining_seconds = 0
+        account_status[_acc.phone] = {
+            "state": state,
+            "remaining_seconds": remaining_seconds,
+            "remaining_minutes": max(1, remaining_seconds // 60) if remaining_seconds else 0,
+        }
+    all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
+        [acc for acc in accounts if acc.is_active and acc.phone in connected_phones]
+    )
+    next_available_at = min(flooded_connected) if flooded_connected else None
     notification_target = await deps.get_notification_target_service(request).describe_target()
     notification_bot = None
     notification_bot_error = None
@@ -487,8 +519,11 @@ async def settings_page(request: Request):
             "auto_delete_filtered": auto_delete_filtered,
             "auto_delete_on_collect": auto_delete_on_collect,
             "accounts": accounts,
+            "account_status": account_status,
             "account_phones": [acc.phone for acc in accounts],
             "connected_phones": connected_phones,
+            "all_accounts_flooded": all_accounts_flooded,
+            "next_available_at": next_available_at,
             "notification_target": notification_target,
             "notification_selected_phone": notification_target.configured_phone or "",
             "notification_bot": notification_bot,

--- a/src/web/templates/_macros_ui.html
+++ b/src/web/templates/_macros_ui.html
@@ -45,11 +45,13 @@
     {% if task.error %}<br><small>{{ task.error[:100] }}</small>{% endif %}
 {% elif task.status == 'cancelled' %}
     Отменена
+    {% if task.note %}<br><small class="text-muted">{{ task.note }}</small>{% endif %}
 {% else %}
     {% if task.run_after %}
         Ожидание до {{ task.run_after|local_dt }}
     {% else %}
         Ожидание
     {% endif %}
+    {% if task.note %}<br><small class="text-muted">{{ task.note }}</small>{% endif %}
 {% endif %}
 {% endmacro %}

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -11,6 +11,7 @@
                 <p class="mb-1"><strong>{{ stats.get('accounts', 0) }}</strong> в базе</p>
                 <p class="mb-1"><strong>{{ accounts_connected }}</strong> подключено</p>
                 {% if accounts_flood_wait %}<p class="mb-0 text-warning"><strong>{{ accounts_flood_wait }}</strong> в flood-wait</p>{% endif %}
+                {% if collector_attention %}<p class="mb-0 small"><a href="/scheduler">Коллектор ограничен, открыть диагностику</a></p>{% endif %}
             </div>
             <div class="card-footer"><a href="/settings">Управление</a></div>
         </div>

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -59,6 +59,78 @@
     </div>
 </div>
 
+{% if collector_health.state != 'healthy' or collector_health.load_level != 'ok' %}
+<div class="card mb-4 border-{% if collector_health.state in ['all_flooded', 'no_clients'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
+    <div class="card-header fw-semibold">
+        Здоровье коллектора
+        {% if collector_health.state == 'all_flooded' %}
+        <span class="badge text-bg-danger ms-2">Все аккаунты во Flood Wait</span>
+        {% elif collector_health.state == 'no_clients' %}
+        <span class="badge text-bg-danger ms-2">Нет доступных клиентов</span>
+        {% elif collector_health.state == 'degraded' %}
+        <span class="badge text-bg-warning ms-2">Частичная деградация</span>
+        {% endif %}
+        {% if collector_health.load_level == 'overload' %}
+        <span class="badge text-bg-danger ms-1">Перегрузка</span>
+        {% elif collector_health.load_level == 'high' %}
+        <span class="badge text-bg-warning ms-1">Высокая нагрузка</span>
+        {% endif %}
+    </div>
+    <div class="card-body">
+        <div class="row g-3 mb-3">
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Аккаунты</div>
+                <div><strong>{{ collector_health.available_accounts_now }}</strong> доступно сейчас</div>
+                <div><strong>{{ collector_health.connected_accounts }}</strong> подключено</div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Flood Wait</div>
+                <div><strong>{{ collector_health.flooded_accounts_count }}</strong> заблокировано</div>
+                {% if collector_health.next_available_label %}
+                <div class="small">Раньше всего: {{ collector_health.next_available_label }}</div>
+                {% endif %}
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Нагрузка</div>
+                <div><strong>{{ collector_health.active_unfiltered_channels }}</strong> активных каналов</div>
+                <div class="small">Интервал: {{ collector_health.collect_interval_minutes }} мин</div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Симптом</div>
+                <div><strong>{{ collector_health.recent_zero_collect_count }}</strong> недавних задач с нулевым результатом</div>
+                <div class="small">{% if collector_health.is_running %}Коллектор занят{% else %}Коллектор ждёт{% endif %}</div>
+            </div>
+        </div>
+
+        {% if collector_health.flooded_accounts %}
+        <p class="mb-2"><strong>Почему сейчас не собираем:</strong> доступных аккаунтов нет или их недостаточно. Flood Wait активен для:
+        {% for item in collector_health.flooded_accounts %}
+            <code>{{ item.phone }}</code>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+        </p>
+        {% endif %}
+
+        {% if collector_health.recommendations %}
+        <p class="mb-1"><strong>Что делать:</strong></p>
+        <ul class="mb-2">
+            {% for item in collector_health.recommendations %}
+            <li>{{ item }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+
+        {% if collector_health.recent_unavailability_events %}
+        <p class="mb-1"><strong>Последние причины недоступности:</strong></p>
+        <ul class="mb-0">
+            {% for item in collector_health.recent_unavailability_events %}
+            <li><small>{{ item }}</small></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+
 <!-- Scheduler Jobs -->
 {% if scheduler_jobs %}
 <div class="card mb-4">

--- a/src/web/templates/settings/_accounts.html
+++ b/src/web/templates/settings/_accounts.html
@@ -1,5 +1,13 @@
 <p><a href="/auth/login" class="btn btn-primary btn-sm"><i class="bi bi-plus-lg me-1" aria-hidden="true"></i>Добавить аккаунт</a></p>
 
+{% if all_accounts_flooded %}
+<div class="alert alert-warning" role="alert">
+    Все подключённые аккаунты сейчас во Flood Wait.
+    {% if next_available_at %}Ближайшая разблокировка: <strong>{{ next_available_at|local_dt }}</strong>.{% endif %}
+    <a href="/scheduler" class="alert-link">Открыть планировщик и посмотреть рекомендации</a>.
+</div>
+{% endif %}
+
 {% if accounts %}
 <!-- Desktop: table -->
 <div class="table-responsive d-none d-md-block">
@@ -10,7 +18,7 @@
             <th>Статус</th>
             <th class="text-center">Premium</th>
             <th class="text-center">Primary</th>
-            <th class="text-center">Подключён</th>
+            <th class="text-center">Доступность</th>
             <th>Flood wait</th>
             <th>Добавлен</th>
             <th>Действия</th>
@@ -23,8 +31,20 @@
             <td>{% if acc.is_active %}<span class="badge-active">&#9679; Активен</span>{% else %}<span class="badge-inactive">&#9679; Отключён</span>{% endif %}</td>
             <td class="text-center">{% if acc.is_premium %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
             <td class="text-center">{% if acc.is_primary %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
-            <td class="text-center">{% if acc.phone in connected_phones %}<span class="badge-active">&#9679;</span>{% else %}<span class="badge-inactive">&#9679;</span>{% endif %}</td>
-            <td>{{ acc.flood_wait_until|local_dt("time") }}</td>
+            <td class="text-center">
+                {% if account_status[acc.phone].state == 'available' %}<span class="badge text-bg-success">OK</span>
+                {% elif account_status[acc.phone].state == 'flood' %}<span class="badge text-bg-warning">Flood</span>
+                {% elif account_status[acc.phone].state == 'disconnected' %}<span class="badge text-bg-secondary">Нет соединения</span>
+                {% else %}<span class="badge text-bg-secondary">Неактивен</span>{% endif %}
+            </td>
+            <td>
+                {% if acc.flood_wait_until and account_status[acc.phone].state == 'flood' %}
+                {{ acc.flood_wait_until|local_dt("time") }}
+                <br><small class="text-muted">ещё {{ account_status[acc.phone].remaining_minutes }} мин</small>
+                {% else %}
+                <span class="text-muted">—</span>
+                {% endif %}
+            </td>
             <td>{{ acc.created_at|local_dt("date") }}</td>
             <td class="text-nowrap">
                 <form method="post" action="/settings/{{ acc.id }}/toggle" class="d-inline" data-busy>
@@ -57,8 +77,9 @@
             <small class="text-muted">
                 {% if acc.is_premium %}Premium{% endif %}
                 {% if acc.is_primary %}&middot; Primary{% endif %}
-                {% if acc.phone in connected_phones %}&middot; Подключён{% endif %}
-                {% if acc.flood_wait_until %}&middot; Flood: {{ acc.flood_wait_until|local_dt("time") }}{% endif %}
+                {% if account_status[acc.phone].state == 'available' %}&middot; Доступен{% endif %}
+                {% if account_status[acc.phone].state == 'disconnected' %}&middot; Не подключён{% endif %}
+                {% if account_status[acc.phone].state == 'flood' %}&middot; Flood до {{ acc.flood_wait_until|local_dt("time") }} ({{ account_status[acc.phone].remaining_minutes }} мин){% endif %}
                 {% if acc.created_at %}&middot; {{ acc.created_at|local_dt("date") }}{% endif %}
             </small>
             <div class="card-actions">

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -186,6 +187,21 @@ async def test_scheduler_shows_collector_status(client):
     # Should show collector status somewhere
     text_lower = resp.text.lower()
     assert "running" in text_lower or "остановлен" in text_lower or "запущен" in text_lower
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shows_collector_health_card_when_all_accounts_flooded(client):
+    db = client._transport.app.state.db
+    accounts = await db.get_accounts(active_only=False)
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    for acc in accounts:
+        await db.update_account_flood(acc.phone, future)
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    assert "Здоровье коллектора" in resp.text
+    assert "Flood Wait" in resp.text
+    assert "Что делать" in resp.text
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -48,6 +49,27 @@ async def test_settings_shows_accounts(client):
         resp = await client.get("/settings/")
         assert resp.status_code == 200
         assert "+1234567890" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_settings_shows_flood_banner_and_account_availability(client, db):
+    accounts = await db.get_accounts(active_only=False)
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    for acc in accounts:
+        await db.update_account_flood(acc.phone, future)
+
+    with patch(
+        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        AsyncMock(return_value={}),
+    ):
+        resp = await client.get("/settings/")
+        assert resp.status_code == 200
+        assert "Все подключённые аккаунты сейчас во Flood Wait" in resp.text
+        assert "Открыть планировщик и посмотреть рекомендации" in resp.text
+        assert "Flood" in resp.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1133,6 +1133,34 @@ async def test_requeue_startup_tasks_cancels_orphaned(db):
 
 
 @pytest.mark.asyncio
+async def test_requeue_startup_tasks_defers_future_run_after(db):
+    """Startup tasks with run_after in the future go to _delayed_requeues, not the main queue."""
+    from datetime import datetime, timedelta, timezone
+
+    from src.collection_queue import CollectionQueue
+
+    ch = Channel(channel_id=-100170, title="Future Task", username="future_ch")
+    await db.add_channel(ch)
+
+    task_id = await db.create_collection_task(
+        -100170, "Future Task", channel_username="future_ch"
+    )
+    run_after = datetime.now(tz=timezone.utc) + timedelta(minutes=5)
+    await db.repos.tasks.reschedule_collection_task(task_id, run_after=run_after)
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
+    collector = Collector(pool, db, SchedulerConfig())
+    queue = CollectionQueue(collector, db)
+
+    count = await queue.requeue_startup_tasks()
+    assert count == 1
+    assert queue._queue.empty(), "Future-dated task should not be in the main queue"
+    assert len(queue._delayed_requeues) == 1, "Future-dated task should be in _delayed_requeues"
+
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_collection_queue_cancels_deleted_channel(db):
     from src.collection_queue import CollectionQueue
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,7 +9,11 @@ from telethon.tl.types import PeerChannel
 
 from src.config import SchedulerConfig
 from src.models import Channel, ChannelStats, CollectionTaskStatus, Message, StatsAllTaskPayload
-from src.telegram.collector import Collector
+from src.telegram.collector import (
+    AllCollectionClientsFloodedError,
+    Collector,
+    NoActiveCollectionClientsError,
+)
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
 from tests.helpers import FakeTelethonClient, make_mock_message, make_mock_pool, make_mock_reactions
@@ -35,8 +39,9 @@ async def test_collect_no_clients(db):
     config = SchedulerConfig()
     collector = Collector(pool, db, config)
     stats = await collector.collect_all_channels()
-    assert stats["channels"] == 1
+    assert stats["channels"] == 0
     assert stats["messages"] == 0
+    assert stats["errors"] == 1
 
 
 @pytest.mark.asyncio
@@ -49,8 +54,9 @@ async def test_collect_all_skips_filtered_channels(db):
     collector = Collector(pool, db, SchedulerConfig())
 
     stats = await collector.collect_all_channels()
-    assert stats["channels"] == 1
+    assert stats["channels"] == 0
     assert stats["messages"] == 0
+    assert stats["errors"] == 1
 
 
 @pytest.mark.asyncio
@@ -63,8 +69,56 @@ async def test_collect_all_invalid_min_subscribers_setting_falls_back_to_zero(db
     collector = Collector(pool, db, SchedulerConfig())
 
     stats = await collector.collect_all_channels()
-    assert stats["channels"] == 1
-    assert stats["errors"] == 0
+    assert stats["channels"] == 0
+    assert stats["errors"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_single_channel_raises_all_clients_flooded(db):
+    ch = Channel(channel_id=-100124, title="Flooded")
+    await db.add_channel(ch)
+
+    next_available_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(return_value=None),
+        get_stats_availability=AsyncMock(
+            return_value=SimpleNamespace(
+                state="all_flooded",
+                retry_after_sec=120,
+                next_available_at_utc=next_available_at,
+            )
+        ),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig())
+
+    with pytest.raises(AllCollectionClientsFloodedError) as exc:
+        await collector.collect_single_channel(ch)
+
+    assert exc.value.retry_after_sec == 120
+    assert exc.value.next_available_at == next_available_at
+
+
+@pytest.mark.asyncio
+async def test_collect_single_channel_raises_no_active_clients(db):
+    ch = Channel(channel_id=-100125, title="No Clients")
+    await db.add_channel(ch)
+
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(return_value=None),
+        get_stats_availability=AsyncMock(
+            return_value=SimpleNamespace(
+                state="no_connected_active",
+                retry_after_sec=None,
+                next_available_at_utc=None,
+            )
+        ),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig())
+
+    with pytest.raises(NoActiveCollectionClientsError):
+        await collector.collect_single_channel(ch)
 
 
 @pytest.mark.asyncio
@@ -678,7 +732,7 @@ async def test_collect_channel_rotates_on_long_flood_wait(db):
 
 @pytest.mark.asyncio
 async def test_collect_channel_long_flood_all_accounts_flooded_returns(db):
-    """FloodWait > max_flood_wait_sec with no other account available — return collected so far."""
+    """FloodWait > max_flood_wait_sec with no other account available surfaces unavailability."""
     ch = Channel(channel_id=-100173, title="AllFlood", username="allflood", last_collected_id=5)
     ch_id = await db.add_channel(ch)
     await db.update_channel_last_id(ch.channel_id, 5)
@@ -709,17 +763,26 @@ async def test_collect_channel_long_flood_all_accounts_flooded_returns(db):
                 (client1, "+70001"),  # first iteration
                 None,  # all accounts flooded on retry
             ]
-        )
+        ),
+        get_stats_availability=AsyncMock(
+            return_value=SimpleNamespace(
+                state="all_flooded",
+                retry_after_sec=600,
+                next_available_at_utc=datetime.now(timezone.utc) + timedelta(minutes=10),
+            )
+        ),
     )
     collector = Collector(
         pool,
         db,
         SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
     )
-    count = await collector._collect_channel(stored)
+    with pytest.raises(AllCollectionClientsFloodedError):
+        await collector._collect_channel(stored)
 
-    # Returns what was collected before the flood
-    assert count == 1
+    updated = await db.get_channel_by_channel_id(stored.channel_id)
+    assert updated is not None
+    assert updated.last_collected_id == 6
     pool.report_flood.assert_awaited_once()
 
 
@@ -914,6 +977,65 @@ async def test_collection_queue_force_tasks_keep_full_collection(db):
     _, kwargs = collector.collect_single_channel.await_args
     assert kwargs["force"] is True
     assert kwargs["full"] is True
+
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_collection_queue_reschedules_when_all_clients_flooded(db):
+    from src.collection_queue import CollectionQueue
+
+    await db.add_channel(Channel(channel_id=-100163, title="Flood Wait", username="flood_wait_ch"))
+
+    collector = Collector(make_mock_pool(), db, SchedulerConfig())
+    next_available_at = datetime.now(timezone.utc)
+    collector.collect_single_channel = AsyncMock(
+        side_effect=AllCollectionClientsFloodedError(
+            retry_after_sec=180,
+            next_available_at=next_available_at,
+        )
+    )
+    queue = CollectionQueue(collector, db)
+    queue._ensure_worker = lambda: None
+
+    stored_ch = next(c for c in await db.get_channels() if c.channel_id == -100163)
+    task_id = await queue.enqueue(stored_ch, force=True)
+
+    await queue._run_worker()
+
+    task = await db.get_collection_task(task_id)
+    assert task is not None
+    assert task.status == CollectionTaskStatus.PENDING
+    assert task.run_after is not None
+    assert task.note is not None
+    assert "Flood Wait" in task.note
+
+    await queue.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_collection_queue_fails_when_no_active_clients(db):
+    from src.collection_queue import CollectionQueue
+
+    await db.add_channel(Channel(channel_id=-100164, title="No Clients", username="no_clients_ch"))
+
+    collector = Collector(make_mock_pool(), db, SchedulerConfig())
+    collector.collect_single_channel = AsyncMock(
+        side_effect=NoActiveCollectionClientsError("No active connected clients")
+    )
+    queue = CollectionQueue(collector, db)
+    queue._ensure_worker = lambda: None
+
+    stored_ch = next(c for c in await db.get_channels() if c.channel_id == -100164)
+    task_id = await queue.enqueue(stored_ch, force=True)
+
+    await queue._run_worker()
+
+    task = await db.get_collection_task(task_id)
+    assert task is not None
+    assert task.status == CollectionTaskStatus.FAILED
+    assert task.error == "No active connected clients"
+    assert task.note == "Нет подключённых активных аккаунтов для сбора."
 
     await queue.shutdown()
 


### PR DESCRIPTION
## Summary
- surface collector health and flood wait diagnostics in the scheduler UI
- stop masking unavailable Telegram clients as completed zero-message collection tasks
- reschedule blocked collection tasks with run_after when all accounts are flooded
- improve account availability display in settings and add a dashboard hint

## Root Cause
Regular collection treated `get_available_client() -> None` as a zero-result success path. When all Telegram accounts were in Flood Wait, the queue marked channel tasks as completed with `messages_collected=0`, which hid the real issue and made the UI look healthy.

## Validation
- `python3 -m pytest tests/test_collector.py tests/routes/test_scheduler_routes.py tests/routes/test_settings_routes.py tests/routes/test_accounts_routes.py -q`
- `ruff check src/telegram/collector.py src/collection_queue.py src/database/repositories/collection_tasks.py src/database/bundles.py src/database/facade.py src/web/routes/scheduler.py src/web/routes/settings.py src/web/routes/dashboard.py tests/test_collector.py tests/routes/test_scheduler_routes.py tests/routes/test_settings_routes.py`
