### PR TITLE
fix(auth): two-step CLI auth + fix 422 on web forms + persist StringSession

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python -m src.main [--config CONFIG] search "query" [--limit N] [--mode MODE]
 python -m src.main messages read <identifier> [--limit N] [--live] [--phone PHONE] [--query TEXT] [--date-from DATE] [--date-to DATE] [--topic-id ID] [--offset-id ID] [--format text|json|csv]
 python -m src.main channel list|add|delete|toggle|collect|stats|refresh-types|refresh-meta|import|add-bulk|tag
 python -m src.main filter analyze|apply|reset|precheck|toggle|purge|purge-messages|hard-delete
-python -m src.main account list|info|toggle|delete|add|flood-status|flood-clear
+python -m src.main account list|info|toggle|delete|send-code|verify-code|flood-status|flood-clear
 python -m src.main scheduler start|trigger|status|stop|job-toggle|set-interval|task-cancel|clear-pending
 python -m src.main notification setup|status|delete|set-account
 python -m src.main test all|read|write|telegram|benchmark

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -82,9 +82,12 @@ def run(args: argparse.Namespace) -> None:
                     phone, code, phone_code_hash,
                     session_str=pending.get("session_str", ""),
                     password_2fa=password_2fa,
+                    code_consumed=pending.get("code_consumed", False),
                 )
                 except ValueError as exc:
                     if "2FA" in str(exc) or "password" in str(exc).lower():
+                        pending["code_consumed"] = True
+                        await db.set_setting(_pending_key(phone), json.dumps(pending))
                         print("2FA required. Re-run with --password YOUR_2FA_PASSWORD")
                     else:
                         print(f"Auth failed: {exc}")

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -88,7 +88,7 @@ def run(args: argparse.Namespace) -> None:
                     if "2FA" in str(exc) or "password" in str(exc).lower():
                         pending["code_consumed"] = True
                         await db.set_setting(_pending_key(phone), json.dumps(pending))
-                        print("2FA required. Re-run with --password YOUR_2FA_PASSWORD")
+                        print(f"2FA required. Re-run with --code {code} --password YOUR_2FA_PASSWORD")
                     else:
                         print(f"Auth failed: {exc}")
                     return

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 from datetime import datetime, timezone
 
@@ -11,24 +12,33 @@ from src.settings_utils import parse_int_setting
 from src.telegram.auth import TelegramAuth
 
 
+def _pending_key(phone: str) -> str:
+    return f"auth_pending:{phone}"
+
+
+async def _resolve_credentials(args: argparse.Namespace, config, db) -> tuple[int, str]:
+    api_id = getattr(args, "api_id", None) or config.telegram.api_id
+    api_hash = getattr(args, "api_hash", None) or config.telegram.api_hash
+    if api_id == 0 or not api_hash:
+        stored_id = await db.get_setting("tg_api_id")
+        stored_hash = await db.get_setting("tg_api_hash")
+        if stored_id and stored_hash:
+            api_id = parse_int_setting(
+                stored_id, setting_name="tg_api_id", default=0,
+                logger=logging.getLogger(__name__),
+            )
+            api_hash = stored_hash
+    return api_id, api_hash
+
+
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         config, db = await runtime.init_db(args.config)
         pool = None
         try:
-            if args.account_action == "add":
+            if args.account_action == "send-code":
                 phone = args.phone
-                api_id = args.api_id or config.telegram.api_id
-                api_hash = args.api_hash or config.telegram.api_hash
-                if api_id == 0 or not api_hash:
-                    stored_id = await db.get_setting("tg_api_id")
-                    stored_hash = await db.get_setting("tg_api_hash")
-                    if stored_id and stored_hash:
-                        api_id = parse_int_setting(
-                            stored_id, setting_name="tg_api_id", default=0,
-                            logger=logging.getLogger(__name__),
-                        )
-                        api_hash = stored_hash
+                api_id, api_hash = await _resolve_credentials(args, config, db)
                 if api_id == 0 or not api_hash:
                     print("ERROR: API credentials not configured.")
                     print("Provide --api-id and --api-hash, or set them in config/DB.")
@@ -41,33 +51,47 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Error sending auth code: {exc}")
                     return
 
-                phone_code_hash = info.phone_code_hash
-                code = input("Enter the code from Telegram: ").strip()
-                if not code:
-                    print("Aborted.")
+                await db.set_setting(_pending_key(phone), json.dumps(info))
+                code_type = info.get("code_type", "Telegram")
+                print(f"Code sent to {phone} via {code_type}.")
+                print(f"Run: account verify-code --phone {phone} --code CODE")
+                return
+
+            elif args.account_action == "verify-code":
+                phone = args.phone
+                code = args.code
+                password_2fa = getattr(args, "password", None) or None
+
+                pending_raw = await db.get_setting(_pending_key(phone))
+                if not pending_raw:
+                    print(f"ERROR: No pending auth for {phone}. Run 'account send-code' first.")
+                    return
+                pending = json.loads(pending_raw)
+                phone_code_hash = pending["phone_code_hash"]
+
+                api_id, api_hash = await _resolve_credentials(args, config, db)
+                if api_id == 0 or not api_hash:
+                    print("ERROR: API credentials not configured.")
                     return
 
+                auth = TelegramAuth(api_id, api_hash)
                 try:
-                    session_string = await auth.verify_code(phone, code, phone_code_hash)
+                    session_string = await auth.sign_in_fresh(
+                    phone, code, phone_code_hash,
+                    session_str=pending.get("session_str", ""),
+                    password_2fa=password_2fa,
+                )
                 except ValueError as exc:
                     if "2FA" in str(exc) or "password" in str(exc).lower():
-                        password = input("Enter 2FA password: ").strip()
-                        if not password:
-                            print("Aborted.")
-                            return
-                        try:
-                            session_string = await auth.verify_code(
-                                phone, code, phone_code_hash, password
-                            )
-                        except Exception as exc2:
-                            print(f"Auth failed: {exc2}")
-                            return
+                        print(f"2FA required. Re-run with --password YOUR_2FA_PASSWORD")
                     else:
                         print(f"Auth failed: {exc}")
-                        return
+                    return
                 except Exception as exc:
                     print(f"Auth failed: {exc}")
                     return
+
+                await db.set_setting(_pending_key(phone), "")
 
                 existing = await db.get_accounts()
                 is_primary = len(existing) == 0

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -48,10 +48,12 @@ def run(args: argparse.Namespace) -> None:
                 try:
                     info = await auth.send_code(phone)
                 except Exception as exc:
+                    await auth.cleanup()
                     print(f"Error sending auth code: {exc}")
                     return
 
                 await db.set_setting(_pending_key(phone), json.dumps(info))
+                await auth.cleanup()
                 code_type = info.get("code_type", "Telegram")
                 print(f"Code sent to {phone} via {code_type}.")
                 print(f"Run: account verify-code --phone {phone} --code CODE")
@@ -83,7 +85,7 @@ def run(args: argparse.Namespace) -> None:
                 )
                 except ValueError as exc:
                     if "2FA" in str(exc) or "password" in str(exc).lower():
-                        print(f"2FA required. Re-run with --password YOUR_2FA_PASSWORD")
+                        print("2FA required. Re-run with --password YOUR_2FA_PASSWORD")
                     else:
                         print(f"Auth failed: {exc}")
                     return

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -581,12 +581,21 @@ def build_parser() -> argparse.ArgumentParser:
     acc_del = acc_sub.add_parser("delete", help="Delete account")
     acc_del.add_argument("id", type=int, help="Account id")
 
-    acc_add = acc_sub.add_parser("add", help="Add Telegram account (interactive auth)")
-    acc_add.add_argument("--api-id", type=int, default=None, dest="api_id",
-                         help="Telegram API ID (uses stored if omitted)")
-    acc_add.add_argument("--api-hash", default=None, dest="api_hash",
-                         help="Telegram API hash (uses stored if omitted)")
-    acc_add.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_send = acc_sub.add_parser("send-code", help="Send Telegram auth code to phone")
+    acc_send.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_send.add_argument("--api-id", type=int, default=None, dest="api_id",
+                          help="Telegram API ID (uses stored if omitted)")
+    acc_send.add_argument("--api-hash", default=None, dest="api_hash",
+                          help="Telegram API hash (uses stored if omitted)")
+
+    acc_verify = acc_sub.add_parser("verify-code", help="Verify Telegram auth code and add account")
+    acc_verify.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_verify.add_argument("--code", required=True, help="Auth code received in Telegram")
+    acc_verify.add_argument("--password", default=None, help="2FA password (if required)")
+    acc_verify.add_argument("--api-id", type=int, default=None, dest="api_id",
+                            help="Telegram API ID (uses stored if omitted)")
+    acc_verify.add_argument("--api-hash", default=None, dest="api_hash",
+                            help="Telegram API hash (uses stored if omitted)")
 
     acc_sub.add_parser("flood-status", help="Show flood wait timers for all accounts")
 

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -205,22 +205,19 @@ class TelegramAuth:
         """
         client = TelegramClient(StringSession(session_str), self._api_id, self._api_hash)
         await client.connect()
-        needs_2fa = False
         try:
             try:
                 await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
             except SessionPasswordNeededError:
                 if not password_2fa:
-                    needs_2fa = True
                     raise ValueError("2FA password required")
                 await client.sign_in(password=password_2fa)
             session_string = client.session.save()
         finally:
-            if not needs_2fa:
-                try:
-                    await client.disconnect()
-                except Exception:
-                    logger.warning("Failed to disconnect fresh auth client for %s", phone)
+            try:
+                await client.disconnect()
+            except Exception:
+                logger.warning("Failed to disconnect fresh auth client for %s", phone)
         logger.info("Successfully authenticated %s", phone)
         return session_string
 

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -197,6 +197,7 @@ class TelegramAuth:
         phone_code_hash: str,
         session_str: str = "",
         password_2fa: str | None = None,
+        code_consumed: bool = False,
     ) -> str:
         """Sign in using a phone_code_hash from a previous send_code call (possibly in a different process).
 
@@ -206,12 +207,17 @@ class TelegramAuth:
         client = TelegramClient(StringSession(session_str), self._api_id, self._api_hash)
         await client.connect()
         try:
-            try:
-                await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
-            except SessionPasswordNeededError:
+            if code_consumed:
                 if not password_2fa:
                     raise ValueError("2FA password required")
                 await client.sign_in(password=password_2fa)
+            else:
+                try:
+                    await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
+                except SessionPasswordNeededError:
+                    if not password_2fa:
+                        raise ValueError("2FA password required")
+                    await client.sign_in(password=password_2fa)
             session_string = client.session.save()
         finally:
             try:

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -121,6 +121,7 @@ class TelegramAuth:
         )
         return {
             "phone_code_hash": result.phone_code_hash,
+            "session_str": client.session.save(),
             "code_type": _describe_code_type(result.type),
             "next_type": _describe_next_type(getattr(result, "next_type", None)),
             "timeout": getattr(result, "timeout", None),
@@ -186,6 +187,40 @@ class TelegramAuth:
                 except Exception:
                     logger.warning("Failed to disconnect temporary auth client for %s", phone)
 
+        logger.info("Successfully authenticated %s", phone)
+        return session_string
+
+    async def sign_in_fresh(
+        self,
+        phone: str,
+        code: str,
+        phone_code_hash: str,
+        session_str: str = "",
+        password_2fa: str | None = None,
+    ) -> str:
+        """Sign in using a phone_code_hash from a previous send_code call (possibly in a different process).
+
+        Pass session_str from the send_code result to reuse the same MTProto session —
+        required because Telegram binds phone_code_hash to the session that sent the request.
+        """
+        client = TelegramClient(StringSession(session_str), self._api_id, self._api_hash)
+        await client.connect()
+        needs_2fa = False
+        try:
+            try:
+                await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
+            except SessionPasswordNeededError:
+                if not password_2fa:
+                    needs_2fa = True
+                    raise ValueError("2FA password required")
+                await client.sign_in(password=password_2fa)
+            session_string = client.session.save()
+        finally:
+            if not needs_2fa:
+                try:
+                    await client.disconnect()
+                except Exception:
+                    logger.warning("Failed to disconnect fresh auth client for %s", phone)
         logger.info("Successfully authenticated %s", phone)
         return session_string
 

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -126,7 +126,10 @@ async def save_credentials(
 @router.post("/send-code")
 async def send_code(request: Request, phone: str = Form("")):
     if not phone:
-        return _render(request, "login.html", {"step": "phone", "error": None, "api_configured": _is_api_configured(request)})
+        return _render(
+            request, "login.html",
+            {"step": "phone", "error": None, "api_configured": _is_api_configured(request)},
+        )
     if not _is_api_configured(request):
         return _render(
             request,

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -108,9 +108,11 @@ async def login_page(request: Request):
 @router.post("/save-credentials")
 async def save_credentials(
     request: Request,
-    api_id: int = Form(...),
-    api_hash: str = Form(...),
+    api_id: int | None = Form(None),
+    api_hash: str = Form(""),
 ):
+    if api_id is None or not api_hash:
+        return RedirectResponse(url="/auth/login", status_code=303)
     db = request.app.state.db
     auth = request.app.state.auth
 
@@ -122,7 +124,9 @@ async def save_credentials(
 
 
 @router.post("/send-code")
-async def send_code(request: Request, phone: str = Form(...)):
+async def send_code(request: Request, phone: str = Form("")):
+    if not phone:
+        return _render(request, "login.html", {"step": "phone", "error": None, "api_configured": _is_api_configured(request)})
     if not _is_api_configured(request):
         return _render(
             request,
@@ -145,8 +149,8 @@ async def send_code(request: Request, phone: str = Form(...)):
 @router.post("/resend-code")
 async def resend_code(
     request: Request,
-    phone: str = Form(...),
-    phone_code_hash: str = Form(...),
+    phone: str = Form(""),
+    phone_code_hash: str = Form(""),
 ):
     command_id = await deps.telegram_command_service(request).enqueue(
         "auth.resend_code",
@@ -159,9 +163,9 @@ async def resend_code(
 @router.post("/verify-code")
 async def verify_code(
     request: Request,
-    phone: str = Form(...),
-    code: str = Form(...),
-    phone_code_hash: str = Form(...),
+    phone: str = Form(""),
+    code: str = Form(""),
+    phone_code_hash: str = Form(""),
     password_2fa: str = Form(""),
     code_type: str = Form(""),
     next_type: str = Form(""),

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -152,6 +152,8 @@ async def resend_code(
     phone: str = Form(""),
     phone_code_hash: str = Form(""),
 ):
+    if not phone or not phone_code_hash:
+        return RedirectResponse(url="/auth/login", status_code=303)
     command_id = await deps.telegram_command_service(request).enqueue(
         "auth.resend_code",
         payload={"phone": phone, "phone_code_hash": phone_code_hash},
@@ -171,6 +173,8 @@ async def verify_code(
     next_type: str = Form(""),
     timeout: str = Form(""),
 ):
+    if not phone or not code or not phone_code_hash:
+        return RedirectResponse(url="/auth/login", status_code=303)
     command_id = await deps.telegram_command_service(request).enqueue(
         "auth.verify_code",
         payload={

--- a/src/web/routes/channels.py
+++ b/src/web/routes/channels.py
@@ -44,7 +44,7 @@ async def channels_list(request: Request):
 
 
 @router.post("/add")
-async def add_channel(request: Request, identifier: str = Form(...)):
+async def add_channel(request: Request, identifier: str = Form("")):
     if not identifier.strip():
         return RedirectResponse(url="/channels?error=resolve", status_code=303)
     return await _enqueue_channel_command(
@@ -104,7 +104,9 @@ async def list_tags(request: Request):
 
 
 @router.post("/tags")
-async def create_tag(request: Request, name: str = Form(...)):
+async def create_tag(request: Request, name: str = Form("")):
+    if not name.strip():
+        return RedirectResponse(url="/channels?error=missing_fields", status_code=303)
     db = deps.get_db(request)
     await db.repos.channels.create_tag(name.strip())
     return RedirectResponse(url="/channels?msg=tag_created", status_code=303)

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -83,7 +83,9 @@ async def dialogs_page(
 
 
 @router.post("/refresh")
-async def refresh_dialogs(request: Request, phone: str = Form(...)):
+async def refresh_dialogs(request: Request, phone: str = Form("")):
+    if not phone:
+        return RedirectResponse(url="/dialogs/?error=missing_fields", status_code=303)
     return await _enqueue_dialog_command(
         request,
         "dialogs.refresh",
@@ -468,11 +470,13 @@ async def create_channel_page(request: Request):
 @router.post("/create-channel")
 async def create_channel(
     request: Request,
-    phone: str = Form(...),
-    title: str = Form(...),
+    phone: str = Form(""),
+    title: str = Form(""),
     about: str = Form(""),
     username: str = Form(""),
 ):
+    if not phone or not title:
+        return RedirectResponse(url="/dialogs/create-channel?error=missing_fields", status_code=303)
     command_id = await deps.telegram_command_service(request).enqueue(
         "dialogs.create_channel",
         payload={

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -282,7 +282,9 @@ async def photo_loader_page(request: Request, phone: str | None = None):
 
 
 @router.post("/refresh")
-async def photo_loader_refresh(request: Request, phone: str = Form(...)):
+async def photo_loader_refresh(request: Request, phone: str = Form("")):
+    if not phone:
+        return _redirect("", "missing_fields", error=True)
     command_id = await deps.telegram_command_service(request).enqueue(
         "dialogs.refresh",
         payload={"phone": phone},
@@ -294,7 +296,7 @@ async def photo_loader_refresh(request: Request, phone: str = Form(...)):
 @router.post("/send")
 async def photo_send(
     request: Request,
-    phone: str = Form(...),
+    phone: str = Form(""),
     target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
@@ -302,6 +304,8 @@ async def photo_send(
     caption: str = Form(""),
     photos: list[UploadFile] = File(...),
 ):
+    if not phone:
+        return _redirect("", "missing_fields", error=True)
     target = None
     saved: list[str] = []
     try:
@@ -346,15 +350,17 @@ async def photo_send(
 @router.post("/schedule")
 async def photo_schedule(
     request: Request,
-    phone: str = Form(...),
+    phone: str = Form(""),
     target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
-    schedule_at: str = Form(...),
+    schedule_at: str = Form(""),
     photos: list[UploadFile] = File(...),
 ):
+    if not phone or not schedule_at:
+        return _redirect(phone, "missing_fields", error=True)
     target = None
     saved: list[str] = []
     try:
@@ -402,13 +408,15 @@ async def photo_schedule(
 @router.post("/batch")
 async def photo_batch(
     request: Request,
-    phone: str = Form(...),
+    phone: str = Form(""),
     target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
     caption: str = Form(""),
     manifest_text: str = Form(""),
 ):
+    if not phone:
+        return _redirect("", "missing_fields", error=True)
     target = None
     try:
         target, target_error = await _validate_target(
@@ -445,15 +453,17 @@ async def photo_batch(
 @router.post("/auto")
 async def photo_auto_create(
     request: Request,
-    phone: str = Form(...),
+    phone: str = Form(""),
     target_dialog_id: str = Form(""),
     target_title: str = Form(""),
     target_type: str = Form(""),
-    folder_path: str = Form(...),
+    folder_path: str = Form(""),
     send_mode: str = Form(PhotoSendMode.SEPARATE.value),
     caption: str = Form(""),
-    interval_minutes: int = Form(...),
+    interval_minutes: int | None = Form(None),
 ):
+    if not phone or not folder_path or interval_minutes is None:
+        return _redirect(phone, "missing_fields", error=True)
     target = None
     try:
         target, target_error = await _validate_target(

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -221,8 +221,8 @@ async def create_wizard_page(request: Request):
 @router.post("/create-wizard")
 async def create_wizard_submit(
     request: Request,
-    name: str = Form(...),
-    pipeline_json: str = Form(...),
+    name: str = Form(""),
+    pipeline_json: str = Form(""),
     source_channel_ids: list[int] = Form(default=[]),
     target_refs: list[str] = Form(default=[]),
     generate_interval_minutes: int = Form(60),
@@ -232,6 +232,8 @@ async def create_wizard_submit(
     since_unit: str = Form("h"),
     account_phone: str = Form(""),
 ):
+    if not name or not pipeline_json:
+        return _pipeline_redirect("pipeline_invalid", error=True)
     import json as _json
 
     svc = deps.pipeline_service(request)
@@ -277,8 +279,8 @@ async def create_wizard_submit(
 @router.post("/add")
 async def add_pipeline(
     request: Request,
-    name: str = Form(...),
-    prompt_template: str = Form(...),
+    name: str = Form(""),
+    prompt_template: str = Form(""),
     source_channel_ids: list[int] = Form(default=[]),
     target_refs: list[str] = Form(default=[]),
     llm_model: str = Form(""),
@@ -288,6 +290,8 @@ async def add_pipeline(
     generate_interval_minutes: int = Form(60),
     is_active: bool = Form(False),
 ):
+    if not name or not prompt_template:
+        return _pipeline_redirect("pipeline_invalid", error=True)
     svc: PipelineService = deps.pipeline_service(request)
     try:
         new_pipeline_id = await svc.add(
@@ -325,7 +329,7 @@ async def add_pipeline(
 async def edit_pipeline(
     request: Request,
     pipeline_id: int,
-    name: str = Form(...),
+    name: str = Form(""),
     prompt_template: str = Form(""),
     source_channel_ids: list[int] = Form(default=[]),
     target_refs: list[str] = Form(default=[]),
@@ -347,6 +351,8 @@ async def edit_pipeline(
     dag_source_channel_ids: list[int] = Form(default=[]),
     account_phone: str = Form(""),
 ):
+    if not name:
+        return _pipeline_redirect("pipeline_invalid", error=True)
     svc: PipelineService = deps.pipeline_service(request)
     phone = request.query_params.get("phone")
     existing = await svc.get(pipeline_id)
@@ -639,7 +645,9 @@ async def generate_pipeline(
 
 
 @router.post("/{pipeline_id}/publish")
-async def publish_pipeline(request: Request, pipeline_id: int, run_id: int = Form(...)):
+async def publish_pipeline(request: Request, pipeline_id: int, run_id: int | None = Form(None)):
+    if run_id is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
     db = deps.get_db(request)
     run = await db.repos.generation_runs.get(run_id)
     if run is None or run.pipeline_id != pipeline_id:
@@ -758,14 +766,16 @@ async def templates_json(request: Request):
 @router.post("/from-template")
 async def create_from_template(
     request: Request,
-    template_id: int = Form(...),
-    name: str = Form(...),
+    template_id: int | None = Form(None),
+    name: str = Form(""),
     source_channel_ids: list[int] = Form(default=[]),
     target_refs: list[str] = Form(default=[]),
     llm_model: str = Form(""),
     image_model: str = Form(""),
     generate_interval_minutes: int = Form(60),
 ):
+    if template_id is None or not name:
+        return _pipeline_redirect("pipeline_invalid", error=True)
     svc: PipelineService = deps.pipeline_service(request)
     try:
         pipeline_id = await svc.create_from_template(

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -19,7 +19,7 @@ async def search_queries_page(request: Request):
 @router.post("/add")
 async def add_search_query(
     request: Request,
-    query: str = Form(...),
+    query: str = Form(""),
     interval_minutes: int = Form(60),
     is_regex: bool = Form(False),
     is_fts: bool = Form(False),
@@ -28,6 +28,8 @@ async def add_search_query(
     exclude_patterns: str = Form(""),
     max_length: int | None = Form(None),
 ):
+    if not query.strip():
+        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
     svc = deps.search_query_service(request)
     try:
         await svc.add(
@@ -62,7 +64,7 @@ async def toggle_search_query(request: Request, sq_id: int):
 async def edit_search_query(
     request: Request,
     sq_id: int,
-    query: str = Form(...),
+    query: str = Form(""),
     interval_minutes: int = Form(60),
     is_regex: bool = Form(False),
     is_fts: bool = Form(False),
@@ -71,6 +73,8 @@ async def edit_search_query(
     exclude_patterns: str = Form(""),
     max_length: int | None = Form(None),
 ):
+    if not query.strip():
+        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
     svc = deps.search_query_service(request)
     try:
         await svc.update(

--- a/src/web/templates/pipelines/create.html
+++ b/src/web/templates/pipelines/create.html
@@ -787,7 +787,7 @@
         } else if (pipelineType === "content_gen") {
             var llmModelG = (document.querySelector('[name="llm_model_gen"]') || {}).value || "";
             var genPrompt = (document.querySelector('[name="gen_prompt"]') || {}).value || "Напиши пост на основе контекста";
-            var safePrompt = genPrompt.replace(/\{/g, "{{").replace(/\}/g, "}}");
+            {% raw %}var safePrompt = genPrompt.replace(/\{/g, "{{").replace(/\}/g, "}}");{% endraw %}
             nodes.push({ id: "context_1", type: "retrieve_context", name: "Контекст", config: {}, position: { x: 220, y: 0 } });
             edges.push({ from: lastSourceId, to: "context_1" });
             nodes.push({ id: "llm_1", type: "llm_generate", name: "Генерация", config: { prompt_template: safePrompt + "\n\n{source_messages}", model: llmModelG }, position: { x: 330, y: 0 } });

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -424,6 +424,28 @@ async def test_save_credentials_validates_input(client_unconfigured):
 
 
 @pytest.mark.asyncio
+async def test_verify_code_missing_phone_code_hash(client):
+    """POST /auth/verify-code without phone_code_hash enqueues with empty hash → 303."""
+    resp = await client.post(
+        "/auth/verify-code",
+        data={"phone": "+1234567890", "code": "12345"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_resend_code_missing_phone_code_hash(client):
+    """POST /auth/resend-code without phone_code_hash enqueues with empty hash → 303."""
+    resp = await client.post(
+        "/auth/resend-code",
+        data={"phone": "+1234567890"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
 async def test_verify_code_empty_password(client):
     """Test empty 2FA password is preserved as empty string in queued payload."""
     db = client._transport.app.state.db
@@ -452,6 +474,35 @@ async def test_verify_code_get_me_error(client):
             "phone_code_hash": "hash",
             "password_2fa": "",
         },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_send_code_missing_phone(client):
+    """POST /auth/send-code without phone renders login page (200)."""
+    resp = await client.post("/auth/send-code", data={}, follow_redirects=False)
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_save_credentials_missing_api_id(client_unconfigured):
+    """POST /auth/save-credentials without api_id returns 422."""
+    resp = await client_unconfigured.post(
+        "/auth/save-credentials",
+        data={"api_hash": "abc123"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_save_credentials_missing_api_hash(client_unconfigured):
+    """POST /auth/save-credentials without api_hash returns 422."""
+    resp = await client_unconfigured.post(
+        "/auth/save-credentials",
+        data={"api_id": "12345"},
         follow_redirects=False,
     )
     assert resp.status_code == 303

--- a/tests/routes/test_channels_routes.py
+++ b/tests/routes/test_channels_routes.py
@@ -244,3 +244,17 @@ async def test_collect_stats(client):
 
         resp = await client.post("/channels/stats/all", follow_redirects=False)
         assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_add_channel_missing_identifier(client):
+    """POST /channels/add without identifier returns 422."""
+    resp = await client.post("/channels/add", data={}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_add_tag_missing_name(client):
+    """POST /channels/tags without name returns 422."""
+    resp = await client.post("/channels/tags", data={}, follow_redirects=False)
+    assert resp.status_code == 303

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -325,7 +325,29 @@ async def test_refresh_dialogs_redirects(client):
 async def test_refresh_dialogs_missing_phone(client):
     """Test refresh without phone returns validation error."""
     resp = await client.post("/dialogs/refresh", follow_redirects=False)
-    assert resp.status_code == 422
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_create_channel_missing_phone(client):
+    """POST /dialogs/create-channel without phone returns 422."""
+    resp = await client.post(
+        "/dialogs/create-channel",
+        data={"title": "Test Channel"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_create_channel_missing_title(client):
+    """POST /dialogs/create-channel without title returns 422."""
+    resp = await client.post(
+        "/dialogs/create-channel",
+        data={"phone": "+1234567890"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_photo_loader_routes.py
+++ b/tests/routes/test_photo_loader_routes.py
@@ -280,3 +280,91 @@ async def test_photo_auto_missing_target(client):
     )
     assert resp.status_code == 303
     assert "error=photo_target_required" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_photos_refresh_missing_phone(client):
+    """POST /dialogs/photos/refresh without phone returns 422."""
+    resp = await client.post("/dialogs/photos/refresh", data={}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_photos_send_missing_phone(client):
+    """POST /dialogs/photos/send without phone returns redirect with error."""
+    from io import BytesIO
+    resp = await client.post(
+        "/dialogs/photos/send",
+        files={"photos": ("x.jpg", BytesIO(b"x"), "image/jpeg")},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_photos_schedule_missing_phone(client):
+    """POST /dialogs/photos/schedule without phone returns redirect with error."""
+    from io import BytesIO
+    resp = await client.post(
+        "/dialogs/photos/schedule",
+        data={"schedule_at": "2026-01-01T10:00"},
+        files={"photos": ("x.jpg", BytesIO(b"x"), "image/jpeg")},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_photos_schedule_missing_schedule_at(client):
+    """POST /dialogs/photos/schedule without schedule_at returns redirect with error."""
+    from io import BytesIO
+    resp = await client.post(
+        "/dialogs/photos/schedule",
+        data={"phone": "+1234567890"},
+        files={"photos": ("x.jpg", BytesIO(b"x"), "image/jpeg")},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_photos_batch_missing_phone(client):
+    """POST /dialogs/photos/batch without phone returns 422."""
+    resp = await client.post("/dialogs/photos/batch", data={}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_photos_auto_missing_phone(client):
+    """POST /dialogs/photos/auto without phone returns 422."""
+    resp = await client.post(
+        "/dialogs/photos/auto",
+        data={"folder_path": "/tmp/photos", "interval_minutes": "60"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_photos_auto_missing_folder_path(client):
+    """POST /dialogs/photos/auto without folder_path returns 422."""
+    resp = await client.post(
+        "/dialogs/photos/auto",
+        data={"phone": "+1234567890", "interval_minutes": "60"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_photos_auto_missing_interval_minutes(client):
+    """POST /dialogs/photos/auto without interval_minutes returns 422."""
+    resp = await client.post(
+        "/dialogs/photos/auto",
+        data={"phone": "+1234567890", "folder_path": "/tmp/photos"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303

--- a/tests/routes/test_pipelines_routes_extra.py
+++ b/tests/routes/test_pipelines_routes_extra.py
@@ -301,6 +301,19 @@ async def test_create_wizard_page_renders(client, base_app):
     assert resp.status_code == 200
 
 
+@pytest.mark.asyncio
+async def test_create_wizard_missing_pipeline_json(client, base_app):
+    """POST /pipelines/create-wizard without pipeline_json returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/create-wizard",
+        data={"name": "Test"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
 # ── add_pipeline validation error ───────────────────────────────────
 
 
@@ -319,6 +332,32 @@ async def test_add_pipeline_validation_error(client, base_app):
         )
     assert resp.status_code == 303
     assert "error=pipeline_invalid" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_add_pipeline_missing_name(client, base_app):
+    """POST /pipelines/add without name returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/add",
+        data={"prompt_template": "test prompt"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_add_pipeline_missing_prompt_template(client, base_app):
+    """POST /pipelines/add without prompt_template returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/add",
+        data={"name": "Test Pipeline"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
 
 
 # ── edit_pipeline DAG preservation ──────────────────────────────────
@@ -395,6 +434,32 @@ async def test_edit_pipeline_dag_preserves_prompt(client_with_dialog, base_app):
         )
     assert resp.status_code == 303
     assert "msg=pipeline_edited" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_edit_pipeline_missing_name(client, base_app):
+    """POST /pipelines/<id>/edit without name returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/1/edit",
+        data={"prompt_template": "test"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_publish_pipeline_missing_run_id(client, base_app):
+    """POST /pipelines/<id>/publish without run_id returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/1/publish",
+        data={},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
 
 
 @pytest.mark.asyncio
@@ -1085,6 +1150,19 @@ async def test_create_from_template_validation_error(client, base_app):
         )
     assert resp.status_code == 303
     assert "error=" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_create_from_template_missing_template_id(client, base_app):
+    """POST /pipelines/from-template without template_id returns 422."""
+    app, _, _ = base_app
+    app.state.llm_provider_service = _make_provider_svc(has=True)
+    resp = await client.post(
+        "/pipelines/from-template",
+        data={"name": "Test"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
 
 
 # ── templates_json ──────────────────────────────────────────────────

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -175,3 +175,17 @@ async def test_delete_nonexistent_no_crash(client):
     """Test delete nonexistent query doesn't crash."""
     resp = await client.post("/search-queries/999999/delete", follow_redirects=False)
     assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_add_search_query_missing_query(client):
+    """POST /search-queries/add without query returns 422."""
+    resp = await client.post("/search-queries/add", data={}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_edit_search_query_missing_query(client):
+    """POST /search-queries/{id}/edit without query returns 422."""
+    resp = await client.post("/search-queries/1/edit", data={}, follow_redirects=False)
+    assert resp.status_code == 303

--- a/tests/test_auth_flow_cli.py
+++ b/tests/test_auth_flow_cli.py
@@ -1,0 +1,136 @@
+"""CLI auth flow tests — pure unit tests covering two-step send-code/verify-code flow."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.telegram_unit
+@pytest.mark.asyncio
+async def test_cli_send_code_saves_hash_to_db(tmp_path):
+    """account send-code saves phone_code_hash to DB under auth_pending:{phone}."""
+    import json
+
+    from src.database import Database
+
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    from src.telegram.auth import TelegramAuth
+
+    auth = TelegramAuth(api_id=12345, api_hash="abc")
+    from telethon.tl.types.auth import SentCodeTypeSms
+
+    mock_result = MagicMock()
+    mock_result.phone_code_hash = "hash_abc"
+    mock_result.type = SentCodeTypeSms(length=5)
+    mock_result.next_type = None
+    mock_result.timeout = 60
+
+    mock_client = AsyncMock()
+    mock_client.send_code_request = AsyncMock(return_value=mock_result)
+    mock_client.session = MagicMock()
+    mock_client.session.save = MagicMock(return_value="")
+
+    with patch("src.telegram.auth.TelegramClient", return_value=mock_client):
+        info = await auth.send_code("+1234567890")
+
+    await db.set_setting("auth_pending:+1234567890", json.dumps(info))
+
+    saved = await db.get_setting("auth_pending:+1234567890")
+    assert saved is not None
+    parsed = json.loads(saved)
+    assert parsed["phone_code_hash"] == "hash_abc"
+
+    await db.close()
+
+
+@pytest.mark.telegram_unit
+@pytest.mark.asyncio
+async def test_sign_in_fresh_success():
+    """sign_in_fresh() passes session_str to StringSession and signs in."""
+    from src.telegram.auth import TelegramAuth
+
+    auth = TelegramAuth(api_id=12345, api_hash="abc")
+    mock_client = AsyncMock()
+    mock_client.sign_in = AsyncMock()
+    mock_client.session.save = MagicMock(return_value="fresh_session_string")
+
+    captured_args = []
+
+    def fake_client(session, api_id, api_hash):
+        captured_args.append(session)
+        return mock_client
+
+    mock_string_session = MagicMock()
+
+    with patch("src.telegram.auth.TelegramClient", side_effect=fake_client), \
+         patch("src.telegram.auth.StringSession", return_value=mock_string_session) as mock_ss:
+        session = await auth.sign_in_fresh("+1234567890", "54321", "hash_abc", session_str="SAVED")
+
+    assert session == "fresh_session_string"
+    mock_ss.assert_called_once_with("SAVED")
+    mock_client.connect.assert_awaited_once()
+    mock_client.sign_in.assert_awaited_once_with("+1234567890", "54321", phone_code_hash="hash_abc")
+    mock_client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.telegram_unit
+@pytest.mark.asyncio
+async def test_sign_in_fresh_2fa_required():
+    """sign_in_fresh raises ValueError('2FA') when SessionPasswordNeededError and no password given."""
+    from telethon.errors import SessionPasswordNeededError
+
+    from src.telegram.auth import TelegramAuth
+
+    auth = TelegramAuth(api_id=12345, api_hash="abc")
+    mock_client = AsyncMock()
+    mock_client.sign_in = AsyncMock(side_effect=SessionPasswordNeededError(request=None))
+
+    with patch("src.telegram.auth.TelegramClient", return_value=mock_client):
+        with pytest.raises(ValueError, match="2FA"):
+            await auth.sign_in_fresh("+1234567890", "54321", "hash_abc")
+
+
+@pytest.mark.telegram_unit
+@pytest.mark.asyncio
+async def test_sign_in_fresh_2fa_with_password():
+    """sign_in_fresh with password succeeds after SessionPasswordNeededError."""
+    from telethon.errors import SessionPasswordNeededError
+
+    from src.telegram.auth import TelegramAuth
+
+    auth = TelegramAuth(api_id=12345, api_hash="abc")
+    mock_client = AsyncMock()
+
+    async def sign_in_side(*args, **kwargs):
+        if "password" not in kwargs:
+            raise SessionPasswordNeededError(request=None)
+
+    mock_client.sign_in = AsyncMock(side_effect=sign_in_side)
+    mock_client.session.save = MagicMock(return_value="session_2fa_ok")
+
+    with patch("src.telegram.auth.TelegramClient", return_value=mock_client):
+        session = await auth.sign_in_fresh("+1234567890", "54321", "hash_abc", password_2fa="mypass")
+
+    assert session == "session_2fa_ok"
+
+
+@pytest.mark.telegram_unit
+@pytest.mark.asyncio
+async def test_sign_in_fresh_does_not_require_pending():
+    """sign_in_fresh works without prior send_code in same process (no _pending check)."""
+    from src.telegram.auth import TelegramAuth
+
+    auth = TelegramAuth(api_id=12345, api_hash="abc")
+    assert "+1234567890" not in auth._pending
+
+    mock_client = AsyncMock()
+    mock_client.sign_in = AsyncMock()
+    mock_client.session.save = MagicMock(return_value="cross_process_session")
+
+    with patch("src.telegram.auth.TelegramClient", return_value=mock_client):
+        session = await auth.sign_in_fresh("+1234567890", "54321", "hash_abc")
+
+    assert session == "cross_process_session"

--- a/tests/test_cli_issue_303.py
+++ b/tests/test_cli_issue_303.py
@@ -10,7 +10,7 @@ from tests.helpers import cli_ns
 
 ISSUE_303_PARSE_CASES = {
     "messages read": ["messages", "read", "demo"],
-    "account add": ["account", "add", "--phone", "+10000000000"],
+    "account send-code": ["account", "send-code", "--phone", "+10000000000"],
     "provider list": ["provider", "list"],
     "provider add": ["provider", "add", "openai", "--api-key", "secret"],
     "provider delete": ["provider", "delete", "openai"],


### PR DESCRIPTION
## Summary

- **CLI auth refactor**: `account add` (interactive, required TTY) replaced with `account send-code` + `account verify-code` — no more `input()`, phone_code_hash and MTProto StringSession persisted in DB between invocations
- **Fix `PhoneCodeExpiredError`**: `sign_in_fresh` now restores the same MTProto session used during `send_code_request` via `session_str` param — Telegram binds `phone_code_hash` to the originating session, a new empty `StringSession()` causes immediate expiry
- **Fix 422 on web forms**: All POST routes replaced `Form(...)` with `Form("")` so missing optional fields return friendly 303 redirects instead of raw 422
- **Fix CLI bug**: `info.phone_code_hash` → `info["phone_code_hash"]` (send_code returns dict)
- **Fix Jinja2 warning**: pipelines/create.html invalid escape sequence in JS regex

## Test plan

- [ ] `pytest tests/test_auth_flow_cli.py -v` — 5 unit tests for two-step CLI flow
- [ ] `pytest tests/routes/test_auth_routes.py -v` — 28 tests including missing-field cases
- [ ] `pytest tests/routes/ -v` — all route tests pass
- [ ] Live: `account send-code --phone X` → `account verify-code --phone X --code CODE`

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)