### PR TITLE
fix(logging): add log_path param to setup_logging to prevent ResourceWarning in tests

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -18,7 +18,8 @@ _TUI_LOG_PATH = _DATA_ROOT / "agent_tui.log"
 APP_LOG_PATH = _DATA_ROOT / "app.log"
 
 
-def setup_logging() -> None:
+def setup_logging(log_path: Path | None = None) -> None:
+    log_path = log_path or APP_LOG_PATH
     logging.basicConfig(
         level=logging.INFO,
         format=_LOG_FORMAT,
@@ -26,11 +27,11 @@ def setup_logging() -> None:
     )
     root = logging.getLogger()
     for h in root.handlers:
-        if isinstance(h, RotatingFileHandler) and getattr(h, "baseFilename", None) == str(APP_LOG_PATH):
+        if isinstance(h, RotatingFileHandler) and getattr(h, "baseFilename", None) == str(log_path):
             return
-    _DATA_ROOT.mkdir(parents=True, exist_ok=True)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
     rfh = RotatingFileHandler(
-        str(APP_LOG_PATH),
+        str(log_path),
         maxBytes=10 * 1024 * 1024,
         backupCount=3,
         encoding="utf-8",

--- a/tests/test_cli_runtime_extra.py
+++ b/tests/test_cli_runtime_extra.py
@@ -14,16 +14,15 @@ from src.cli.runtime import (
 
 
 class TestSetupLogging:
-    def test_setup_logging_configures_root_logger(self):
+    def test_setup_logging_configures_root_logger(self, tmp_path):
         """setup_logging sets basicConfig on the root logger."""
         root = logging.getLogger()
-        # Clear any existing handlers to ensure clean test
         original_handlers = root.handlers[:]
         original_level = root.level
         root.handlers.clear()
 
         try:
-            setup_logging()
+            setup_logging(log_path=tmp_path / "app.log")
             assert root.level == logging.INFO
             assert len(root.handlers) >= 1
         finally:


### PR DESCRIPTION
## Summary
- `setup_logging()` wrote to shared `data/app.log`; in xdist parallel runs multiple workers opened the same file, causing `ResourceWarning: unclosed file` after GC teardown
- Added optional `log_path: Path | None = None` parameter (defaults to `APP_LOG_PATH` — no prod behavior change)
- Test now passes `tmp_path / "app.log"` — fully isolated per worker

Follow-up to #477 (4th leak point identified in issue comment [#477/#4322291868](https://github.com/axisrow/tg_content_factory/issues/477#issuecomment-4322291868)).

## Test plan
- [x] `pytest tests/test_cli_runtime_extra.py -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning` — 10 passed, 0 warnings
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)