### PR TITLE
fix(pipeline,collector): wire client_pool in CLI; safe JSON for Telethon action payloads

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -403,10 +403,12 @@ def run(args: argparse.Namespace) -> None:
                     )
                     return
 
+                _, client_pool = await runtime.init_pool(config, db)
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
                     config=config,
+                    client_pool=client_pool,
                     quality_service=QualityScoringService(db, provider_service=provider_service),
                     provider_service=provider_service,
                 )
@@ -456,10 +458,12 @@ def run(args: argparse.Namespace) -> None:
                         "env var (e.g. OPENAI_API_KEY). Non-LLM pipelines run without a provider."
                     )
                     return
+                _, client_pool = await runtime.init_pool(config, db)
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
                     config=config,
+                    client_pool=client_pool,
                     agent_manager=agent_manager,
                     quality_service=QualityScoringService(db, provider_service=provider_svc),
                     provider_service=provider_svc,

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -403,7 +403,8 @@ def run(args: argparse.Namespace) -> None:
                     )
                     return
 
-                _, client_pool = await runtime.init_pool(config, db)
+                _, pool = await runtime.init_pool(config, db)
+                client_pool = pool
                 gen_svc = ContentGenerationService(
                     db,
                     engine,
@@ -458,7 +459,8 @@ def run(args: argparse.Namespace) -> None:
                         "env var (e.g. OPENAI_API_KEY). Non-LLM pipelines run without a provider."
                     )
                     return
-                _, client_pool = await runtime.init_pool(config, db)
+                _, pool = await runtime.init_pool(config, db)
+                client_pool = pool
                 gen_svc = ContentGenerationService(
                     db,
                     engine,

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1331,8 +1331,17 @@ class Collector:
         action = getattr(msg, "action", None)
         if action is None:
             return None
+        from datetime import datetime, date
         payload = {key: value for key, value in action.to_dict().items() if key != "_"}
-        return json.dumps(payload, ensure_ascii=False, sort_keys=True) if payload else None
+
+        def _default(obj):
+            if isinstance(obj, (datetime, date)):
+                return obj.isoformat()
+            if isinstance(obj, bytes):
+                return obj.hex()
+            return repr(obj)
+
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=_default) if payload else None
 
     @staticmethod
     def _get_sender_kind(msg) -> str:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import (
@@ -1331,7 +1331,6 @@ class Collector:
         action = getattr(msg, "action", None)
         if action is None:
             return None
-        from datetime import datetime, date
         payload = {key: value for key, value in action.to_dict().items() if key != "_"}
 
         def _default(obj):


### PR DESCRIPTION
## Summary

- `pipeline run` и `pipeline generate` в CLI теперь инициализируют `ClientPool` через `runtime.init_pool()` и передают его в `ContentGenerationService` — фиксит молчаливый пропуск `ReactHandler`/`ForwardHandler` с `no client_pool` при запуске вне веб-воркера
- `Collector._get_service_action_payload`: добавлен `default=` обработчик для `datetime` (`.isoformat()`), `bytes` (`.hex()`) и любых других неизвестных типов (`repr()`) — фиксит краш `channel collect` на сервисных сообщениях типа `MessageActionChatJoinedByRequest`

## Closes

- #469 — `json.dumps` crash on non-serializable Telethon types

## Test plan

- [ ] `python -m src.main pipeline run 1` — реакции ставятся, нет `no client_pool` warning
- [ ] `python -m src.main channel collect <channel_with_join_requests>` — завершается без `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)