### PR TITLE
test: add coverage for json, provider_service, dialogs, images, agent routes

### DIFF
--- a/tests/routes/test_agent_routes_extra2.py
+++ b/tests/routes/test_agent_routes_extra2.py
@@ -1,0 +1,240 @@
+"""Additional coverage tests for agent routes — generate(), large context, edge cases."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+async def client(route_client, agent_manager_mock):
+    client = route_client
+    client._transport_app.state.agent_manager = agent_manager_mock
+    yield client
+
+
+@pytest.fixture
+async def db(base_app):
+    _, db, _ = base_app
+    return db
+
+
+# === inject_context: large context warning (line 181-185) ===
+
+
+@pytest.mark.asyncio
+async def test_inject_context_large_context_warning(client, db):
+    """Test inject context logs warning for very large content (>200K chars)."""
+    thread_id = await db.create_agent_thread("Context")
+
+    with patch("src.agent.context.format_context", return_value="x" * 250_000):
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/context",
+            content=json.dumps({"channel_id": 100, "limit": 50000}),
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 200
+    data = json.loads(resp.text)
+    assert len(data["content"]) > 200_000
+
+
+# === chat: generate() — save assistant message on done (line 282-283) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_saves_assistant_message(client, db):
+    """Test chat streaming saves assistant message when done."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hello"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+
+    # Consume the stream to trigger the save
+    async for line in resp.aiter_lines():
+        pass
+
+    messages = await db.get_agent_messages(thread_id)
+    assistant_msgs = [m for m in messages if m["role"] == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0]["content"] == "hi"
+
+
+# === chat: generate() — IntegrityError on save (line 284-285) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_integrity_error_on_save(client, db):
+    """Test chat streaming handles IntegrityError when saving assistant message."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    mock_mgr = client._transport_app.state.agent_manager
+
+    async def _fake_stream(*a, **kw):
+        yield 'data: {"done": true, "full_text": "response"}\n\n'
+
+    mock_mgr.chat_stream = _fake_stream
+
+    real_save = db.save_agent_message
+
+    async def _failing_save(*args, **kwargs):
+        if args[1] == "assistant":
+            raise sqlite3.IntegrityError("deleted")
+        return await real_save(*args, **kwargs)
+
+    with patch.object(db, "save_agent_message", side_effect=_failing_save):
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            content=json.dumps({"message": "hello"}),
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 200
+    async for line in resp.aiter_lines():
+        pass
+
+
+# === chat: generate() — error in stream (line 286-290) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_error_in_stream(client, db):
+    """Test chat streaming handles error chunk from agent."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    mock_mgr = client._transport_app.state.agent_manager
+
+    async def _error_stream(*a, **kw):
+        yield 'data: {"error": "model overloaded"}\n\n'
+
+    mock_mgr.chat_stream = _error_stream
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hello"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    async for line in resp.aiter_lines():
+        pass
+
+
+# === chat: generate() — IntegrityError on delete_last_exchange (line 289) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_error_integrity_delete(client, db):
+    """Test chat streaming handles IntegrityError during error cleanup."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    mock_mgr = client._transport_app.state.agent_manager
+
+    async def _error_stream(*a, **kw):
+        yield 'data: {"error": "failed"}\n\n'
+
+    mock_mgr.chat_stream = _error_stream
+
+    with patch.object(db, "delete_last_agent_exchange", side_effect=sqlite3.IntegrityError("gone")):
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            content=json.dumps({"message": "hello"}),
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 200
+    async for line in resp.aiter_lines():
+        pass
+
+
+# === chat: generate() — JSONDecodeError (line 291) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_malformed_chunk(client, db):
+    """Test chat streaming skips malformed JSON chunks."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    mock_mgr = client._transport_app.state.agent_manager
+
+    async def _bad_stream(*a, **kw):
+        yield "data: not-json\n\n"
+        yield 'data: {"done": true, "full_text": "ok"}\n\n'
+
+    mock_mgr.chat_stream = _bad_stream
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hello"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    async for line in resp.aiter_lines():
+        pass
+
+
+# === chat: generate() — generic exception (line 293) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_generic_exception(client, db):
+    """Test chat streaming handles generic exceptions during message processing."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    mock_mgr = client._transport_app.state.agent_manager
+
+    async def _fail_stream(*a, **kw):
+        yield 'data: {"done": true, "full_text": "response"}\n\n'
+
+    mock_mgr.chat_stream = _fail_stream
+
+    real_save = db.save_agent_message
+
+    async def _failing_save(*args, **kwargs):
+        if args[1] == "assistant":
+            raise RuntimeError("unexpected")
+        return await real_save(*args, **kwargs)
+
+    with patch.object(db, "save_agent_message", side_effect=_failing_save):
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            content=json.dumps({"message": "hello"}),
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 200
+    async for line in resp.aiter_lines():
+        pass
+
+
+# === chat: no model parameter (line 232-233) ===
+
+
+@pytest.mark.asyncio
+async def test_chat_with_invalid_model_ignored(client, db):
+    """Test chat with invalid model string is ignored (model=None)."""
+    thread_id = await db.create_agent_thread("Chat")
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hello", "model": "nonexistent-model"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+
+
+# === forum-topics cached (line 130-131) ===
+
+
+@pytest.mark.asyncio
+async def test_forum_topics_cached(client, db):
+    """Test get forum topics returns cached data from DB."""
+    # Insert topics via upsert_forum_topics (not RuntimeSnapshot)
+    await db.upsert_forum_topics(100, [{"id": 1, "title": "Cached Topic"}])
+
+    resp = await client.get("/agent/forum-topics?channel_id=100")
+    assert resp.status_code == 200
+    data = json.loads(resp.text)
+    assert len(data) == 1
+    assert data[0]["title"] == "Cached Topic"

--- a/tests/routes/test_dialogs_coverage.py
+++ b/tests/routes/test_dialogs_coverage.py
@@ -1,0 +1,264 @@
+"""Tests for uncovered dialogs route endpoints."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+async def client(route_client):
+    return route_client
+
+
+# === participants ===
+
+
+@pytest.mark.asyncio
+async def test_participants_missing_fields(client):
+    resp = await client.get("/dialogs/participants?phone=")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_participants_queues(client):
+    resp = await client.get(
+        "/dialogs/participants?phone=%2B1234567890&chat_id=-100123",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 202
+    assert resp.json()["command_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_participants_with_search_queues(client):
+    resp = await client.get(
+        "/dialogs/participants?phone=%2B1234567890&chat_id=-100123&search=test",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 202
+    assert resp.json()["command_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_participants_cache_hit(client, monkeypatch):
+    snapshot = SimpleNamespace(payload={"participants": [{"id": 1}]})
+    mock_db = MagicMock()
+    mock_db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=snapshot)
+    monkeypatch.setattr("src.web.deps.get_db", lambda r: mock_db)
+    resp = await client.get("/dialogs/participants?phone=%2B1234567890&chat_id=-100123")
+    assert resp.status_code == 200
+    assert resp.json()["participants"]
+
+
+# === edit-admin ===
+
+
+@pytest.mark.asyncio
+async def test_edit_admin_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/edit-admin",
+        data={"phone": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_edit_admin_success(client):
+    resp = await client.post(
+        "/dialogs/edit-admin",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "user_id": "42",
+            "is_admin": "1",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "command_id=" in resp.headers.get("location", "")
+
+
+# === edit-permissions ===
+
+
+@pytest.mark.asyncio
+async def test_edit_permissions_no_flags(client):
+    resp = await client.post(
+        "/dialogs/edit-permissions",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "user_id": "42",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "no_permission_flags" in resp.headers.get("location", "")
+
+
+@pytest.mark.asyncio
+async def test_edit_permissions_success(client):
+    resp = await client.post(
+        "/dialogs/edit-permissions",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "user_id": "42",
+            "send_messages": "1",
+            "send_media": "0",
+            "until_date": "2026-12-31",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_edit_permissions_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/edit-permissions",
+        data={"send_messages": "1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "missing_fields" in resp.headers.get("location", "")
+
+
+# === kick ===
+
+
+@pytest.mark.asyncio
+async def test_kick_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/kick",
+        data={"phone": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_kick_success(client):
+    resp = await client.post(
+        "/dialogs/kick",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "user_id": "42",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+# === broadcast-stats ===
+
+
+@pytest.mark.asyncio
+async def test_broadcast_stats_missing_fields(client):
+    resp = await client.get("/dialogs/broadcast-stats?phone=")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_broadcast_stats_queues(client):
+    resp = await client.get(
+        "/dialogs/broadcast-stats?phone=%2B1234567890&chat_id=-100123",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 202
+
+
+# === archive ===
+
+
+@pytest.mark.asyncio
+async def test_archive_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/archive",
+        data={"phone": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_archive_success(client):
+    resp = await client.post(
+        "/dialogs/archive",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+# === unarchive ===
+
+
+@pytest.mark.asyncio
+async def test_unarchive_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/unarchive",
+        data={"phone": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_unarchive_success(client):
+    resp = await client.post(
+        "/dialogs/unarchive",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+# === mark-read ===
+
+
+@pytest.mark.asyncio
+async def test_mark_read_missing_fields(client):
+    resp = await client.post(
+        "/dialogs/mark-read",
+        data={"phone": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_mark_read_success(client):
+    resp = await client.post(
+        "/dialogs/mark-read",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "max_id": "999",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+
+@pytest.mark.asyncio
+async def test_mark_read_no_max_id(client):
+    resp = await client.post(
+        "/dialogs/mark-read",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -143,3 +143,51 @@ async def test_generate_with_model(client, monkeypatch):
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "test:model"
+
+
+@pytest.mark.asyncio
+async def test_get_provider_api_key_from_db_config(monkeypatch):
+    """API key returned from DB provider config."""
+    mock_config = MagicMock(provider="together", api_key="db-key-123")
+    mock_svc = MagicMock()
+    mock_svc.load_provider_configs = AsyncMock(return_value=[mock_config])
+
+    from src.web.routes.images import _get_provider_api_key
+
+    with patch("src.services.image_provider_service.ImageProviderService", return_value=mock_svc):
+        result = await _get_provider_api_key(MagicMock(), "together")
+    assert result == "db-key-123"
+
+
+@pytest.mark.asyncio
+async def test_get_provider_api_key_env_fallback(monkeypatch):
+    """Falls back to env var when DB config has no matching key."""
+    mock_config = MagicMock(provider="other", api_key="other-key")
+    mock_svc = MagicMock()
+    mock_svc.load_provider_configs = AsyncMock(return_value=[mock_config])
+
+    from src.services.image_provider_service import IMAGE_PROVIDER_SPECS
+
+    first_provider = next(iter(IMAGE_PROVIDER_SPECS), None)
+    if not first_provider:
+        pytest.skip("No IMAGE_PROVIDER_SPECS")
+
+    spec = IMAGE_PROVIDER_SPECS[first_provider]
+    for var in spec.env_vars:
+        monkeypatch.setenv(var, "env-key-456")
+
+    from src.web.routes.images import _get_provider_api_key
+
+    with patch("src.services.image_provider_service.ImageProviderService", return_value=mock_svc):
+        result = await _get_provider_api_key(MagicMock(), first_provider)
+    assert result == "env-key-456"
+
+
+@pytest.mark.asyncio
+async def test_get_provider_api_key_exception_returns_empty():
+    """Returns empty string on any exception."""
+    from src.web.routes.images import _get_provider_api_key
+
+    with patch("src.services.image_provider_service.ImageProviderService", side_effect=Exception("boom")):
+        result = await _get_provider_api_key(MagicMock(), "anything")
+    assert result == ""

--- a/tests/test_provider_service_coverage.py
+++ b/tests/test_provider_service_coverage.py
@@ -1,0 +1,258 @@
+"""Additional tests for provider_service uncovered paths."""
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.provider_service import AgentProviderService
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    saved = {}
+    for var in [
+        "OPENAI_API_KEY", "COHERE_API_KEY", "OLLAMA_BASE", "OLLAMA_URL",
+        "HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN", "FIREWORKS_BASE",
+        "FIREWORKS_API_BASE", "FIREWORKS_API_KEY", "DEEPSEEK_BASE",
+        "DEEPSEEK_API_BASE", "DEEPSEEK_API_KEY", "TOGETHER_BASE",
+        "TOGETHER_API_BASE", "TOGETHER_API_KEY", "CONTEXT7_API_KEY",
+        "CTX7_API_KEY", "ZAI_API_KEY",
+    ]:
+        saved[var] = os.environ.get(var)
+        if var in os.environ:
+            del os.environ[var]
+    yield
+    for var, val in saved.items():
+        if val is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = val
+
+
+# === Z.AI registration failure ===
+
+
+def test_zai_registration_failure_path(clean_env):
+    """Z.AI adapter registration failure is caught gracefully."""
+    os.environ["ZAI_API_KEY"] = "zai-test-key"
+    with patch("src.agent.provider_registry.ZAI_DEFAULT_BASE_URL", "http://zai.test", create=True):
+        with patch("src.services.provider_adapters.make_anthropic_adapter", side_effect=ImportError("no anthropic")):
+            svc = AgentProviderService()
+    assert "zai" not in svc._registry
+
+
+# === Context7 registration failure ===
+
+
+def test_context7_registration_failure_path(clean_env):
+    """Context7 adapter registration failure is caught gracefully."""
+    os.environ["CONTEXT7_API_KEY"] = "ctx7-test-key"
+    with patch("src.services.provider_adapters.make_context7_adapter", side_effect=ImportError("no ctx7")):
+        svc = AgentProviderService()
+    assert "context7" not in svc._registry
+
+
+# === Import failure for HTTP adapters ===
+
+
+def test_http_adapter_import_failure(clean_env):
+    """When provider_adapters import fails, adapters are skipped."""
+    os.environ["COHERE_API_KEY"] = "cohere-test"
+    # Simulate ImportError by patching the import
+    with patch.dict("sys.modules", {"src.services.provider_adapters": None}):
+        svc = AgentProviderService()
+    assert "cohere" not in svc._registry
+
+
+# === Exception during individual HTTP adapter registration ===
+
+
+def test_http_adapter_registration_exception(clean_env):
+    """Single adapter failure doesn't prevent others from registering."""
+    os.environ["COHERE_API_KEY"] = "cohere-key"
+    os.environ["OLLAMA_BASE"] = "http://localhost:11434"
+
+    call_count = 0
+
+    def mock_cohere(key):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ValueError("bad adapter")
+        return AsyncMock()
+
+    with patch("src.services.provider_adapters.make_cohere_adapter", mock_cohere):
+        with patch("src.services.provider_adapters.make_ollama_adapter", return_value=AsyncMock()):
+            with patch("src.services.provider_adapters.make_huggingface_adapter"):
+                with patch("src.services.provider_adapters.make_generic_http_adapter"):
+                    svc = AgentProviderService()
+
+    # cohere failed but ollama may have registered
+    assert "cohere" not in svc._registry
+
+
+# === get_provider_status_list exception ===
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_db_exception():
+    """Returns empty list when DB load fails."""
+    svc = AgentProviderService()
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    svc.db = mock_db
+    svc._config = mock_config
+
+    with patch("src.services.agent_provider_service.AgentProviderService") as mock_cls:
+        mock_instance = MagicMock()
+        mock_instance.load_provider_configs = AsyncMock(side_effect=Exception("DB error"))
+        mock_cls.return_value = mock_instance
+        result = await svc.get_provider_status_list()
+
+    assert result == []
+
+
+# === get_provider_callable: OpenAI not registered but GPT model requested ===
+
+
+@pytest.mark.asyncio
+async def test_get_provider_gpt_fallback_without_openai():
+    """When OpenAI not registered but gpt model requested, falls back to default."""
+    svc = AgentProviderService()
+    provider = svc.get_provider_callable("gpt-4")
+    result = await provider(prompt="test")
+    assert "DRAFT" in result
+
+
+# === _make_openai_compat_provider: non-200 status ===
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_provider_non_200():
+    """Provider raises RuntimeError on non-200 status."""
+    svc = AgentProviderService()
+    provider_fn = svc._make_openai_compat_provider("http://localhost:1234", "test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.status = 429
+    mock_resp.text = AsyncMock(return_value="rate limited")
+    mock_resp.json = AsyncMock(return_value={})
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_cm
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.provider_service.aiohttp.ClientSession", return_value=mock_session_cm):
+        with pytest.raises(RuntimeError, match="Provider error 429"):
+            await provider_fn(prompt="test")
+
+
+# === _make_openai_compat_provider: malformed response ===
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_provider_malformed_response():
+    """Provider returns stringified response when choices not found."""
+    svc = AgentProviderService()
+    provider_fn = svc._make_openai_compat_provider("http://localhost:1234", "test-key")
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.text = AsyncMock(return_value="ok")
+    mock_resp.json = AsyncMock(return_value={"error": "no choices"})
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_cm
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.provider_service.aiohttp.ClientSession", return_value=mock_session_cm):
+        result = await provider_fn(prompt="test")
+    # Falls back to str(data) since choices[0].message.content fails
+    assert "no choices" in result
+
+
+# === _make_openai_provider: malformed response fallback ===
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_malformed_response_fallback(clean_env):
+    """OpenAI provider returns stringified response when choices not found."""
+    os.environ["OPENAI_API_KEY"] = "test-key"
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.text = AsyncMock(return_value="ok")
+    mock_resp.json = AsyncMock(return_value={"unexpected": "format"})
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_cm
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.provider_service.aiohttp.ClientSession", return_value=mock_session_cm):
+        svc = AgentProviderService()
+        provider = svc.get_provider_callable("openai")
+        result = await provider(prompt="test")
+    assert "unexpected" in result
+
+
+# === get_provider_status_list: with configs ===
+
+
+@pytest.mark.asyncio
+async def test_get_provider_status_list_with_configs():
+    """Returns status list for configured providers."""
+    svc = AgentProviderService()
+
+    async def fake_provider(**kwargs):
+        return "test"
+
+    svc.register_provider("openai", fake_provider)
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    svc.db = mock_db
+    svc._config = mock_config
+
+    cfg1 = MagicMock()
+    cfg1.provider = "openai"
+    cfg1.enabled = True
+
+    cfg2 = MagicMock()
+    cfg2.provider = "disabled_prov"
+    cfg2.enabled = False
+
+    cfg3 = MagicMock()
+    cfg3.provider = "no_secrets"
+    cfg3.enabled = True
+
+    with patch("src.services.agent_provider_service.AgentProviderService") as mock_cls:
+        mock_instance = MagicMock()
+        mock_instance.load_provider_configs = AsyncMock(return_value=[cfg1, cfg2, cfg3])
+        mock_cls.return_value = mock_instance
+
+        with patch.object(svc, "_has_valid_secrets", side_effect=lambda c: c.provider != "no_secrets"):
+            result = await svc.get_provider_status_list()
+
+    assert len(result) == 3
+    assert result[0]["status"] == "active"
+    assert result[1]["status"] == "disabled"
+    assert result[2]["status"] == "invalid_secrets"

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -1,0 +1,75 @@
+"""Tests for src/utils/json.py — safe_json_dumps."""
+from datetime import date, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from src.utils.json import safe_json_dumps
+
+
+class _SampleModel(BaseModel):
+    name: str
+    value: int
+
+
+def test_plain_types():
+    assert safe_json_dumps({"a": 1, "b": "hello"}) == '{"a": 1, "b": "hello"}'
+
+
+def test_datetime_serialization():
+    dt = datetime(2026, 4, 19, 12, 30, 45)
+    result = safe_json_dumps({"ts": dt})
+    assert '"2026-04-19T12:30:45"' in result
+
+
+def test_date_serialization():
+    d = date(2026, 1, 15)
+    result = safe_json_dumps({"d": d})
+    assert '"2026-01-15"' in result
+
+
+def test_bytes_serialization():
+    data = b"\xde\xad\xbe\xef"
+    result = safe_json_dumps({"raw": data})
+    assert "deadbeef" in result
+
+
+def test_pydantic_model_serialization():
+    m = _SampleModel(name="test", value=42)
+    result = safe_json_dumps(m)
+    assert '"name": "test"' in result
+    assert '"value": 42' in result
+
+
+def test_unknown_type_raises_type_error():
+    class Custom:
+        pass
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        safe_json_dumps(Custom())
+
+
+def test_mixed_types():
+    payload = {
+        "dt": datetime(2026, 1, 1),
+        "data": b"\xff",
+        "model": _SampleModel(name="x", value=1),
+        "plain": "text",
+    }
+    result = safe_json_dumps(payload)
+    assert "2026-01-01" in result
+    assert "ff" in result
+    assert '"name": "x"' in result
+    assert '"plain": "text"' in result
+
+
+def test_kwargs_forwarded():
+    result = safe_json_dumps({"b": 1, "a": 2}, sort_keys=True)
+    assert result == '{"a": 2, "b": 1}'
+
+
+def test_list_of_datetime():
+    items = [datetime(2026, 1, 1), datetime(2026, 6, 15)]
+    result = safe_json_dumps(items)
+    assert "2026-01-01" in result
+    assert "2026-06-15" in result


### PR DESCRIPTION
## Summary
- New test files targeting low-coverage modules: `safe_json_dumps` (42%→100%), `provider_service` (83%→98%), `images` routes (63%→90%), `dialogs` routes, `agent` routes streaming/error paths
- Overall coverage improved from 92.36% to 92.60% (7531 tests, 0 failures)
- All new tests pass lint (`ruff check`) and integrate cleanly with existing suite

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ --timeout=30 --cov=src` — 7531 passed, 92.60% coverage
- [ ] CI green (ruff + parallel + serial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)