### PR TITLE
fix(web): embed worker in serve by default + e2e collection test (#457)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 Core code lives in `src/`. Use `src/cli/` for command-line entrypoints, `src/web/` for the FastAPI dashboard, `src/services/` for orchestration/business logic, `src/telegram/` for Telethon integrations, and `src/database/` plus `src/database/repositories/` for SQLite access. Tests live under `tests/`, with route coverage in `tests/routes/` and repository coverage in `tests/repositories/`. Documentation lives in `docs/`; static web assets are in `src/web/static/` and Jinja templates in `src/web/templates/`.
 
 ## Build, Test, and Development Commands
-Install locally with `pip install -e .` from the repo root. Run the app with `python -m src.main serve` and open `http://localhost:8080`. Start the Docker stack with `docker-compose up -d`.
+Install locally with `pip install -e .` from the repo root. Run `python -m src.main serve` — it spawns the embedded Telegram worker by default, so a single command gives you the web UI plus real collection, scheduler jobs, and `/agent` tools. Open `http://localhost:8080`. For Docker/k8s split deployments add `--no-worker` and run `python -m src.main worker` in a separate container. Start the Docker stack with `docker-compose up -d`.
 
 Use these validation commands during development:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Install dev dependencies
 pip install -e ".[dev]"
 
-# Run the web server
-python -m src.main serve [--web-pass PASS]
+# Run the web server — spawns the embedded Telegram worker by default so a
+# single command gives you UI + actual collection (#457 round 4). For split
+# deployments (Docker/k8s) pass --no-worker and run `worker` separately.
+python -m src.main serve [--web-pass PASS] [--no-worker]
+
+# Standalone Telegram worker — only needed alongside `serve --no-worker`.
+python -m src.main worker
 
 # Lint
 ruff check src/ tests/ conftest.py
@@ -34,6 +39,7 @@ Full CLI reference:
 
 ```bash
 python -m src.main [--config CONFIG] serve [--web-pass PASS]
+python -m src.main [--config CONFIG] worker
 python -m src.main [--config CONFIG] collect [--channel-id ID]
 python -m src.main [--config CONFIG] search "query" [--limit N] [--mode MODE]
 
@@ -65,6 +71,10 @@ Primary CLI name for Telegram dialogs is `dialogs`; legacy alias `my-telegram` i
 
 Three layers: **CLI/Web** → **Telegram + Search + Scheduler + Agent/Pipeline** → **SQLite**
 
+- **Runtime split (web ↔ worker)**: since #444 the runtime consists of two `AppContainer` flavours keyed on `runtime_mode` ("web" vs "worker") in `src/web/bootstrap.py`. Since #457 round 4 they normally run in the **same process**: `serve` spawns an `EmbeddedWorker` (`src/web/embedded_worker.py`) as an asyncio task next to the web container. Pass `--no-worker` to run only the web side and start `python -m src.main worker` separately (Docker/k8s split deployments).
+  - Web container (`runtime_mode="web"`) uses snapshot shims (`SnapshotClientPool`, `SnapshotCollector`, `SnapshotSchedulerManager` in `src/web/runtime_shims.py`). It does NOT open Telegram connections; UI actions enqueue work into `collection_tasks` / `telegram_commands` / task tables and read `runtime_snapshots` to render status.
+  - Worker container (`runtime_mode="worker"`, either embedded or standalone via `src/runtime/worker.py`) owns the live `ClientPool`, `CollectionQueue`, `UnifiedDispatcher`, `TelegramCommandDispatcher`, and `SchedulerManager`, and publishes `runtime_snapshots` (heartbeat, accounts_status, scheduler_status, …) that the web side reads.
+  - In web-mode `collection_queue = None` and `CollectionService` falls back to writing a PENDING row — the worker picks those up at startup via `CollectionQueue.requeue_startup_tasks()`.
 - CLI (`src/main.py` → `src/cli/commands/`) and Web (`src/web/`) are parallel entry points to the same logic
 - Telegram layer: `ClientPool` manages multi-account connections, `Collector` fetches messages, `Notifier` sends alerts
 - Search layer: `SearchEngine` (local DB), `AISearchEngine` (LLM-powered)

--- a/README.md
+++ b/README.md
@@ -54,13 +54,29 @@ AGENT_FALLBACK_MODEL=      # optional, provider:model for deepagents fallback
 AGENT_FALLBACK_API_KEY=    # optional, explicit API key for deepagents fallback provider
 ```
 
-Start the server:
+Start the server — one command, everything works:
 
 ```bash
 python -m src.main serve
 ```
 
 Open http://localhost:8080 in your browser and enter the `WEB_PASS` password.
+
+### Split deployment (Docker / k8s)
+
+`serve` spawns an embedded Telegram worker inside the same process by default,
+so a single `python -m src.main serve` command runs the web UI and the
+collection worker together. For Docker or Kubernetes where you want the web
+and worker in separate containers, pass `--no-worker` and run a dedicated
+worker service:
+
+```bash
+# container 1 — web UI + API only
+python -m src.main serve --no-worker
+
+# container 2 — Telegram worker (shared SQLite volume)
+python -m src.main worker
+```
 
 ## Docker
 
@@ -133,10 +149,13 @@ Supports `${ENV_VAR}` substitution. Empty env vars are dropped (defaults apply).
 ## CLI
 
 ```bash
-# Web server
-python -m src.main [--config CONFIG] serve [--web-pass PASS]
+# Web server (spawns the embedded Telegram worker by default)
+python -m src.main [--config CONFIG] serve [--web-pass PASS] [--no-worker]
 python -m src.main [--config CONFIG] stop
 python -m src.main [--config CONFIG] restart [--web-pass PASS]
+
+# Standalone Telegram worker (only needed with `serve --no-worker` in split deployments)
+python -m src.main [--config CONFIG] worker
 
 # One-shot collection
 python -m src.main [--config CONFIG] collect [--channel-id ID]

--- a/README.ru.md
+++ b/README.ru.md
@@ -53,13 +53,28 @@ AGENT_FALLBACK_MODEL=      # опционально, provider:model для deepa
 AGENT_FALLBACK_API_KEY=    # опционально, явный API key для fallback-провайдера
 ```
 
-Запустите сервер:
+Запустите сервер — одна команда, всё работает:
 
 ```bash
 python -m src.main serve
 ```
 
 Откройте http://localhost:8080 в браузере и введите пароль из `WEB_PASS`.
+
+### Split-деплой (Docker / k8s)
+
+По умолчанию `serve` поднимает встроенный Telegram-воркер в том же процессе,
+поэтому одна команда `python -m src.main serve` даёт и веб-панель, и реальный
+сбор. Для Docker/k8s, где веб и воркер живут в разных контейнерах, передайте
+`--no-worker` и запустите отдельный воркер-сервис:
+
+```bash
+# контейнер 1 — только веб-панель и API
+python -m src.main serve --no-worker
+
+# контейнер 2 — Telegram-воркер (общий SQLite-том)
+python -m src.main worker
+```
 
 ## Docker
 
@@ -125,10 +140,13 @@ search остаются целевым контрактом.
 ## CLI
 
 ```bash
-# Веб-сервер
-python -m src.main [--config CONFIG] serve [--web-pass PASS]
+# Веб-сервер (по умолчанию поднимает встроенный Telegram-воркер)
+python -m src.main [--config CONFIG] serve [--web-pass PASS] [--no-worker]
 python -m src.main [--config CONFIG] stop
 python -m src.main [--config CONFIG] restart [--web-pass PASS]
+
+# Отдельный Telegram-воркер (нужен только с `serve --no-worker` в split-деплое)
+python -m src.main [--config CONFIG] worker
 
 # Разовый сбор
 python -m src.main [--config CONFIG] collect [--channel-id ID]

--- a/src/cli/commands/serve.py
+++ b/src/cli/commands/serve.py
@@ -23,6 +23,11 @@ def run(args: argparse.Namespace) -> None:
         logging.error("WEB_PASS must be set for web panel authentication")
         sys.exit(1)
     app = create_app(config)
+    # The lifespan hook in src/web/app.py spawns an embedded Telegram worker
+    # unless this flag is set. See #457 round 4: by default `serve` owns the
+    # worker too; `--no-worker` is for production split deployments where
+    # `python -m src.main worker` runs in its own process/container.
+    app.state.embed_worker = not getattr(args, "no_worker", False)
     pid_path = pid_file_path(config)
     try:
         register_current_process(pid_path)

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -13,6 +13,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     serve_parser = sub.add_parser("serve", help="Start web server")
     serve_parser.add_argument("--web-pass", help="Web panel password (overrides config)")
+    serve_parser.add_argument(
+        "--no-worker",
+        action="store_true",
+        help=(
+            "Do not spawn the embedded Telegram worker inside this process. "
+            "Use this when you run `python -m src.main worker` in a separate "
+            "process / container (Docker, k8s). Without this flag the serve "
+            "command runs both the web app and the worker in one process — "
+            "clicking 'Collect' in the UI immediately triggers collection."
+        ),
+    )
 
     sub.add_parser("worker", help="Start Telegram worker runtime")
 

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -87,6 +87,34 @@ class CollectionService:
             total_candidates=len(channels),
         )
 
+    async def cancel_task(self, task_id: int, note: str | None = None) -> bool:
+        """Cancel a pending/running collection task.
+
+        When the worker process is live (`self._queue is not None`) the call is
+        delegated to `CollectionQueue.cancel_task` so an in-flight collection
+        gets interrupted immediately. In web-mode (`self._queue is None`) we
+        fall back to a DB-only status flip — the worker will pick up the
+        cancellation on its next fetch of the task row.
+
+        Mirrors the `_enqueue_channel` fallback pattern so that /scheduler
+        routes do not 500 when `collection_queue` is absent (#457).
+        """
+        if self._queue is not None:
+            return await self._queue.cancel_task(task_id, note=note)
+        return await self._channels.cancel_collection_task(task_id, note=note)
+
+    async def clear_pending_collect_tasks(self) -> int:
+        """Delete every PENDING channel-collect task.
+
+        With a live queue this also drains the in-memory asyncio.Queue and
+        cancels any Flood-Wait requeue timers. Without a queue (web-mode) we
+        just delete the DB rows — memory state lives only in the worker
+        process, which is not running anyway.
+        """
+        if self._queue is not None:
+            return await self._queue.clear_pending_tasks()
+        return await self._channels.delete_pending_channel_tasks()
+
     async def collect_channel_stats(self, channel: Channel) -> None:
         await self._collector.collect_channel_stats(channel)
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -25,6 +25,7 @@ from src.web.assembly import (
 )
 from src.web.bootstrap import build_container_with_templates, start_container, stop_container
 from src.web.csrf import OriginCSRFMiddleware
+from src.web.embedded_worker import EmbeddedWorker
 from src.web.panel_auth import (
     get_cookie_user,
     is_public_path,
@@ -251,10 +252,28 @@ async def lifespan(app: FastAPI):
 
     await start_container(container)
 
+    # #457 round 4: `serve` CLI sets `app.state.embed_worker=True` so a user
+    # running `python -m src.main serve` gets the full functionality (UI +
+    # actual collection) in a single command. Tests and split production
+    # setups (Docker/k8s with `--no-worker` + a separate `worker` container)
+    # leave `embed_worker` unset → no background worker here.
+    embedded_worker: EmbeddedWorker | None = None
+    if getattr(app.state, "embed_worker", False):
+        embedded_worker = EmbeddedWorker(app.state.config)
+        await embedded_worker.start()
+        app.state.embedded_worker = embedded_worker
+    else:
+        logger.debug("Embedded worker not spawned (app.state.embed_worker is not True)")
+
     try:
         yield
     finally:
         logger.info("Shutting down...")
+        if embedded_worker is not None:
+            try:
+                await embedded_worker.stop()
+            except Exception:
+                logger.exception("Error stopping embedded worker")
         await stop_container(container)
         logger.info("Application shut down")
 

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -192,15 +192,20 @@ def get_collector(request: Request) -> Collector:
     return get_container(request).collector
 
 
-def get_queue(request: Request) -> CollectionQueue:
+def get_queue(request: Request) -> CollectionQueue | None:
+    # In web-mode this is always None (worker-mode only — see bootstrap.py).
+    # Route code must either check for None or go through CollectionService,
+    # which has built-in DB-only fallbacks for queue operations.
     return get_container(request).collection_queue
 
 
-def get_unified_dispatcher(request: Request) -> UnifiedDispatcher:
+def get_unified_dispatcher(request: Request) -> UnifiedDispatcher | None:
+    # worker-only; None in web-mode. See bootstrap.py.
     return get_container(request).unified_dispatcher
 
 
-def get_task_enqueuer(request: Request) -> TaskEnqueuer:
+def get_task_enqueuer(request: Request) -> TaskEnqueuer | None:
+    # worker-only; None in web-mode. See bootstrap.py.
     return get_container(request).task_enqueuer
 
 

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -1,0 +1,137 @@
+"""Embedded Telegram worker that runs inside the `serve` process.
+
+Background for #457: before round 4, `python -m src.main serve` started only
+the FastAPI web app with snapshot shims. The real Telethon pool, collection
+queue, dispatchers and scheduler lived in a separate `python -m src.main
+worker` process. Users who did not know they had to run both processes saw
+UI buttons accept clicks while nothing was collected, the scheduler stayed
+"stopped", and tasks piled up in `collection_tasks` with status=pending
+forever.
+
+Round 4 attaches the worker runtime to the same process by default — the
+lifespan hook spawns an asyncio task that is the exact moral equivalent of
+`src.runtime.worker._run_worker_async`, just running inside the web loop
+instead of its own `asyncio.run()`. The code path that production split
+deployments take (dedicated worker container) stays available via
+`python -m src.main serve --no-worker` plus a separately launched
+`python -m src.main worker` — both processes keep sharing the SQLite file
+and `runtime_snapshots` rows as before.
+
+We deliberately do NOT reuse the web container's `Database` instance: each
+AppContainer owns its own aiosqlite connection (`Database.close()` is called
+in both `stop_container` paths), so sharing would double-close. Two
+connections to the same SQLite file are fine because SQLite file-level
+locking already serialises writes, which is exactly how the two-process
+deployment has worked since #444.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.config import AppConfig
+from src.runtime.worker import _publish_snapshots
+from src.web.bootstrap import build_worker_container, start_container, stop_container
+from src.web.container import AppContainer
+from src.web.log_handler import LogBuffer
+
+logger = logging.getLogger(__name__)
+
+# How often the embedded worker republishes `worker_heartbeat` and the other
+# runtime snapshots. Matches `src/runtime/worker.py:_run_worker_async` and is
+# what `_is_worker_alive` compares against (`WORKER_HEARTBEAT_STALE_AFTER_SEC`
+# is 60s, so 5s gives 12 beats of slack before the UI marks the worker down).
+HEARTBEAT_INTERVAL_SEC = 5.0
+
+
+class EmbeddedWorker:
+    """Lifecycle wrapper around an in-process worker container.
+
+    Owns a separate `AppContainer` with runtime_mode="worker", its own
+    aiosqlite connection, ClientPool, CollectionQueue, UnifiedDispatcher,
+    TelegramCommandDispatcher and SchedulerManager — i.e. everything that
+    `src/runtime/worker.py` bootstraps in its own process.
+    """
+
+    def __init__(self, config: AppConfig):
+        self._config = config
+        self._container: AppContainer | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        self._ready_event = asyncio.Event()
+
+    @property
+    def container(self) -> AppContainer | None:
+        return self._container
+
+    async def wait_ready(self, timeout: float | None = None) -> bool:
+        """Wait until the worker has published its first heartbeat.
+
+        Used by tests to know when it is safe to trigger a collection and
+        expect the worker to pick it up.
+        """
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    async def start(self) -> None:
+        if self._task is not None:
+            raise RuntimeError("EmbeddedWorker already started")
+        self._task = asyncio.create_task(self._run(), name="embedded-worker")
+
+    async def stop(self, timeout: float = 10.0) -> None:
+        if self._task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning("[embedded-worker] did not stop within %.1fs; cancelling", timeout)
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._task = None
+
+    async def _run(self) -> None:
+        logger.info("[embedded-worker] starting")
+        try:
+            self._container = await build_worker_container(
+                self._config, log_buffer=LogBuffer(maxlen=500)
+            )
+            await start_container(self._container)
+        except Exception:
+            logger.exception(
+                "[embedded-worker] failed to start; UI will show worker_down banner"
+            )
+            # A start-up failure must not kill the web process — the user still
+            # gets an accessible dashboard (round 1's worker_down banner will
+            # fire after ~60s of missing heartbeats).
+            return
+
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    await _publish_snapshots(self._container)
+                    self._ready_event.set()
+                except Exception:
+                    # Snapshot publishing must never crash the loop — the worker
+                    # is still processing queued tasks even if snapshots fail.
+                    logger.exception("[embedded-worker] _publish_snapshots failed")
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=HEARTBEAT_INTERVAL_SEC
+                    )
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            logger.info("[embedded-worker] stopping")
+            try:
+                await stop_container(self._container)
+            except Exception:
+                logger.exception("[embedded-worker] stop_container raised")
+            self._container = None
+            logger.info("[embedded-worker] stopped")

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -107,9 +107,12 @@ class EmbeddedWorker:
             logger.exception(
                 "[embedded-worker] failed to start; UI will show worker_down banner"
             )
-            # A start-up failure must not kill the web process — the user still
-            # gets an accessible dashboard (round 1's worker_down banner will
-            # fire after ~60s of missing heartbeats).
+            if self._container is not None:
+                try:
+                    await stop_container(self._container)
+                except Exception:
+                    logger.exception("[embedded-worker] stop_container during startup-failure cleanup raised")
+                self._container = None
             return
 
         try:

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 from datetime import datetime, timezone
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -19,6 +20,10 @@ JOB_LABELS = {
     "photo_auto": "Автозагрузка фото",
     "warm_all_dialogs": "Прогрев кэша диалогов",
 }
+
+# Worker publishes `worker_heartbeat` every ~5s (src/runtime/worker.py:_publish_snapshots).
+# 60s gives us 12 missed publishes before we conclude the worker is down.
+WORKER_HEARTBEAT_STALE_AFTER_SEC = 60
 
 
 def _job_label(job_id: str) -> str:
@@ -46,7 +51,7 @@ def _compute_load_level(
     available_accounts_now: int,
     state: str,
 ) -> str:
-    if state in {"all_flooded", "no_clients"}:
+    if state in {"worker_down", "all_flooded", "no_clients"}:
         return "overload"
     capacity_accounts = max(1, available_accounts_now)
     pressure = active_unfiltered_channels / capacity_accounts
@@ -68,6 +73,11 @@ def _collector_health_recommendations(
     available_accounts_now: int,
 ) -> list[str]:
     recommendations: list[str] = []
+    if state == "worker_down":
+        recommendations.append(
+            "Запустите Telegram-воркер во втором терминале: `python -m src.main worker`. "
+            "Без него задачи сбора и планировщика копятся в БД, но не исполняются."
+        )
     if state == "all_flooded":
         recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
     if state == "no_clients":
@@ -85,6 +95,29 @@ def _collector_health_recommendations(
     return recommendations
 
 
+async def _is_worker_alive(db) -> bool:
+    """Return True when the worker-process heartbeat snapshot is fresh.
+
+    The worker publishes `worker_heartbeat` every ~5s
+    (`src/runtime/worker.py:_publish_snapshots`). We treat anything older than
+    `WORKER_HEARTBEAT_STALE_AFTER_SEC` as the worker being down — that turns the
+    silent failure from #444 (serve running alone, collection tasks piling up
+    with no executor) into an explicit banner.
+    """
+    try:
+        snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
+        return True
+    if snapshot is None or snapshot.updated_at is None:
+        return False
+    updated_at = snapshot.updated_at
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - updated_at).total_seconds()
+    return age <= WORKER_HEARTBEAT_STALE_AFTER_SEC
+
+
 async def _build_collector_health_context(request: Request) -> dict[str, object]:
     db = deps.get_db(request)
     pool = deps.get_pool(request)
@@ -94,6 +127,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     active_accounts = [acc for acc in accounts if acc.is_active]
     connected_active_accounts = [acc for acc in active_accounts if acc.phone in connected_phones]
     now = datetime.now(timezone.utc)
+    worker_alive = await _is_worker_alive(db)
 
     flooded_accounts = []
     next_available_at = None
@@ -138,7 +172,11 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     ][:5]
 
     state = "healthy"
-    if not connected_active_accounts:
+    if not worker_alive:
+        # Worker-process absent dominates: without it `no_clients` /
+        # `all_flooded` are symptoms, not the root cause.
+        state = "worker_down"
+    elif not connected_active_accounts:
         state = "no_clients"
     elif availability_state == "all_flooded" or available_accounts_now == 0:
         state = "all_flooded"
@@ -181,20 +219,22 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
 @router.post("/tasks/{task_id}/cancel")
 async def cancel_task(request: Request, task_id: int):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-    queue = deps.get_queue(request)
-    await queue.cancel_task(task_id)
-    return RedirectResponse(url="/scheduler?msg=task_cancelled", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
+    # Go through CollectionService so web-mode (where collection_queue is None)
+    # falls back to a DB-only cancellation instead of raising AttributeError.
+    service = deps.collection_service(request)
+    await service.cancel_task(task_id)
+    return _scheduler_redirect(request, msg="task_cancelled")
 
 
 @router.post("/tasks/clear-pending-collect")
 async def clear_pending_collect_tasks(request: Request):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
-    queue = deps.get_queue(request)
-    deleted = await queue.clear_pending_tasks()
+        return _scheduler_redirect(request, error="shutting_down")
+    service = deps.collection_service(request)
+    deleted = await service.clear_pending_collect_tasks()
     msg = "pending_collect_tasks_deleted" if deleted > 0 else "pending_collect_tasks_empty"
-    return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
+    return _scheduler_redirect(request, msg=msg)
 
 
 VALID_STATUS_FILTERS = {"all", "active", "completed"}
@@ -256,6 +296,44 @@ async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
     return payload if isinstance(payload, dict) else {}
 
 
+_PRESERVED_SCHEDULER_QUERY_KEYS = ("status", "page", "limit")
+
+
+def _scheduler_redirect(
+    request: Request,
+    *,
+    msg: str | None = None,
+    error: str | None = None,
+    extra: dict[str, object] | None = None,
+) -> RedirectResponse:
+    """Redirect to /scheduler preserving the user's current filter/page.
+
+    Fix for #457 round 3: POST routes used to redirect to `/scheduler?msg=...`
+    and drop `?status=active&page=N&limit=M` — the user ended up back on the
+    default `status=all` view, which on a large DB could look like "the button
+    replaced the page with 143 pages of noise". Now every POST keeps the tab
+    the user was looking at when they clicked.
+
+    Only the whitelisted `status/page/limit` params travel — we deliberately
+    drop any inbound `msg=`, `error=`, `command_id=` so they don't stack.
+    """
+    qp: dict[str, str] = {}
+    for key in _PRESERVED_SCHEDULER_QUERY_KEYS:
+        value = request.query_params.get(key)
+        if value is not None and value != "":
+            qp[key] = value
+    if msg is not None:
+        qp["msg"] = msg
+    if error is not None:
+        qp["error"] = error
+    if extra:
+        for k, v in extra.items():
+            if v is not None:
+                qp[k] = str(v)
+    suffix = f"?{urlencode(qp)}" if qp else ""
+    return RedirectResponse(url=f"/scheduler{suffix}", status_code=303)
+
+
 async def _enqueue_scheduler_command(
     request: Request,
     command_type: str,
@@ -268,9 +346,8 @@ async def _enqueue_scheduler_command(
         payload=payload or {},
         requested_by=f"web:scheduler.{command_type}",
     )
-    return RedirectResponse(
-        url=f"/scheduler?msg={redirect_code}&command_id={command_id}",
-        status_code=303,
+    return _scheduler_redirect(
+        request, msg=redirect_code, extra={"command_id": command_id}
     )
 
 
@@ -366,9 +443,9 @@ async def _scheduler_page_inner(
 @router.post("/jobs/{job_id}/toggle")
 async def toggle_scheduler_job(request: Request, job_id: str):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     if not _VALID_JOB_ID_RE.match(job_id):
-        return RedirectResponse(url="/scheduler?error=invalid_job", status_code=303)
+        return _scheduler_redirect(request, error="invalid_job")
     db = deps.get_db(request)
     key = f"scheduler_job_disabled:{job_id}"
     current = await db.repos.settings.get_setting(key)
@@ -384,17 +461,17 @@ async def toggle_scheduler_job(request: Request, job_id: str):
 @router.post("/jobs/{job_id}/set-interval")
 async def set_job_interval(request: Request, job_id: str):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     if not _VALID_JOB_ID_RE.match(job_id):
-        return RedirectResponse(url="/scheduler?error=invalid_job", status_code=303)
+        return _scheduler_redirect(request, error="invalid_job")
     if job_id in ("photo_due", "photo_auto"):
-        return RedirectResponse(url="/scheduler?error=invalid_job", status_code=303)
+        return _scheduler_redirect(request, error="invalid_job")
     form = await request.form()
     try:
         minutes = int(form["interval_minutes"])
         minutes = max(1, min(minutes, 1440))
     except (KeyError, ValueError):
-        return RedirectResponse(url="/scheduler?error=invalid_interval", status_code=303)
+        return _scheduler_redirect(request, error="invalid_interval")
     db = deps.get_db(request)
     if job_id == "collect_all":
         await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
@@ -421,7 +498,7 @@ async def set_job_interval(request: Request, job_id: str):
 @router.post("/start")
 async def start_scheduler(request: Request):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     await deps.get_db(request).set_setting("scheduler_autostart", "1")
     return await _enqueue_scheduler_command(
         request,
@@ -443,17 +520,17 @@ async def stop_scheduler(request: Request):
 @router.post("/trigger")
 async def trigger_collection(request: Request):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     service = deps.collection_service(request)
     result = await service.enqueue_all_channels()
     msg = bulk_enqueue_msg(result)
-    return RedirectResponse(url=f"/scheduler?msg={msg}", status_code=303)
+    return _scheduler_redirect(request, msg=msg)
 
 
 @router.post("/trigger-warm")
 async def trigger_warm_dialogs(request: Request):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     return await _enqueue_scheduler_command(
         request,
         "scheduler.trigger_warm",
@@ -464,7 +541,7 @@ async def trigger_warm_dialogs(request: Request):
 @router.post("/test-notification")
 async def test_notification(request: Request):
     if getattr(request.app.state, "shutting_down", False):
-        return RedirectResponse(url="/scheduler?error=shutting_down", status_code=303)
+        return _scheduler_redirect(request, error="shutting_down")
     return await _enqueue_scheduler_command(
         request,
         "notifications.test",

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -75,8 +75,9 @@ def _collector_health_recommendations(
     recommendations: list[str] = []
     if state == "worker_down":
         recommendations.append(
-            "Запустите Telegram-воркер во втором терминале: `python -m src.main worker`. "
-            "Без него задачи сбора и планировщика копятся в БД, но не исполняются."
+            "Telegram-воркер не запущен. Если используете `serve` — перезапустите его; "
+            "если `serve --no-worker` — запустите воркер отдельно: `python -m src.main worker`. "
+            "Без воркера задачи сбора копятся в БД, но не исполняются."
         )
     if state == "all_flooded":
         recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -15,6 +15,19 @@
     {% endif %}
 {% endmacro %}
 
+{#
+  Preserve user's filter/page/limit on every POST — the route handlers read
+  these via request.query_params and echo them in the redirect Location.
+  Fix for #457 round 3: clicking "Запустить" used to reset the page to the
+  default `status=all` (all 7000+ tasks, 143 pages) even if the user was on
+  `status=active`.
+#}
+{% set _q_parts = [] %}
+{% if status_filter and status_filter != 'all' %}{% set _ = _q_parts.append('status=' ~ status_filter) %}{% endif %}
+{% if page and page != 1 %}{% set _ = _q_parts.append('page=' ~ page) %}{% endif %}
+{% if limit and limit != 50 %}{% set _ = _q_parts.append('limit=' ~ limit) %}{% endif %}
+{% set filter_qs = ('?' ~ _q_parts|join('&')) if _q_parts else '' %}
+
 <div class="card mb-4">
     <div class="card-header fw-semibold">
         Планировщик
@@ -26,25 +39,25 @@
 
         <div class="d-flex flex-wrap gap-2">
             {% if not is_running %}
-            <form method="post" action="/scheduler/start" data-busy>
+            <form method="post" action="/scheduler/start{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-primary">{{ icon("run") }} Запустить</button>
             </form>
             {% else %}
-            <form method="post" action="/scheduler/stop" data-busy>
+            <form method="post" action="/scheduler/stop{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-secondary">&#9724; Остановить</button>
             </form>
             {% endif %}
-            <form method="post" action="/scheduler/trigger" data-busy>
+            <form method="post" action="/scheduler/trigger{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-outline-primary">{{ icon("run") }} Собрать все каналы</button>
             </form>
             {% if pending_collect_count > 0 %}
-            <form method="post" action="/scheduler/tasks/clear-pending-collect" data-busy>
+            <form method="post" action="/scheduler/tasks/clear-pending-collect{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-outline-danger">
                     Очистить очередь загрузки ({{ pending_collect_count }})
                 </button>
             </form>
             {% endif %}
-            <form method="post" action="/scheduler/test-notification" data-busy>
+            <form method="post" action="/scheduler/test-notification{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-outline-secondary"
                         {% if not bot_configured %}disabled title="Подключите бот в Настройках → Уведомления"{% endif %}>
                     Тест
@@ -60,10 +73,12 @@
 </div>
 
 {% if collector_health.state != 'healthy' or collector_health.load_level != 'ok' %}
-<div class="card mb-4 border-{% if collector_health.state in ['all_flooded', 'no_clients'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
+<div class="card mb-4 border-{% if collector_health.state in ['worker_down', 'all_flooded', 'no_clients'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
     <div class="card-header fw-semibold">
         Здоровье коллектора
-        {% if collector_health.state == 'all_flooded' %}
+        {% if collector_health.state == 'worker_down' %}
+        <span class="badge text-bg-danger ms-2">Telegram-воркер не запущен</span>
+        {% elif collector_health.state == 'all_flooded' %}
         <span class="badge text-bg-danger ms-2">Все аккаунты во Flood Wait</span>
         {% elif collector_health.state == 'no_clients' %}
         <span class="badge text-bg-danger ms-2">Нет доступных клиентов</span>
@@ -101,6 +116,12 @@
                 <div class="small">{% if collector_health.is_running %}Коллектор занят{% else %}Коллектор ждёт{% endif %}</div>
             </div>
         </div>
+
+        {% if collector_health.state == 'worker_down' %}
+        <p class="mb-2"><strong>Почему сейчас не собираем:</strong> веб-процесс принимает задачи и пишет их в БД, но Telegram-коннекты держит отдельный воркер-процесс — он сейчас не запущен (нет свежего heartbeat в <code>runtime_snapshots</code>). Задачи из <code>collection_tasks</code> копятся в статусе <em>pending</em>, но никто их не исполняет.</p>
+        <p class="mb-2"><strong>Как починить:</strong> запустите воркер во втором терминале — он подхватит все накопившиеся задачи автоматически:</p>
+        <pre class="mb-2"><code>python -m src.main worker</code></pre>
+        {% endif %}
 
         {% if collector_health.flooded_accounts %}
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> доступных аккаунтов нет или их недостаточно. Flood Wait активен для:
@@ -156,7 +177,7 @@
                 {% for j in scheduler_jobs %}
                 <tr>
                     <td>
-                        <form method="post" action="/scheduler/jobs/{{ j.job_id }}/toggle" class="mb-0">
+                        <form method="post" action="/scheduler/jobs/{{ j.job_id }}/toggle{{ filter_qs }}" class="mb-0">
                             <input type="checkbox" onchange="this.form.submit()"
                                    {% if j.enabled %}checked{% endif %}
                                    title="{{ 'Отключить' if j.enabled else 'Включить' }}">
@@ -165,7 +186,7 @@
                     <td class="{% if not j.enabled %}text-muted{% endif %}">{{ j.label }}</td>
                     <td>
                         {% if j.interval_editable and j.interval_minutes is not none %}
-                            <form method="post" action="/scheduler/jobs/{{ j.job_id }}/set-interval"
+                            <form method="post" action="/scheduler/jobs/{{ j.job_id }}/set-interval{{ filter_qs }}"
                                   class="d-flex gap-1 mb-0">
                                 <input type="number" name="interval_minutes" value="{{ j.interval_minutes }}"
                                        min="1" max="1440" class="form-control form-control-sm" style="width:75px">
@@ -308,11 +329,11 @@
                     <td>{{ t.completed_at|local_dt }}</td>
                     <td>
                         {% if t.status == 'running' %}
-                            <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel" class="mb-0" data-busy>
+                            <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel{{ filter_qs }}" class="mb-0" data-busy>
                                 <button type="submit" class="btn btn-outline-secondary btn-sm">Отменить</button>
                             </form>
                         {% elif t.status == 'pending' %}
-                            <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel" class="mb-0" data-busy>
+                            <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel{{ filter_qs }}" class="mb-0" data-busy>
                                 <button type="submit" class="btn btn-outline-secondary btn-sm">Удалить</button>
                             </form>
                         {% endif %}
@@ -347,7 +368,7 @@
                     </small>
                     {% if t.status == 'running' or t.status == 'pending' %}
                     <div class="mt-1">
-                        <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel" class="mb-0" data-busy>
+                        <form method="post" action="/scheduler/tasks/{{ t.id }}/cancel{{ filter_qs }}" class="mb-0" data-busy>
                             <button type="submit" class="btn btn-outline-secondary btn-sm">{{ 'Отменить' if t.status == 'running' else 'Удалить' }}</button>
                         </form>
                     </div>

--- a/tests/e2e/test_collection_flow.py
+++ b/tests/e2e/test_collection_flow.py
@@ -107,11 +107,11 @@ async def _serve_app(tmp_path, *, embed_worker: bool):
 
 async def _wait_for_messages(db_path: str, channel_id: int, n: int, timeout: float = 15.0) -> int:
     """Poll the DB until at least `n` messages for `channel_id` are present."""
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     db = Database(db_path)
     await db.initialize()
     try:
-        while asyncio.get_event_loop().time() < deadline:
+        while asyncio.get_running_loop().time() < deadline:
             rows = await db.execute_fetchall(
                 "SELECT COUNT(*) AS c FROM messages WHERE channel_id = ?",
                 (channel_id,),
@@ -203,9 +203,9 @@ async def test_embedded_worker_publishes_heartbeat(tmp_path):
             db = Database(config.database.path)
             await db.initialize()
             try:
-                deadline = asyncio.get_event_loop().time() + 10.0
+                deadline = asyncio.get_running_loop().time() + 10.0
                 snapshot = None
-                while asyncio.get_event_loop().time() < deadline:
+                while asyncio.get_running_loop().time() < deadline:
                     snapshot = await db.repos.runtime_snapshots.get_snapshot(
                         "worker_heartbeat"
                     )

--- a/tests/e2e/test_collection_flow.py
+++ b/tests/e2e/test_collection_flow.py
@@ -1,0 +1,218 @@
+"""End-to-end test of the collection flow (the main feature of this project).
+
+Context (#457 round 4): previous rounds only checked HTTP status codes via
+curl and asserted that a redirect happened. They did NOT check that clicking
+"Собрать все каналы" actually causes messages to be written to the DB. That
+gap is why the same "I pressed the button, nothing collected" bug kept
+coming back: the user's report was about the FULL pipeline, but my tests
+only covered the very first step (web enqueues a DB row) and the very last
+step (redirect URL).
+
+This test closes the gap. It runs `serve` as an ASGI app with the embedded
+worker enabled (the new default), stubs `Collector.collect_single_channel`
+to persist a couple of fake messages directly into `messages`, POSTs
+`/scheduler/trigger`, then waits for the DB to see those rows. If any link
+in the chain breaks — web doesn't enqueue, worker doesn't pick up, collector
+isn't called — the test fails.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.config import AppConfig, DatabaseConfig
+from src.database import Database
+from src.models import Account, Channel, CollectionTaskStatus, Message
+from src.web.app import create_app
+
+_PASS = "testpass"
+
+
+async def _fake_collect_single_channel(
+    self, channel: Channel, *, full: bool = False, progress_callback=None, force: bool = False,
+) -> int:
+    """Stand-in for `Collector.collect_single_channel` used by e2e tests.
+
+    Writes two deterministic messages into the `messages` table as if they
+    were fetched from Telegram. Advances `last_collected_id` so subsequent
+    incremental collections behave like the real thing.
+    """
+    base_id = (channel.last_collected_id or 0) + 1
+    messages_to_write = [
+        Message(
+            channel_id=channel.channel_id,
+            message_id=base_id,
+            text=f"fake message {base_id} for channel {channel.channel_id}",
+            date=datetime.now(timezone.utc),
+        ),
+        Message(
+            channel_id=channel.channel_id,
+            message_id=base_id + 1,
+            text=f"fake message {base_id + 1} for channel {channel.channel_id}",
+            date=datetime.now(timezone.utc),
+        ),
+    ]
+    await self._db.repos.messages.insert_messages_batch(messages_to_write)
+    await self._db.repos.channels.update_channel_last_id(channel.channel_id, base_id + 1)
+    return len(messages_to_write)
+
+
+@asynccontextmanager
+async def _serve_app(tmp_path, *, embed_worker: bool):
+    """Boot the real `serve` app lifespan (web container + optional embedded worker).
+
+    Note: `ASGITransport` does NOT drive ASGI lifespan events by itself (httpx
+    removed that in 0.27+). We drive them manually via `app.router.lifespan_context`
+    so `configure_app(...)` runs and `app.state.db` / container are populated,
+    just like when uvicorn boots the real process.
+    """
+    config = AppConfig(database=DatabaseConfig(path=str(tmp_path / "e2e.db")))
+    config.web.password = _PASS
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+
+    # Seed one active channel so trigger_collection finds something to enqueue.
+    # We also pre-create an account row so the worker's ClientPool.initialize()
+    # skips fast (it sees no usable session and doesn't try to connect).
+    seed_db = Database(str(tmp_path / "e2e.db"))
+    await seed_db.initialize()
+    try:
+        await seed_db.add_account(Account(phone="+7999", session_string=""))
+        await seed_db.add_channel(
+            Channel(channel_id=-1001, title="E2E Channel", is_active=True)
+        )
+    finally:
+        await seed_db.close()
+
+    app = create_app(config)
+    app.state.embed_worker = embed_worker
+    transport = ASGITransport(app=app)
+    auth = base64.b64encode(f":{_PASS}".encode()).decode()
+
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            follow_redirects=False,
+            headers={"Authorization": f"Basic {auth}", "Origin": "http://test"},
+        ) as client:
+            yield client, config
+
+
+async def _wait_for_messages(db_path: str, channel_id: int, n: int, timeout: float = 15.0) -> int:
+    """Poll the DB until at least `n` messages for `channel_id` are present."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    db = Database(db_path)
+    await db.initialize()
+    try:
+        while asyncio.get_event_loop().time() < deadline:
+            rows = await db.execute_fetchall(
+                "SELECT COUNT(*) AS c FROM messages WHERE channel_id = ?",
+                (channel_id,),
+            )
+            count = rows[0][0] if rows else 0
+            if count >= n:
+                return count
+            await asyncio.sleep(0.25)
+        return count
+    finally:
+        await db.close()
+
+
+async def _task_status(db_path: str, channel_id: int) -> str | None:
+    db = Database(db_path)
+    await db.initialize()
+    try:
+        rows = await db.execute_fetchall(
+            "SELECT status FROM collection_tasks WHERE channel_id = ? ORDER BY id DESC LIMIT 1",
+            (channel_id,),
+        )
+        return rows[0][0] if rows else None
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_trigger_collection_persists_messages_via_embedded_worker(tmp_path):
+    """`serve` with the embedded worker must complete the full collect tract.
+
+    Click `Собрать все каналы` → task enqueued in DB → embedded worker picks
+    it up → Collector.collect_single_channel (stubbed) writes messages → DB
+    sees them → task status becomes COMPLETED. If any link breaks, the test
+    hangs on the message-count assertion rather than passing silently.
+    """
+    with patch(
+        "src.telegram.collector.Collector.collect_single_channel",
+        new=_fake_collect_single_channel,
+    ):
+        async with _serve_app(tmp_path, embed_worker=True) as (client, config):
+            resp = await client.post("/scheduler/trigger")
+            assert resp.status_code == 303
+            assert "collect_all_queued" in resp.headers.get("location", "")
+
+            count = await _wait_for_messages(config.database.path, -1001, 2, timeout=15.0)
+            assert count >= 2, f"expected >=2 messages for channel -1001, got {count}"
+
+            status = await _task_status(config.database.path, -1001)
+            assert status == CollectionTaskStatus.COMPLETED.value
+
+
+@pytest.mark.asyncio
+async def test_trigger_collection_stuck_without_worker(tmp_path):
+    """Regression guard: if `serve` is started with `--no-worker`, the same
+    click leaves the task in PENDING. This proves the happy-path test above
+    isn't passing by coincidence (e.g. DB writes happening on the web side).
+    """
+    with patch(
+        "src.telegram.collector.Collector.collect_single_channel",
+        new=_fake_collect_single_channel,
+    ):
+        async with _serve_app(tmp_path, embed_worker=False) as (client, config):
+            resp = await client.post("/scheduler/trigger")
+            assert resp.status_code == 303
+
+            # Poll briefly; nothing should happen.
+            await asyncio.sleep(2.0)
+            count = await _wait_for_messages(config.database.path, -1001, 1, timeout=1.0)
+            assert count == 0, (
+                f"without the embedded worker, no messages should be collected, got {count}"
+            )
+            status = await _task_status(config.database.path, -1001)
+            assert status == CollectionTaskStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_embedded_worker_publishes_heartbeat(tmp_path):
+    """Sanity: the embedded worker writes a fresh `worker_heartbeat` snapshot.
+
+    Without this, round 1's UI banner can't detect a live worker and would
+    always flip to `worker_down`.
+    """
+    with patch(
+        "src.telegram.collector.Collector.collect_single_channel",
+        new=_fake_collect_single_channel,
+    ):
+        async with _serve_app(tmp_path, embed_worker=True) as (_, config):
+            # Wait for the first heartbeat — the worker publishes every ~5s.
+            db = Database(config.database.path)
+            await db.initialize()
+            try:
+                deadline = asyncio.get_event_loop().time() + 10.0
+                snapshot = None
+                while asyncio.get_event_loop().time() < deadline:
+                    snapshot = await db.repos.runtime_snapshots.get_snapshot(
+                        "worker_heartbeat"
+                    )
+                    if snapshot is not None and snapshot.updated_at is not None:
+                        break
+                    await asyncio.sleep(0.25)
+                assert snapshot is not None, "embedded worker didn't publish a heartbeat"
+                assert snapshot.payload.get("status") == "alive"
+            finally:
+                await db.close()

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,9 +11,9 @@ from httpx import ASGITransport, AsyncClient
 
 from src.agent.manager import AgentManager
 from src.collection_queue import CollectionQueue
-from src.config import AppConfig
+from src.config import AppConfig, DatabaseConfig
 from src.database import Database
-from src.models import Account, Channel
+from src.models import Account, Channel, RuntimeSnapshot
 from src.scheduler.service import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -20,6 +21,8 @@ from src.services.provider_service import AgentProviderService
 from src.telegram.auth import TelegramAuth
 from src.telegram.collector import Collector
 from src.web.app import create_app
+from src.web.bootstrap import build_container_with_templates
+from src.web.log_handler import LogBuffer
 
 
 @pytest.fixture
@@ -72,6 +75,22 @@ async def base_app(tmp_path):
 
     await db.add_account(Account(phone="+1234567890", session_string="test_session"))
     await db.add_channel(Channel(channel_id=100, title="Test Channel"))
+
+    # Route tests reuse the web process model (`runtime_mode="web"` in real
+    # setups), but they instantiate a live ClientPool-like mock instead of the
+    # Snapshot shim. The `/scheduler/` health path now treats a missing
+    # `worker_heartbeat` snapshot as `state=worker_down` (fix for #457), which
+    # would regress every pre-existing scheduler test. Stamp a fresh heartbeat
+    # so tests keep exercising the same pre-#457 states (healthy / no_clients /
+    # all_flooded / degraded). Individual tests that want to exercise the new
+    # `worker_down` branch should delete this snapshot.
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
 
     yield app, db, pool_mock
 
@@ -133,6 +152,98 @@ def agent_manager_mock():
     m.chat_stream = _fake_stream
 
     return m
+
+
+# === Web-mode fixture (#457 round 3) =================================
+#
+# Why: `base_app` above is convenience — it wires a live `CollectionQueue`
+# + real `SchedulerManager`, which *looks* like the worker runtime. That
+# masked the #457 regressions (500 on /scheduler/tasks/clear-pending-collect,
+# 500 in pipelines /run, silent-no-op /scheduler/start) because route tests
+# never saw the production web-mode wiring — where `collection_queue=None`,
+# `task_enqueuer=None`, `unified_dispatcher=None`, and `pool`/`collector`/
+# `scheduler` are `SnapshotClientPool` / `SnapshotCollector` /
+# `SnapshotSchedulerManager` shims.
+#
+# This fixture goes through the real `build_container_with_templates`
+# bootstrap with `runtime_mode="web"` — the exact same wiring that
+# `python -m src.main serve` uses in production. Tests that want to exercise
+# the web-mode code path should take this fixture instead of `base_app`.
+
+_WEB_MODE_PASSWORD = "testpass"
+
+
+@pytest.fixture
+async def web_mode_app(tmp_path):
+    """Production-like web-mode app — the same bootstrap path as `serve`."""
+    config = AppConfig(database=DatabaseConfig(path=str(tmp_path / "web_mode.db")))
+    config.web.password = _WEB_MODE_PASSWORD
+    config.telegram.api_id = 12345
+    config.telegram.api_hash = "test_hash"
+
+    container = await build_container_with_templates(
+        config,
+        log_buffer=LogBuffer(),
+        templates=None,
+        runtime_mode="web",
+    )
+
+    # Seed one account + one channel so scheduler/channels pages render cleanly.
+    await container.db.add_account(
+        Account(phone="+1234567890", session_string="test_session")
+    )
+    await container.db.add_channel(Channel(channel_id=-1001, title="Web Mode Test Channel"))
+
+    # Stamp a fresh worker_heartbeat so /scheduler/ doesn't auto-flip to the
+    # `worker_down` banner unless a test removes it explicitly.
+    await container.db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+
+    app = create_app(config)
+    # Copy every relevant attribute from the real container — this is the exact
+    # surface `src/web/app.py:lifespan` sets up when `serve` boots.
+    for attr in (
+        "db", "config", "pool", "collector", "scheduler", "auth", "notifier",
+        "collection_queue", "unified_dispatcher", "telegram_command_dispatcher",
+        "task_enqueuer", "agent_manager", "search_engine", "ai_search",
+        "llm_provider_service", "runtime_mode",
+    ):
+        setattr(app.state, attr, getattr(container, attr, None))
+    app.state.session_secret = "test_secret_key"
+    app.state.shutting_down = False
+
+    try:
+        yield app, container
+    finally:
+        await container.db.close()
+
+
+@pytest.fixture
+async def web_mode_client(web_mode_app):
+    """HTTP client against a production-like web-mode app.
+
+    `follow_redirects=False` is intentional — round 3 tests assert on the
+    Location header (e.g. filter-preserve redirects), which would be lost
+    by the default follow-redirects behaviour.
+    """
+    app, _ = web_mode_app
+    transport = ASGITransport(app=app)
+    auth_header = base64.b64encode(f":{_WEB_MODE_PASSWORD}".encode()).decode()
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=False,
+        headers={
+            "Authorization": f"Basic {auth_header}",
+            "Origin": "http://test",
+        },
+    ) as c:
+        yield c
 
 
 # === Helper functions ===

--- a/tests/routes/test_scheduler_routes_extra.py
+++ b/tests/routes/test_scheduler_routes_extra.py
@@ -39,151 +39,10 @@ async def client(base_app):
         yield c
 
 
-# ── _format_retry_hint: line 38 ────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_format_retry_hint_with_value():
-    """Test _format_retry_hint with a datetime value (line 38)."""
-    from src.web.routes.scheduler import _format_retry_hint
-
-    dt = datetime(2025, 6, 15, 12, 30, 0, tzinfo=timezone.utc)
-    result = _format_retry_hint(dt)
-    assert "2025-06-15" in result
-    assert "12:30:00" in result
-
-
-@pytest.mark.asyncio
-async def test_format_retry_hint_none():
-    """Test _format_retry_hint with None (line 37)."""
-    from src.web.routes.scheduler import _format_retry_hint
-
-    result = _format_retry_hint(None)
-    assert result == ""
-
-
-# ── _compute_load_level: lines 53, 55, 57 ──────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_compute_load_level_overload_short_interval():
-    """Test load level overload with short interval and high pressure (line 53)."""
-    from src.web.routes.scheduler import _compute_load_level
-
-    result = _compute_load_level(
-        interval_minutes=15,
-        active_unfiltered_channels=120,
-        available_accounts_now=2,
-        state="healthy",
-    )
-    assert result == "overload"
-
-
-@pytest.mark.asyncio
-async def test_compute_load_level_high_medium_interval():
-    """Test load level high with medium interval and moderate pressure (line 55)."""
-    from src.web.routes.scheduler import _compute_load_level
-
-    result = _compute_load_level(
-        interval_minutes=30,
-        active_unfiltered_channels=80,
-        available_accounts_now=2,
-        state="healthy",
-    )
-    assert result == "high"
-
-
-@pytest.mark.asyncio
-async def test_compute_load_level_high_very_high_pressure():
-    """Test load level high with very high pressure regardless of interval (line 57)."""
-    from src.web.routes.scheduler import _compute_load_level
-
-    result = _compute_load_level(
-        interval_minutes=60,
-        active_unfiltered_channels=150,
-        available_accounts_now=2,
-        state="healthy",
-    )
-    assert result == "high"
-
-
-@pytest.mark.asyncio
-async def test_compute_load_level_ok():
-    """Test load level ok with normal parameters."""
-    from src.web.routes.scheduler import _compute_load_level
-
-    result = _compute_load_level(
-        interval_minutes=60,
-        active_unfiltered_channels=10,
-        available_accounts_now=2,
-        state="healthy",
-    )
-    assert result == "ok"
-
-
-@pytest.mark.asyncio
-async def test_compute_load_level_overload_all_flooded():
-    """Test load level overload when all flooded (line 48)."""
-    from src.web.routes.scheduler import _compute_load_level
-
-    result = _compute_load_level(
-        interval_minutes=60,
-        active_unfiltered_channels=10,
-        available_accounts_now=2,
-        state="all_flooded",
-    )
-    assert result == "overload"
-
-
-# ── _collector_health_recommendations: line 71 ─────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_collector_health_recommendations_no_clients():
-    """Test recommendations for no_clients state (line 73)."""
-    from src.web.routes.scheduler import _collector_health_recommendations
-
-    recs = _collector_health_recommendations(
-        state="no_clients",
-        load_level="ok",
-        interval_minutes=60,
-        active_unfiltered_channels=10,
-        available_accounts_now=0,
-    )
-    assert any("переподключить" in r.lower() for r in recs)
-
-
-@pytest.mark.asyncio
-async def test_collector_health_recommendations_single_account():
-    """Test recommendations for single account (line 83)."""
-    from src.web.routes.scheduler import _collector_health_recommendations
-
-    recs = _collector_health_recommendations(
-        state="healthy",
-        load_level="ok",
-        interval_minutes=60,
-        active_unfiltered_channels=10,
-        available_accounts_now=1,
-    )
-    assert any("Добавить ещё Telegram-аккаунт" in r for r in recs)
-
-
-@pytest.mark.asyncio
-async def test_collector_health_recommendations_high_load():
-    """Test recommendations for high load (lines 78-81)."""
-    from src.web.routes.scheduler import _collector_health_recommendations
-
-    recs = _collector_health_recommendations(
-        state="healthy",
-        load_level="high",
-        interval_minutes=30,
-        active_unfiltered_channels=100,
-        available_accounts_now=2,
-    )
-    assert len(recs) >= 2
-    assert any("интервал" in r.lower() for r in recs)
-    assert any("Сократить" in r for r in recs)
-
+# NOTE: pure-function tests for _format_retry_hint / _compute_load_level /
+# _collector_health_recommendations / _job_label live in
+# tests/test_web_scheduler_helpers.py (introduced in #456). Route-level tests
+# that actually exercise HTTP behaviour stay here.
 
 # ── cancel_task: line 179 (shutting_down) ──────────────────────────────
 
@@ -597,43 +456,7 @@ async def test_scheduler_health_with_naive_flood_wait(client, base_app):
     assert resp.status_code == 200
 
 
-# ── _job_label: various job IDs ────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_job_label_search_query():
-    """Test _job_label for search query job."""
-    from src.web.routes.scheduler import _job_label
-
-    result = _job_label("sq_42")
-    assert "42" in result
-
-
-@pytest.mark.asyncio
-async def test_job_label_pipeline_run():
-    """Test _job_label for pipeline run job."""
-    from src.web.routes.scheduler import _job_label
-
-    result = _job_label("pipeline_run_7")
-    assert "7" in result
-
-
-@pytest.mark.asyncio
-async def test_job_label_content_generate():
-    """Test _job_label for content generate job."""
-    from src.web.routes.scheduler import _job_label
-
-    result = _job_label("content_generate_3")
-    assert "3" in result
-
-
-@pytest.mark.asyncio
-async def test_job_label_unknown():
-    """Test _job_label for unknown job."""
-    from src.web.routes.scheduler import _job_label
-
-    result = _job_label("custom_job")
-    assert result == "custom_job"
+# NOTE: _job_label() has full unit coverage in tests/test_web_scheduler_helpers.py (#456).
 
 
 # ── _build_jobs_context: lines 202-244 ─────────────────────────────────
@@ -687,3 +510,366 @@ async def test_trigger_collection_uses_bulk_enqueue_msg(client, base_app):
         resp = await client.post("/scheduler/trigger", follow_redirects=False)
         assert resp.status_code == 303
         mock_msg.assert_called_once_with(result)
+
+
+# ── _is_worker_alive / state=worker_down (fix for #457) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_is_worker_alive_fresh_heartbeat(base_app):
+    """Fresh heartbeat → worker is alive."""
+    from src.web.routes.scheduler import _is_worker_alive
+
+    _, db, _ = base_app
+    # Default base_app fixture already stamps a fresh heartbeat.
+    assert await _is_worker_alive(db) is True
+
+
+@pytest.mark.asyncio
+async def test_is_worker_alive_missing_heartbeat(tmp_path):
+    """No heartbeat snapshot → worker is considered down.
+
+    Uses a clean DB (not `base_app`) so no default heartbeat is stamped.
+    """
+    from src.database import Database
+    from src.web.routes.scheduler import _is_worker_alive
+
+    db = Database(str(tmp_path / "worker_down.db"))
+    await db.initialize()
+    try:
+        assert await _is_worker_alive(db) is False
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_is_worker_alive_stale_heartbeat(base_app):
+    """Heartbeat older than threshold → worker is considered down."""
+    from src.models import RuntimeSnapshot
+    from src.web.routes.scheduler import _is_worker_alive
+
+    _, db, _ = base_app
+    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=stale,
+        )
+    )
+    assert await _is_worker_alive(db) is False
+
+
+@pytest.mark.asyncio
+async def test_is_worker_alive_naive_datetime(base_app):
+    """Heartbeat with a naive datetime must still be comparable (UTC assumed)."""
+    from src.models import RuntimeSnapshot
+    from src.web.routes.scheduler import _is_worker_alive
+
+    _, db, _ = base_app
+    # Stamp a recent naive datetime — the helper must treat it as UTC.
+    now_naive = datetime.now(timezone.utc).replace(tzinfo=None)
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=now_naive,
+        )
+    )
+    assert await _is_worker_alive(db) is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_page_renders_worker_down_banner(client, base_app):
+    """/scheduler/ surfaces the `worker_down` banner when the heartbeat is stale.
+
+    Regression guard for #457: before the fix, web mode silently dropped all
+    collection tasks into a PENDING pile without any UI signal that no worker
+    was executing them.
+    """
+    from src.models import RuntimeSnapshot
+
+    _, db, _ = base_app
+    # Override the fresh heartbeat stamped by base_app with a stale one.
+    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=stale,
+        )
+    )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Telegram-воркер не запущен" in body
+    assert "python -m src.main worker" in body
+
+
+@pytest.mark.asyncio
+async def test_scheduler_page_no_worker_banner_when_heartbeat_fresh(client, base_app):
+    """Fresh heartbeat must NOT render the worker_down banner."""
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    assert "Telegram-воркер не запущен" not in resp.text
+
+
+# ── web_mode fixture sanity (#457 round 3) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_web_mode_app_has_snapshot_shims(web_mode_app):
+    """Sanity check — the new fixture must really produce the web-mode wiring."""
+    from src.web.runtime_shims import (
+        SnapshotClientPool,
+        SnapshotCollector,
+        SnapshotSchedulerManager,
+    )
+    app, container = web_mode_app
+    assert app.state.runtime_mode == "web"
+    assert app.state.collection_queue is None
+    assert app.state.unified_dispatcher is None
+    # Note: task_enqueuer is NOT None in web-mode (it only writes rows to
+    # collection_tasks; no asyncio.Queue involved). So pipelines /run etc.
+    # stay as silent no-ops rather than 500s — that's expected behaviour.
+    assert app.state.task_enqueuer is not None
+    assert isinstance(app.state.pool, SnapshotClientPool)
+    assert isinstance(app.state.collector, SnapshotCollector)
+    assert isinstance(app.state.scheduler, SnapshotSchedulerManager)
+    # Production-parity: the real container agrees.
+    assert isinstance(container.pool, SnapshotClientPool)
+
+
+@pytest.mark.asyncio
+async def test_web_mode_scheduler_page_renders(web_mode_client):
+    """/scheduler/ must render a 200 OK under the real web-mode wiring, no 500."""
+    resp = await web_mode_client.get("/scheduler/", follow_redirects=True)
+    assert resp.status_code == 200
+
+
+# ── web-mode fallback: collection_queue=None must not 500 (fix for #457 round 2) ─
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_collect_web_mode_falls_back_to_db(client, base_app):
+    """POST /scheduler/tasks/clear-pending-collect must NOT 500 in web-mode.
+
+    Regression guard for the second half of #457: before the fix,
+    `deps.get_queue()` returned None and the route crashed with
+    `AttributeError: 'NoneType' object has no attribute 'clear_pending_tasks'`.
+    """
+    from src.models import Channel
+
+    app, db, _ = base_app
+    # Drop the live CollectionQueue so the route sees the same state as `serve`
+    # running without a worker.
+    app.state.collection_queue = None
+
+    # Seed a pending task so the DELETE has something to count.
+    channel_pk = await db.add_channel(Channel(channel_id=555, title="Pending Clear"))
+    task_id = await db.repos.tasks.create_collection_task_if_not_active(
+        channel_id=555,
+        channel_title="Pending Clear",
+    )
+    assert task_id is not None
+    assert channel_pk is not None
+
+    resp = await client.post(
+        "/scheduler/tasks/clear-pending-collect", follow_redirects=False
+    )
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert "pending_collect_tasks_deleted" in location or "pending_collect_tasks_empty" in location
+
+    # The row must be gone from the DB.
+    remaining = await db.repos.tasks.get_pending_channel_tasks()
+    assert not any(t.id == task_id for t in remaining)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_web_mode_falls_back_to_db(client, base_app):
+    """POST /scheduler/tasks/{id}/cancel must NOT 500 in web-mode.
+
+    Same class of regression as clear-pending-collect: the route used to dereference
+    a None queue. With the fix it delegates through CollectionService, which flips
+    the DB row to CANCELLED without the in-memory queue.
+    """
+    from src.models import Channel, CollectionTaskStatus
+
+    app, db, _ = base_app
+    app.state.collection_queue = None
+
+    await db.add_channel(Channel(channel_id=777, title="Cancel Target"))
+    task_id = await db.repos.tasks.create_collection_task_if_not_active(
+        channel_id=777,
+        channel_title="Cancel Target",
+    )
+    assert task_id is not None
+
+    resp = await client.post(
+        f"/scheduler/tasks/{task_id}/cancel", follow_redirects=False
+    )
+    assert resp.status_code == 303
+    assert "task_cancelled" in resp.headers.get("location", "")
+
+    # DB status must reflect the cancellation even though no worker was listening.
+    task = await db.repos.tasks.get_collection_task(task_id)
+    assert task is not None
+    assert task.status == CollectionTaskStatus.CANCELLED
+
+
+# ── #457 round 3: filter preserved on redirect ────────────────────────────
+#
+# Before round 3, every POST-handler in scheduler.py redirected to
+# `/scheduler?msg=...` and dropped the user's `?status=active&page=N&limit=M`
+# query. Clicking "Запустить" on the "Активные" tab threw the user back to
+# "Все" (default status=all) — on a big DB that looked like the button replaced
+# the page with 143 pages of unrelated tasks. These tests lock that fixed
+# behaviour in place for every POST route in scheduler.py.
+
+
+@pytest.fixture
+def _filter_qs() -> str:
+    return "status=active&page=3&limit=25"
+
+
+async def _assert_filter_preserved(resp, expected_msg_or_error: str) -> str:
+    """Redirect must carry status/page/limit AND the msg/error code."""
+    assert resp.status_code == 303, f"expected 303, got {resp.status_code} body={resp.text[:200]}"
+    location = resp.headers.get("location", "")
+    assert "status=active" in location, location
+    assert "page=3" in location, location
+    assert "limit=25" in location, location
+    assert expected_msg_or_error in location, location
+    return location
+
+
+@pytest.mark.asyncio
+async def test_trigger_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/trigger?{_filter_qs}")
+    # On empty DB there are no active channels → bulk_enqueue_msg returns
+    # a `collect_all_*` code; we don't care which, as long as the filter survives.
+    assert resp.status_code == 303
+    loc = resp.headers.get("location", "")
+    assert "status=active" in loc
+    assert "page=3" in loc
+    assert "limit=25" in loc
+
+
+@pytest.mark.asyncio
+async def test_start_scheduler_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/start?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=scheduler_started")
+
+
+@pytest.mark.asyncio
+async def test_stop_scheduler_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/stop?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=scheduler_stopped")
+
+
+@pytest.mark.asyncio
+async def test_trigger_warm_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/trigger-warm?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=warm_dialogs_started")
+
+
+@pytest.mark.asyncio
+async def test_test_notification_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/test-notification?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=test_notification_queued")
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_collect_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(
+        f"/scheduler/tasks/clear-pending-collect?{_filter_qs}"
+    )
+    await _assert_filter_preserved(resp, "msg=pending_collect_tasks_empty")
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_preserves_filter(web_mode_client, web_mode_app, _filter_qs):
+    _, container = web_mode_app
+    task_id = await container.db.repos.tasks.create_collection_task_if_not_active(
+        channel_id=-1001, channel_title="Web Mode Test Channel",
+    )
+    resp = await web_mode_client.post(f"/scheduler/tasks/{task_id}/cancel?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=task_cancelled")
+
+
+@pytest.mark.asyncio
+async def test_toggle_scheduler_job_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/jobs/collect_all/toggle?{_filter_qs}")
+    await _assert_filter_preserved(resp, "msg=job_toggled")
+
+
+@pytest.mark.asyncio
+async def test_set_job_interval_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(
+        f"/scheduler/jobs/collect_all/set-interval?{_filter_qs}",
+        data={"interval_minutes": "15"},
+    )
+    await _assert_filter_preserved(resp, "msg=interval_updated")
+
+
+# Error branches also must keep the filter — otherwise an invalid_job bounces
+# the user to status=all on top of the error, which was the actual bad UX.
+
+
+@pytest.mark.asyncio
+async def test_invalid_job_toggle_preserves_filter(web_mode_client, _filter_qs):
+    resp = await web_mode_client.post(f"/scheduler/jobs/not-a-real-job/toggle?{_filter_qs}")
+    await _assert_filter_preserved(resp, "error=invalid_job")
+
+
+@pytest.mark.asyncio
+async def test_shutting_down_preserves_filter(web_mode_app, web_mode_client, _filter_qs):
+    app, _ = web_mode_app
+    app.state.shutting_down = True
+    try:
+        resp = await web_mode_client.post(f"/scheduler/start?{_filter_qs}")
+        await _assert_filter_preserved(resp, "error=shutting_down")
+    finally:
+        app.state.shutting_down = False
+
+
+@pytest.mark.asyncio
+async def test_default_filter_omitted_from_url(web_mode_client):
+    """When user is already on default filters, the redirect URL stays clean."""
+    resp = await web_mode_client.post("/scheduler/start")
+    assert resp.status_code == 303
+    loc = resp.headers.get("location", "")
+    # Default tab (status=all, page=1, limit=50) — we *don't* want those echoed.
+    assert "status=" not in loc
+    assert "page=" not in loc
+    assert "limit=" not in loc
+    assert "msg=scheduler_started" in loc
+
+
+# Regression guard: all POST routes listed here must return 2xx/3xx in web-mode,
+# never 500. This catches the next #457-class bug (route dereferencing a None
+# nullable service) automatically.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method, path, form",
+    [
+        ("POST", "/scheduler/start", None),
+        ("POST", "/scheduler/stop", None),
+        ("POST", "/scheduler/trigger", None),
+        ("POST", "/scheduler/trigger-warm", None),
+        ("POST", "/scheduler/test-notification", None),
+        ("POST", "/scheduler/tasks/clear-pending-collect", None),
+        ("POST", "/scheduler/jobs/collect_all/toggle", None),
+        ("POST", "/scheduler/jobs/collect_all/set-interval", {"interval_minutes": "15"}),
+    ],
+)
+async def test_scheduler_post_routes_never_500_in_web_mode(web_mode_client, method, path, form):
+    resp = await web_mode_client.request(method, path, data=form)
+    assert resp.status_code < 500, (
+        f"{method} {path} returned {resp.status_code} "
+        f"(body: {resp.text[:300]}) — web-mode must never 500"
+    )

--- a/tests/test_collection_service_new.py
+++ b/tests/test_collection_service_new.py
@@ -173,3 +173,62 @@ async def test_collect_single_channel_full():
     count = await svc.collect_single_channel_full(ch)
     assert count == 42
     collector.collect_single_channel.assert_called_once_with(ch, full=True)
+
+
+# ── cancel_task / clear_pending_collect_tasks fallback (fix for #457) ─────
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_with_live_queue_delegates():
+    """With a live queue the service must delegate so RUNNING tasks get interrupted."""
+    channels = MagicMock()
+    channels.cancel_collection_task = AsyncMock(return_value=True)
+    collector = MagicMock()
+    queue = MagicMock()
+    queue.cancel_task = AsyncMock(return_value=True)
+
+    svc = CollectionService(channels, collector, collection_queue=queue)
+    result = await svc.cancel_task(77, note="manual stop")
+    assert result is True
+    queue.cancel_task.assert_awaited_once_with(77, note="manual stop")
+    channels.cancel_collection_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_without_queue_falls_back_to_db():
+    """In web-mode (queue=None) the DB path must keep the route from 500'ing (#457)."""
+    channels = MagicMock()
+    channels.cancel_collection_task = AsyncMock(return_value=True)
+    collector = MagicMock()
+
+    svc = CollectionService(channels, collector, collection_queue=None)
+    result = await svc.cancel_task(77)
+    assert result is True
+    channels.cancel_collection_task.assert_awaited_once_with(77, note=None)
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_collect_tasks_with_live_queue_delegates():
+    """With a queue the service must delegate to drain memory + cancel requeue timers."""
+    channels = MagicMock()
+    collector = MagicMock()
+    queue = MagicMock()
+    queue.clear_pending_tasks = AsyncMock(return_value=12)
+
+    svc = CollectionService(channels, collector, collection_queue=queue)
+    result = await svc.clear_pending_collect_tasks()
+    assert result == 12
+    queue.clear_pending_tasks.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_collect_tasks_without_queue_falls_back_to_db():
+    """Without a queue the service just deletes PENDING rows — memory lives in the worker."""
+    channels = MagicMock()
+    channels.delete_pending_channel_tasks = AsyncMock(return_value=5)
+    collector = MagicMock()
+
+    svc = CollectionService(channels, collector, collection_queue=None)
+    result = await svc.clear_pending_collect_tasks()
+    assert result == 5
+    channels.delete_pending_channel_tasks.assert_awaited_once()


### PR DESCRIPTION
## Summary

- `python -m src.main serve` now spawns the Telegram worker inside the same process via the new `EmbeddedWorker` (`src/web/embedded_worker.py`). One command — UI + real collection. For Docker/k8s split deployments add `--no-worker` and run a standalone `python -m src.main worker`.
- First real end-to-end test of the main feature: `tests/e2e/test_collection_flow.py` exercises click → enqueue → embedded worker → stubbed Collector → rows in `messages` table → task=COMPLETED, plus a negative guard that proves the happy path needs the worker.
- Round 1 banner, round 2 DB fallbacks (`CollectionService.cancel_task` / `clear_pending_collect_tasks`) and round 3 query-preserving redirects + `web_mode_app` fixture + "never 500 in web-mode" parametrized guard all stay as safety nets for `--no-worker` and crash scenarios.

Closes #457 (the repeated "I pressed the button, nothing collected" class of bugs). Previous rounds patched symptoms (docs, UI banner, 500 fallbacks, UX redirect); this round removes the root cause.

## Test plan

- [x] `ruff check src/ tests/ conftest.py` — All checks passed
- [x] `pytest tests/ -m "not aiosqlite_serial" -n auto` — 6515 passed, 1 skipped
- [x] `pytest tests/ -m aiosqlite_serial` — 816 passed
- [x] `pytest tests/e2e/ -v` — 3 passed (happy path + `--no-worker` stuck + heartbeat)
- [x] Live run on the user's real DB: single `python -m src.main serve` → embedded worker started → 3 accounts connected → 219 re-enqueued → collection started, `pending 219→205`, `completed 5936→5949`, all 7 `runtime_snapshots` fresh
- [x] `serve --no-worker` path: tasks stay PENDING (verified via e2e `test_trigger_collection_stuck_without_worker`), round 2 fallback `clear-pending-collect` returns 303 (not 500), round 3 `?status=active` preserved on redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)