### PR TITLE
fix: pipeline generation — ZAI URL, empty context, provider fallback

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 from src.agent.models import CLAUDE_MODELS
 
-ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/anthropic"
+ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/anthropic/v1"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -891,7 +891,10 @@ class AgentProviderService:
                 )
                 continue
             if key == "base_url" and provider_name == "zai":
-                normalized[key] = self._normalize_urlish(value or ZAI_DEFAULT_BASE_URL)
+                v = value or ZAI_DEFAULT_BASE_URL
+                if v.rstrip("/") == "https://api.z.ai/api/anthropic":
+                    v = "https://api.z.ai/api/anthropic/v1"
+                normalized[key] = self._normalize_urlish(v)
                 continue
             if key == "base_url" and provider_name in _OPENAI_STYLE_DEFAULT_BASE_URLS:
                 normalized[key] = self._normalize_urlish(

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -893,7 +893,7 @@ class AgentProviderService:
             if key == "base_url" and provider_name == "zai":
                 v = value or ZAI_DEFAULT_BASE_URL
                 if v.rstrip("/") == "https://api.z.ai/api/anthropic":
-                    v = "https://api.z.ai/api/anthropic/v1"
+                    v = ZAI_DEFAULT_BASE_URL
                 normalized[key] = self._normalize_urlish(v)
                 continue
             if key == "base_url" and provider_name in _OPENAI_STYLE_DEFAULT_BASE_URLS:

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -243,7 +243,15 @@ class ContentGenerationService:
 
         gen = GenerationService(self._search, provider_callable=provider_callable)
 
-        query = pipeline.prompt_template or pipeline.name or ""
+        # Use pipeline name as search query; constrain to first source channel if available
+        query = pipeline.name or ""
+        channel_id: int | None = None
+        try:
+            sources = await self._db.repos.content_pipelines.list_sources(pipeline.id)
+            if sources:
+                channel_id = sources[0].channel_id
+        except Exception:
+            pass
 
         return await gen.generate(
             query=query,
@@ -251,6 +259,7 @@ class ContentGenerationService:
             model=(model or pipeline.llm_model),
             max_tokens=max_tokens,
             temperature=temperature,
+            channel_id=channel_id,
         )
 
     async def _run_deep_agents(

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -248,10 +248,15 @@ class ContentGenerationService:
         channel_id: int | None = None
         try:
             sources = await self._db.repos.content_pipelines.list_sources(pipeline.id)
-            if sources:
+            if len(sources) == 1:
                 channel_id = sources[0].channel_id
+            # For multi-source pipelines keep channel_id=None to retrieve from all channels
         except Exception:
-            pass
+            logger.warning(
+                "Failed to load pipeline sources for %s, continuing without channel scoping",
+                pipeline.id,
+                exc_info=True,
+            )
 
         return await gen.generate(
             query=query,

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -26,7 +26,9 @@ class GenerationService:
         self._provider = provider_callable
         self._default_prompt = default_prompt_template
 
-    async def _collect_context(self, query: str, limit: int = 8) -> List[Message]:
+    async def _collect_context(
+        self, query: str, limit: int = 8, channel_id: int | None = None
+    ) -> List[Message]:
         """Retrieve context messages using the SearchEngine.
 
         Uses hybrid (semantic+FTS) search when embeddings are available, falls back to
@@ -35,12 +37,21 @@ class GenerationService:
         import logging
 
         if getattr(self._search, "semantic_available", True):
-            result: SearchResult = await self._search.search_hybrid(query, limit=limit)
+            try:
+                result: SearchResult = await self._search.search_hybrid(
+                    query, channel_id=channel_id, limit=limit
+                )
+                return result.messages
+            except RuntimeError as exc:
+                logging.getLogger(__name__).warning(
+                    "Hybrid search failed (%s), falling back to FTS local search for context retrieval",
+                    exc,
+                )
         else:
             logging.getLogger(__name__).warning(
                 "Semantic search unavailable, falling back to FTS local search for context retrieval"
             )
-            result = await self._search.search_local(query, limit=limit)
+        result = await self._search.search_local(query, channel_id=channel_id, limit=limit)
         return result.messages
 
     def _build_source_messages(self, messages: List[Message]) -> str:
@@ -184,6 +195,7 @@ class GenerationService:
         provider_override: Optional[str] = None,
         stream: bool = False,
         provider_callable: Optional[Callable[..., Awaitable[str]]] = None,
+        channel_id: int | None = None,
     ) -> Dict[str, Any]:
         """Generate a draft from `query` using retrieval-augmented generation.
 
@@ -224,7 +236,7 @@ class GenerationService:
             }
 
         # Non-streaming path (preserve existing behaviour)
-        messages = await self._collect_context(query, limit=limit)
+        messages = await self._collect_context(query, limit=limit, channel_id=channel_id)
         source_messages = self._build_source_messages(messages)
 
         rendered_prompt = render_prompt_template(

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -75,6 +75,7 @@ class GenerationService:
         temperature: float = 0.0,
         provider_override: Optional[str] = None,
         provider_callable: Optional[Callable[..., Awaitable[str]]] = None,
+        channel_id: int | None = None,
     ) -> AsyncIterator[Dict[str, Any]]:
         """Async generator that yields partial generation updates when the
         provider supports streaming. Each yield is a dict with keys:
@@ -87,7 +88,7 @@ class GenerationService:
         if prompt_template is None:
             prompt_template = self._default_prompt
 
-        messages = await self._collect_context(query, limit=limit)
+        messages = await self._collect_context(query, limit=limit, channel_id=channel_id)
         source_messages = self._build_source_messages(messages)
 
         rendered_prompt = render_prompt_template(
@@ -217,11 +218,12 @@ class GenerationService:
                 temperature=temperature,
                 provider_override=provider_override,
                 provider_callable=provider_callable,
+                channel_id=channel_id,
             ):
                 last = update
             if last is None:
                 # No output produced
-                messages = await self._collect_context(query, limit=limit)
+                messages = await self._collect_context(query, limit=limit, channel_id=channel_id)
                 return {
                     "prompt": render_prompt_template(
                         prompt_template, {"source_messages": self._build_source_messages(messages)}

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -58,6 +58,17 @@ class AgentProviderService:
         if openai_key:
             self.register_provider("openai", self._make_openai_provider(openai_key))
 
+        # optional Z.AI provider
+        zai_key = os.environ.get("ZAI_API_KEY")
+        if zai_key and "zai" not in self._registry:
+            try:
+                from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL
+                from src.services.provider_adapters import make_anthropic_adapter
+
+                self.register_provider("zai", make_anthropic_adapter(zai_key, base_url=ZAI_DEFAULT_BASE_URL))
+            except Exception:
+                logger.debug("Failed to register zai adapter", exc_info=True)
+
         # optional Context7 provider (user may supply CONTEXT7_API_KEY)
         context7_key = os.environ.get("CONTEXT7_API_KEY") or os.environ.get("CTX7_API_KEY")
         if context7_key:
@@ -246,8 +257,8 @@ class AgentProviderService:
         if provider == "zai":
             from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL
 
-            base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
-            return make_anthropic_adapter(api_key, base_url=base_url or ZAI_DEFAULT_BASE_URL)
+            base_url = (cfg.plain_fields.get("base_url", "") or "").strip() or ZAI_DEFAULT_BASE_URL
+            return make_anthropic_adapter(api_key, base_url=base_url)
 
         if provider == "google_genai":
             # Google GenAI also needs a different request schema.
@@ -351,7 +362,9 @@ class AgentProviderService:
         the model preset to `name`.
         """
         if not name:
-            return self._registry["default"]
+            # Return the first non-default registered provider; fall back to stub.
+            real = next((fn for n, fn in self._registry.items() if n != "default"), None)
+            return real if real is not None else self._registry["default"]
         if name in self._registry:
             return self._registry[name]
         lower = name.lower() if isinstance(name, str) else ""

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1524,9 +1524,9 @@ def test_pipeline_add_run_after(tmp_path, cli_init_patch, capsys):
 
     with (
         cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
-        patch("src.services.task_enqueuer.TaskEnqueuer") as MockEnqueuer,
+        patch("src.services.task_enqueuer.TaskEnqueuer") as mock_enqueuer,
     ):
-        MockEnqueuer.return_value.enqueue_pipeline_run = fake_enqueue
+        mock_enqueuer.return_value.enqueue_pipeline_run = fake_enqueue
 
         from src.cli.commands.pipeline import run
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1418,6 +1418,7 @@ def test_pipeline_add_legacy_requires_source(tmp_path, cli_init_patch, capsys):
             )
         )
 
+    asyncio.run(db.close())
     out = capsys.readouterr().out
     assert "--source is required" in out
 
@@ -1451,6 +1452,7 @@ def test_pipeline_add_legacy_requires_target(tmp_path, cli_init_patch, capsys):
             )
         )
 
+    asyncio.run(db.close())
     out = capsys.readouterr().out
     assert "--target is required" in out
 
@@ -1493,6 +1495,7 @@ def test_pipeline_add_inactive_flag(tmp_path, cli_init_patch, capsys):
     assert "Added pipeline id=" in out
     assert "InactivePipeline" in out
 
+    asyncio.run(db.close())
     verify_db = Database(db_path)
     asyncio.run(verify_db.initialize())
     pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
@@ -1549,6 +1552,7 @@ def test_pipeline_add_run_after(tmp_path, cli_init_patch, capsys):
             )
         )
 
+    asyncio.run(db.close())
     out = capsys.readouterr().out
     assert "Added pipeline id=" in out
     assert "Enqueued pipeline run" in out

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1329,6 +1329,8 @@ def test_pipeline_add_node_dsl_integration(tmp_path, cli_init_patch, capsys):
         assert "source" in graph_out
         assert "react" in graph_out
 
+    asyncio.run(db.close())
+
     # Verify via a third fresh connection
     final_db = _make_db(tmp_path, "integ_dag.db")
     pipeline = asyncio.run(final_db.repos.content_pipelines.get_by_id(pipeline_id))
@@ -1366,6 +1368,8 @@ def test_pipeline_add_legacy_integration(tmp_path, cli_init_patch, capsys):
 
         run(_ns(pipeline_action="list"))
         assert "Legacy Integration" in capsys.readouterr().out
+
+    asyncio.run(db.close())
 
     final_db = _make_db(tmp_path, "integ_legacy.db")
     pipeline = asyncio.run(final_db.repos.content_pipelines.get_by_id(pipeline_id))

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1612,6 +1612,7 @@ def test_pipeline_add_json_file(tmp_path, cli_init_patch, capsys):
             )
         )
 
+    asyncio.run(db.close())
     out = capsys.readouterr().out
     assert "Added pipeline id=" in out
     assert "JsonFilePipeline" in out

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1289,3 +1289,328 @@ def test_pipeline_edge_add_remove(tmp_path, cli_init_patch, capsys):
 
     out = capsys.readouterr().out
     assert "Removed edge a -> b" in out
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: fresh DB connection per CLI call (fresh_database=True)
+# ---------------------------------------------------------------------------
+
+
+def _make_db(tmp_path, name):
+    db = Database(str(tmp_path / name))
+    asyncio.run(db.initialize())
+    return db
+
+
+def test_pipeline_add_node_dsl_integration(tmp_path, cli_init_patch, capsys):
+    """DAG pipeline via --node persists valid pipeline_json to SQLite (fresh connection per call)."""
+    db = _make_db(tmp_path, "integ_dag.db")
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS, fresh_database=True):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(
+            pipeline_action="add", name="Integration DAG",
+            prompt_template=None, source=[1001], target=["+100|77"],
+            llm_model=None, image_model=None, publish_mode="moderated",
+            generation_backend="chain", interval=120, inactive=False,
+            node_specs=["react:emoji=fire"], edge=None, node_configs=None,
+        ))
+        add_out = capsys.readouterr().out
+        assert "Added pipeline id=" in add_out
+        pipeline_id = int(add_out.split("id=")[1].split(":")[0].strip())
+
+        run(_ns(pipeline_action="show", id=pipeline_id))
+        assert "Integration DAG" in capsys.readouterr().out
+
+        run(_ns(pipeline_action="graph", id=pipeline_id))
+        graph_out = capsys.readouterr().out
+        assert "source" in graph_out
+        assert "react" in graph_out
+
+    # Verify via a third fresh connection
+    final_db = _make_db(tmp_path, "integ_dag.db")
+    pipeline = asyncio.run(final_db.repos.content_pipelines.get_by_id(pipeline_id))
+    asyncio.run(final_db.close())
+
+    assert pipeline is not None and pipeline.pipeline_json is not None
+    node_types = {n.type.value for n in pipeline.pipeline_json.nodes}
+    assert {"source", "fetch_messages", "react", "publish"} <= node_types
+
+    edge_froms = {e.from_node for e in pipeline.pipeline_json.edges}
+    for node in pipeline.pipeline_json.nodes:
+        if node.type.value != "publish":
+            assert node.id in edge_froms, f"node {node.id} ({node.type}) has no outgoing edge"
+
+
+def test_pipeline_add_legacy_integration(tmp_path, cli_init_patch, capsys):
+    """Legacy prompt-template pipeline persists all fields to SQLite (fresh connection per call)."""
+    db = _make_db(tmp_path, "integ_legacy.db")
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS, fresh_database=True):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(
+            pipeline_action="add", name="Legacy Integration",
+            prompt_template="Summarize: {source_messages}",
+            source=[1001], target=["+100|77"],
+            llm_model=None, image_model=None, publish_mode="auto",
+            generation_backend="chain", interval=30, inactive=False,
+            node_specs=None, edge=None, node_configs=None,
+        ))
+        add_out = capsys.readouterr().out
+        assert "Added pipeline id=" in add_out
+        pipeline_id = int(add_out.split("id=")[1].split(":")[0].strip())
+
+        run(_ns(pipeline_action="list"))
+        assert "Legacy Integration" in capsys.readouterr().out
+
+    final_db = _make_db(tmp_path, "integ_legacy.db")
+    pipeline = asyncio.run(final_db.repos.content_pipelines.get_by_id(pipeline_id))
+    sources = asyncio.run(final_db.repos.content_pipelines.list_sources(pipeline_id))
+    targets = asyncio.run(final_db.repos.content_pipelines.list_targets(pipeline_id))
+    asyncio.run(final_db.close())
+
+    assert pipeline.prompt_template == "Summarize: {source_messages}"
+    assert pipeline.publish_mode.value == "auto"
+    assert pipeline.generate_interval_minutes == 30
+    assert pipeline.is_active is True
+    assert len(sources) == 1 and sources[0].channel_id == 1001
+    assert len(targets) == 1 and targets[0].dialog_id == 77
+
+
+# ---------------------------------------------------------------------------
+# pipeline add – missing required fields validation (legacy mode)
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_add_legacy_requires_source(tmp_path, cli_init_patch, capsys):
+    """Legacy mode without --source prints error."""
+    db_path = str(tmp_path / "cli_pipeline_add_no_source.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="NoSource",
+                prompt_template="Summarize {source_messages}",
+                source=None,
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "--source is required" in out
+
+
+def test_pipeline_add_legacy_requires_target(tmp_path, cli_init_patch, capsys):
+    """Legacy mode without --target prints error."""
+    db_path = str(tmp_path / "cli_pipeline_add_no_target.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="NoTarget",
+                prompt_template="Summarize {source_messages}",
+                source=[1001],
+                target=None,
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "--target is required" in out
+
+
+# ---------------------------------------------------------------------------
+# pipeline add – --inactive flag
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_add_inactive_flag(tmp_path, cli_init_patch, capsys):
+    """--inactive creates a pipeline with is_active=False."""
+    db_path = str(tmp_path / "cli_pipeline_add_inactive.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="InactivePipeline",
+                prompt_template="Summarize {source_messages}",
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=True,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Added pipeline id=" in out
+    assert "InactivePipeline" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    asyncio.run(verify_db.close())
+    assert len(pipelines) == 1
+    assert pipelines[0].is_active is False
+
+
+# ---------------------------------------------------------------------------
+# pipeline add – --run-after flag
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_add_run_after(tmp_path, cli_init_patch, capsys):
+    """--run-after enqueues a pipeline run immediately after creation."""
+    db_path = str(tmp_path / "cli_pipeline_add_run_after.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    enqueued = {}
+
+    async def fake_enqueue(pipeline_id, since_hours=24):
+        enqueued["pipeline_id"] = pipeline_id
+        enqueued["since_hours"] = since_hours
+
+    with (
+        cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
+        patch("src.services.task_enqueuer.TaskEnqueuer") as MockEnqueuer,
+    ):
+        MockEnqueuer.return_value.enqueue_pipeline_run = fake_enqueue
+
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="RunAfterPipeline",
+                prompt_template="Summarize {source_messages}",
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+                run_after=True,
+                since_value=12,
+                since_unit="h",
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Added pipeline id=" in out
+    assert "Enqueued pipeline run" in out
+    assert enqueued.get("pipeline_id") is not None
+    assert enqueued["since_hours"] == 12
+
+
+# ---------------------------------------------------------------------------
+# pipeline add – --json-file import
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_add_json_file(tmp_path, cli_init_patch, capsys):
+    """--json-file imports a DAG pipeline from a JSON file."""
+    import json
+
+    db_path = str(tmp_path / "cli_pipeline_add_json.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    graph_data = {
+        "nodes": [
+            {"id": "s", "type": "source", "name": "src", "config": {}},
+            {"id": "f", "type": "fetch_messages", "name": "fetch", "config": {}},
+            {"id": "p", "type": "publish", "name": "pub", "config": {}},
+        ],
+        "edges": [
+            {"from_node": "s", "to_node": "f"},
+            {"from_node": "f", "to_node": "p"},
+        ],
+    }
+    json_path = str(tmp_path / "graph.json")
+    with open(json_path, "w") as f:
+        json.dump(graph_data, f)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="JsonFilePipeline",
+                prompt_template=None,
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=False,
+                json_file=json_path,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Added pipeline id=" in out
+    assert "JsonFilePipeline" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    asyncio.run(verify_db.close())
+    assert len(pipelines) == 1
+    assert pipelines[0].pipeline_json is not None


### PR DESCRIPTION
Closes #435

## Summary

- Fix `ZAI_DEFAULT_BASE_URL` missing `/v1` suffix → 404 on `/api/anthropic/messages`
- Normalize legacy saved ZAI `base_url` in `_normalize_plain_fields`
- Add `ZAI_API_KEY` env var support in `_register_env_providers`
- Fix `get_provider_callable(None)` returning stub instead of first real provider
- Catch `RuntimeError` in `_collect_context` and fall back to FTS when embeddings unavailable
- Fix `_run_rag` using prompt template as FTS query → use `pipeline.name` + source `channel_id`
- Add `channel_id` param to `GenerationService._collect_context` and `generate`
- Add integration and validation tests for `pipeline add` CLI

## Test plan

- [ ] `pytest tests/test_pipeline_cli.py -m aiosqlite_serial` — 43 passed
- [ ] `python -m src.main pipeline generate <id>` — генерирует реальный дайджест из source-канала

🤖 Generated with [Claude Code](https://claude.com/claude-code)