### PR TITLE
fix(client-pool): round-robin account selection in AccountLeasePool

### DIFF
--- a/src/telegram/account_lease_pool.py
+++ b/src/telegram/account_lease_pool.py
@@ -22,6 +22,7 @@ class AccountLeasePool:
         self._db = db
         self._in_use = in_use
         self._lock = asyncio.Lock()
+        self._last_phone: str | None = None
 
     async def acquire_available(self, connected_phones: set[str]) -> AccountLease | None:
         async with self._lock:
@@ -35,7 +36,19 @@ class AccountLeasePool:
                     await self._db.update_account_flood(account.phone, None)
                     account.flood_wait_until = None
 
-            for account in accounts:
+            n = len(accounts)
+            if n == 0:
+                return None
+
+            start = 0
+            if self._last_phone is not None:
+                for i, acc in enumerate(accounts):
+                    if acc.phone == self._last_phone:
+                        start = (i + 1) % n
+                        break
+
+            for offset in range(n):
+                account = accounts[(start + offset) % n]
                 if account.phone not in connected_phones:
                     continue
                 if account.phone in self._in_use:
@@ -43,6 +56,7 @@ class AccountLeasePool:
                 if self._is_flood_waited(account, now):
                     continue
                 self._in_use.add(account.phone)
+                self._last_phone = account.phone
                 return AccountLease(account=account, shared=False)
 
             for account in accounts:

--- a/tests/test_account_lease_pool.py
+++ b/tests/test_account_lease_pool.py
@@ -73,3 +73,142 @@ async def test_is_flood_waited_returns_true_for_future(db):
     future = datetime.now(timezone.utc) + timedelta(hours=1)
     account = Account(phone="+70006", session_string="s6", is_active=True, flood_wait_until=future)
     assert AccountLeasePool._is_flood_waited(account)
+
+
+@pytest.mark.asyncio
+async def test_acquire_available_round_robin_distributes(db, pool):
+    """Sequential acquire/release calls cycle through all available accounts."""
+    phones = ["+71001", "+71002", "+71003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+    connected = set(phones)
+
+    seen: list[str] = []
+    for _ in range(4):
+        lease = await pool.acquire_available(connected)
+        assert lease is not None
+        seen.append(lease.account.phone)
+        await pool.release(lease.account.phone)
+
+    # First three calls hit each phone exactly once.
+    assert set(seen[:3]) == set(phones)
+    # Fourth call wraps around to the first phone.
+    assert seen[3] == seen[0]
+
+
+@pytest.mark.asyncio
+async def test_round_robin_skips_in_use(db):
+    """Phones already in_use are skipped by the round-robin walk."""
+    phones = ["+72001", "+72002", "+72003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    pool = AccountLeasePool(db, {"+72002"})
+    connected = set(phones)
+
+    lease1 = await pool.acquire_available(connected)
+    assert lease1 is not None
+    assert lease1.account.phone == "+72001"
+    await pool.release("+72001")
+
+    # cursor now sits at +72001; next exclusive should skip +72002 (in_use)
+    # and return +72003.
+    lease2 = await pool.acquire_available(connected)
+    assert lease2 is not None
+    assert lease2.account.phone == "+72003"
+
+
+@pytest.mark.asyncio
+async def test_round_robin_skips_flood_waited(db, pool):
+    """Flood-waited accounts are skipped during round-robin selection."""
+    phones = ["+73001", "+73002", "+73003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    await db.update_account_flood("+73002", future)
+    connected = set(phones)
+
+    seen: list[str] = []
+    for _ in range(2):
+        lease = await pool.acquire_available(connected)
+        assert lease is not None
+        seen.append(lease.account.phone)
+        await pool.release(lease.account.phone)
+
+    assert set(seen) == {"+73001", "+73003"}
+    assert "+73002" not in seen
+
+
+@pytest.mark.asyncio
+async def test_round_robin_skips_disconnected(db, pool):
+    """Phones missing from connected_phones are skipped."""
+    phones = ["+74001", "+74002", "+74003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    connected = {"+74001", "+74003"}
+
+    seen: list[str] = []
+    for _ in range(2):
+        lease = await pool.acquire_available(connected)
+        assert lease is not None
+        seen.append(lease.account.phone)
+        await pool.release(lease.account.phone)
+
+    assert set(seen) == {"+74001", "+74003"}
+
+
+@pytest.mark.asyncio
+async def test_round_robin_survives_account_change(db, pool):
+    """Cursor based on phone (not index) survives account list mutations."""
+    a_id = await db.add_account(Account(phone="+75001", session_string="A", is_active=True))
+    b_id = await db.add_account(Account(phone="+75002", session_string="B", is_active=True))
+    c_id = await db.add_account(Account(phone="+75003", session_string="C", is_active=True))
+    assert a_id and b_id and c_id
+
+    connected = {"+75001", "+75002", "+75003"}
+
+    lease1 = await pool.acquire_available(connected)
+    assert lease1 is not None
+    assert lease1.account.phone == "+75001"
+    await pool.release("+75001")
+
+    # Remove B from the DB. Cursor (last_phone="+75001") should still find A's
+    # position in the new list (now [A, C]) and advance to C.
+    await db.delete_account(b_id)
+
+    lease2 = await pool.acquire_available(connected)
+    assert lease2 is not None
+    assert lease2.account.phone == "+75003"
+
+
+@pytest.mark.asyncio
+async def test_cursor_unchanged_when_all_flooded(db, pool):
+    """When no exclusive account is available, cursor must not advance."""
+    phones = ["+76001", "+76002", "+76003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    for p in phones:
+        await db.update_account_flood(p, future)
+
+    connected = set(phones)
+
+    # All accounts flooded → exclusive returns None (no cursor advance), then
+    # falls through to shared (which DOES return one, but shared also must
+    # not advance the cursor).
+    result = await pool.acquire_available(connected)
+    # shared is allowed to return any flooded account — actually no, shared
+    # also skips flood-waited; so result is None.
+    assert result is None
+    assert pool._last_phone is None
+
+    # Clear flood on the middle phone. Next acquire returns it (cursor was
+    # never moved, so the walk starts from index 0; +76002 is the first
+    # eligible candidate).
+    await db.update_account_flood("+76002", None)
+    lease = await pool.acquire_available(connected)
+    assert lease is not None
+    assert lease.account.phone == "+76002"


### PR DESCRIPTION
## Summary

- Fixes #496. `AccountLeasePool.acquire_available()` always returned the first eligible account from `ORDER BY is_primary DESC, id ASC`, so all generic traffic concentrated on primary — which combined with #495 produced one long (hours/day) flood wait on that single phone.
- Adds an in-memory `_last_phone` cursor: each exclusive acquire walks the accounts as a ring starting at the position after `last_phone`. Cursor advances **only** on successful exclusive selection. Shared fallback and `acquire_by_phone` / `acquire_premium` are unchanged.
- Cursor is keyed by phone (not list index), so it survives account list mutations (deactivation / deletion / new primary) between calls. `_lock` already serializes `acquire_available`, so no race on the cursor.
- Notifier (`get_native_client_by_phone`) and collector `preferred_phone` (`get_client_by_phone`) bypass `acquire_available`, so they are untouched. SQL `ORDER BY is_primary DESC, id ASC` is preserved — `notification_target_service.py` still picks primary first.

## Test plan

- [x] `pytest tests/test_account_lease_pool.py -v` — 5 existing + 6 new tests, all green
- [x] `pytest tests/test_client_pool.py tests/test_client_pool_extended.py tests/test_client_pool_runtime.py` — 42 passed
- [x] `pytest tests/test_cross_domain_regression_paths.py::TestAccountLeasePoolCoverage tests/test_main_client_pool_collector_paths.py` — 111 passed
- [x] Full parallel suite: 6709 passed / 1 skipped
- [x] Full serial suite: 828 passed
- [x] `ruff check src/ tests/ conftest.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)