### PR TITLE
fix(scheduler): periodic DB pull picks up freshly enqueued PENDING tasks

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -323,7 +323,7 @@ class CollectionQueue:
         except asyncio.QueueFull:
             logger.warning(
                 "Collection queue full on reconnect requeue; task %d stays PENDING "
-                "and will be picked up by requeue_startup_tasks",
+                "and will be picked up by the DB pull loop",
                 task_id,
             )
             return False

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -94,6 +94,7 @@ class CollectionQueue:
         for task in list(self._delayed_requeues):
             task.cancel()
         self._delayed_requeues.clear()
+        self._known_task_ids.clear()
         logger.info(
             "Cleared %d pending collection tasks from DB and %d queued items from memory",
             deleted,
@@ -124,9 +125,10 @@ class CollectionQueue:
             except asyncio.QueueFull:
                 logger.warning(
                     "Collection queue full on delayed requeue; task %d stays PENDING "
-                    "in DB and will be picked up by requeue_startup_tasks",
+                    "in DB and will be picked up by the DB pull loop",
                     task_id,
                 )
+                self._known_task_ids.discard(task_id)
             self._ensure_worker()
 
         # Reserve the slot up front so the periodic DB pull does not double-ingest

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 class CollectionQueue:
+    # How often the worker re-checks the DB for new PENDING channel-collect tasks
+    # written by the web container in split / embedded-worker setups (#491 follow-up).
+    DB_PULL_INTERVAL_SEC = 3.0
+
     def __init__(self, collector: Collector, channels: ChannelBundle | Database):
         self._collector = collector
         if isinstance(channels, Database):
@@ -28,6 +32,12 @@ class CollectionQueue:
         self._current_task_id: int | None = None
         self._retried_tasks: set[int] = set()
         self._delayed_requeues: set[asyncio.Task] = set()
+        # Task IDs already pushed into the in-memory queue or scheduled via
+        # delayed-requeue. Prevents double-ingestion when the periodic DB pull
+        # sees a task that's still waiting in `self._queue`.
+        self._known_task_ids: set[int] = set()
+        self._pull_task: asyncio.Task | None = None
+        self._pull_stop = asyncio.Event()
 
     async def enqueue(self, channel: Channel, force: bool = False, full: bool = True) -> int | None:
         """Enqueue a channel for collection, atomically skipping duplicates.
@@ -49,6 +59,7 @@ class CollectionQueue:
             return None
         try:
             self._queue.put_nowait((task_id, channel, force, full))
+            self._known_task_ids.add(task_id)
         except asyncio.QueueFull:
             logger.warning(
                 "Collection queue full (maxsize=%d); task %d stays PENDING in DB "
@@ -109,6 +120,7 @@ class CollectionQueue:
                 await asyncio.sleep(remaining)
             try:
                 self._queue.put_nowait((task_id, channel, force, full))
+                self._known_task_ids.add(task_id)
             except asyncio.QueueFull:
                 logger.warning(
                     "Collection queue full on delayed requeue; task %d stays PENDING "
@@ -116,6 +128,10 @@ class CollectionQueue:
                     task_id,
                 )
             self._ensure_worker()
+
+        # Reserve the slot up front so the periodic DB pull does not double-ingest
+        # a task whose delayed requeue is still sleeping.
+        self._known_task_ids.add(task_id)
 
         task = asyncio.create_task(_requeue_later())
         self._delayed_requeues.add(task)
@@ -279,6 +295,7 @@ class CollectionQueue:
                 self._retried_tasks.discard(task_id)
             finally:
                 self._current_task_id = None
+                self._known_task_ids.discard(task_id)
                 self._queue.task_done()
 
     async def _try_reconnect_and_requeue(
@@ -300,6 +317,7 @@ class CollectionQueue:
         await self._channels.update_collection_task(task_id, CollectionTaskStatus.PENDING, note="Reconnect retry")
         try:
             self._queue.put_nowait((task_id, channel, force, full))
+            self._known_task_ids.add(task_id)
         except asyncio.QueueFull:
             logger.warning(
                 "Collection queue full on reconnect requeue; task %d stays PENDING "
@@ -313,19 +331,18 @@ class CollectionQueue:
         )
         return True
 
-    async def requeue_startup_tasks(self) -> int:
-        """Re-enqueue pending collection tasks that survived a server restart.
-
-        Also resets orphaned RUNNING tasks (left from ungraceful shutdown) to PENDING.
+    async def _ingest_pending_tasks(self) -> int:
+        """Pull all currently-PENDING channel-collect tasks from the DB into the
+        in-memory queue. Used both at startup (after resetting orphaned RUNNING
+        rows) and from the periodic DB-pull loop. De-duplicates against
+        `_known_task_ids` so tasks already sitting in the queue or scheduled
+        for delayed requeue are not pushed twice.
         """
-        # Reset orphaned RUNNING tasks from previous ungraceful shutdown
-        reset_count = await self._channels.reset_orphaned_running_tasks()
-        if reset_count:
-            logger.info("Reset %d orphaned RUNNING tasks to PENDING", reset_count)
-
         pending = await self._channels.get_pending_channel_tasks()
         count = 0
         for task in pending:
+            if task.id is None or task.id in self._known_task_ids:
+                continue
             if task.channel_id is None:
                 logger.warning("Skipping task %d: channel_id is None", task.id)
                 continue
@@ -351,9 +368,10 @@ class CollectionQueue:
             else:
                 try:
                     self._queue.put_nowait((task.id, channel, force, full))
+                    self._known_task_ids.add(task.id)
                 except asyncio.QueueFull:
                     logger.warning(
-                        "Collection queue full during startup requeue; task %d stays PENDING "
+                        "Collection queue full during pending-task ingest; task %d stays PENDING "
                         "in DB and will be picked up after the queue drains",
                         task.id,
                     )
@@ -361,10 +379,66 @@ class CollectionQueue:
             count += 1
         if count:
             self._ensure_worker()
+        return count
+
+    async def requeue_startup_tasks(self) -> int:
+        """Re-enqueue pending collection tasks that survived a server restart.
+
+        Also resets orphaned RUNNING tasks (left from ungraceful shutdown) to PENDING.
+        """
+        reset_count = await self._channels.reset_orphaned_running_tasks()
+        if reset_count:
+            logger.info("Reset %d orphaned RUNNING tasks to PENDING", reset_count)
+
+        count = await self._ingest_pending_tasks()
+        if count:
             logger.info("Re-enqueued %d pending collection tasks on startup", count)
         return count
 
+    def start_db_pull(self, *, interval: float | None = None) -> None:
+        """Start the background loop that periodically ingests new PENDING
+        channel-collect tasks from the DB.
+
+        Without this, tasks created via `CollectionService._enqueue_channel`
+        (the web-mode fallback that writes a PENDING row when no in-memory
+        queue is available) sit in the DB forever — only `requeue_startup_tasks`
+        picks them up, and that runs only at worker startup.
+        """
+        if self._pull_task is not None and not self._pull_task.done():
+            return
+        self._pull_stop.clear()
+        self._pull_task = asyncio.create_task(
+            self._db_pull_loop(interval or self.DB_PULL_INTERVAL_SEC),
+            name="collection-queue-db-pull",
+        )
+
+    async def stop_db_pull(self, timeout: float = 5.0) -> None:
+        if self._pull_task is None:
+            return
+        self._pull_stop.set()
+        try:
+            await asyncio.wait_for(self._pull_task, timeout=timeout)
+        except asyncio.TimeoutError:
+            self._pull_task.cancel()
+            try:
+                await self._pull_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._pull_task = None
+
+    async def _db_pull_loop(self, interval: float) -> None:
+        while not self._pull_stop.is_set():
+            try:
+                await self._ingest_pending_tasks()
+            except Exception:
+                logger.exception("[collection-queue] DB pull failed")
+            try:
+                await asyncio.wait_for(self._pull_stop.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                continue
+
     async def shutdown(self) -> None:
+        await self.stop_db_pull()
         if self._worker and not self._worker.done():
             self._worker.cancel()
             try:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -333,6 +333,10 @@ async def start_container(container: AppContainer) -> None:
         requeued = await container.collection_queue.requeue_startup_tasks()
         if requeued:
             logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
+        # Periodically re-check the DB for new PENDING tasks created by the
+        # web container in split / embedded-worker setups (CollectionService
+        # falls back to a DB-only insert when collection_queue is None).
+        container.collection_queue.start_db_pull()
     logger.info("startup: collection queue done (%.1fs)", time.monotonic() - t_start)
 
     if _is_dev:

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -1,0 +1,163 @@
+"""Tests for the periodic DB-pull loop in CollectionQueue.
+
+Regression for: clicking "Собрать все каналы" on /scheduler/ wrote PENDING rows
+into `collection_tasks` from the web side, but the worker's CollectionQueue
+only ran `requeue_startup_tasks` once at boot — so freshly enqueued tasks were
+ignored until the next worker restart.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.collection_queue import CollectionQueue
+from src.database import Database
+from src.models import Channel
+
+
+class _FakeCollector:
+    def __init__(self):
+        self.calls: list[int] = []
+        self.is_cancelled = False
+
+    async def collect_single_channel(self, channel, *, full=False, progress_callback=None, force=False):
+        self.calls.append(channel.channel_id)
+        return 0
+
+    async def cancel(self):
+        return None
+
+
+async def _seed_channel(db: Database, channel_id: int = -1001) -> None:
+    await db.add_channel(Channel(channel_id=channel_id, title="t", is_active=True))
+
+
+async def _create_pending_task(db: Database, channel_id: int = -1001) -> int:
+    """Insert a PENDING channel_collect task the same way CollectionService does in web mode."""
+    return await db.repos.tasks.create_collection_task_if_not_active(
+        channel_id, "t", channel_username=None, payload=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_db_pull_picks_up_pending_task_added_after_startup(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+        # Startup ingest sees nothing yet.
+        assert await queue.requeue_startup_tasks() == 0
+
+        # Web side writes a PENDING row directly (no in-memory queue).
+        task_id = await _create_pending_task(db)
+        assert task_id is not None
+
+        # Without the pull loop the worker would never see it.
+        queue.start_db_pull(interval=0.05)
+        try:
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                if collector.calls:
+                    break
+                await asyncio.sleep(0.05)
+            assert collector.calls == [-1001]
+        finally:
+            await queue.stop_db_pull()
+            await queue.shutdown()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_db_pull_does_not_double_ingest(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+
+        # Pre-enqueue via the regular API — the task is in `_known_task_ids`
+        # and in the in-memory queue.
+        ch = (await db.get_channels(active_only=True))[0]
+        task_id = await queue.enqueue(ch)
+        assert task_id is not None
+
+        # Tight pull interval so we'd see double-ingest immediately.
+        queue.start_db_pull(interval=0.02)
+        try:
+            await asyncio.sleep(0.3)
+        finally:
+            await queue.stop_db_pull()
+            await queue.shutdown()
+
+        # Exactly one collection call, not multiple.
+        assert collector.calls.count(-1001) == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_db_pull_swallows_errors(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+
+        calls = {"n": 0}
+        original = queue._ingest_pending_tasks
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient")
+            return await original()
+
+        monkeypatch.setattr(queue, "_ingest_pending_tasks", flaky)
+
+        queue.start_db_pull(interval=0.02)
+        try:
+            await _create_pending_task(db)
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while asyncio.get_event_loop().time() < deadline:
+                if collector.calls:
+                    break
+                await asyncio.sleep(0.05)
+            # First tick raised, but the loop survived; subsequent ticks
+            # ingested the pending task.
+            assert calls["n"] >= 2
+            assert collector.calls == [-1001]
+        finally:
+            await queue.stop_db_pull()
+            await queue.shutdown()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stop_db_pull_is_idempotent(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+
+        # Stop without start — no-op.
+        await queue.stop_db_pull()
+
+        queue.start_db_pull(interval=0.05)
+        await queue.stop_db_pull()
+        # Second stop also no-op.
+        await queue.stop_db_pull()
+
+        # Re-start works after stop.
+        queue.start_db_pull(interval=0.05)
+        await queue.stop_db_pull()
+    finally:
+        await db.close()

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -8,6 +8,7 @@ ignored until the next worker restart.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 
 import pytest
 
@@ -160,4 +161,57 @@ async def test_stop_db_pull_is_idempotent(tmp_path):
         queue.start_db_pull(interval=0.05)
         await queue.stop_db_pull()
     finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_delayed_requeue_queue_full_releases_known_task_id(tmp_path, monkeypatch):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+        task_id = await _create_pending_task(db)
+        channel = (await db.get_channels(active_only=True))[0]
+
+        queue._queue = asyncio.Queue(maxsize=1)
+        queue._queue.put_nowait((999999, channel, False, True))
+        monkeypatch.setattr(queue, "_ensure_worker", lambda: None)
+        queue._schedule_requeue_after_delay(
+            task_id=task_id,
+            channel=channel,
+            force=False,
+            full=True,
+            run_after=datetime.fromtimestamp(0, tz=timezone.utc),
+        )
+        await asyncio.sleep(0)
+
+        assert task_id not in queue._known_task_ids
+        queue._queue.get_nowait()
+        queue._queue.task_done()
+        assert await queue._ingest_pending_tasks() == 1
+    finally:
+        await queue.shutdown()
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_clear_pending_tasks_clears_known_task_ids(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+        collector = _FakeCollector()
+        queue = CollectionQueue(collector, db)
+        channel = (await db.get_channels(active_only=True))[0]
+        task_id = await queue.enqueue(channel)
+        assert task_id in queue._known_task_ids
+
+        deleted = await queue.clear_pending_tasks()
+
+        assert deleted == 1
+        assert queue._known_task_ids == set()
+    finally:
+        await queue.shutdown()
         await db.close()


### PR DESCRIPTION
## Symptom

Clicking **«Собрать все каналы»** on http://0.0.0.0:8080/scheduler/ — request returns 303 with \`collect_all_queued\` and the badge updates, but the worker never starts collecting. Tasks pile up as PENDING in \`collection_tasks\` and only get picked up after a worker restart.

## Root cause

In split / embedded-worker setups (web container has \`collection_queue=None\` because it uses snapshot shims), \`CollectionService._enqueue_channel\` falls back to a DB-only insert (\`src/services/collection_service.py:48-58\`). The worker's \`CollectionQueue\` only runs \`requeue_startup_tasks\` **once**, in \`bootstrap.py:333\`. There is no periodic re-check, so a PENDING row written after worker startup is invisible to the in-memory queue forever.

\`UnifiedDispatcher\` polls the DB every 5s but explicitly skips \`channel_collect\` (\`src/services/unified_dispatcher.py:46\` — _\"Polls DB for non-CHANNEL_COLLECT tasks\"_), so it doesn't cover this either.

## Fix

Add a periodic DB-pull loop to \`CollectionQueue\` (\`DB_PULL_INTERVAL_SEC=3.0\`):

- Extracted the existing requeue body into \`_ingest_pending_tasks()\`, used by both the startup path (\`requeue_startup_tasks\`) and the new \`_db_pull_loop\`.
- Added \`_known_task_ids: set[int]\` to dedupe against tasks already sitting in the in-memory queue or in delayed-requeue, so the pull loop never double-ingests.
- \`start_db_pull()\` is called from \`bootstrap.start_container\` right after \`requeue_startup_tasks\`; \`shutdown()\` stops the loop cleanly.
- The loop swallows exceptions per iteration with \`logger.exception\` — never crashes the worker.

## Closes

Closes the \"trigger collection does nothing\" symptom that has surfaced repeatedly since the worker/web split (#444 / #457). The existing e2e \`test_trigger_collection_persists_messages_via_embedded_worker\` was passing only by luck (web wrote PENDING before the worker's startup requeue ran); now the pickup is guaranteed.

## Test plan

- [x] 4 new unit tests in \`tests/test_collection_queue_db_pull.py\` (pickup, no double-ingest, error swallowing, idempotent stop).
- [x] Existing \`test_collection_flow.py\` e2e suite still green (3 tests).
- [x] Full suite: 7535 passed, 1 skipped.
- [x] \`ruff check\` clean.
- [ ] Manual: click \"Собрать все каналы\" with embedded worker, watch logs — collection should start within ~3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)