### PR TITLE
fix(collector): select correct account for private groups

### DIFF
--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -277,6 +277,12 @@ class Database:
         self._require()
         await self._channels.set_channel_type(channel_id, channel_type)
 
+    async def update_channel_preferred_phone(
+        self, channel_id: int, phone: str | None
+    ) -> None:
+        self._require()
+        await self._channels.update_channel_preferred_phone(channel_id, phone)
+
     async def update_channel_meta(
         self, channel_id: int, *, username: str | None, title: str | None
     ) -> None:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -120,6 +120,9 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     if "created_at" not in ch_columns:
         await db.execute("ALTER TABLE channels ADD COLUMN created_at TEXT")
         await db.commit()
+    if "preferred_phone" not in ch_columns:
+        await db.execute("ALTER TABLE channels ADD COLUMN preferred_phone TEXT")
+        await db.commit()
 
     cur = await db.execute("PRAGMA table_info(collection_tasks)")
     task_rows = await cur.fetchall()

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -213,6 +213,14 @@ class ChannelsRepository:
         )
         await self._db.commit()
 
+    async def get_preferred_phone(self, channel_id: int) -> str | None:
+        """Return the preferred phone for a channel, or None if not set."""
+        row = await self._db.fetchone(
+            "SELECT preferred_phone FROM channels WHERE channel_id = ?",
+            (channel_id,),
+        )
+        return row["preferred_phone"] if row else None
+
     async def update_channel_created_at(self, channel_id: int, created_at) -> None:
         """Set created_at only if currently NULL (backfill from entity.date)."""
         iso = created_at.isoformat() if hasattr(created_at, "isoformat") else created_at

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -69,6 +69,9 @@ class ChannelsRepository:
                 if "message_count" in keys and row["message_count"] is not None
                 else 0
             ),
+            preferred_phone=(
+                row["preferred_phone"] if "preferred_phone" in keys else None
+            ),
         )
 
     async def get_channels(
@@ -197,6 +200,16 @@ class ChannelsRepository:
         await self._db.execute(
             "UPDATE channels SET about = ?, linked_chat_id = ?, has_comments = ? WHERE channel_id = ?",
             (about, linked_chat_id, int(has_comments), channel_id),
+        )
+        await self._db.commit()
+
+    async def update_channel_preferred_phone(
+        self, channel_id: int, phone: str | None
+    ) -> None:
+        """Set or clear the preferred Telegram account phone for collecting this channel."""
+        await self._db.execute(
+            "UPDATE channels SET preferred_phone = ? WHERE channel_id = ?",
+            (phone, channel_id),
         )
         await self._db.commit()
 

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS channels (
     about TEXT,
     linked_chat_id INTEGER,
     has_comments INTEGER DEFAULT 0,
-    created_at TEXT
+    created_at TEXT,
+    preferred_phone TEXT
 );
 
 CREATE TABLE IF NOT EXISTS messages (

--- a/src/models.py
+++ b/src/models.py
@@ -43,6 +43,7 @@ class Channel(BaseModel):
     linked_chat_id: int | None = None
     has_comments: bool = False
     last_collected_id: int = 0
+    preferred_phone: str | None = None
     added_at: datetime | None = None
     created_at: datetime | None = None
     message_count: int = 0

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -27,6 +28,7 @@ class SchedulerManager:
         search_query_bundle: SearchQueryBundle | None = None,
         task_enqueuer: TaskEnqueuer | None = None,
         pipeline_bundle: PipelineBundle | None = None,
+        warm_dialogs_callback: Callable[[], Awaitable[None]] | None = None,
     ):
         if config is None:
             config = SchedulerConfig()
@@ -35,10 +37,13 @@ class SchedulerManager:
         self._scheduler_bundle = scheduler_bundle
         self._sq_bundle = search_query_bundle
         self._pipeline_bundle = pipeline_bundle
+        self._warm_dialogs_callback = warm_dialogs_callback
         self._scheduler: AsyncIOScheduler | None = None
         self._job_id = "collect_all"
         self._photo_due_job_id = "photo_due"
         self._photo_auto_job_id = "photo_auto"
+        self._warm_dialogs_job_id = "warm_all_dialogs"
+        self._warm_dialogs_interval_minutes: int = 1440  # 24 hours default
         self._current_interval_minutes: int = config.collect_interval_minutes
         self._bg_task: asyncio.Task | None = None
         self._jobs_cache: dict[str, object] = {}
@@ -87,6 +92,13 @@ class SchedulerManager:
             self._scheduler.add_job(
                 self._run_photo_auto,
                 IntervalTrigger(minutes=1),
+                id=job_id,
+                replace_existing=True,
+            )
+        elif job_id == self._warm_dialogs_job_id and self._warm_dialogs_callback:
+            self._scheduler.add_job(
+                self._run_warm_dialogs,
+                IntervalTrigger(minutes=self._warm_dialogs_interval_minutes),
                 id=job_id,
                 replace_existing=True,
             )
@@ -169,6 +181,36 @@ class SchedulerManager:
             else:
                 logger.info("Job %s is disabled, skipping registration", self._photo_auto_job_id)
 
+        if self._warm_dialogs_callback:
+            if self._scheduler_bundle:
+                saved_warm = await self._scheduler_bundle.get_setting(
+                    "warm_dialogs_interval_minutes"
+                )
+            else:
+                saved_warm = None
+            self._warm_dialogs_interval_minutes = parse_int_setting(
+                saved_warm,
+                setting_name="warm_dialogs_interval_minutes",
+                default=1440,
+                logger=logger,
+            )
+            if await self.is_job_enabled(self._warm_dialogs_job_id):
+                self._scheduler.add_job(
+                    self._run_warm_dialogs,
+                    IntervalTrigger(minutes=self._warm_dialogs_interval_minutes),
+                    id=self._warm_dialogs_job_id,
+                    replace_existing=True,
+                )
+                logger.info(
+                    "Registered job %s (every %d min)",
+                    self._warm_dialogs_job_id,
+                    self._warm_dialogs_interval_minutes,
+                )
+            else:
+                logger.info(
+                    "Job %s is disabled, skipping registration", self._warm_dialogs_job_id
+                )
+
         self._scheduler.start()
         total_jobs = len(self._scheduler.get_jobs())
         logger.info("Scheduler started with %d jobs, collecting every %d min", total_jobs, collect_interval)
@@ -241,6 +283,20 @@ class SchedulerManager:
         if self._bg_task and not self._bg_task.done():
             return
         self._bg_task = asyncio.create_task(self._run_collection())
+
+    async def trigger_warm_background(self) -> None:
+        """Fire-and-forget dialog cache warm run."""
+        asyncio.create_task(self._run_warm_dialogs(), name="warm_all_dialogs_manual")
+
+    async def _run_warm_dialogs(self) -> None:
+        if not self._warm_dialogs_callback:
+            return
+        logger.info("Scheduler: starting dialog cache warm")
+        try:
+            await self._warm_dialogs_callback()
+            logger.info("Scheduler: dialog cache warm complete")
+        except Exception:
+            logger.exception("Scheduler: dialog cache warm failed")
 
     async def _run_collection(self) -> dict:
         """Enqueue all channels for collection."""
@@ -419,4 +475,9 @@ class SchedulerManager:
                         })
             except Exception:
                 logger.exception("Error fetching pipelines for potential jobs")
+        if self._warm_dialogs_callback is not None:
+            jobs.append({
+                "job_id": self._warm_dialogs_job_id,
+                "interval_minutes": self._warm_dialogs_interval_minutes,
+            })
         return jobs

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -95,6 +95,9 @@ class ClientPool:
             native=self._native_backend,
         )
         self._dialogs_fetched: set[str] = set()
+        self._channel_phone_map: dict[int, str] = {}
+        # channel_id (positive MTProto) → phone that has it in dialogs
+        self._warming_task: asyncio.Task | None = None
         self._dialogs_cache: dict[tuple[str, str], DialogCacheEntry] = {}
         self._dialogs_cache_ttl_sec = 60.0
         self._dialogs_db_cache_ttl_sec = 3600.0  # 1 hour; stale DB cache triggers fresh Telegram fetch
@@ -107,6 +110,69 @@ class ClientPool:
     def mark_dialogs_fetched(self, phone: str) -> None:
         """Mark that get_dialogs() has been called for this phone."""
         self._dialogs_fetched.add(phone)
+
+    def connected_phones(self) -> set[str]:
+        """Return the set of currently connected phone numbers."""
+        return self._connected_phones()
+
+    def get_phone_for_channel(self, channel_id: int) -> str | None:
+        """Return the phone known to have channel_id in its dialogs, or None."""
+        return self._channel_phone_map.get(channel_id)
+
+    def register_channel_phone(self, channel_id: int, phone: str) -> None:
+        """Cache the discovered phone for a channel (for post-startup additions)."""
+        self._channel_phone_map[channel_id] = phone
+
+    def is_warming(self) -> bool:
+        """True while warm_all_dialogs() is still running."""
+        return self._warming_task is not None and not self._warming_task.done()
+
+    async def wait_for_warm(self, timeout: float = 30.0) -> None:
+        """Wait for warm_all_dialogs() to finish, up to `timeout` seconds."""
+        if self._warming_task is None or self._warming_task.done():
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(self._warming_task), timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+
+    async def warm_all_dialogs(self) -> None:
+        """Warm entity cache for all connected phones and persist channel→phone to DB.
+
+        Records which channels are accessible from which account so that
+        private-group collection can target the right phone without guessing.
+        Stores self._warming_task so the collector can wait during a race.
+        """
+        self._warming_task = asyncio.current_task()
+        for phone in list(self._connected_phones()):
+            result = await self.get_client_by_phone(phone)
+            if result is None:
+                continue
+            session, p = result
+            try:
+                dialogs = await asyncio.wait_for(session.warm_dialog_cache(), timeout=60.0)
+                self.mark_dialogs_fetched(p)
+                for dialog in dialogs or []:
+                    entity = getattr(dialog, "entity", None)
+                    if entity is None:
+                        continue
+                    eid = getattr(entity, "id", None)
+                    if eid and eid not in self._channel_phone_map:
+                        self._channel_phone_map[eid] = p
+                        # Persist to DB (first-wins; channel may not exist in our DB — OK)
+                        try:
+                            await self._db.repos.channels.update_channel_preferred_phone(
+                                eid, p
+                            )
+                        except Exception:
+                            pass
+                logger.info(
+                    "warm_all_dialogs: warmed %s (%d dialogs)", p, len(dialogs or [])
+                )
+            except Exception as e:
+                logger.warning("warm_all_dialogs: failed for %s: %s", p, e)
+            finally:
+                await self.release_client(p)
 
     def invalidate_dialogs_cache(self, phone: str | None = None) -> None:
         if phone is None:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -16,7 +16,8 @@ from telethon.errors import (
     UsernameInvalidError,
     UsernameNotOccupiedError,
 )
-from telethon.tl.types import ChannelForbidden, PeerChannel, PeerUser
+from telethon.tl.types import Channel as TLChannel
+from telethon.tl.types import ChannelForbidden, Chat, PeerChannel, PeerUser
 
 from src.config import TelegramRuntimeConfig
 from src.database import Database
@@ -123,6 +124,10 @@ class ClientPool:
         """Cache the discovered phone for a channel (for post-startup additions)."""
         self._channel_phone_map[channel_id] = phone
 
+    def clear_channel_phone(self, channel_id: int) -> None:
+        """Remove cached phone mapping for a channel (used during error recovery)."""
+        self._channel_phone_map.pop(channel_id, None)
+
     def is_warming(self) -> bool:
         """True while warm_all_dialogs() is still running."""
         return self._warming_task is not None and not self._warming_task.done()
@@ -156,14 +161,19 @@ class ClientPool:
                     entity = getattr(dialog, "entity", None)
                     if entity is None:
                         continue
+                    if not isinstance(entity, (TLChannel, Chat)):
+                        continue
                     eid = getattr(entity, "id", None)
                     if eid and eid not in self._channel_phone_map:
                         self._channel_phone_map[eid] = p
-                        # Persist to DB (first-wins; channel may not exist in our DB — OK)
+                        # Persist to DB only if no preferred_phone set yet
+                        # (avoid overwriting a valid value from previous error recovery)
                         try:
-                            await self._db.repos.channels.update_channel_preferred_phone(
-                                eid, p
-                            )
+                            existing = await self._db.repos.channels.get_preferred_phone(eid)
+                            if not existing:
+                                await self._db.repos.channels.update_channel_preferred_phone(
+                                    eid, p
+                                )
                         except Exception:
                             pass
                 logger.info(

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 
-from telethon.errors import UsernameInvalidError, UsernameNotOccupiedError
+from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import (
     DocumentAttributeAnimated,
     DocumentAttributeAudio,
@@ -614,7 +614,7 @@ class Collector:
                             channel_id
                         ):
                             channel = channel.model_copy(update={"preferred_phone": None})
-                            self._pool._channel_phone_map.pop(channel_id, None)
+                            self._pool.clear_channel_phone(channel_id)
                             try:
                                 await self._db.repos.channels.update_channel_preferred_phone(
                                     channel_id, None
@@ -937,6 +937,9 @@ class Collector:
                     self._pool.mark_dialogs_fetched(p)
                 await session.resolve_entity(PeerChannel(channel_id))
                 return p
+            except FloodWaitError as fwe:
+                self._pool.report_flood(p, fwe.seconds)
+                continue
             except Exception:
                 continue
             finally:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -425,7 +425,25 @@ class Collector:
             channel_id = channel.channel_id
             min_id = channel.last_collected_id
 
-            result = await self._pool.get_available_client()
+            # For private groups (no username):
+            #   1. preferred_phone from DB (persists across restarts)
+            #   2. in-memory map built by warm_all_dialogs()
+            #   3. if warming is still in progress — wait, then re-check map
+            #   4. fall back to any available phone (new channel, no info yet)
+            if not channel.username:
+                preferred = channel.preferred_phone or self._pool.get_phone_for_channel(
+                    channel_id
+                )
+                if not preferred and self._pool.is_warming():
+                    await self._pool.wait_for_warm(timeout=30.0)
+                    preferred = self._pool.get_phone_for_channel(channel_id)
+                if preferred:
+                    result = await self._pool.get_client_by_phone(preferred)
+                else:
+                    result = await self._pool.get_available_client()
+            else:
+                result = await self._pool.get_available_client()
+
             if result is None:
                 await self._raise_collection_unavailability()
 
@@ -589,6 +607,39 @@ class Collector:
                     except HandledFloodWaitError as exc:
                         flood_wait_sec = exc.info.wait_seconds
                         raise
+                    except ValueError:
+                        # preferred_phone turned out to be wrong (account was kicked,
+                        # or channel added before warming finished). Invalidate and rediscover.
+                        if channel.preferred_phone or self._pool.get_phone_for_channel(
+                            channel_id
+                        ):
+                            channel = channel.model_copy(update={"preferred_phone": None})
+                            self._pool._channel_phone_map.pop(channel_id, None)
+                            try:
+                                await self._db.repos.channels.update_channel_preferred_phone(
+                                    channel_id, None
+                                )
+                            except Exception:
+                                pass
+                        found = await self._discover_phone_for_channel(
+                            channel_id, exclude=phone
+                        )
+                        if found is not None:
+                            self._pool.register_channel_phone(channel_id, found)
+                            try:
+                                await self._db.repos.channels.update_channel_preferred_phone(
+                                    channel_id, found
+                                )
+                            except Exception:
+                                pass
+                            logger.info(
+                                "Channel %d: rediscovered on %s, retrying",
+                                channel_id,
+                                found,
+                            )
+                            # finally releases current phone; next iter picks up found
+                            continue
+                        raise  # no phone has access — show error in UI
 
                 # Превентивная фильтрация по subscriber_ratio до загрузки
                 # сообщений.
@@ -864,6 +915,33 @@ class Collector:
                         # channel will be deleted on the next collection run.
 
             return total_collected + len(all_messages)
+
+    async def _discover_phone_for_channel(
+        self, channel_id: int, exclude: str
+    ) -> str | None:
+        """Try all connected phones (except `exclude`) to find one with access to channel_id.
+
+        Used when a private group was added after startup warming and its phone is not
+        yet in the pool's channel→phone map. Returns the first phone that can resolve
+        the entity, or None if no account has access.
+        """
+        for candidate in self._pool.connected_phones() - {exclude}:
+            result = await self._pool.get_client_by_phone(candidate)
+            if result is None:
+                continue
+            session, p = result
+            session = adapt_transport_session(session, disconnect_on_close=False)
+            try:
+                if not self._pool.is_dialogs_fetched(p):
+                    await session.warm_dialog_cache()
+                    self._pool.mark_dialogs_fetched(p)
+                await session.resolve_entity(PeerChannel(channel_id))
+                return p
+            except Exception:
+                continue
+            finally:
+                await self._pool.release_client(p)
+        return None
 
     async def _precheck_sample(self, session, entity, limit: int) -> list[str]:
         """Sample up to `limit` messages for cross-channel precheck."""

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -263,7 +263,7 @@ async def start_container(container: AppContainer) -> None:
         # Warm entity cache + preferred_phone map for all accounts in background.
         # Store the task so the collector can wait on it during a race condition.
         if hasattr(container.pool, "warm_all_dialogs"):
-            _warm_task = asyncio.get_event_loop().create_task(
+            _warm_task = asyncio.create_task(
                 container.pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
             )
             container.pool._warming_task = _warm_task

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -178,6 +178,7 @@ async def build_container_with_templates(
         search_query_bundle=search_query_bundle,
         task_enqueuer=task_enqueuer,
         pipeline_bundle=pipeline_bundle,
+        warm_dialogs_callback=pool.warm_all_dialogs,
     )
     agent_manager = AgentManager(db, config, client_pool=pool, scheduler_manager=scheduler)
 
@@ -259,6 +260,13 @@ async def start_container(container: AppContainer) -> None:
                 "startup: telegram pool timed out after %ds — continuing without full init",
                 _POOL_INIT_TIMEOUT,
             )
+        # Warm entity cache + preferred_phone map for all accounts in background.
+        # Store the task so the collector can wait on it during a race condition.
+        if hasattr(container.pool, "warm_all_dialogs"):
+            _warm_task = asyncio.get_event_loop().create_task(
+                container.pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
+            )
+            container.pool._warming_task = _warm_task
     logger.info("startup: telegram pool done (%.1fs)", time.monotonic() - t_start)
     if _is_dev:
         logger.info("startup/start: telegram_pool %.2fs", time.monotonic() - t1)

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -18,6 +18,7 @@ JOB_LABELS = {
     "collect_all": "Сбор всех каналов",
     "photo_due": "Фото по расписанию",
     "photo_auto": "Автозагрузка фото",
+    "warm_all_dialogs": "Прогрев кэша диалогов",
 }
 
 
@@ -399,6 +400,11 @@ async def set_job_interval(request: Request, job_id: str):
             await db.repos.content_pipelines.update_generate_interval(pid, minutes)
             if sched.is_running:
                 await sched.sync_pipeline_jobs()
+    elif job_id == "warm_all_dialogs":
+        await db.repos.settings.set_setting("warm_dialogs_interval_minutes", str(minutes))
+        sched._warm_dialogs_interval_minutes = minutes
+        if sched.is_running:
+            await sched.sync_job_state(job_id, enabled=True)
     return RedirectResponse(url="/scheduler?msg=interval_updated", status_code=303)
 
 
@@ -426,6 +432,15 @@ async def trigger_collection(request: Request):
     result = await service.enqueue_all_channels()
     msg = bulk_enqueue_msg(result)
     return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
+
+
+@router.post("/trigger-warm")
+async def trigger_warm_dialogs(request: Request):
+    if getattr(request.app.state, "shutting_down", False):
+        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+    sched = deps.get_scheduler(request)
+    await sched.trigger_warm_background()
+    return RedirectResponse(url="/scheduler?msg=warm_dialogs_started", status_code=303)
 
 
 @router.post("/test-notification")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -386,8 +386,15 @@ class FakeClientPool(MagicMock):
         self.get_available_client = kwargs.pop("get_available_client", AsyncMock(return_value=None))
         self.get_stats_availability = kwargs.pop("get_stats_availability", AsyncMock())
         self._dialogs_fetched: set[str] = set()
+        self._channel_phone_map: dict[int, str] = {}
+        self._warming_task = None
         self.is_dialogs_fetched = lambda phone: phone in self._dialogs_fetched
         self.mark_dialogs_fetched = lambda phone: self._dialogs_fetched.add(phone)
+        self.connected_phones = lambda: set(self.clients.keys())
+        self.get_phone_for_channel = lambda cid: self._channel_phone_map.get(cid)
+        self.register_channel_phone = lambda cid, phone: self._channel_phone_map.__setitem__(cid, phone)
+        self.is_warming = lambda: False
+        self.wait_for_warm = AsyncMock()
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -295,6 +295,69 @@ async def test_collect_channel_no_username_no_cache_reports_error(db):
 
 
 @pytest.mark.asyncio
+async def test_collect_private_group_uses_map_phone(db):
+    """When channel→phone map has an entry, get_client_by_phone is used directly."""
+    ch = Channel(channel_id=1877929309, title="Private Group")
+    await db.add_channel(ch)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=_AsyncIterEmpty())
+
+    pool = make_mock_pool(
+        clients={"+7001": object()},
+        get_client_by_phone=AsyncMock(return_value=(mock_client, "+7001")),
+    )
+    pool._channel_phone_map[1877929309] = "+7001"
+
+    collector = Collector(pool, db, SchedulerConfig())
+    stats = await collector.collect_all_channels()
+
+    assert stats["errors"] == 0
+    pool.get_available_client.assert_not_awaited()
+    pool.get_client_by_phone.assert_awaited_once_with("+7001")
+
+
+@pytest.mark.asyncio
+async def test_collect_private_group_discovers_access_phone(db):
+    """When channel not in map, _discover_phone_for_channel finds the right phone
+    and registers it so the next iteration uses it directly."""
+    ch = Channel(channel_id=1877929309, title="Private Group")
+    await db.add_channel(ch)
+
+    # Phone "+7000" doesn't have access; "+7001" does.
+    mock_client_7000 = AsyncMock()
+    mock_client_7000.get_entity = AsyncMock(
+        side_effect=ValueError("Could not find the input entity")
+    )
+    mock_client_7001 = AsyncMock()
+    mock_client_7001.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client_7001.iter_messages = MagicMock(return_value=_AsyncIterEmpty())
+
+    call_count = 0
+
+    async def get_client_by_phone_side_effect(phone):
+        nonlocal call_count
+        call_count += 1
+        if phone == "+7001":
+            return (mock_client_7001, "+7001")
+        return None
+
+    pool = make_mock_pool(
+        clients={"+7000": object(), "+7001": object()},
+        get_available_client=AsyncMock(return_value=(mock_client_7000, "+7000")),
+        get_client_by_phone=AsyncMock(side_effect=get_client_by_phone_side_effect),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig())
+    stats = await collector.collect_all_channels()
+
+    assert stats["errors"] == 0
+    # "+7001" must have been registered into the map
+    assert pool._channel_phone_map.get(1877929309) == "+7001"
+
+
+@pytest.mark.asyncio
 async def test_collect_all_dialogs_timeout(db):
     """Hanging get_dialogs() must not block collection (30s timeout)."""
     ch = Channel(channel_id=123, title="Test", username="test")

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -14,9 +14,15 @@ from src.telegram.collector import AllStatsClientsFloodedError, Collector, NoAct
 def mock_pool():
     pool = AsyncMock()
     pool.get_available_client = AsyncMock()
+    pool.get_client_by_phone = AsyncMock(return_value=None)
     pool.release_client = AsyncMock()
     pool.report_flood = AsyncMock()
     pool.is_dialogs_fetched = MagicMock(return_value=True)
+    pool.get_phone_for_channel = MagicMock(return_value=None)
+    pool.register_channel_phone = MagicMock()
+    pool.connected_phones = MagicMock(return_value=set())
+    pool.is_warming = MagicMock(return_value=False)
+    pool.wait_for_warm = AsyncMock()
     return pool
 
 


### PR DESCRIPTION
Closes #442

## What changed

Collection of private Telegram groups (supergroups without username) picks the account that actually has access, instead of failing with `Could not find the input entity for PeerChannel(...)`.

- **`channels.preferred_phone`** — new DB column; persists `channel_id → phone` across restarts.
- **`warm_all_dialogs()`** — prefills Telethon's entity cache for **every connected account** and populates `preferred_phone`. Runs at startup (background task) and on a scheduler job (default: every 24h).
- **Lookup chain for no-username channels**: `channels.preferred_phone` → in-memory map → wait for ongoing warm (with 30s timeout) → fallback to `get_available_client()`.
- **Error recovery**: on `ValueError` from `resolve_entity` (stale phone, account was kicked, etc.) — invalidate cached phone, rediscover across remaining phones, persist new mapping, retry. If no account has access — raises → error visible in UI.
- **Scheduler UI**: `warm_all_dialogs` shows up alongside other jobs with "Запустить сейчас" trigger and configurable interval.

## Why

`get_available_client()` picks any available phone arbitrarily. In multi-account setups the selected phone may not be a member of the private group — its entity cache has no `access_hash` for that channel and Telethon fails the resolve. Users saw "Ошибка" in the UI for every sync of a private group that the pool happened to route through the wrong account.

## Root cause

Two layers:

1. **Wrong account selected** — no routing by membership.
2. **Cache cold after restart** — dialogs were fetched lazily (once per phone, per process) on first collection attempt, so a fresh start left the cache empty.

Both are fixed: account is explicitly chosen by DB mapping, and the cache is warmed up-front for all accounts.

## Impact

- End users: collection of private groups now works as long as at least one connected account is a member.
- DB: new nullable `preferred_phone` column; migration is additive (`ALTER TABLE ADD COLUMN`), no downtime.
- Scheduler: one new visible job; disabled users can toggle or adjust interval.
- Behaviour unchanged for public channels (username path).

## Test coverage gap

The original single-phone tests passed because in a single-phone setup "entity not found → error" is the correct outcome. The bug only manifests in multi-phone setups, which no test covered.

This PR adds:

- `test_collect_private_group_uses_map_phone` — map hit, uses the phone directly (no fallback).
- `test_collect_private_group_discovers_access_phone` — two phones, first fails, second succeeds; map + DB get updated.

See #442 for the broader audit of `get_available_client()` call sites and fixture-level improvements.

## Validation

- `ruff check src/ tests/` — clean.
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — **4938 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)