### PR TITLE
fix: close #472/#473 tail — record_error in FetchMessages + safe_json_dumps in two repos

### DIFF
--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import aiosqlite
 
 from src.models import GenerationRun
+from src.utils.json import safe_json_dumps
 
 
 def _dt(value: str | None) -> datetime | None:
@@ -74,7 +75,7 @@ class GenerationRunsRepository:
             await self._db.execute(
                 ("UPDATE generation_runs SET status = ?, metadata = ?, "
                  "updated_at = datetime('now') WHERE id = ?"),
-                (status, json.dumps(metadata, ensure_ascii=False), run_id),
+                (status, safe_json_dumps(metadata, ensure_ascii=False), run_id),
             )
         else:
             await self._db.execute(
@@ -89,7 +90,7 @@ class GenerationRunsRepository:
         await self._db.execute(
             ("UPDATE generation_runs SET generated_text = ?, metadata = ?, status = 'completed', "
              "updated_at = datetime('now') WHERE id = ?"),
-            (generated_text, json.dumps(metadata or {}, ensure_ascii=False), run_id),
+            (generated_text, safe_json_dumps(metadata or {}, ensure_ascii=False), run_id),
         )
         await self._db.commit()
 
@@ -111,7 +112,7 @@ class GenerationRunsRepository:
     async def set_quality_score(
         self, run_id: int, score: float, issues: list[str] | None = None
     ) -> None:
-        issues_json = json.dumps(issues, ensure_ascii=False) if issues else None
+        issues_json = safe_json_dumps(issues, ensure_ascii=False) if issues else None
         await self._db.execute(
             ("UPDATE generation_runs SET quality_score = ?, quality_issues = ?, "
              "updated_at = datetime('now') WHERE id = ?"),
@@ -122,7 +123,7 @@ class GenerationRunsRepository:
     async def set_variants(self, run_id: int, variants: list[str]) -> None:
         await self._db.execute(
             "UPDATE generation_runs SET variants = ?, updated_at = datetime('now') WHERE id = ?",
-            (json.dumps(variants, ensure_ascii=False), run_id),
+            (safe_json_dumps(variants, ensure_ascii=False), run_id),
         )
         await self._db.commit()
 

--- a/src/database/repositories/runtime_snapshots.py
+++ b/src/database/repositories/runtime_snapshots.py
@@ -7,6 +7,7 @@ from typing import Any
 import aiosqlite
 
 from src.models import RuntimeSnapshot
+from src.utils.json import safe_json_dumps
 
 
 def _parse_json(raw: str | None) -> dict[str, Any]:
@@ -44,7 +45,7 @@ class RuntimeSnapshotsRepository:
             (
                 snapshot.snapshot_type,
                 snapshot.scope,
-                json.dumps(snapshot.payload),
+                safe_json_dumps(snapshot.payload),
                 snapshot.updated_at.isoformat() if snapshot.updated_at is not None else None,
             ),
         )

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -70,6 +70,13 @@ class FetchMessagesHandler(BaseNodeHandler):
     async def execute(self, node_config: dict, context: NodeContext, services: dict) -> None:
         db = services.get("db")
         if db is None:
+            node_id = _current_node_id(services, default="fetch_messages")
+            context.record_error(
+                node_id=node_id,
+                code="missing_dependency",
+                detail="db not available in services",
+            )
+            logger.warning("FetchMessagesHandler[%s]: no db, skipping", node_id)
             context.set_global("context_messages", [])
             return
         channel_ids = context.get_global("source_channel_ids", [])

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -117,3 +117,28 @@ async def test_runtime_snapshots_repository_upsert_and_get(tmp_path):
         assert stored.payload == {"status": "alive"}
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshots_repository_handles_non_primitive_payload(tmp_path):
+    """Regression for #473 tail: payload with datetime/bytes must round-trip
+    via safe_json_dumps without raising TypeError.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        snap_dt = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+        snapshot = RuntimeSnapshot(
+            snapshot_type="exotic_payload",
+            scope="global",
+            payload={"published_at": snap_dt, "blob": b"\xde\xad\xbe\xef"},
+        )
+        await db.repos.runtime_snapshots.upsert_snapshot(snapshot)
+
+        stored = await db.repos.runtime_snapshots.get_snapshot("exotic_payload", "global")
+        assert stored is not None
+        assert stored.payload["published_at"] == "2026-04-27T12:00:00+00:00"
+        assert stored.payload["blob"] == "deadbeef"
+    finally:
+        await db.close()

--- a/tests/test_pipeline_nodes_handler_edge_cases.py
+++ b/tests/test_pipeline_nodes_handler_edge_cases.py
@@ -69,11 +69,15 @@ async def test_source_handler_missing_channel_ids_key():
 
 @pytest.mark.asyncio
 async def test_fetch_messages_no_db_service():
-    """When db is None in services, sets empty context_messages."""
+    """When db is None in services, sets empty context_messages and records the error."""
     ctx = NodeContext()
     ctx.set_global("source_channel_ids", [1, 2])
     await FetchMessagesHandler().execute({}, ctx, {})
     assert ctx.get_global("context_messages") == []
+    errors = ctx.get_errors()
+    assert len(errors) == 1
+    assert errors[0]["code"] == "missing_dependency"
+    assert "db" in errors[0]["detail"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #474 closed the bulk of issues #472 (silent skip) and #473 (unsafe `json.dumps`). This PR finishes the three remaining tail items uncovered during a follow-up audit:

- **#472**: `FetchMessagesHandler` was the last pipeline handler still doing a silent skip (`if db is None: set_global([]) ; return`). Now records `missing_dependency` in the node context, logs a warning, and still gracefully degrades to an empty message list.
- **#473**: `runtime_snapshots.upsert_snapshot` and four call sites in `generation_runs` repo still used raw `json.dumps` on `dict[str, Any]` payloads/metadata that can carry `datetime`/`bytes` from worker publishers and pipeline runs. Switched all five to `safe_json_dumps` (defined in `src/utils/json.py`), aligning with the rest of the repos already on it.

## Changes

### #472 — silent skip
- `src/services/pipeline_nodes/handlers.py` — `FetchMessagesHandler` now calls `context.record_error(code="missing_dependency", detail="db not available in services")` before falling back to an empty message list.

### #473 — safe JSON serialization
- `src/database/repositories/runtime_snapshots.py:47` — `safe_json_dumps(snapshot.payload)`.
- `src/database/repositories/generation_runs.py:77, 92, 114, 125` — `safe_json_dumps` for `metadata`, `issues`, `variants` columns.

### Tests
- `tests/test_pipeline_nodes_handler_edge_cases.py` — extended `test_fetch_messages_no_db_service` to assert the recorded error.
- `tests/repositories/test_runtime_repositories.py` — new `test_runtime_snapshots_repository_handles_non_primitive_payload` (round-trips a payload with `datetime` + `bytes` through upsert/get).

## Closes

- Closes #472
- Closes #473

## Test plan

- [x] `ruff check src/ tests/ conftest.py` — clean.
- [x] Parallel suite: 6704 passed, 1 skipped (~58s).
- [x] Serial suite: 828 passed (~24s).
- [x] Targeted: 6 tests in the two changed test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)