### PR TITLE
feat(cli): unified pipeline add via --node DSL + auto-wiring

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -88,23 +88,117 @@ def run(args: argparse.Namespace) -> None:
                     print(f" - {target.phone}:{target.dialog_id} ({target.title or '—'})")
 
             elif args.pipeline_action == "add":
-                try:
-                    pipeline_id = await svc.add(
-                        name=args.name,
-                        prompt_template=args.prompt_template,
-                        source_channel_ids=args.source,
-                        target_refs=_parse_target_refs(args.target),
-                        llm_model=args.llm_model,
-                        image_model=args.image_model,
-                        publish_mode=args.publish_mode,
-                        generation_backend=args.generation_backend,
-                        generate_interval_minutes=args.interval,
-                        is_active=not args.inactive,
-                    )
-                except PipelineValidationError as exc:
-                    print(f"Error: {exc}")
-                    return
-                print(f"Added pipeline id={pipeline_id}: {args.name}")
+                node_specs_raw = getattr(args, "node_specs", None)
+                if node_specs_raw:
+                    # DAG mode: build graph from --node specs
+                    import json as _json
+
+                    from src.cli.graph_builder import GraphBuilder, GraphBuilderError
+                    from src.cli.node_dsl import NodeSpecError, parse_node_spec
+
+                    specs = []
+                    for raw in node_specs_raw:
+                        try:
+                            specs.append(parse_node_spec(raw))
+                        except NodeSpecError as exc:
+                            print(f"Invalid node spec '{raw}': {exc}")
+                            return
+
+                    builder = GraphBuilder()
+                    for spec in specs:
+                        builder.add_node_spec(spec)
+
+                    if args.source:
+                        builder.set_sources(args.source)
+
+                    target_refs_list = []
+                    if args.target:
+                        target_refs_list = [
+                            {"phone": t.phone, "dialog_id": t.dialog_id}
+                            for t in _parse_target_refs(args.target)
+                        ]
+                        builder.set_targets(target_refs_list)
+
+                    if getattr(args, "edge", None):
+                        for edge_str in args.edge:
+                            from_id, _, to_id = edge_str.partition("->")
+                            if not to_id:
+                                print(f"Invalid edge format '{edge_str}'; use FROM->TO")
+                                return
+                            builder.add_explicit_edge(from_id.strip(), to_id.strip())
+
+                    if getattr(args, "node_configs", None):
+                        for nc_str in args.node_configs:
+                            node_id, _, json_str = nc_str.partition("=")
+                            try:
+                                config = _json.loads(json_str)
+                            except _json.JSONDecodeError as exc:
+                                print(f"Invalid JSON in --node-config for {node_id}: {exc}")
+                                return
+                            builder.set_node_config_override(node_id.strip(), config)
+
+                    try:
+                        graph = builder.build()
+                    except GraphBuilderError as exc:
+                        print(f"Graph build error: {exc}")
+                        return
+
+                    try:
+                        pipeline_id = await svc.import_json(
+                            {
+                                "name": args.name,
+                                "prompt_template": args.prompt_template or ".",
+                                "llm_model": args.llm_model,
+                                "image_model": args.image_model,
+                                "generation_backend": args.generation_backend,
+                                "publish_mode": args.publish_mode,
+                                "generate_interval_minutes": args.interval,
+                                "pipeline_json": _json.loads(graph.to_json()),
+                                "source_ids": args.source or [],
+                                "target_refs": (
+                                    [f"{t.phone}|{t.dialog_id}" for t in _parse_target_refs(args.target)]
+                                    if args.target
+                                    else []
+                                ),
+                            },
+                        )
+                    except PipelineValidationError as exc:
+                        print(f"Error: {exc}")
+                        return
+
+                    # Activate if --inactive was not passed
+                    if not args.inactive and pipeline_id:
+                        await svc._bundle.set_active(pipeline_id, True)
+
+                    print(f"Added DAG pipeline id={pipeline_id}: {args.name}")
+                else:
+                    # Legacy mode: --prompt-template + --source + --target required
+                    if not args.prompt_template:
+                        print("Error: --prompt-template is required when not using --node")
+                        return
+                    if not args.source:
+                        print("Error: --source is required when not using --node")
+                        return
+                    if not args.target:
+                        print("Error: --target is required when not using --node")
+                        return
+                    try:
+                        pipeline_id = await svc.add(
+                            name=args.name,
+                            prompt_template=args.prompt_template,
+                            source_channel_ids=args.source,
+                            target_refs=_parse_target_refs(args.target),
+                            llm_model=args.llm_model,
+                            image_model=args.image_model,
+                            publish_mode=args.publish_mode,
+                            generation_backend=args.generation_backend,
+                            generate_interval_minutes=args.interval,
+                            is_active=not args.inactive,
+                        )
+                    except PipelineValidationError as exc:
+                        print(f"Error: {exc}")
+                        return
+                    print(f"Added pipeline id={pipeline_id}: {args.name}")
 
             elif args.pipeline_action == "edit":
                 existing = await svc.get(args.id)
@@ -484,6 +578,74 @@ def run(args: argparse.Namespace) -> None:
                         print(json.dumps(result["pipeline_json"], ensure_ascii=False, indent=2))
                 else:
                     print(f"Error: {result['error']}")
+
+            elif args.pipeline_action == "node":
+                from src.cli.node_dsl import NodeSpecError, parse_node_spec
+                from src.models import PipelineNode
+
+                if args.node_action == "add":
+                    try:
+                        spec = parse_node_spec(args.node_spec)
+                    except NodeSpecError as exc:
+                        print(f"Invalid node spec: {exc}")
+                        return
+                    from src.cli.node_dsl import generate_node_id
+
+                    node_id = spec.id or generate_node_id(spec.type, 0)
+                    node = PipelineNode(id=node_id, type=spec.type, name=spec.type.value, config=spec.config)
+                    ok = await svc.add_node(args.pipeline_id, node)
+                    if ok:
+                        print(f"Added node '{node_id}' to pipeline id={args.pipeline_id}")
+                    else:
+                        print(f"Pipeline id={args.pipeline_id} not found or has no graph")
+
+                elif args.node_action == "replace":
+                    try:
+                        spec = parse_node_spec(args.node_spec)
+                    except NodeSpecError as exc:
+                        print(f"Invalid node spec: {exc}")
+                        return
+                    node = PipelineNode(id=args.node_id, type=spec.type, name=spec.type.value, config=spec.config)
+                    ok = await svc.replace_node(args.pipeline_id, args.node_id, node)
+                    if ok:
+                        print(f"Replaced node '{args.node_id}' in pipeline id={args.pipeline_id}")
+                    else:
+                        print(f"Node '{args.node_id}' not found")
+
+                elif args.node_action == "remove":
+                    ok = await svc.remove_node(args.pipeline_id, args.node_id)
+                    if ok:
+                        print(f"Removed node '{args.node_id}' from pipeline id={args.pipeline_id}")
+                    else:
+                        print(f"Node '{args.node_id}' not found")
+
+            elif args.pipeline_action == "edge":
+                if args.edge_action == "add":
+                    ok = await svc.add_edge(args.pipeline_id, args.from_node, args.to_node)
+                    if ok:
+                        print(f"Added edge {args.from_node} -> {args.to_node}")
+                    else:
+                        print(f"Pipeline id={args.pipeline_id} not found or has no graph")
+
+                elif args.edge_action == "remove":
+                    ok = await svc.remove_edge(args.pipeline_id, args.from_node, args.to_node)
+                    if ok:
+                        print(f"Removed edge {args.from_node} -> {args.to_node}")
+                    else:
+                        print(f"Edge {args.from_node} -> {args.to_node} not found")
+
+            elif args.pipeline_action == "graph":
+                graph = await svc.get_graph(args.id)
+                if graph is None:
+                    pipeline = await svc.get(args.id)
+                    if pipeline is None:
+                        print(f"Pipeline id={args.id} not found")
+                    else:
+                        print(f"Pipeline id={args.id} has no graph (legacy pipeline)")
+                    return
+                from src.cli.graph_viz import render_ascii
+
+                print(render_ascii(graph))
 
         finally:
             if pool is not None:

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -591,7 +591,21 @@ def run(args: argparse.Namespace) -> None:
                         return
                     from src.cli.node_dsl import generate_node_id
 
-                    node_id = spec.id or generate_node_id(spec.type, 0)
+                    if spec.id:
+                        node_id = spec.id
+                    else:
+                        graph = await svc.get_graph(args.pipeline_id)
+                        existing_type_prefix = spec.type.value
+                        max_idx = -1
+                        if graph:
+                            for n in graph.nodes:
+                                if n.id.startswith(existing_type_prefix + "_"):
+                                    try:
+                                        idx = int(n.id.split("_")[-1])
+                                        max_idx = max(max_idx, idx)
+                                    except (ValueError, IndexError):
+                                        pass
+                        node_id = generate_node_id(spec.type, max_idx + 1)
                     node = PipelineNode(id=node_id, type=spec.type, name=spec.type.value, config=spec.config)
                     ok = await svc.add_node(args.pipeline_id, node)
                     if ok:
@@ -605,7 +619,8 @@ def run(args: argparse.Namespace) -> None:
                     except NodeSpecError as exc:
                         print(f"Invalid node spec: {exc}")
                         return
-                    node = PipelineNode(id=args.node_id, type=spec.type, name=spec.type.value, config=spec.config)
+                    new_id = spec.id or args.node_id
+                    node = PipelineNode(id=new_id, type=spec.type, name=spec.type.value, config=spec.config)
                     ok = await svc.replace_node(args.pipeline_id, args.node_id, node)
                     if ok:
                         print(f"Replaced node '{args.node_id}' in pipeline id={args.pipeline_id}")

--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -162,7 +162,7 @@ class GraphBuilder:
         if self._target_refs:
             for node in nodes:
                 if node.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD):
-                    if "targets" not in node.config:
+                    if not node.config.get("targets"):
                         node.config["targets"] = self._target_refs
                     break
 
@@ -173,14 +173,19 @@ class GraphBuilder:
             chain.append(source_node_id)
         if fetch_node_id:
             chain.append(fetch_node_id)
-        chain.extend(user_node_ids)
+        chain.extend(nid for nid in user_node_ids if nid not in chain)
 
         for i in range(len(chain) - 1):
             edges.append(PipelineEdge(from_node=chain[i], to_node=chain[i + 1]))
 
         # -- 7. Explicit edges ---------------------------------------------------
+        node_ids = {n.id for n in nodes}
         existing = {(e.from_node, e.to_node) for e in edges}
         for from_id, to_id in self._explicit_edges:
+            if from_id not in node_ids or to_id not in node_ids:
+                raise GraphBuilderError(
+                    f"Edge references non-existent node: {from_id} -> {to_id}"
+                )
             if (from_id, to_id) not in existing:
                 edges.append(PipelineEdge(from_node=from_id, to_node=to_id))
 

--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -100,8 +100,12 @@ class GraphBuilder:
             config = dict(spec.config)
 
             # Inject channel_ids into user source node
-            if spec.type == PipelineNodeType.SOURCE and self._source_channel_ids:
-                config["channel_ids"] = self._source_channel_ids
+            if spec.type == PipelineNodeType.SOURCE:
+                cids = config.get("channel_ids")
+                if cids is not None and not isinstance(cids, list):
+                    config["channel_ids"] = [int(cids)]
+                if self._source_channel_ids:
+                    config["channel_ids"] = self._source_channel_ids
 
             node = PipelineNode(
                 id=nid,

--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -103,7 +103,10 @@ class GraphBuilder:
             if spec.type == PipelineNodeType.SOURCE:
                 cids = config.get("channel_ids")
                 if cids is not None and not isinstance(cids, list):
-                    config["channel_ids"] = [int(cids)]
+                    try:
+                        config["channel_ids"] = [int(cids)]
+                    except (ValueError, TypeError):
+                        raise GraphBuilderError(f"channel_ids must be an integer, got: {cids!r}") from None
                 if self._source_channel_ids:
                     config["channel_ids"] = self._source_channel_ids
 

--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -1,0 +1,211 @@
+"""Pipeline graph builder with auto-wiring.
+
+Assembles a :class:`~src.models.PipelineGraph` from a list of
+:class:`~src.cli.node_dsl.NodeSpec` objects plus optional source/target/edge
+hints, applying auto-wiring rules:
+
+1. ``set_sources()`` auto-creates a *source* node (or injects into existing).
+2. A *source* followed by user nodes triggers auto-insertion of *fetch_messages*.
+3. ``--node`` order defines linear edges.
+4. ``--edge FROM->TO`` adds extra edges on top.
+5. ``set_targets()`` injects targets into the first *publish*/*forward* node
+   or auto-creates a *publish* node at the end.
+6. ``--node-config NODE_ID JSON`` merges into the node config.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from src.cli.node_dsl import NodeSpec, generate_node_id
+from src.models import (
+    PipelineEdge,
+    PipelineGraph,
+    PipelineNode,
+    PipelineNodeType,
+)
+
+
+class GraphBuilderError(ValueError):
+    """Raised when graph construction fails validation."""
+
+
+_AUTO_INSERT_TYPES = {PipelineNodeType.FETCH_MESSAGES}
+
+
+class GraphBuilder:
+    """Incremental builder that produces a :class:`PipelineGraph`."""
+
+    def __init__(self) -> None:
+        self._node_specs: list[NodeSpec] = []
+        self._source_channel_ids: list[int] = []
+        self._target_refs: list[dict[str, Any]] = []
+        self._explicit_edges: list[tuple[str, str]] = []
+        self._node_config_overrides: dict[str, dict[str, Any]] = {}
+
+    # -- Public API ----------------------------------------------------------
+
+    def add_node_spec(self, spec: NodeSpec) -> None:
+        self._node_specs.append(spec)
+
+    def set_sources(self, channel_ids: list[int]) -> None:
+        self._source_channel_ids = sorted(set(int(cid) for cid in channel_ids))
+
+    def set_targets(self, target_refs: list[dict[str, Any]]) -> None:
+        self._target_refs = list(target_refs)
+
+    def add_explicit_edge(self, from_id: str, to_id: str) -> None:
+        self._explicit_edges.append((from_id, to_id))
+
+    def set_node_config_override(self, node_id: str, config: dict[str, Any]) -> None:
+        self._node_config_overrides[node_id] = config
+
+    def build(self) -> PipelineGraph:
+        """Build and return a :class:`PipelineGraph`."""
+        if not self._node_specs and not self._source_channel_ids:
+            raise GraphBuilderError("Cannot build an empty graph. Add --node specs or --source.")
+
+        nodes: list[PipelineNode] = []
+        edges: list[PipelineEdge] = []
+        type_counters: dict[str, int] = {}
+
+        def _next_id(spec: NodeSpec) -> str:
+            if spec.id is not None:
+                return spec.id
+            key = spec.type.value
+            idx = type_counters.get(key, 0)
+            type_counters[key] = idx + 1
+            return generate_node_id(spec.type, idx)
+
+        # -- 1. Resolve source --------------------------------------------------
+        has_user_source = any(s.type == PipelineNodeType.SOURCE for s in self._node_specs)
+        source_node_id: str | None = None
+
+        if self._source_channel_ids and not has_user_source:
+            # Auto-create source node (channel_ids injection into user source happens at step 2)
+            source_id = "source_0"
+            type_counters["source"] = 1
+            source_node_id = source_id
+            nodes.append(PipelineNode(
+                id=source_id,
+                type=PipelineNodeType.SOURCE,
+                name="source",
+                config={"channel_ids": self._source_channel_ids},
+                position={"x": 0.0, "y": 0.0},
+            ))
+
+        # -- 2. Process user node specs ------------------------------------------
+        user_node_ids: list[str] = []
+        for spec in self._node_specs:
+            nid = _next_id(spec)
+            config = dict(spec.config)
+
+            # Inject channel_ids into user source node
+            if spec.type == PipelineNodeType.SOURCE and self._source_channel_ids:
+                config["channel_ids"] = self._source_channel_ids
+
+            node = PipelineNode(
+                id=nid,
+                type=spec.type,
+                name=spec.type.value,
+                config=config,
+            )
+            nodes.append(node)
+            user_node_ids.append(nid)
+
+            if spec.type == PipelineNodeType.SOURCE and source_node_id is None:
+                source_node_id = nid
+
+        # -- 3. Auto-insert fetch_messages after source --------------------------
+        need_fetch = (
+            source_node_id is not None
+            and not any(
+                s.type in _AUTO_INSERT_TYPES for s in self._node_specs
+            )
+            and (len(user_node_ids) > 0 or self._target_refs)
+        )
+        fetch_node_id: str | None = None
+        if need_fetch:
+            fetch_id = "fetch_messages_0"
+            type_counters["fetch_messages"] = 1
+            fetch_node_id = fetch_id
+            # Insert after source
+            source_idx = next(
+                (i for i, n in enumerate(nodes) if n.id == source_node_id), -1
+            )
+            fetch_node = PipelineNode(
+                id=fetch_id,
+                type=PipelineNodeType.FETCH_MESSAGES,
+                name="fetch_messages",
+                config={},
+                position={"x": float(source_idx + 1) * 200, "y": 0.0},
+            )
+            nodes.insert(source_idx + 1, fetch_node)
+
+        # -- 4. Auto-publish from targets ----------------------------------------
+        has_publish_or_forward = any(
+            n.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD)
+            for n in nodes
+        )
+        if self._target_refs and not has_publish_or_forward:
+            pub_id = "publish_0"
+            type_counters["publish"] = 1
+            pub_node = PipelineNode(
+                id=pub_id,
+                type=PipelineNodeType.PUBLISH,
+                name="publish",
+                config={"targets": self._target_refs},
+            )
+            nodes.append(pub_node)
+            user_node_ids.append(pub_id)
+
+        # -- 5. Inject targets into first publish/forward ------------------------
+        if self._target_refs:
+            for node in nodes:
+                if node.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD):
+                    if "targets" not in node.config:
+                        node.config["targets"] = self._target_refs
+                    break
+
+        # -- 6. Build linear edges -----------------------------------------------
+        # Chain: source -> [fetch] -> user_0 -> user_1 -> ...
+        chain: list[str] = []
+        if source_node_id:
+            chain.append(source_node_id)
+        if fetch_node_id:
+            chain.append(fetch_node_id)
+        chain.extend(user_node_ids)
+
+        for i in range(len(chain) - 1):
+            edges.append(PipelineEdge(from_node=chain[i], to_node=chain[i + 1]))
+
+        # -- 7. Explicit edges ---------------------------------------------------
+        existing = {(e.from_node, e.to_node) for e in edges}
+        for from_id, to_id in self._explicit_edges:
+            if (from_id, to_id) not in existing:
+                edges.append(PipelineEdge(from_node=from_id, to_node=to_id))
+
+        # -- 8. Apply node config overrides --------------------------------------
+        node_by_id = {n.id: n for n in nodes}
+        for nid, override in self._node_config_overrides.items():
+            node = node_by_id.get(nid)
+            if node is not None:
+                node.config.update(override)
+
+        # -- 9. Assign positions --------------------------------------------------
+        _assign_positions(nodes)
+
+        # -- 10. Validate: no duplicate IDs --------------------------------------
+        seen_ids: set[str] = set()
+        for n in nodes:
+            if n.id in seen_ids:
+                raise GraphBuilderError(f"Duplicate node ID: {n.id}")
+            seen_ids.add(n.id)
+
+        return PipelineGraph(nodes=nodes, edges=edges)
+
+
+def _assign_positions(nodes: list[PipelineNode]) -> None:
+    """Assign auto-layout x positions if they are still 0,0."""
+    for i, node in enumerate(nodes):
+        if node.position.get("x") == 0.0 and node.position.get("y") == 0.0:
+            node.position = {"x": float(i) * 200.0, "y": 0.0}

--- a/src/cli/graph_viz.py
+++ b/src/cli/graph_viz.py
@@ -1,0 +1,99 @@
+"""ASCII visualisation for :class:`~src.models.PipelineGraph`.
+
+Renders a pipeline DAG as a vertical text diagram suitable for terminal output.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from src.models import PipelineGraph
+
+
+def render_ascii(graph: PipelineGraph) -> str:
+    """Render *graph* as an ASCII diagram.
+
+    Linear chains are printed top-to-bottom with ``|`` / ``v`` connectors.
+    Nodes with multiple outgoing edges produce a fan-out.
+    """
+    if not graph.nodes:
+        return "(empty graph)"
+
+    # Build adjacency info
+    node_by_id = {n.id: n for n in graph.nodes}
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        outgoing[edge.from_node].append(edge.to_node)
+
+    # Topological order (Kahn's algorithm)
+    in_degree: dict[str, int] = {n.id: 0 for n in graph.nodes}
+    for edge in graph.edges:
+        in_degree[edge.to_node] = in_degree.get(edge.to_node, 0) + 1
+    queue = [nid for nid, d in in_degree.items() if d == 0]
+    order: list[str] = []
+    while queue:
+        queue.sort()  # deterministic
+        nid = queue.pop(0)
+        order.append(nid)
+        for child in outgoing.get(nid, []):
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+
+    # Fallback: include any nodes not in topological order (cycles / orphans)
+    remaining = [n.id for n in graph.nodes if n.id not in set(order)]
+    order.extend(remaining)
+
+    lines: list[str] = []
+    for idx, nid in enumerate(order):
+        node = node_by_id.get(nid)
+        if node is None:
+            continue
+        config_summary = _config_summary(node.config)
+        lines.append(f"[{node.type.value}] id={node.id}{config_summary}")
+
+        children = outgoing.get(nid, [])
+        if idx < len(order) - 1 or children:
+            if len(children) <= 1:
+                # Simple linear connector
+                next_nid = children[0] if children else None
+                if next_nid and next_nid in node_by_id:
+                    lines.append("   |")
+                    lines.append("   v")
+            else:
+                # Fan-out
+                prefix = "   "
+                for ci, child_id in enumerate(children):
+                    child = node_by_id.get(child_id)
+                    if child is None:
+                        continue
+                    c_summary = _config_summary(child.config)
+                    label = f"[{child.type.value}] id={child.id}{c_summary}"
+                    if ci == 0:
+                        lines.append(f"{prefix}|")
+                        lines.append(f"{prefix}+---> {label}")
+                    else:
+                        lines.append(f"{prefix}|")
+                        lines.append(f"{prefix}+---> {label}")
+                # Skip children already rendered in fan-out
+                for child_id in children:
+                    if child_id in order:
+                        order.remove(child_id)
+
+    return "\n".join(lines)
+
+
+def _config_summary(config: dict[str, Any]) -> str:
+    """Short summary of node config for display."""
+    if not config:
+        return ""
+    parts: list[str] = []
+    for key, value in list(config.items())[:3]:
+        sv = str(value)
+        if len(sv) > 30:
+            sv = sv[:27] + "..."
+        parts.append(f"{key}={sv}")
+    summary = ", ".join(parts)
+    if len(config) > 3:
+        summary += ", ..."
+    return f" ({summary})" if summary else ""

--- a/src/cli/graph_viz.py
+++ b/src/cli/graph_viz.py
@@ -45,7 +45,10 @@ def render_ascii(graph: PipelineGraph) -> str:
     order.extend(remaining)
 
     lines: list[str] = []
-    for idx, nid in enumerate(order):
+    rendered: set[str] = set()
+    for idx, nid in enumerate(list(order)):
+        if nid in rendered:
+            continue
         node = node_by_id.get(nid)
         if node is None:
             continue
@@ -75,10 +78,7 @@ def render_ascii(graph: PipelineGraph) -> str:
                     else:
                         lines.append(f"{prefix}|")
                         lines.append(f"{prefix}+---> {label}")
-                # Skip children already rendered in fan-out
-                for child_id in children:
-                    if child_id in order:
-                        order.remove(child_id)
+                rendered.update(children)
 
     return "\n".join(lines)
 

--- a/src/cli/node_dsl.py
+++ b/src/cli/node_dsl.py
@@ -1,0 +1,246 @@
+"""Mini-DSL parser for pipeline node specs.
+
+Parses ``type:key=value,key=value`` strings into :class:`NodeSpec` objects
+used by :mod:`src.cli.graph_builder` to assemble DAG pipelines on the CLI.
+
+Grammar (informal)::
+
+    node_spec   := type [ ":" kv_list ]
+    kv_list     := kv ("," kv)*
+    kv          := "id=" IDENT                -- extracted as explicit node ID
+                 | IDENT "=" value
+    value       := QUOTED_STRING
+                 | JSON_ARRAY
+                 | JSON_OBJECT
+                 | "true" | "false"           -- bool
+                 | INT | FLOAT                -- numeric
+                 | BARE_WORD                  -- string
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.models import PipelineNodeType
+
+
+class NodeSpecError(ValueError):
+    """Raised when a node spec string is malformed."""
+
+
+@dataclass
+class NodeSpec:
+    """Parsed representation of a ``type:key=value`` node spec."""
+
+    type: PipelineNodeType
+    config: dict[str, Any] = field(default_factory=dict)
+    id: str | None = None
+
+
+def generate_node_id(node_type: PipelineNodeType, counter: int) -> str:
+    """Generate a deterministic node ID like ``react_0``."""
+    return f"{node_type.value}_{counter}"
+
+
+def parse_node_spec(raw: str) -> NodeSpec:
+    """Parse a ``type:key=value,key=value`` string into a :class:`NodeSpec`.
+
+    See module docstring for grammar details.
+    """
+    raw = raw.strip()
+    if not raw:
+        raise NodeSpecError("Node spec cannot be empty.")
+
+    # Split on first ':' — everything before is the type, after is config.
+    colon_idx = raw.find(":")
+    if colon_idx == -1:
+        type_str = raw
+        config_part = ""
+    else:
+        type_str = raw[:colon_idx]
+        config_part = raw[colon_idx + 1 :]
+
+    # Validate type
+    type_str = type_str.strip()
+    try:
+        node_type = PipelineNodeType(type_str)
+    except ValueError:
+        valid = ", ".join(t.value for t in PipelineNodeType)
+        raise NodeSpecError(
+            f"Unknown node type '{type_str}'. Valid types: {valid}"
+        ) from None
+
+    # Parse config key=value pairs
+    config: dict[str, Any] = {}
+    explicit_id: str | None = None
+
+    if config_part.strip():
+        pairs = _split_kv_pairs(config_part)
+        for key, value in pairs:
+            if key == "id":
+                explicit_id = str(value)
+            else:
+                config[key] = value
+
+    return NodeSpec(type=node_type, config=config, id=explicit_id)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _split_kv_pairs(text: str) -> list[tuple[str, Any]]:
+    """Split comma-separated key=value pairs, respecting quotes and brackets."""
+    pairs: list[tuple[str, Any]] = []
+    pos = 0
+    length = len(text)
+
+    while pos < length:
+        # Skip leading whitespace
+        while pos < length and text[pos] in " \t":
+            pos += 1
+        if pos >= length:
+            break
+
+        # Read key (up to '=')
+        key_start = pos
+        while pos < length and text[pos] != "=" and text[pos] != ",":
+            pos += 1
+
+        key = text[key_start:pos].strip()
+        if not key:
+            pos += 1
+            continue
+
+        if pos >= length or text[pos] == ",":
+            # Key without value — skip bare keys
+            pos += 1
+            continue
+
+        # Skip '='
+        pos += 1  # skip '='
+
+        # Skip whitespace after '='
+        while pos < length and text[pos] in " \t":
+            pos += 1
+
+        # Read value
+        value, pos = _read_value(text, pos)
+        pairs.append((key, value))
+
+        # Skip comma separator
+        if pos < length and text[pos] == ",":
+            pos += 1
+
+    return pairs
+
+
+def _read_value(text: str, pos: int) -> tuple[Any, int]:
+    """Read a value starting at *pos* and return (parsed_value, new_pos)."""
+    if pos >= len(text):
+        return "", pos
+
+    ch = text[pos]
+
+    # Quoted string
+    if ch == '"':
+        return _read_quoted(text, pos)
+
+    # JSON array
+    if ch == "[":
+        return _read_bracketed(text, pos, "[", "]")
+
+    # JSON object
+    if ch == "{":
+        return _read_bracketed(text, pos, "{", "}")
+
+    # Bare value (until comma or end)
+    start = pos
+    while pos < len(text) and text[pos] != ",":
+        pos += 1
+    raw = text[start:pos].strip()
+    return _coerce_bare(raw), pos
+
+
+def _read_quoted(text: str, pos: int) -> tuple[str, int]:
+    """Read a double-quoted string starting at *pos*."""
+    assert text[pos] == '"'
+    pos += 1  # skip opening quote
+    start = pos
+    while pos < len(text):
+        if text[pos] == '"':
+            return text[start:pos], pos + 1
+        if text[pos] == "\\" and pos + 1 < len(text):
+            pos += 2  # skip escaped char
+            continue
+        pos += 1
+    raise NodeSpecError("Unterminated quoted value in node spec.")
+
+
+def _read_bracketed(text: str, pos: int, open_ch: str, close_ch: str) -> tuple[Any, int]:
+    """Read a JSON array or object starting at *pos*."""
+    start = pos
+    depth = 0
+    while pos < len(text):
+        if text[pos] == open_ch:
+            depth += 1
+        elif text[pos] == close_ch:
+            depth -= 1
+            if depth == 0:
+                pos += 1
+                raw = text[start:pos]
+                try:
+                    return json.loads(raw), pos
+                except json.JSONDecodeError:
+                    # Relaxed array syntax: [a,b,c] → ["a","b","c"]
+                    if open_ch == "[" and close_ch == "]":
+                        try:
+                            return _parse_relaxed_array(raw), pos
+                        except Exception as exc:
+                            raise NodeSpecError(f"Invalid JSON in node spec: {exc}") from exc
+                    raise NodeSpecError("Invalid JSON in node spec.") from None
+        elif text[pos] == '"':
+            # Skip quoted strings inside JSON to avoid false bracket matches
+            pos += 1
+            while pos < len(text):
+                if text[pos] == '"':
+                    break
+                if text[pos] == "\\" and pos + 1 < len(text):
+                    pos += 1
+                pos += 1
+        pos += 1
+    raise NodeSpecError(f"Unterminated {open_ch}{close_ch} group in node spec.")
+
+
+def _parse_relaxed_array(raw: str) -> list:
+    """Parse ``[a, b, 3]`` as ``["a", "b", 3]`` — bare items become strings."""
+    inner = raw.strip()[1:-1]
+    if not inner.strip():
+        return []
+    items: list[Any] = []
+    for part in inner.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        items.append(_coerce_bare(part))
+    return items
+
+
+def _coerce_bare(raw: str) -> Any:
+    """Coerce a bare value string to int/float/bool if appropriate."""
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    # Try int
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    # Try float
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -238,18 +238,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     pipeline_add = pipeline_sub.add_parser("add", help="Add pipeline")
     pipeline_add.add_argument("name", help="Pipeline name")
-    pipeline_add.add_argument("--prompt-template", required=True, help="Prompt template")
+    pipeline_add.add_argument("--prompt-template", default=None, help="Prompt template (legacy mode)")
     pipeline_add.add_argument(
         "--source",
         type=int,
         action="append",
-        required=True,
+        default=None,
         help="Source channel_id; repeat for multiple channels",
     )
     pipeline_add.add_argument(
         "--target",
         action="append",
-        required=True,
+        default=None,
         help="Target in PHONE|DIALOG_ID format; repeat for multiple targets",
     )
     pipeline_add.add_argument("--llm-model", default=None, help="Optional LLM model")
@@ -273,6 +273,26 @@ def build_parser() -> argparse.ArgumentParser:
         help="Generate interval in minutes",
     )
     pipeline_add.add_argument("--inactive", action="store_true", help="Create pipeline disabled")
+    pipeline_add.add_argument(
+        "--node",
+        action="append",
+        default=None,
+        dest="node_specs",
+        help="Node spec in type:key=value format; repeat for multiple nodes",
+    )
+    pipeline_add.add_argument(
+        "--edge",
+        action="append",
+        default=None,
+        help="Explicit edge FROM_ID->TO_ID; repeat for multiple edges",
+    )
+    pipeline_add.add_argument(
+        "--node-config",
+        action="append",
+        default=None,
+        dest="node_configs",
+        help="JSON config override for a node: NODE_ID='{\"key\":\"value\"}'",
+    )
 
     pipeline_edit = pipeline_sub.add_parser("edit", help="Edit pipeline")
     pipeline_edit.add_argument("id", type=int, help="Pipeline id")
@@ -419,6 +439,41 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_ai_edit.add_argument("id", type=int, help="Pipeline id")
     pipeline_ai_edit.add_argument("instruction", help="Instruction for the LLM (e.g. 'Add an image generation node')")
     pipeline_ai_edit.add_argument("--show", action="store_true", help="Print updated JSON after edit")
+
+    # Node CRUD
+    pipeline_node = pipeline_sub.add_parser("node", help="Node CRUD operations on pipeline graph")
+    node_sub = pipeline_node.add_subparsers(dest="node_action")
+
+    node_add = node_sub.add_parser("add", help="Add node to pipeline graph")
+    node_add.add_argument("pipeline_id", type=int, help="Pipeline id")
+    node_add.add_argument("node_spec", help="Node spec: type:key=value,...")
+
+    node_replace = node_sub.add_parser("replace", help="Replace node in pipeline graph")
+    node_replace.add_argument("pipeline_id", type=int, help="Pipeline id")
+    node_replace.add_argument("node_id", help="Node ID to replace")
+    node_replace.add_argument("node_spec", help="New node spec: type:key=value,...")
+
+    node_remove = node_sub.add_parser("remove", help="Remove node from pipeline graph")
+    node_remove.add_argument("pipeline_id", type=int, help="Pipeline id")
+    node_remove.add_argument("node_id", help="Node ID to remove")
+
+    # Edge CRUD
+    pipeline_edge = pipeline_sub.add_parser("edge", help="Edge CRUD operations on pipeline graph")
+    edge_sub = pipeline_edge.add_subparsers(dest="edge_action")
+
+    edge_add = edge_sub.add_parser("add", help="Add edge to pipeline graph")
+    edge_add.add_argument("pipeline_id", type=int, help="Pipeline id")
+    edge_add.add_argument("from_node", help="Source node ID")
+    edge_add.add_argument("to_node", help="Target node ID")
+
+    edge_rm = edge_sub.add_parser("remove", help="Remove edge from pipeline graph")
+    edge_rm.add_argument("pipeline_id", type=int, help="Pipeline id")
+    edge_rm.add_argument("from_node", help="Source node ID")
+    edge_rm.add_argument("to_node", help="Target node ID")
+
+    # Graph visualization
+    pipeline_graph = pipeline_sub.add_parser("graph", help="Show pipeline graph (ASCII)")
+    pipeline_graph.add_argument("id", type=int, help="Pipeline id")
 
     # ── image ──
     image_parser = sub.add_parser("image", help="Image generation")

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -569,6 +569,8 @@ class PipelineService:
             if n.id == node_id:
                 graph.nodes[i] = new_node
                 break
+        # If the new node has a different ID, update edges
+        if new_node.id != node_id:
             for edge in graph.edges:
                 if edge.from_node == node_id:
                     edge.from_node = new_node.id

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -517,9 +517,11 @@ class PipelineService:
         return pipeline.pipeline_json
 
     async def add_node(self, pipeline_id: int, node: PipelineNode) -> bool:
-        """Add *node* to the pipeline's graph. Returns False if pipeline/graph not found."""
+        """Add *node* to the pipeline's graph. Returns False if pipeline/graph not found or ID is a duplicate."""
         graph = await self.get_graph(pipeline_id)
         if graph is None:
+            return False
+        if any(n.id == node.id for n in graph.nodes):
             return False
         # Auto-assign position: place after the last node
         if not node.position or (node.position.get("x") == 0 and node.position.get("y") == 0):
@@ -554,13 +556,19 @@ class PipelineService:
         found = False
         for i, n in enumerate(graph.nodes):
             if n.id == node_id:
-                graph.nodes[i] = new_node
                 found = True
                 break
         if not found:
             return False
-        # If the new node has a different ID, update edges too
+        # If the new node has a different ID, check for collisions first
         if new_node.id != node_id:
+            if any(n.id == new_node.id for n in graph.nodes):
+                return False
+        # Perform the replacement
+        for i, n in enumerate(graph.nodes):
+            if n.id == node_id:
+                graph.nodes[i] = new_node
+                break
             for edge in graph.edges:
                 if edge.from_node == node_id:
                     edge.from_node = new_node.id
@@ -570,9 +578,12 @@ class PipelineService:
         return True
 
     async def add_edge(self, pipeline_id: int, from_node: str, to_node: str) -> bool:
-        """Add an edge to the pipeline's graph. Returns False if pipeline/graph not found."""
+        """Add an edge to the pipeline's graph. Returns False if pipeline/graph not found or endpoints don't exist."""
         graph = await self.get_graph(pipeline_id)
         if graph is None:
+            return False
+        node_ids = {n.id for n in graph.nodes}
+        if from_node not in node_ids or to_node not in node_ids:
             return False
         # Idempotent: don't add duplicate edges
         existing = {(e.from_node, e.to_node) for e in graph.edges}

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -11,8 +11,10 @@ from src.database import Database
 from src.database.bundles import PipelineBundle
 from src.models import (
     ContentPipeline,
+    PipelineEdge,
     PipelineGenerationBackend,
     PipelineGraph,
+    PipelineNode,
     PipelineNodeType,
     PipelinePublishMode,
     PipelineSource,
@@ -502,6 +504,97 @@ class PipelineService:
         except Exception as exc:
             logger.warning("edit_via_llm failed for pipeline_id=%s: %s", pipeline_id, exc, exc_info=True)
             return {"ok": False, "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Graph CRUD operations
+    # ------------------------------------------------------------------
+
+    async def get_graph(self, pipeline_id: int) -> PipelineGraph | None:
+        """Return the pipeline graph, or None for legacy pipelines."""
+        pipeline = await self.get(pipeline_id)
+        if pipeline is None:
+            return None
+        return pipeline.pipeline_json
+
+    async def add_node(self, pipeline_id: int, node: PipelineNode) -> bool:
+        """Add *node* to the pipeline's graph. Returns False if pipeline/graph not found."""
+        graph = await self.get_graph(pipeline_id)
+        if graph is None:
+            return False
+        # Auto-assign position: place after the last node
+        if not node.position or (node.position.get("x") == 0 and node.position.get("y") == 0):
+            max_x = max((n.position.get("x", 0) for n in graph.nodes), default=0)
+            node = node.model_copy(update={"position": {"x": max_x + 200, "y": 0}})
+        graph.nodes.append(node)
+        await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
+        return True
+
+    async def remove_node(self, pipeline_id: int, node_id: str) -> bool:
+        """Remove a node and all its edges. Returns False if not found."""
+        graph = await self.get_graph(pipeline_id)
+        if graph is None:
+            return False
+        original_len = len(graph.nodes)
+        graph.nodes = [n for n in graph.nodes if n.id != node_id]
+        if len(graph.nodes) == original_len:
+            return False  # node not found
+        # Remove edges referencing this node
+        graph.edges = [
+            e for e in graph.edges
+            if e.from_node != node_id and e.to_node != node_id
+        ]
+        await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
+        return True
+
+    async def replace_node(self, pipeline_id: int, node_id: str, new_node: PipelineNode) -> bool:
+        """Replace a node in the pipeline's graph, preserving edges."""
+        graph = await self.get_graph(pipeline_id)
+        if graph is None:
+            return False
+        found = False
+        for i, n in enumerate(graph.nodes):
+            if n.id == node_id:
+                graph.nodes[i] = new_node
+                found = True
+                break
+        if not found:
+            return False
+        # If the new node has a different ID, update edges too
+        if new_node.id != node_id:
+            for edge in graph.edges:
+                if edge.from_node == node_id:
+                    edge.from_node = new_node.id
+                if edge.to_node == node_id:
+                    edge.to_node = new_node.id
+        await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
+        return True
+
+    async def add_edge(self, pipeline_id: int, from_node: str, to_node: str) -> bool:
+        """Add an edge to the pipeline's graph. Returns False if pipeline/graph not found."""
+        graph = await self.get_graph(pipeline_id)
+        if graph is None:
+            return False
+        # Idempotent: don't add duplicate edges
+        existing = {(e.from_node, e.to_node) for e in graph.edges}
+        if (from_node, to_node) not in existing:
+            graph.edges.append(PipelineEdge(from_node=from_node, to_node=to_node))
+            await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
+        return True
+
+    async def remove_edge(self, pipeline_id: int, from_node: str, to_node: str) -> bool:
+        """Remove an edge. Returns False if edge not found."""
+        graph = await self.get_graph(pipeline_id)
+        if graph is None:
+            return False
+        original_len = len(graph.edges)
+        graph.edges = [
+            e for e in graph.edges
+            if not (e.from_node == from_node and e.to_node == to_node)
+        ]
+        if len(graph.edges) == original_len:
+            return False
+        await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
+        return True
 
     async def _normalize_targets(
         self,

--- a/tests/test_cli_graph_builder.py
+++ b/tests/test_cli_graph_builder.py
@@ -1,0 +1,215 @@
+"""Unit tests for the pipeline graph builder (src/cli/graph_builder.py) and ASCII viz."""
+from __future__ import annotations
+
+import pytest
+
+from src.cli.graph_viz import render_ascii
+from src.models import (
+    PipelineEdge,
+    PipelineGraph,
+    PipelineNode,
+    PipelineNodeType,
+)
+
+# ---------------------------------------------------------------------------
+# GraphBuilder tests
+# ---------------------------------------------------------------------------
+
+def _builder():
+    from src.cli.graph_builder import GraphBuilder
+    return GraphBuilder()
+
+
+def _spec(raw: str):
+    from src.cli.node_dsl import parse_node_spec
+    return parse_node_spec(raw)
+
+
+class TestSimpleLinearChain:
+    def test_two_nodes(self):
+        b = _builder()
+        b.add_node_spec(_spec("delay"))
+        b.add_node_spec(_spec("react:emoji=heart"))
+        g = b.build()
+        assert len(g.nodes) == 2
+        assert len(g.edges) == 1
+        assert g.edges[0].from_node == g.nodes[0].id
+        assert g.edges[0].to_node == g.nodes[1].id
+
+
+class TestAutoSourceAndFetch:
+    def test_auto_source_and_fetch_messages(self):
+        b = _builder()
+        b.set_sources([1001])
+        b.add_node_spec(_spec("llm_generate:model=claude"))
+        g = b.build()
+        # Expect: source_0, fetch_messages_0, llm_generate_0
+        types = [n.type for n in g.nodes]
+        assert PipelineNodeType.SOURCE in types
+        assert PipelineNodeType.FETCH_MESSAGES in types
+        assert PipelineNodeType.LLM_GENERATE in types
+        assert len(g.nodes) == 3
+
+    def test_source_injects_channel_ids(self):
+        b = _builder()
+        b.set_sources([1001, 1002])
+        b.add_node_spec(_spec("react:emoji=heart"))
+        g = b.build()
+        source = next(n for n in g.nodes if n.type == PipelineNodeType.SOURCE)
+        assert source.config["channel_ids"] == [1001, 1002]
+
+    def test_user_specified_source_gets_channel_ids_injected(self):
+        b = _builder()
+        b.add_node_spec(_spec("source"))
+        b.set_sources([1001])
+        b.add_node_spec(_spec("react:emoji=heart"))
+        g = b.build()
+        source = next(n for n in g.nodes if n.type == PipelineNodeType.SOURCE)
+        assert source.config["channel_ids"] == [1001]
+
+
+class TestAutoPublish:
+    def test_auto_publish_from_targets(self):
+        b = _builder()
+        b.set_sources([1001])
+        b.set_targets([{"phone": "+100", "dialog_id": 77}])
+        b.add_node_spec(_spec("react:emoji=heart"))
+        g = b.build()
+        types = [n.type for n in g.nodes]
+        assert PipelineNodeType.PUBLISH in types
+
+    def test_target_injection_into_existing_publish(self):
+        b = _builder()
+        b.set_sources([1001])
+        b.add_node_spec(_spec("publish"))
+        b.set_targets([{"phone": "+100", "dialog_id": 77}])
+        g = b.build()
+        pub = next(n for n in g.nodes if n.type == PipelineNodeType.PUBLISH)
+        assert pub.config["targets"] == [{"phone": "+100", "dialog_id": 77}]
+
+    def test_target_injection_into_forward(self):
+        b = _builder()
+        b.set_sources([1001])
+        b.add_node_spec(_spec("forward"))
+        b.set_targets([{"phone": "+100", "dialog_id": 77}])
+        g = b.build()
+        fwd = next(n for n in g.nodes if n.type == PipelineNodeType.FORWARD)
+        assert fwd.config["targets"] == [{"phone": "+100", "dialog_id": 77}]
+
+
+class TestExplicitEdges:
+    def test_explicit_edge_on_top_of_linear(self):
+        b = _builder()
+        b.add_node_spec(_spec("delay:id=a"))
+        b.add_node_spec(_spec("delay:id=b"))
+        b.add_node_spec(_spec("delay:id=c"))
+        b.add_explicit_edge("a", "c")
+        g = b.build()
+        # Linear: a->b, b->c. Plus explicit a->c
+        edge_set = {(e.from_node, e.to_node) for e in g.edges}
+        assert ("a", "b") in edge_set
+        assert ("b", "c") in edge_set
+        assert ("a", "c") in edge_set
+
+
+class TestNodeConfigOverride:
+    def test_override_merges_into_config(self):
+        b = _builder()
+        b.add_node_spec(_spec("react:id=r1,emoji=heart"))
+        b.set_node_config_override("r1", {"emoji": "fire", "random_emojis": ["fire", "100"]})
+        g = b.build()
+        node = next(n for n in g.nodes if n.id == "r1")
+        assert node.config["emoji"] == "fire"
+        assert node.config["random_emojis"] == ["fire", "100"]
+
+
+class TestIdAssignment:
+    def test_explicit_id_preserved(self):
+        b = _builder()
+        b.add_node_spec(_spec("delay:id=my_delay"))
+        g = b.build()
+        assert g.nodes[0].id == "my_delay"
+
+    def test_auto_id_generated(self):
+        b = _builder()
+        b.add_node_spec(_spec("delay"))
+        g = b.build()
+        assert g.nodes[0].id == "delay_0"
+
+    def test_duplicate_id_raises(self):
+        from src.cli.graph_builder import GraphBuilderError
+        b = _builder()
+        b.add_node_spec(_spec("delay:id=dup"))
+        b.add_node_spec(_spec("react:id=dup"))
+        with pytest.raises(GraphBuilderError, match="[Dd]uplicate"):
+            b.build()
+
+
+class TestAutoPosition:
+    def test_positions_spread_horizontally(self):
+        b = _builder()
+        b.add_node_spec(_spec("delay"))
+        b.add_node_spec(_spec("react:emoji=heart"))
+        g = b.build()
+        xs = [n.position["x"] for n in g.nodes]
+        assert xs[0] < xs[1]
+
+
+class TestMinimalGraph:
+    def test_source_only_creates_full_chain(self):
+        """set_sources only → source → fetch → publish."""
+        b = _builder()
+        b.set_sources([1001])
+        b.set_targets([{"phone": "+100", "dialog_id": 77}])
+        g = b.build()
+        types = [n.type for n in g.nodes]
+        assert types == [PipelineNodeType.SOURCE, PipelineNodeType.FETCH_MESSAGES, PipelineNodeType.PUBLISH]
+
+
+class TestEmptyBuilder:
+    def test_empty_raises(self):
+        from src.cli.graph_builder import GraphBuilderError
+        b = _builder()
+        with pytest.raises(GraphBuilderError):
+            b.build()
+
+
+# ---------------------------------------------------------------------------
+# ASCII viz tests
+# ---------------------------------------------------------------------------
+
+class TestRenderAscii:
+    def test_linear_graph(self):
+        g = PipelineGraph(
+            nodes=[
+                PipelineNode(id="s", type=PipelineNodeType.SOURCE, name="src"),
+                PipelineNode(id="f", type=PipelineNodeType.FETCH_MESSAGES, name="fetch"),
+            ],
+            edges=[PipelineEdge(from_node="s", to_node="f")],
+        )
+        out = render_ascii(g)
+        assert "source" in out
+        assert "fetch_messages" in out
+        assert "|" in out
+
+    def test_branching_graph(self):
+        g = PipelineGraph(
+            nodes=[
+                PipelineNode(id="c", type=PipelineNodeType.CONDITION, name="cond"),
+                PipelineNode(id="p", type=PipelineNodeType.PUBLISH, name="pub"),
+                PipelineNode(id="n", type=PipelineNodeType.NOTIFY, name="notif"),
+            ],
+            edges=[
+                PipelineEdge(from_node="c", to_node="p"),
+                PipelineEdge(from_node="c", to_node="n"),
+            ],
+        )
+        out = render_ascii(g)
+        assert "condition" in out
+        assert "publish" in out
+        assert "notify" in out
+
+    def test_empty_graph(self):
+        g = PipelineGraph()
+        out = render_ascii(g)
+        assert "empty" in out

--- a/tests/test_cli_node_dsl.py
+++ b/tests/test_cli_node_dsl.py
@@ -1,0 +1,146 @@
+"""Unit tests for the mini-DSL node spec parser (src/cli/node_dsl.py)."""
+from __future__ import annotations
+
+import pytest
+
+from src.models import PipelineNodeType
+
+
+def _make_spec(raw: str):
+    from src.cli.node_dsl import parse_node_spec
+
+    return parse_node_spec(raw)
+
+
+class TestParseSimple:
+    def test_type_no_config(self):
+        spec = _make_spec("delay")
+        assert spec.type == PipelineNodeType.DELAY
+        assert spec.config == {}
+        assert spec.id is None
+
+    def test_type_empty_config_after_colon(self):
+        spec = _make_spec("forward:")
+        assert spec.type == PipelineNodeType.FORWARD
+        assert spec.config == {}
+
+    def test_type_with_colon_no_equals(self):
+        """Bare word after colon is treated as a flag (empty-string value)."""
+        spec = _make_spec("publish:")
+        assert spec.type == PipelineNodeType.PUBLISH
+        assert spec.config == {}
+
+
+class TestParseKeyValues:
+    def test_single_kv(self):
+        spec = _make_spec("react:emoji=heart")
+        assert spec.type == PipelineNodeType.REACT
+        assert spec.config == {"emoji": "heart"}
+
+    def test_multiple_kv(self):
+        spec = _make_spec("llm_generate:model=claude-sonnet-4-6,max_tokens=2000")
+        assert spec.type == PipelineNodeType.LLM_GENERATE
+        assert spec.config["model"] == "claude-sonnet-4-6"
+        assert spec.config["max_tokens"] == 2000
+
+    def test_numeric_int_values(self):
+        spec = _make_spec("delay:min_seconds=1,max_seconds=5")
+        assert spec.config["min_seconds"] == 1
+        assert spec.config["max_seconds"] == 5
+
+    def test_numeric_float_values(self):
+        spec = _make_spec("delay:min_seconds=0.5,max_seconds=2.5")
+        assert spec.config["min_seconds"] == 0.5
+        assert spec.config["max_seconds"] == 2.5
+
+    def test_boolean_values(self):
+        spec = _make_spec("publish:reply=true,mode=moderated")
+        assert spec.config["reply"] is True
+        assert spec.config["mode"] == "moderated"
+
+    def test_false_boolean(self):
+        spec = _make_spec("filter:match_links=false")
+        assert spec.config["match_links"] is False
+
+
+class TestParseQuotedValues:
+    def test_quoted_value_with_comma(self):
+        spec = _make_spec('llm_generate:prompt="Summarize: {text}"')
+        assert spec.config["prompt"] == "Summarize: {text}"
+
+    def test_quoted_value_with_spaces(self):
+        spec = _make_spec('agent_loop:system_prompt="You are a helpful assistant"')
+        assert spec.config["system_prompt"] == "You are a helpful assistant"
+
+    def test_quoted_value_with_equals(self):
+        spec = _make_spec('llm_generate:prompt="Use model=claude"')
+        assert spec.config["prompt"] == "Use model=claude"
+
+    def test_unclosed_quote_raises(self):
+        from src.cli.node_dsl import NodeSpecError
+
+        with pytest.raises(NodeSpecError, match="quote|unclosed|unterminated"):
+            _make_spec('react:emoji="unclosed')
+
+    def test_quoted_value_preserves_unicode(self):
+        spec = _make_spec('react:emoji="\u2764\ufe0f"')
+        assert spec.config["emoji"] == "\u2764\ufe0f"
+
+
+class TestParseJsonValues:
+    def test_json_array(self):
+        spec = _make_spec("filter:type=service_message,service_types=[user_joined,user_left]")
+        assert spec.config["service_types"] == ["user_joined", "user_left"]
+
+    def test_json_array_with_numbers(self):
+        spec = _make_spec("fetch_messages:limit=10,ids=[1,2,3]")
+        assert spec.config["ids"] == [1, 2, 3]
+
+    def test_json_object(self):
+        spec = _make_spec('source:meta={"key":"val"}')
+        assert spec.config["meta"] == {"key": "val"}
+
+
+class TestExplicitId:
+    def test_id_extracted_from_config(self):
+        spec = _make_spec("agent_loop:id=agent1,model=claude")
+        assert spec.id == "agent1"
+        assert "id" not in spec.config
+        assert spec.config["model"] == "claude"
+
+    def test_id_standalone(self):
+        spec = _make_spec("publish:id=pub1")
+        assert spec.id == "pub1"
+        assert spec.config == {}
+
+
+class TestValidation:
+    def test_unknown_type_raises(self):
+        from src.cli.node_dsl import NodeSpecError
+
+        with pytest.raises(NodeSpecError, match="[Uu]nknown.*type|invalid.*type"):
+            _make_spec("nonexistent_type:x=1")
+
+    def test_empty_string_raises(self):
+        from src.cli.node_dsl import NodeSpecError
+
+        with pytest.raises(NodeSpecError):
+            _make_spec("")
+
+    def test_whitespace_trimmed(self):
+        spec = _make_spec("  delay  ")
+        assert spec.type == PipelineNodeType.DELAY
+
+    def test_all_valid_types(self):
+        """Every PipelineNodeType value should be parseable as a bare type."""
+        for node_type in PipelineNodeType:
+            spec = _make_spec(node_type.value)
+            assert spec.type == node_type
+
+
+class TestGenerateNodeId:
+    def test_default_naming(self):
+        from src.cli.node_dsl import generate_node_id
+
+        assert generate_node_id(PipelineNodeType.REACT, 0) == "react_0"
+        assert generate_node_id(PipelineNodeType.LLM_GENERATE, 3) == "llm_generate_3"

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -901,3 +901,391 @@ def test_pipeline_list_empty(tmp_path, cli_init_patch, capsys):
 
     out = capsys.readouterr().out
     assert "No pipelines found" in out
+
+
+# ---------------------------------------------------------------------------
+# DAG mode tests (issue #426)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_add_dag_with_node(tmp_path, cli_init_patch, capsys):
+    """DAG mode: pipeline add with --node creates a DAG pipeline."""
+    db_path = str(tmp_path / "cli_pipeline_dag_add.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="React Pipeline",
+                prompt_template=None,
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=["react:emoji=heart"],
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Added DAG pipeline id=" in out
+    assert "React Pipeline" in out
+
+    # Verify graph was stored
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    asyncio.run(verify_db.close())
+    assert len(pipelines) == 1
+    p = pipelines[0]
+    assert p.pipeline_json is not None
+    types = [n.type.value for n in p.pipeline_json.nodes]
+    assert "source" in types
+    assert "fetch_messages" in types
+    assert "react" in types
+    assert "publish" in types
+
+
+def test_pipeline_add_dag_invalid_spec(tmp_path, cli_init_patch, capsys):
+    """DAG mode: invalid node spec prints error."""
+    db_path = str(tmp_path / "cli_pipeline_dag_invalid.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="Bad",
+                prompt_template=None,
+                source=[1001],
+                target=None,
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=["nonexistent_type:x=1"],
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Invalid node spec" in out
+
+
+def test_pipeline_add_legacy_requires_prompt_template(tmp_path, cli_init_patch, capsys):
+    """Legacy mode without --prompt-template prints error."""
+    db_path = str(tmp_path / "cli_pipeline_legacy_no_prompt.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="NoPrompt",
+                prompt_template=None,
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "--prompt-template is required" in out
+
+
+def test_pipeline_add_dag_with_edges(tmp_path, cli_init_patch, capsys):
+    """DAG mode: --edge adds explicit edges on top of linear chain."""
+    db_path = str(tmp_path / "cli_pipeline_dag_edges.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="EdgeTest",
+                prompt_template=None,
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=["delay:id=a", "delay:id=b", "delay:id=c"],
+                edge=["a->c"],
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Added DAG pipeline id=" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    asyncio.run(verify_db.close())
+    p = pipelines[0]
+    edge_set = {(e.from_node, e.to_node) for e in p.pipeline_json.edges}
+    assert ("a", "c") in edge_set
+
+
+def test_pipeline_graph_cmd(tmp_path, cli_init_patch, capsys):
+    """pipeline graph shows ASCII visualization."""
+    db_path = str(tmp_path / "cli_pipeline_graph_cmd.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    from src.models import PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
+
+    pid = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="GraphTest",
+                prompt_template=".",
+                publish_mode="moderated",
+            ),
+            source_channel_ids=[1001],
+            targets=[],
+        )
+    )
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="s", type=PipelineNodeType.SOURCE, name="src"),
+            PipelineNode(id="f", type=PipelineNodeType.FETCH_MESSAGES, name="fetch"),
+        ],
+        edges=[PipelineEdge(from_node="s", to_node="f")],
+    )
+    asyncio.run(db.repos.content_pipelines.set_pipeline_json(pid, graph))
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="graph", id=pid))
+
+    out = capsys.readouterr().out
+    assert "source" in out
+    assert "fetch_messages" in out
+
+
+def test_pipeline_graph_legacy_pipeline(tmp_path, cli_init_patch, capsys):
+    """pipeline graph on legacy pipeline shows 'has no graph' message."""
+    db_path = str(tmp_path / "cli_pipeline_graph_legacy.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="Legacy",
+                prompt_template="Test",
+                publish_mode="moderated",
+            ),
+            source_channel_ids=[1001],
+            targets=[
+                PipelineTarget(
+                    pipeline_id=0, phone="+100", dialog_id=77, title="T", dialog_type="channel"
+                )
+            ],
+        )
+    )
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="graph", id=pipeline_id))
+
+    out = capsys.readouterr().out
+    assert "has no graph" in out
+
+
+def test_pipeline_node_add(tmp_path, cli_init_patch, capsys):
+    """pipeline node add adds a node to existing graph."""
+    db_path = str(tmp_path / "cli_pipeline_node_add.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    from src.models import PipelineGraph, PipelineNode, PipelineNodeType
+
+    pid = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(name="NodeAdd", prompt_template=".", publish_mode="moderated"),
+            source_channel_ids=[1001],
+            targets=[],
+        )
+    )
+    graph = PipelineGraph(
+        nodes=[PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="src")],
+        edges=[],
+    )
+    asyncio.run(db.repos.content_pipelines.set_pipeline_json(pid, graph))
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="node", node_action="add", pipeline_id=pid, node_spec="delay:min_seconds=1"))
+
+    out = capsys.readouterr().out
+    assert "Added node" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    p = asyncio.run(verify_db.repos.content_pipelines.get_by_id(pid))
+    asyncio.run(verify_db.close())
+    assert len(p.pipeline_json.nodes) == 2
+
+
+def test_pipeline_node_remove(tmp_path, cli_init_patch, capsys):
+    """pipeline node remove removes a node and its edges."""
+    db_path = str(tmp_path / "cli_pipeline_node_rm.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    from src.models import PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
+
+    pid = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(name="NodeRm", prompt_template=".", publish_mode="moderated"),
+            source_channel_ids=[],
+            targets=[],
+        )
+    )
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="a", type=PipelineNodeType.DELAY, name="d1"),
+            PipelineNode(id="b", type=PipelineNodeType.DELAY, name="d2"),
+        ],
+        edges=[PipelineEdge(from_node="a", to_node="b")],
+    )
+    asyncio.run(db.repos.content_pipelines.set_pipeline_json(pid, graph))
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="node", node_action="remove", pipeline_id=pid, node_id="b"))
+
+    out = capsys.readouterr().out
+    assert "Removed node" in out
+
+
+def test_pipeline_node_replace(tmp_path, cli_init_patch, capsys):
+    """pipeline node replace swaps a node's type and config."""
+    db_path = str(tmp_path / "cli_pipeline_node_replace.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    from src.models import PipelineGraph, PipelineNode, PipelineNodeType
+
+    pid = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(name="NodeReplace", prompt_template=".", publish_mode="moderated"),
+            source_channel_ids=[],
+            targets=[],
+        )
+    )
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="gen", type=PipelineNodeType.LLM_GENERATE, name="gen", config={"model": "claude"}),
+            PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="pub"),
+        ],
+        edges=[],
+    )
+    asyncio.run(db.repos.content_pipelines.set_pipeline_json(pid, graph))
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="node",
+                node_action="replace",
+                pipeline_id=pid,
+                node_id="gen",
+                node_spec="agent_loop:max_steps=5",
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Replaced node" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    p = asyncio.run(verify_db.repos.content_pipelines.get_by_id(pid))
+    asyncio.run(verify_db.close())
+    replaced = next(n for n in p.pipeline_json.nodes if n.id == "gen")
+    assert replaced.type == PipelineNodeType.AGENT_LOOP
+    assert replaced.config["max_steps"] == 5
+
+
+def test_pipeline_edge_add_remove(tmp_path, cli_init_patch, capsys):
+    """pipeline edge add and remove work correctly."""
+    db_path = str(tmp_path / "cli_pipeline_edge.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    from src.models import PipelineGraph, PipelineNode, PipelineNodeType
+
+    pid = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(name="EdgeTest", prompt_template=".", publish_mode="moderated"),
+            source_channel_ids=[],
+            targets=[],
+        )
+    )
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="a", type=PipelineNodeType.DELAY, name="d1"),
+            PipelineNode(id="b", type=PipelineNodeType.DELAY, name="d2"),
+        ],
+        edges=[],
+    )
+    asyncio.run(db.repos.content_pipelines.set_pipeline_json(pid, graph))
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="edge", edge_action="add", pipeline_id=pid, from_node="a", to_node="b"))
+
+    out = capsys.readouterr().out
+    assert "Added edge a -> b" in out
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="edge", edge_action="remove", pipeline_id=pid, from_node="a", to_node="b"))
+
+    out = capsys.readouterr().out
+    assert "Removed edge a -> b" in out

--- a/tests/test_pipeline_service_extra.py
+++ b/tests/test_pipeline_service_extra.py
@@ -10,6 +10,7 @@ from src.database.bundles import PipelineBundle
 from src.models import (
     Account,
     Channel,
+    PipelineEdge,
     PipelineGraph,
     PipelineNode,
     PipelineNodeType,
@@ -854,3 +855,159 @@ async def test_init_with_database(db):
     # Should not raise -- bundle was created from db
     items = await svc.list()
     assert isinstance(items, list)
+
+
+# ---------------------------------------------------------------------------
+# Graph CRUD operations (get_graph, add_node, remove_node, replace_node,
+#                        add_edge, remove_edge)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def graph_pipeline_id(svc, db):
+    """Create a pipeline with a DAG graph for CRUD tests."""
+    pid = await svc.add(
+        name="GraphPipeline",
+        prompt_template="Test",
+        source_channel_ids=[1001],
+        target_refs=[PipelineTargetRef(phone="+100", dialog_id=77)],
+    )
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="source", config={"channel_ids": [1001]}),
+            PipelineNode(id="fetch", type=PipelineNodeType.FETCH_MESSAGES, name="fetch"),
+            PipelineNode(id="gen", type=PipelineNodeType.LLM_GENERATE, name="gen", config={"model": "claude"}),
+        ],
+        edges=[
+            PipelineEdge(from_node="src", to_node="fetch"),
+            PipelineEdge(from_node="fetch", to_node="gen"),
+        ],
+    )
+    await db.repos.content_pipelines.set_pipeline_json(pid, graph)
+    return pid
+
+
+@pytest.mark.asyncio
+async def test_get_graph_returns_graph(svc, graph_pipeline_id):
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert graph is not None
+    assert len(graph.nodes) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_graph_returns_none_for_legacy(svc, pipeline_id):
+    graph = await svc.get_graph(pipeline_id)
+    assert graph is None
+
+
+@pytest.mark.asyncio
+async def test_get_graph_pipeline_not_found(svc):
+    graph = await svc.get_graph(99999)
+    assert graph is None
+
+
+@pytest.mark.asyncio
+async def test_add_node(svc, graph_pipeline_id):
+    new_node = PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="publish", config={"targets": []})
+    ok = await svc.add_node(graph_pipeline_id, new_node)
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert len(graph.nodes) == 4
+    assert graph.nodes[3].id == "pub"
+
+
+@pytest.mark.asyncio
+async def test_add_node_auto_position(svc, graph_pipeline_id):
+    new_node = PipelineNode(id="delay1", type=PipelineNodeType.DELAY, name="delay", config={})
+    await svc.add_node(graph_pipeline_id, new_node)
+    graph = await svc.get_graph(graph_pipeline_id)
+    added = next(n for n in graph.nodes if n.id == "delay1")
+    assert added.position["x"] > 0
+
+
+@pytest.mark.asyncio
+async def test_add_node_no_graph(svc, pipeline_id):
+    new_node = PipelineNode(id="x", type=PipelineNodeType.DELAY, name="d")
+    ok = await svc.add_node(pipeline_id, new_node)
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_remove_node_removes_edges(svc, graph_pipeline_id):
+    ok = await svc.remove_node(graph_pipeline_id, "fetch")
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    ids = [n.id for n in graph.nodes]
+    assert "fetch" not in ids
+    # Edges referencing "fetch" should also be removed
+    for e in graph.edges:
+        assert e.from_node != "fetch" and e.to_node != "fetch"
+
+
+@pytest.mark.asyncio
+async def test_remove_node_not_found(svc, graph_pipeline_id):
+    ok = await svc.remove_node(graph_pipeline_id, "nonexistent")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_replace_node_preserves_edges(svc, graph_pipeline_id):
+    new_node = PipelineNode(id="gen", type=PipelineNodeType.AGENT_LOOP, name="agent", config={"max_steps": 5})
+    ok = await svc.replace_node(graph_pipeline_id, "gen", new_node)
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    replaced = next(n for n in graph.nodes if n.id == "gen")
+    assert replaced.type == PipelineNodeType.AGENT_LOOP
+    # Edges should still exist
+    edge_from_fetch = [e for e in graph.edges if e.from_node == "fetch"]
+    assert len(edge_from_fetch) == 1
+    assert edge_from_fetch[0].to_node == "gen"
+
+
+@pytest.mark.asyncio
+async def test_replace_node_with_new_id_updates_edges(svc, graph_pipeline_id):
+    new_node = PipelineNode(id="agent_v2", type=PipelineNodeType.AGENT_LOOP, name="agent", config={})
+    ok = await svc.replace_node(graph_pipeline_id, "gen", new_node)
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    # Old "gen" edges should now point to "agent_v2"
+    for e in graph.edges:
+        assert "gen" not in (e.from_node, e.to_node)
+    assert any(e.to_node == "agent_v2" for e in graph.edges)
+
+
+@pytest.mark.asyncio
+async def test_add_edge(svc, graph_pipeline_id):
+    ok = await svc.add_edge(graph_pipeline_id, "src", "gen")
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert any(e.from_node == "src" and e.to_node == "gen" for e in graph.edges)
+
+
+@pytest.mark.asyncio
+async def test_add_edge_idempotent(svc, graph_pipeline_id):
+    await svc.add_edge(graph_pipeline_id, "src", "gen")
+    graph1 = await svc.get_graph(graph_pipeline_id)
+    await svc.add_edge(graph_pipeline_id, "src", "gen")
+    graph2 = await svc.get_graph(graph_pipeline_id)
+    assert len(graph1.edges) == len(graph2.edges)
+
+
+@pytest.mark.asyncio
+async def test_add_edge_no_graph(svc, pipeline_id):
+    ok = await svc.add_edge(pipeline_id, "a", "b")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_remove_edge(svc, graph_pipeline_id):
+    ok = await svc.remove_edge(graph_pipeline_id, "src", "fetch")
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert not any(e.from_node == "src" and e.to_node == "fetch" for e in graph.edges)
+
+
+@pytest.mark.asyncio
+async def test_remove_edge_not_found(svc, graph_pipeline_id):
+    ok = await svc.remove_edge(graph_pipeline_id, "src", "gen")
+    assert ok is False

--- a/tests/test_pipeline_service_extra.py
+++ b/tests/test_pipeline_service_extra.py
@@ -977,6 +977,17 @@ async def test_replace_node_with_new_id_updates_edges(svc, graph_pipeline_id):
 
 
 @pytest.mark.asyncio
+async def test_replace_first_node_with_new_id_updates_edges(svc, graph_pipeline_id):
+    """Regression: replacing the first node (index 0) must still rewrite edges."""
+    new_node = PipelineNode(id="src_v2", type=PipelineNodeType.SOURCE, name="source", config={})
+    ok = await svc.replace_node(graph_pipeline_id, "src", new_node)
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert not any("src" in (e.from_node, e.to_node) for e in graph.edges)
+    assert any(e.from_node == "src_v2" for e in graph.edges)
+
+
+@pytest.mark.asyncio
 async def test_add_edge(svc, graph_pipeline_id):
     ok = await svc.add_edge(graph_pipeline_id, "src", "gen")
     assert ok is True


### PR DESCRIPTION
## Summary
- Adds `type:key=value` node-spec DSL for pipeline creation (`--node` flag)
- `GraphBuilder` auto-wires source/fetch/publish nodes and linear edges
- `--edge FROM->TO` for extra edges, `--node-config` for JSON overrides
- ASCII graph visualization via `pipeline graph` command
- Service-layer graph CRUD: `add_node`, `remove_node`, `replace_node`, `add_edge`, `remove_edge`
- CLI subcommands: `pipeline node add|remove|replace`, `pipeline edge add|remove`
- Comprehensive test coverage for DSL parsing, graph building, CLI flows, and service CRUD

### Review fixes included
- `add_node()` rejects duplicate IDs; CLI computes next available index
- `replace_node()` validates new ID uniqueness before replacing
- `add_edge()` / GraphBuilder validate both edge endpoints exist
- Linear chain deduplicates source_node_id to prevent self-edge/cycle
- Target injection catches both missing and empty `targets` via `not node.config.get("targets")`
- `node replace` honors `spec.id` when provided

## Test plan
- [x] `pytest tests/test_cli_node_dsl.py` — DSL parsing and coercion
- [x] `pytest tests/test_cli_graph_builder.py` — auto-wiring, edges, viz
- [x] `pytest tests/test_pipeline_cli.py` — CLI flows and CRUD
- [x] `pytest tests/test_pipeline_service_extra.py` — service graph CRUD
- [x] `ruff check src/ tests/` — lint passes
- [ ] Manual: `python -m src.main pipeline add --name test --node 'source:channel_ids=1' --node 'react:prompt=test' --target phone|123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)