### PR TITLE
feat(scheduler): show flood wait countdown next to earliest unlock time

### DIFF
--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -193,6 +193,12 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         available_accounts_now=available_accounts_now,
         state=state,
     )
+    # Compute retry_after_sec from next_available_at if available
+    computed_retry_after_sec = availability_retry_after
+    if computed_retry_after_sec is None and (next_available_at or availability_next):
+        effective_next = next_available_at or availability_next
+        delta = effective_next - now
+        computed_retry_after_sec = max(0, int(delta.total_seconds()))
     return {
         "state": state,
         "connected_accounts": len(connected_phones),
@@ -201,7 +207,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         "flooded_accounts": flooded_accounts,
         "flooded_accounts_count": len(flooded_accounts),
         "next_available_at": next_available_at or availability_next,
-        "retry_after_sec": availability_retry_after,
+        "retry_after_sec": computed_retry_after_sec,
         "active_unfiltered_channels": active_unfiltered_channels,
         "collect_interval_minutes": interval_minutes,
         "load_level": load_level,

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -102,7 +102,14 @@
                 <div class="small text-muted">Flood Wait</div>
                 <div><strong>{{ collector_health.flooded_accounts_count }}</strong> заблокировано</div>
                 {% if collector_health.next_available_label %}
-                <div class="small">Раньше всего: {{ collector_health.next_available_label }}</div>
+                {% set _secs = collector_health.retry_after_sec %}
+                <div class="small">Раньше всего: {{ collector_health.next_available_label }}
+                  {%- if _secs and _secs >= 60 %}
+                    {% set _h = (_secs // 3600) | int %}
+                    {% set _m = ((_secs % 3600) // 60) | int %}
+                    ({% if _h > 0 %}{{ _h }} ч {% endif %}{{ _m }} мин)
+                  {%- endif %}
+                </div>
                 {% endif %}
             </div>
             <div class="col-6 col-md-3">

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -842,3 +842,45 @@ async def test_scheduler_mixed_page_non_pipeline_tasks_unaffected(base_app, rout
     assert "Сгенерировано" not in plain_text
     assert "Обработано" not in plain_text
     assert "42" in plain_text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_shows_flood_wait_countdown(client):
+    """Test that scheduler page shows flood wait countdown in hours and minutes."""
+    db = client._transport.app.state.db
+    pool = client._transport.app.state.pool
+    accounts = await db.get_accounts(active_only=False)
+
+    # Put account in pool so it appears in connected_active_accounts
+    pool.clients = {acc.phone: MagicMock() for acc in accounts}
+
+    # Set flood wait for 3 hours in future (round number avoids second-boundary races)
+    future = datetime.now(timezone.utc) + timedelta(hours=3)
+    for acc in accounts:
+        await db.update_account_flood(acc.phone, future)
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    # Check that countdown is displayed — "3 ч 0 мин" or similar
+    assert " ч " in resp.text or " мин)" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_scheduler_hides_countdown_if_too_short(client):
+    """Test that countdown is hidden if less than 60 seconds remain."""
+    db = client._transport.app.state.db
+    pool = client._transport.app.state.pool
+    accounts = await db.get_accounts(active_only=False)
+
+    # Put account in pool so it appears in connected_active_accounts
+    pool.clients = {acc.phone: MagicMock() for acc in accounts}
+
+    # Set flood wait for only 30 seconds (below the 60s threshold, shouldn't show countdown)
+    future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    for acc in accounts:
+        await db.update_account_flood(acc.phone, future)
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    # Countdown should not appear for very short waits
+    assert "(0 мин)" not in resp.text


### PR DESCRIPTION
## Summary

- Adds `(N ч M мин)` remaining time label next to "Раньше всего: ..." in the Collector Health card on the Scheduler page
- Computes `retry_after_sec` from `next_available_at` datetime when the collector availability object doesn't provide it directly (fallback path)
- Countdown is hidden when less than 60 seconds remain to avoid showing "(0 мин)"

## Test plan

- [ ] Run `pytest tests/routes/test_scheduler_routes.py` — all 51 tests pass
- [ ] Verify `test_scheduler_shows_flood_wait_countdown` passes (countdown appears for 3h flood wait)
- [ ] Verify `test_scheduler_hides_countdown_if_too_short` passes (no countdown for <60s)
- [ ] Manual: trigger flood wait on a real account and verify scheduler page shows e.g. "(2 ч 15 мин)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)