### PR TITLE
fix(queue): shutdown race, unbounded queue, silent task failures

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -23,7 +23,7 @@ class CollectionQueue:
         if isinstance(channels, Database):
             channels = ChannelBundle.from_database(channels)
         self._channels = channels
-        self._queue: asyncio.Queue[tuple[int, Channel, bool, bool]] = asyncio.Queue()
+        self._queue: asyncio.Queue[tuple[int, Channel, bool, bool]] = asyncio.Queue(maxsize=500)
         self._worker: asyncio.Task | None = None
         self._current_task_id: int | None = None
         self._retried_tasks: set[int] = set()
@@ -99,7 +99,7 @@ class CollectionQueue:
             remaining = max(0.0, run_after.timestamp() - time.time())
             if remaining > 0:
                 await asyncio.sleep(remaining)
-            self._queue.put_nowait((task_id, channel, force, full))
+            await self._queue.put((task_id, channel, force, full))
             self._ensure_worker()
 
         task = asyncio.create_task(_requeue_later())
@@ -283,7 +283,7 @@ class CollectionQueue:
             return False
         self._retried_tasks.add(task_id)
         await self._channels.update_collection_task(task_id, CollectionTaskStatus.PENDING, note="Reconnect retry")
-        self._queue.put_nowait((task_id, channel, force, full))
+        await self._queue.put((task_id, channel, force, full))
         logger.warning(
             "ConnectionError for channel %d, reconnected and re-queued task %d: %s",
             channel.channel_id, task_id, exc,
@@ -340,11 +340,16 @@ class CollectionQueue:
                 await self._worker
             except asyncio.CancelledError:
                 pass
-        for task in list(self._delayed_requeues):
+        # Snapshot tasks before cancelling — the done_callback (discard)
+        # removes them from the set as soon as each resolves, so iterating
+        # the live set in a second loop would see an empty collection.
+        pending = list(self._delayed_requeues)
+        for task in pending:
             task.cancel()
-        for task in list(self._delayed_requeues):
+        for task in pending:
             try:
                 await task
             except asyncio.CancelledError:
                 pass
+        self._delayed_requeues.clear()
         self._retried_tasks.clear()

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Done-callback that logs unhandled exceptions from fire-and-forget tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Background task %s failed: %s", task.get_name(), exc)
+
+
 class SchedulerManager:
     def __init__(
         self,
@@ -286,7 +295,8 @@ class SchedulerManager:
 
     async def trigger_warm_background(self) -> None:
         """Fire-and-forget dialog cache warm run."""
-        asyncio.create_task(self._run_warm_dialogs(), name="warm_all_dialogs_manual")
+        task = asyncio.create_task(self._run_warm_dialogs(), name="warm_all_dialogs_manual")
+        task.add_done_callback(_log_task_exception)
 
     async def _run_warm_dialogs(self) -> None:
         if not self._warm_dialogs_callback:


### PR DESCRIPTION
## Summary
- Fix `CollectionQueue.shutdown()` iterating `_delayed_requeues` twice — `done_callback(discard)` empties the set after the first cancel loop, so cancelled tasks were never `await`ed, causing `RuntimeWarning: coroutine was never awaited` and resource leaks
- Add `maxsize=500` to the `asyncio.Queue` to prevent unbounded memory growth under mass enqueue; replace `put_nowait` with `await put()` for proper backpressure
- Add `_log_task_exception` done-callback to `trigger_warm_background()` so fire-and-forget task errors are logged instead of silently swallowed

## Test plan
- [x] All 5859 parallel tests pass
- [x] All 741 serial tests pass
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)