### PR TITLE
feat: finish web-mode cutover for accounts and /agent (#453)

### DIFF
--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -548,6 +548,35 @@ class TelegramCommandDispatcher:
         await self._db.update_account_premium(phone, is_premium)
         return {"phone": phone, "is_premium": is_premium}
 
+    async def _handle_accounts_toggle(self, payload: dict[str, Any]) -> dict[str, Any]:
+        account_id = int(payload["account_id"])
+        accounts = await self._db.get_accounts()
+        account = next((a for a in accounts if a.id == account_id), None)
+        if account is None:
+            raise RuntimeError(f"account_not_found:{account_id}")
+        new_active = not account.is_active
+        await self._db.set_account_active(account_id, new_active)
+        if new_active:
+            try:
+                await self._pool.add_client(account.phone, account.session_string)
+            except Exception as exc:
+                logger.warning("accounts.toggle: failed to add client %s: %s", account.phone, exc)
+        else:
+            await self._pool.remove_client(account.phone)
+        return {"account_id": account_id, "is_active": new_active}
+
+    async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:
+        account_id = int(payload["account_id"])
+        accounts = await self._db.get_accounts()
+        account = next((a for a in accounts if a.id == account_id), None)
+        if account is not None:
+            try:
+                await self._pool.remove_client(account.phone)
+            except Exception as exc:
+                logger.warning("accounts.delete: failed to remove client %s: %s", account.phone, exc)
+        await self._db.delete_account(account_id)
+        return {"account_id": account_id, "deleted": True}
+
     async def _handle_notifications_setup_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
         bot = await self._notification_service().setup_bot()
         return {"bot_username": bot.bot_username, "bot_id": bot.bot_id}

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -562,7 +562,10 @@ class TelegramCommandDispatcher:
             except Exception as exc:
                 logger.warning("accounts.toggle: failed to add client %s: %s", account.phone, exc)
         else:
-            await self._pool.remove_client(account.phone)
+            try:
+                await self._pool.remove_client(account.phone)
+            except Exception as exc:
+                logger.warning("accounts.toggle: failed to remove client %s: %s", account.phone, exc)
         return {"account_id": account_id, "is_active": new_active}
 
     async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -23,7 +23,6 @@ from src.database.bundles import (
 from src.scheduler.service import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
-from src.services.account_service import AccountService
 from src.services.channel_service import ChannelService
 from src.services.collection_service import CollectionService
 from src.services.filter_deletion_service import FilterDeletionService
@@ -273,14 +272,6 @@ def channel_service(request: Request) -> ChannelService:
         request,
         "_channel_service",
         lambda: ChannelService(get_db(request), get_pool(request), get_queue(request)),
-    )
-
-
-def account_service(request: Request) -> AccountService:
-    return _request_cached(
-        request,
-        "_account_service",
-        lambda: AccountService(get_account_bundle(request), get_pool(request)),
     )
 
 

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -12,14 +12,28 @@ router = APIRouter()
 
 @router.post("/{account_id}/toggle")
 async def toggle_account(request: Request, account_id: int):
-    await deps.account_service(request).toggle(account_id)
-    return RedirectResponse(url="/settings?msg=account_toggled", status_code=303)
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "accounts.toggle",
+        payload={"account_id": account_id},
+        requested_by="web:accounts.toggle",
+    )
+    return RedirectResponse(
+        url=f"/settings?msg=account_toggle_queued&command_id={command_id}",
+        status_code=303,
+    )
 
 
 @router.post("/{account_id}/delete")
 async def delete_account(request: Request, account_id: int):
-    await deps.account_service(request).delete(account_id)
-    return RedirectResponse(url="/settings?msg=account_deleted", status_code=303)
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "accounts.delete",
+        payload={"account_id": account_id},
+        requested_by="web:accounts.delete",
+    )
+    return RedirectResponse(
+        url=f"/settings?msg=account_delete_queued&command_id={command_id}",
+        status_code=303,
+    )
 
 
 @router.get("/flood-status")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -26,6 +26,7 @@ async def agent_page(request: Request, thread_id: int | None = None):
     agent_manager = deps.get_agent_manager(request)
     threads = await db.get_agent_threads()
     agent_status = None
+    agent_disabled_reason = None
     if agent_manager is not None:
         runtime_status = await agent_manager.get_runtime_status()
         agent_status = {
@@ -39,6 +40,11 @@ async def agent_page(request: Request, thread_id: int | None = None):
             "using_override": runtime_status.using_override,
             "error": runtime_status.error,
         }
+    else:
+        agent_disabled_reason = (
+            "Agent chat is only available in the worker process. "
+            "Run `python -m src.main worker` alongside the web server to enable it."
+        )
 
     messages = []
     active_thread = None
@@ -66,6 +72,7 @@ async def agent_page(request: Request, thread_id: int | None = None):
             "active_thread": active_thread,
             "messages": messages,
             "agent_status": agent_status,
+            "agent_disabled_reason": agent_disabled_reason,
             "model_options": CLAUDE_MODELS,
         },
     )
@@ -193,7 +200,13 @@ async def resolve_permission(request: Request, thread_id: int, request_id: str):
         raise HTTPException(status_code=400, detail="Invalid choice")
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is None:
-        raise HTTPException(status_code=503, detail="AgentManager not initialized")
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Agent chat is only available in the worker process. "
+                "Run `python -m src.main worker` alongside the web server."
+            ),
+        )
     ok = agent_manager.permission_gate.resolve(request_id, choice)
     return JSONResponse({"ok": ok})
 
@@ -222,7 +235,13 @@ async def chat(request: Request, thread_id: int):
     db = deps.get_db(request)
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is None:
-        raise HTTPException(status_code=503, detail="AgentManager not initialized")
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Agent chat is only available in the worker process. "
+                "Run `python -m src.main worker` alongside the web server."
+            ),
+        )
     runtime_status = await agent_manager.get_runtime_status()
     if runtime_status.selected_backend is None:
         raise HTTPException(

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -515,6 +515,12 @@
 {% block content %}
 <h1>Агент</h1>
 
+{% if agent_disabled_reason %}
+<div class="alert alert-warning" role="alert">
+    <strong>Чат недоступен в web-процессе.</strong> {{ agent_disabled_reason }}
+</div>
+{% endif %}
+
 <!-- Mobile toolbar -->
 <div class="mobile-agent-toolbar gap-2 mb-2" style="display:none">
     <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar-offcanvas">Треды</button>

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -1,0 +1,159 @@
+"""Production-like tests for accounts/agent routes in web runtime mode.
+
+These tests exercise the real `build_web_container` wiring — i.e. the same
+bootstrap path the production `src/main.py serve` entrypoint uses. No live
+ClientPool / Collector / SchedulerManager are constructed; web code only
+sees the snapshot shims (`SnapshotClientPool`, `SnapshotCollector`,
+`SnapshotSchedulerManager`). Failures here indicate the web request path
+is still reaching for runtime components it should not see.
+"""
+from __future__ import annotations
+
+import base64
+from contextlib import asynccontextmanager
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import AppConfig, DatabaseConfig
+from src.models import Account
+from src.web.app import create_app
+from src.web.bootstrap import build_container_with_templates
+from src.web.log_handler import LogBuffer
+from src.web.runtime_shims import SnapshotClientPool, SnapshotCollector, SnapshotSchedulerManager
+
+
+@asynccontextmanager
+async def _web_mode_client(tmp_path):
+    config = AppConfig(database=DatabaseConfig(path=str(tmp_path / "test.db")))
+    config.web.password = "testpass"
+
+    log_buffer = LogBuffer()
+    container = await build_container_with_templates(
+        config,
+        log_buffer=log_buffer,
+        templates=None,
+        runtime_mode="web",
+    )
+    await container.db.add_account(Account(phone="+1234567890", session_string="test_session"))
+
+    app = create_app(config)
+    app.state.db = container.db
+    app.state.config = config
+    app.state.pool = container.pool
+    app.state.collector = container.collector
+    app.state.scheduler = container.scheduler
+    app.state.auth = container.auth
+    app.state.notifier = container.notifier
+    app.state.collection_queue = container.collection_queue
+    app.state.unified_dispatcher = container.unified_dispatcher
+    app.state.telegram_command_dispatcher = container.telegram_command_dispatcher
+    app.state.agent_manager = container.agent_manager
+    app.state.search_engine = container.search_engine
+    app.state.ai_search = container.ai_search
+    app.state.llm_provider_service = container.llm_provider_service
+    app.state.runtime_mode = container.runtime_mode
+    app.state.session_secret = "test_secret_key"
+    app.state.shutting_down = False
+
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(b":testpass").decode()
+    try:
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={
+                "Authorization": f"Basic {auth_header}",
+                "Origin": "http://test",
+            },
+        ) as client:
+            yield client, container
+    finally:
+        await container.db.close()
+
+
+@pytest.mark.asyncio
+async def test_web_container_uses_snapshot_shims(tmp_path):
+    """Verify runtime_mode="web" really produces the snapshot shims."""
+    async with _web_mode_client(tmp_path) as (_, container):
+        assert container.runtime_mode == "web"
+        assert isinstance(container.pool, SnapshotClientPool)
+        assert isinstance(container.collector, SnapshotCollector)
+        assert isinstance(container.scheduler, SnapshotSchedulerManager)
+        assert container.agent_manager is None
+        assert container.telegram_command_dispatcher is None
+
+
+@pytest.mark.asyncio
+async def test_account_toggle_in_web_mode_enqueues_command(tmp_path):
+    """POST /settings/{id}/toggle in real web bootstrap: no live pool, just a queued command."""
+    async with _web_mode_client(tmp_path) as (client, container):
+        accounts = await container.db.get_accounts(active_only=False)
+        acc = accounts[0]
+
+        resp = await client.post(f"/settings/{acc.id}/toggle")
+        assert resp.status_code == 303
+        assert "account_toggle_queued" in resp.headers["location"]
+
+        commands = await container.db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].command_type == "accounts.toggle"
+        assert commands[0].payload == {"account_id": acc.id}
+
+
+@pytest.mark.asyncio
+async def test_account_delete_in_web_mode_enqueues_command(tmp_path):
+    """POST /settings/{id}/delete in real web bootstrap: DB row untouched, command enqueued."""
+    async with _web_mode_client(tmp_path) as (client, container):
+        accounts = await container.db.get_accounts(active_only=False)
+        acc = accounts[0]
+
+        resp = await client.post(f"/settings/{acc.id}/delete")
+        assert resp.status_code == 303
+        assert "account_delete_queued" in resp.headers["location"]
+
+        remaining = await container.db.get_accounts(active_only=False)
+        assert any(a.id == acc.id for a in remaining)
+
+        commands = await container.db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].command_type == "accounts.delete"
+
+
+@pytest.mark.asyncio
+async def test_agent_chat_in_web_mode_returns_worker_only_error(tmp_path):
+    """POST /agent/threads/{id}/chat in real web bootstrap returns a clear 503,
+    not the old opaque 'AgentManager not initialized'."""
+    async with _web_mode_client(tmp_path) as (client, container):
+        thread_id = await container.db.create_agent_thread("Test thread")
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            json={"message": "hi"},
+        )
+        assert resp.status_code == 503
+        detail = resp.json().get("detail", "")
+        assert "worker" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_agent_permission_in_web_mode_returns_worker_only_error(tmp_path):
+    """POST /agent/threads/{id}/permission/{req_id} in web returns the same 503 contract."""
+    async with _web_mode_client(tmp_path) as (client, container):
+        thread_id = await container.db.create_agent_thread("Test thread")
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/permission/abc-123",
+            json={"choice": "once"},
+        )
+        assert resp.status_code == 503
+        detail = resp.json().get("detail", "")
+        assert "worker" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_agent_page_in_web_mode_renders_banner(tmp_path):
+    """GET /agent in web mode renders the disabled banner but does not 500."""
+    async with _web_mode_client(tmp_path) as (client, container):
+        resp = await client.get("/agent", follow_redirects=True)
+        assert resp.status_code == 200
+        assert "worker" in resp.text.lower()

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -14,34 +14,52 @@ async def client(route_client):
 
 
 @pytest.mark.asyncio
-async def test_toggle_account(client, base_app):
-    """Toggle account active/inactive."""
+async def test_toggle_account_enqueues_command(client, base_app):
+    """Web toggle only enqueues `accounts.toggle`; worker reconciles the pool."""
     app, db, pool = base_app
     accounts = await db.get_accounts(active_only=False)
     assert len(accounts) > 0
     acc = accounts[0]
 
     resp = await client.post(f"/settings/{acc.id}/toggle", follow_redirects=False)
-    assert resp.status_code in (303, 302), f"Expected redirect, got {resp.status_code}"
-    assert "/settings" in resp.headers.get("location", "")
+    assert resp.status_code in (303, 302)
+    location = resp.headers.get("location", "")
+    assert "/settings" in location
+    assert "account_toggle_queued" in location
+    assert "command_id=" in location
+
+    pool.add_client.assert_not_called() if hasattr(pool, "add_client") else None
+    pool.remove_client.assert_not_called()
+
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "accounts.toggle"
+    assert commands[0].payload == {"account_id": acc.id}
 
 
 @pytest.mark.asyncio
-async def test_delete_account(client, base_app):
-    """Delete account."""
+async def test_delete_account_enqueues_command(client, base_app):
+    """Web delete only enqueues `accounts.delete`; the DB row survives until the worker runs."""
     app, db, pool = base_app
-    # Add a second account so we still have one after deletion
     await db.add_account(Account(phone="+9999999999", session_string="session_del"))
     accounts = await db.get_accounts(active_only=False)
     to_delete = next(a for a in accounts if a.phone == "+9999999999")
 
     resp = await client.post(f"/settings/{to_delete.id}/delete", follow_redirects=False)
     assert resp.status_code in (303, 302)
-    assert "/settings" in resp.headers.get("location", "")
+    location = resp.headers.get("location", "")
+    assert "/settings" in location
+    assert "account_delete_queued" in location
+    assert "command_id=" in location
 
-    # Verify deleted
+    # Web must not have touched the DB row directly — only a worker running
+    # `accounts.delete` is allowed to delete.
+    pool.remove_client.assert_not_called()
     remaining = await db.get_accounts(active_only=False)
-    assert not any(a.phone == "+9999999999" for a in remaining)
+    assert any(a.phone == "+9999999999" for a in remaining)
+
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "accounts.delete"
+    assert commands[0].payload == {"account_id": to_delete.id}
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -137,23 +137,31 @@ async def test_save_credentials_invalid_id(client):
 
 
 @pytest.mark.asyncio
-async def test_toggle_account(client):
-    """Test toggle account."""
-    with patch("src.web.routes.settings.deps.account_service") as mock_svc:
-        mock_svc.return_value.toggle = AsyncMock()
-        resp = await client.post("/settings/1/toggle", follow_redirects=False)
-        assert resp.status_code == 303
-        assert "msg=account_toggled" in resp.headers["location"]
+async def test_toggle_account_enqueues_command(client):
+    """Web route only enqueues a telegram command; worker flips is_active and reconciles the pool."""
+    resp = await client.post("/settings/1/toggle", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=account_toggle_queued" in resp.headers["location"]
+    assert "command_id=" in resp.headers["location"]
+
+    db = client._transport.app.state.db
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "accounts.toggle"
+    assert commands[0].payload == {"account_id": 1}
 
 
 @pytest.mark.asyncio
-async def test_delete_account(client):
-    """Test delete account."""
-    with patch("src.web.routes.settings.deps.account_service") as mock_svc:
-        mock_svc.return_value.delete = AsyncMock()
-        resp = await client.post("/settings/1/delete", follow_redirects=False)
-        assert resp.status_code == 303
-        assert "msg=account_deleted" in resp.headers["location"]
+async def test_delete_account_enqueues_command(client):
+    """Web route only enqueues a telegram command; worker removes the client and deletes the row."""
+    resp = await client.post("/settings/1/delete", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=account_delete_queued" in resp.headers["location"]
+    assert "command_id=" in resp.headers["location"]
+
+    db = client._transport.app.state.db
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "accounts.delete"
+    assert commands[0].payload == {"account_id": 1}
 
 
 @pytest.mark.asyncio

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon import TelegramClient
 
+from src.config import AppConfig, DatabaseConfig
 from src.database import Database
 from src.search.engine import SearchEngine
-from src.web.bootstrap import start_container
+from src.web.bootstrap import build_web_container, start_container
+from src.web.log_handler import LogBuffer
+from src.web.runtime_shims import SnapshotClientPool
 
 
 def _make_container(db: Database) -> MagicMock:
@@ -165,3 +169,37 @@ async def test_search_engine_accepts_none_pool(tmp_path):
         assert quota is None
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_build_web_container_does_not_connect_telethon(tmp_path, monkeypatch):
+    """Regression for #444 Test Plan: web startup without internet must not
+    initiate a single Telegram connect/reconnect.
+
+    We verify two things:
+    1. The web container uses SnapshotClientPool, not live ClientPool.
+    2. No TelegramClient.connect() call was made while building the container.
+    """
+    connect_calls: list[object] = []
+
+    real_connect = TelegramClient.connect
+
+    async def _tracking_connect(self, *args, **kwargs):
+        connect_calls.append(self)
+        return await real_connect(self, *args, **kwargs)
+
+    monkeypatch.setattr(TelegramClient, "connect", _tracking_connect)
+
+    config = AppConfig(database=DatabaseConfig(path=str(tmp_path / "test.db")))
+    log_buffer = LogBuffer()
+
+    container = await build_web_container(config, log_buffer=log_buffer)
+    try:
+        assert container.runtime_mode == "web"
+        assert isinstance(container.pool, SnapshotClientPool)
+        assert connect_calls == [], (
+            f"web container must not connect to Telegram during build; "
+            f"got {len(connect_calls)} connect call(s)"
+        )
+    finally:
+        await container.db.close()

--- a/tests/test_web_runtime_guards.py
+++ b/tests/test_web_runtime_guards.py
@@ -24,6 +24,20 @@ _DISALLOWED = (
     "pool.resolve_channel(",
     "pool.get_forum_topics(",
     "pool.remove_client(",
+    # Mutation of the shim's clients dict (reads via `pool.clients` are OK —
+    # SnapshotClientPool exposes a readonly property).
+    "pool.clients[",
+    "pool.clients.pop(",
+    "pool.clients.update(",
+    "pool.clients.clear(",
+    # Private-attribute reads that bypass the snapshot contract. If anyone
+    # needs one of these in web mode, wrap it with `getattr(pool, "_…", …)`
+    # (which is how src/web/routes/debug.py already does it).
+    "pool._dialogs_cache",
+    "pool._active_leases",
+    "pool._in_use",
+    "pool._session_overrides",
+    "pool._premium_flood_wait_until",
     # Collector live calls
     "collector.collect_",
     "collector.resolve_channel(",
@@ -74,6 +88,66 @@ def test_web_services_do_not_call_live_pool_methods() -> None:
         # bootstrap is the only legitimate place where worker-mode initializes
         # the live pool/scheduler — gated behind `if runtime_mode == "worker":`.
         if path.name == "bootstrap.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for token in _DISALLOWED:
+            if token in text:
+                offenders.append(f"{path}: {token}")
+
+    assert offenders == [], "\n".join(offenders)
+
+
+# src/services/* files that are reachable from src/web/* (constructed via
+# deps.py, imported from routes, or aggregated into containers). These
+# services must never call live ClientPool methods inside a web request —
+# everything must go through telegram_commands + worker dispatcher.
+#
+# NOTE: keep this list tight. A service only belongs here if the web
+# process can actually import/instantiate it (directly or transitively).
+# Included on purpose: services where EVERY code path is safe for web mode.
+# Excluded on purpose:
+# - channel_service.py / collection_service.py — genuinely hybrid today
+#   (web uses some methods, worker uses others that touch the live
+#   pool/collector). Moving them fully off the live pool is a larger
+#   follow-up tracked separately.
+# - account_service.py — still calls pool.add_client/remove_client, but it
+#   is NOT wired into web anymore (see `test_account_service_not_imported_by_web`
+#   below) so the web path cannot reach those calls.
+_WEB_CONSUMED_SERVICES = (
+    "filter_deletion_service.py",
+    "notification_service.py",
+    "notification_target_service.py",
+    "telegram_command_service.py",
+)
+
+
+def test_account_service_not_imported_by_web() -> None:
+    """AccountService still calls pool.add_client/remove_client directly,
+    which is only safe from worker-side code paths (telegram_command_dispatcher,
+    CLI `account` command). Any re-introduction of the import into src/web/
+    would re-open the HTTP 500 regression fixed for #453.
+    """
+    token = "src.services.account_service"
+    web_dir = Path("src/web")
+    offenders: list[str] = []
+    for path in web_dir.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if token in text:
+            offenders.append(str(path))
+
+    assert offenders == [], "\n".join(offenders)
+
+
+def test_web_consumed_services_do_not_call_live_pool_methods() -> None:
+    """Services imported by web routes/deps must stay off the live pool."""
+    services_dir = Path("src/services")
+    offenders: list[str] = []
+    for name in _WEB_CONSUMED_SERVICES:
+        path = services_dir / name
+        if not path.exists():
+            offenders.append(f"{path}: missing (update _WEB_CONSUMED_SERVICES)")
             continue
         text = path.read_text(encoding="utf-8")
         for token in _DISALLOWED:


### PR DESCRIPTION
## Summary

Closes #453. Finishes the web/worker cutover started in #444 for the two
remaining web-mode production-path gaps.

- **Accounts** — web `POST /settings/{id}/toggle` and `/delete` now
  enqueue `accounts.toggle` / `accounts.delete` commands; the worker
  flips `is_active` (or deletes the row) and reconciles pool membership
  from DB truth. `AccountService` stays in the repo for worker/CLI
  callers but is no longer wired into the web container.
- **/agent in web mode** — explicit 503 contract with actionable
  message (`Agent chat is only available in the worker process.
  Run \`python -m src.main worker\` alongside the web server.`) plus a
  banner on `GET /agent` instead of the old opaque "AgentManager not
  initialized".
- **Guard tests** — extended to cover mutating attribute access on
  `pool.clients`, direct private-attr reads, and a new check over
  web-consumed services outside `src/web/` (`filter_deletion_service`,
  `notification_service`, `notification_target_service`,
  `telegram_command_service`). A dedicated test blocks any re-import
  of `AccountService` into `src/web/`.
- **Offline-startup regression** — `test_build_web_container_does_not_connect_telethon`
  patches `TelegramClient.connect`, builds a real web container, and
  asserts no Telethon connect happens. Covers the #444 Test Plan item.
- **Production-like web-mode route tests** — new
  `tests/routes/test_accounts_agent_web_mode.py` exercises accounts and
  agent endpoints through the real `build_web_container` wiring
  (SnapshotClientPool/SnapshotCollector/SnapshotSchedulerManager, no
  `MagicMock` pool).

## Deliberate non-goals

- `channel_service.py` / `collection_service.py` are genuinely hybrid
  (some methods used by web, others only by worker) and are deferred
  from the guard list. Converting their remaining pool-touching paths
  to queued commands is a separate follow-up.
- `src/cli/commands/account.py:76` still calls `pool.add_client`
  directly. CLI runs in a worker-equivalent runtime, so this is correct
  and explicitly out of scope for #453.

## Test plan

- [x] `ruff check src/ tests/ conftest.py`
- [x] `pytest tests/ -q -m "not aiosqlite_serial" -n auto` — 5859 passed
- [x] `pytest tests/ -q -m aiosqlite_serial` — 741 passed
- [x] New tests:
  - `tests/routes/test_accounts_agent_web_mode.py::*` (6 tests, real web bootstrap)
  - `tests/test_bootstrap.py::test_build_web_container_does_not_connect_telethon`
  - `tests/test_web_runtime_guards.py::test_web_consumed_services_do_not_call_live_pool_methods`
  - `tests/test_web_runtime_guards.py::test_account_service_not_imported_by_web`
- [ ] Manual: GET /agent in web mode shows the yellow banner and POSTs to
  chat/permission return `{"detail": "Agent chat is only available in the
  worker process..."}` (503).