### PR TITLE
feat(web): queue auth and scheduler actions through worker commands

### DIFF
--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -164,6 +164,7 @@ class TelegramCommandsRepository:
         status: TelegramCommandStatus,
         error: str | None = None,
         result_payload: dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
     ) -> None:
         finished_at = None
         if status in {
@@ -172,35 +173,38 @@ class TelegramCommandsRepository:
             TelegramCommandStatus.CANCELLED,
         }:
             finished_at = datetime.now(timezone.utc).isoformat()
+        payload_json = json.dumps(payload) if payload is not None else None
         if status == TelegramCommandStatus.PENDING:
             # Reset started_at when re-queueing so a retried command shows
             # a fresh run timestamp rather than the interrupted attempt's.
+            sets = ["status = ?", "error = ?", "result_payload = ?", "started_at = NULL", "finished_at = NULL"]
+            params: list[Any] = [
+                status.value,
+                error,
+                json.dumps(result_payload) if result_payload is not None else None,
+            ]
+            if payload_json is not None:
+                sets.append("payload = ?")
+                params.append(payload_json)
+            params.append(command_id)
             await self._db.execute(
-                """
-                UPDATE telegram_commands
-                SET status = ?, error = ?, result_payload = ?, started_at = NULL, finished_at = NULL
-                WHERE id = ?
-                """,
-                (
-                    status.value,
-                    error,
-                    json.dumps(result_payload) if result_payload is not None else None,
-                    command_id,
-                ),
+                f"UPDATE telegram_commands SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
             )
         else:
+            sets = ["status = ?", "error = ?", "result_payload = ?", "finished_at = COALESCE(?, finished_at)"]
+            params = [
+                status.value,
+                error,
+                json.dumps(result_payload) if result_payload is not None else None,
+                finished_at,
+            ]
+            if payload_json is not None:
+                sets.append("payload = ?")
+                params.append(payload_json)
+            params.append(command_id)
             await self._db.execute(
-                """
-                UPDATE telegram_commands
-                SET status = ?, error = ?, result_payload = ?, finished_at = COALESCE(?, finished_at)
-                WHERE id = ?
-                """,
-                (
-                    status.value,
-                    error,
-                    json.dumps(result_payload) if result_payload is not None else None,
-                    finished_at,
-                    command_id,
-                ),
+                f"UPDATE telegram_commands SET {', '.join(sets)} WHERE id = ?",
+                tuple(params),
             )
         await self._db.commit()

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -83,7 +83,8 @@ class TelegramCommandDispatcher:
                 await self._db.repos.telegram_commands.update_command(
                     command.id,
                     status=TelegramCommandStatus.SUCCEEDED,
-                    result_payload=result or {},
+                    result_payload=result.get("result") or {},
+                    payload=result.get("payload_update"),
                 )
 
     async def _dispatch(self, command_type: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -161,7 +162,7 @@ class TelegramCommandDispatcher:
         )
         await self._db.add_account(account)
         connect_result = await self._handle_accounts_connect({"phone": phone})
-        return {"phone": phone, **connect_result}
+        return {"result": {"phone": phone, **connect_result}, "payload_update": {**payload}}
 
     async def _handle_scheduler_reconcile(self, payload: dict[str, Any]) -> dict[str, Any]:
         if self._scheduler is None:

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -144,11 +144,13 @@ class TelegramCommandDispatcher:
         if self._auth is None or not self._auth.is_configured:
             raise RuntimeError("auth_not_configured")
         phone = str(payload["phone"]).strip()
+        password_2fa = str(payload.get("password_2fa", "")).strip() or None
+        payload["password_2fa"] = ""
         session_string = await self._auth.verify_code(
             phone,
             str(payload["code"]),
             str(payload["phone_code_hash"]),
-            str(payload["password_2fa"]).strip() or None,
+            password_2fa,
         )
         existing = await self._db.get_accounts()
         account = Account(

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -78,6 +78,7 @@ class TelegramCommandDispatcher:
                     command.id,
                     status=TelegramCommandStatus.FAILED,
                     error=str(exc),
+                    payload=command.payload,
                 )
             else:
                 await self._db.repos.telegram_commands.update_command(

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -7,11 +7,13 @@ from typing import Any
 
 from src.config import AppConfig
 from src.database import Database
-from src.models import RuntimeSnapshot, TelegramCommandStatus
+from src.models import Account, RuntimeSnapshot, TelegramCommandStatus
+from src.scheduler.service import SchedulerManager
 from src.services.notification_service import NotificationService
 from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
@@ -26,11 +28,16 @@ class TelegramCommandDispatcher:
         pool: ClientPool,
         config: AppConfig | None = None,
         collector: Collector | None = None,
+        *,
+        scheduler: SchedulerManager | None = None,
+        auth: TelegramAuth | None = None,
     ):
         self._db = db
         self._pool = pool
         self._config = config
         self._collector = collector
+        self._scheduler = scheduler
+        self._auth = auth
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
 
@@ -118,6 +125,62 @@ class TelegramCommandDispatcher:
         from src.database.bundles import NotificationBundle
 
         return NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
+
+    async def _handle_auth_send_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        result = await self._auth.send_code(phone)
+        return {"phone": phone, **result}
+
+    async def _handle_auth_resend_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        result = await self._auth.resend_code(phone)
+        return {"phone": phone, **result}
+
+    async def _handle_auth_verify_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        session_string = await self._auth.verify_code(
+            phone,
+            str(payload["code"]),
+            str(payload["phone_code_hash"]),
+            str(payload["password_2fa"]).strip() or None,
+        )
+        existing = await self._db.get_accounts()
+        account = Account(
+            phone=phone,
+            session_string=session_string,
+            is_primary=not any(acc.phone == phone for acc in existing) and len(existing) == 0,
+            is_premium=False,
+        )
+        await self._db.add_account(account)
+        connect_result = await self._handle_accounts_connect({"phone": phone})
+        return {"phone": phone, **connect_result}
+
+    async def _handle_scheduler_reconcile(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._scheduler is None:
+            raise RuntimeError("scheduler_unavailable")
+        autostart = await self._db.get_setting("scheduler_autostart")
+        desired_running = autostart == "1"
+        if not desired_running:
+            await self._scheduler.stop()
+            await self._scheduler.load_settings()
+            return {"running": False}
+        if self._scheduler.is_running:
+            await self._scheduler.stop()
+        await self._scheduler.load_settings()
+        await self._scheduler.start()
+        return {"running": True, "interval_minutes": self._scheduler.interval_minutes}
+
+    async def _handle_scheduler_trigger_warm(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._scheduler is None:
+            raise RuntimeError("scheduler_unavailable")
+        await self._scheduler.trigger_warm_background()
+        return {"started": True}
 
     async def _handle_dialogs_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -210,7 +210,6 @@ async def build_container_with_templates(
             config=config,
             llm_provider_service=llm_provider_service,
         )
-        telegram_command_dispatcher = TelegramCommandDispatcher(db, pool, config, collector)
         scheduler = SchedulerManager(
             config.scheduler,
             scheduler_bundle=scheduler_bundle,
@@ -218,6 +217,14 @@ async def build_container_with_templates(
             task_enqueuer=task_enqueuer,
             pipeline_bundle=pipeline_bundle,
             warm_dialogs_callback=pool.warm_all_dialogs,
+        )
+        telegram_command_dispatcher = TelegramCommandDispatcher(
+            db,
+            pool,
+            config,
+            collector,
+            scheduler=scheduler,
+            auth=auth,
         )
         agent_manager = AgentManager(db, config, client_pool=pool, scheduler_manager=scheduler)
     else:

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -167,10 +167,6 @@ async def verify_code(
     next_type: str = Form(""),
     timeout: str = Form(""),
 ):
-    db = request.app.state.db
-
-    existing = await db.get_accounts()
-    _ = len(existing) == 0  # is_primary computed by worker from fresh DB state
     command_id = await deps.telegram_command_service(request).enqueue(
         "auth.verify_code",
         payload={

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -170,8 +170,7 @@ async def verify_code(
     db = request.app.state.db
 
     existing = await db.get_accounts()
-    is_primary = len(existing) == 0
-    # Preserve is_primary decision in payload for deterministic worker behavior if needed later.
+    _ = len(existing) == 0  # is_primary computed by worker from fresh DB state
     command_id = await deps.telegram_command_service(request).enqueue(
         "auth.verify_code",
         payload={
@@ -182,7 +181,6 @@ async def verify_code(
             "code_type": code_type or "",
             "next_type": next_type or "",
             "timeout": timeout or "",
-            "is_primary": is_primary,
         },
         requested_by="web:auth.verify_code",
     )

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from src.models import Account
+from src.models import TelegramCommandStatus
 from src.web import deps
 
 logger = logging.getLogger(__name__)
@@ -19,14 +19,89 @@ def _is_api_configured(request: Request) -> bool:
     return request.app.state.auth.is_configured
 
 
+async def _auth_command(request: Request):
+    raw = request.query_params.get("command_id", "").strip()
+    if not raw.isdigit():
+        return None
+    return await deps.telegram_command_service(request).get(int(raw))
+
+
+def _auth_redirect(request: Request, command_id: int, *, phone: str = "") -> RedirectResponse:
+    target = f"/auth/login?command_id={command_id}"
+    if phone:
+        target += f"&phone={phone}"
+    return RedirectResponse(url=target, status_code=303)
+
+
 @router.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     api_configured = _is_api_configured(request)
     step = "phone" if api_configured else "credentials"
+    command = await _auth_command(request)
+    context = {"step": step, "error": None, "phone": "", "api_configured": api_configured}
+    if command is not None and command.command_type.startswith("auth."):
+        payload = command.payload or {}
+        result = command.result_payload or {}
+        context["phone"] = payload.get("phone", request.query_params.get("phone", ""))
+        if command.status in {TelegramCommandStatus.PENDING, TelegramCommandStatus.RUNNING}:
+            context.update(
+                {
+                    "step": "pending",
+                    "command_id": command.id,
+                    "pending_action": command.command_type,
+                }
+            )
+        elif command.command_type in {"auth.send_code", "auth.resend_code"}:
+            if command.status == TelegramCommandStatus.SUCCEEDED:
+                context.update(
+                    {
+                        "step": "code",
+                        "phone": result.get("phone", context["phone"]),
+                        "phone_code_hash": result.get("phone_code_hash", ""),
+                        "code_type": result.get("code_type"),
+                        "next_type": result.get("next_type"),
+                        "timeout": result.get("timeout"),
+                    }
+                )
+            else:
+                context.update(
+                    {
+                        "step": "code" if command.command_type == "auth.resend_code" else "phone",
+                        "error": command.error,
+                        "phone_code_hash": payload.get("phone_code_hash", ""),
+                        "code_type": payload.get("code_type", ""),
+                        "next_type": payload.get("next_type", ""),
+                        "timeout": payload.get("timeout", ""),
+                    }
+                )
+        elif command.command_type == "auth.verify_code":
+            if command.status == TelegramCommandStatus.SUCCEEDED:
+                return RedirectResponse(url="/settings?msg=account_connected", status_code=303)
+            error = command.error or ""
+            if "2FA" in error or "password" in error.lower():
+                context.update(
+                    {
+                        "step": "2fa",
+                        "error": error,
+                        "code": payload.get("code", ""),
+                        "phone_code_hash": payload.get("phone_code_hash", ""),
+                    }
+                )
+            else:
+                context.update(
+                    {
+                        "step": "code",
+                        "error": error,
+                        "phone_code_hash": payload.get("phone_code_hash", ""),
+                        "code_type": payload.get("code_type", ""),
+                        "next_type": payload.get("next_type", ""),
+                        "timeout": payload.get("timeout", ""),
+                    }
+                )
     return _render(
         request,
         "login.html",
-        {"step": step, "error": None, "phone": "", "api_configured": api_configured},
+        context,
     )
 
 
@@ -48,9 +123,7 @@ async def save_credentials(
 
 @router.post("/send-code")
 async def send_code(request: Request, phone: str = Form(...)):
-    auth = request.app.state.auth
-
-    if not auth.is_configured:
+    if not _is_api_configured(request):
         return _render(
             request,
             "login.html",
@@ -61,30 +134,12 @@ async def send_code(request: Request, phone: str = Form(...)):
                 "api_configured": False,
             },
         )
-
-    try:
-        info = await auth.send_code(phone)
-        return _render(
-            request,
-            "login.html",
-            {
-                "step": "code",
-                "phone": phone,
-                "phone_code_hash": info["phone_code_hash"],
-                "code_type": info["code_type"],
-                "next_type": info["next_type"],
-                "timeout": info["timeout"],
-                "error": None,
-                "api_configured": True,
-            },
-        )
-    except Exception as e:
-        logger.exception("Failed to send auth code for phone=%s", phone)
-        return _render(
-            request,
-            "login.html",
-            {"step": "phone", "error": str(e), "phone": phone, "api_configured": True},
-        )
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "auth.send_code",
+        payload={"phone": phone},
+        requested_by="web:auth.send_code",
+    )
+    return _auth_redirect(request, command_id, phone=phone)
 
 
 @router.post("/resend-code")
@@ -93,36 +148,12 @@ async def resend_code(
     phone: str = Form(...),
     phone_code_hash: str = Form(...),
 ):
-    auth = request.app.state.auth
-    try:
-        info = await auth.resend_code(phone)
-        return _render(
-            request,
-            "login.html",
-            {
-                "step": "code",
-                "phone": phone,
-                "phone_code_hash": info["phone_code_hash"],
-                "code_type": info["code_type"],
-                "next_type": info["next_type"],
-                "timeout": info["timeout"],
-                "error": None,
-                "api_configured": True,
-            },
-        )
-    except Exception as e:
-        logger.exception("Failed to resend auth code for phone=%s", phone)
-        return _render(
-            request,
-            "login.html",
-            {
-                "step": "code",
-                "phone": phone,
-                "phone_code_hash": phone_code_hash,
-                "error": str(e),
-                "api_configured": True,
-            },
-        )
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "auth.resend_code",
+        payload={"phone": phone, "phone_code_hash": phone_code_hash},
+        requested_by="web:auth.resend_code",
+    )
+    return _auth_redirect(request, command_id, phone=phone)
 
 
 @router.post("/verify-code")
@@ -136,63 +167,23 @@ async def verify_code(
     next_type: str = Form(""),
     timeout: str = Form(""),
 ):
-    auth = request.app.state.auth
     db = request.app.state.db
 
-    try:
-        session_string = await auth.verify_code(phone, code, phone_code_hash, password_2fa or None)
-
-        existing = await db.get_accounts()
-        is_primary = len(existing) == 0
-
-        account = Account(
-            phone=phone,
-            session_string=session_string,
-            is_primary=is_primary,
-            is_premium=False,
-        )
-        await db.add_account(account)
-        await deps.telegram_command_service(request).enqueue(
-            "accounts.connect",
-            payload={"phone": phone},
-            requested_by="web:auth.verify_code",
-        )
-
-        return RedirectResponse(url="/settings?msg=account_connected", status_code=303)
-    except ValueError as e:
-        error = str(e)
-        timeout_val = int(timeout) if timeout.isdigit() else None
-        if "2FA" in error or "password" in error.lower():
-            return _render(
-                request,
-                "login.html",
-                {
-                    "step": "2fa",
-                    "phone": phone,
-                    "code": code,
-                    "phone_code_hash": phone_code_hash,
-                    "error": error,
-                    "api_configured": True,
-                },
-            )
-        return _render(
-            request,
-            "login.html",
-            {
-                "step": "code",
-                "phone": phone,
-                "phone_code_hash": phone_code_hash,
-                "code_type": code_type or None,
-                "next_type": next_type or None,
-                "timeout": timeout_val,
-                "error": error,
-                "api_configured": True,
-            },
-        )
-    except Exception as e:
-        logger.exception("Failed to verify auth code for phone=%s", phone)
-        return _render(
-            request,
-            "login.html",
-            {"step": "phone", "phone": phone, "error": str(e), "api_configured": True},
-        )
+    existing = await db.get_accounts()
+    is_primary = len(existing) == 0
+    # Preserve is_primary decision in payload for deterministic worker behavior if needed later.
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "auth.verify_code",
+        payload={
+            "phone": phone,
+            "code": code,
+            "phone_code_hash": phone_code_hash,
+            "password_2fa": password_2fa or "",
+            "code_type": code_type or "",
+            "next_type": next_type or "",
+            "timeout": timeout or "",
+            "is_primary": is_primary,
+        },
+        requested_by="web:auth.verify_code",
+    )
+    return _auth_redirect(request, command_id, phone=phone)

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from src.telegram.notifier import Notifier
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
 
@@ -251,6 +250,30 @@ async def _build_jobs_context(sched, db) -> list[dict]:
     return jobs
 
 
+async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
+    snapshot = await deps.get_db(request).repos.runtime_snapshots.get_snapshot("notification_target_status")
+    payload = snapshot.payload if snapshot is not None else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _enqueue_scheduler_command(
+    request: Request,
+    command_type: str,
+    *,
+    payload: dict[str, object] | None = None,
+    redirect_code: str,
+):
+    command_id = await deps.telegram_command_service(request).enqueue(
+        command_type,
+        payload=payload or {},
+        requested_by=f"web:scheduler.{command_type}",
+    )
+    return RedirectResponse(
+        url=f"/scheduler?msg={redirect_code}&command_id={command_id}",
+        status_code=303,
+    )
+
+
 @router.get("/", response_class=HTMLResponse)
 async def scheduler_page(
     request: Request,
@@ -279,11 +302,9 @@ async def _scheduler_page_inner(
 
     offset = (page - 1) * limit
 
-    async def _safe_bot_status():
-        try:
-            return await deps.notification_service(request).get_status()
-        except Exception:
-            return None
+    notification_snapshot = await _notification_snapshot_payload(request)
+    bot_payload = notification_snapshot.get("bot")
+    bot_configured = bool(isinstance(bot_payload, dict) and bot_payload.get("configured"))
 
     (
         tasks_page,
@@ -291,7 +312,6 @@ async def _scheduler_page_inner(
         active_count,
         pending_collect,
         search_log,
-        bot,
         scheduler_jobs,
         collector_health,
     ) = await asyncio.gather(
@@ -300,7 +320,6 @@ async def _scheduler_page_inner(
         db.count_collection_tasks("active"),
         db.get_pending_channel_tasks(),
         db.get_recent_searches(),
-        _safe_bot_status(),
         _build_jobs_context(sched, db),
         _build_collector_health_context(request),
     )
@@ -317,11 +336,6 @@ async def _scheduler_page_inner(
     completed_count = all_count - active_count
     has_active_tasks = active_count > 0
     pending_collect_count = len(pending_collect)
-
-    notifier = deps.get_notifier(request)
-    bot_configured = (
-        notifier is not None and notifier.admin_chat_id is not None
-    ) or bot is not None
 
     context = {
         "is_running": sched.is_running,
@@ -360,10 +374,11 @@ async def toggle_scheduler_job(request: Request, job_id: str):
     current = await db.repos.settings.get_setting(key)
     new_disabled = current != "1"
     await db.repos.settings.set_setting(key, "1" if new_disabled else "0")
-    sched = deps.get_scheduler(request)
-    if sched.is_running:
-        await sched.sync_job_state(job_id, enabled=not new_disabled)
-    return RedirectResponse(url="/scheduler?msg=job_toggled", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "scheduler.reconcile",
+        redirect_code="job_toggled",
+    )
 
 
 @router.post("/jobs/{job_id}/set-interval")
@@ -381,47 +396,48 @@ async def set_job_interval(request: Request, job_id: str):
     except (KeyError, ValueError):
         return RedirectResponse(url="/scheduler?error=invalid_interval", status_code=303)
     db = deps.get_db(request)
-    sched = deps.get_scheduler(request)
     if job_id == "collect_all":
         await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
-        sched.update_interval(minutes)
     elif job_id.startswith("sq_"):
         sq_id = int(job_id.removeprefix("sq_"))
         sq = await db.repos.search_queries.get_by_id(sq_id)
         if sq:
             await db.repos.search_queries.update(sq_id, sq.model_copy(update={"interval_minutes": minutes}))
-            if sched.is_running:
-                await sched.sync_search_query_jobs()
     elif job_id.startswith(("pipeline_run_", "content_generate_")):
         pid_str = job_id.removeprefix("pipeline_run_").removeprefix("content_generate_")
         pid = int(pid_str)
         pipeline = await db.repos.content_pipelines.get_by_id(pid)
         if pipeline:
             await db.repos.content_pipelines.update_generate_interval(pid, minutes)
-            if sched.is_running:
-                await sched.sync_pipeline_jobs()
     elif job_id == "warm_all_dialogs":
         await db.repos.settings.set_setting("warm_dialogs_interval_minutes", str(minutes))
-        sched._warm_dialogs_interval_minutes = minutes
-        if sched.is_running:
-            await sched.sync_job_state(job_id, enabled=True)
-    return RedirectResponse(url="/scheduler?msg=interval_updated", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "scheduler.reconcile",
+        redirect_code="interval_updated",
+    )
 
 
 @router.post("/start")
 async def start_scheduler(request: Request):
     if getattr(request.app.state, "shutting_down", False):
         return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-    await deps.scheduler_service(request).start()
     await deps.get_db(request).set_setting("scheduler_autostart", "1")
-    return RedirectResponse(url="/scheduler?msg=scheduler_started", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "scheduler.reconcile",
+        redirect_code="scheduler_started",
+    )
 
 
 @router.post("/stop")
 async def stop_scheduler(request: Request):
-    await deps.scheduler_service(request).stop()
     await deps.get_db(request).set_setting("scheduler_autostart", "0")
-    return RedirectResponse(url="/scheduler?msg=scheduler_stopped", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "scheduler.reconcile",
+        redirect_code="scheduler_stopped",
+    )
 
 
 @router.post("/trigger")
@@ -438,51 +454,22 @@ async def trigger_collection(request: Request):
 async def trigger_warm_dialogs(request: Request):
     if getattr(request.app.state, "shutting_down", False):
         return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-    sched = deps.get_scheduler(request)
-    await sched.trigger_warm_background()
-    return RedirectResponse(url="/scheduler?msg=warm_dialogs_started", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "scheduler.trigger_warm",
+        redirect_code="warm_dialogs_started",
+    )
 
 
 @router.post("/test-notification")
 async def test_notification(request: Request):
     if getattr(request.app.state, "shutting_down", False):
         return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-
-    notifier = deps.get_notifier(request)
-    admin_chat_id = notifier.admin_chat_id if notifier else None
-    try:
-        bot = await deps.notification_service(request).get_status()
-    except Exception:
-        bot = None
-    if not admin_chat_id and bot:
-        admin_chat_id = bot.tg_user_id
-    if not admin_chat_id and not bot:
-        return RedirectResponse(url="/scheduler?error=bot_not_configured", status_code=303)
-
-    db = deps.get_db(request)
-    queries = await db.repos.search_queries.get_all(active_only=True)
-    sample_query = next((sq for sq in queries if not sq.is_regex), None)
-    if not sample_query:
-        text = "🔔 Тест уведомлений: нет поисковых запросов"
-    else:
-        messages, _ = await db.search_messages_for_query(sample_query, limit=1)
-        if messages:
-            msg = messages[0]
-            preview = (msg.text or "")[:200]
-            if msg.channel_username:
-                link = f"https://t.me/{msg.channel_username}/{msg.message_id}"
-            else:
-                bare_id = str(msg.channel_id).lstrip("-").removeprefix("100")
-                link = f"https://t.me/c/{bare_id}/{msg.message_id}"
-            text = f"🔔 Тест уведомлений:\n{preview}\n{link}"
-        else:
-            text = "🔔 Тест уведомлений: нет сообщений для отправки"
-
-    target_svc = deps.get_notification_target_service(request)
-    test_notifier = Notifier(target_svc, admin_chat_id, deps.get_notification_bundle(request))
-    ok = await test_notifier.notify(text)
-    msg = "test_notification_sent" if ok else "test_notification_failed"
-    return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
+    return await _enqueue_scheduler_command(
+        request,
+        "notifications.test",
+        redirect_code="test_notification_queued",
+    )
 
 
 @router.post("/dry-run-notifications", response_class=HTMLResponse)

--- a/src/web/templates/login.html
+++ b/src/web/templates/login.html
@@ -28,7 +28,22 @@
 <div class="alert alert-danger" role="alert">{{ error }}</div>
 {% endif %}
 
-{% if step == 'credentials' %}
+{% if step == 'pending' %}
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="mb-2">Команда отправлена в worker и сейчас обрабатывается.</p>
+        <p class="text-muted small mb-0">Страница обновится автоматически, когда команда завершится.</p>
+    </div>
+</div>
+<script>
+(function() {
+    setTimeout(function() {
+        window.location.reload();
+    }, 1500);
+})();
+</script>
+
+{% elif step == 'credentials' %}
 <div class="card mb-4">
     <div class="card-header fw-semibold">Шаг 1: API Credentials</div>
     <div class="card-body">

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -337,7 +337,7 @@ async def test_verify_code_sets_primary(client):
         follow_redirects=False,
     )
     commands = await db.repos.telegram_commands.list_commands(limit=1)
-    assert commands[0].payload["is_primary"] is False
+    assert "is_primary" not in commands[0].payload  # worker recomputes from fresh DB state
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -347,7 +347,7 @@ async def test_verify_code_detects_premium(client):
     await client.post(
         "/auth/verify-code",
         data={
-            "phone": "+1234567890",
+            "phone": "+9999999999",
             "code": "12345",
             "phone_code_hash": "hash",
             "password_2fa": "",
@@ -355,7 +355,7 @@ async def test_verify_code_detects_premium(client):
         follow_redirects=False,
     )
     accounts = await db.get_accounts()
-    assert len(accounts) == 1
+    assert len(accounts) == 1  # only the fixture account, new phone not added synchronously
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import base64
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+from src.models import TelegramCommand, TelegramCommandStatus
 
 
 @pytest.fixture
@@ -117,23 +118,22 @@ async def test_save_credentials_updates_auth(client_unconfigured):
 
 @pytest.mark.asyncio
 async def test_send_code_success(client):
-    """Test send code success."""
+    """Test send code is enqueued instead of executed inline."""
+    db = client._transport.app.state.db
     auth = client._transport.app.state.auth
 
     with patch.object(auth, "send_code", new_callable=AsyncMock) as mock_send:
-        mock_send.return_value = {
-            "phone_code_hash": "abc123",
-            "code_type": "sms",
-            "next_type": "call",
-            "timeout": 60,
-        }
-
         resp = await client.post(
             "/auth/send-code",
             data={"phone": "+1234567890"},
+            follow_redirects=False,
         )
-        assert resp.status_code == 200
-        assert "code" in resp.text.lower()
+        assert resp.status_code == 303
+        assert "/auth/login?command_id=" in resp.headers["location"]
+        mock_send.assert_not_awaited()
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.send_code"
+    assert commands[0].payload["phone"] == "+1234567890"
 
 
 @pytest.mark.asyncio
@@ -150,7 +150,8 @@ async def test_send_code_unconfigured(client_unconfigured):
 
 @pytest.mark.asyncio
 async def test_send_code_error(client):
-    """Test send code handles error."""
+    """Test send code route does not call TelegramAuth inline on web."""
+    db = client._transport.app.state.db
     auth = client._transport.app.state.auth
 
     with patch.object(auth, "send_code", new_callable=AsyncMock) as mock_send:
@@ -159,35 +160,37 @@ async def test_send_code_error(client):
         resp = await client.post(
             "/auth/send-code",
             data={"phone": "+1234567890"},
+            follow_redirects=False,
         )
-        assert resp.status_code == 200
-        # Should show error
-        assert "error" in resp.text.lower() or "Network error" in resp.text
+        assert resp.status_code == 303
+        mock_send.assert_not_awaited()
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.send_code"
 
 
 @pytest.mark.asyncio
 async def test_resend_code_success(client):
-    """Test resend code success."""
+    """Test resend code is enqueued instead of executed inline."""
+    db = client._transport.app.state.db
     auth = client._transport.app.state.auth
 
     with patch.object(auth, "resend_code", new_callable=AsyncMock) as mock_resend:
-        mock_resend.return_value = {
-            "phone_code_hash": "xyz789",
-            "code_type": "call",
-            "next_type": "flash",
-            "timeout": 120,
-        }
-
         resp = await client.post(
             "/auth/resend-code",
             data={"phone": "+1234567890", "phone_code_hash": "old_hash"},
+            follow_redirects=False,
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 303
+        mock_resend.assert_not_awaited()
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.resend_code"
+    assert commands[0].payload["phone_code_hash"] == "old_hash"
 
 
 @pytest.mark.asyncio
 async def test_resend_code_error(client):
-    """Test resend code handles error."""
+    """Test resend code route does not call TelegramAuth inline on web."""
+    db = client._transport.app.state.db
     auth = client._transport.app.state.auth
 
     with patch.object(auth, "resend_code", new_callable=AsyncMock) as mock_resend:
@@ -196,261 +199,208 @@ async def test_resend_code_error(client):
         resp = await client.post(
             "/auth/resend-code",
             data={"phone": "+1234567890", "phone_code_hash": "hash"},
+            follow_redirects=False,
         )
-        assert resp.status_code == 200
-        # Should show error in template
-        assert "error" in resp.text.lower() or "Flood" in resp.text
+        assert resp.status_code == 303
+        mock_resend.assert_not_awaited()
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.resend_code"
 
 
 @pytest.mark.asyncio
 async def test_verify_code_success(client):
-    """Test verify code success."""
+    """Test verify code is enqueued instead of executed inline."""
     auth = client._transport.app.state.auth
     db = client._transport.app.state.db
-    pool = client._transport.app.state.pool
 
     with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session_string_123"
-
-        with patch.object(pool, "add_client", new_callable=AsyncMock) as mock_add_client:
-            with patch.object(
-                pool,
-                "get_client_by_phone",
-                new_callable=AsyncMock,
-            ) as mock_get_client:
-                with patch.object(pool, "release_client", new_callable=AsyncMock):
-                    resp = await client.post(
-                        "/auth/verify-code",
-                        data={
-                            "phone": "+1234567890",
-                            "code": "12345",
-                            "phone_code_hash": "hash123",
-                            "password_2fa": "",
-                            "code_type": "sms",
-                            "next_type": "call",
-                            "timeout": "60",
-                        },
-                        follow_redirects=False,
-                    )
-                    assert resp.status_code == 303
-                    assert "/settings" in resp.headers.get("location", "")
-                    mock_add_client.assert_not_awaited()
-                    mock_get_client.assert_not_awaited()
-    commands = await db.repos.telegram_commands.list_commands(limit=1)
-    assert commands[0].command_type == "accounts.connect"
-    assert commands[0].payload["phone"] == "+1234567890"
-    assert "session_string" not in commands[0].payload
-
-
-@pytest.mark.asyncio
-async def test_verify_code_2fa_required(client):
-    """Test verify code shows 2FA form when needed."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.side_effect = ValueError("2FA password required")
-
         resp = await client.post(
             "/auth/verify-code",
             data={
                 "phone": "+1234567890",
                 "code": "12345",
-                "phone_code_hash": "hash123",
-                "password_2fa": "",
-            },
-        )
-        assert resp.status_code == 200
-        # Should show 2FA step
-        assert "2fa" in resp.text.lower() or "password" in resp.text.lower()
-
-
-@pytest.mark.asyncio
-async def test_verify_code_with_2fa(client):
-    """Test verify code with 2FA password."""
-    auth = client._transport.app.state.auth
-    pool = client._transport.app.state.pool
-
-    mock_session = MagicMock()
-    mock_session.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=True))
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session_string_123"
-
-        with patch.object(pool, "add_client", new_callable=AsyncMock):
-            with patch.object(
-                pool,
-                "get_client_by_phone",
-                new_callable=AsyncMock,
-                return_value=(mock_session, "+1234567890"),
-            ):
-                with patch.object(pool, "release_client", new_callable=AsyncMock):
-                    await client.post(
-                        "/auth/verify-code",
-                        data={
-                            "phone": "+1234567890",
-                            "code": "12345",
-                            "phone_code_hash": "hash123",
-                            "password_2fa": "mypassword",
-                        },
-                        follow_redirects=False,
-                    )
-                    # Password should be passed to verify_code
-                    mock_verify.assert_called_once()
-                    call_args = mock_verify.call_args[0]
-                    assert call_args[3] == "mypassword"
-
-
-@pytest.mark.asyncio
-async def test_verify_code_invalid_code(client):
-    """Test verify code with invalid code."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.side_effect = ValueError("Invalid code")
-
-        resp = await client.post(
-            "/auth/verify-code",
-            data={
-                "phone": "+1234567890",
-                "code": "00000",
                 "phone_code_hash": "hash123",
                 "password_2fa": "",
                 "code_type": "sms",
                 "next_type": "call",
                 "timeout": "60",
             },
+            follow_redirects=False,
         )
-        assert resp.status_code == 200
-        # Should show error
-        assert "Invalid" in resp.text or "error" in resp.text.lower()
+        assert resp.status_code == 303
+        assert "/auth/login?command_id=" in resp.headers.get("location", "")
+        mock_verify.assert_not_awaited()
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.verify_code"
+    assert commands[0].payload["phone"] == "+1234567890"
+    assert commands[0].payload["password_2fa"] == ""
+
+
+@pytest.mark.asyncio
+async def test_verify_code_2fa_required(client):
+    """Test login page shows 2FA form for failed queued verify command."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.verify_code",
+            payload={"phone": "+1234567890", "code": "12345", "phone_code_hash": "hash123"},
+        )
+    )
+    await db.repos.telegram_commands.update_command(
+        command_id,
+        status=TelegramCommandStatus.FAILED,
+        error="2FA password required",
+    )
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
+    assert "2fa" in resp.text.lower() or "password" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_code_with_2fa(client):
+    """Test verify code enqueues 2FA password for worker processing."""
+    db = client._transport.app.state.db
+    resp = await client.post(
+        "/auth/verify-code",
+        data={
+            "phone": "+1234567890",
+            "code": "12345",
+            "phone_code_hash": "hash123",
+            "password_2fa": "mypassword",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].payload["password_2fa"] == "mypassword"
+
+
+@pytest.mark.asyncio
+async def test_verify_code_invalid_code(client):
+    """Test login page surfaces invalid-code error from failed queued command."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.verify_code",
+            payload={
+                "phone": "+1234567890",
+                "code": "00000",
+                "phone_code_hash": "hash123",
+                "code_type": "sms",
+                "next_type": "call",
+                "timeout": "60",
+            },
+        )
+    )
+    await db.repos.telegram_commands.update_command(
+        command_id,
+        status=TelegramCommandStatus.FAILED,
+        error="Invalid code",
+    )
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
+    assert "Invalid code" in resp.text
 
 
 @pytest.mark.asyncio
 async def test_verify_code_generic_error(client):
-    """Test verify code handles generic error."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.side_effect = Exception("Connection lost")
-
-        resp = await client.post(
-            "/auth/verify-code",
-            data={
-                "phone": "+1234567890",
-                "code": "12345",
-                "phone_code_hash": "hash123",
-                "password_2fa": "",
-            },
+    """Test login page surfaces generic verify error from failed queued command."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.verify_code",
+            payload={"phone": "+1234567890", "code": "12345", "phone_code_hash": "hash123"},
         )
-        assert resp.status_code == 200
+    )
+    await db.repos.telegram_commands.update_command(
+        command_id,
+        status=TelegramCommandStatus.FAILED,
+        error="Connection lost",
+    )
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
+    assert "Connection lost" in resp.text
 
 
 @pytest.mark.asyncio
 async def test_verify_code_sets_primary(client):
-    """Test first account becomes primary."""
-    auth = client._transport.app.state.auth
-    pool = client._transport.app.state.pool
-
-    mock_session = MagicMock()
-    mock_session.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session_string"
-
-        with patch.object(pool, "add_client", new_callable=AsyncMock):
-            with patch.object(
-                pool,
-                "get_client_by_phone",
-                new_callable=AsyncMock,
-                return_value=(mock_session, "+1234567890"),
-            ):
-                with patch.object(pool, "release_client", new_callable=AsyncMock):
-                    await client.post(
-                        "/auth/verify-code",
-                        data={
-                            "phone": "+1234567890",
-                            "code": "12345",
-                            "phone_code_hash": "hash",
-                            "password_2fa": "",
-                        },
-                        follow_redirects=False,
-                    )
-
-                    # Check account was added
-                    db = client._transport.app.state.db
-                    accounts = await db.get_accounts()
-                    assert len(accounts) >= 1
+    """Test verify_code command reflects existing DB primary-state context."""
+    db = client._transport.app.state.db
+    await client.post(
+        "/auth/verify-code",
+        data={
+            "phone": "+1234567890",
+            "code": "12345",
+            "phone_code_hash": "hash",
+            "password_2fa": "",
+        },
+        follow_redirects=False,
+    )
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].payload["is_primary"] is False
 
 
 @pytest.mark.asyncio
 async def test_verify_code_detects_premium(client):
-    """Test verify code defers premium detection to worker."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session_string"
-
-        await client.post(
-            "/auth/verify-code",
-            data={
-                "phone": "+1234567890",
-                "code": "12345",
-                "phone_code_hash": "hash",
-                "password_2fa": "",
-            },
-            follow_redirects=False,
-        )
-
-        db = client._transport.app.state.db
-        accounts = await db.get_accounts()
-        if accounts:
-            assert accounts[-1].is_premium is False
+    """Test verify code route no longer mutates accounts synchronously."""
+    db = client._transport.app.state.db
+    await client.post(
+        "/auth/verify-code",
+        data={
+            "phone": "+1234567890",
+            "code": "12345",
+            "phone_code_hash": "hash",
+            "password_2fa": "",
+        },
+        follow_redirects=False,
+    )
+    accounts = await db.get_accounts()
+    assert len(accounts) == 1
 
 
 @pytest.mark.asyncio
 async def test_verify_code_timeout_parsing(client):
-    """Test verify code handles timeout parsing."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.side_effect = ValueError("Code expired")
-
-        resp = await client.post(
-            "/auth/verify-code",
-            data={
+    """Test login page tolerates non-numeric timeout from failed queued command."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.verify_code",
+            payload={
                 "phone": "+1234567890",
                 "code": "12345",
                 "phone_code_hash": "hash",
-                "password_2fa": "",
-                "timeout": "not_a_number",  # Invalid timeout
+                "timeout": "not_a_number",
             },
+            status=TelegramCommandStatus.FAILED,
+            error="Code expired",
         )
-        assert resp.status_code == 200
-        # Should handle invalid timeout gracefully
+    )
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_send_code_returns_code_info(client):
-    """Test send code returns all code info."""
-    auth = client._transport.app.state.auth
-
-    with patch.object(auth, "send_code", new_callable=AsyncMock) as mock_send:
-        mock_send.return_value = {
-            "phone_code_hash": "hash123",
-            "code_type": "app",
-            "next_type": "sms",
-            "timeout": 30,
-        }
-
-        resp = await client.post(
-            "/auth/send-code",
-            data={"phone": "+1234567890"},
+    """Test login page renders code-step data from successful queued command."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.send_code",
+            payload={"phone": "+1234567890"},
+            status=TelegramCommandStatus.SUCCEEDED,
+            result_payload={
+                "phone": "+1234567890",
+                "phone_code_hash": "hash123",
+                "code_type": "app",
+                "next_type": "sms",
+                "timeout": 30,
+            },
         )
-        assert resp.status_code == 200
-        # Should contain code info in template
-        text_lower = resp.text.lower()
-        # Just verify page renders with code step
-        assert "code" in text_lower or "код" in text_lower
+    )
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
+    text_lower = resp.text.lower()
+    assert "code" in text_lower or "код" in text_lower
 
 
 @pytest.mark.asyncio
@@ -475,69 +425,33 @@ async def test_save_credentials_validates_input(client_unconfigured):
 
 @pytest.mark.asyncio
 async def test_verify_code_empty_password(client):
-    """Test verify code handles empty 2FA password."""
-    auth = client._transport.app.state.auth
-    pool = client._transport.app.state.pool
-
-    mock_session = MagicMock()
-    mock_session.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session"
-
-        with patch.object(pool, "add_client", new_callable=AsyncMock):
-            with patch.object(
-                pool,
-                "get_client_by_phone",
-                new_callable=AsyncMock,
-                return_value=(mock_session, "+1234567890"),
-            ):
-                with patch.object(pool, "release_client", new_callable=AsyncMock):
-                    await client.post(
-                        "/auth/verify-code",
-                        data={
-                            "phone": "+1234567890",
-                            "code": "12345",
-                            "phone_code_hash": "hash",
-                            "password_2fa": "",  # Empty password
-                        },
-                        follow_redirects=False,
-                    )
-
-                    # Empty string should become None
-                    call_args = mock_verify.call_args[0]
-                    assert call_args[3] is None
+    """Test empty 2FA password is preserved as empty string in queued payload."""
+    db = client._transport.app.state.db
+    await client.post(
+        "/auth/verify-code",
+        data={
+            "phone": "+1234567890",
+            "code": "12345",
+            "phone_code_hash": "hash",
+            "password_2fa": "",
+        },
+        follow_redirects=False,
+    )
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].payload["password_2fa"] == ""
 
 
 @pytest.mark.asyncio
 async def test_verify_code_get_me_error(client):
-    """Test verify code handles fetch_me error gracefully."""
-    auth = client._transport.app.state.auth
-    pool = client._transport.app.state.pool
-
-    mock_session = MagicMock()
-    mock_session.fetch_me = AsyncMock(side_effect=Exception("API error"))
-
-    with patch.object(auth, "verify_code", new_callable=AsyncMock) as mock_verify:
-        mock_verify.return_value = "session"
-
-        with patch.object(pool, "add_client", new_callable=AsyncMock):
-            with patch.object(
-                pool,
-                "get_client_by_phone",
-                new_callable=AsyncMock,
-                return_value=(mock_session, "+1234567890"),
-            ):
-                with patch.object(pool, "release_client", new_callable=AsyncMock):
-                    resp = await client.post(
-                        "/auth/verify-code",
-                        data={
-                            "phone": "+1234567890",
-                            "code": "12345",
-                            "phone_code_hash": "hash",
-                            "password_2fa": "",
-                        },
-                        follow_redirects=False,
-                    )
-                    # Should still succeed even if fetch_me fails
-                    assert resp.status_code == 303
+    """Test verify_code route itself is unaffected by later worker-side premium refresh."""
+    resp = await client.post(
+        "/auth/verify-code",
+        data={
+            "phone": "+1234567890",
+            "code": "12345",
+            "phone_code_hash": "hash",
+            "password_2fa": "",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -297,24 +297,20 @@ async def test_scheduler_search_interval_minutes(client):
 
 @pytest.mark.asyncio
 async def test_start_scheduler_calls_service(client):
-    """Test start scheduler calls service method."""
-    mock_service = MagicMock()
-    mock_service.start = AsyncMock()
-
-    with patch("src.web.routes.scheduler.deps.scheduler_service", return_value=mock_service):
-        await client.post("/scheduler/start")
-        mock_service.start.assert_called_once()
+    """Test start scheduler enqueues reconcile command."""
+    db = client._transport.app.state.db
+    await client.post("/scheduler/start")
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "scheduler.reconcile"
 
 
 @pytest.mark.asyncio
 async def test_stop_scheduler_calls_service(client):
-    """Test stop scheduler calls service method."""
-    mock_service = MagicMock()
-    mock_service.stop = AsyncMock()
-
-    with patch("src.web.routes.scheduler.deps.scheduler_service", return_value=mock_service):
-        await client.post("/scheduler/stop")
-        mock_service.stop.assert_called_once()
+    """Test stop scheduler enqueues reconcile command."""
+    db = client._transport.app.state.db
+    await client.post("/scheduler/stop")
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "scheduler.reconcile"
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_scheduler_routes_extra.py
+++ b/tests/routes/test_scheduler_routes_extra.py
@@ -472,96 +472,57 @@ async def test_test_notification_shutting_down(client):
 
 @pytest.mark.asyncio
 async def test_test_notification_bot_not_configured(client):
-    """Test notification when no notifier and no bot (line 428-429)."""
-    with patch("src.web.routes.scheduler.deps.get_notifier") as mock_get_notifier:
-        mock_get_notifier.return_value = None
-
-        with patch(
-            "src.web.routes.scheduler.deps.notification_service"
-        ) as mock_notif_svc:
-            mock_service = MagicMock()
-            mock_service.get_status = AsyncMock(return_value=None)
-            mock_notif_svc.return_value = mock_service
-
-            resp = await client.post(
-                "/scheduler/test-notification",
-                follow_redirects=False,
-            )
-            assert resp.status_code == 303
-            location = resp.headers.get("location", "")
-            assert "error=bot_not_configured" in location
+    """Test notification route now queues a worker command."""
+    db = client._transport.app.state.db
+    resp = await client.post(
+        "/scheduler/test-notification",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in location
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_with_search_query(client, base_app):
-    """Test notification with an active search query (lines 432-448)."""
+    """Test notification route queues command even when queries exist."""
     app, db, _ = base_app
 
     await db.repos.search_queries.add(SearchQuery(
         query="test_keyword", name="TestQuery",
         notify_on_collect=True, is_active=True, is_fts=False,
     ))
-
-    with patch("src.web.routes.scheduler.deps.get_notifier") as mock_get_notifier:
-        mock_notifier = MagicMock()
-        mock_notifier.admin_chat_id = 12345
-        mock_get_notifier.return_value = mock_notifier
-
-        with patch(
-            "src.web.routes.scheduler.deps.notification_service"
-        ) as mock_notif_svc:
-            mock_service = MagicMock()
-            mock_service.get_status = AsyncMock(return_value=None)
-            mock_notif_svc.return_value = mock_service
-
-            with patch("src.web.routes.scheduler.Notifier") as mock_notifier_cls:
-                mock_instance = MagicMock()
-                mock_instance.notify = AsyncMock(return_value=True)
-                mock_notifier_cls.return_value = mock_instance
-
-                resp = await client.post(
-                    "/scheduler/test-notification",
-                    follow_redirects=False,
-                )
-                assert resp.status_code == 303
-                location = resp.headers.get("location", "")
-                assert "msg=test_notification_sent" in location
+    resp = await client.post(
+        "/scheduler/test-notification",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in location
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_no_messages(client, base_app):
-    """Test notification with query but no messages (lines 447-448)."""
+    """Test notification route queues command when there are no matches."""
     app, db, _ = base_app
 
     await db.repos.search_queries.add(SearchQuery(
         query="nonexistent_keyword_xyz", name="NoMatch",
         notify_on_collect=True, is_active=True, is_fts=False,
     ))
-
-    with patch("src.web.routes.scheduler.deps.get_notifier") as mock_get_notifier:
-        mock_notifier = MagicMock()
-        mock_notifier.admin_chat_id = 12345
-        mock_get_notifier.return_value = mock_notifier
-
-        with patch(
-            "src.web.routes.scheduler.deps.notification_service"
-        ) as mock_notif_svc:
-            mock_service = MagicMock()
-            mock_service.get_status = AsyncMock(return_value=None)
-            mock_notif_svc.return_value = mock_service
-
-            with patch("src.web.routes.scheduler.Notifier") as mock_notifier_cls:
-                mock_instance = MagicMock()
-                mock_instance.notify = AsyncMock(return_value=True)
-                mock_notifier_cls.return_value = mock_instance
-
-                resp = await client.post(
-                    "/scheduler/test-notification",
-                    follow_redirects=False,
-                )
-                assert resp.status_code == 303
-                location = resp.headers.get("location", "")
-                assert "msg=test_notification_sent" in location
+    resp = await client.post(
+        "/scheduler/test-notification",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in location
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 # ── dry-run-notifications: lines 490-492 ────────────────────────────────

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -396,31 +396,53 @@ class TestSchedulerStartStop:
 
     @pytest.mark.asyncio
     async def test_start_and_stop_scheduler(self, auth_client, app_with_db):
-        app, _ = app_with_db
+        app, db = app_with_db
         sched = app.state.scheduler
 
         assert sched.is_running is False
 
-        # Start
-        resp = await auth_client.post("/scheduler/start")
-        assert resp.status_code == 200
-        assert sched.is_running is True
+        # Start — now enqueues scheduler.reconcile command
+        transport = ASGITransport(app=app)
+        auth_header = base64.b64encode(b":testpass").decode()
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
+        ) as c:
+            resp = await c.post("/scheduler/start")
+            assert resp.status_code == 303
+            assert "scheduler_started" in resp.headers["location"]
+        assert await db.get_setting("scheduler_autostart") == "1"
 
         # Stop
-        resp = await auth_client.post("/scheduler/stop")
-        assert resp.status_code == 200
-        assert sched.is_running is False
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
+        ) as c:
+            resp = await c.post("/scheduler/stop")
+            assert resp.status_code == 303
+            assert "scheduler_stopped" in resp.headers["location"]
+        assert await db.get_setting("scheduler_autostart") == "0"
 
     @pytest.mark.asyncio
     async def test_double_start_is_safe(self, auth_client, app_with_db):
         app, _ = app_with_db
-        sched = app.state.scheduler
 
-        await auth_client.post("/scheduler/start")
-        await auth_client.post("/scheduler/start")  # should not crash
-        assert sched.is_running is True
-
-        await auth_client.post("/scheduler/stop")
+        transport = ASGITransport(app=app)
+        auth_header = base64.b64encode(b":testpass").decode()
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth_header}", "Origin": "http://test"},
+        ) as c:
+            resp1 = await c.post("/scheduler/start")
+            assert resp1.status_code == 303
+            resp2 = await c.post("/scheduler/start")  # should not crash
+            assert resp2.status_code == 303
 
     @pytest.mark.asyncio
     async def test_trigger_enqueues_channels(self, app_with_db):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1830,6 +1830,7 @@ async def test_channels_add_logs_unexpected_error(client, monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_auth_send_code_logs_exception(client, monkeypatch, caplog):
+    db = client._transport.app.state.db
     monkeypatch.setattr(
         client._transport.app.state.auth,
         "send_code",
@@ -1837,11 +1838,14 @@ async def test_auth_send_code_logs_exception(client, monkeypatch, caplog):
     )
 
     with caplog.at_level(logging.ERROR, logger="src.web.routes.auth"):
-        resp = await client.post("/auth/send-code", data={"phone": "+7000"})
+        resp = await client.post("/auth/send-code", data={"phone": "+7000"}, follow_redirects=False)
 
-    assert resp.status_code == 200
-    assert "boom" in resp.text
-    assert "Failed to send auth code for phone=+7000" in caplog.text
+    assert resp.status_code == 303
+    assert "command_id=" in resp.headers["location"]
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "auth.send_code"
+    assert commands[0].payload["phone"] == "+7000"
+    assert "Failed to send auth code for phone=+7000" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3202,71 +3206,51 @@ class TestWebAgent:
 
 @pytest.mark.asyncio
 async def test_test_notification_no_bot(client):
-    """No notifier and no bot → bot_not_configured error."""
-    app = client._transport.app
-    app.state.notifier = None
-
+    """Route now queues worker-side notification test command."""
+    db = client._transport.app.state.db
     resp = await client.post("/scheduler/test-notification", follow_redirects=False)
     assert resp.status_code == 303
-    assert "error=bot_not_configured" in resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in resp.headers.get("location", "")
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_no_queries(client, monkeypatch):
-    """Notifier configured but no search queries → fallback text."""
-    app = client._transport.app
-    app.state.notifier = SimpleNamespace(admin_chat_id=123)
-
-    captured = {}
-
-    async def fake_notify(self, text):
-        captured["text"] = text
-        return True
-
-    monkeypatch.setattr("src.telegram.notifier.Notifier.notify", fake_notify)
-
+    """Notification route queues command even without matching queries."""
+    db = client._transport.app.state.db
     resp = await client.post("/scheduler/test-notification", follow_redirects=False)
     assert resp.status_code == 303
-    assert "нет поисковых запросов" in captured["text"]
-    assert "msg=test_notification_sent" in resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in resp.headers.get("location", "")
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_no_messages(client, monkeypatch):
-    """Active query exists but no matching messages → fallback text."""
+    """Active query exists but web still only queues notification command."""
     from src.models import SearchQuery
 
     db = client._transport.app.state.db
-    app = client._transport.app
-    app.state.notifier = SimpleNamespace(admin_chat_id=123)
 
     await db.repos.search_queries.add(
         SearchQuery(query="testword", notify_on_collect=True, is_active=True)
     )
 
-    captured = {}
-
-    async def fake_notify(self, text):
-        captured["text"] = text
-        return True
-
-    monkeypatch.setattr("src.telegram.notifier.Notifier.notify", fake_notify)
-
     resp = await client.post("/scheduler/test-notification")
     assert resp.status_code == 200
-    assert "нет сообщений для отправки" in captured["text"]
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_with_public_channel_message(client, monkeypatch):
-    """Message with channel username → t.me/username/id link."""
+    """Message preview generation moved to worker; web only queues command."""
     from datetime import datetime, timezone
 
     from src.models import Channel, Message, SearchQuery
 
     db = client._transport.app.state.db
-    app = client._transport.app
-    app.state.notifier = SimpleNamespace(admin_chat_id=123)
 
     await db.repos.search_queries.add(
         SearchQuery(query="hello", notify_on_collect=True, is_active=True)
@@ -3281,30 +3265,20 @@ async def test_test_notification_with_public_channel_message(client, monkeypatch
         )
     )
 
-    captured = {}
-
-    async def fake_notify(self, text):
-        captured["text"] = text
-        return True
-
-    monkeypatch.setattr("src.telegram.notifier.Notifier.notify", fake_notify)
-
     resp = await client.post("/scheduler/test-notification")
     assert resp.status_code == 200
-    assert "hello world" in captured["text"]
-    assert "https://t.me/mychan/42" in captured["text"]
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_with_private_channel_message(client, monkeypatch):
-    """Private channel → t.me/c/channel_id/id link."""
+    """Private channel preview generation moved to worker; web only queues command."""
     from datetime import datetime, timezone
 
     from src.models import Channel, Message, SearchQuery
 
     db = client._transport.app.state.db
-    app = client._transport.app
-    app.state.notifier = SimpleNamespace(admin_chat_id=123)
 
     await db.repos.search_queries.add(
         SearchQuery(query="secret", notify_on_collect=True, is_active=True)
@@ -3319,34 +3293,21 @@ async def test_test_notification_with_private_channel_message(client, monkeypatc
         )
     )
 
-    captured = {}
-
-    async def fake_notify(self, text):
-        captured["text"] = text
-        return True
-
-    monkeypatch.setattr("src.telegram.notifier.Notifier.notify", fake_notify)
-
     resp = await client.post("/scheduler/test-notification")
     assert resp.status_code == 200
-    assert "secret data here" in captured["text"]
-    assert "https://t.me/c/888/77" in captured["text"]
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 @pytest.mark.asyncio
 async def test_test_notification_notify_fails(client, monkeypatch):
-    """Notifier.notify returns False → failure flash."""
-    app = client._transport.app
-    app.state.notifier = SimpleNamespace(admin_chat_id=123)
-
-    async def fake_notify(self, text):
-        return False
-
-    monkeypatch.setattr("src.telegram.notifier.Notifier.notify", fake_notify)
-
+    """Route now queues command and leaves success/failure to worker result."""
+    db = client._transport.app.state.db
     resp = await client.post("/scheduler/test-notification", follow_redirects=False)
     assert resp.status_code == 303
-    assert "msg=test_notification_failed" in resp.headers.get("location", "")
+    assert "msg=test_notification_queued" in resp.headers.get("location", "")
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "notifications.test"
 
 
 # --- Global error handler ---

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -6,13 +6,12 @@ with /login which is for the web panel itself).
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.config import AppConfig
-from src.models import Account
+from src.models import Account, TelegramCommand, TelegramCommandStatus
 from src.telegram.auth import TelegramAuth
 from tests.helpers import build_web_app, make_auth_client
 
@@ -128,7 +127,7 @@ class TestSendCode:
 
     @pytest.mark.asyncio
     async def test_send_code_success(self, db, real_pool_harness_factory):
-        """Test successful code sending."""
+        """Test send-code enqueues command instead of direct RPC."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -139,30 +138,22 @@ class TestSendCode:
         app, _ = await build_web_app(config, harness, db=db, add_account=None)
         app.state.auth = auth
 
-        with patch.object(
-            auth,
-            "send_code",
-            new_callable=AsyncMock,
-            return_value={
-                "phone_code_hash": "abc123",
-                "code_type": "SMS",
-                "next_type": "call",
-                "timeout": 120,
-            },
-        ):
+        with patch.object(auth, "send_code", new_callable=AsyncMock) as mock_send:
             async with make_auth_client(app, password="testpass", with_auth=True) as client:
                 response = await client.post(
                     "/auth/send-code",
                     data={"phone": "+70001112233"},
+                    follow_redirects=False,
                 )
 
-        assert response.status_code == 200
-        # Should show code input step
-        assert "code" in response.text.lower() or "код" in response.text.lower()
+        assert response.status_code == 303
+        mock_send.assert_not_awaited()
+        commands = await db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].command_type == "auth.send_code"
 
     @pytest.mark.asyncio
     async def test_send_code_exception(self, db, real_pool_harness_factory):
-        """Test send-code handles exceptions gracefully."""
+        """Test send-code route does not execute auth inline."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -178,16 +169,16 @@ class TestSendCode:
             "send_code",
             new_callable=AsyncMock,
             side_effect=Exception("Phone number invalid"),
-        ):
+        ) as mock_send:
             async with make_auth_client(app, password="testpass", with_auth=True) as client:
                 response = await client.post(
                     "/auth/send-code",
                     data={"phone": "+70001112233"},
+                    follow_redirects=False,
                 )
 
-        assert response.status_code == 200
-        # Should show error message
-        assert "Phone number invalid" in response.text
+        assert response.status_code == 303
+        mock_send.assert_not_awaited()
 
 
 class TestResendCode:
@@ -195,7 +186,7 @@ class TestResendCode:
 
     @pytest.mark.asyncio
     async def test_resend_code_success(self, db, real_pool_harness_factory):
-        """Test successful code resend."""
+        """Test resend-code enqueues command instead of direct RPC."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -206,29 +197,22 @@ class TestResendCode:
         app, _ = await build_web_app(config, harness, db=db, add_account=None)
         app.state.auth = auth
 
-        with patch.object(
-            auth,
-            "resend_code",
-            new_callable=AsyncMock,
-            return_value={
-                "phone_code_hash": "xyz789",
-                "code_type": "call",
-                "next_type": None,
-                "timeout": 60,
-            },
-        ):
+        with patch.object(auth, "resend_code", new_callable=AsyncMock) as mock_resend:
             async with make_auth_client(app, password="testpass", with_auth=True) as client:
                 response = await client.post(
                     "/auth/resend-code",
                     data={"phone": "+70001112233", "phone_code_hash": "abc123"},
+                    follow_redirects=False,
                 )
 
-        assert response.status_code == 200
-        assert "code" in response.text.lower() or "код" in response.text.lower()
+        assert response.status_code == 303
+        mock_resend.assert_not_awaited()
+        commands = await db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].command_type == "auth.resend_code"
 
     @pytest.mark.asyncio
     async def test_resend_code_exception(self, db, real_pool_harness_factory):
-        """Test resend-code handles exceptions gracefully."""
+        """Test resend-code route does not execute auth inline."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -244,15 +228,16 @@ class TestResendCode:
             "resend_code",
             new_callable=AsyncMock,
             side_effect=Exception("Rate limit exceeded"),
-        ):
+        ) as mock_resend:
             async with make_auth_client(app, password="testpass", with_auth=True) as client:
                 response = await client.post(
                     "/auth/resend-code",
                     data={"phone": "+70001112233", "phone_code_hash": "abc123"},
+                    follow_redirects=False,
                 )
 
-        assert response.status_code == 200
-        assert "Rate limit exceeded" in response.text
+        assert response.status_code == 303
+        mock_resend.assert_not_awaited()
 
 
 class TestVerifyCode:
@@ -260,64 +245,7 @@ class TestVerifyCode:
 
     @pytest.mark.asyncio
     async def test_verify_code_success(self, db, real_pool_harness_factory):
-        """Test successful code verification."""
-        config = AppConfig()
-        config.web.password = "testpass"
-        config.telegram.api_id = 12345
-        config.telegram.api_hash = "test_hash"
-
-        harness = real_pool_harness_factory()
-        auth = TelegramAuth(12345, "test_hash")
-        app, _ = await build_web_app(config, harness, db=db, add_account=None)
-        app.state.auth = auth
-
-        # Mock pool.add_client to capture the session
-        added_sessions = []
-
-        async def mock_add_client(phone, session_string):
-            added_sessions.append((phone, session_string))
-
-        app.state.pool.add_client = mock_add_client
-
-        # Mock pool.get_client_by_phone and release_client
-        mock_client = MagicMock()
-        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
-        app.state.pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+70001112233"))
-        app.state.pool.release_client = AsyncMock()
-
-        with patch.object(
-            auth,
-            "verify_code",
-            new_callable=AsyncMock,
-            return_value="session_string_123",
-        ):
-            async with make_auth_client(app, password="testpass", with_auth=True) as client:
-                response = await client.post(
-                    "/auth/verify-code",
-                    data={
-                        "phone": "+70001112233",
-                        "code": "12345",
-                        "phone_code_hash": "abc123",
-                        "password_2fa": "",
-                        "code_type": "",
-                        "next_type": "",
-                        "timeout": "",
-                    },
-                    follow_redirects=False,
-                )
-
-        assert response.status_code == 303
-        assert "settings" in response.headers["location"]
-
-        # Verify account was added to DB
-        accounts = await db.get_accounts()
-        assert len(accounts) == 1
-        assert accounts[0].phone == "+70001112233"
-        assert accounts[0].is_primary is True  # First account is primary
-
-    @pytest.mark.asyncio
-    async def test_verify_code_2fa_required(self, db, real_pool_harness_factory):
-        """Test code verification when 2FA password is required."""
+        """Test verify-code enqueues command instead of direct RPC."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -332,126 +260,6 @@ class TestVerifyCode:
             auth,
             "verify_code",
             new_callable=AsyncMock,
-            side_effect=ValueError("2FA password required"),
-        ):
-            async with make_auth_client(app, password="testpass", with_auth=True) as client:
-                response = await client.post(
-                    "/auth/verify-code",
-                    data={
-                        "phone": "+70001112233",
-                        "code": "12345",
-                        "phone_code_hash": "abc123",
-                        "password_2fa": "",
-                        "code_type": "",
-                        "next_type": "",
-                        "timeout": "",
-                    },
-                )
-
-        assert response.status_code == 200
-        # Should show 2FA password input
-        assert "2fa" in response.text.lower() or "password" in response.text.lower()
-
-    @pytest.mark.asyncio
-    async def test_verify_code_invalid_code(self, db, real_pool_harness_factory):
-        """Test code verification with invalid code."""
-        config = AppConfig()
-        config.web.password = "testpass"
-        config.telegram.api_id = 12345
-        config.telegram.api_hash = "test_hash"
-
-        harness = real_pool_harness_factory()
-        auth = TelegramAuth(12345, "test_hash")
-        app, _ = await build_web_app(config, harness, db=db, add_account=None)
-        app.state.auth = auth
-
-        with patch.object(
-            auth,
-            "verify_code",
-            new_callable=AsyncMock,
-            side_effect=ValueError("Invalid code"),
-        ):
-            async with make_auth_client(app, password="testpass", with_auth=True) as client:
-                response = await client.post(
-                    "/auth/verify-code",
-                    data={
-                        "phone": "+70001112233",
-                        "code": "00000",
-                        "phone_code_hash": "abc123",
-                        "password_2fa": "",
-                        "code_type": "SMS",
-                        "next_type": "call",
-                        "timeout": "120",
-                    },
-                )
-
-        assert response.status_code == 200
-        assert "Invalid code" in response.text
-
-    @pytest.mark.asyncio
-    async def test_verify_code_exception(self, db, real_pool_harness_factory):
-        """Test code verification handles general exceptions."""
-        config = AppConfig()
-        config.web.password = "testpass"
-        config.telegram.api_id = 12345
-        config.telegram.api_hash = "test_hash"
-
-        harness = real_pool_harness_factory()
-        auth = TelegramAuth(12345, "test_hash")
-        app, _ = await build_web_app(config, harness, db=db, add_account=None)
-        app.state.auth = auth
-
-        with patch.object(
-            auth,
-            "verify_code",
-            new_callable=AsyncMock,
-            side_effect=Exception("Flood wait: 60 seconds"),
-        ):
-            async with make_auth_client(app, password="testpass", with_auth=True) as client:
-                response = await client.post(
-                    "/auth/verify-code",
-                    data={
-                        "phone": "+70001112233",
-                        "code": "12345",
-                        "phone_code_hash": "abc123",
-                        "password_2fa": "",
-                        "code_type": "",
-                        "next_type": "",
-                        "timeout": "",
-                    },
-                )
-
-        assert response.status_code == 200
-        assert "Flood wait" in response.text
-
-    @pytest.mark.asyncio
-    async def test_verify_code_with_2fa_password(self, db, real_pool_harness_factory):
-        """Test code verification with 2FA password provided."""
-        config = AppConfig()
-        config.web.password = "testpass"
-        config.telegram.api_id = 12345
-        config.telegram.api_hash = "test_hash"
-
-        harness = real_pool_harness_factory()
-        auth = TelegramAuth(12345, "test_hash")
-        app, _ = await build_web_app(config, harness, db=db, add_account=None)
-        app.state.auth = auth
-
-        # Mock pool methods
-        async def mock_add_client(phone, session_string):
-            pass
-
-        app.state.pool.add_client = mock_add_client
-        mock_client = MagicMock()
-        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=True))
-        app.state.pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+70001112233"))
-        app.state.pool.release_client = AsyncMock()
-
-        with patch.object(
-            auth,
-            "verify_code",
-            new_callable=AsyncMock,
-            return_value="session_string_with_2fa",
         ) as mock_verify:
             async with make_auth_client(app, password="testpass", with_auth=True) as client:
                 response = await client.post(
@@ -460,7 +268,7 @@ class TestVerifyCode:
                         "phone": "+70001112233",
                         "code": "12345",
                         "phone_code_hash": "abc123",
-                        "password_2fa": "my2fapassword",
+                        "password_2fa": "",
                         "code_type": "",
                         "next_type": "",
                         "timeout": "",
@@ -469,17 +277,144 @@ class TestVerifyCode:
                 )
 
         assert response.status_code == 303
-        # Verify 2FA password was passed to verify_code
-        mock_verify.assert_awaited_once_with("+70001112233", "12345", "abc123", "my2fapassword")
+        assert "command_id=" in response.headers["location"]
+        mock_verify.assert_not_awaited()
+        commands = await db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].command_type == "auth.verify_code"
 
-        # Premium status is now refreshed asynchronously by the worker.
-        accounts = await db.get_accounts()
-        assert len(accounts) == 1
-        assert accounts[0].is_premium is False
+    @pytest.mark.asyncio
+    async def test_verify_code_2fa_required(self, db, real_pool_harness_factory):
+        """Test login page shows 2FA state from failed queued command."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        cid = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="auth.verify_code",
+                payload={"phone": "+70001112233", "code": "12345", "phone_code_hash": "abc123"},
+                status=TelegramCommandStatus.FAILED,
+                error="2FA password required",
+            )
+        )
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.get(f"/auth/login?command_id={cid}")
+
+        assert response.status_code == 200
+        assert "2fa" in response.text.lower() or "password" in response.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_verify_code_invalid_code(self, db, real_pool_harness_factory):
+        """Test login page surfaces invalid-code error from failed queued command."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        cid = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="auth.verify_code",
+                payload={
+                    "phone": "+70001112233",
+                    "code": "00000",
+                    "phone_code_hash": "abc123",
+                    "code_type": "SMS",
+                    "next_type": "call",
+                    "timeout": "120",
+                },
+            )
+        )
+        await db.repos.telegram_commands.update_command(
+            cid,
+            status=TelegramCommandStatus.FAILED,
+            error="Invalid code",
+        )
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.get(f"/auth/login?command_id={cid}")
+
+        assert response.status_code == 200
+        assert "Invalid code" in response.text
+
+    @pytest.mark.asyncio
+    async def test_verify_code_exception(self, db, real_pool_harness_factory):
+        """Test login page surfaces generic queued verify error."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        cid = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="auth.verify_code",
+                payload={
+                    "phone": "+70001112233",
+                    "code": "12345",
+                    "phone_code_hash": "abc123",
+                },
+            )
+        )
+        await db.repos.telegram_commands.update_command(
+            cid,
+            status=TelegramCommandStatus.FAILED,
+            error="Flood wait: 60 seconds",
+        )
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.get(f"/auth/login?command_id={cid}")
+
+        assert response.status_code == 200
+        assert "Flood wait" in response.text
+
+    @pytest.mark.asyncio
+    async def test_verify_code_with_2fa_password(self, db, real_pool_harness_factory):
+        """Test verify-code enqueues 2FA password for worker processing."""
+        config = AppConfig()
+        config.web.password = "testpass"
+        config.telegram.api_id = 12345
+        config.telegram.api_hash = "test_hash"
+
+        harness = real_pool_harness_factory()
+        auth = TelegramAuth(12345, "test_hash")
+        app, _ = await build_web_app(config, harness, db=db, add_account=None)
+        app.state.auth = auth
+
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.post(
+                "/auth/verify-code",
+                data={
+                    "phone": "+70001112233",
+                    "code": "12345",
+                    "phone_code_hash": "abc123",
+                    "password_2fa": "my2fapassword",
+                    "code_type": "",
+                    "next_type": "",
+                    "timeout": "",
+                },
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 303
+        commands = await db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].payload["password_2fa"] == "my2fapassword"
 
     @pytest.mark.asyncio
     async def test_verify_code_existing_account_not_primary(self, db, real_pool_harness_factory):
-        """Test that subsequent accounts are not marked as primary."""
+        """Test queued verify-code carries non-primary context for later accounts."""
         config = AppConfig()
         config.web.password = "testpass"
         config.telegram.api_id = 12345
@@ -495,41 +430,21 @@ class TestVerifyCode:
             Account(phone="+70001110000", session_string="first_session", is_primary=True)
         )
 
-        # Mock pool methods
-        async def mock_add_client(phone, session_string):
-            pass
-
-        app.state.pool.add_client = mock_add_client
-        mock_client = MagicMock()
-        mock_client.fetch_me = AsyncMock(return_value=SimpleNamespace(premium=False))
-        app.state.pool.get_client_by_phone = AsyncMock(return_value=(mock_client, "+70001112233"))
-        app.state.pool.release_client = AsyncMock()
-
-        with patch.object(
-            auth,
-            "verify_code",
-            new_callable=AsyncMock,
-            return_value="second_session",
-        ):
-            async with make_auth_client(app, password="testpass", with_auth=True) as client:
-                response = await client.post(
-                    "/auth/verify-code",
-                    data={
-                        "phone": "+70001112233",
-                        "code": "12345",
-                        "phone_code_hash": "abc123",
-                        "password_2fa": "",
-                        "code_type": "",
-                        "next_type": "",
-                        "timeout": "",
-                    },
-                    follow_redirects=False,
-                )
+        async with make_auth_client(app, password="testpass", with_auth=True) as client:
+            response = await client.post(
+                "/auth/verify-code",
+                data={
+                    "phone": "+70001112233",
+                    "code": "12345",
+                    "phone_code_hash": "abc123",
+                    "password_2fa": "",
+                    "code_type": "",
+                    "next_type": "",
+                    "timeout": "",
+                },
+                follow_redirects=False,
+            )
 
         assert response.status_code == 303
-
-        # Verify second account is NOT primary
-        accounts = await db.get_accounts()
-        assert len(accounts) == 2
-        new_account = next(a for a in accounts if a.phone == "+70001112233")
-        assert new_account.is_primary is False
+        commands = await db.repos.telegram_commands.list_commands(limit=1)
+        assert commands[0].payload["is_primary"] is False

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -447,4 +447,4 @@ class TestVerifyCode:
 
         assert response.status_code == 303
         commands = await db.repos.telegram_commands.list_commands(limit=1)
-        assert commands[0].payload["is_primary"] is False
+        assert "is_primary" not in commands[0].payload  # worker recomputes from fresh DB state


### PR DESCRIPTION
## Summary
- move web auth routes to enqueue durable worker-owned commands instead of calling Telegram auth inline
- route scheduler state-changing actions through command queue and worker dispatcher handlers
- update auth, scheduler, and web tests to validate redirect-and-command flow

## Test Plan
- [x] ./.venv/bin/python -m pytest tests/routes/test_auth_routes.py tests/routes/test_scheduler_routes.py tests/routes/test_scheduler_routes_extra.py tests/test_web.py tests/test_web_auth.py -q