### PR TITLE
fix(web): periodic SnapshotRefresher to keep shim caches in sync

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -34,6 +34,7 @@ from src.web.panel_auth import (
     set_session_cookie,
 )
 from src.web.paths import TEMPLATES_DIR
+from src.web.snapshot_refresher import SnapshotRefresher
 from src.web.template_globals import configure_template_globals
 
 logger = logging.getLogger(__name__)
@@ -265,10 +266,24 @@ async def lifespan(app: FastAPI):
     else:
         logger.debug("Embedded worker not spawned (app.state.embed_worker is not True)")
 
+    # Periodic reader of `runtime_snapshots` so the web container's read-only
+    # shims (SnapshotClientPool / SnapshotCollector / SnapshotSchedulerManager)
+    # stay in sync with whatever worker is publishing — embedded or split.
+    refresher: SnapshotRefresher | None = None
+    if container.runtime_mode == "web":
+        refresher = SnapshotRefresher(container)
+        await refresher.start()
+        app.state.snapshot_refresher = refresher
+
     try:
         yield
     finally:
         logger.info("Shutting down...")
+        if refresher is not None:
+            try:
+                await refresher.stop()
+            except Exception:
+                logger.exception("Error stopping snapshot refresher")
         if embedded_worker is not None:
             try:
                 await embedded_worker.stop()

--- a/src/web/snapshot_refresher.py
+++ b/src/web/snapshot_refresher.py
@@ -37,6 +37,7 @@ class SnapshotRefresher:
     async def start(self) -> None:
         if self._task is not None:
             raise RuntimeError("SnapshotRefresher already started")
+        self._stop.clear()
         self._task = asyncio.create_task(self._run(), name="snapshot-refresher")
 
     async def stop(self, timeout: float = 5.0) -> None:

--- a/src/web/snapshot_refresher.py
+++ b/src/web/snapshot_refresher.py
@@ -1,0 +1,81 @@
+"""Periodic reader of `runtime_snapshots` for the web container.
+
+Mirror of `src/web/embedded_worker.py` from the *reader* side. The worker (either
+embedded inside `serve` or a separate `python -m src.main worker` process)
+publishes `accounts_status` / `collector_status` / `scheduler_status` snapshots
+every ~5s; this task re-hydrates the read-only shims in
+`src/web/runtime_shims.py` every `REFRESH_INTERVAL_SEC` seconds so pages like
+`/scheduler/`, `/dashboard/` and `/health` reflect live state instead of the
+single startup snapshot from `src/web/bootstrap.py`.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from src.web.container import AppContainer
+from src.web.runtime_shims import (
+    SnapshotClientPool,
+    SnapshotCollector,
+    SnapshotSchedulerManager,
+)
+
+logger = logging.getLogger(__name__)
+
+# Reader cadence. Worker writes every 5s; 3s gives worst-case staleness ≤ 8s
+# without excess phase drift (5s reader would drift toward 10s lag).
+REFRESH_INTERVAL_SEC = 3.0
+
+
+class SnapshotRefresher:
+    def __init__(self, container: AppContainer, *, interval: float = REFRESH_INTERVAL_SEC):
+        self._container = container
+        self._interval = interval
+        self._task: asyncio.Task[None] | None = None
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task is not None:
+            raise RuntimeError("SnapshotRefresher already started")
+        self._task = asyncio.create_task(self._run(), name="snapshot-refresher")
+
+    async def stop(self, timeout: float = 5.0) -> None:
+        if self._task is None:
+            return
+        self._stop.set()
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning("[snapshot-refresher] did not stop within %.1fs; cancelling", timeout)
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._task = None
+
+    async def _run(self) -> None:
+        logger.debug("[snapshot-refresher] starting (interval=%.2fs)", self._interval)
+        try:
+            while not self._stop.is_set():
+                try:
+                    await self._refresh_once()
+                except Exception:
+                    logger.exception("[snapshot-refresher] refresh failed")
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=self._interval)
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            logger.debug("[snapshot-refresher] stopped")
+
+    async def _refresh_once(self) -> None:
+        pool = self._container.pool
+        collector = self._container.collector
+        scheduler = self._container.scheduler
+        if isinstance(pool, SnapshotClientPool):
+            await pool.refresh()
+        if isinstance(collector, SnapshotCollector):
+            await collector.refresh()
+        if isinstance(scheduler, SnapshotSchedulerManager):
+            await scheduler.load_settings()

--- a/tests/e2e/test_collection_flow.py
+++ b/tests/e2e/test_collection_flow.py
@@ -28,7 +28,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.config import AppConfig, DatabaseConfig
 from src.database import Database
-from src.models import Account, Channel, CollectionTaskStatus, Message
+from src.models import Account, Channel, CollectionTaskStatus, Message, RuntimeSnapshot
 from src.web.app import create_app
 
 _PASS = "testpass"
@@ -216,3 +216,44 @@ async def test_embedded_worker_publishes_heartbeat(tmp_path):
                 assert snapshot.payload.get("status") == "alive"
             finally:
                 await db.close()
+
+
+@pytest.mark.asyncio
+async def test_health_reflects_accounts_after_snapshot_publish(tmp_path):
+    """Regression guard for the `/scheduler/` shows 0/0 bug.
+
+    Web container's read-only shims used to refresh exactly once at startup,
+    so `/health` and `/scheduler/` reported `accounts_connected = 0` forever
+    even when the worker kept publishing fresh `accounts_status` snapshots.
+
+    Here we boot `serve` without an embedded worker (so nothing internally
+    overwrites the snapshot), seed an `accounts_status` row directly, and
+    expect the web container's `SnapshotRefresher` to pick it up within a
+    couple of refresh ticks.
+    """
+    async with _serve_app(tmp_path, embed_worker=False) as (client, config):
+        resp = await client.get("/health")
+        assert resp.json()["accounts_connected"] == 0
+
+        db = Database(config.database.path)
+        await db.initialize()
+        try:
+            await db.repos.runtime_snapshots.upsert_snapshot(
+                RuntimeSnapshot(
+                    snapshot_type="accounts_status",
+                    payload={"connected_phones": ["+7999"], "connected_count": 1},
+                )
+            )
+        finally:
+            await db.close()
+
+        # SnapshotRefresher cadence is 3s; allow up to ~5s of jitter.
+        deadline = asyncio.get_running_loop().time() + 6.0
+        connected = 0
+        while asyncio.get_running_loop().time() < deadline:
+            resp = await client.get("/health")
+            connected = resp.json()["accounts_connected"]
+            if connected >= 1:
+                break
+            await asyncio.sleep(0.25)
+        assert connected == 1, f"expected refresher to pick up snapshot, got accounts_connected={connected}"

--- a/tests/test_web_snapshot_refresher.py
+++ b/tests/test_web_snapshot_refresher.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.web.runtime_shims import (
+    SnapshotClientPool,
+    SnapshotCollector,
+    SnapshotSchedulerManager,
+)
+from src.web.snapshot_refresher import SnapshotRefresher
+
+
+def _mock_db():
+    db = MagicMock()
+    db.repos = MagicMock()
+    db.repos.runtime_snapshots = MagicMock()
+    db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=None)
+    return db
+
+
+def _container_with_shims(db):
+    return SimpleNamespace(
+        pool=SnapshotClientPool(db),
+        collector=SnapshotCollector(db),
+        scheduler=SnapshotSchedulerManager(db, default_interval_minutes=60),
+    )
+
+
+async def _wait_for(predicate, *, timeout: float = 1.0, step: float = 0.02) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(step)
+    return predicate()
+
+
+async def test_refresher_starts_and_stops_cleanly():
+    db = _mock_db()
+    container = _container_with_shims(db)
+    refresher = SnapshotRefresher(container, interval=0.05)
+    await refresher.start()
+    await asyncio.sleep(0.1)
+    await refresher.stop()
+
+
+async def test_refresher_double_start_raises():
+    db = _mock_db()
+    refresher = SnapshotRefresher(_container_with_shims(db), interval=0.05)
+    await refresher.start()
+    try:
+        with pytest.raises(RuntimeError):
+            await refresher.start()
+    finally:
+        await refresher.stop()
+
+
+async def test_refresher_picks_up_new_snapshots():
+    db = _mock_db()
+    container = _container_with_shims(db)
+
+    # Initially: no snapshots → empty caches.
+    await container.pool.refresh()
+    await container.collector.refresh()
+    await container.scheduler.load_settings()
+    assert container.pool.clients == {}
+    assert container.collector.is_running is False
+    assert container.scheduler.interval_minutes == 60
+
+    refresher = SnapshotRefresher(container, interval=0.02)
+    await refresher.start()
+
+    # Now publish fresh snapshots and let the refresher pick them up.
+    accounts_snap = MagicMock(payload={"connected_phones": ["+79991", "+79992"]})
+    collector_snap = MagicMock(payload={"is_running": True})
+    scheduler_snap = MagicMock(payload={"is_running": True, "interval_minutes": 15})
+
+    def _route(snapshot_type, scope="global"):
+        if snapshot_type == "accounts_status":
+            return accounts_snap
+        if snapshot_type == "collector_status":
+            return collector_snap
+        if snapshot_type == "scheduler_status":
+            return scheduler_snap
+        return None
+
+    db.repos.runtime_snapshots.get_snapshot = AsyncMock(side_effect=_route)
+
+    try:
+        assert await _wait_for(
+            lambda: set(container.pool.clients.keys()) == {"+79991", "+79992"}, timeout=1.0
+        )
+        assert container.collector.is_running is True
+        assert container.scheduler.is_running is True
+        assert container.scheduler.interval_minutes == 15
+    finally:
+        await refresher.stop()
+
+
+async def test_refresher_swallows_db_errors():
+    db = _mock_db()
+    container = _container_with_shims(db)
+
+    snapshot = MagicMock(payload={"connected_phones": ["+79991"]})
+    db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=snapshot)
+
+    calls = {"n": 0}
+    real_refresh = container.pool.refresh
+
+    async def flaky_refresh():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")
+        await real_refresh()
+
+    container.pool.refresh = flaky_refresh
+
+    refresher = SnapshotRefresher(container, interval=0.02)
+    await refresher.start()
+    try:
+        # Despite the first refresh raising, the loop survives and the
+        # second tick populates the cache from the snapshot.
+        assert await _wait_for(
+            lambda: set(container.pool.clients.keys()) == {"+79991"}, timeout=1.0
+        )
+        assert calls["n"] >= 2
+    finally:
+        await refresher.stop()
+
+
+async def test_refresher_noop_in_worker_mode():
+    # Worker-mode containers hold the real ClientPool/Collector/SchedulerManager.
+    # The isinstance guards must skip refresh on them — represented here by
+    # plain objects without `refresh` / `load_settings` attributes.
+    container = SimpleNamespace(
+        pool=object(),
+        collector=object(),
+        scheduler=object(),
+    )
+    refresher = SnapshotRefresher(container, interval=0.02)
+    await refresher.start()
+    try:
+        await asyncio.sleep(0.1)
+    finally:
+        await refresher.stop()
+
+
+async def test_refresher_stop_without_start_is_noop():
+    db = _mock_db()
+    refresher = SnapshotRefresher(_container_with_shims(db), interval=0.05)
+    await refresher.stop()  # must not raise

--- a/tests/test_web_snapshot_refresher.py
+++ b/tests/test_web_snapshot_refresher.py
@@ -153,3 +153,21 @@ async def test_refresher_stop_without_start_is_noop():
     db = _mock_db()
     refresher = SnapshotRefresher(_container_with_shims(db), interval=0.05)
     await refresher.stop()  # must not raise
+
+
+async def test_refresher_can_restart_after_stop():
+    db = _mock_db()
+    container = _container_with_shims(db)
+    refresher = SnapshotRefresher(container, interval=0.02)
+
+    await refresher.start()
+    await refresher.stop()
+
+    snapshot = MagicMock(payload={"connected_phones": ["+79991"]})
+    db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=snapshot)
+
+    await refresher.start()
+    try:
+        assert await _wait_for(lambda: set(container.pool.clients.keys()) == {"+79991"}, timeout=1.0)
+    finally:
+        await refresher.stop()

--- a/tests/test_web_snapshot_refresher.py
+++ b/tests/test_web_snapshot_refresher.py
@@ -31,8 +31,9 @@ def _container_with_shims(db):
 
 
 async def _wait_for(predicate, *, timeout: float = 1.0, step: float = 0.02) -> bool:
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
         if predicate():
             return True
         await asyncio.sleep(step)


### PR DESCRIPTION
## Summary
- Web container's read-only shims (`SnapshotClientPool` / `SnapshotCollector` / `SnapshotSchedulerManager`) refreshed exactly once in `bootstrap.py:162/181/232` and never re-read `runtime_snapshots`, so `/scheduler/`, `/dashboard/` and `/health` reported `0 connected / 0 available` forever — even when the worker (embedded or split) kept publishing fresh snapshots every 5s.
- Added `src/web/snapshot_refresher.py`: a background `asyncio.Task` symmetric to the worker's `_publish_snapshots` loop. Reads `accounts_status` / `collector_status` / `scheduler_status` every 3s; `isinstance` guards make it a strict no-op in worker-mode containers.
- Wired into `app.py` lifespan independently of `app.state.embed_worker`, so it works in both `serve` (embedded worker) and `serve --no-worker` + separate `worker` process deployments.

## Test plan
- [x] Unit: `tests/test_web_snapshot_refresher.py` — 6 tests (lifecycle, double-start, picks up new snapshots, swallows DB errors, no-op in worker mode, stop-without-start).
- [x] E2E regression: `tests/e2e/test_collection_flow.py::test_health_reflects_accounts_after_snapshot_publish` — boots `serve --no-worker`, seeds `accounts_status` directly, expects `/health` to flip from 0 → 1 within ~5s.
- [x] Full suite: 7538 passed, 1 skipped (≈80s).
- [x] ruff: clean.
- [ ] Manual smoke in browser at `/scheduler/` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)