### PR TITLE
fix(agent): harden ACL and provider generation paths

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -6,7 +6,6 @@ import logging
 import os
 import shutil
 import time
-import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -419,9 +418,6 @@ class ClaudeSdkBackend:
         extra: dict = {}
         if resolved_model:
             extra["model"] = resolved_model
-        # claude-agent-sdk ≥0.1.52 requires a fresh valid UUID per call
-        extra["session_id"] = str(uuid.uuid4())
-
         stderr_lines: list[str] = []
         debug_lines: list[str] = []
         # Heartbeat: updated when real SDK events arrive (text, tools, results).

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -81,13 +81,19 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
 
         raw = await db.get_setting(TOOL_PERMISSIONS_SETTING)
     except Exception:
-        return None  # DB error → allow all
+        logger.warning("Failed to load agent tool permissions; blocking '%s'", tool_name, exc_info=True)
+        return _text_response(
+            f"❌ Не удалось загрузить ACL для '{tool_name}'. Действие заблокировано до восстановления настроек."
+        )
     if not raw:
         return None  # no restrictions configured → allow all
     try:
         perms = _json.loads(raw)
     except (ValueError, TypeError):
-        return None  # malformed → allow all
+        logger.warning("Malformed agent tool permissions JSON; blocking '%s'", tool_name)
+        return _text_response(
+            f"❌ ACL для '{tool_name}' повреждён. Действие заблокировано до исправления настроек."
+        )
     # Collect phones allowed for this tool
     allowed_phones = [p for p, tools in perms.items() if isinstance(tools, dict) and tools.get(tool_name, False)]
     if not allowed_phones:

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -94,6 +94,11 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
         return _text_response(
             f"❌ ACL для '{tool_name}' повреждён. Действие заблокировано до исправления настроек."
         )
+    if not isinstance(perms, dict):
+        logger.warning("Agent tool permissions JSON is not an object; blocking '%s'", tool_name)
+        return _text_response(
+            f"❌ ACL для '{tool_name}' повреждён. Действие заблокировано до исправления настроек."
+        )
     # Collect phones allowed for this tool
     allowed_phones = [p for p, tools in perms.items() if isinstance(tools, dict) and tools.get(tool_name, False)]
     if not allowed_phones:

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -234,6 +234,7 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
             from src.search.engine import SearchEngine
             from src.services.content_generation_service import ContentGenerationService
             from src.services.pipeline_service import PipelineService
+            from src.services.provider_service import build_provider_service
 
             svc = PipelineService(db)
             pipeline = _run_sync("run_pipeline_get", lambda: svc.get(pipeline_id))
@@ -241,7 +242,14 @@ def build_deepagents_tools(db, client_pool=None, config=None) -> list[Callable]:
                 return f"Пайплайн id={pipeline_id} не найден."
             engine = SearchEngine(db, config=config)
             image_service = _build_image_service_sync()
-            gen_svc = ContentGenerationService(db, engine, image_service=image_service)
+            provider_service = _run_sync("run_pipeline_provider_service", lambda: build_provider_service(db, config))
+            gen_svc = ContentGenerationService(
+                db,
+                engine,
+                config=config,
+                image_service=image_service,
+                provider_service=provider_service,
+            )
             run = _run_sync("run_pipeline", lambda: gen_svc.generate(pipeline))
             preview = (run.generated_text or "")[:300]
             return f"Генерация завершена (run id={run.id}). Превью:\n{preview}"

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -367,6 +367,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.search.engine import SearchEngine
             from src.services.content_generation_service import ContentGenerationService
             from src.services.pipeline_service import PipelineService
+            from src.services.provider_service import build_provider_service
 
             svc = PipelineService(db)
             pipeline = await svc.get(int(pipeline_id))
@@ -377,7 +378,14 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             engine = SearchEngine(db, config=config)
             image_service = await _build_image_service()
-            gen_svc = ContentGenerationService(db, engine, image_service=image_service)
+            provider_service = await build_provider_service(db, config)
+            gen_svc = ContentGenerationService(
+                db,
+                engine,
+                config=config,
+                image_service=image_service,
+                provider_service=provider_service,
+            )
             run = await gen_svc.generate(pipeline)
 
             preview = (run.generated_text or "")[:500]
@@ -410,24 +418,32 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.search.engine import SearchEngine
             from src.services.generation_service import GenerationService
             from src.services.pipeline_service import PipelineService
-            from src.services.provider_service import AgentProviderService
+            from src.services.provider_service import build_provider_service
 
             engine = SearchEngine(db, config=config)
             prompt_template = None
             llm_model = None
+            channel_id = None
             if pipeline_id is not None:
                 svc = PipelineService(db)
                 pipeline = await svc.get(int(pipeline_id))
                 if pipeline is not None:
                     prompt_template = pipeline.prompt_template
                     llm_model = pipeline.llm_model
+                    scope = await svc.get_retrieval_scope(pipeline)
+                    channel_id = scope.channel_id
                     if not query:
-                        query = prompt_template or pipeline.name or ""
-            provider_service = AgentProviderService(db)
+                        query = scope.query
+            provider_service = await build_provider_service(db, config)
             provider_callable = provider_service.get_provider_callable(llm_model)
 
             gen = GenerationService(engine, provider_callable=provider_callable)
-            result = await gen.generate(query=query, limit=limit, prompt_template=prompt_template)
+            result = await gen.generate(
+                query=query,
+                limit=limit,
+                prompt_template=prompt_template,
+                channel_id=channel_id,
+            )
             text = result.get("generated_text", "")
             citations = result.get("citations", [])
             content = f"Generated draft:\n\n{text}\n\nCitations:\n" + "\n".join(
@@ -771,7 +787,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.pipeline_service import PipelineService
 
             svc = PipelineService(db)
-            result = await svc.edit_via_llm(int(pipeline_id), instruction, db)
+            result = await svc.edit_via_llm(int(pipeline_id), instruction, db, config=config)
             if result["ok"]:
                 preview = _json.dumps(result["pipeline_json"], ensure_ascii=False, indent=2)[:800]
                 return _text_response(

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -302,15 +302,16 @@ def run(args: argparse.Namespace) -> None:
                 )
                 await db.repos.generation_runs.set_status(run_id, "running")
                 print(f"Created generation run id={run_id}")
-                retrieval_query = pipeline.prompt_template or pipeline.name or ""
+                scope = await svc.get_retrieval_scope(pipeline)
                 try:
                     result = await gen_svc.generate(
-                        query=retrieval_query,
+                        query=scope.query,
                         prompt_template=pipeline.prompt_template,
                         limit=args.limit,
                         model=pipeline.llm_model,
                         max_tokens=args.max_tokens,
                         temperature=args.temperature,
+                        channel_id=scope.channel_id,
                     )
                     await db.repos.generation_runs.save_result(
                         run_id,
@@ -355,8 +356,9 @@ def run(args: argparse.Namespace) -> None:
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
+                    config=config,
                     agent_manager=agent_manager,
-                    quality_service=QualityScoringService(db),
+                    quality_service=QualityScoringService(db, provider_service=provider_svc),
                     provider_service=provider_svc,
                 )
                 try:
@@ -599,7 +601,7 @@ def run(args: argparse.Namespace) -> None:
 
             elif args.pipeline_action == "ai-edit":
                 instruction = args.instruction
-                result = await svc.edit_via_llm(args.id, instruction, db)
+                result = await svc.edit_via_llm(args.id, instruction, db, config=config)
                 import json
 
                 if result["ok"]:

--- a/src/cli/commands/translate.py
+++ b/src/cli/commands/translate.py
@@ -39,7 +39,7 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Language detection complete: {total_updated} messages updated.")
 
             elif action == "run":
-                from src.services.provider_service import AgentProviderService
+                from src.services.provider_service import build_provider_service
                 from src.services.translation_service import TranslationService
 
                 target = getattr(args, "target", "en")
@@ -53,7 +53,7 @@ def run(args: argparse.Namespace) -> None:
                 provider_name = await db.get_setting("translation_provider")
                 model = await db.get_setting("translation_model")
 
-                provider_service = AgentProviderService(db)
+                provider_service = await build_provider_service(db, _config)
                 svc = TranslationService(db, provider_service=provider_service)
 
                 msgs = await db.repos.messages.get_untranslated_messages(
@@ -70,7 +70,7 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Translated {len(results)}/{len(msgs)} messages.")
 
             elif action == "message":
-                from src.services.provider_service import AgentProviderService
+                from src.services.provider_service import build_provider_service
                 from src.services.translation_service import TranslationService
 
                 message_id = args.message_id
@@ -87,7 +87,7 @@ def run(args: argparse.Namespace) -> None:
 
                 provider_name = await db.get_setting("translation_provider")
                 model = await db.get_setting("translation_model")
-                provider_service = AgentProviderService(db)
+                provider_service = await build_provider_service(db, _config)
                 svc = TranslationService(db, provider_service=provider_service)
 
                 results = await svc.translate_batch([msg], target, provider_name=provider_name, model=model)

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -47,7 +47,15 @@ class CollectionQueue:
         )
         if task_id is None:
             return None
-        await self._queue.put((task_id, channel, force, full))
+        try:
+            self._queue.put_nowait((task_id, channel, force, full))
+        except asyncio.QueueFull:
+            logger.warning(
+                "Collection queue full (maxsize=%d); task %d stays PENDING in DB "
+                "and will be picked up on the next restart/requeue cycle",
+                self._queue.maxsize,
+                task_id,
+            )
         self._ensure_worker()
         return task_id
 
@@ -99,7 +107,14 @@ class CollectionQueue:
             remaining = max(0.0, run_after.timestamp() - time.time())
             if remaining > 0:
                 await asyncio.sleep(remaining)
-            await self._queue.put((task_id, channel, force, full))
+            try:
+                self._queue.put_nowait((task_id, channel, force, full))
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Collection queue full on delayed requeue; task %d stays PENDING "
+                    "in DB and will be picked up by requeue_startup_tasks",
+                    task_id,
+                )
             self._ensure_worker()
 
         task = asyncio.create_task(_requeue_later())
@@ -283,7 +298,15 @@ class CollectionQueue:
             return False
         self._retried_tasks.add(task_id)
         await self._channels.update_collection_task(task_id, CollectionTaskStatus.PENDING, note="Reconnect retry")
-        await self._queue.put((task_id, channel, force, full))
+        try:
+            self._queue.put_nowait((task_id, channel, force, full))
+        except asyncio.QueueFull:
+            logger.warning(
+                "Collection queue full on reconnect requeue; task %d stays PENDING "
+                "and will be picked up by requeue_startup_tasks",
+                task_id,
+            )
+            return False
         logger.warning(
             "ConnectionError for channel %d, reconnected and re-queued task %d: %s",
             channel.channel_id, task_id, exc,
@@ -326,7 +349,15 @@ class CollectionQueue:
                     run_after=task.run_after,
                 )
             else:
-                await self._queue.put((task.id, channel, force, full))
+                try:
+                    self._queue.put_nowait((task.id, channel, force, full))
+                except asyncio.QueueFull:
+                    logger.warning(
+                        "Collection queue full during startup requeue; task %d stays PENDING "
+                        "in DB and will be picked up after the queue drains",
+                        task.id,
+                    )
+                    break
             count += 1
         if count:
             self._ensure_worker()

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -23,7 +23,7 @@ class CollectionQueue:
         if isinstance(channels, Database):
             channels = ChannelBundle.from_database(channels)
         self._channels = channels
-        self._queue: asyncio.Queue[tuple[int, Channel, bool, bool]] = asyncio.Queue()
+        self._queue: asyncio.Queue[tuple[int, Channel, bool, bool]] = asyncio.Queue(maxsize=500)
         self._worker: asyncio.Task | None = None
         self._current_task_id: int | None = None
         self._retried_tasks: set[int] = set()
@@ -99,7 +99,7 @@ class CollectionQueue:
             remaining = max(0.0, run_after.timestamp() - time.time())
             if remaining > 0:
                 await asyncio.sleep(remaining)
-            self._queue.put_nowait((task_id, channel, force, full))
+            await self._queue.put((task_id, channel, force, full))
             self._ensure_worker()
 
         task = asyncio.create_task(_requeue_later())
@@ -283,7 +283,7 @@ class CollectionQueue:
             return False
         self._retried_tasks.add(task_id)
         await self._channels.update_collection_task(task_id, CollectionTaskStatus.PENDING, note="Reconnect retry")
-        self._queue.put_nowait((task_id, channel, force, full))
+        await self._queue.put((task_id, channel, force, full))
         logger.warning(
             "ConnectionError for channel %d, reconnected and re-queued task %d: %s",
             channel.channel_id, task_id, exc,
@@ -340,11 +340,16 @@ class CollectionQueue:
                 await self._worker
             except asyncio.CancelledError:
                 pass
-        for task in list(self._delayed_requeues):
+        # Snapshot tasks before cancelling — the done_callback (discard)
+        # removes them from the set as soon as each resolves, so iterating
+        # the live set in a second loop would see an empty collection.
+        pending = list(self._delayed_requeues)
+        for task in pending:
             task.cancel()
-        for task in list(self._delayed_requeues):
+        for task in pending:
             try:
                 await task
             except asyncio.CancelledError:
                 pass
+        self._delayed_requeues.clear()
         self._retried_tasks.clear()

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Done-callback that logs unhandled exceptions from fire-and-forget tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Background task %s failed: %s", task.get_name(), exc)
+
+
 class SchedulerManager:
     def __init__(
         self,
@@ -286,7 +295,8 @@ class SchedulerManager:
 
     async def trigger_warm_background(self) -> None:
         """Fire-and-forget dialog cache warm run."""
-        asyncio.create_task(self._run_warm_dialogs(), name="warm_all_dialogs_manual")
+        task = asyncio.create_task(self._run_warm_dialogs(), name="warm_all_dialogs_manual")
+        task.add_done_callback(_log_task_exception)
 
     async def _run_warm_dialogs(self) -> None:
         if not self._warm_dialogs_callback:

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -30,6 +30,7 @@ class ContentGenerationService:
         self,
         db: Database,
         search_engine: SearchEngine,
+        config: Any | None = None,
         agent_manager: Any | None = None,
         image_service: Any | None = None,
         notification_service: "DraftNotificationService | None" = None,
@@ -39,6 +40,7 @@ class ContentGenerationService:
     ) -> None:
         self._db = db
         self._search = search_engine
+        self._config = config
         self._agent_manager = agent_manager
         self._image_service = image_service
         self._notification_service = notification_service
@@ -190,8 +192,15 @@ class ContentGenerationService:
     ) -> dict[str, Any]:
         """Execute the pipeline using the node-based DAG executor."""
         from src.services.pipeline_executor import PipelineExecutor
+        from src.services.pipeline_service import resolve_retrieval_scope
 
-        provider_callable = self._get_provider_callable(pipeline.llm_model)
+        provider_callable = await self._get_provider_callable(pipeline.llm_model)
+        list_sources = getattr(
+            getattr(getattr(self._db, "repos", None), "content_pipelines", None),
+            "list_sources",
+            None,
+        )
+        scope = await resolve_retrieval_scope(pipeline, list_sources)
 
         default_image_model = await self._db.get_setting("default_image_model") or ""
 
@@ -205,6 +214,8 @@ class ContentGenerationService:
             "default_image_model": pipeline.image_model or default_image_model,
             "db": self._db,
             "since_hours": since_hours,
+            "generation_query": scope.query,
+            "channel_id": scope.channel_id,
         }
 
         # Inject read-only agent tools for AgentLoopHandler
@@ -239,32 +250,25 @@ class ContentGenerationService:
         temperature: float,
     ) -> dict[str, Any]:
         """Run RAG-based generation using GenerationService."""
-        provider_callable = self._get_provider_callable(pipeline.llm_model)
+        from src.services.pipeline_service import resolve_retrieval_scope
+
+        provider_callable = await self._get_provider_callable(pipeline.llm_model)
 
         gen = GenerationService(self._search, provider_callable=provider_callable)
-
-        # Use pipeline name as search query; constrain to first source channel if available
-        query = pipeline.name or ""
-        channel_id: int | None = None
-        try:
-            sources = await self._db.repos.content_pipelines.list_sources(pipeline.id)
-            if len(sources) == 1:
-                channel_id = sources[0].channel_id
-            # For multi-source pipelines keep channel_id=None to retrieve from all channels
-        except Exception:
-            logger.warning(
-                "Failed to load pipeline sources for %s, continuing without channel scoping",
-                pipeline.id,
-                exc_info=True,
-            )
+        list_sources = getattr(
+            getattr(getattr(self._db, "repos", None), "content_pipelines", None),
+            "list_sources",
+            None,
+        )
+        scope = await resolve_retrieval_scope(pipeline, list_sources)
 
         return await gen.generate(
-            query=query,
+            query=scope.query,
             prompt_template=pipeline.prompt_template,
             model=(model or pipeline.llm_model),
             max_tokens=max_tokens,
             temperature=temperature,
-            channel_id=channel_id,
+            channel_id=scope.channel_id,
         )
 
     async def _run_deep_agents(
@@ -316,7 +320,7 @@ class ContentGenerationService:
         temperature: float,
     ) -> str:
         """Apply each refinement step sequentially, replacing {text} with current output."""
-        provider_callable = self._get_provider_callable(pipeline.llm_model)
+        provider_callable = await self._get_provider_callable(pipeline.llm_model)
 
         for step in pipeline.refinement_steps:
             step_prompt = step.get("prompt", "")
@@ -361,10 +365,15 @@ class ContentGenerationService:
             return None
         return await self._image_service.generate(model or pipeline.image_model, text)
 
-    def _get_provider_callable(self, model: str | None) -> Any:
-        """Resolve provider callable — prefer injected shared service, fall back to local."""
-        if self._provider_service is not None:
-            return self._provider_service.get_provider_callable(model)
-        from src.services.provider_service import AgentProviderService
+    async def _ensure_provider_service(self) -> Any:
+        """Resolve or build provider service, loading DB-backed providers when config is available."""
+        if self._provider_service is None:
+            from src.services.provider_service import build_provider_service
 
-        return AgentProviderService(self._db).get_provider_callable(model)
+            self._provider_service = await build_provider_service(self._db, self._config)
+        return self._provider_service
+
+    async def _get_provider_callable(self, model: str | None) -> Any:
+        """Resolve provider callable — prefer injected shared service, fall back to local."""
+        provider_service = await self._ensure_provider_service()
+        return provider_service.get_provider_callable(model)

--- a/src/services/pipeline_executor.py
+++ b/src/services/pipeline_executor.py
@@ -89,7 +89,8 @@ class PipelineExecutor:
 
         # Seed initial values from pipeline model (for legacy-compat)
         context.set_global("prompt_template", pipeline.prompt_template or "")
-        context.set_global("generation_query", pipeline.prompt_template or pipeline.name or "")
+        context.set_global("generation_query", services.get("generation_query", pipeline.name or ""))
+        context.set_global("channel_id", services.get("channel_id"))
         context.set_global("default_model", pipeline.llm_model or "")
 
         ordered = _topological_sort(graph)

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -49,14 +49,16 @@ class RetrieveContextHandler(BaseNodeHandler):
         query = context.get_global("generation_query", "") or context.get_global("prompt_template", "")
         limit = int(node_config.get("limit", 8))
         method = node_config.get("method", "hybrid")
+        source_channel_ids = context.get_global("source_channel_ids", [])
+        channel_id = source_channel_ids[0] if len(source_channel_ids) == 1 else context.get_global("channel_id")
 
         try:
             if method == "hybrid" and search_engine.semantic_available:
-                result = await search_engine.search_hybrid(query, limit=limit)
+                result = await search_engine.search_hybrid(query, channel_id=channel_id, limit=limit)
             elif method == "semantic" and search_engine.semantic_available:
-                result = await search_engine.search_semantic(query, limit=limit)
+                result = await search_engine.search_semantic(query, channel_id=channel_id, limit=limit)
             else:
-                result = await search_engine.search_local(query, limit=limit)
+                result = await search_engine.search_local(query, channel_id=channel_id, limit=limit)
             context.set_global("context_messages", result.messages)
         except Exception:
             logger.warning("RetrieveContextHandler: search failed, using empty context", exc_info=True)

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from src.agent.prompt_template import PromptTemplateError, validate_prompt_template
 from src.database import Database
@@ -47,6 +47,34 @@ def to_since_hours(value: int, unit: str) -> float:
 class PipelineTargetRef:
     phone: str
     dialog_id: int
+
+
+@dataclass(frozen=True)
+class PipelineRetrievalScope:
+    query: str
+    channel_id: int | None
+
+
+async def resolve_retrieval_scope(
+    pipeline: ContentPipeline,
+    list_sources: Callable[[int], Awaitable[list[Any]]] | None = None,
+) -> PipelineRetrievalScope:
+    """Return retrieval query and optional single-source scope for a pipeline."""
+    query = pipeline.name or ""
+    channel_id: int | None = None
+    if list_sources is None:
+        return PipelineRetrievalScope(query=query, channel_id=channel_id)
+    try:
+        sources = await list_sources(pipeline.id)
+        if len(sources) == 1:
+            channel_id = sources[0].channel_id
+    except Exception:
+        logger.warning(
+            "Failed to load pipeline sources for %s, continuing without channel scoping",
+            pipeline.id,
+            exc_info=True,
+        )
+    return PipelineRetrievalScope(query=query, channel_id=channel_id)
 
 
 class PipelineValidationError(ValueError):
@@ -464,7 +492,18 @@ class PipelineService:
         targets = await self._normalize_targets(target_refs) if target_refs else []
         return await self._bundle.add(pipeline, sources, targets)
 
-    async def edit_via_llm(self, pipeline_id: int, instruction: str, db: Database) -> dict:
+    async def get_retrieval_scope(self, pipeline: ContentPipeline) -> PipelineRetrievalScope:
+        """Return the retrieval query and optional single-source channel scope for a pipeline."""
+        return await resolve_retrieval_scope(pipeline, self._bundle.list_sources)
+
+    async def edit_via_llm(
+        self,
+        pipeline_id: int,
+        instruction: str,
+        db: Database,
+        *,
+        config: Any | None = None,
+    ) -> dict:
         """Edit a pipeline's JSON config via LLM instruction.
 
         Returns {"ok": True, "pipeline_json": {...}} or {"ok": False, "error": "..."}.
@@ -494,10 +533,16 @@ class PipelineService:
         )
 
         try:
-            from src.services.provider_service import AgentProviderService
-            provider_service = AgentProviderService(db)
+            from src.services.provider_service import build_provider_service
+
+            provider_service = await build_provider_service(db, config)
             provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
-            result = await provider_callable(prompt, model=pipeline.llm_model or "", max_tokens=4096, temperature=0.2)
+            result = await provider_callable(
+                prompt,
+                model=pipeline.llm_model or "",
+                max_tokens=4096,
+                temperature=0.2,
+            )
             raw = result if isinstance(result, str) else (result.get("text") or result.get("generated_text") or "")
             # Strip markdown fences if present
             raw = raw.strip()

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import logging
 import os
 from typing import Any, Awaitable, Callable, Dict, Optional
@@ -29,9 +28,7 @@ async def build_provider_service(
     """Create AgentProviderService and eagerly load DB-backed providers when possible."""
     svc = AgentProviderService(db, config)
     if db is not None and config is not None:
-        maybe_awaitable = svc.load_db_providers()
-        if inspect.isawaitable(maybe_awaitable):
-            await maybe_awaitable
+        await svc.load_db_providers()
     return svc
 
 

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import Any, Awaitable, Callable, Dict, Optional
@@ -19,6 +20,19 @@ _OPENAI_STYLE_BASE_URLS: Dict[str, str] = {
     "fireworks": "https://api.fireworks.ai/inference/v1",
     "mistralai": "https://api.mistral.ai/v1",
 }
+
+
+async def build_provider_service(
+    db: object | None = None,
+    config: object | None = None,
+) -> "AgentProviderService":
+    """Create AgentProviderService and eagerly load DB-backed providers when possible."""
+    svc = AgentProviderService(db, config)
+    if db is not None and config is not None:
+        maybe_awaitable = svc.load_db_providers()
+        if inspect.isawaitable(maybe_awaitable):
+            await maybe_awaitable
+    return svc
 
 
 class AgentProviderService:

--- a/src/services/quality_scoring_service.py
+++ b/src/services/quality_scoring_service.py
@@ -52,9 +52,11 @@ class QualityScoringService:
         self,
         db: Database,
         default_threshold: float = 0.7,
+        provider_service=None,
     ):
         self._db = db
         self._default_threshold = default_threshold
+        self._provider_service = provider_service
 
     async def score_content(
         self,
@@ -85,7 +87,7 @@ class QualityScoringService:
             return _default_score
 
         try:
-            provider_service = AgentProviderService(self._db)
+            provider_service = self._provider_service or AgentProviderService(self._db)
             provider_callable = provider_service.get_provider_callable(model)
 
             prompt = f"{QUALITY_RUBRIC}\n\nКонтент для оценки:\n{text}"

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -503,18 +503,17 @@ class UnifiedDispatcher:
 
             db = self._db
             notification_service = DraftNotificationService(db, self._notifier)
-            quality_service = QualityScoringService(db)
-
             image_service = await self._build_image_service()
             provider_service = self._llm_provider_service
             if provider_service is None:
-                from src.services.provider_service import AgentProviderService
+                from src.services.provider_service import build_provider_service
 
-                provider_service = AgentProviderService(db, self._config)
-                await provider_service.load_db_providers()
+                provider_service = await build_provider_service(db, self._config)
+            quality_service = QualityScoringService(db, provider_service=provider_service)
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                config=self._config,
                 image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,
@@ -595,18 +594,17 @@ class UnifiedDispatcher:
 
             db = self._db
             notification_service = DraftNotificationService(db, self._notifier)
-            quality_service = QualityScoringService(db)
-
             image_service = await self._build_image_service()
             provider_service = self._llm_provider_service
             if provider_service is None:
-                from src.services.provider_service import AgentProviderService
+                from src.services.provider_service import build_provider_service
 
-                provider_service = AgentProviderService(db, self._config)
-                await provider_service.load_db_providers()
+                provider_service = await build_provider_service(db, self._config)
+            quality_service = QualityScoringService(db, provider_service=provider_service)
             gen = ContentGenerationService(
                 db,
                 self._search_engine,
+                config=self._config,
                 image_service=image_service,
                 notification_service=notification_service,
                 quality_service=quality_service,
@@ -745,14 +743,14 @@ class UnifiedDispatcher:
             return
 
         try:
-            from src.services.provider_service import AgentProviderService
+            from src.services.provider_service import build_provider_service
             from src.services.translation_service import TranslationService
 
             # Load translation settings
             provider_name = await self._db.get_setting("translation_provider")
             model = await self._db.get_setting("translation_model")
 
-            provider_service = AgentProviderService(self._db)
+            provider_service = await build_provider_service(self._db, self._config)
 
             # Fail fast if no real provider is configured (only stub default available)
             resolved = provider_service.get_provider_callable(provider_name)

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -478,8 +478,10 @@ async def generate_stream(
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService
+    from src.services.pipeline_service import PipelineService
 
     gen = GenerationService(engine, provider_callable=provider_callable)
+    scope = await PipelineService(db).get_retrieval_scope(pipeline)
 
     # persist run
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
@@ -488,17 +490,16 @@ async def generate_stream(
     except Exception:
         await db.repos.generation_runs.set_status(run_id, "failed")
         raise
-    retrieval_query = pipeline.prompt_template or pipeline.name or ""
-
     async def event_gen():
         last = None
         try:
             async for update in gen.generate_stream(
-                query=retrieval_query,
+                query=scope.query,
                 prompt_template=pipeline.prompt_template,
                 model=(model or pipeline.llm_model),
                 max_tokens=max_tokens,
                 temperature=temperature,
+                channel_id=scope.channel_id,
             ):
                 last = update
                 data = {
@@ -548,22 +549,24 @@ async def generate_pipeline(
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService
+    from src.services.pipeline_service import PipelineService
 
     gen = GenerationService(engine, provider_callable=provider_callable)
+    scope = await PipelineService(db).get_retrieval_scope(pipeline)
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
     try:
         await db.repos.generation_runs.set_status(run_id, "running")
     except Exception:
         await db.repos.generation_runs.set_status(run_id, "failed")
         raise
-    retrieval_query = pipeline.prompt_template or pipeline.name or ""
     try:
         result = await gen.generate(
-            query=retrieval_query,
+            query=scope.query,
             prompt_template=pipeline.prompt_template,
             model=(model or pipeline.llm_model),
             max_tokens=max_tokens,
             temperature=temperature,
+            channel_id=scope.channel_id,
         )
         await db.repos.generation_runs.save_result(
             run_id, result.get("generated_text", ""), {"citations": result.get("citations", [])}
@@ -830,7 +833,7 @@ async def ai_edit_pipeline(request: Request, pipeline_id: int):
         instruction = body.get("instruction", "").strip()
         if not instruction:
             return JSONResponse(content={"ok": False, "error": "instruction is required"}, status_code=400)
-        result = await svc.edit_via_llm(pipeline_id, instruction, db)
+        result = await svc.edit_via_llm(pipeline_id, instruction, db, config=request.app.state.config)
         return JSONResponse(content=result)
     except Exception as exc:
         return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=500)

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -478,10 +478,9 @@ async def generate_stream(
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService
-    from src.services.pipeline_service import PipelineService
 
     gen = GenerationService(engine, provider_callable=provider_callable)
-    scope = await PipelineService(db).get_retrieval_scope(pipeline)
+    scope = await svc.get_retrieval_scope(pipeline)
 
     # persist run
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
@@ -549,10 +548,9 @@ async def generate_pipeline(
     provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
     from src.services.generation_service import GenerationService
-    from src.services.pipeline_service import PipelineService
 
     gen = GenerationService(engine, provider_callable=provider_callable)
-    scope = await PipelineService(db).get_retrieval_scope(pipeline)
+    scope = await svc.get_retrieval_scope(pipeline)
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
     try:
         await db.repos.generation_runs.set_status(run_id, "running")

--- a/tests/agent_tools_helpers.py
+++ b/tests/agent_tools_helpers.py
@@ -1,11 +1,23 @@
 """Shared helpers for agent tools tests."""
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _normalize_get_setting_mock(mock_db) -> None:
+    """Default unconfigured Database.get_setting() mocks to None."""
+    get_setting = getattr(mock_db, "get_setting", None)
+    if not isinstance(get_setting, AsyncMock):
+        return
+    if get_setting.side_effect is not None:
+        return
+    if isinstance(get_setting.return_value, (AsyncMock, MagicMock)):
+        get_setting.return_value = None
 
 
 def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
     """Build MCP tools and return their handlers keyed by name."""
+    _normalize_get_setting_mock(mock_db)
     captured_tools = []
     with patch(
         "src.agent.tools.create_sdk_mcp_server",

--- a/tests/test_agent_tools_pipelines_extra.py
+++ b/tests/test_agent_tools_pipelines_extra.py
@@ -1209,6 +1209,9 @@ class TestGenerateDraftTool:
         ):
             mock_se.return_value = MagicMock()
             mock_pipe_svc.return_value.get = AsyncMock(return_value=pipeline)
+            mock_pipe_svc.return_value.get_retrieval_scope = AsyncMock(
+                return_value=SimpleNamespace(query="pipeline", channel_id=None)
+            )
             mock_prov_svc.return_value.get_provider_callable = MagicMock(
                 return_value=None
             )

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -174,18 +174,20 @@ class TestRequirePhonePermission:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_malformed_json_allows_all(self):
+    async def test_malformed_json_blocks(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value="not-json")
         result = await require_phone_permission(db, "+7900", "search_messages")
-        assert result is None
+        assert result is not None
+        assert "заблокировано" in result["content"][0]["text"]
 
     @pytest.mark.asyncio
-    async def test_db_exception_allows_all(self):
+    async def test_db_exception_blocks(self):
         db = MagicMock()
         db.get_setting = AsyncMock(side_effect=Exception("err"))
         result = await require_phone_permission(db, "+7900", "search_messages")
-        assert result is None
+        assert result is not None
+        assert "заблокировано" in result["content"][0]["text"]
 
     @pytest.mark.asyncio
     async def test_phone_in_allowed_list(self):

--- a/tests/test_cli_translate.py
+++ b/tests/test_cli_translate.py
@@ -24,6 +24,11 @@ def cli_env(cli_db):
         yield cli_db
 
 
+def _prep_prov_mock(mock_prov_svc):
+    """Configure the class-level mock so that an instance's load_db_providers() is awaitable."""
+    mock_prov_svc.return_value.load_db_providers = AsyncMock(return_value=0)
+
+
 class TestStats:
     @patch("src.database.repositories.messages.MessagesRepository.get_language_stats")
     def test_stats_no_data(self, mock_stats, cli_env, capsys):
@@ -96,6 +101,7 @@ class TestRun:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_untranslated_messages")
     def test_run_no_messages(self, mock_get, mock_prov_svc, mock_trans_svc, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         mock_get.return_value = []
         from src.cli.commands.translate import run
         run(_ns(translate_action="run"))
@@ -107,6 +113,7 @@ class TestRun:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_untranslated_messages")
     def test_run_translates_messages(self, mock_get, mock_prov_svc, mock_trans_svc, mock_update, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         msgs = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
         mock_get.return_value = msgs
         svc = mock_trans_svc.return_value
@@ -121,6 +128,7 @@ class TestRun:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_untranslated_messages")
     def test_run_with_source_filter(self, mock_get, mock_prov_svc, mock_trans_svc, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         msgs = [SimpleNamespace(id=1)]
         mock_get.return_value = msgs
         svc = mock_trans_svc.return_value
@@ -134,6 +142,7 @@ class TestRun:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_untranslated_messages")
     def test_run_with_limit(self, mock_get, mock_prov_svc, mock_trans_svc, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         mock_get.return_value = []
         from src.cli.commands.translate import run
         run(_ns(translate_action="run", limit=10))
@@ -145,6 +154,7 @@ class TestRun:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_untranslated_messages")
     def test_run_partial_failure(self, mock_get, mock_prov_svc, mock_trans_svc, mock_update, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         msgs = [SimpleNamespace(id=1), SimpleNamespace(id=2), SimpleNamespace(id=3)]
         mock_get.return_value = msgs
         svc = mock_trans_svc.return_value
@@ -177,6 +187,7 @@ class TestMessage:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_by_id")
     def test_message_success(self, mock_get, mock_prov_svc, mock_trans_svc, mock_update, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         mock_get.return_value = SimpleNamespace(id=1, text="Привет мир")
         svc = mock_trans_svc.return_value
         svc.translate_batch = AsyncMock(return_value=[(1, "Hello world")])
@@ -190,6 +201,7 @@ class TestMessage:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_by_id")
     def test_message_translation_failed(self, mock_get, mock_prov_svc, mock_trans_svc, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         mock_get.return_value = SimpleNamespace(id=1, text="Some text here")
         svc = mock_trans_svc.return_value
         svc.translate_batch = AsyncMock(return_value=[])
@@ -203,6 +215,7 @@ class TestMessage:
     @patch("src.services.provider_service.AgentProviderService")
     @patch("src.database.repositories.messages.MessagesRepository.get_by_id")
     def test_message_with_custom_target(self, mock_get, mock_prov_svc, mock_trans_svc, mock_update, cli_env, capsys):
+        _prep_prov_mock(mock_prov_svc)
         mock_get.return_value = SimpleNamespace(id=1, text="Hello")
         svc = mock_trans_svc.return_value
         svc.translate_batch = AsyncMock(return_value=[(1, "Hallo")])

--- a/tests/test_cli_translate_commands.py
+++ b/tests/test_cli_translate_commands.py
@@ -99,6 +99,7 @@ def test_run_no_messages(capsys):
     db = _make_db()
     db.repos.messages.get_untranslated_messages = AsyncMock(return_value=[])
     mock_ps = MagicMock()
+    mock_ps.load_db_providers = AsyncMock(return_value=0)
     mock_ts = MagicMock()
     mock_ts.translate_batch = AsyncMock(return_value=[])
     with _patches(db)[0], _patches(db)[1], \
@@ -114,6 +115,7 @@ def test_run_with_messages(capsys):
     db.repos.messages.get_untranslated_messages = AsyncMock(return_value=msgs)
     db.repos.messages.update_translation = AsyncMock()
     mock_ps = MagicMock()
+    mock_ps.load_db_providers = AsyncMock(return_value=0)
     mock_ts = MagicMock()
     mock_ts.translate_batch = AsyncMock(return_value=[(1, "translated text")])
     with _patches(db)[0], _patches(db)[1], \
@@ -153,6 +155,7 @@ def test_message_with_text(capsys):
     db.repos.messages.get_by_id = AsyncMock(return_value=msg)
     db.repos.messages.update_translation = AsyncMock()
     mock_ps = MagicMock()
+    mock_ps.load_db_providers = AsyncMock(return_value=0)
     mock_ts = MagicMock()
     mock_ts.translate_batch = AsyncMock(return_value=[(1, "Hello world")])
     with _patches(db)[0], _patches(db)[1], \
@@ -169,6 +172,7 @@ def test_message_translation_failed(capsys):
     msg = MagicMock(text="Привет")
     db.repos.messages.get_by_id = AsyncMock(return_value=msg)
     mock_ps = MagicMock()
+    mock_ps.load_db_providers = AsyncMock(return_value=0)
     mock_ts = MagicMock()
     mock_ts.translate_batch = AsyncMock(return_value=[])
     with _patches(db)[0], _patches(db)[1], \

--- a/tests/test_content_generation_extra.py
+++ b/tests/test_content_generation_extra.py
@@ -722,6 +722,8 @@ async def test_run_graph_passes_services():
         assert captured_services["image_service"] is image_svc
         assert captured_services["notification_service"] is notification_svc
         assert captured_services["client_pool"] is client_pool
+        assert captured_services["generation_query"] == "GraphTest"
+        assert captured_services["channel_id"] is None
     finally:
         _restore_provider(orig)
         if original_execute:

--- a/tests/test_coverage_batch2.py
+++ b/tests/test_coverage_batch2.py
@@ -1060,6 +1060,9 @@ class TestPipelinesToolGenerateDraft:
         gen_result = {"generated_text": "Pipeline draft", "citations": []}
         with patch("src.services.pipeline_service.PipelineService") as mock_ps:
             mock_ps.return_value.get = AsyncMock(return_value=p)
+            mock_ps.return_value.get_retrieval_scope = AsyncMock(
+                return_value=SimpleNamespace(query="P", channel_id=None)
+            )
             with patch("src.search.engine.SearchEngine"):
                 with patch("src.services.generation_service.GenerationService") as mock_gen:
                     with patch("src.services.provider_service.AgentProviderService") as mock_aps:

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -56,6 +56,11 @@ def _make_pool_with_clients(phones=None):
 
 def _get_messaging_handlers(mock_db, client_pool=None):
     """Build MCP tools and return messaging handlers keyed by name."""
+    get_setting = getattr(mock_db, "get_setting", None)
+    if isinstance(get_setting, AsyncMock) and get_setting.side_effect is None and isinstance(
+        get_setting.return_value, (AsyncMock, MagicMock)
+    ):
+        get_setting.return_value = None
     captured_tools = []
 
     with patch(
@@ -1683,6 +1688,7 @@ class TestImageToolEdgeCases:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()
@@ -1763,6 +1769,7 @@ class TestCollectionToolErrors:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()
@@ -1824,6 +1831,7 @@ class TestFilterToolEdge:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()
@@ -1866,6 +1874,7 @@ class TestNotificationToolErrors:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()
@@ -2005,6 +2014,7 @@ class TestMyTelegramToolErrors:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()
@@ -2098,6 +2108,7 @@ class TestPhotoLoaderToolErrors:
         mock_db.get_accounts = AsyncMock(return_value=[
             Account(id=1, phone="+1111", session_string="s", is_active=True, is_primary=True),
         ])
+        mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos.settings = MagicMock()
         mock_db.repos.settings.get = AsyncMock(return_value=None)
         mock_db.repos.tool_permissions = MagicMock()

--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -314,7 +314,8 @@ class TestExecuteSeedsContext:
 
         assert captured_context is not None
         assert captured_context.get_global("prompt_template") == "my prompt"
-        assert captured_context.get_global("generation_query") == "my prompt"
+        assert captured_context.get_global("generation_query") == "test-pipeline"
+        assert captured_context.get_global("channel_id") is None
         assert captured_context.get_global("default_model") == "gpt-4o"
         # publish_mode falls back to pipeline's value
         assert result["publish_mode"] == PipelinePublishMode.MODERATED.value

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -117,6 +117,27 @@ async def test_retrieve_context_search_exception():
     assert ctx.get_global("context_messages") == []
 
 
+@pytest.mark.asyncio
+async def test_retrieve_context_single_source_scopes_channel():
+    ctx = NodeContext()
+    ctx.set_global("source_channel_ids", [42])
+    engine = _search_engine([_msg("hybrid")])
+    await RetrieveContextHandler().execute({"method": "hybrid"}, ctx, {"search_engine": engine})
+    _, kwargs = engine.search_hybrid.await_args
+    assert kwargs["channel_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_uses_preseeded_channel_scope_when_multiple_sources():
+    ctx = NodeContext()
+    ctx.set_global("source_channel_ids", [1, 2])
+    ctx.set_global("channel_id", 99)
+    engine = _search_engine([_msg("hybrid")])
+    await RetrieveContextHandler().execute({"method": "hybrid"}, ctx, {"search_engine": engine})
+    _, kwargs = engine.search_hybrid.await_args
+    assert kwargs["channel_id"] == 99
+
+
 # ── LlmGenerateHandler ────────────────────────────────────────────────────────
 
 

--- a/tests/test_pipeline_service_extra.py
+++ b/tests/test_pipeline_service_extra.py
@@ -95,6 +95,28 @@ async def test_get_nonexistent(svc):
 
 
 @pytest.mark.asyncio
+async def test_get_retrieval_scope_single_source(svc):
+    pipeline_id = await svc.add(
+        name="SingleSource",
+        prompt_template="Prompt {source_messages}",
+        source_channel_ids=[1001],
+        target_refs=[PipelineTargetRef(phone="+100", dialog_id=77)],
+    )
+    pipeline = await svc.get(pipeline_id)
+    scope = await svc.get_retrieval_scope(pipeline)
+    assert scope.query == "SingleSource"
+    assert scope.channel_id == 1001
+
+
+@pytest.mark.asyncio
+async def test_get_retrieval_scope_multi_source(svc, pipeline_id):
+    pipeline = await svc.get(pipeline_id)
+    scope = await svc.get_retrieval_scope(pipeline)
+    assert scope.query == "TestPipeline"
+    assert scope.channel_id is None
+
+
+@pytest.mark.asyncio
 async def test_toggle_deactivates(svc, pipeline_id):
     result = await svc.toggle(pipeline_id)
     assert result is True

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.services.provider_service import AgentProviderService
+from src.services.provider_service import AgentProviderService, build_provider_service
 
 
 @pytest.fixture
@@ -151,6 +151,16 @@ async def test_reload_db_providers_clears_and_reloads(mock_db, mock_config):
 
     assert added == 0
     assert "groq" not in svc._registry
+
+
+@pytest.mark.asyncio
+async def test_build_provider_service_loads_db_providers(mock_db, mock_config):
+    """Async helper should eagerly load DB-backed providers when config is available."""
+    with patch("src.services.provider_service.AgentProviderService.load_db_providers", new=AsyncMock()) as mock_load:
+        svc = await build_provider_service(mock_db, mock_config)
+
+    assert isinstance(svc, AgentProviderService)
+    mock_load.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler_pipeline.py
+++ b/tests/test_scheduler_pipeline.py
@@ -130,7 +130,7 @@ async def test_pipeline_run_handler_uses_content_generation_service(monkeypatch)
             captured["notification_notifier"] = notifier
 
     class FakeQualityScoringService:
-        def __init__(self, db):
+        def __init__(self, db, **kwargs):
             captured["quality_db"] = db
 
     class FakeContentGenerationService:

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -148,13 +148,17 @@ class TestRequirePhonePermission:
         mock_db.get_setting = AsyncMock(return_value=None)
         assert await require_phone_permission(mock_db, "+79990001111", "leave_dialogs") is None
 
-    async def test_db_error_allows(self, mock_db):
+    async def test_db_error_blocks(self, mock_db):
         mock_db.get_setting = AsyncMock(side_effect=Exception("DB down"))
-        assert await require_phone_permission(mock_db, "+79990001111", "leave_dialogs") is None
+        result = await require_phone_permission(mock_db, "+79990001111", "leave_dialogs")
+        assert result is not None
+        assert "заблокировано" in _text(result)
 
-    async def test_malformed_json_allows(self, mock_db):
+    async def test_malformed_json_blocks(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value="not json{{{")
-        assert await require_phone_permission(mock_db, "+79990001111", "leave_dialogs") is None
+        result = await require_phone_permission(mock_db, "+79990001111", "leave_dialogs")
+        assert result is not None
+        assert "поврежд" in _text(result)
 
     async def test_phone_in_allowed(self, mock_db):
         perms = {"+79990001111": {"leave_dialogs": True}}


### PR DESCRIPTION
## Summary

- harden agent tool ACL handling to fail closed on unreadable or malformed settings
- load DB-backed providers consistently across generation, translation, dispatcher, web, CLI, and agent entrypoints
- unify pipeline retrieval scoping/query resolution and remove outdated `ClaudeAgentOptions.session_id` usage
- align affected tests and helpers with the new ACL and provider-loading behavior

## Validation

- `.venv/bin/ruff check src/ tests/ conftest.py`
- `.venv/bin/pytest tests/ -q -m "not aiosqlite_serial" -n auto`
- `.venv/bin/pytest tests/ -q -m aiosqlite_serial`

## Notes

- no repository PR template was present
- branch previously had a closed PR; this PR supersedes it with the current fixes
