### PR TITLE
[codex] Fix pipeline dry-run refs and show ids

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -103,6 +103,9 @@ python -m src.main pipeline reject RUN_ID
 python -m src.main pipeline bulk-approve RUN_ID [RUN_ID ...]
 python -m src.main pipeline bulk-reject RUN_ID [RUN_ID ...]
 python -m src.main pipeline refinement-steps ID [--set JSON]
+python -m src.main pipeline filter set ID [--message-kind KIND ...] [--service-action ACTION ...] [--media-type TYPE ...] [--sender-kind KIND ...] [--keyword TEXT ...] [--regex PATTERN] [--forwarded true|false] [--has-text true|false]
+python -m src.main pipeline filter show ID
+python -m src.main pipeline filter clear ID
 ```
 
 ## image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "httpx==0.28.1",
     "ruff==0.14.13",
     "pytest-cov==7.0.0",
+    "beautifulsoup4>=4.12",
 ]
 
 [project.optional-dependencies]

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -483,9 +483,15 @@ def register(db, client_pool, embedding_service, **kwargs):
             lines = [f"Генерации пайплайна id={pipeline_id} ({len(runs)} шт.):"]
             for r in runs:
                 preview = (r.generated_text or "")[:150]
+                result_kind = getattr(r, "result_kind", None)
+                result_count = getattr(r, "result_count", None)
+                if result_kind is not None and result_count is not None:
+                    result_part = f"result={result_kind}:{result_count}, "
+                else:
+                    result_part = ""
                 lines.append(
                     f"- run_id={r.id}, status={r.status}, moderation={r.moderation_status}, "
-                    f"created={r.created_at}: {preview}"
+                    f"{result_part}created={r.created_at}: {preview}"
                 )
             return _text_response("\n".join(lines))
         except Exception as e:
@@ -511,12 +517,25 @@ def register(db, client_pool, embedding_service, **kwargs):
                 f"  Статус: {run.status}",
                 f"  Модерация: {run.moderation_status}",
                 f"  Качество: {run.quality_score if hasattr(run, 'quality_score') and run.quality_score else 'n/a'}",
-                f"  Создан: {run.created_at}",
-                f"  Обновлён: {run.updated_at}",
-                "",
-                "Текст:",
-                run.generated_text or "(пусто)",
             ]
+            result_kind = getattr(run, "result_kind", None)
+            result_count = getattr(run, "result_count", None)
+            if result_kind is not None and result_count is not None:
+                from src.services.pipeline_result import result_kind_label
+
+                lines.append(
+                    f"  Результат: {result_kind_label(result_kind)} "
+                    f"({result_kind}:{result_count})"
+                )
+            lines.extend(
+                [
+                    f"  Создан: {run.created_at}",
+                    f"  Обновлён: {run.updated_at}",
+                    "",
+                    "Текст:",
+                    run.generated_text or "(пусто)",
+                ]
+            )
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения run: {e}")

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -263,6 +263,54 @@ def run_with_dependencies(
                 except Exception as exc:
                     print(f"Error deleting messages: {exc}")
 
+            elif args.dialogs_action == "react":
+                accounts = sorted(pool.clients.keys())
+                if not accounts:
+                    print("No connected accounts.")
+                    return
+                phone = args.phone or accounts[0]
+                if phone not in pool.clients:
+                    print(f"Account {phone} not connected.")
+                    return
+                # Surface flood-wait state explicitly instead of silently failing
+                # lease acquisition (issue #463 observability).
+                acc = await pool._get_account_for_phone(phone)
+                if acc is not None and acc.flood_wait_until is not None:
+                    from datetime import datetime
+                    from datetime import timezone as _tz
+
+                    if acc.flood_wait_until > datetime.now(_tz.utc):
+                        print(
+                            f"Account {phone} is flood-waited until "
+                            f"{acc.flood_wait_until.isoformat()}."
+                        )
+                        return
+                native_result = await pool.get_native_client_by_phone(phone)
+                if native_result is None:
+                    print(f"Client for {phone} unavailable (no lease could be acquired).")
+                    return
+                client, acquired_phone = native_result
+                try:
+                    from telethon.tl.functions.messages import SendReactionRequest
+                    from telethon.tl.types import ReactionEmoji
+
+                    entity = await client.get_entity(args.chat_id)
+                    await client(
+                        SendReactionRequest(
+                            peer=entity,
+                            msg_id=args.message_id,
+                            reaction=[ReactionEmoji(emoticon=args.emoji)],
+                        )
+                    )
+                    print(
+                        f"Reaction {args.emoji!r} sent to message #{args.message_id} "
+                        f"in {args.chat_id} (account {acquired_phone})"
+                    )
+                except Exception as exc:
+                    print(f"Error sending reaction: {type(exc).__name__}: {exc}")
+                finally:
+                    await pool.release_client(acquired_phone)
+
             elif args.dialogs_action == "pin-message":
                 accounts = sorted(pool.clients.keys())
                 if not accounts:

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -4,10 +4,12 @@ import argparse
 import asyncio
 
 from src.cli import runtime
+from src.models import PipelineNode, PipelineNodeType
 from src.search.engine import SearchEngine
 from src.services.content_generation_service import ContentGenerationService
-from src.services.generation_service import GenerationService
+from src.services.pipeline_filters import normalize_filter_config
 from src.services.pipeline_llm_requirements import pipeline_needs_llm
+from src.services.pipeline_result import result_kind_label
 from src.services.pipeline_service import (
     PipelineService,
     PipelineTargetRef,
@@ -38,6 +40,105 @@ def _preview_text(value: str | None, limit: int = 60) -> str:
     if len(compact) <= limit:
         return compact
     return f"{compact[: limit - 3]}..."
+
+
+def _str_to_bool(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    return value == "true"
+
+
+def _find_filter_node(graph) -> PipelineNode | None:
+    return next((node for node in graph.nodes if node.type == PipelineNodeType.FILTER), None)
+
+
+def _build_message_filter_config(args: argparse.Namespace) -> dict:
+    return {
+        "type": "message_filter",
+        "message_kinds": list(getattr(args, "message_kinds", None) or []),
+        "service_actions": list(getattr(args, "service_actions", None) or []),
+        "media_types": list(getattr(args, "media_types", None) or []),
+        "sender_kinds": list(getattr(args, "sender_kinds", None) or []),
+        "keywords": list(getattr(args, "keywords", None) or []),
+        "regex": getattr(args, "regex", None) or "",
+        "forwarded": _str_to_bool(getattr(args, "forwarded", None)),
+        "has_text": _str_to_bool(getattr(args, "has_text", None)),
+    }
+
+
+def _format_filter_config(config: dict) -> list[str]:
+    normalized = normalize_filter_config(config)
+    return [
+        f"message_kinds={','.join(normalized.get('message_kinds', [])) or '—'}",
+        f"service_actions={','.join(normalized.get('service_actions', [])) or '—'}",
+        f"media_types={','.join(normalized.get('media_types', [])) or '—'}",
+        f"sender_kinds={','.join(normalized.get('sender_kinds', [])) or '—'}",
+        f"keywords={','.join(normalized.get('keywords', [])) or '—'}",
+        f"regex={normalized.get('regex') or '—'}",
+        f"forwarded={normalized.get('forwarded') if normalized.get('forwarded') is not None else '—'}",
+        f"has_text={normalized.get('has_text') if normalized.get('has_text') is not None else '—'}",
+    ]
+
+
+async def _upsert_filter_node(svc: PipelineService, pipeline_id: int, config: dict) -> bool:
+    graph = await svc.get_graph(pipeline_id)
+    if graph is None:
+        return False
+
+    existing = _find_filter_node(graph)
+    if existing is not None:
+        replacement = existing.model_copy(update={"config": config})
+        return await svc.replace_node(pipeline_id, existing.id, replacement)
+
+    new_node = PipelineNode(
+        id="filter_1",
+        type=PipelineNodeType.FILTER,
+        name="Фильтр",
+        config=config,
+        position={"x": 330.0, "y": 0.0},
+    )
+    if not await svc.add_node(pipeline_id, new_node):
+        return False
+
+    graph = await svc.get_graph(pipeline_id)
+    if graph is None:
+        return False
+
+    upstream_id = None
+    for candidate in ("fetch_1", "source_1"):
+        if any(node.id == candidate for node in graph.nodes):
+            upstream_id = candidate
+            break
+    if upstream_id is None and graph.nodes:
+        upstream_id = graph.nodes[0].id
+
+    downstream_ids = [edge.to_node for edge in graph.edges if edge.from_node == upstream_id] if upstream_id else []
+    for downstream_id in downstream_ids:
+        await svc.remove_edge(pipeline_id, upstream_id, downstream_id)
+    if upstream_id:
+        await svc.add_edge(pipeline_id, upstream_id, "filter_1")
+    for downstream_id in downstream_ids:
+        if downstream_id != "filter_1":
+            await svc.add_edge(pipeline_id, "filter_1", downstream_id)
+    return True
+
+
+async def _clear_filter_node(svc: PipelineService, pipeline_id: int) -> bool:
+    graph = await svc.get_graph(pipeline_id)
+    if graph is None:
+        return False
+    existing = _find_filter_node(graph)
+    if existing is None:
+        return True
+    incoming = [edge.from_node for edge in graph.edges if edge.to_node == existing.id]
+    outgoing = [edge.to_node for edge in graph.edges if edge.from_node == existing.id]
+    ok = await svc.remove_node(pipeline_id, existing.id)
+    if not ok:
+        return False
+    for source in incoming:
+        for target in outgoing:
+            await svc.add_edge(pipeline_id, source, target)
+    return True
 
 
 def run(args: argparse.Namespace) -> None:
@@ -81,6 +182,12 @@ def run(args: argparse.Namespace) -> None:
                 print(f"active={pipeline.is_active}")
                 print(f"llm_model={pipeline.llm_model or '—'}")
                 print(f"image_model={pipeline.image_model or '—'}")
+                if pipeline.pipeline_json is not None:
+                    filter_node = _find_filter_node(pipeline.pipeline_json)
+                    if filter_node is not None:
+                        print("filter:")
+                        for line in _format_filter_config(filter_node.config):
+                            print(f" - {line}")
                 print("sources:")
                 for title in detail["source_titles"]:
                     print(f" - {title}")
@@ -285,6 +392,7 @@ def run(args: argparse.Namespace) -> None:
                 engine = SearchEngine(db)
 
                 from src.services.provider_service import AgentProviderService
+                from src.services.quality_scoring_service import QualityScoringService
 
                 provider_service = AgentProviderService(db, config)
                 await provider_service.load_db_providers()
@@ -294,41 +402,36 @@ def run(args: argparse.Namespace) -> None:
                         "env var (e.g. OPENAI_API_KEY). Non-LLM pipelines run without a provider."
                     )
                     return
-                provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
-                gen_svc = GenerationService(engine, provider_callable=provider_callable)
-                run_id = await db.repos.generation_runs.create_run(
-                    pipeline.id, pipeline.prompt_template
+                gen_svc = ContentGenerationService(
+                    db,
+                    engine,
+                    config=config,
+                    quality_service=QualityScoringService(db, provider_service=provider_service),
+                    provider_service=provider_service,
                 )
-                await db.repos.generation_runs.set_status(run_id, "running")
-                print(f"Created generation run id={run_id}")
-                scope = await svc.get_retrieval_scope(pipeline)
                 try:
-                    result = await gen_svc.generate(
-                        query=scope.query,
-                        prompt_template=pipeline.prompt_template,
-                        limit=args.limit,
+                    run_obj = await gen_svc.generate(
+                        pipeline=pipeline,
                         model=pipeline.llm_model,
                         max_tokens=args.max_tokens,
                         temperature=args.temperature,
-                        channel_id=scope.channel_id,
                     )
-                    await db.repos.generation_runs.save_result(
-                        run_id,
-                        result.get("generated_text", ""),
-                        {"citations": result.get("citations", [])},
+                    print(f"Created generation run id={run_obj.id}")
+                    print(f"Generation completed for run id={run_obj.id}")
+                    print(
+                        f"result_kind={run_obj.result_kind} "
+                        f"result_count={run_obj.result_count}"
                     )
-                    print(f"Generation completed for run id={run_id}")
-                    if args.preview:
+                    if args.preview and run_obj.generated_text:
                         print("--- DRAFT PREVIEW ---")
-                        print(result.get("generated_text"))
+                        print(run_obj.generated_text)
                     if args.publish:
                         print(
                             "Publish requested — publishing via targets is not implemented in CLI; "
                             "Use the web UI or implement account targets."
                         )
                 except Exception as exc:
-                    await db.repos.generation_runs.set_status(run_id, "failed")
                     print(f"Generation failed: {exc}")
 
             elif args.pipeline_action == "generate":
@@ -388,11 +491,12 @@ def run(args: argparse.Namespace) -> None:
                 if not runs:
                     print("No generation runs found.")
                     return
-                print(f"{'ID':<8} {'Status':<12} {'ModStatus':<12} {'Created':<20}")
-                print("-" * 56)
+                print(f"{'ID':<8} {'Status':<12} {'ModStatus':<12} {'Result':<22} {'Created':<20}")
+                print("-" * 82)
                 for r in runs:
                     created = r.created_at.isoformat() if r.created_at else "—"
-                    print(f"{r.id:<8} {r.status:<12} {r.moderation_status:<12} {created:<20}")
+                    result_summary = f"{r.result_kind}:{r.result_count}"
+                    print(f"{r.id:<8} {r.status:<12} {r.moderation_status:<12} {result_summary:<22} {created:<20}")
 
             elif args.pipeline_action == "run-show":
                 run = await db.repos.generation_runs.get(args.run_id)
@@ -403,16 +507,34 @@ def run(args: argparse.Namespace) -> None:
                 print(f"pipeline_id={run.pipeline_id}")
                 print(f"status={run.status}")
                 print(f"moderation_status={run.moderation_status}")
+                print(f"result_kind={run.result_kind}")
+                print(f"result_count={run.result_count}")
                 print(f"created_at={run.created_at}")
                 if run.generated_text:
                     print("--- GENERATED TEXT ---")
                     print(run.generated_text[:500])
                     if len(run.generated_text) > 500:
                         print(f"... ({len(run.generated_text) - 500} more chars)")
+                else:
+                    print(f"result_label={result_kind_label(run.result_kind)}")
                 if run.image_url:
                     print(f"image_url={run.image_url}")
                 if run.published_at:
                     print(f"published_at={run.published_at}")
+                metadata = run.metadata if isinstance(run.metadata, dict) else {}
+                node_errors = metadata.get("node_errors")
+                if isinstance(node_errors, list) and node_errors:
+                    print(f"Ошибки нод: {len(node_errors)}")
+                    for err in node_errors:
+                        if not isinstance(err, dict):
+                            continue
+                        node_id = err.get("node_id", "?")
+                        code = err.get("code", "unknown")
+                        detail = err.get("detail", "")
+                        line = f"  - [{node_id}] {code}: {detail}"
+                        if err.get("retry_after") is not None:
+                            line += f" retry_after={err['retry_after']}"
+                        print(line)
 
             elif args.pipeline_action == "queue":
                 pipeline = await svc.get(args.id)
@@ -611,9 +733,43 @@ def run(args: argparse.Namespace) -> None:
                 else:
                     print(f"Error: {result['error']}")
 
+            elif args.pipeline_action == "filter":
+                pipeline = await svc.get(args.id)
+                if pipeline is None:
+                    print(f"Pipeline id={args.id} not found")
+                    return
+                graph = await svc.get_graph(args.id)
+                if graph is None:
+                    print(f"Pipeline id={args.id} has no graph (legacy pipeline)")
+                    return
+
+                if args.filter_action == "set":
+                    config = _build_message_filter_config(args)
+                    ok = await _upsert_filter_node(svc, args.id, config)
+                    if not ok:
+                        print(f"Failed to update filter for pipeline id={args.id}")
+                        return
+                    print(f"Updated filter for pipeline id={args.id}")
+                    for line in _format_filter_config(config):
+                        print(line)
+
+                elif args.filter_action == "show":
+                    filter_node = _find_filter_node(graph)
+                    if filter_node is None:
+                        print(f"Pipeline id={args.id} has no filter")
+                        return
+                    for line in _format_filter_config(filter_node.config):
+                        print(line)
+
+                elif args.filter_action == "clear":
+                    ok = await _clear_filter_node(svc, args.id)
+                    if not ok:
+                        print(f"Failed to clear filter for pipeline id={args.id}")
+                        return
+                    print(f"Cleared filter for pipeline id={args.id}")
+
             elif args.pipeline_action == "node":
                 from src.cli.node_dsl import NodeSpecError, parse_node_spec
-                from src.models import PipelineNode
 
                 if args.node_action == "add":
                     try:

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -499,6 +499,26 @@ def build_parser() -> argparse.ArgumentParser:
     pipeline_ai_edit.add_argument("instruction", help="Instruction for the LLM (e.g. 'Add an image generation node')")
     pipeline_ai_edit.add_argument("--show", action="store_true", help="Print updated JSON after edit")
 
+    pipeline_filter = pipeline_sub.add_parser("filter", help="Manage semantic filters on pipeline DAGs")
+    filter_sub = pipeline_filter.add_subparsers(dest="filter_action")
+
+    filter_set = filter_sub.add_parser("set", help="Create or replace the pipeline filter node")
+    filter_set.add_argument("id", type=int, help="Pipeline id")
+    filter_set.add_argument("--message-kind", action="append", default=None, dest="message_kinds")
+    filter_set.add_argument("--service-action", action="append", default=None, dest="service_actions")
+    filter_set.add_argument("--media-type", action="append", default=None, dest="media_types")
+    filter_set.add_argument("--sender-kind", action="append", default=None, dest="sender_kinds")
+    filter_set.add_argument("--keyword", action="append", default=None, dest="keywords")
+    filter_set.add_argument("--regex", default=None, dest="regex")
+    filter_set.add_argument("--forwarded", choices=["true", "false"], default=None)
+    filter_set.add_argument("--has-text", choices=["true", "false"], default=None, dest="has_text")
+
+    filter_show = filter_sub.add_parser("show", help="Show the resolved filter config")
+    filter_show.add_argument("id", type=int, help="Pipeline id")
+
+    filter_clear = filter_sub.add_parser("clear", help="Remove the pipeline filter node")
+    filter_clear.add_argument("id", type=int, help="Pipeline id")
+
     # Node CRUD
     pipeline_node = pipeline_sub.add_parser("node", help="Node CRUD operations on pipeline graph")
     node_sub = pipeline_node.add_subparsers(dest="node_action")
@@ -668,6 +688,12 @@ def build_parser() -> argparse.ArgumentParser:
     my_tg_pin.add_argument("--phone", default=None, help="Account phone (default: first connected)")
     my_tg_pin.add_argument("--notify", action="store_true", help="Notify members about pinned message")
     my_tg_pin.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
+    my_tg_react = dialogs_sub.add_parser("react", help="Set a reaction on a message")
+    my_tg_react.add_argument("chat_id", help="Chat ID or @username")
+    my_tg_react.add_argument("message_id", type=int, help="Message ID to react on")
+    my_tg_react.add_argument("emoji", help="Reaction emoji (e.g. 👍)")
+    my_tg_react.add_argument("--phone", default=None, help="Account phone (default: first connected)")
 
     my_tg_unpin = dialogs_sub.add_parser("unpin-message", help="Unpin a message in a chat")
     my_tg_unpin.add_argument("chat_id", help="Chat ID or @username")

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 import time
 from pathlib import Path
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
 
 _PROFILING_ENABLED = os.environ.get("ENV", "PROD").upper() == "DEV"
 
@@ -98,6 +101,7 @@ class DBConnection:
     async def execute(self, sql: str, params: tuple = ()) -> aiosqlite.Cursor:
         assert self.db is not None
         if sql.strip().upper().startswith("BEGIN") and self.db.in_transaction:
+            logger.warning("DBConnection.execute: rolling back active transaction before BEGIN")
             await self.db.rollback()
         return await self.db.execute(sql, params)
 

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -97,6 +97,8 @@ class DBConnection:
 
     async def execute(self, sql: str, params: tuple = ()) -> aiosqlite.Cursor:
         assert self.db is not None
+        if sql.strip().upper().startswith("BEGIN") and self.db.in_transaction:
+            await self.db.rollback()
         return await self.db.execute(sql, params)
 
     async def execute_fetchall(self, sql: str, params: tuple = ()) -> list:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -63,6 +63,21 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     if "media_type" not in msg_columns:
         await db.execute("ALTER TABLE messages ADD COLUMN media_type TEXT")
         await db.commit()
+    if "message_kind" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN message_kind TEXT")
+        await db.commit()
+    if "service_action_raw" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN service_action_raw TEXT")
+        await db.commit()
+    if "service_action_semantic" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN service_action_semantic TEXT")
+        await db.commit()
+    if "service_action_payload_json" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN service_action_payload_json TEXT")
+        await db.commit()
+    if "sender_kind" not in msg_columns:
+        await db.execute("ALTER TABLE messages ADD COLUMN sender_kind TEXT")
+        await db.commit()
     if "topic_id" not in msg_columns:
         await db.execute("ALTER TABLE messages ADD COLUMN topic_id INTEGER")
         await db.commit()
@@ -692,6 +707,9 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     # Node-based pipeline graph JSON (issue #343)
     if "pipeline_json" not in cp2_columns:
         await db.execute("ALTER TABLE content_pipelines ADD COLUMN pipeline_json TEXT")
+        await db.commit()
+    if "account_phone" not in cp2_columns:
+        await db.execute("ALTER TABLE content_pipelines ADD COLUMN account_phone TEXT")
         await db.commit()
 
     # Pipeline templates table (issue #343)

--- a/src/database/repositories/_transactions.py
+++ b/src/database/repositories/_transactions.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+
+
+async def begin_immediate(db: aiosqlite.Connection) -> None:
+    """Start a write transaction, recovering from stale nested transactions."""
+    if db.in_transaction:
+        await db.rollback()
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+    except sqlite3.OperationalError as exc:
+        if "cannot start a transaction within a transaction" not in str(exc):
+            raise
+        await db.rollback()
+        await db.execute("BEGIN IMMEDIATE")

--- a/src/database/repositories/_transactions.py
+++ b/src/database/repositories/_transactions.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
+import logging
 import sqlite3
 
 import aiosqlite
+
+logger = logging.getLogger(__name__)
 
 
 async def begin_immediate(db: aiosqlite.Connection) -> None:
     """Start a write transaction, recovering from stale nested transactions."""
     if db.in_transaction:
+        logger.warning("begin_immediate: rolling back existing transaction (pending writes will be lost)")
         await db.rollback()
     try:
         await db.execute("BEGIN IMMEDIATE")
     except sqlite3.OperationalError as exc:
         if "cannot start a transaction within a transaction" not in str(exc):
             raise
+        logger.warning("begin_immediate: nested-transaction fallback, rolling back")
         await db.rollback()
         await db.execute("BEGIN IMMEDIATE")

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
 from src.models import (
     CollectionTask,
     CollectionTaskStatus,
@@ -556,7 +557,7 @@ class CollectionTasksRepository:
 
         # Phase 2: acquire write lock only when there is work to claim
         try:
-            await self._db.execute("BEGIN IMMEDIATE")
+            await begin_immediate(self._db)
             selected_id = peek["id"]
             updated = await self._db.execute(
                 "UPDATE collection_tasks "

--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
 from src.models import (
     ContentPipeline,
     PipelineGenerationBackend,
@@ -51,6 +52,7 @@ class ContentPipelinesRepository:
                 else []
             ),
             pipeline_json=pipeline_graph,
+            account_phone=row["account_phone"] if "account_phone" in keys else None,
             created_at=_dt(row["created_at"]),
         )
 
@@ -81,7 +83,7 @@ class ContentPipelinesRepository:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> int:
-        await self._db.execute("BEGIN IMMEDIATE")
+        await begin_immediate(self._db)
         try:
             pipeline_json_str = pipeline.pipeline_json.to_json() if pipeline.pipeline_json else None
             cur = await self._db.execute(
@@ -89,8 +91,8 @@ class ContentPipelinesRepository:
                 INSERT INTO content_pipelines (
                     name, prompt_template, llm_model, image_model, publish_mode,
                     generation_backend, is_active, last_generated_id, generate_interval_minutes,
-                    publish_times, pipeline_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    publish_times, pipeline_json, account_phone
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     pipeline.name,
@@ -104,6 +106,7 @@ class ContentPipelinesRepository:
                     pipeline.generate_interval_minutes,
                     pipeline.publish_times,
                     pipeline_json_str,
+                    pipeline.account_phone,
                 ),
             )
             pipeline_id = cur.lastrowid or 0
@@ -146,7 +149,7 @@ class ContentPipelinesRepository:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> bool:
-        await self._db.execute("BEGIN IMMEDIATE")
+        await begin_immediate(self._db)
         try:
             pipeline_json_str = pipeline.pipeline_json.to_json() if pipeline.pipeline_json else None
             cur = await self._db.execute(
@@ -154,7 +157,8 @@ class ContentPipelinesRepository:
                 UPDATE content_pipelines
                 SET name = ?, prompt_template = ?, llm_model = ?, image_model = ?,
                     publish_mode = ?, generation_backend = ?, is_active = ?,
-                    generate_interval_minutes = ?, publish_times = ?, pipeline_json = ?
+                    generate_interval_minutes = ?, publish_times = ?, pipeline_json = ?,
+                    account_phone = ?
                 WHERE id = ?
                 """,
                 (
@@ -168,6 +172,7 @@ class ContentPipelinesRepository:
                     pipeline.generate_interval_minutes,
                     pipeline.publish_times,
                     pipeline_json_str,
+                    pipeline.account_phone,
                     pipeline_id,
                 ),
             )

--- a/src/database/repositories/dialog_cache.py
+++ b/src/database/repositories/dialog_cache.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
+
 
 def _dt(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value) if value else None
@@ -59,7 +61,7 @@ class DialogCacheRepository:
         ]
 
     async def replace_dialogs(self, phone: str, dialogs: list[dict]) -> None:
-        await self._db.execute("BEGIN IMMEDIATE")
+        await begin_immediate(self._db)
         try:
             await self._db.execute("DELETE FROM dialog_cache WHERE phone = ?", (phone,))
             if dialogs:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -107,17 +107,24 @@ class MessagesRepository:
             cur = await self._db.execute(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
-                    text, media_type, topic_id, reactions_json,
+                    text, message_kind, media_type, service_action_raw,
+                    service_action_semantic, service_action_payload_json, sender_kind,
+                    topic_id, reactions_json,
                     views, forwards, reply_count, date, detected_lang,
                     forward_from_channel_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     msg.channel_id,
                     msg.message_id,
                     msg.sender_id,
                     msg.sender_name,
                     msg.text,
+                    msg.message_kind,
                     msg.media_type,
+                    msg.service_action_raw,
+                    msg.service_action_semantic,
+                    msg.service_action_payload_json,
+                    msg.sender_kind,
                     msg.topic_id,
                     msg.reactions_json,
                     msg.views,
@@ -173,7 +180,12 @@ class MessagesRepository:
                 m.sender_id,
                 m.sender_name,
                 m.text,
+                m.message_kind,
                 m.media_type,
+                m.service_action_raw,
+                m.service_action_semantic,
+                m.service_action_payload_json,
+                m.sender_kind,
                 m.topic_id,
                 m.reactions_json,
                 m.views,
@@ -189,10 +201,12 @@ class MessagesRepository:
             cur = await self._db.executemany(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
-                    text, media_type, topic_id, reactions_json,
+                    text, message_kind, media_type, service_action_raw,
+                    service_action_semantic, service_action_payload_json, sender_kind,
+                    topic_id, reactions_json,
                     views, forwards, reply_count, date, detected_lang,
                     forward_from_channel_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 data,
             )
             await self._db.commit()
@@ -690,7 +704,16 @@ class MessagesRepository:
                 sender_id=r["sender_id"],
                 sender_name=r["sender_name"],
                 text=r["text"],
+                message_kind=r["message_kind"] if "message_kind" in r.keys() else None,
                 media_type=r["media_type"],
+                service_action_raw=r["service_action_raw"] if "service_action_raw" in r.keys() else None,
+                service_action_semantic=(
+                    r["service_action_semantic"] if "service_action_semantic" in r.keys() else None
+                ),
+                service_action_payload_json=(
+                    r["service_action_payload_json"] if "service_action_payload_json" in r.keys() else None
+                ),
+                sender_kind=r["sender_kind"] if "sender_kind" in r.keys() else None,
                 topic_id=r["topic_id"],
                 reactions_json=r["reactions_json"],
                 views=r["views"],

--- a/src/database/repositories/photo_loader.py
+++ b/src/database/repositories/photo_loader.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
 from src.models import (
     PhotoAutoUploadJob,
     PhotoBatch,
@@ -253,7 +254,7 @@ class PhotoLoaderRepository:
     async def claim_next_due_item(self, now: datetime) -> PhotoBatchItem | None:
         now_iso = now.astimezone(timezone.utc).isoformat()
         try:
-            await self._db.execute("BEGIN IMMEDIATE")
+            await begin_immediate(self._db)
             cur = await self._db.execute(
                 """
                 SELECT id FROM photo_batch_items

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
 from src.models import TelegramCommand, TelegramCommandStatus
 
 
@@ -120,7 +121,7 @@ class TelegramCommandsRepository:
 
     async def claim_next_command(self) -> TelegramCommand | None:
         now = datetime.now(timezone.utc).isoformat()
-        await self._db.execute("BEGIN IMMEDIATE")
+        await begin_immediate(self._db)
         try:
             cur = await self._db.execute(
                 """

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -34,7 +34,12 @@ CREATE TABLE IF NOT EXISTS messages (
     sender_id INTEGER,
     sender_name TEXT,
     text TEXT,
+    message_kind TEXT,
     media_type TEXT,
+    service_action_raw TEXT,
+    service_action_semantic TEXT,
+    service_action_payload_json TEXT,
+    sender_kind TEXT,
     topic_id INTEGER,
     reactions_json TEXT,
     views INTEGER,
@@ -265,6 +270,7 @@ CREATE TABLE IF NOT EXISTS content_pipelines (
     is_active INTEGER NOT NULL DEFAULT 1,
     last_generated_id INTEGER NOT NULL DEFAULT 0,
     generate_interval_minutes INTEGER NOT NULL DEFAULT 60,
+    account_phone TEXT,
     created_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/models.py
+++ b/src/models.py
@@ -57,7 +57,12 @@ class Message(BaseModel):
     sender_id: int | None = None
     sender_name: str | None = None
     text: str | None = None
+    message_kind: str | None = None
     media_type: str | None = None
+    service_action_raw: str | None = None
+    service_action_semantic: str | None = None
+    service_action_payload_json: str | None = None
+    sender_kind: str | None = None
     topic_id: int | None = None
     reactions_json: str | None = None
     views: int | None = None
@@ -283,6 +288,7 @@ class ContentPipeline(BaseModel):
     is_active: bool = True
     last_generated_id: int = 0
     generate_interval_minutes: int = Field(60, ge=1)
+    account_phone: str | None = None
     publish_times: str | None = None  # JSON array of "HH:MM" times, e.g. '["09:00", "18:00"]'
     refinement_steps: list[dict] = []  # list of {name, prompt} dicts; {text} in prompt is replaced
     pipeline_json: PipelineGraph | None = None  # node-based DAG config (issue #343)
@@ -386,6 +392,29 @@ class GenerationRun(BaseModel):
     published_at: datetime | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+    @property
+    def result_kind(self) -> str:
+        metadata = self.metadata if isinstance(self.metadata, dict) else {}
+        value = metadata.get("result_kind")
+        if isinstance(value, str) and value:
+            return value
+        if self.generated_text:
+            return "generated_items"
+        return "processed_messages"
+
+    @property
+    def result_count(self) -> int:
+        metadata = self.metadata if isinstance(self.metadata, dict) else {}
+        value = metadata.get("result_count")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        citations = metadata.get("citations")
+        if isinstance(citations, list):
+            return len(citations)
+        return 1 if self.generated_text else 0
 
 
 class PhotoSendMode(StrEnum):

--- a/src/services/collection_service.py
+++ b/src/services/collection_service.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal
 
 from src.database import Database
 from src.database.bundles import ChannelBundle
-from src.models import Channel
+from src.models import Channel, CollectionTaskType
 
 if TYPE_CHECKING:
     from src.collection_queue import CollectionQueue
@@ -91,17 +91,29 @@ class CollectionService:
         """Cancel a pending/running collection task.
 
         When the worker process is live (`self._queue is not None`) the call is
-        delegated to `CollectionQueue.cancel_task` so an in-flight collection
-        gets interrupted immediately. In web-mode (`self._queue is None`) we
-        fall back to a DB-only status flip — the worker will pick up the
-        cancellation on its next fetch of the task row.
+        routes `channel_collect` through `CollectionQueue.cancel_task` so an
+        in-flight message collection gets interrupted immediately. Generic
+        tasks like `stats_all` run under `UnifiedDispatcher`, so they need a
+        direct DB cancellation plus a collector stop signal instead.
+
+        In web-mode (`self._queue is None`) we fall back to a DB-only status
+        flip — the worker will pick up the cancellation on its next fetch of
+        the task row.
 
         Mirrors the `_enqueue_channel` fallback pattern so that /scheduler
         routes do not 500 when `collection_queue` is absent (#457).
         """
-        if self._queue is not None:
+        task = await self._channels.get_collection_task(task_id)
+        if task is None:
+            return False
+
+        if self._queue is not None and task.task_type == CollectionTaskType.CHANNEL_COLLECT:
             return await self._queue.cancel_task(task_id, note=note)
-        return await self._channels.cancel_collection_task(task_id, note=note)
+
+        cancelled = await self._channels.cancel_collection_task(task_id, note=note)
+        if cancelled and task.task_type == CollectionTaskType.STATS_ALL:
+            await self._collector.cancel()
+        return cancelled
 
     async def clear_pending_collect_tasks(self) -> int:
         """Delete every PENDING channel-collect task.

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -48,6 +48,36 @@ class ContentGenerationService:
         self._client_pool = client_pool
         self._provider_service = provider_service
 
+    @staticmethod
+    def _build_metadata(result: dict, *, dry_run: bool) -> dict[str, Any]:
+        """Assemble the metadata dict stored on a generation run.
+
+        Encodes the invariants from issue #463:
+          - ``result_kind``/``result_count`` are always present.
+          - ``action_counts`` survives for mixed and action-only runs.
+          - Optional flags (dry_run, publish_reply, reply_to_message_id) are
+            included only when set — absence is treated as implicit False/None.
+        """
+        metadata: dict[str, Any] = {
+            "citations": result.get("citations", []),
+            "effective_publish_mode": result.get("publish_mode"),
+            "result_kind": result.get("result_kind", "generated_items"),
+            "result_count": int(result.get("result_count", 0) or 0),
+        }
+        action_counts = result.get("action_counts")
+        if isinstance(action_counts, dict) and action_counts:
+            metadata["action_counts"] = action_counts
+        node_errors = result.get("node_errors")
+        if isinstance(node_errors, list) and node_errors:
+            metadata["node_errors"] = node_errors
+        if dry_run:
+            metadata["dry_run"] = True
+        if result.get("publish_reply"):
+            metadata["publish_reply"] = True
+        if result.get("reply_to_message_id") is not None:
+            metadata["reply_to_message_id"] = result["reply_to_message_id"]
+        return metadata
+
     async def generate(
         self,
         pipeline: ContentPipeline,
@@ -91,16 +121,10 @@ class ContentGenerationService:
             )
             generated_text = result.get("generated_text", "")
             effective_publish_mode = result.get("publish_mode") or pipeline.publish_mode.value
-            metadata: dict[str, Any] = {
-                "citations": result.get("citations", []),
-                "effective_publish_mode": effective_publish_mode,
-            }
-            if dry_run:
-                metadata["dry_run"] = True
-            if result.get("publish_reply"):
-                metadata["publish_reply"] = True
-            if result.get("reply_to_message_id") is not None:
-                metadata["reply_to_message_id"] = result["reply_to_message_id"]
+            metadata = self._build_metadata(
+                {**result, "publish_mode": effective_publish_mode},
+                dry_run=dry_run,
+            )
 
             if pipeline.refinement_steps and generated_text and pipeline.pipeline_json is None:
                 # Refinement steps are only applied for legacy pipelines (graph-based ones encode them as nodes)
@@ -216,6 +240,7 @@ class ContentGenerationService:
             "since_hours": since_hours,
             "generation_query": scope.query,
             "channel_id": scope.channel_id,
+            "account_phone": pipeline.account_phone,
         }
 
         # Inject read-only agent tools for AgentLoopHandler
@@ -240,6 +265,10 @@ class ContentGenerationService:
             "publish_mode": result.get("publish_mode"),
             "publish_reply": result.get("publish_reply", False),
             "reply_to_message_id": result.get("reply_to_message_id"),
+            "action_counts": result.get("action_counts", {}),
+            "result_kind": result.get("result_kind", "generated_items"),
+            "result_count": result.get("result_count", 0),
+            "node_errors": result.get("node_errors", []),
         }
 
     async def _run_rag(

--- a/src/services/pipeline_executor.py
+++ b/src/services/pipeline_executor.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from src.models import ContentPipeline, PipelineGraph, PipelineNode, PipelineNodeType
 from src.services.pipeline_nodes import NodeContext, get_handler
+from src.services.pipeline_result import get_action_counts, summarize_result
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,8 @@ class PipelineExecutor:
                 continue
 
             handler = get_handler(node.type)
+            prev_current_node_id = services.get("_current_node_id")
+            services["_current_node_id"] = node.id
             try:
                 logger.debug("Executing node %s (%s)", node.id, node.type)
                 await handler.execute(node.config, context, services)
@@ -120,13 +123,32 @@ class PipelineExecutor:
             except Exception:
                 logger.exception("Node %s (%s) failed during pipeline execution", node.id, node.type)
                 raise
+            finally:
+                if prev_current_node_id is None:
+                    services.pop("_current_node_id", None)
+                else:
+                    services["_current_node_id"] = prev_current_node_id
+
+        generated_text = context.get_global("generated_text", "")
+        citations = context.get_global("citations", [])
+        action_counts = get_action_counts(context)
+        node_errors = context.get_errors()
+        result_kind, result_count = summarize_result(
+            generated_text=generated_text,
+            citations=citations,
+            action_counts=action_counts,
+        )
 
         return {
-            "generated_text": context.get_global("generated_text", ""),
+            "generated_text": generated_text,
             "image_url": context.get_global("image_url"),
-            "citations": context.get_global("citations", []),
+            "citations": citations,
             "publish_mode": context.get_global("publish_mode", pipeline.publish_mode.value),
             "publish_reply": context.get_global("publish_reply", False),
             "reply_to_message_id": context.get_global("reply_to_message_id"),
+            "action_counts": action_counts,
+            "result_kind": result_kind,
+            "result_count": result_count,
+            "node_errors": node_errors,
             "context": context,
         }

--- a/src/services/pipeline_filters.py
+++ b/src/services/pipeline_filters.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+
+def _empty_message_filter() -> dict:
+    return {
+        "type": "message_filter",
+        "message_kinds": [],
+        "service_actions": [],
+        "media_types": [],
+        "sender_kinds": [],
+        "forwarded": None,
+        "has_text": None,
+        "keywords": [],
+        "regex": "",
+        "match_links": False,
+    }
+
+
+def normalize_filter_config(raw_config: dict | None) -> dict:
+    config = dict(raw_config or {})
+    filter_type = config.get("type", "keywords")
+
+    if filter_type == "message_filter":
+        normalized = _empty_message_filter()
+        normalized.update(
+            {
+                "message_kinds": list(config.get("message_kinds", []) or []),
+                "service_actions": list(config.get("service_actions", []) or []),
+                "media_types": list(config.get("media_types", []) or []),
+                "sender_kinds": list(config.get("sender_kinds", []) or []),
+                "forwarded": config.get("forwarded"),
+                "has_text": config.get("has_text"),
+                "keywords": list(config.get("keywords", []) or []),
+                "regex": config.get("regex", "") or "",
+                "match_links": bool(config.get("match_links", False)),
+            }
+        )
+        return normalized
+
+    if filter_type == "keywords":
+        normalized = _empty_message_filter()
+        normalized["keywords"] = list(config.get("keywords", []) or [])
+        normalized["match_links"] = bool(config.get("match_links", False))
+        normalized["_filter_type"] = "keywords"
+        return normalized
+
+    if filter_type == "regex":
+        normalized = _empty_message_filter()
+        normalized["regex"] = config.get("pattern", "") or ""
+        normalized["_filter_type"] = "regex"
+        return normalized
+
+    if filter_type == "anonymous_sender":
+        normalized = _empty_message_filter()
+        normalized["sender_kinds"] = ["anonymous_admin"]
+        return normalized
+
+    if filter_type == "service_message":
+        mapping = {
+            "user_joined": "join",
+            "user_left": "leave",
+            "joined": "join",
+            "left": "leave",
+            "pinned": "pin",
+            "pin": "pin",
+            "title_changed": "title_changed",
+            "photo_changed": "photo_changed",
+            "migrate": "migrate",
+            "created": "created",
+        }
+        normalized = _empty_message_filter()
+        normalized["message_kinds"] = ["service"]
+        normalized["service_actions"] = [
+            mapping.get(item, item) for item in list(config.get("service_types", []) or [])
+        ]
+        return normalized
+
+    return _empty_message_filter()
+
+
+def filter_messages(messages: Iterable, raw_config: dict | None) -> list:
+    return [message for message in messages if match_message_filter(message, raw_config)]
+
+
+def match_message_filter(message, raw_config: dict | None) -> bool:
+    config = normalize_filter_config(raw_config)
+    if config.get("type") != "message_filter":
+        return True
+
+    text = getattr(message, "text", None) or ""
+    text_lower = text.lower()
+    message_kind = _safe_scalar(getattr(message, "message_kind", None))
+    service_action = _safe_scalar(getattr(message, "service_action_semantic", None))
+    sender_kind = _safe_scalar(getattr(message, "sender_kind", None))
+    sender_id = _safe_scalar(getattr(message, "sender_id", None))
+    sender_name = _safe_scalar(getattr(message, "sender_name", None))
+
+    if config["message_kinds"] and message_kind not in config["message_kinds"]:
+        if not (
+            config["message_kinds"] == ["service"]
+            and service_action is None
+            and any(item in text_lower for item in ("join", "left", "pinned", "title", "photo", "migrat", "create"))
+        ):
+            return False
+    if config["service_actions"] and service_action not in config["service_actions"]:
+        legacy_aliases = {
+            "join": ("joined", "join"),
+            "leave": ("left", "leave"),
+            "pin": ("pinned", "pin"),
+            "title_changed": ("title",),
+            "photo_changed": ("photo",),
+            "migrate": ("migrat",),
+            "created": ("create", "created"),
+        }
+        if service_action is None:
+            matched = any(
+                any(alias in text_lower for alias in legacy_aliases.get(expected, (expected,)))
+                for expected in config["service_actions"]
+            )
+            if not matched:
+                return False
+        else:
+            return False
+    if config["media_types"] and getattr(message, "media_type", None) not in config["media_types"]:
+        return False
+    if config["sender_kinds"] and sender_kind not in config["sender_kinds"]:
+        if not (
+            sender_kind is None
+            and "anonymous_admin" in config["sender_kinds"]
+            and sender_id is None
+            and sender_name is None
+        ):
+            return False
+
+    expected_forwarded = config.get("forwarded")
+    if expected_forwarded is not None:
+        is_forwarded = getattr(message, "forward_from_channel_id", None) is not None
+        if is_forwarded is not bool(expected_forwarded):
+            return False
+
+    expected_has_text = config.get("has_text")
+    if expected_has_text is not None:
+        has_text = bool(text.strip())
+        if has_text is not bool(expected_has_text):
+            return False
+
+    keywords = [item.lower() for item in config["keywords"] if item]
+    has_keyword_filter = bool(keywords)
+    has_link_filter = config["match_links"]
+    if not has_keyword_filter and not has_link_filter and config.get("_filter_type") == "keywords":
+        return False
+    if keywords and not any(item in text_lower for item in keywords):
+        return False
+
+    if config["match_links"] and not re.search(r"https?://\S+|t\.me/\S+", text):
+        return False
+
+    pattern = config["regex"]
+    if config.get("_filter_type") == "regex" and not pattern:
+        return False
+    if pattern:
+        try:
+            if not re.search(pattern, text, re.IGNORECASE):
+                return False
+        except re.error:
+            return False
+
+    return True
+
+
+def _safe_scalar(value):
+    return value if isinstance(value, (str, int, bool)) or value is None else None

--- a/src/services/pipeline_filters.py
+++ b/src/services/pipeline_filters.py
@@ -82,6 +82,8 @@ def normalize_filter_config(raw_config: dict | None) -> dict:
 
 
 def filter_messages(messages: Iterable, raw_config: dict | None) -> list:
+    if not raw_config:
+        return list(messages)
     return [message for message in messages if match_message_filter(message, raw_config)]
 
 

--- a/src/services/pipeline_nodes/base.py
+++ b/src/services/pipeline_nodes/base.py
@@ -30,6 +30,41 @@ class NodeContext:
     def get_global(self, key: str, default: Any = None) -> Any:
         return self._data.get(f"__global__.{key}", default)
 
+    def record_error(
+        self,
+        *,
+        node_id: str,
+        code: str,
+        detail: str,
+        retry_after: int | None = None,
+    ) -> None:
+        """Record a structured error raised while executing a node.
+
+        Errors are surfaced via ``get_errors()`` and propagated up through
+        ``PipelineExecutor.execute`` into ``metadata["node_errors"]`` so that
+        CLI/web can show why an action-only pipeline produced zero actions.
+        """
+        entry: dict[str, Any] = {
+            "node_id": node_id,
+            "code": code,
+            "detail": detail,
+        }
+        if retry_after is not None:
+            entry["retry_after"] = int(retry_after)
+        key = "__node_errors__"
+        current = self._data.get(key)
+        if not isinstance(current, list):
+            current = []
+            self._data[key] = current
+        current.append(entry)
+
+    def get_errors(self) -> list[dict[str, Any]]:
+        """Return a *copy* of the errors recorded so far."""
+        current = self._data.get("__node_errors__")
+        if not isinstance(current, list):
+            return []
+        return list(current)
+
 
 class BaseNodeHandler(ABC):
     """Abstract base class for pipeline node handlers."""

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -6,9 +6,54 @@ import logging
 import random
 import re
 
+from src.services.pipeline_filters import filter_messages
 from src.services.pipeline_nodes.base import BaseNodeHandler, NodeContext
+from src.services.pipeline_result import increment_action_count
+
+try:  # telethon is an optional dependency at test-time
+    from telethon.errors import (
+        ChatWriteForbiddenError,
+        FloodWaitError,
+        ReactionInvalidError,
+    )
+except ImportError:  # pragma: no cover — handlers import path used without telethon
+    class FloodWaitError(Exception):  # type: ignore[no-redef]
+        seconds = 0
+
+    class ChatWriteForbiddenError(Exception):  # type: ignore[no-redef]
+        pass
+
+    class ReactionInvalidError(Exception):  # type: ignore[no-redef]
+        pass
+
 
 logger = logging.getLogger(__name__)
+
+
+def _current_node_id(services: dict, default: str = "?") -> str:
+    """Return the node id for the currently-executing handler.
+
+    PipelineExecutor.execute injects ``_current_node_id`` into services right
+    before dispatching each handler so that node-level error records carry the
+    source-of-truth id (issue #463).
+    """
+    value = services.get("_current_node_id")
+    return str(value) if value else default
+
+
+def _resolve_account_phone(account_phone: str | None, services: dict, context: NodeContext) -> str | None:
+    """Return explicit account_phone, or discover one from source channel access map."""
+    if account_phone:
+        return account_phone
+    client_pool = services.get("client_pool")
+    if client_pool is None:
+        return None
+    source_ids = context.get_global("source_channel_ids") or []
+    for cid in source_ids:
+        phone = client_pool.get_phone_for_channel(cid)
+        if phone:
+            return phone
+    return None
 
 
 class SourceHandler(BaseNodeHandler):
@@ -221,46 +266,8 @@ class FilterHandler(BaseNodeHandler):
     """Filter messages by various criteria."""
 
     async def execute(self, node_config: dict, context: NodeContext, services: dict) -> None:
-        filter_type = node_config.get("type", "keywords")
         messages = context.get_global("context_messages", [])
-        filtered = []
-
-        if filter_type == "keywords":
-            keywords = [k.lower() for k in node_config.get("keywords", []) if k]
-            match_links = bool(node_config.get("match_links", False))
-            for m in messages:
-                text_lower = (m.text or "").lower()
-                if match_links and re.search(r"https?://\S+|t\.me/\S+", m.text or ""):
-                    filtered.append(m)
-                elif any(kw in text_lower for kw in keywords):
-                    filtered.append(m)
-
-        elif filter_type == "service_message":
-            service_types = node_config.get("service_types", ["user_joined", "user_left"])
-            for m in messages:
-                text_lower = (m.text or "").lower()
-                if any(st in text_lower for st in service_types):
-                    filtered.append(m)
-
-        elif filter_type == "anonymous_sender":
-            for m in messages:
-                if m.sender_id is None or m.sender_name is None:
-                    filtered.append(m)
-
-        elif filter_type == "regex":
-            pattern_str = node_config.get("pattern", "")
-            if pattern_str:
-                try:
-                    pattern = re.compile(pattern_str, re.IGNORECASE)
-                    for m in messages:
-                        if pattern.search(m.text or ""):
-                            filtered.append(m)
-                except re.error:
-                    logger.warning("FilterHandler: invalid regex pattern: %s", pattern_str)
-
-        else:
-            filtered = messages
-
+        filtered = filter_messages(messages, node_config)
         context.set_global("filtered_messages", filtered)
         context.set_global("context_messages", filtered)
 
@@ -283,26 +290,77 @@ class ReactHandler(BaseNodeHandler):
     """Put a reaction on messages (requires Telegram client)."""
 
     async def execute(self, node_config: dict, context: NodeContext, services: dict) -> None:
+        node_id = _current_node_id(services, default="react")
         client_pool = services.get("client_pool")
         if client_pool is None:
-            logger.warning("ReactHandler: no client_pool, skipping")
+            context.record_error(
+                node_id=node_id,
+                code="no_client_pool",
+                detail="client_pool not available in services",
+            )
+            logger.warning("ReactHandler[%s]: no client_pool, skipping", node_id)
             return
 
         messages = context.get_global("context_messages", [])
         emoji = node_config.get("emoji") or "👍"
         random_emoji_list = node_config.get("random_emojis", [])
+        resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
 
         for message in messages:
             acquired_phone: str | None = None
             try:
-                result = await client_pool.get_available_client()
+                if resolved_phone:
+                    result = await client_pool.get_client_by_phone(resolved_phone)
+                else:
+                    result = await client_pool.get_available_client()
                 if result is None:
+                    context.record_error(
+                        node_id=node_id,
+                        code="no_available_client",
+                        detail=(
+                            f"no client_pool slot available for phone={resolved_phone}"
+                            if resolved_phone
+                            else "all accounts are flood-waited or disconnected"
+                        ),
+                    )
                     break
                 session, acquired_phone = result
                 chosen_emoji = random.choice(random_emoji_list) if random_emoji_list else emoji
                 await session.send_reaction(message.channel_id, message.message_id, chosen_emoji)
-            except Exception:
-                logger.warning("ReactHandler: failed to react to message %s", message.message_id, exc_info=True)
+                increment_action_count(context, "react")
+            except FloodWaitError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="flood_wait",
+                    detail=f"FloodWaitError on message {message.message_id}: {exc}",
+                    retry_after=int(getattr(exc, "seconds", 0) or 0),
+                )
+            except ChatWriteForbiddenError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="chat_write_forbidden",
+                    detail=(
+                        f"ChatWriteForbiddenError on message {message.message_id}: {exc}"
+                    ),
+                )
+            except ReactionInvalidError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="reaction_invalid",
+                    detail=f"ReactionInvalidError on message {message.message_id}: {exc}",
+                )
+            except Exception as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="unexpected_error",
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
+                logger.warning(
+                    "ReactHandler[%s]: failed to react to message %s",
+                    node_id,
+                    message.message_id,
+                    exc_info=True,
+                )
             finally:
                 if acquired_phone is not None:
                     await client_pool.release_client(acquired_phone)
@@ -312,9 +370,15 @@ class ForwardHandler(BaseNodeHandler):
     """Forward messages to target dialogs (requires Telegram client)."""
 
     async def execute(self, node_config: dict, context: NodeContext, services: dict) -> None:
+        node_id = _current_node_id(services, default="forward")
         client_pool = services.get("client_pool")
         if client_pool is None:
-            logger.warning("ForwardHandler: no client_pool, skipping")
+            context.record_error(
+                node_id=node_id,
+                code="no_client_pool",
+                detail="client_pool not available in services",
+            )
+            logger.warning("ForwardHandler[%s]: no client_pool, skipping", node_id)
             return
 
         messages = context.get_global("context_messages", [])
@@ -329,12 +393,43 @@ class ForwardHandler(BaseNodeHandler):
             try:
                 result = await client_pool.get_client_by_phone(phone)
                 if result is None:
+                    context.record_error(
+                        node_id=node_id,
+                        code="no_available_client",
+                        detail=(
+                            f"no client_pool slot available for phone={phone}"
+                        ),
+                    )
                     continue
                 session, acquired_phone = result
                 for message in messages:
                     await session.forward_messages(dialog_id, message.message_id, message.channel_id)
-            except Exception:
-                logger.warning("ForwardHandler: failed to forward to %s", dialog_id, exc_info=True)
+                    increment_action_count(context, "forward")
+            except FloodWaitError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="flood_wait",
+                    detail=f"FloodWaitError forwarding to {dialog_id}: {exc}",
+                    retry_after=int(getattr(exc, "seconds", 0) or 0),
+                )
+            except ChatWriteForbiddenError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="chat_write_forbidden",
+                    detail=f"ChatWriteForbiddenError forwarding to {dialog_id}: {exc}",
+                )
+            except Exception as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="unexpected_error",
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
+                logger.warning(
+                    "ForwardHandler[%s]: failed to forward to %s",
+                    node_id,
+                    dialog_id,
+                    exc_info=True,
+                )
             finally:
                 if acquired_phone is not None:
                     await client_pool.release_client(acquired_phone)
@@ -344,24 +439,67 @@ class DeleteMessageHandler(BaseNodeHandler):
     """Delete filtered messages (requires Telegram client)."""
 
     async def execute(self, node_config: dict, context: NodeContext, services: dict) -> None:
+        node_id = _current_node_id(services, default="delete_message")
         client_pool = services.get("client_pool")
         if client_pool is None:
-            logger.warning("DeleteMessageHandler: no client_pool, skipping")
+            context.record_error(
+                node_id=node_id,
+                code="no_client_pool",
+                detail="client_pool not available in services",
+            )
+            logger.warning("DeleteMessageHandler[%s]: no client_pool, skipping", node_id)
             return
 
         messages = context.get_global("context_messages", [])
+        resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
 
         for message in messages:
             acquired_phone: str | None = None
             try:
-                result = await client_pool.get_available_client()
+                if resolved_phone:
+                    result = await client_pool.get_client_by_phone(resolved_phone)
+                else:
+                    result = await client_pool.get_available_client()
                 if result is None:
+                    context.record_error(
+                        node_id=node_id,
+                        code="no_available_client",
+                        detail=(
+                            f"no client_pool slot available for phone={resolved_phone}"
+                            if resolved_phone
+                            else "all accounts are flood-waited or disconnected"
+                        ),
+                    )
                     break
                 session, acquired_phone = result
                 await session.delete_messages(message.channel_id, [message.message_id])
-            except Exception:
+                increment_action_count(context, "delete_message")
+            except FloodWaitError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="flood_wait",
+                    detail=f"FloodWaitError deleting message {message.message_id}: {exc}",
+                    retry_after=int(getattr(exc, "seconds", 0) or 0),
+                )
+            except ChatWriteForbiddenError as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="chat_write_forbidden",
+                    detail=(
+                        f"ChatWriteForbiddenError deleting message {message.message_id}: {exc}"
+                    ),
+                )
+            except Exception as exc:
+                context.record_error(
+                    node_id=node_id,
+                    code="unexpected_error",
+                    detail=f"{type(exc).__name__}: {exc}",
+                )
                 logger.warning(
-                    "DeleteMessageHandler: failed to delete message %s", message.message_id, exc_info=True
+                    "DeleteMessageHandler[%s]: failed to delete message %s",
+                    node_id,
+                    message.message_id,
+                    exc_info=True,
                 )
             finally:
                 if acquired_phone is not None:

--- a/src/services/pipeline_result.py
+++ b/src/services/pipeline_result.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+RESULT_KIND_GENERATED_ITEMS = "generated_items"
+RESULT_KIND_PROCESSED_MESSAGES = "processed_messages"
+_ACTION_COUNTS_KEY = "action_counts"
+
+
+def increment_action_count(context: Any, action: str, amount: int = 1) -> None:
+    if amount <= 0:
+        return
+    current = context.get_global(_ACTION_COUNTS_KEY, {}) or {}
+    counts = dict(current)
+    counts[action] = int(counts.get(action, 0)) + amount
+    context.set_global(_ACTION_COUNTS_KEY, counts)
+
+
+def get_action_counts(context: Any) -> dict[str, int]:
+    raw = context.get_global(_ACTION_COUNTS_KEY, {}) or {}
+    return {
+        str(key): int(value)
+        for key, value in raw.items()
+        if isinstance(key, str) and isinstance(value, int | float)
+    }
+
+
+def summarize_result(
+    *,
+    generated_text: str | None,
+    citations: list[Any] | None,
+    action_counts: dict[str, int] | None,
+) -> tuple[str, int]:
+    citation_count = len(citations or [])
+    text_present = bool((generated_text or "").strip())
+    if citation_count > 0 or text_present:
+        return RESULT_KIND_GENERATED_ITEMS, citation_count or 1
+    processed_count = sum(max(0, int(value)) for value in (action_counts or {}).values())
+    return RESULT_KIND_PROCESSED_MESSAGES, processed_count
+
+
+def result_kind_label(result_kind: str | None) -> str:
+    if result_kind == RESULT_KIND_PROCESSED_MESSAGES:
+        return "Обработано"
+    return "Сгенерировано"

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -22,6 +22,7 @@ from src.models import (
     PipelineTarget,
     PipelineTemplate,
 )
+from src.services.pipeline_filters import normalize_filter_config
 from src.services.pipeline_llm_requirements import pipeline_needs_llm
 
 logger = logging.getLogger(__name__)
@@ -153,7 +154,9 @@ class PipelineService:
         generate_interval_minutes: int = 60,
         is_active: bool = True,
         react_emoji: str | None = None,
+        filter_config: dict | None = None,
         dag_source_channel_ids: list[int] | None = None,
+        account_phone: str | None = None,
     ) -> bool:
         existing = await self.get(pipeline_id)
         existing_pipeline_json = existing.pipeline_json if existing else None
@@ -176,6 +179,7 @@ class PipelineService:
             generate_interval_minutes=generate_interval_minutes,
             is_active=is_active,
             skip_llm_validation=skip_llm_validation,
+            account_phone=account_phone,
         )
 
         # Preserve existing pipeline_json and apply node-level config updates
@@ -195,6 +199,11 @@ class PipelineService:
                         else:
                             node.config["emoji"] = emojis[0] if emojis else "👍"
                             node.config["random_emojis"] = []
+            if filter_config is not None:
+                normalized_filter = normalize_filter_config(filter_config)
+                for node in updated_graph.nodes:
+                    if node.type == PipelineNodeType.FILTER:
+                        node.config = normalized_filter
         pipeline = pipeline.model_copy(update={"pipeline_json": updated_graph})
 
         # For DAG pipelines, source/target are managed via pipeline_json nodes, not DB tables
@@ -355,6 +364,7 @@ class PipelineService:
         is_active: bool,
         last_generated_id: int = 0,
         skip_llm_validation: bool = False,
+        account_phone: str | None = None,
     ) -> ContentPipeline:
         cleaned_name = name.strip()
         if not cleaned_name:
@@ -384,6 +394,7 @@ class PipelineService:
             is_active=is_active,
             last_generated_id=last_generated_id,
             generate_interval_minutes=generate_interval_minutes,
+            account_phone=account_phone or None,
         )
 
     @staticmethod
@@ -494,6 +505,7 @@ class PipelineService:
             generation_backend=data.get("generation_backend", PipelineGenerationBackend.CHAIN),
             generate_interval_minutes=int(data.get("generate_interval_minutes", 60)),
             is_active=False,
+            account_phone=data.get("account_phone"),
         )
         self._inject_runtime_refs(pipeline_json, source_ids, target_refs)
         pipeline = pipeline.model_copy(update={"pipeline_json": pipeline_json})

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -88,6 +88,28 @@ class PipelineService:
             bundle = PipelineBundle.from_database(bundle)
         self._bundle = bundle
 
+    @staticmethod
+    def _hydrate_runtime_refs(
+        pipeline: ContentPipeline,
+        sources: list[PipelineSource],
+        targets: list[PipelineTarget],
+    ) -> ContentPipeline:
+        """Backfill graph source/target refs from sidecar tables for runtime consistency."""
+        if pipeline.pipeline_json is None:
+            return pipeline
+
+        graph = pipeline.pipeline_json.model_copy(deep=True)
+        PipelineService._inject_runtime_refs(
+            graph,
+            [source.channel_id for source in sources],
+            [
+                PipelineTargetRef(phone=target.phone, dialog_id=target.dialog_id)
+                for target in targets
+                if target.phone
+            ],
+        )
+        return pipeline.model_copy(update={"pipeline_json": graph})
+
     async def add(
         self,
         *,
@@ -185,10 +207,41 @@ class PipelineService:
         return await self._bundle.update(pipeline_id, pipeline, sources, targets)
 
     async def list(self, active_only: bool = False) -> list[ContentPipeline]:
-        return await self._bundle.get_all(active_only)
+        pipelines = await self._bundle.get_all(active_only)
+        pipeline_ids = [
+            pipeline.id
+            for pipeline in pipelines
+            if pipeline.id is not None and pipeline.pipeline_json is not None
+        ]
+        if not pipeline_ids:
+            return pipelines
+
+        all_sources, all_targets = await asyncio.gather(
+            self._batch_sources(pipeline_ids),
+            self._batch_targets(pipeline_ids),
+        )
+        sources_by_pid = _group_by_pipeline(all_sources)
+        targets_by_pid = _group_by_pipeline(all_targets)
+        return [
+            self._hydrate_runtime_refs(
+                pipeline,
+                sources_by_pid.get(pipeline.id, []),
+                targets_by_pid.get(pipeline.id, []),
+            )
+            if pipeline.id is not None and pipeline.pipeline_json is not None else pipeline
+            for pipeline in pipelines
+        ]
 
     async def get(self, pipeline_id: int) -> ContentPipeline | None:
-        return await self._bundle.get_by_id(pipeline_id)
+        pipeline = await self._bundle.get_by_id(pipeline_id)
+        if pipeline is None or pipeline.pipeline_json is None or pipeline.id is None:
+            return pipeline
+
+        sources, targets = await asyncio.gather(
+            self._bundle.list_sources(pipeline_id),
+            self._bundle.list_targets(pipeline_id),
+        )
+        return self._hydrate_runtime_refs(pipeline, sources, targets)
 
     async def delete(self, pipeline_id: int) -> None:
         await self._bundle.delete(pipeline_id)
@@ -215,6 +268,7 @@ class PipelineService:
             self._bundle.list_targets(pipeline_id),
             self._bundle.list_channels(include_filtered=True),
         )
+        pipeline = self._hydrate_runtime_refs(pipeline, sources, targets)
         channels_by_id = {channel.channel_id: channel for channel in channels}
         return {
             "pipeline": pipeline,
@@ -247,7 +301,11 @@ class PipelineService:
         targets_by_pid = _group_by_pipeline(all_targets)
         return [
             {
-                "pipeline": p,
+                "pipeline": self._hydrate_runtime_refs(
+                    p,
+                    sources_by_pid.get(p.id, []),
+                    targets_by_pid.get(p.id, []),
+                ) if p.id is not None and p.pipeline_json is not None else p,
                 "sources": sources_by_pid.get(p.id, []),
                 "targets": targets_by_pid.get(p.id, []),
                 "source_ids": [s.channel_id for s in sources_by_pid.get(p.id, [])],

--- a/src/services/task_enqueuer.py
+++ b/src/services/task_enqueuer.py
@@ -87,7 +87,7 @@ class TaskEnqueuer:
             return None
         task_id = await self._db.repos.tasks.create_generic_task(
             CollectionTaskType.PIPELINE_RUN,
-            title=f"Pipeline run #{pipeline_id}",
+            title=f"Запуск пайплайна #{pipeline_id}",
             payload=PipelineRunTaskPayload(pipeline_id=pipeline_id, dry_run=dry_run, since_hours=since_hours),
         )
         logger.info("Enqueued PIPELINE_RUN task #%d for pipeline_id=%d", task_id, pipeline_id)

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -278,6 +278,9 @@ class UnifiedDispatcher:
                 channels_err += 1
                 cursor += 1
             else:
+                fresh = await self._tasks.get_collection_task(task.id)
+                if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
+                    return
                 if result is None:
                     availability = await self._collector.get_stats_availability()
                     if (
@@ -531,7 +534,7 @@ class UnifiedDispatcher:
                 await self._tasks.update_collection_task(
                     task.id,
                     CollectionTaskStatus.COMPLETED,
-                    messages_collected=1,
+                    messages_collected=run.result_count,
                     note=f"Pipeline run id={run_id}",
                 )
             except Exception as exc:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -78,6 +78,21 @@ class AllCollectionClientsFloodedError(RuntimeError):
 
 
 class Collector:
+    _SERVICE_ACTION_SEMANTICS = {
+        "MessageActionChatAddUser": "join",
+        "MessageActionChatJoinedByLink": "join",
+        "MessageActionChatJoinedByRequest": "join",
+        "MessageActionChatDeleteUser": "leave",
+        "MessageActionPinMessage": "pin",
+        "MessageActionChatEditTitle": "title_changed",
+        "MessageActionChatEditPhoto": "photo_changed",
+        "MessageActionChatDeletePhoto": "photo_changed",
+        "MessageActionChatMigrateTo": "migrate",
+        "MessageActionChannelMigrateFrom": "migrate",
+        "MessageActionChatCreate": "created",
+        "MessageActionChannelCreate": "created",
+    }
+
     def __init__(
         self,
         pool: ClientPool,
@@ -763,8 +778,13 @@ class Collector:
                             sender_id=msg.sender_id,
                             sender_name=self._get_sender_name(msg),
                             text=msg.text,
+                            message_kind=self._get_message_kind(msg),
                             detected_lang=TranslationService.detect_language(msg.text),
                             media_type=self._get_media_type(msg),
+                            service_action_raw=self._get_service_action_raw(msg),
+                            service_action_semantic=self._get_service_action_semantic(msg),
+                            service_action_payload_json=self._get_service_action_payload(msg),
+                            sender_kind=self._get_sender_kind(msg),
                             topic_id=topic_id,
                             reactions_json=self._extract_reactions(msg),
                             views=getattr(msg, "views", None),
@@ -1289,3 +1309,35 @@ class Collector:
             if hasattr(msg.sender, "title"):
                 return msg.sender.title
         return None
+
+    @classmethod
+    def _get_message_kind(cls, msg) -> str:
+        return "service" if getattr(msg, "action", None) is not None else "regular"
+
+    @staticmethod
+    def _get_service_action_raw(msg) -> str | None:
+        action = getattr(msg, "action", None)
+        return type(action).__name__ if action is not None else None
+
+    @classmethod
+    def _get_service_action_semantic(cls, msg) -> str | None:
+        action_raw = cls._get_service_action_raw(msg)
+        if action_raw is None:
+            return None
+        return cls._SERVICE_ACTION_SEMANTICS.get(action_raw, "other")
+
+    @staticmethod
+    def _get_service_action_payload(msg) -> str | None:
+        action = getattr(msg, "action", None)
+        if action is None:
+            return None
+        payload = {key: value for key, value in action.to_dict().items() if key != "_"}
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True) if payload else None
+
+    @staticmethod
+    def _get_sender_kind(msg) -> str:
+        if getattr(msg, "post", False):
+            return "channel"
+        if getattr(msg, "sender_id", None) is None:
+            return "anonymous_admin"
+        return "user"

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -50,6 +50,7 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
         app.state.session_secret = container.session_secret
         app.state.llm_provider_service = container.llm_provider_service
         app.state.timing_buffer = container.timing_buffer
+        app.state.task_enqueuer = container.task_enqueuer
     elif not hasattr(app.state, "templates"):
         app.state.templates = configure_template_globals(
             Jinja2Templates(directory=str(TEMPLATES_DIR)),

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Resp
 
 from src.agent.prompt_template import ALLOWED_TEMPLATE_VARIABLES
 from src.models import PipelineGenerationBackend, PipelinePublishMode
+from src.services.pipeline_filters import filter_messages, normalize_filter_config
 from src.services.pipeline_llm_requirements import (
     get_dag_source_channel_ids,
     get_react_emoji_config,
@@ -53,6 +54,44 @@ def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
             raise PipelineValidationError("Некорректный dialog id для pipeline target.") from exc
         refs.append(PipelineTargetRef(phone=phone, dialog_id=dialog_id))
     return refs
+
+
+def _get_filter_config(pipeline) -> dict | None:
+    graph = getattr(pipeline, "pipeline_json", None)
+    if graph is None:
+        return None
+    node = next((item for item in graph.nodes if item.type.value == "filter"), None)
+    if node is None:
+        return None
+    return normalize_filter_config(node.config)
+
+
+def _build_filter_config_from_form(
+    *,
+    filter_present: str,
+    filter_message_kinds: list[str],
+    filter_service_actions: list[str],
+    filter_media_types: list[str],
+    filter_sender_kinds: list[str],
+    filter_keywords: str,
+    filter_regex: str,
+    filter_has_text: str,
+) -> dict | None:
+    if not filter_present:
+        return None
+    keywords = [item.strip() for item in filter_keywords.splitlines() if item.strip()]
+    return normalize_filter_config(
+        {
+            "type": "message_filter",
+            "message_kinds": filter_message_kinds,
+            "service_actions": filter_service_actions,
+            "media_types": filter_media_types,
+            "sender_kinds": filter_sender_kinds,
+            "keywords": keywords,
+            "regex": filter_regex.strip(),
+            "has_text": True if filter_has_text else None,
+        }
+    )
 
 
 @router.get("/api/channels/search", response_class=JSONResponse)
@@ -191,6 +230,7 @@ async def create_wizard_submit(
     run_after: str = Form(""),
     since_value: int = Form(24),
     since_unit: str = Form("h"),
+    account_phone: str = Form(""),
 ):
     import json as _json
 
@@ -211,6 +251,7 @@ async def create_wizard_submit(
             "target_refs": target_refs,
             "generate_interval_minutes": generate_interval_minutes,
             "pipeline_json": graph_data,
+            "account_phone": account_phone or None,
         }
         pipeline_id = await svc.import_json(data)
     except PipelineValidationError as exc:
@@ -295,7 +336,16 @@ async def edit_pipeline(
     generate_interval_minutes: int = Form(60),
     is_active: bool = Form(False),
     react_emoji: str = Form(""),
+    filter_present: str = Form(""),
+    filter_message_kinds: list[str] = Form(default=[]),
+    filter_service_actions: list[str] = Form(default=[]),
+    filter_media_types: list[str] = Form(default=[]),
+    filter_sender_kinds: list[str] = Form(default=[]),
+    filter_keywords: str = Form(""),
+    filter_regex: str = Form(""),
+    filter_has_text: str = Form(""),
     dag_source_channel_ids: list[int] = Form(default=[]),
+    account_phone: str = Form(""),
 ):
     svc: PipelineService = deps.pipeline_service(request)
     phone = request.query_params.get("phone")
@@ -322,7 +372,18 @@ async def edit_pipeline(
             generate_interval_minutes=generate_interval_minutes,
             is_active=is_active,
             react_emoji=react_emoji,
+            filter_config=_build_filter_config_from_form(
+                filter_present=filter_present,
+                filter_message_kinds=filter_message_kinds,
+                filter_service_actions=filter_service_actions,
+                filter_media_types=filter_media_types,
+                filter_sender_kinds=filter_sender_kinds,
+                filter_keywords=filter_keywords,
+                filter_regex=filter_regex,
+                filter_has_text=filter_has_text,
+            ),
             dag_source_channel_ids=dag_source_channel_ids,
+            account_phone=account_phone,
         )
     except PipelineValidationError as exc:
         return _pipeline_redirect(str(exc), error=True, phone=phone)
@@ -435,6 +496,7 @@ async def edit_page(request: Request, pipeline_id: int):
             "needs_publish_mode": pipeline_needs_publish_mode(pipeline),
             "is_dag": pipeline_is_dag(pipeline),
             "react_emoji": get_react_emoji_config(pipeline),
+            "filter_config": _get_filter_config(pipeline),
             "dag_source_channel_ids": get_dag_source_channel_ids(pipeline),
         },
     )
@@ -543,43 +605,32 @@ async def generate_pipeline(
     provider_service = deps.get_llm_provider_service(request)
     if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
         return _pipeline_redirect("llm_not_configured", error=True)
-    if not pipeline_needs_llm(pipeline):
-        return _pipeline_redirect("pipeline_no_llm_nodes", error=True)
-    provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
 
-    from src.services.generation_service import GenerationService
+    from src.services.content_generation_service import ContentGenerationService
+    from src.services.quality_scoring_service import QualityScoringService
 
-    gen = GenerationService(engine, provider_callable=provider_callable)
-    scope = await svc.get_retrieval_scope(pipeline)
-    run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
+    gen = ContentGenerationService(
+        db,
+        engine,
+        config=request.app.state.config,
+        quality_service=QualityScoringService(db, provider_service=provider_service),
+        provider_service=provider_service,
+    )
     try:
-        await db.repos.generation_runs.set_status(run_id, "running")
-    except Exception:
-        await db.repos.generation_runs.set_status(run_id, "failed")
-        raise
-    try:
-        result = await gen.generate(
-            query=scope.query,
-            prompt_template=pipeline.prompt_template,
+        run = await gen.generate(
+            pipeline=pipeline,
             model=(model or pipeline.llm_model),
             max_tokens=max_tokens,
             temperature=temperature,
-            channel_id=scope.channel_id,
         )
-        await db.repos.generation_runs.save_result(
-            run_id, result.get("generated_text", ""), {"citations": result.get("citations", [])}
-        )
-        await db.repos.generation_runs.set_status(run_id, "completed")
     except Exception:
-        logger.exception("Generation failed for pipeline_id=%d run_id=%d", pipeline_id, run_id)
-        await db.repos.generation_runs.set_status(run_id, "failed")
+        logger.exception("Generation failed for pipeline_id=%d", pipeline_id)
         runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
         return deps.get_templates(request).TemplateResponse(
             request,
             "pipelines/generate.html",
             {"pipeline": pipeline, "runs": runs, "error": "Generation failed", "request": request},
         )
-    run = await db.repos.generation_runs.get(run_id)
     return deps.get_templates(request).TemplateResponse(
         request,
         "pipelines/generate.html",
@@ -620,8 +671,6 @@ async def get_refinement_steps(request: Request, pipeline_id: int):
 
 def _apply_pipeline_filter(pipeline, messages: list) -> int:
     """Count messages that would pass the filter node, if any."""
-    import re as _re
-
     if pipeline.pipeline_json is None:
         return len(messages)
     graph = pipeline.pipeline_json
@@ -631,32 +680,7 @@ def _apply_pipeline_filter(pipeline, messages: list) -> int:
     )
     if filter_node is None:
         return len(messages)
-    cfg = filter_node.config
-    ft = cfg.get("type", "keywords")
-    count = 0
-    for m in messages:
-        text = (m.text or "").lower() if hasattr(m, "text") else ""
-        if ft == "keywords":
-            kws = [k.lower() for k in cfg.get("keywords", [])]
-            if any(k in text for k in kws):
-                count += 1
-        elif ft == "regex":
-            pat = cfg.get("pattern", "")
-            try:
-                if pat and _re.search(pat, text, _re.IGNORECASE):
-                    count += 1
-            except _re.error:
-                pass  # treat malformed pattern as non-matching
-        elif ft == "service_message":
-            stypes = cfg.get("service_types", [])
-            if any(s in text for s in stypes):
-                count += 1
-        elif ft == "anonymous_sender":
-            if not getattr(m, "sender_id", None):
-                count += 1
-        else:
-            count += 1
-    return count
+    return len(filter_messages(messages, filter_node.config))
 
 
 @router.get("/dry-run-count", response_class=JSONResponse)

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -7,10 +7,12 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from src.services.pipeline_result import result_kind_label
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
 
 logger = logging.getLogger(__name__)
+_PIPELINE_RUN_NOTE_RE = re.compile(r"Pipeline run id=(\d+)")
 
 router = APIRouter()
 
@@ -297,6 +299,42 @@ async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
     return payload if isinstance(payload, dict) else {}
 
 
+async def _load_pipeline_run_result_meta(db, tasks) -> dict[int, dict[str, object]]:
+    run_ids_by_task_id: dict[int, int] = {}
+    for task in tasks:
+        if task.id is None or task.task_type.value != "pipeline_run" or not task.note:
+            continue
+        match = _PIPELINE_RUN_NOTE_RE.search(task.note)
+        if match is None:
+            continue
+        run_ids_by_task_id[task.id] = int(match.group(1))
+    if not run_ids_by_task_id:
+        return {}
+
+    runs = await asyncio.gather(*(db.repos.generation_runs.get(run_id) for run_id in run_ids_by_task_id.values()))
+    result: dict[int, dict[str, object]] = {}
+    for task_id, run in zip(run_ids_by_task_id.keys(), runs, strict=False):
+        if run is None:
+            continue
+        metadata = run.metadata if isinstance(run.metadata, dict) else {}
+        raw_errors = metadata.get("node_errors")
+        node_errors = raw_errors if isinstance(raw_errors, list) else []
+        errors_count = len(node_errors)
+        first_error_detail: str | None = None
+        if node_errors and isinstance(node_errors[0], dict):
+            detail = node_errors[0].get("detail")
+            if isinstance(detail, str):
+                first_error_detail = detail
+        result[task_id] = {
+            "kind": run.result_kind,
+            "count": run.result_count,
+            "label": result_kind_label(run.result_kind),
+            "errors_count": errors_count,
+            "first_error_detail": first_error_detail,
+        }
+    return result
+
+
 _PRESERVED_SCHEDULER_QUERY_KEYS = ("status", "page", "limit")
 
 
@@ -402,6 +440,15 @@ async def _scheduler_page_inner(
         _build_collector_health_context(request),
     )
     tasks, filtered_count = tasks_page
+    pipeline_result_meta = await _load_pipeline_run_result_meta(db, tasks)
+    result_column_title = "Результат"
+    visible_pipeline_labels = {
+        str(meta["label"])
+        for meta in pipeline_result_meta.values()
+        if isinstance(meta.get("label"), str)
+    }
+    if tasks and all(task.task_type.value == "pipeline_run" for task in tasks) and len(visible_pipeline_labels) == 1:
+        result_column_title = next(iter(visible_pipeline_labels))
 
     total_pages = max(1, (filtered_count + limit - 1) // limit)
     if page > total_pages:
@@ -433,6 +480,8 @@ async def _scheduler_page_inner(
         "pending_collect_count": pending_collect_count,
         "scheduler_jobs": scheduler_jobs,
         "collector_health": collector_health,
+        "pipeline_result_meta": pipeline_result_meta,
+        "result_column_title": result_column_title,
     }
 
     templates = deps.get_templates(request)

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -212,6 +212,9 @@
                             <i class="bi bi-circle text-secondary" title="Неактивен"></i>
                             {% endif %}
                             <strong class="text-truncate">{{ pipeline.name }}</strong>
+                            {% if pipeline.id is not none %}
+                            <span class="badge bg-light text-dark border">ID: {{ pipeline.id }}</span>
+                            {% endif %}
                         </div>
                         <div class="small text-muted">
                             {{ pipeline.generation_backend.value }} / {{ pipeline.publish_mode.value }}

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -17,10 +17,21 @@
 
 <form id="wizard-form" method="post" action="/pipelines/create-wizard" data-busy>
 
-<div class="mb-4">
-    <label class="form-label fw-semibold">Название пайплайна</label>
-    <input class="form-control" type="text" name="name" placeholder="Мой пайплайн" id="wizard-name" required>
-    <div class="form-text">Обязательное поле — заполните до перехода на следующий шаг.</div>
+<div class="row g-3 mb-4">
+    <div class="col-12 col-lg-6">
+        <label class="form-label fw-semibold">Название пайплайна</label>
+        <input class="form-control" type="text" name="name" placeholder="Мой пайплайн" id="wizard-name" required>
+        <div class="form-text">Обязательное поле — заполните до перехода на следующий шаг.</div>
+    </div>
+    <div class="col-6 col-md-3 col-lg-2">
+        <label class="form-label">Аккаунт</label>
+        <select class="form-select" name="account_phone">
+            <option value="">Автовыбор</option>
+            {% for account in accounts %}
+            <option value="{{ account.phone }}">{{ account.phone }}</option>
+            {% endfor %}
+        </select>
+    </div>
 </div>
 
 {# === Step 1: Pipeline Type === #}
@@ -244,17 +255,59 @@
             <input class="form-control" type="text" name="filter_pattern" placeholder="https?://\S+">
         </div>
         <div id="filter-service" class="mb-3 d-none">
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="filter_joined" value="1" checked>
-                <label class="form-check-label">user_joined</label>
-            </div>
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" name="filter_left" value="1" checked>
-                <label class="form-check-label">user_left</label>
+            <div class="row g-3">
+                <div class="col-12 col-md-6">
+                    <label class="form-label">Message kind</label>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="filter_message_kind_service" value="1" checked>
+                        <label class="form-check-label">service</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="filter_message_kind_regular" value="1">
+                        <label class="form-check-label">regular</label>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <label class="form-label">Sender kind</label>
+                    {% for value in ["user", "anonymous_admin", "channel", "unknown"] %}
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="filter_sender_kind_{{ value }}" value="1">
+                        <label class="form-check-label">{{ value }}</label>
+                    </div>
+                    {% endfor %}
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Service actions</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        {% for value in ["join", "leave", "pin", "title_changed", "photo_changed", "migrate", "created", "other"] %}
+                        <label class="form-check">
+                            <input class="form-check-input" type="checkbox" name="filter_service_action_{{ value }}" value="1" {{ "checked" if value in ["join", "leave"] else "" }}>
+                            <span class="form-check-label">{{ value }}</span>
+                        </label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Media types</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        {% for value in ["service", "text", "photo", "video", "voice", "audio", "sticker", "document", "poll"] %}
+                        <label class="form-check">
+                            <input class="form-check-input" type="checkbox" name="filter_media_type_{{ value }}" value="1">
+                            <span class="form-check-label">{{ value }}</span>
+                        </label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" name="filter_has_text" value="1">
+                        <label class="form-check-label">Только сообщения с текстом</label>
+                    </div>
+                </div>
             </div>
         </div>
         <div id="filter-anonymous" class="mb-3 d-none">
-            <p class="text-muted">Будут отфильтрованы все сообщения от анонимных отправителей.</p>
+            <p class="text-muted">Будут отфильтрованы сообщения c `sender_kind=anonymous_admin`.</p>
         </div>
 
         <h5 class="mt-4 mb-3">Действие с отфильтрованными</h5>
@@ -653,12 +706,34 @@
             } else if (ft === "regex") {
                 filterConfig = { type: "regex", pattern: document.querySelector('[name="filter_pattern"]').value };
             } else if (ft === "service_message") {
-                var stypes = [];
-                if (document.querySelector('[name="filter_joined"]').checked) stypes.push("user_joined");
-                if (document.querySelector('[name="filter_left"]').checked) stypes.push("user_left");
-                filterConfig = { type: "service_message", service_types: stypes };
+                var messageKinds = [];
+                if (document.querySelector('[name="filter_message_kind_service"]').checked) messageKinds.push("service");
+                if (document.querySelector('[name="filter_message_kind_regular"]').checked) messageKinds.push("regular");
+                var serviceActions = [];
+                ["join", "leave", "pin", "title_changed", "photo_changed", "migrate", "created", "other"].forEach(function(value) {
+                    var el = document.querySelector('[name="filter_service_action_' + value + '"]');
+                    if (el && el.checked) serviceActions.push(value);
+                });
+                var senderKinds = [];
+                ["user", "anonymous_admin", "channel", "unknown"].forEach(function(value) {
+                    var el = document.querySelector('[name="filter_sender_kind_' + value + '"]');
+                    if (el && el.checked) senderKinds.push(value);
+                });
+                var mediaTypes = [];
+                ["service", "text", "photo", "video", "voice", "audio", "sticker", "document", "poll"].forEach(function(value) {
+                    var el = document.querySelector('[name="filter_media_type_' + value + '"]');
+                    if (el && el.checked) mediaTypes.push(value);
+                });
+                filterConfig = {
+                    type: "message_filter",
+                    message_kinds: messageKinds,
+                    service_actions: serviceActions,
+                    sender_kinds: senderKinds,
+                    media_types: mediaTypes,
+                    has_text: document.querySelector('[name="filter_has_text"]').checked ? true : null
+                };
             } else {
-                filterConfig = { type: "anonymous_sender" };
+                filterConfig = { type: "message_filter", sender_kinds: ["anonymous_admin"] };
             }
             nodes.push({ id: "filter_1", type: "filter", name: "Фильтр", config: filterConfig, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "filter_1" });
@@ -680,7 +755,7 @@
             edges.push({ from: "filter_1", to: "action_1" });
 
         } else if (pipelineType === "cleanup") {
-            nodes.push({ id: "filter_1", type: "filter", name: "Фильтр join/leave", config: { type: "service_message", service_types: ["user_joined", "user_left"] }, position: { x: 220, y: 0 } });
+            nodes.push({ id: "filter_1", type: "filter", name: "Фильтр join/leave", config: { type: "message_filter", message_kinds: ["service"], service_actions: ["join", "leave"] }, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "filter_1" });
             nodes.push({ id: "delete_1", type: "delete_message", name: "Удаление", config: {}, position: { x: 440, y: 0 } });
             edges.push({ from: "filter_1", to: "delete_1" });

--- a/src/web/templates/pipelines/edit.html
+++ b/src/web/templates/pipelines/edit.html
@@ -13,6 +13,15 @@
             <label class="form-label">Название</label>
             <input class="form-control" type="text" name="name" value="{{ pipeline.name }}" required>
         </div>
+        <div class="col-6 col-md-3 col-lg-2">
+            <label class="form-label">Аккаунт</label>
+            <select class="form-select" name="account_phone">
+                <option value="">Автовыбор</option>
+                {% for account in accounts %}
+                <option value="{{ account.phone }}" {{ "selected" if account.phone == pipeline.account_phone }}>{{ account.phone }}</option>
+                {% endfor %}
+            </select>
+        </div>
         {% if not is_dag %}
         <div class="col-6 col-md-3 col-lg-2">
             <label class="form-label">Бэкенд</label>
@@ -97,6 +106,63 @@
         <label class="form-label"><i class="bi bi-emoji-smile"></i> Реакция</label>
         <input class="form-control" type="text" name="react_emoji" value="{{ react_emoji }}" placeholder="Например: 👍 🔥 ❤️">
         <div class="form-text">Один или несколько emoji через запятую или пробел — на каждое сообщение будет выбрана случайная.</div>
+    </div>
+    {% endif %}
+
+    {% if filter_config is not none %}
+    <input type="hidden" name="filter_present" value="1">
+    <div class="card border-0 shadow-sm mb-3">
+        <div class="card-body">
+            <div class="d-flex align-items-center gap-2 mb-3">
+                <i class="bi bi-funnel"></i>
+                <strong>Semantic filter</strong>
+            </div>
+            <div class="row g-3">
+                <div class="col-12 col-lg-6">
+                    <label class="form-label">Message kind</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="filter_message_kinds" value="regular" {{ "checked" if "regular" in filter_config.message_kinds }}> <span class="form-check-label">regular</span></label>
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="filter_message_kinds" value="service" {{ "checked" if "service" in filter_config.message_kinds }}> <span class="form-check-label">service</span></label>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <label class="form-label">Sender kind</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        {% for value in ["user", "anonymous_admin", "channel", "unknown"] %}
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="filter_sender_kinds" value="{{ value }}" {{ "checked" if value in filter_config.sender_kinds }}> <span class="form-check-label">{{ value }}</span></label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Service actions</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        {% for value in ["join", "leave", "pin", "title_changed", "photo_changed", "migrate", "created", "other"] %}
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="filter_service_actions" value="{{ value }}" {{ "checked" if value in filter_config.service_actions }}> <span class="form-check-label">{{ value }}</span></label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Media types</label>
+                    <div class="d-flex flex-wrap gap-3">
+                        {% for value in ["service", "text", "photo", "video", "voice", "audio", "sticker", "document", "poll"] %}
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="filter_media_types" value="{{ value }}" {{ "checked" if value in filter_config.media_types }}> <span class="form-check-label">{{ value }}</span></label>
+                        {% endfor %}
+                    </div>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <label class="form-label">Keywords</label>
+                    <textarea class="form-control" rows="3" name="filter_keywords">{{ filter_config.keywords | join('\n') }}</textarea>
+                </div>
+                <div class="col-12 col-lg-6">
+                    <label class="form-label">Regex</label>
+                    <input class="form-control" type="text" name="filter_regex" value="{{ filter_config.regex or '' }}">
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" name="filter_has_text" value="1" id="filter-has-text" {{ "checked" if filter_config.has_text }}>
+                        <label class="form-check-label" for="filter-has-text">Только сообщения с текстом</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     {% endif %}
 

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -299,7 +299,7 @@
                     <th>Тип</th>
                     <th>Канал / Описание</th>
                     <th>Статус</th>
-                    <th>Результат</th>
+                    <th>{{ result_column_title }}</th>
                     <th>Создана</th>
                     <th>Завершена</th>
                     <th>Действие</th>
@@ -319,8 +319,16 @@
                         {{ task_status_text(t) }}
                     </td>
                     <td>
+                        {% set pipeline_meta = pipeline_result_meta.get(t.id) if pipeline_result_meta else None %}
                         {% if t.task_type == 'stats_all' and t.payload and t.payload.channel_ids %}
                             {{ t.messages_collected }}/{{ t.payload.channel_ids|length }}
+                        {% elif t.task_type.value == 'pipeline_run' and pipeline_meta %}
+                            <small class="text-muted d-block">{{ pipeline_meta.label }}</small>
+                            {{ pipeline_meta.count }}
+                            {% if pipeline_meta.errors_count %}
+                                <span class="badge text-bg-warning pipe-run-warning ms-1"
+                                      title="{{ pipeline_meta.first_error_detail or '' }}">⚠ {{ pipeline_meta.errors_count }}</span>
+                            {% endif %}
                         {% else %}
                             {{ t.messages_collected }}
                         {% endif %}
@@ -359,8 +367,15 @@
                         </span>
                     </div>
                     <small class="text-muted">
+                        {% set pipeline_meta = pipeline_result_meta.get(t.id) if pipeline_result_meta else None %}
                         {% if t.task_type == 'stats_all' and t.payload and t.payload.channel_ids %}
                             {{ t.messages_collected }}/{{ t.payload.channel_ids|length }}
+                        {% elif t.task_type.value == 'pipeline_run' and pipeline_meta %}
+                            {{ pipeline_meta.label }}: {{ pipeline_meta.count }}
+                            {% if pipeline_meta.errors_count %}
+                                <span class="badge text-bg-warning pipe-run-warning ms-1"
+                                      title="{{ pipeline_meta.first_error_detail or '' }}">⚠ {{ pipeline_meta.errors_count }}</span>
+                            {% endif %}
                         {% else %}
                             {{ t.messages_collected }} сообщ.
                         {% endif %}

--- a/tests/factories/pipeline_runs.py
+++ b/tests/factories/pipeline_runs.py
@@ -1,0 +1,171 @@
+"""Shared factories for pipeline-run related test fixtures.
+
+Used across executor, dispatcher, CLI, web route, and agent tool tests so that
+scenario drift cannot make the same "run" mean different things in different
+layers (issue #463).
+
+All factories produce real Pydantic models (not SimpleNamespace) so type/field
+drift surfaces as a test failure rather than silently passing.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    GenerationRun,
+    PipelineRunTaskPayload,
+)
+from src.services.pipeline_result import (
+    RESULT_KIND_GENERATED_ITEMS,
+    RESULT_KIND_PROCESSED_MESSAGES,
+)
+
+
+def _default_created_at() -> datetime:
+    return datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _build_citations(count: int) -> list[dict[str, Any]]:
+    return [
+        {
+            "channel_id": -1000 - i,
+            "channel_title": f"Channel {i}",
+            "message_id": 100 + i,
+            "date": "2026-04-19T10:00:00+00:00",
+        }
+        for i in range(count)
+    ]
+
+
+def make_generation_run(
+    *,
+    run_id: int | None = 1,
+    pipeline_id: int = 1,
+    text: str = "Generated content",
+    citations_count: int = 2,
+    status: str = "completed",
+    moderation_status: str = "pending",
+    quality_score: float | None = None,
+    created_at: datetime | None = None,
+) -> GenerationRun:
+    """Factory for a *pure generation* run — result_kind=generated_items."""
+    citations = _build_citations(citations_count)
+    metadata: dict[str, Any] = {
+        "citations": citations,
+        "result_kind": RESULT_KIND_GENERATED_ITEMS,
+        "result_count": citations_count,
+    }
+    ts = created_at or _default_created_at()
+    return GenerationRun(
+        id=run_id,
+        pipeline_id=pipeline_id,
+        status=status,
+        generated_text=text,
+        metadata=metadata,
+        moderation_status=moderation_status,
+        quality_score=quality_score,
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+def make_action_only_run(
+    *,
+    run_id: int | None = 1,
+    pipeline_id: int = 1,
+    action_counts: dict[str, int] | None = None,
+    status: str = "completed",
+    moderation_status: str = "pending",
+    created_at: datetime | None = None,
+) -> GenerationRun:
+    """Factory for an *action-only* run (no text, no citations).
+
+    result_kind=processed_messages, result_count=sum(action_counts).
+    """
+    counts = dict(action_counts or {"react": 3})
+    total = sum(max(0, int(v)) for v in counts.values())
+    metadata: dict[str, Any] = {
+        "citations": [],
+        "action_counts": counts,
+        "result_kind": RESULT_KIND_PROCESSED_MESSAGES,
+        "result_count": total,
+    }
+    ts = created_at or _default_created_at()
+    return GenerationRun(
+        id=run_id,
+        pipeline_id=pipeline_id,
+        status=status,
+        generated_text="",
+        metadata=metadata,
+        moderation_status=moderation_status,
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+def make_mixed_run(
+    *,
+    run_id: int | None = 1,
+    pipeline_id: int = 1,
+    text: str = "Generated with actions",
+    citations_count: int = 2,
+    action_counts: dict[str, int] | None = None,
+    status: str = "completed",
+    moderation_status: str = "pending",
+    created_at: datetime | None = None,
+) -> GenerationRun:
+    """Factory for a *mixed* run (generation + actions).
+
+    Per issue #463 decision: generation semantics wins (result_kind=generated_items,
+    result_count=citations_count), but metadata.action_counts is ALWAYS present so
+    UI/tests can surface both dimensions.
+    """
+    counts = dict(action_counts or {"react": 4})
+    citations = _build_citations(citations_count)
+    metadata: dict[str, Any] = {
+        "citations": citations,
+        "action_counts": counts,
+        "result_kind": RESULT_KIND_GENERATED_ITEMS,
+        "result_count": citations_count,
+    }
+    ts = created_at or _default_created_at()
+    return GenerationRun(
+        id=run_id,
+        pipeline_id=pipeline_id,
+        status=status,
+        generated_text=text,
+        metadata=metadata,
+        moderation_status=moderation_status,
+        created_at=ts,
+        updated_at=ts,
+    )
+
+
+def make_pipeline_run_task(
+    *,
+    task_id: int | None = 1,
+    pipeline_id: int = 1,
+    run_id: int | None = 1,
+    status: CollectionTaskStatus = CollectionTaskStatus.COMPLETED,
+    messages_collected: int = 0,
+    note: str | None = None,
+) -> CollectionTask:
+    """Factory for a CollectionTask representing a completed pipeline_run."""
+    effective_note = note if note is not None else (
+        f"Pipeline run id={run_id}" if run_id is not None else None
+    )
+    return CollectionTask(
+        id=task_id,
+        task_type=CollectionTaskType.PIPELINE_RUN,
+        status=status,
+        payload=PipelineRunTaskPayload(pipeline_id=pipeline_id),
+        messages_collected=messages_collected,
+        note=effective_note,
+        created_at=_default_created_at(),
+        completed_at=_default_created_at(),
+    )

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -371,6 +371,20 @@ async def test_claim_next_due_stats_task_success(collection_tasks_repo):
     assert claimed.started_at is not None
 
 
+async def test_claim_next_due_stats_task_recovers_from_stale_transaction(collection_tasks_repo):
+    """A stale transaction on the shared connection must not break claim flow."""
+    payload = StatsAllTaskPayload(channel_ids=[1, 2])
+    task_id = await collection_tasks_repo.create_stats_task(payload)
+
+    await collection_tasks_repo._db.execute("BEGIN")
+    now = datetime.now(tz=timezone.utc)
+    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
+
+    assert claimed is not None
+    assert claimed.id == task_id
+    assert claimed.status == CollectionTaskStatus.RUNNING
+
+
 async def test_claim_next_due_stats_task_respects_run_after(collection_tasks_repo):
     """Test that run_after is respected."""
     now = datetime.now(tz=timezone.utc)

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -81,6 +81,32 @@ async def test_insert_message_with_all_fields(messages_repo):
     assert messages[0].topic_id == 5
 
 
+async def test_insert_message_with_structured_facets(messages_repo):
+    """Structured message classification fields should round-trip through storage."""
+    msg = Message(
+        channel_id=1,
+        message_id=101,
+        text="Alice joined via invite link",
+        media_type="service",
+        message_kind="service",
+        service_action_raw="MessageActionChatJoinedByLink",
+        service_action_semantic="join",
+        service_action_payload_json='{"inviter_id": 42}',
+        sender_kind="user",
+        date=datetime(2026, 3, 16, 12, 5, 0),
+    )
+    result = await messages_repo.insert_message(msg)
+    assert result is True
+
+    messages, _ = await messages_repo.search_messages()
+    stored = next(m for m in messages if m.message_id == 101)
+    assert stored.message_kind == "service"
+    assert stored.service_action_raw == "MessageActionChatJoinedByLink"
+    assert stored.service_action_semantic == "join"
+    assert stored.service_action_payload_json == '{"inviter_id": 42}'
+    assert stored.sender_kind == "user"
+
+
 # insert_messages_batch tests
 
 

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -72,6 +72,30 @@ async def test_claim_next_command_rolls_back_on_error(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_claim_next_command_recovers_from_stale_transaction(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.refresh",
+                payload={"phone": "+1"},
+                requested_by="test",
+            )
+        )
+
+        assert db.db is not None
+        await db.db.execute("BEGIN")
+
+        claimed = await db.repos.telegram_commands.claim_next_command()
+        assert claimed is not None
+        assert claimed.status == TelegramCommandStatus.RUNNING
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
 async def test_runtime_snapshots_repository_upsert_and_get(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()

--- a/tests/routes/test_pipeline_run_cross_layer.py
+++ b/tests/routes/test_pipeline_run_cross_layer.py
@@ -1,0 +1,196 @@
+"""Cross-layer regression for pipeline result semantics (issue #463).
+
+Chains per scenario: real metadata → DB → task row → /scheduler renders
+a semantic cell. This guards against drift between layers — if any single
+layer starts interpreting the result differently, the test fails in that
+layer rather than silently passing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.models import (
+    CollectionTaskStatus,
+    CollectionTaskType,
+    PipelineRunTaskPayload,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_run_and_task(
+    db,
+    *,
+    pipeline_id: int = 1,
+    generated_text: str,
+    metadata: dict,
+    messages_collected: int,
+) -> tuple[int, int]:
+    """Insert a generation_run + completed pipeline_run task, return (task_id, run_id)."""
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "prompt")
+    await db.repos.generation_runs.save_result(run_id, generated_text, metadata)
+
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.PIPELINE_RUN,
+        payload=PipelineRunTaskPayload(pipeline_id=pipeline_id),
+    )
+    await db.repos.tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        messages_collected=messages_collected,
+        note=f"Pipeline run id={run_id}",
+    )
+    return task_id, run_id
+
+
+def _first_pipeline_row(soup):
+    """Return the first tbody <tr> whose type-cell badge indicates a pipeline run."""
+    for table in soup.select("table.tga-table-striped"):
+        tbody = table.find("tbody")
+        if tbody is None:
+            continue
+        for tr in tbody.find_all("tr"):
+            tds = tr.find_all("td")
+            if not tds:
+                continue
+            first = tds[0].get_text(strip=True, separator=" ").lower()
+            if "pipeline" in first or "пайплайн" in first:
+                return tr
+    return None
+
+
+async def test_generation_run_end_to_end(base_app, route_client):
+    """Generation run: DB → task → /scheduler renders 'Сгенерировано N'."""
+    _, db, _ = base_app
+    task_id, run_id = await _seed_run_and_task(
+        db,
+        pipeline_id=1,
+        generated_text="hello",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}],
+            "result_kind": "generated_items",
+            "result_count": 4,
+        },
+        messages_collected=4,
+    )
+
+    # Verify DB contract
+    stored_task = await db.repos.tasks.get_collection_task(task_id)
+    assert stored_task is not None
+    assert stored_task.messages_collected == 4
+
+    stored_run = await db.repos.generation_runs.get(run_id)
+    assert stored_run is not None
+    assert stored_run.result_kind == "generated_items"
+    assert stored_run.result_count == 4
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _first_pipeline_row(soup)
+    assert row is not None
+    cell = row.find_all("td")[3].get_text(strip=True, separator=" ")
+    assert "Сгенерировано" in cell
+    assert "4" in cell
+
+
+async def test_action_only_run_end_to_end_empty_text_no_zero(base_app, route_client):
+    """The #463 headline regression: empty text must NOT manifest as '0 messages'."""
+    _, db, _ = base_app
+    task_id, run_id = await _seed_run_and_task(
+        db,
+        pipeline_id=1,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "action_counts": {"react": 9},
+            "result_kind": "processed_messages",
+            "result_count": 9,
+        },
+        messages_collected=9,
+    )
+
+    # Verify the DB chain preserved the count.
+    stored_run = await db.repos.generation_runs.get(run_id)
+    assert stored_run is not None
+    assert (stored_run.generated_text or "") == ""
+    assert stored_run.result_kind == "processed_messages"
+    assert stored_run.result_count == 9
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _first_pipeline_row(soup)
+    assert row is not None
+    cell = row.find_all("td")[3].get_text(strip=True, separator=" ")
+    assert "Обработано" in cell, f"expected 'Обработано' in {cell!r}"
+    assert "9" in cell
+
+
+async def test_action_run_with_node_errors_shows_warning_badge_end_to_end(base_app, route_client):
+    """Issue #463 observability: when action handler records node_errors
+    (e.g. all accounts flood-waited), scheduler UI must show a warning badge.
+    """
+    _, db, _ = base_app
+    task_id, run_id = await _seed_run_and_task(
+        db,
+        pipeline_id=1,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "result_kind": "processed_messages",
+            "result_count": 0,
+            "node_errors": [
+                {
+                    "node_id": "react_1",
+                    "code": "no_available_client",
+                    "detail": "all accounts are flood-waited",
+                }
+            ],
+        },
+        messages_collected=0,
+    )
+
+    # DB round-trip preserves node_errors.
+    stored = await db.repos.generation_runs.get(run_id)
+    assert stored is not None
+    assert (stored.metadata or {}).get("node_errors")
+
+    resp = await route_client.get("/scheduler/?status=all")
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _first_pipeline_row(soup)
+    assert row is not None
+    cell_html = str(row.find_all("td")[3])
+    assert "⚠" in cell_html or "pipe-run-warning" in cell_html
+
+
+async def test_mixed_run_end_to_end_shows_generation_count(base_app, route_client):
+    """Mixed run — generation semantics wins, UI shows 'Сгенерировано N_citations'."""
+    _, db, _ = base_app
+    task_id, run_id = await _seed_run_and_task(
+        db,
+        pipeline_id=1,
+        generated_text="draft",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}],
+            "action_counts": {"react": 7},
+            "result_kind": "generated_items",
+            "result_count": 2,
+        },
+        messages_collected=2,
+    )
+
+    # Verify metadata survived the DB round-trip.
+    stored_run = await db.repos.generation_runs.get(run_id)
+    assert stored_run is not None
+    assert stored_run.metadata["action_counts"] == {"react": 7}
+
+    resp = await route_client.get("/scheduler/?status=all")
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _first_pipeline_row(soup)
+    assert row is not None
+    cell = row.find_all("td")[3].get_text(strip=True, separator=" ")
+    assert "Сгенерировано" in cell
+    assert "2" in cell

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -92,6 +92,17 @@ async def test_pipelines_page_lists_pipeline(client):
 
 
 @pytest.mark.asyncio
+async def test_pipelines_page_shows_pipeline_id(client):
+    await client.post(
+        "/pipelines/add",
+        data={**_ADD_DATA, "name": "Pipeline With Id"},
+    )
+    resp = await client.get("/pipelines/")
+    assert resp.status_code == 200
+    assert "ID: 1" in resp.text
+
+
+@pytest.mark.asyncio
 async def test_toggle_pipeline(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     resp = await client.post("/pipelines/1/toggle", follow_redirects=False)

--- a/tests/routes/test_pipelines_routes_extra.py
+++ b/tests/routes/test_pipelines_routes_extra.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.models import (
     ContentPipeline,
+    Message,
     PipelineEdge,
     PipelineGenerationBackend,
     PipelineGraph,
@@ -684,6 +686,46 @@ async def test_dry_run_count_dag_pipeline(client, base_app):
     assert resp.status_code == 200
     data = resp.json()
     assert "total" in data
+
+
+@pytest.mark.asyncio
+async def test_dry_run_count_dag_pipeline_falls_back_to_sidecar_sources(client, base_app):
+    """Broken DAG source config should still use persisted pipeline_sources."""
+    app, db, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc()
+
+    await db.insert_message(
+        Message(
+            channel_id=100,
+            message_id=1,
+            text="Recent message",
+            date=datetime.now(timezone.utc),
+        )
+    )
+
+    dag = PipelineGraph(
+        nodes=[
+            PipelineNode(
+                id="src",
+                type=PipelineNodeType.SOURCE,
+                name="src",
+                config={"channel_ids": []},
+            ),
+            PipelineNode(id="react", type=PipelineNodeType.REACT, name="react"),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="react")],
+    )
+    pipeline = ContentPipeline(
+        name="Broken DAG",
+        prompt_template=".",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        pipeline_json=dag,
+    )
+    pipeline_id = await db.repos.content_pipelines.add(pipeline, [100], [])
+
+    resp = await client.get(f"/pipelines/{pipeline_id}/dry-run-count")
+    assert resp.status_code == 200
+    assert resp.json() == {"total": 1, "after_filter": 1}
 
 
 # ── dry_run_count_new ───────────────────────────────────────────────

--- a/tests/routes/test_pipelines_routes_extra.py
+++ b/tests/routes/test_pipelines_routes_extra.py
@@ -528,8 +528,12 @@ async def test_generate_stream_llm_not_configured(client_with_dialog, base_app):
 
 
 @pytest.mark.asyncio
-async def test_generate_pipeline_no_llm_nodes(client, base_app):
-    """POST /pipelines/<id>/generate for pipeline with no LLM nodes redirects."""
+async def test_generate_pipeline_no_llm_nodes_runs_graph(client, base_app):
+    """POST /pipelines/<id>/generate on a pipeline WITHOUT LLM nodes (pure
+    action/publish graph) must NOT be rejected — it's a legitimate use case.
+    The route must run the graph via ContentGenerationService/PipelineExecutor
+    and return a rendered page.
+    """
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
@@ -541,15 +545,32 @@ async def test_generate_pipeline_no_llm_nodes(client, base_app):
         edges=[PipelineEdge(from_node="src", to_node="pub")],
     )
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    async def fake_run_generation(self, pipeline, model, max_tokens, temperature, since_hours=24.0):
+        return {
+            "generated_text": "",
+            "citations": [],
+            "publish_mode": None,
+            "action_counts": {},
+            "result_kind": "processed_messages",
+            "result_count": 0,
+        }
+
+    with (
+        patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc,
+        patch(
+            "src.services.content_generation_service.ContentGenerationService._run_generation",
+            fake_run_generation,
+        ),
+    ):
         mock_svc.return_value.get = AsyncMock(return_value=_make_pipeline(1, dag=dag))
         resp = await client.post(
             "/pipelines/1/generate",
             data={"model": "", "max_tokens": "256", "temperature": "0.0"},
             follow_redirects=False,
         )
-    assert resp.status_code == 303
-    assert "error=pipeline_no_llm_nodes" in resp.headers["location"]
+    # 200 for rendered template (not a redirect with error=pipeline_no_llm_nodes).
+    assert resp.status_code == 200, resp.text
+    assert "pipeline_no_llm_nodes" not in resp.text
 
 
 @pytest.mark.asyncio
@@ -1382,3 +1403,28 @@ def test_apply_pipeline_filter_service_message():
         MagicMock(text="normal message"),
     ]
     assert _apply_pipeline_filter(pipeline, messages) == 2
+
+
+def test_apply_pipeline_filter_message_filter_semantic_service():
+    """Structured message_filter should use semantic service fields, not text."""
+    from src.web.routes.pipelines import _apply_pipeline_filter
+
+    pipeline = MagicMock()
+    pipeline.pipeline_json = PipelineGraph(
+        nodes=[
+            PipelineNode(
+                id="f",
+                type=PipelineNodeType.FILTER,
+                name="f",
+                config={"type": "message_filter", "message_kinds": ["service"], "service_actions": ["join"]},
+            ),
+        ],
+        edges=[],
+    )
+    join_msg = MagicMock(text="localized join text")
+    join_msg.message_kind = "service"
+    join_msg.service_action_semantic = "join"
+    leave_msg = MagicMock(text="localized leave text")
+    leave_msg.message_kind = "service"
+    leave_msg.service_action_semantic = "leave"
+    assert _apply_pipeline_filter(pipeline, [join_msg, leave_msg]) == 1

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.models import Channel, CollectionTaskStatus, SearchQuery, StatsAllTaskPayload
+from src.models import Channel, CollectionTaskStatus, ContentPipeline, SearchQuery, StatsAllTaskPayload
 
 
 @pytest.fixture
@@ -165,6 +165,40 @@ async def test_scheduler_page_shows_tasks(client):
 
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_scheduler_page_shows_processed_message_label_for_pipeline_runs(client):
+    db = client._transport.app.state.db
+
+    pipeline_id = await db.repos.content_pipelines.add(
+        pipeline=ContentPipeline(name="Reaction Pipeline", prompt_template=".", publish_mode="moderated"),
+        source_channel_ids=[],
+        targets=[],
+    )
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, ".")
+    await db.repos.generation_runs.save_result(
+        run_id,
+        "",
+        {"result_kind": "processed_messages", "result_count": 3, "action_counts": {"react": 3}},
+    )
+    await db.repos.tasks.create_generic_task(
+        task_type="pipeline_run",
+        title="Reaction Pipeline",
+        payload={"task_kind": "pipeline_run", "pipeline_id": pipeline_id, "dry_run": False, "since_hours": 24.0},
+    )
+    tasks = await db.get_collection_tasks(limit=5)
+    task_id = next(t.id for t in tasks if t.note is None and t.task_type.value == "pipeline_run")
+    await db.repos.tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        messages_collected=3,
+        note=f"Pipeline run id={run_id}",
+    )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    assert "Обработано" in resp.text
 
 
 @pytest.mark.asyncio
@@ -557,3 +591,254 @@ async def test_dry_run_excludes_disabled_scheduler_job(client):
     assert resp.status_code == 200
     assert "enabled_job_query" in resp.text
     assert "disabled_job_query" not in resp.text
+
+
+# ── Issue #463: semantic scheduler cell assertions ───────────────────────────
+
+
+async def _seed_pipeline_run_for_scheduler(
+    db,
+    *,
+    pipeline_id: int = 1,
+    generated_text: str = "",
+    metadata: dict | None = None,
+    messages_collected: int = 0,
+) -> int:
+    """Seed a completed pipeline_run task + generation_run; return task_id."""
+    from src.models import CollectionTaskStatus, CollectionTaskType, PipelineRunTaskPayload
+
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "prompt")
+    await db.repos.generation_runs.save_result(run_id, generated_text, metadata or {})
+
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.PIPELINE_RUN,
+        payload=PipelineRunTaskPayload(pipeline_id=pipeline_id),
+    )
+    await db.repos.tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        messages_collected=messages_collected,
+        note=f"Pipeline run id={run_id}",
+    )
+    return task_id
+
+
+def _find_scheduler_row_by_task_id(soup, task_id):
+    """Find a scheduler table row for the given task_id.
+
+    For running/pending tasks, matches the cancel-form action.
+    For completed tasks (no form), falls back to searching the /pipelines/ links
+    or other task-id-bearing attributes. If none, returns None.
+    """
+    form = soup.find(
+        "form",
+        attrs={
+            "action": lambda v: v is not None and f"/scheduler/tasks/{task_id}/cancel" in v
+        },
+    )
+    if form:
+        return form.find_parent("tr")
+    # Completed tasks have no cancel form — fall back to rows where the task
+    # metadata is embedded elsewhere. The current template does not stamp a
+    # data-task-id, so we can't locate by id alone for COMPLETED rows. Callers
+    # should assert on page-level text in that case.
+    return None
+
+
+def _scheduler_desktop_rows(soup):
+    """Return all <tr> rows inside the Tasks desktop table."""
+    # The tasks table is preceded by card-header "Задачи"; select tbody rows.
+    tables = soup.select("table.tga-table-striped")
+    rows: list = []
+    for table in tables:
+        tbody = table.find("tbody")
+        if tbody is None:
+            continue
+        rows.extend(tbody.find_all("tr"))
+    return rows
+
+
+def _pipeline_row(soup):
+    """Return the <tr> whose first <td> badge text equals 'pipeline_run' label.
+
+    The task-type badge is rendered via `task_type_label(t)` in the template;
+    for PIPELINE_RUN that returns a Russian label. We look for rows whose first
+    cell contains any of the expected labels.
+    """
+    for row in _scheduler_desktop_rows(soup):
+        tds = row.find_all("td")
+        if not tds:
+            continue
+        first_text = tds[0].get_text(strip=True, separator=" ")
+        if "pipeline" in first_text.lower() or "пайплайн" in first_text.lower():
+            return row
+    return None
+
+
+def _non_pipeline_rows(soup):
+    return [
+        r
+        for r in _scheduler_desktop_rows(soup)
+        if (
+            r.find_all("td")
+            and "pipeline" not in r.find_all("td")[0].get_text(strip=True).lower()
+            and "пайплайн" not in r.find_all("td")[0].get_text(strip=True).lower()
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scheduler_renders_processed_label_for_action_only_run(base_app, route_client):
+    """Action-only pipeline run should render «Обработано» label + action count."""
+    from bs4 import BeautifulSoup
+
+    _, db, _ = base_app
+    await _seed_pipeline_run_for_scheduler(
+        db,
+        pipeline_id=1,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "action_counts": {"react": 5},
+            "result_kind": "processed_messages",
+            "result_count": 5,
+        },
+        messages_collected=5,
+    )
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _pipeline_row(soup)
+    assert row is not None, "scheduler must render the pipeline_run task row"
+    result_cell_text = row.find_all("td")[3].get_text(strip=True, separator=" ")
+    assert "Обработано" in result_cell_text, (
+        f"Expected 'Обработано' in result cell, got: {result_cell_text!r}"
+    )
+    assert "5" in result_cell_text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_renders_generation_label_for_generation_run(base_app, route_client):
+    from bs4 import BeautifulSoup
+
+    _, db, _ = base_app
+    await _seed_pipeline_run_for_scheduler(
+        db,
+        pipeline_id=1,
+        generated_text="draft",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "result_kind": "generated_items",
+            "result_count": 3,
+        },
+        messages_collected=3,
+    )
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _pipeline_row(soup)
+    assert row is not None
+    result_cell_text = row.find_all("td")[3].get_text(strip=True, separator=" ")
+    assert "Сгенерировано" in result_cell_text, (
+        f"Expected 'Сгенерировано' in result cell, got: {result_cell_text!r}"
+    )
+    assert "3" in result_cell_text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shows_warning_badge_when_run_has_node_errors(base_app, route_client):
+    """Issue #463: when metadata.node_errors is non-empty, scheduler must render
+    a warning badge with count next to result_count, so users see why 0.
+    """
+    from bs4 import BeautifulSoup
+
+    _, db, _ = base_app
+    await _seed_pipeline_run_for_scheduler(
+        db,
+        pipeline_id=1,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "result_kind": "processed_messages",
+            "result_count": 0,
+            "node_errors": [
+                {"node_id": "react", "code": "flood_wait", "detail": "..."}
+            ],
+        },
+        messages_collected=0,
+    )
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.text, "html.parser")
+    row = _pipeline_row(soup)
+    assert row is not None
+    cell_html = str(row.find_all("td")[3])
+    assert "⚠" in cell_html or "pipe-run-warning" in cell_html
+
+
+@pytest.mark.asyncio
+async def test_scheduler_mixed_page_non_pipeline_tasks_unaffected(base_app, route_client):
+    """When a pipeline_run coexists with a plain non-pipeline task on /scheduler,
+    the non-pipeline row must keep its plain messages_collected display
+    (no spurious «Обработано»/«Сгенерировано» labels).
+    """
+    from bs4 import BeautifulSoup
+
+    from src.models import CollectionTaskStatus, CollectionTaskType
+
+    _, db, _ = base_app
+
+    # Pipeline-run task (generation semantics).
+    await _seed_pipeline_run_for_scheduler(
+        db,
+        pipeline_id=1,
+        generated_text="draft",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}],
+            "result_kind": "generated_items",
+            "result_count": 2,
+        },
+        messages_collected=2,
+    )
+
+    # Plain non-pipeline task sharing the same scheduler page.
+    plain_task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.STATS_ALL,
+    )
+    await db.repos.tasks.update_collection_task(
+        plain_task_id,
+        CollectionTaskStatus.COMPLETED,
+        messages_collected=42,
+    )
+
+    resp = await route_client.get("/scheduler/?status=all")
+    assert resp.status_code == 200
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    pipe_row = _pipeline_row(soup)
+    plain_rows = _non_pipeline_rows(soup)
+
+    assert pipe_row is not None, "pipeline row missing"
+    assert plain_rows, "plain (non-pipeline) row missing"
+    pipe_text = pipe_row.find_all("td")[3].get_text(strip=True, separator=" ")
+    # pick the plain row whose result cell contains '42' (our seeded value)
+    plain_text = None
+    for r in plain_rows:
+        cell = r.find_all("td")[3].get_text(strip=True, separator=" ")
+        if "42" in cell:
+            plain_text = cell
+            break
+    assert plain_text is not None, (
+        "Could not find non-pipeline row with messages_collected=42"
+    )
+
+    assert "Сгенерировано" in pipe_text
+    # Plain (non-pipeline) row must NOT inherit the pipeline-specific labels.
+    assert "Сгенерировано" not in plain_text
+    assert "Обработано" not in plain_text
+    assert "42" in plain_text

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -558,3 +558,65 @@ class TestEditPipelineTool:
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["edit_pipeline"]({"confirm": True})
         assert "pipeline_id обязателен" in _text(result)
+
+
+# ── Issue #463: agent tools expose result semantics ──────────────────────────
+
+
+class TestPipelineRunsToolResultSemantics:
+    @pytest.mark.asyncio
+    async def test_list_runs_shows_result_kind_and_count(self, mock_db):
+        from tests.factories.pipeline_runs import make_action_only_run, make_generation_run
+
+        runs = [
+            make_generation_run(run_id=10, pipeline_id=1, citations_count=3, text="hello"),
+            make_action_only_run(run_id=11, pipeline_id=1, action_counts={"react": 5}),
+        ]
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=runs)
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["list_pipeline_runs"]({"pipeline_id": 1, "limit": 10})
+
+        text = _text(result)
+        # generation run
+        assert "run_id=10" in text
+        assert "generated_items:3" in text
+        # action-only run
+        assert "run_id=11" in text
+        assert "processed_messages:5" in text
+
+    @pytest.mark.asyncio
+    async def test_get_run_shows_semantic_fields_for_empty_text_run(self, mock_db):
+        """Regression #463: action-only run with empty text must still show
+        result_kind/result_count (not just «(пусто)»).
+        """
+        from tests.factories.pipeline_runs import make_action_only_run
+
+        run = make_action_only_run(run_id=12, pipeline_id=1, action_counts={"forward": 8})
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_run"]({"run_id": 12})
+        text = _text(result)
+
+        assert "Обработано" in text
+        assert "processed_messages:8" in text
+        assert "Run id=12" in text
+
+    @pytest.mark.asyncio
+    async def test_get_run_generation_shows_text_and_label(self, mock_db):
+        from tests.factories.pipeline_runs import make_generation_run
+
+        run = make_generation_run(run_id=13, pipeline_id=1, citations_count=2, text="hello")
+        mock_db.repos = MagicMock()
+        mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_run"]({"run_id": 13})
+        text = _text(result)
+
+        assert "Сгенерировано" in text
+        assert "generated_items:2" in text
+        assert "hello" in text

--- a/tests/test_collection_service_new.py
+++ b/tests/test_collection_service_new.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import Channel
+from src.models import Channel, CollectionTask, CollectionTaskStatus, CollectionTaskType
 from src.services.collection_service import CollectionService
 
 
@@ -183,6 +183,15 @@ async def test_cancel_task_with_live_queue_delegates():
     """With a live queue the service must delegate so RUNNING tasks get interrupted."""
     channels = MagicMock()
     channels.cancel_collection_task = AsyncMock(return_value=True)
+    channels.get_collection_task = AsyncMock(
+        return_value=CollectionTask(
+            id=77,
+            channel_id=100,
+            channel_title="Collect",
+            task_type=CollectionTaskType.CHANNEL_COLLECT,
+            status=CollectionTaskStatus.RUNNING,
+        )
+    )
     collector = MagicMock()
     queue = MagicMock()
     queue.cancel_task = AsyncMock(return_value=True)
@@ -199,12 +208,66 @@ async def test_cancel_task_without_queue_falls_back_to_db():
     """In web-mode (queue=None) the DB path must keep the route from 500'ing (#457)."""
     channels = MagicMock()
     channels.cancel_collection_task = AsyncMock(return_value=True)
+    channels.get_collection_task = AsyncMock(
+        return_value=CollectionTask(
+            id=77,
+            channel_id=100,
+            channel_title="Collect",
+            task_type=CollectionTaskType.CHANNEL_COLLECT,
+            status=CollectionTaskStatus.RUNNING,
+        )
+    )
     collector = MagicMock()
 
     svc = CollectionService(channels, collector, collection_queue=None)
     result = await svc.cancel_task(77)
     assert result is True
     channels.cancel_collection_task.assert_awaited_once_with(77, note=None)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_stats_all_bypasses_queue_and_cancels_collector():
+    channels = MagicMock()
+    channels.get_collection_task = AsyncMock(
+        return_value=CollectionTask(
+            id=88,
+            channel_title="Stats",
+            task_type=CollectionTaskType.STATS_ALL,
+            status=CollectionTaskStatus.RUNNING,
+        )
+    )
+    channels.cancel_collection_task = AsyncMock(return_value=True)
+    collector = MagicMock()
+    collector.cancel = AsyncMock()
+    queue = MagicMock()
+    queue.cancel_task = AsyncMock(return_value=True)
+
+    svc = CollectionService(channels, collector, collection_queue=queue)
+    result = await svc.cancel_task(88, note="stop stats")
+
+    assert result is True
+    channels.cancel_collection_task.assert_awaited_once_with(88, note="stop stats")
+    collector.cancel.assert_awaited_once()
+    queue.cancel_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_returns_false_when_task_missing():
+    channels = MagicMock()
+    channels.get_collection_task = AsyncMock(return_value=None)
+    channels.cancel_collection_task = AsyncMock(return_value=True)
+    collector = MagicMock()
+    collector.cancel = AsyncMock()
+    queue = MagicMock()
+    queue.cancel_task = AsyncMock(return_value=True)
+
+    svc = CollectionService(channels, collector, collection_queue=queue)
+    result = await svc.cancel_task(999)
+
+    assert result is False
+    channels.cancel_collection_task.assert_not_called()
+    collector.cancel.assert_not_called()
+    queue.cancel_task.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -496,6 +496,22 @@ async def test_extract_reactions_custom_emoji():
 
 
 @pytest.mark.asyncio
+async def test_classify_message_service_joined_by_link():
+    from telethon.tl.types import MessageActionChatJoinedByLink
+
+    msg = SimpleNamespace(
+        action=MessageActionChatJoinedByLink(inviter_id=42),
+        sender_id=100,
+        post=False,
+        from_id=None,
+    )
+    assert Collector._get_message_kind(msg) == "service"
+    assert Collector._get_service_action_raw(msg) == "MessageActionChatJoinedByLink"
+    assert Collector._get_service_action_semantic(msg) == "join"
+    assert Collector._get_sender_kind(msg) == "user"
+
+
+@pytest.mark.asyncio
 async def test_collect_channel_collects_media_without_text(db):
     """Collector should collect messages without text (media-only)."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=5)

--- a/tests/test_content_generation_service.py
+++ b/tests/test_content_generation_service.py
@@ -345,3 +345,192 @@ async def test_content_generation_service_records_quality_score():
     finally:
         if original_get:
             provider_service.AgentProviderService.get_provider_callable = original_get
+
+
+# ── Issue #463: _build_metadata invariants ───────────────────────────────────
+
+
+class TestBuildMetadataInvariants:
+    """Pure unit tests on ContentGenerationService._build_metadata.
+
+    Invariants (issue #463):
+      - action_counts ALWAYS survives for mixed / action-only runs.
+      - Pure generation runs stay lean (no action_counts key).
+      - dry_run / publish_reply / reply_to_message_id are opt-in flags.
+    """
+
+    def test_mixed_result_preserves_action_counts(self):
+        result = {
+            "generated_text": "draft",
+            "citations": [{"id": 1}, {"id": 2}],
+            "result_kind": "generated_items",
+            "result_count": 2,
+            "action_counts": {"react": 3},
+            "publish_mode": "moderated",
+        }
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert metadata["action_counts"] == {"react": 3}
+        assert metadata["result_kind"] == "generated_items"
+        assert metadata["result_count"] == 2
+        assert metadata["citations"] == [{"id": 1}, {"id": 2}]
+        assert metadata["effective_publish_mode"] == "moderated"
+        assert "dry_run" not in metadata
+
+    def test_pure_generation_has_no_action_counts_key(self):
+        result = {
+            "generated_text": "draft",
+            "citations": [{"id": 1}],
+            "result_kind": "generated_items",
+            "result_count": 1,
+            "action_counts": {},
+            "publish_mode": "auto",
+        }
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert "action_counts" not in metadata
+        assert metadata["result_kind"] == "generated_items"
+        assert metadata["result_count"] == 1
+
+    def test_action_only_includes_action_counts(self):
+        result = {
+            "generated_text": "",
+            "citations": [],
+            "result_kind": "processed_messages",
+            "result_count": 5,
+            "action_counts": {"react": 5},
+            "publish_mode": "moderated",
+        }
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert metadata["action_counts"] == {"react": 5}
+        assert metadata["result_kind"] == "processed_messages"
+        assert metadata["result_count"] == 5
+
+    def test_dry_run_flag_set(self):
+        result = {"result_kind": "generated_items", "result_count": 1, "publish_mode": "auto"}
+        metadata = ContentGenerationService._build_metadata(result, dry_run=True)
+        assert metadata["dry_run"] is True
+
+    def test_publish_reply_propagates(self):
+        result = {
+            "result_kind": "generated_items",
+            "result_count": 1,
+            "publish_mode": "auto",
+            "publish_reply": True,
+            "reply_to_message_id": 12345,
+        }
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert metadata["publish_reply"] is True
+        assert metadata["reply_to_message_id"] == 12345
+
+    def test_missing_result_count_defaults_to_zero(self):
+        result = {"result_kind": "processed_messages", "publish_mode": "auto"}
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert metadata["result_count"] == 0
+
+    def test_node_errors_preserved_in_metadata(self):
+        """Issue #463: errors from node execution must survive into run.metadata."""
+        result = {
+            "result_kind": "processed_messages",
+            "result_count": 0,
+            "publish_mode": "moderated",
+            "node_errors": [
+                {
+                    "node_id": "react_1",
+                    "code": "chat_write_forbidden",
+                    "detail": "ChatWriteForbiddenError on message 6239",
+                }
+            ],
+        }
+        metadata = ContentGenerationService._build_metadata(result, dry_run=False)
+        assert metadata["node_errors"] == result["node_errors"]
+
+    def test_no_node_errors_key_when_empty(self):
+        """A clean run should not have an empty node_errors key in metadata."""
+        metadata = ContentGenerationService._build_metadata(
+            {
+                "result_kind": "generated_items",
+                "result_count": 1,
+                "publish_mode": "auto",
+                "node_errors": [],
+            },
+            dry_run=False,
+        )
+        assert "node_errors" not in metadata
+
+    def test_no_node_errors_key_when_missing(self):
+        metadata = ContentGenerationService._build_metadata(
+            {
+                "result_kind": "generated_items",
+                "result_count": 1,
+                "publish_mode": "auto",
+            },
+            dry_run=False,
+        )
+        assert "node_errors" not in metadata
+
+
+# ── Issue #463: _run_graph propagates node_errors from PipelineExecutor ──────
+
+
+async def test_run_graph_copies_node_errors_from_executor(monkeypatch):
+    """_run_graph must forward node_errors from PipelineExecutor.execute() so
+    that ContentGenerationService.generate -> _build_metadata sees them.
+    Previously the dict passthrough dropped the key entirely.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.models import ContentPipeline, PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
+    from src.services.content_generation_service import ContentGenerationService
+
+    pipeline = ContentPipeline(
+        id=1,
+        name="X",
+        prompt_template="",
+        pipeline_json=PipelineGraph(
+            nodes=[PipelineNode(id="react", type=PipelineNodeType.REACT, name="react", config={})],
+            edges=[],
+        ),
+    )
+
+    executor_result = {
+        "generated_text": "",
+        "citations": [],
+        "publish_mode": None,
+        "action_counts": {},
+        "result_kind": "processed_messages",
+        "result_count": 0,
+        "node_errors": [
+            {"node_id": "react", "code": "no_client_pool", "detail": "..."}
+        ],
+    }
+
+    class _FakeExecutor:
+        async def execute(self, p, g, services):
+            return executor_result
+
+    monkeypatch.setattr(
+        "src.services.pipeline_executor.PipelineExecutor",
+        _FakeExecutor,
+    )
+    # resolve_retrieval_scope + list_sources path
+    async def _fake_scope(pipeline, list_sources):
+        s = MagicMock()
+        s.query = ""
+        s.channel_id = None
+        return s
+
+    monkeypatch.setattr("src.services.pipeline_service.resolve_retrieval_scope", _fake_scope)
+
+    db = MagicMock()
+    db.repos = MagicMock()
+    db.repos.content_pipelines = MagicMock()
+    db.repos.content_pipelines.list_sources = AsyncMock(return_value=[])
+    db.get_setting = AsyncMock(return_value="")
+
+    svc = ContentGenerationService(db, MagicMock(), config=MagicMock())
+    # Stub _get_provider_callable to avoid hitting provider_service
+    async def _noop_provider(model):
+        return None
+    svc._get_provider_callable = _noop_provider  # type: ignore[attr-defined]
+
+    out = await svc._run_graph(pipeline, None, 100, 0.0)
+    assert out["node_errors"] == executor_result["node_errors"]

--- a/tests/test_content_generation_service.py
+++ b/tests/test_content_generation_service.py
@@ -478,7 +478,7 @@ async def test_run_graph_copies_node_errors_from_executor(monkeypatch):
     """
     from unittest.mock import AsyncMock, MagicMock
 
-    from src.models import ContentPipeline, PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
+    from src.models import ContentPipeline, PipelineGraph, PipelineNode, PipelineNodeType
     from src.services.content_generation_service import ContentGenerationService
 
     pipeline = ContentPipeline(

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -136,3 +136,89 @@ async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
     assert run_after is not None
     assert run_after.status == "published"
     assert run_after.metadata and run_after.metadata.get("published") is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_generate_action_only_runs_graph(pipeline_client, monkeypatch):
+    """Regression: POST /pipelines/{id}/generate on an action-only pipeline
+    (with pipeline_json graph) must exercise PipelineExecutor — not the legacy
+    GenerationService — so action_counts accumulate and result_count>0.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.models import (
+        ContentPipeline,
+        PipelineEdge,
+        PipelineGraph,
+        PipelineNode,
+        PipelineNodeType,
+        PipelinePublishMode,
+        PipelineTarget,
+    )
+    from src.services.pipeline_result import increment_action_count
+
+    app = pipeline_client._transport.app  # type: ignore
+    db = app.state.db
+
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="src", config={}),
+            PipelineNode(id="react", type=PipelineNodeType.REACT, name="react", config={}),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="react")],
+    )
+    pipeline_id = await db.repos.content_pipelines.add(
+        pipeline=ContentPipeline(
+            name="ActionOnlyWeb",
+            prompt_template="",
+            publish_mode=PipelinePublishMode.MODERATED,
+            pipeline_json=graph,
+        ),
+        source_channel_ids=[1001],
+        targets=[
+            PipelineTarget(
+                pipeline_id=0,
+                phone="+100",
+                dialog_id=77,
+                title="Target A",
+                dialog_type="channel",
+            )
+        ],
+    )
+
+    # Ensure the web route's LLM gate lets this action-only pipeline through.
+    mock_llm_service = MagicMock()
+    mock_llm_service.has_providers = MagicMock(return_value=True)
+    mock_llm_service.get_provider_callable = MagicMock(return_value=None)
+    app.state.llm_provider_service = mock_llm_service
+
+    def fake_get_handler(node_type):
+        h = AsyncMock()
+
+        async def _execute(config, ctx, services):
+            if node_type == PipelineNodeType.REACT:
+                increment_action_count(ctx, "react", amount=4)
+
+        h.execute.side_effect = _execute
+        return h
+
+    monkeypatch.setattr(
+        "src.services.pipeline_executor.get_handler", fake_get_handler
+    )
+
+    resp = await pipeline_client.post(
+        f"/pipelines/{pipeline_id}/generate",
+        data={"model": "", "max_tokens": "256", "temperature": "0.0"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200, resp.text
+
+    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+    assert runs, "web generate must create a generation_run"
+    run = runs[0]
+    assert run.status == "completed", (
+        f"run status={run.status}, metadata={run.metadata}"
+    )
+    assert run.result_kind == "processed_messages"
+    assert run.result_count == 4
+    assert (run.metadata or {}).get("action_counts") == {"react": 4}

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -12,7 +12,11 @@ from src.models import (
     Channel,
     ContentPipeline,
     GenerationRun,
+    PipelineEdge,
     PipelineGenerationBackend,
+    PipelineGraph,
+    PipelineNode,
+    PipelineNodeType,
     PipelinePublishMode,
     PipelineTarget,
 )
@@ -237,6 +241,125 @@ def test_pipeline_generate_prints_draft_preview(tmp_path, cli_init_patch, capsys
     assert "Created generation run id=123" in out
     assert "--- DRAFT PREVIEW ---" in out
     assert "Generated draft for CLI" in out
+
+
+def _make_simple_dag_pipeline(db: Database, name: str = "React DAG") -> int:
+    return asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name=name,
+                prompt_template=".",
+                publish_mode=PipelinePublishMode.MODERATED,
+                generation_backend=PipelineGenerationBackend.CHAIN,
+                pipeline_json=PipelineGraph(
+                    nodes=[
+                        PipelineNode(
+                            id="source_1",
+                            type=PipelineNodeType.SOURCE,
+                            name="Источник",
+                            config={"channel_ids": [1001]},
+                        ),
+                        PipelineNode(
+                            id="fetch_1",
+                            type=PipelineNodeType.FETCH_MESSAGES,
+                            name="Загрузка сообщений",
+                            config={},
+                        ),
+                        PipelineNode(
+                            id="react_1",
+                            type=PipelineNodeType.REACT,
+                            name="Реакция",
+                            config={"emoji": "👍"},
+                        ),
+                    ],
+                    edges=[
+                        PipelineEdge(from_node="source_1", to_node="fetch_1"),
+                        PipelineEdge(from_node="fetch_1", to_node="react_1"),
+                    ],
+                ),
+            ),
+            source_channel_ids=[1001],
+            targets=[],
+        )
+    )
+
+
+def test_pipeline_filter_set_show_clear(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_pipeline_filter.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    pipeline_id = _make_simple_dag_pipeline(db)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="filter",
+                filter_action="set",
+                id=pipeline_id,
+                message_kinds=["service"],
+                service_actions=["join"],
+                media_types=[],
+                sender_kinds=[],
+                keywords=[],
+                regex=None,
+                forwarded=None,
+                has_text=None,
+            )
+        )
+        run(_ns(pipeline_action="filter", filter_action="show", id=pipeline_id))
+        run(_ns(pipeline_action="filter", filter_action="clear", id=pipeline_id))
+
+    out = capsys.readouterr().out
+    assert f"Updated filter for pipeline id={pipeline_id}" in out
+    assert "service_actions=join" in out
+    assert f"Cleared filter for pipeline id={pipeline_id}" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    stored = asyncio.run(verify_db.repos.content_pipelines.get_by_id(pipeline_id))
+    asyncio.run(verify_db.close())
+    assert stored is not None
+    assert stored.pipeline_json is not None
+    node_ids = {node.id for node in stored.pipeline_json.nodes}
+    assert "filter_1" not in node_ids
+    edge_pairs = {(edge.from_node, edge.to_node) for edge in stored.pipeline_json.edges}
+    assert ("fetch_1", "react_1") in edge_pairs
+
+
+def test_pipeline_show_includes_filter_summary(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_pipeline_show_filter.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    pipeline_id = _make_simple_dag_pipeline(db, name="Show Filter")
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="filter",
+                filter_action="set",
+                id=pipeline_id,
+                message_kinds=["service"],
+                service_actions=["join"],
+                media_types=[],
+                sender_kinds=[],
+                keywords=[],
+                regex=None,
+                forwarded=None,
+                has_text=None,
+            )
+        )
+        run(_ns(pipeline_action="show", id=pipeline_id))
+
+    out = capsys.readouterr().out
+    assert "name=Show Filter" in out
+    assert "filter:" in out
+    assert "service_actions=join" in out
 
 
 def test_pipeline_generate_wires_agent_manager_for_deep_agents(tmp_path, cli_init_patch, capsys):
@@ -560,7 +683,12 @@ def test_pipeline_delete(tmp_path, cli_init_patch, capsys):
 
 
 def test_pipeline_run_with_preview(tmp_path, cli_init_patch, capsys):
-    """Test run action with preview flag."""
+    """Test run action with preview flag.
+
+    Since the CLI `run` now flows through ContentGenerationService →
+    _run_generation (RAG for pipelines without pipeline_json), we patch
+    _run_generation directly to return a deterministic payload.
+    """
     db_path = str(tmp_path / "cli_pipeline_run_preview.db")
     db = Database(db_path)
     asyncio.run(db.initialize())
@@ -586,16 +714,21 @@ def test_pipeline_run_with_preview(tmp_path, cli_init_patch, capsys):
         )
     )
 
-    class FakeGenerationService:
-        def __init__(self, engine, provider_callable=None):
-            pass
-
-        async def generate(self, **kwargs):
-            return {"generated_text": "Preview content here", "citations": []}
+    async def fake_run_generation(self, pipeline, model, max_tokens, temperature, since_hours=24.0):
+        return {
+            "generated_text": "Preview content here",
+            "citations": [{"id": 1}],
+            "publish_mode": None,
+            "result_kind": "generated_items",
+            "result_count": 1,
+        }
 
     with (
         cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS),
-        patch("src.cli.commands.pipeline.GenerationService", FakeGenerationService),
+        patch(
+            "src.services.content_generation_service.ContentGenerationService._run_generation",
+            fake_run_generation,
+        ),
         patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True),
     ):
         from src.cli.commands.pipeline import run
@@ -795,6 +928,87 @@ def test_pipeline_run_show_not_found(tmp_path, cli_init_patch, capsys):
 
     out = capsys.readouterr().out
     assert "not found" in out
+
+
+def test_pipeline_run_show_prints_result_semantics(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_pipeline_runshow_result.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    import src.cli.runtime  # noqa: F401
+
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="Reaction Pipeline",
+                prompt_template=".",
+                pipeline_json=PipelineGraph(
+                    nodes=[PipelineNode(id="react", type=PipelineNodeType.REACT, name="React", config={})],
+                    edges=[],
+                ),
+                publish_mode=PipelinePublishMode.MODERATED,
+            ),
+            source_channel_ids=[1001],
+            targets=[],
+        )
+    )
+    run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "."))
+    asyncio.run(
+        db.repos.generation_runs.save_result(
+            run_id,
+            "",
+            {
+                "result_kind": "processed_messages",
+                "result_count": 4,
+                "action_counts": {"react": 4},
+            },
+        )
+    )
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="run-show", run_id=run_id))
+
+    out = capsys.readouterr().out
+    assert "result_kind=processed_messages" in out
+    assert "result_count=4" in out
+
+
+def test_pipeline_runs_prints_result_columns(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_pipeline_runs_result.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="Runs Result Pipeline",
+                prompt_template=".",
+                publish_mode=PipelinePublishMode.MODERATED,
+            ),
+            source_channel_ids=[1001],
+            targets=[],
+        )
+    )
+    run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
+    asyncio.run(
+        db.repos.generation_runs.save_result(
+            run_id,
+            "",
+            {"result_kind": "processed_messages", "result_count": 2},
+        )
+    )
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="runs", id=pipeline_id, limit=20, status=None))
+
+    out = capsys.readouterr().out
+    assert "Result" in out
+    assert "processed_messages" in out
+    assert "2" in out
 
 
 def test_pipeline_approve_not_found(tmp_path, cli_init_patch, capsys):
@@ -1623,3 +1837,447 @@ def test_pipeline_add_json_file(tmp_path, cli_init_patch, capsys):
     asyncio.run(verify_db.close())
     assert len(pipelines) == 1
     assert pipelines[0].pipeline_json is not None
+
+
+# ── Issue #463: runs/run-show semantic display ───────────────────────────────
+
+
+def _add_pipeline_and_return_id(db: Database, name: str = "Digest") -> int:
+    _add_pipeline_prereqs(db)
+    return asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name=name,
+                prompt_template="Summarize {source_messages}",
+                publish_mode="moderated",
+            ),
+            source_channel_ids=[1001],
+            targets=[
+                PipelineTarget(
+                    pipeline_id=0,
+                    phone="+100",
+                    dialog_id=77,
+                    title="Target A",
+                    dialog_type="channel",
+                )
+            ],
+        )
+    )
+
+
+def _seed_generation_run(db: Database, *, pipeline_id: int, generated_text: str, metadata: dict) -> int:
+    """Insert a generation run with explicit generated_text/metadata via repo API."""
+    run_id = asyncio.run(db.repos.generation_runs.create_run(pipeline_id, "prompt"))
+    asyncio.run(db.repos.generation_runs.save_result(run_id, generated_text, metadata))
+    return run_id
+
+
+def test_pipeline_runs_shows_semantic_result_for_generation(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_runs_gen.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="Gen")
+    _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="draft",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "result_kind": "generated_items",
+            "result_count": 3,
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="runs", id=pipeline_id, limit=10, status=None))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "generated_items:3" in out
+    assert "completed" in out
+
+
+def test_pipeline_runs_shows_semantic_result_for_action_only(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_runs_act.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="ActOnly")
+    _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "action_counts": {"react": 5},
+            "result_kind": "processed_messages",
+            "result_count": 5,
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(_ns(pipeline_action="runs", id=pipeline_id, limit=10, status=None))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "processed_messages:5" in out
+
+
+def test_pipeline_run_show_prints_semantic_fields_when_text_empty(tmp_path, cli_init_patch, capsys):
+    """Regression #463: run_show must expose result_kind/result_count even when
+    generated_text is empty (action-only run).
+    """
+    db_path = str(tmp_path / "cli_show_empty.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="ShowEmpty")
+    run_id = _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "action_counts": {"react": 7},
+            "result_kind": "processed_messages",
+            "result_count": 7,
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run as cli_run
+
+        cli_run(_ns(pipeline_action="run-show", run_id=run_id))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "result_kind=processed_messages" in out
+    assert "result_count=7" in out
+    assert "result_label=Обработано" in out
+    assert "GENERATED TEXT" not in out  # no preview block for empty text
+
+
+def test_pipeline_run_show_prints_node_errors(tmp_path, cli_init_patch, capsys):
+    """Regression #463: run-show must surface metadata.node_errors so users
+    can diagnose why an action-only pipeline produced result_count=0.
+    """
+    db_path = str(tmp_path / "cli_show_errs.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="Errs")
+    run_id = _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="",
+        metadata={
+            "citations": [],
+            "result_kind": "processed_messages",
+            "result_count": 0,
+            "node_errors": [
+                {
+                    "node_id": "react_1",
+                    "code": "flood_wait",
+                    "detail": "FloodWaitError: 120 seconds",
+                    "retry_after": 120,
+                },
+                {
+                    "node_id": "react_1",
+                    "code": "chat_write_forbidden",
+                    "detail": "ChatWriteForbiddenError on service message",
+                },
+            ],
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run as cli_run
+
+        cli_run(_ns(pipeline_action="run-show", run_id=run_id))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "Ошибки нод:" in out
+    assert "flood_wait" in out
+    assert "chat_write_forbidden" in out
+    assert "retry_after=120" in out
+    assert "react_1" in out
+
+
+def test_pipeline_run_show_no_errors_section_when_clean(tmp_path, cli_init_patch, capsys):
+    """A clean run must not print an empty Ошибки нод: section."""
+    db_path = str(tmp_path / "cli_show_clean.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="Clean")
+    run_id = _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="hi",
+        metadata={
+            "citations": [{"id": 1}],
+            "result_kind": "generated_items",
+            "result_count": 1,
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run as cli_run
+
+        cli_run(_ns(pipeline_action="run-show", run_id=run_id))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "Ошибки нод" not in out
+
+
+def test_pipeline_run_show_generation_case_shows_text_preview(tmp_path, cli_init_patch, capsys):
+    db_path = str(tmp_path / "cli_show_gen.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    pipeline_id = _add_pipeline_and_return_id(db, name="ShowGen")
+    run_id = _seed_generation_run(
+        db,
+        pipeline_id=pipeline_id,
+        generated_text="hello world",
+        metadata={
+            "citations": [{"id": 1}, {"id": 2}],
+            "result_kind": "generated_items",
+            "result_count": 2,
+        },
+    )
+    asyncio.run(db.close())
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run as cli_run
+
+        cli_run(_ns(pipeline_action="run-show", run_id=run_id))
+    asyncio.run(verify_db.close())
+
+    out = capsys.readouterr().out
+    assert "result_kind=generated_items" in out
+    assert "result_count=2" in out
+    assert "hello world" in out
+
+
+# ── Regression: CLI `pipeline run` must use ContentGenerationService ──────────
+
+
+def test_pipeline_run_action_only_records_result_count(tmp_path, cli_init_patch, capsys):
+    """Regression: `pipeline run <id>` on an action-only pipeline must exercise
+    the pipeline graph (PipelineExecutor), so action_counts accumulate and
+    result_count reflects the number of actions — NOT zero.
+
+    Prior bug: CLI called GenerationService (legacy RAG) directly, which had no
+    concept of action nodes, so action-only pipelines always saved result_count=0.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from src.services.pipeline_result import increment_action_count
+
+    db_path = str(tmp_path / "cli_run_action.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="src", config={}),
+            PipelineNode(id="react", type=PipelineNodeType.REACT, name="react", config={}),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="react")],
+    )
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="ActionOnlyCLI",
+                prompt_template="",
+                publish_mode="moderated",
+                pipeline_json=graph,
+            ),
+            source_channel_ids=[1001],
+            targets=[
+                PipelineTarget(
+                    pipeline_id=0,
+                    phone="+100",
+                    dialog_id=77,
+                    title="Target A",
+                    dialog_type="channel",
+                )
+            ],
+        )
+    )
+    asyncio.run(db.close())
+
+    # Fake handlers: SOURCE is a no-op, REACT bumps the action counter 3 times
+    # (as if 3 messages got a reaction). This mirrors ReactHandler's contract
+    # without touching Telegram.
+    def fake_get_handler(node_type):
+        h = AsyncMock()
+
+        async def _execute(config, ctx, services):
+            if node_type == PipelineNodeType.REACT:
+                increment_action_count(ctx, "react", amount=3)
+
+        h.execute.side_effect = _execute
+        return h
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with (
+        cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS),
+        patch(
+            "src.services.pipeline_executor.get_handler",
+            side_effect=fake_get_handler,
+        ),
+    ):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="run",
+                id=pipeline_id,
+                preview=False,
+                publish=False,
+                limit=20,
+                max_tokens=256,
+                temperature=0.0,
+            )
+        )
+    asyncio.run(verify_db.close())
+
+    verify_db2 = Database(db_path)
+    asyncio.run(verify_db2.initialize())
+    runs = asyncio.run(
+        verify_db2.repos.generation_runs.list_by_pipeline(pipeline_id, limit=10)
+    )
+    asyncio.run(verify_db2.close())
+    assert runs, "pipeline run must create a generation_run row"
+    run_row = runs[0]
+    assert run_row.status == "completed", (
+        f"expected status=completed, got {run_row.status!r}"
+    )
+    assert run_row.result_kind == "processed_messages", (
+        f"expected processed_messages, got {run_row.result_kind!r}"
+    )
+    assert run_row.result_count == 3, (
+        f"expected result_count=3 from 3 reactions, got {run_row.result_count}"
+    )
+    assert (run_row.metadata or {}).get("action_counts") == {"react": 3}
+
+
+def test_pipeline_run_generation_pipeline_preserves_result_metadata(
+    tmp_path, cli_init_patch, capsys
+):
+    """Sibling to the action-only regression: generation-flavour pipelines run
+    through the graph and end up with generated_items metadata as well (not the
+    bare {citations: []} that legacy RAG wrote).
+    """
+    from unittest.mock import AsyncMock, patch
+
+    db_path = str(tmp_path / "cli_run_gen.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="src", config={}),
+            PipelineNode(
+                id="gen", type=PipelineNodeType.LLM_GENERATE, name="gen", config={}
+            ),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="gen")],
+    )
+    pipeline_id = asyncio.run(
+        db.repos.content_pipelines.add(
+            pipeline=ContentPipeline(
+                name="GenCLI",
+                prompt_template="hi",
+                llm_model="test-model",
+                publish_mode="moderated",
+                pipeline_json=graph,
+            ),
+            source_channel_ids=[1001],
+            targets=[
+                PipelineTarget(
+                    pipeline_id=0,
+                    phone="+100",
+                    dialog_id=77,
+                    title="Target A",
+                    dialog_type="channel",
+                )
+            ],
+        )
+    )
+    asyncio.run(db.close())
+
+    def fake_get_handler(node_type):
+        h = AsyncMock()
+
+        async def _execute(config, ctx, services):
+            if node_type == PipelineNodeType.LLM_GENERATE:
+                ctx.set_global("generated_text", "hello from graph")
+                ctx.set_global("citations", [{"id": 1}, {"id": 2}])
+
+        h.execute.side_effect = _execute
+        return h
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    with (
+        cli_init_patch(verify_db, *_PIPELINE_INIT_DB_TARGETS),
+        patch(
+            "src.services.pipeline_executor.get_handler",
+            side_effect=fake_get_handler,
+        ),
+        patch(
+            "src.services.provider_service.AgentProviderService.has_providers",
+            lambda self: True,
+        ),
+    ):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="run",
+                id=pipeline_id,
+                preview=False,
+                publish=False,
+                limit=20,
+                max_tokens=256,
+                temperature=0.0,
+            )
+        )
+    asyncio.run(verify_db.close())
+
+    verify_db2 = Database(db_path)
+    asyncio.run(verify_db2.initialize())
+    runs = asyncio.run(
+        verify_db2.repos.generation_runs.list_by_pipeline(pipeline_id, limit=10)
+    )
+    asyncio.run(verify_db2.close())
+    assert runs
+    run_row = runs[0]
+    assert run_row.status == "completed"
+    assert run_row.generated_text == "hello from graph"
+    assert run_row.result_kind == "generated_items"
+    assert run_row.result_count == 2

--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -319,3 +319,224 @@ class TestExecuteSeedsContext:
         assert captured_context.get_global("default_model") == "gpt-4o"
         # publish_mode falls back to pipeline's value
         assert result["publish_mode"] == PipelinePublishMode.MODERATED.value
+
+
+# ---------------------------------------------------------------------------
+# 12. Issue #463 — result semantics per pipeline shape
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorResultSemantics:
+    """Verify executor.execute() returns correct result_kind/result_count for
+    each pipeline shape: generation-only, action-only, mixed, empty-success.
+    """
+
+    @pytest.mark.asyncio
+    async def test_generation_only_graph_returns_generated_items(self):
+        graph = PipelineGraph(
+            nodes=[
+                _node("src", PipelineNodeType.SOURCE),
+                _node("gen", PipelineNodeType.LLM_GENERATE),
+            ],
+            edges=[_edge("src", "gen")],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+
+            async def _execute(config, ctx, services):
+                if node_type == PipelineNodeType.LLM_GENERATE:
+                    ctx.set_global("generated_text", "draft text")
+                    ctx.set_global("citations", [{"id": 1}, {"id": 2}])
+
+            h.execute.side_effect = _execute
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        assert result["result_kind"] == "generated_items"
+        assert result["result_count"] == 2
+        assert result["generated_text"] == "draft text"
+
+    @pytest.mark.asyncio
+    async def test_mixed_graph_generation_wins_but_action_counts_preserved(self):
+        from src.services.pipeline_result import increment_action_count
+
+        graph = PipelineGraph(
+            nodes=[
+                _node("src", PipelineNodeType.SOURCE),
+                _node("gen", PipelineNodeType.LLM_GENERATE),
+                _node("react", PipelineNodeType.REACT),
+            ],
+            edges=[_edge("src", "gen"), _edge("gen", "react")],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+
+            async def _execute(config, ctx, services):
+                if node_type == PipelineNodeType.LLM_GENERATE:
+                    ctx.set_global("generated_text", "mixed draft")
+                    ctx.set_global("citations", [{"id": 1}])
+                if node_type == PipelineNodeType.REACT:
+                    increment_action_count(ctx, "react", amount=3)
+
+            h.execute.side_effect = _execute
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        # Generation wins result_kind/result_count per issue #463.
+        assert result["result_kind"] == "generated_items"
+        assert result["result_count"] == 1
+        # But action counts remain visible for UI/metadata consumers.
+        assert result["action_counts"] == {"react": 3}
+
+    @pytest.mark.asyncio
+    async def test_action_only_graph_with_empty_text_is_not_zero_result(self):
+        """Regression: empty generated_text MUST NOT collapse result_count to 0."""
+        from src.services.pipeline_result import increment_action_count
+
+        graph = PipelineGraph(
+            nodes=[
+                _node("src", PipelineNodeType.SOURCE),
+                _node("react", PipelineNodeType.REACT),
+            ],
+            edges=[_edge("src", "react")],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+
+            async def _execute(config, ctx, services):
+                if node_type == PipelineNodeType.REACT:
+                    increment_action_count(ctx, "react", amount=5)
+
+            h.execute.side_effect = _execute
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        assert result["result_kind"] == "processed_messages"
+        assert result["result_count"] == 5
+        assert (result.get("generated_text") or "") == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_successful_graph_returns_zero_processed(self):
+        graph = PipelineGraph(
+            nodes=[_node("src", PipelineNodeType.SOURCE)],
+            edges=[],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+            h.execute.return_value = None
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        assert result["result_kind"] == "processed_messages"
+        assert result["result_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_executor_propagates_node_errors_from_context(self):
+        """Issue #463: errors recorded via ctx.record_error() must appear in result['node_errors']."""
+        graph = PipelineGraph(
+            nodes=[_node("react", PipelineNodeType.REACT)],
+            edges=[],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+
+            async def _execute(config, ctx, services):
+                ctx.record_error(
+                    node_id="react",
+                    code="no_available_client",
+                    detail="all accounts are flood-waited",
+                )
+
+            h.execute.side_effect = _execute
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        assert result["node_errors"] == [
+            {
+                "node_id": "react",
+                "code": "no_available_client",
+                "detail": "all accounts are flood-waited",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_executor_node_errors_default_empty(self):
+        graph = PipelineGraph(nodes=[_node("src", PipelineNodeType.SOURCE)], edges=[])
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+            h.execute.return_value = None
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            result = await PipelineExecutor().execute(pipeline, graph, {})
+
+        assert result["node_errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_action_types_all_preserved(self):
+        """Multiple action types (react + forward + delete) all surface in action_counts."""
+        from src.services.pipeline_result import increment_action_count
+
+        graph = PipelineGraph(
+            nodes=[
+                _node("src", PipelineNodeType.SOURCE),
+                _node("react", PipelineNodeType.REACT),
+                _node("fwd", PipelineNodeType.FORWARD),
+                _node("del", PipelineNodeType.DELETE_MESSAGE),
+            ],
+            edges=[
+                _edge("src", "react"),
+                _edge("src", "fwd"),
+                _edge("src", "del"),
+            ],
+        )
+        pipeline = _pipeline()
+
+        def fake_get_handler(node_type):
+            h = AsyncMock()
+
+            async def _execute(config, ctx, services):
+                if node_type == PipelineNodeType.REACT:
+                    increment_action_count(ctx, "react", amount=2)
+                elif node_type == PipelineNodeType.FORWARD:
+                    increment_action_count(ctx, "forward", amount=3)
+                elif node_type == PipelineNodeType.DELETE_MESSAGE:
+                    increment_action_count(ctx, "delete_message", amount=1)
+
+            h.execute.side_effect = _execute
+            return h
+
+        with patch("src.services.pipeline_executor.get_handler", side_effect=fake_get_handler):
+            executor = PipelineExecutor()
+            result = await executor.execute(pipeline, graph, {})
+
+        assert result["result_kind"] == "processed_messages"
+        assert result["result_count"] == 6  # 2+3+1
+        assert result["action_counts"] == {"react": 2, "forward": 3, "delete_message": 1}

--- a/tests/test_pipeline_graph.py
+++ b/tests/test_pipeline_graph.py
@@ -17,6 +17,7 @@ from src.services.pipeline_nodes.handlers import (
     DelayHandler,
     FilterHandler,
     LlmGenerateHandler,
+    ReactHandler,
     SourceHandler,
 )
 
@@ -278,6 +279,64 @@ async def test_executor_condition_stops_on_false():
     # condition_result should be False, publish_targets not set
     assert result["context"].get_global("condition_result") is False
     assert result["context"].get_global("publish_targets") is None
+
+
+@pytest.mark.asyncio
+async def test_react_handler_tracks_successful_reactions():
+    class FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        async def send_reaction(self, channel_id, message_id, emoji):
+            self.calls.append((channel_id, message_id, emoji))
+
+    class FakePool:
+        def __init__(self, session):
+            self._session = session
+
+        async def get_client_by_phone(self, phone):
+            return self._session, phone
+
+        async def release_client(self, phone):
+            return None
+
+    msg = type("Msg", (), {"channel_id": 1001, "message_id": 42})()
+    session = FakeSession()
+    handler = ReactHandler()
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [msg])
+
+    await handler.execute(
+        {"emoji": "🔥"},
+        ctx,
+        {"client_pool": FakePool(session), "account_phone": "+100"},
+    )
+
+    assert session.calls == [(1001, 42, "🔥")]
+    assert ctx.get_global("action_counts") == {"react": 1}
+
+
+@pytest.mark.asyncio
+async def test_executor_returns_processed_message_result_for_action_only_pipeline(monkeypatch):
+    class FakeHandler:
+        async def execute(self, node_config, context, services):
+            context.set_global("action_counts", {"react": 3})
+
+    graph = PipelineGraph(
+        nodes=[_node("react", PipelineNodeType.REACT)],
+        edges=[],
+    )
+    pipeline = ContentPipeline(name="reaction", prompt_template=".", pipeline_json=graph)
+    executor = PipelineExecutor()
+
+    monkeypatch.setattr("src.services.pipeline_executor.get_handler", lambda _node_type: FakeHandler())
+
+    result = await executor.execute(pipeline, graph, {})
+
+    assert result["generated_text"] == ""
+    assert result["result_kind"] == "processed_messages"
+    assert result["result_count"] == 3
+    assert result["action_counts"] == {"react": 3}
 
 
 # ── Pipeline model with pipeline_json ────────────────────────────────────────

--- a/tests/test_pipeline_node_context_errors.py
+++ b/tests/test_pipeline_node_context_errors.py
@@ -1,0 +1,39 @@
+"""NodeContext.record_error / get_errors API — issue #463 observability."""
+from __future__ import annotations
+
+from src.services.pipeline_nodes.base import NodeContext
+
+
+def test_record_error_stores_structured_entry():
+    ctx = NodeContext()
+    ctx.record_error(node_id="react_1", code="no_available_client", detail="all flooded")
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    e = errors[0]
+    assert e["node_id"] == "react_1"
+    assert e["code"] == "no_available_client"
+    assert e["detail"] == "all flooded"
+    assert "retry_after" not in e
+
+
+def test_multiple_errors_preserve_order():
+    ctx = NodeContext()
+    ctx.record_error(node_id="a", code="x", detail="first")
+    ctx.record_error(node_id="b", code="y", detail="second", retry_after=42)
+    errs = ctx.get_errors()
+    assert [e["node_id"] for e in errs] == ["a", "b"]
+    assert errs[1]["retry_after"] == 42
+
+
+def test_get_errors_empty_by_default():
+    ctx = NodeContext()
+    assert ctx.get_errors() == []
+
+
+def test_get_errors_returns_copy_not_reference():
+    """Callers must not be able to mutate internal state by editing the list."""
+    ctx = NodeContext()
+    ctx.record_error(node_id="a", code="x", detail="y")
+    errs = ctx.get_errors()
+    errs.append({"node_id": "fake"})
+    assert len(ctx.get_errors()) == 1

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -420,6 +420,42 @@ async def test_filter_invalid_regex():
 
 
 @pytest.mark.asyncio
+async def test_filter_message_filter_service_join():
+    ctx = NodeContext()
+    m1 = _msg(text="joined")
+    m1.message_kind = "service"
+    m1.service_action_semantic = "join"
+    m1.sender_kind = "user"
+    m2 = _msg(text="left")
+    m2.message_kind = "service"
+    m2.service_action_semantic = "leave"
+    m2.sender_kind = "user"
+    ctx.set_global("context_messages", [m1, m2])
+    await FilterHandler().execute(
+        {"type": "message_filter", "message_kinds": ["service"], "service_actions": ["join"]},
+        ctx,
+        {},
+    )
+    assert ctx.get_global("context_messages") == [m1]
+
+
+@pytest.mark.asyncio
+async def test_filter_message_filter_sender_kind():
+    ctx = NodeContext()
+    m1 = _msg(text="anon")
+    m1.sender_kind = "anonymous_admin"
+    m2 = _msg(text="user")
+    m2.sender_kind = "user"
+    ctx.set_global("context_messages", [m1, m2])
+    await FilterHandler().execute(
+        {"type": "message_filter", "sender_kinds": ["anonymous_admin"]},
+        ctx,
+        {},
+    )
+    assert ctx.get_global("context_messages") == [m1]
+
+
+@pytest.mark.asyncio
 async def test_filter_unknown_type_returns_all():
     ctx = NodeContext()
     m1 = _msg(text="a")
@@ -508,6 +544,99 @@ async def test_react_random_emojis():
     session.send_reaction.assert_awaited_once_with(-100, 1, "🎉")
 
 
+# ── Issue #463: ReactHandler records structured node errors ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_react_records_error_when_no_client_pool():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    await ReactHandler().execute(
+        {"emoji": "👍"}, ctx, {"client_pool": None, "_current_node_id": "react_1"}
+    )
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "no_client_pool"
+    assert errors[0]["node_id"] == "react_1"
+
+
+@pytest.mark.asyncio
+async def test_react_records_no_available_client_when_pool_returns_none():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=None)
+    await ReactHandler().execute(
+        {"emoji": "👍"}, ctx, {"client_pool": pool, "_current_node_id": "react_1"}
+    )
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "no_available_client"
+    assert errors[0]["node_id"] == "react_1"
+
+
+@pytest.mark.asyncio
+async def test_react_records_flood_wait_error():
+    from telethon.errors import FloodWaitError
+
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=42)])
+    session = AsyncMock()
+    session.send_reaction = AsyncMock(
+        side_effect=FloodWaitError(request=None, capture=120)
+    )
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=(session, "+1"))
+    pool.release_client = AsyncMock()
+    await ReactHandler().execute(
+        {"emoji": "👍"}, ctx, {"client_pool": pool, "_current_node_id": "react_1"}
+    )
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "flood_wait"
+    assert errors[0]["retry_after"] == 120
+    assert errors[0]["node_id"] == "react_1"
+
+
+@pytest.mark.asyncio
+async def test_react_records_chat_write_forbidden_error():
+    from telethon.errors import ChatWriteForbiddenError
+
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=42)])
+    session = AsyncMock()
+    session.send_reaction = AsyncMock(
+        side_effect=ChatWriteForbiddenError(request=None)
+    )
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=(session, "+1"))
+    pool.release_client = AsyncMock()
+    await ReactHandler().execute(
+        {"emoji": "👍"}, ctx, {"client_pool": pool, "_current_node_id": "react_1"}
+    )
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "chat_write_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_react_records_unexpected_error_for_generic_exception():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=42)])
+    session = AsyncMock()
+    session.send_reaction = AsyncMock(side_effect=ValueError("boom"))
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=(session, "+1"))
+    pool.release_client = AsyncMock()
+    await ReactHandler().execute(
+        {"emoji": "👍"}, ctx, {"client_pool": pool, "_current_node_id": "react_1"}
+    )
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "unexpected_error"
+    assert "ValueError" in errors[0]["detail"]
+
+
 # ── ForwardHandler ────────────────────────────────────────────────────────────
 
 
@@ -559,6 +688,61 @@ async def test_forward_get_client_returns_none_skips():
     pool.get_client_by_phone.assert_awaited_once_with("+123")
 
 
+# ── Issue #463: ForwardHandler records structured node errors ────────────────
+
+
+@pytest.mark.asyncio
+async def test_forward_records_error_when_no_client_pool():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    await ForwardHandler().execute(
+        {"targets": [{"phone": "+1", "dialog_id": -1}]},
+        ctx,
+        {"client_pool": None, "_current_node_id": "fwd_1"},
+    )
+    errors = ctx.get_errors()
+    assert errors and errors[0]["code"] == "no_client_pool"
+    assert errors[0]["node_id"] == "fwd_1"
+
+
+@pytest.mark.asyncio
+async def test_forward_records_no_available_client_when_pool_returns_none():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    pool = AsyncMock()
+    pool.get_client_by_phone = AsyncMock(return_value=None)
+    await ForwardHandler().execute(
+        {"targets": [{"phone": "+123", "dialog_id": -1}]},
+        ctx,
+        {"client_pool": pool, "_current_node_id": "fwd_1"},
+    )
+    errors = ctx.get_errors()
+    assert errors and errors[0]["code"] == "no_available_client"
+
+
+@pytest.mark.asyncio
+async def test_forward_records_flood_wait_error():
+    from telethon.errors import FloodWaitError
+
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=7)])
+    session = AsyncMock()
+    session.forward_messages = AsyncMock(
+        side_effect=FloodWaitError(request=None, capture=60)
+    )
+    pool = AsyncMock()
+    pool.get_client_by_phone = AsyncMock(return_value=(session, "+1"))
+    pool.release_client = AsyncMock()
+    await ForwardHandler().execute(
+        {"targets": [{"phone": "+1", "dialog_id": -200}]},
+        ctx,
+        {"client_pool": pool, "_current_node_id": "fwd_1"},
+    )
+    errors = ctx.get_errors()
+    assert errors and errors[0]["code"] == "flood_wait"
+    assert errors[0]["retry_after"] == 60
+
+
 # ── DeleteMessageHandler ─────────────────────────────────────────────────────
 
 
@@ -593,6 +777,34 @@ async def test_delete_client_none_breaks():
     pool.get_available_client = AsyncMock(return_value=None)
     await DeleteMessageHandler().execute({}, ctx, {"client_pool": pool})
     pool.get_available_client.assert_awaited_once()
+
+
+# ── Issue #463: DeleteMessageHandler records structured node errors ──────────
+
+
+@pytest.mark.asyncio
+async def test_delete_records_error_when_no_client_pool():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    await DeleteMessageHandler().execute(
+        {}, ctx, {"client_pool": None, "_current_node_id": "del_1"}
+    )
+    errors = ctx.get_errors()
+    assert errors and errors[0]["code"] == "no_client_pool"
+    assert errors[0]["node_id"] == "del_1"
+
+
+@pytest.mark.asyncio
+async def test_delete_records_no_available_client_when_pool_returns_none():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg()])
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=None)
+    await DeleteMessageHandler().execute(
+        {}, ctx, {"client_pool": pool, "_current_node_id": "del_1"}
+    )
+    errors = ctx.get_errors()
+    assert errors and errors[0]["code"] == "no_available_client"
 
 
 # ── ConditionHandler ──────────────────────────────────────────────────────────

--- a/tests/test_pipeline_result_invariants.py
+++ b/tests/test_pipeline_result_invariants.py
@@ -1,0 +1,253 @@
+"""Unit tests for pipeline result semantic primitives (issue #463).
+
+Covers:
+  - summarize_result() — all (generation, action, mixed, empty) cases.
+  - increment_action_count() — accumulation, zero/negative amounts.
+  - get_action_counts() — malformed input handling.
+  - GenerationRun.result_kind/result_count — all fallback branches.
+  - result_kind_label() — Russian labels.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models import GenerationRun
+from src.services.pipeline_result import (
+    RESULT_KIND_GENERATED_ITEMS,
+    RESULT_KIND_PROCESSED_MESSAGES,
+    get_action_counts,
+    increment_action_count,
+    result_kind_label,
+    summarize_result,
+)
+
+# ── summarize_result ─────────────────────────────────────────────────────────
+
+
+class TestSummarizeResult:
+    def test_generation_with_citations(self):
+        kind, count = summarize_result(
+            generated_text="hello", citations=[{"id": 1}, {"id": 2}], action_counts=None
+        )
+        assert kind == RESULT_KIND_GENERATED_ITEMS
+        assert count == 2
+
+    def test_generation_with_text_no_citations(self):
+        kind, count = summarize_result(generated_text="hello", citations=[], action_counts=None)
+        assert kind == RESULT_KIND_GENERATED_ITEMS
+        assert count == 1
+
+    def test_generation_whitespace_only_text_falls_through(self):
+        kind, count = summarize_result(
+            generated_text="   \n", citations=[], action_counts={"react": 2}
+        )
+        assert kind == RESULT_KIND_PROCESSED_MESSAGES
+        assert count == 2
+
+    def test_action_only(self):
+        kind, count = summarize_result(
+            generated_text=None, citations=None, action_counts={"react": 3, "forward": 2}
+        )
+        assert kind == RESULT_KIND_PROCESSED_MESSAGES
+        assert count == 5
+
+    def test_mixed_generation_wins(self):
+        """Mixed: generation present AND actions performed.
+
+        Per issue #463: generation semantics wins for result_kind/result_count;
+        action_counts survives in metadata (ContentGenerationService responsibility).
+        """
+        kind, count = summarize_result(
+            generated_text="draft",
+            citations=[{"id": 1}, {"id": 2}],
+            action_counts={"react": 7},
+        )
+        assert kind == RESULT_KIND_GENERATED_ITEMS
+        assert count == 2
+
+    def test_empty_everything(self):
+        kind, count = summarize_result(generated_text=None, citations=None, action_counts=None)
+        assert kind == RESULT_KIND_PROCESSED_MESSAGES
+        assert count == 0
+
+    def test_action_counts_with_zero_values(self):
+        kind, count = summarize_result(
+            generated_text=None, citations=[], action_counts={"react": 0, "forward": 0}
+        )
+        assert kind == RESULT_KIND_PROCESSED_MESSAGES
+        assert count == 0
+
+    def test_action_counts_negative_values_clamped(self):
+        kind, count = summarize_result(
+            generated_text=None, citations=[], action_counts={"react": -5, "forward": 3}
+        )
+        assert kind == RESULT_KIND_PROCESSED_MESSAGES
+        assert count == 3
+
+
+# ── increment_action_count ───────────────────────────────────────────────────
+
+
+class _FakeContext:
+    """Minimal context substitute mirroring NodeContext global-store API."""
+
+    def __init__(self):
+        self._globals: dict[str, object] = {}
+
+    def get_global(self, key, default=None):
+        return self._globals.get(key, default)
+
+    def set_global(self, key, value):
+        self._globals[key] = value
+
+
+class TestIncrementActionCount:
+    def test_single_increment(self):
+        ctx = _FakeContext()
+        increment_action_count(ctx, "react")
+        assert ctx.get_global("action_counts") == {"react": 1}
+
+    def test_accumulates_same_action(self):
+        ctx = _FakeContext()
+        increment_action_count(ctx, "react")
+        increment_action_count(ctx, "react", amount=3)
+        assert ctx.get_global("action_counts") == {"react": 4}
+
+    def test_mixed_actions(self):
+        ctx = _FakeContext()
+        increment_action_count(ctx, "react", amount=2)
+        increment_action_count(ctx, "forward", amount=1)
+        increment_action_count(ctx, "delete_message", amount=5)
+        assert ctx.get_global("action_counts") == {
+            "react": 2,
+            "forward": 1,
+            "delete_message": 5,
+        }
+
+    def test_zero_amount_noop(self):
+        ctx = _FakeContext()
+        increment_action_count(ctx, "react", amount=0)
+        assert ctx.get_global("action_counts") is None
+
+    def test_negative_amount_noop(self):
+        ctx = _FakeContext()
+        increment_action_count(ctx, "react", amount=-3)
+        assert ctx.get_global("action_counts") is None
+
+
+class TestGetActionCounts:
+    def test_empty(self):
+        ctx = _FakeContext()
+        assert get_action_counts(ctx) == {}
+
+    def test_filters_non_string_keys(self):
+        ctx = _FakeContext()
+        ctx.set_global("action_counts", {"react": 3, 42: 1})
+        assert get_action_counts(ctx) == {"react": 3}
+
+    def test_coerces_float_values(self):
+        ctx = _FakeContext()
+        ctx.set_global("action_counts", {"react": 3.7, "forward": 2})
+        result = get_action_counts(ctx)
+        assert result == {"react": 3, "forward": 2}
+
+
+# ── GenerationRun.result_kind / result_count ─────────────────────────────────
+
+
+class TestGenerationRunResultKind:
+    def test_metadata_kind_wins(self):
+        run = GenerationRun(metadata={"result_kind": "processed_messages"}, generated_text="hi")
+        assert run.result_kind == "processed_messages"
+
+    def test_falls_back_to_generated_text(self):
+        run = GenerationRun(metadata={}, generated_text="hi")
+        assert run.result_kind == "generated_items"
+
+    def test_falls_back_to_processed_when_no_text(self):
+        run = GenerationRun(metadata={}, generated_text=None)
+        assert run.result_kind == "processed_messages"
+
+    def test_none_metadata_treated_as_empty(self):
+        run = GenerationRun(metadata=None, generated_text="hi")
+        assert run.result_kind == "generated_items"
+
+    def test_non_string_kind_ignored(self):
+        run = GenerationRun(metadata={"result_kind": 42}, generated_text="hi")
+        assert run.result_kind == "generated_items"
+
+    def test_empty_string_kind_ignored(self):
+        run = GenerationRun(metadata={"result_kind": ""}, generated_text="hi")
+        assert run.result_kind == "generated_items"
+
+
+class TestGenerationRunResultCount:
+    def test_metadata_count_int(self):
+        run = GenerationRun(metadata={"result_count": 5})
+        assert run.result_count == 5
+
+    def test_metadata_count_float_coerced(self):
+        run = GenerationRun(metadata={"result_count": 3.7})
+        assert run.result_count == 3
+
+    def test_falls_back_to_citations_length(self):
+        run = GenerationRun(metadata={"citations": [{"id": 1}, {"id": 2}, {"id": 3}]})
+        assert run.result_count == 3
+
+    def test_falls_back_to_generated_text_truthy(self):
+        run = GenerationRun(metadata={}, generated_text="hello")
+        assert run.result_count == 1
+
+    def test_empty_text_no_metadata(self):
+        run = GenerationRun(metadata={}, generated_text=None)
+        assert run.result_count == 0
+
+    def test_count_zero_still_zero(self):
+        run = GenerationRun(metadata={"result_count": 0}, generated_text="hi")
+        assert run.result_count == 0
+
+
+# ── REGRESSION: empty text but positive count ────────────────────────────────
+
+
+class TestEmptyTextPositiveCountRegression:
+    """Issue #463: action-only run has empty generated_text but result_count > 0.
+
+    UI/CLI layers must never show "0 messages" for such runs.
+    """
+
+    def test_action_only_run_has_positive_count_with_empty_text(self):
+        run = GenerationRun(
+            metadata={
+                "result_kind": "processed_messages",
+                "result_count": 7,
+                "action_counts": {"react": 7},
+            },
+            generated_text="",
+        )
+        assert run.result_kind == "processed_messages"
+        assert run.result_count == 7
+        assert (run.generated_text or "") == ""
+
+
+# ── result_kind_label ────────────────────────────────────────────────────────
+
+
+class TestResultKindLabel:
+    def test_processed_messages_label(self):
+        assert result_kind_label("processed_messages") == "Обработано"
+
+    def test_generated_items_label(self):
+        assert result_kind_label("generated_items") == "Сгенерировано"
+
+    def test_unknown_defaults_to_generated(self):
+        assert result_kind_label("unknown_kind") == "Сгенерировано"
+
+    def test_none_defaults_to_generated(self):
+        assert result_kind_label(None) == "Сгенерировано"
+
+
+# Ensure pytest doesn't get confused about the suite being empty.
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_task_enqueuer.py
+++ b/tests/test_task_enqueuer.py
@@ -244,7 +244,7 @@ async def test_enqueue_pipeline_run_creates_task(task_enqueuer, mock_db):
     mock_db.repos.tasks.create_generic_task.assert_called_once()
     args, kwargs = mock_db.repos.tasks.create_generic_task.call_args
     assert args[0] == CollectionTaskType.PIPELINE_RUN
-    assert "Pipeline run #3" in kwargs.get("title", "")
+    assert "пайплайна #3" in kwargs.get("title", "")
     payload = kwargs.get("payload")
     assert isinstance(payload, PipelineRunTaskPayload)
     assert payload.pipeline_id == 3

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -175,6 +175,41 @@ async def test_start_requeues_interrupted_tasks(mock_collector, mock_channel_bun
     mock_tasks_repo.requeue_running_generic_tasks_on_startup.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_handle_stats_all_stops_after_cancelled_result(
+    mock_collector,
+    mock_channel_bundle,
+    mock_tasks_repo,
+):
+    task = CollectionTask(
+        id=55,
+        channel_title="Stats",
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[123]),
+    )
+    mock_collector.collect_channel_stats = AsyncMock(return_value=MagicMock(subscriber_count=100))
+    mock_tasks_repo.get_collection_task = AsyncMock(
+        side_effect=[
+            CollectionTask(id=55, status=CollectionTaskStatus.RUNNING),
+            CollectionTask(id=55, status=CollectionTaskStatus.CANCELLED),
+        ]
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    mock_collector.collect_channel_stats.assert_awaited_once()
+    mock_tasks_repo.persist_stats_progress.assert_not_called()
+    mock_tasks_repo.update_collection_task.assert_not_called()
+
+
 # === _run_loop tests ===
 
 
@@ -758,6 +793,7 @@ async def test_handle_pipeline_run_success_with_mocked_services(
     mock_pipeline = MagicMock()
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline.pipeline_json = None
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
 
     mock_search_engine = MagicMock()
@@ -777,6 +813,7 @@ async def test_handle_pipeline_run_success_with_mocked_services(
 
     mock_run = MagicMock()
     mock_run.id = 42
+    mock_run.metadata = {}
 
     with patch(
         "src.services.content_generation_service.ContentGenerationService"
@@ -826,6 +863,7 @@ async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_r
     mock_pipeline = MagicMock()
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
+    mock_pipeline.pipeline_json = None
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
 
     mock_db = MagicMock()
@@ -871,6 +909,7 @@ async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
     mock_pipeline.publish_mode = PipelinePublishMode.AUTO
+    mock_pipeline.pipeline_json = None
 
     mock_pipeline_bundle = MagicMock()
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
@@ -928,6 +967,7 @@ async def test_handle_content_generate_without_auto_publish(
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
     mock_pipeline.publish_mode = PipelinePublishMode.MODERATED
+    mock_pipeline.pipeline_json = None
 
     mock_pipeline_bundle = MagicMock()
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)

--- a/tests/test_unified_dispatcher_extra.py
+++ b/tests/test_unified_dispatcher_extra.py
@@ -352,3 +352,195 @@ async def test_build_image_service_db_exception():
     with patch("src.services.image_provider_service.ImageProviderService", side_effect=Exception("nope")):
         svc = await d._build_image_service()
         assert svc is not None
+
+
+# ── Issue #463: happy path with semantic assertions ──────────────────────────
+
+
+def _make_pipeline_for_dispatcher(pipeline_id: int):
+    from src.models import ContentPipeline, PipelinePublishMode
+
+    return ContentPipeline(
+        id=pipeline_id,
+        name="Test",
+        llm_model="gpt-4",
+        publish_mode=PipelinePublishMode.MODERATED,
+        is_active=True,
+    )
+
+
+def _dispatcher_for_pipeline_run(run, *, pipeline_id: int = 7):
+    """Build a dispatcher with just enough pipeline deps to reach ContentGenerationService.generate."""
+    db = MagicMock()
+    db.repos = MagicMock()
+    db.repos.generation_runs = MagicMock()
+    db.repos.generation_runs.set_status = AsyncMock()
+
+    d = _dispatcher(
+        pipeline_bundle=MagicMock(),
+        search_engine=MagicMock(),
+        db=db,
+        llm_provider_service=MagicMock(),
+    )
+    return d
+
+
+class TestPipelineRunHappyPathSemantics:
+    """Verify that messages_collected on the CollectionTask row reflects
+    GenerationRun.result_count exactly — for all three run shapes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_generation_run_maps_citation_count_to_messages_collected(self, monkeypatch):
+        from tests.factories.pipeline_runs import make_generation_run
+
+        run = make_generation_run(run_id=42, pipeline_id=7, citations_count=3)
+        d = _dispatcher_for_pipeline_run(run, pipeline_id=7)
+
+        async def fake_get(self, pipeline_id):
+            return _make_pipeline_for_dispatcher(pipeline_id)
+
+        async def fake_generate(self, *, pipeline, model, dry_run, since_hours):
+            return run
+
+        monkeypatch.setattr(
+            "src.services.pipeline_service.PipelineService.get",
+            fake_get,
+        )
+        monkeypatch.setattr(
+            "src.services.content_generation_service.ContentGenerationService.generate",
+            fake_generate,
+        )
+        monkeypatch.setattr(
+            UnifiedDispatcher,
+            "_build_image_service",
+            AsyncMock(return_value=MagicMock()),
+        )
+
+        task = _task(
+            CollectionTaskType.PIPELINE_RUN,
+            task_id=100,
+            payload=PipelineRunTaskPayload(pipeline_id=7),
+        )
+        await d._handle_pipeline_run(task)
+
+        call = d._tasks.update_collection_task.call_args
+        assert call.args[0] == 100
+        assert call.args[1] == CollectionTaskStatus.COMPLETED
+        assert call.kwargs["messages_collected"] == 3
+        assert "id=42" in call.kwargs["note"]
+
+    @pytest.mark.asyncio
+    async def test_action_only_run_propagates_action_count(self, monkeypatch):
+        from tests.factories.pipeline_runs import make_action_only_run
+
+        run = make_action_only_run(run_id=43, pipeline_id=7, action_counts={"react": 5})
+        d = _dispatcher_for_pipeline_run(run, pipeline_id=7)
+
+        async def fake_get(self, pipeline_id):
+            return _make_pipeline_for_dispatcher(pipeline_id)
+
+        async def fake_generate(self, *, pipeline, model, dry_run, since_hours):
+            return run
+
+        monkeypatch.setattr("src.services.pipeline_service.PipelineService.get", fake_get)
+        monkeypatch.setattr(
+            "src.services.content_generation_service.ContentGenerationService.generate",
+            fake_generate,
+        )
+        monkeypatch.setattr(
+            UnifiedDispatcher,
+            "_build_image_service",
+            AsyncMock(return_value=MagicMock()),
+        )
+
+        task = _task(
+            CollectionTaskType.PIPELINE_RUN,
+            task_id=101,
+            payload=PipelineRunTaskPayload(pipeline_id=7),
+        )
+        await d._handle_pipeline_run(task)
+
+        call = d._tasks.update_collection_task.call_args
+        assert call.kwargs["messages_collected"] == 5
+        assert call.args[1] == CollectionTaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_mixed_run_uses_generation_count(self, monkeypatch):
+        """Mixed run: dispatcher stores generation count (not action count),
+        consistent with summarize_result() precedence.
+        """
+        from tests.factories.pipeline_runs import make_mixed_run
+
+        run = make_mixed_run(run_id=44, pipeline_id=7, citations_count=2, action_counts={"react": 9})
+        d = _dispatcher_for_pipeline_run(run, pipeline_id=7)
+
+        async def fake_get(self, pipeline_id):
+            return _make_pipeline_for_dispatcher(pipeline_id)
+
+        async def fake_generate(self, *, pipeline, model, dry_run, since_hours):
+            return run
+
+        monkeypatch.setattr("src.services.pipeline_service.PipelineService.get", fake_get)
+        monkeypatch.setattr(
+            "src.services.content_generation_service.ContentGenerationService.generate",
+            fake_generate,
+        )
+        monkeypatch.setattr(
+            UnifiedDispatcher,
+            "_build_image_service",
+            AsyncMock(return_value=MagicMock()),
+        )
+
+        task = _task(
+            CollectionTaskType.PIPELINE_RUN,
+            task_id=102,
+            payload=PipelineRunTaskPayload(pipeline_id=7),
+        )
+        await d._handle_pipeline_run(task)
+
+        call = d._tasks.update_collection_task.call_args
+        assert call.kwargs["messages_collected"] == 2  # generation wins
+
+    @pytest.mark.asyncio
+    async def test_empty_text_positive_count_regression(self, monkeypatch):
+        """Issue #463 regression: run with empty text but positive result_count
+        must NOT be stored as messages_collected=0.
+        """
+        from tests.factories.pipeline_runs import make_action_only_run
+
+        run = make_action_only_run(run_id=45, pipeline_id=7, action_counts={"forward": 4})
+        assert (run.generated_text or "") == ""
+        assert run.result_count == 4
+
+        d = _dispatcher_for_pipeline_run(run, pipeline_id=7)
+
+        async def fake_get(self, pipeline_id):
+            return _make_pipeline_for_dispatcher(pipeline_id)
+
+        async def fake_generate(self, *, pipeline, model, dry_run, since_hours):
+            return run
+
+        monkeypatch.setattr("src.services.pipeline_service.PipelineService.get", fake_get)
+        monkeypatch.setattr(
+            "src.services.content_generation_service.ContentGenerationService.generate",
+            fake_generate,
+        )
+        monkeypatch.setattr(
+            UnifiedDispatcher,
+            "_build_image_service",
+            AsyncMock(return_value=MagicMock()),
+        )
+
+        task = _task(
+            CollectionTaskType.PIPELINE_RUN,
+            task_id=103,
+            payload=PipelineRunTaskPayload(pipeline_id=7),
+        )
+        await d._handle_pipeline_run(task)
+
+        call = d._tasks.update_collection_task.call_args
+        assert call.kwargs["messages_collected"] == 4, (
+            "Dispatcher must derive messages_collected from run.result_count, "
+            "NOT from len(generated_text) or similar heuristics."
+        )

--- a/tests/test_unified_dispatcher_extra2.py
+++ b/tests/test_unified_dispatcher_extra2.py
@@ -238,6 +238,7 @@ async def test_content_generate_auto_publish_failure():
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
     mock_pipeline.publish_mode = MagicMock(value="auto")
+    mock_pipeline.pipeline_json = None
 
     mock_pipeline_bundle = MagicMock()
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
@@ -315,6 +316,7 @@ async def test_content_publish_with_approved_runs():
 
     mock_pipeline = MagicMock()
     mock_pipeline.id = 1
+    mock_pipeline.pipeline_json = None
     mock_pipeline_bundle = MagicMock()
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)
 
@@ -691,6 +693,7 @@ async def test_content_generate_moderated_mode_no_publish():
     mock_pipeline.id = 1
     mock_pipeline.llm_model = "gpt-4"
     mock_pipeline.publish_mode = MagicMock(value="moderated")
+    mock_pipeline.pipeline_json = None
 
     mock_pipeline_bundle = MagicMock()
     mock_pipeline_bundle.get_by_id = AsyncMock(return_value=mock_pipeline)


### PR DESCRIPTION
## What changed
- show pipeline `id` in the `/pipelines` list so existing pipelines can be referenced from the web UI
- hydrate DAG source and target refs from `pipeline_sources` / `pipeline_targets` when reading pipelines so runtime and web dry-run use the persisted refs even if `pipeline_json` has empty `channel_ids`
- add regression coverage for the pipeline id badge and for `dry-run-count` with broken DAG source config

## Why
The web test for pipeline execution was returning `0` because `dry-run-count` for DAG pipelines relied on source ids inside `pipeline_json`, while some persisted pipelines stored the real source refs only in sidecar tables. That left the source node empty in memory and made the UI count zero messages even though the pipeline had a real source channel.

## Impact
- `/pipelines` now exposes the pipeline id directly in the card UI
- `/pipelines/{id}/dry-run-count` now counts messages from persisted sidecar sources for DAG pipelines
- runtime reads of DAG pipelines stay consistent with the persisted source/target relations

## Validation
- `ruff check src/services/pipeline_service.py tests/routes/test_pipelines_routes.py tests/routes/test_pipelines_routes_extra.py`
- `python3 -m pytest tests/routes/test_pipelines_routes.py::test_pipelines_page_shows_pipeline_id tests/routes/test_pipelines_routes.py::test_pipelines_page_lists_pipeline tests/routes/test_pipelines_routes_extra.py::test_dry_run_count_dag_pipeline_falls_back_to_sidecar_sources tests/routes/test_pipelines_routes_extra.py::test_dry_run_count_dag_pipeline tests/test_pipeline_service_extra.py::test_get_existing tests/test_pipeline_service_extra.py::test_get_detail tests/test_pipeline_service_extra.py::test_get_with_relations -v`
