### PR TITLE
Handle Telegram flood waits by surfacing errors instead of silently sleeping

### DIFF
--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -15,6 +15,7 @@ from src.agent.tools._registry import (
     resolve_entity,
     resolve_phone,
 )
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -313,9 +314,22 @@ def register(db, client_pool, embedding_service, **kwargs):
             if err:
                 return err
             msg = None
-            async for m in client.iter_messages(entity, ids=int(message_id)):
-                msg = m
-                break
+
+            async def _lookup_message() -> None:
+                nonlocal msg
+                async for m in client.iter_messages(entity, ids=int(message_id)):
+                    msg = m
+                    break
+
+            try:
+                await run_with_flood_wait(
+                    _lookup_message(),
+                    operation="agent_download_media_lookup",
+                    phone=phone,
+                    pool=client_pool,
+                )
+            except HandledFloodWaitError as exc:
+                return _text_response(f"Flood wait: {exc.info.detail}")
             if msg is None:
                 return _text_response(f"Сообщение #{message_id} не найдено.")
             output_dir = pathlib.Path(__file__).resolve().parents[3] / "data" / "downloads"
@@ -736,19 +750,34 @@ def register(db, client_pool, embedding_service, **kwargs):
             count = 0
             total_chars = 0
             budget = 50_000
-            async for msg in client.iter_messages(entity, limit=limit):
-                if not msg.text:
-                    continue
-                sender = f" [id:{msg.sender_id}]" if msg.sender_id else ""
-                date_str = msg.date.strftime("%Y-%m-%d %H:%M") if msg.date else ""
-                preview = msg.text[:500]
-                line = f"#{msg.id} {date_str}{sender}: {preview}"
-                lines.append(line)
-                total_chars += len(line)
-                count += 1
-                if total_chars >= budget:
-                    lines.append(f"\n[Вывод обрезан после {count} сообщений, достигнут лимит символов]")
-                    break
+
+            async def _read_recent() -> None:
+                nonlocal count, total_chars
+                async for msg in client.iter_messages(entity, limit=limit):
+                    if not msg.text:
+                        continue
+                    sender = f" [id:{msg.sender_id}]" if msg.sender_id else ""
+                    date_str = msg.date.strftime("%Y-%m-%d %H:%M") if msg.date else ""
+                    preview = msg.text[:500]
+                    line = f"#{msg.id} {date_str}{sender}: {preview}"
+                    lines.append(line)
+                    total_chars += len(line)
+                    count += 1
+                    if total_chars >= budget:
+                        lines.append(
+                            f"\n[Вывод обрезан после {count} сообщений, достигнут лимит символов]"
+                        )
+                        break
+
+            try:
+                await run_with_flood_wait(
+                    _read_recent(),
+                    operation="agent_read_recent_messages",
+                    phone=phone,
+                    pool=client_pool,
+                )
+            except HandledFloodWaitError as exc:
+                return _text_response(f"Flood wait: {exc.info.detail}")
             if count == 0:
                 return _text_response("Сообщений с текстом не найдено.")
             lines.append(f"\nИтого: {count} сообщений.")

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -333,7 +333,15 @@ def register(db, client_pool, embedding_service, **kwargs):
             if msg is None:
                 return _text_response(f"Сообщение #{message_id} не найдено.")
             output_dir = pathlib.Path(__file__).resolve().parents[3] / "data" / "downloads"
-            path = await client.download_media(msg, file=str(output_dir))
+            try:
+                path = await run_with_flood_wait(
+                    client.download_media(msg, file=str(output_dir)),
+                    operation="agent_download_media",
+                    phone=phone,
+                    pool=client_pool,
+                )
+            except HandledFloodWaitError as exc:
+                return _text_response(f"Flood wait: {exc.info.detail}")
             if not path:
                 return _text_response("В сообщении нет медиа.")
             resolved = pathlib.Path(path).resolve()

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -406,7 +406,16 @@ def run_with_dependencies(
                     if message is None:
                         print(f"Message #{args.message_id} not found.")
                         return
-                    path = await client.download_media(message, file=args.output_dir)
+                    try:
+                        path = await run_with_flood_wait(
+                            client.download_media(message, file=args.output_dir),
+                            operation="cli_dialogs_download_media",
+                            phone=phone,
+                            pool=pool,
+                        )
+                    except HandledFloodWaitError as exc:
+                        print(f"Flood wait: {exc.info.detail}")
+                        return
                     if path:
                         print(f"Downloaded: {path}")
                     else:

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -6,6 +6,7 @@ import time
 
 from src.cli import runtime
 from src.services.channel_service import ChannelService
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 
 
 def run_with_dependencies(
@@ -383,9 +384,25 @@ def run_with_dependencies(
                 try:
                     entity = await client.get_entity(args.chat_id)
                     message = None
-                    async for current_message in client.iter_messages(entity, ids=args.message_id):
-                        message = current_message
-                        break
+
+                    async def _lookup_message() -> None:
+                        nonlocal message
+                        async for current_message in client.iter_messages(
+                            entity, ids=args.message_id
+                        ):
+                            message = current_message
+                            break
+
+                    try:
+                        await run_with_flood_wait(
+                            _lookup_message(),
+                            operation="cli_dialogs_download_media_lookup",
+                            phone=phone,
+                            pool=pool,
+                        )
+                    except HandledFloodWaitError as exc:
+                        print(f"Flood wait: {exc.info.detail}")
+                        return
                     if message is None:
                         print(f"Message #{args.message_id} not found.")
                         return

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -9,6 +9,7 @@ import json
 from src.cli import runtime
 from src.cli.commands.common import resolve_channel
 from src.models import Message
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 
 
 def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
@@ -104,9 +105,22 @@ def run(args: argparse.Namespace) -> None:
                             kwargs["offset_id"] = args.offset_id
                         if args.topic_id:
                             kwargs["reply_to"] = args.topic_id
-                        collected = []
-                        async for msg in client.iter_messages(entity, **kwargs):
-                            collected.append(msg)
+                        collected: list = []
+
+                        async def _read_messages() -> None:
+                            async for msg in client.iter_messages(entity, **kwargs):
+                                collected.append(msg)
+
+                        try:
+                            await run_with_flood_wait(
+                                _read_messages(),
+                                operation="cli_messages_read",
+                                phone=phone,
+                                pool=pool,
+                            )
+                        except HandledFloodWaitError as exc:
+                            print(f"Flood wait: {exc.info.detail}")
+                            return
                         if not collected:
                             print("No messages found.")
                             return

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -16,7 +16,7 @@ from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
-from src.telegram.flood_wait import run_with_flood_wait
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
@@ -588,12 +588,15 @@ class TelegramCommandDispatcher:
                     msg = item
                     break
 
-            await run_with_flood_wait(
-                _lookup_message(),
-                operation="dispatcher_dialogs_download_media_lookup",
-                phone=phone,
-                pool=self._pool,
-            )
+            try:
+                await run_with_flood_wait(
+                    _lookup_message(),
+                    operation="dispatcher_dialogs_download_media_lookup",
+                    phone=phone,
+                    pool=self._pool,
+                )
+            except HandledFloodWaitError as exc:
+                raise RuntimeError(f"flood_wait:{exc.info.wait_seconds}") from exc
             if msg is None:
                 raise RuntimeError("message_not_found")
             output_dir = Path(__file__).resolve().parents[2] / "data" / "downloads"

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -16,6 +16,7 @@ from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
+from src.telegram.flood_wait import run_with_flood_wait
 from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
@@ -578,9 +579,21 @@ class TelegramCommandDispatcher:
         try:
             entity = await client.get_entity(payload["chat_id"])
             msg = None
-            async for item in client.iter_messages(entity, ids=int(payload["message_id"])):
-                msg = item
-                break
+
+            async def _lookup_message() -> None:
+                nonlocal msg
+                async for item in client.iter_messages(
+                    entity, ids=int(payload["message_id"])
+                ):
+                    msg = item
+                    break
+
+            await run_with_flood_wait(
+                _lookup_message(),
+                operation="dispatcher_dialogs_download_media_lookup",
+                phone=phone,
+                pool=self._pool,
+            )
             if msg is None:
                 raise RuntimeError("message_not_found")
             output_dir = Path(__file__).resolve().parents[2] / "data" / "downloads"

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -602,7 +602,15 @@ class TelegramCommandDispatcher:
             output_dir = Path(__file__).resolve().parents[2] / "data" / "downloads"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir_resolved = output_dir.resolve()
-            path = await client.download_media(msg, file=str(output_dir_resolved))
+            try:
+                path = await run_with_flood_wait(
+                    client.download_media(msg, file=str(output_dir_resolved)),
+                    operation="dispatcher_dialogs_download_media",
+                    phone=phone,
+                    pool=self._pool,
+                )
+            except HandledFloodWaitError as exc:
+                raise RuntimeError(f"flood_wait:{exc.info.wait_seconds}") from exc
             if not path:
                 raise RuntimeError("no_media")
             resolved = Path(path).resolve()

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -343,7 +343,10 @@ class NativeTelethonBackend(TelegramBackend):
 
     async def acquire_client(self, account: Account) -> BackendClientLease:
         client = await self._auth.create_client_from_session(account.session_string)
-        client.flood_sleep_threshold = 60
+        # Surface every FloodWaitError so run_with_flood_wait can call
+        # pool.report_flood and rotate accounts (#495). Telethon's default
+        # silently sleeps on waits ≤ threshold and hides the flood from us.
+        client.flood_sleep_threshold = 0
         return BackendClientLease(
             phone=account.phone,
             session=TelegramTransportSession(client),
@@ -383,7 +386,7 @@ class TelethonCliBackend(TelegramBackend):
             client: TelegramClient = telethon_cli_runtime.create_client(namespace)
             client._connection_retries = None
             client._retry_delay = 2
-            client.flood_sleep_threshold = 60
+            client.flood_sleep_threshold = 0
             await client.connect()
             if not await client.is_user_authorized():
                 await client.disconnect()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.telegram.backends import TelegramTransportSession
+from src.models import Account
+from src.telegram.backends import (
+    NativeTelethonBackend,
+    TelegramTransportSession,
+    TelethonCliBackend,
+)
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
 
 
@@ -395,3 +400,48 @@ async def test_get_broadcast_stats():
     result = await session.get_broadcast_stats("channel")
     assert result is stats
     session.raw_client.invoke.assert_awaited_once()
+
+
+# --- flood_sleep_threshold (#495) ---
+
+
+@pytest.mark.asyncio
+async def test_native_backend_disables_flood_auto_sleep():
+    """NativeTelethonBackend.acquire_client must set flood_sleep_threshold=0
+    so Telethon raises FloodWaitError instead of sleeping silently (#495)."""
+    fake_client = SimpleNamespace(flood_sleep_threshold=60)
+    auth = SimpleNamespace(create_client_from_session=AsyncMock(return_value=fake_client))
+    backend = NativeTelethonBackend(auth)
+
+    lease = await backend.acquire_client(
+        Account(phone="+70001112233", session_string="session-xyz")
+    )
+
+    assert fake_client.flood_sleep_threshold == 0
+    assert lease.phone == "+70001112233"
+    assert lease.backend_name == "native"
+
+
+@pytest.mark.asyncio
+async def test_telethon_cli_backend_disables_flood_auto_sleep(monkeypatch, tmp_path):
+    """TelethonCliBackend.acquire_client must also set flood_sleep_threshold=0 (#495)."""
+    fake_client = FakeCliTelethonClient()
+    monkeypatch.setattr(
+        "src.telegram.backends.telethon_cli_runtime.create_client",
+        lambda namespace: fake_client,
+    )
+
+    materializer = SimpleNamespace(
+        materialize=lambda phone, session_string: str(tmp_path / "session"),
+        ensure_empty_env_file=lambda: str(tmp_path / ".env"),
+    )
+    auth = SimpleNamespace(api_id=1, api_hash="hash")
+    backend = TelethonCliBackend(auth, materializer, transport="hybrid")
+
+    lease = await backend.acquire_client(
+        Account(phone="+70001112233", session_string="session-xyz")
+    )
+
+    assert fake_client.flood_sleep_threshold == 0
+    assert lease.phone == "+70001112233"
+    assert lease.backend_name == "telethon_cli"

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -150,6 +150,29 @@ async def test_handle_flood_wait_without_pool():
 
 
 @pytest.mark.asyncio
+async def test_run_with_flood_wait_reports_short_floods():
+    """Short FloodWait (≤60s) must still trigger pool.report_flood. Regression
+    guard for #495: previously Telethon's flood_sleep_threshold=60 swallowed
+    these silently and the pool never learned about the flooded account."""
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 5  # the kind of value Telethon would have swallowed
+    pool = AsyncMock()
+
+    async def _short_flood():
+        raise err
+
+    with pytest.raises(HandledFloodWaitError):
+        await run_with_flood_wait(
+            _short_flood(),
+            operation="op",
+            phone="+7000",
+            pool=pool,
+        )
+
+    pool.report_flood.assert_awaited_once_with("+7000", 5)
+
+
+@pytest.mark.asyncio
 async def test_run_with_flood_wait_with_timeout(monkeypatch):
     """Timeout parameter is forwarded to asyncio.wait_for."""
     captured: dict[str, float] = {}


### PR DESCRIPTION
## Summary
This PR fixes issue #495 by disabling Telethon's automatic flood wait sleeping mechanism and instead explicitly handling `FloodWaitError` exceptions. This allows the client pool to properly track flooded accounts and rotate them, rather than silently sleeping and hiding the flood condition from the application.

## Key Changes

- **Disable automatic flood sleep in backends**: Changed `flood_sleep_threshold` from 60 to 0 in both `NativeTelethonBackend` and `TelethonCliBackend` to ensure all `FloodWaitError` exceptions are raised instead of being silently handled by Telethon.

- **Wrap message iteration operations with flood wait handling**: Updated four locations where `client.iter_messages()` is called to use the `run_with_flood_wait()` helper:
  - `src/agent/tools/messaging.py`: `download_media()` and `read_messages()` functions
  - `src/cli/commands/dialogs.py`: Media download message lookup
  - `src/cli/commands/messages.py`: Message reading operation
  - `src/services/telegram_command_dispatcher.py`: Dispatcher media download message lookup

- **Consistent error handling**: All wrapped operations now catch `HandledFloodWaitError` and return appropriate error responses to the user.

- **Test coverage**: Added tests to verify:
  - Both backends properly disable flood auto-sleep on client acquisition
  - Short flood waits (≤60s) are properly reported to the pool even though Telethon would have previously swallowed them

## Implementation Details

The changes wrap async message iteration operations in helper functions and pass them to `run_with_flood_wait()`, which handles `FloodWaitError` exceptions by:
1. Calling `pool.report_flood()` to mark the account as flooded
2. Raising `HandledFloodWaitError` with flood details for the caller to handle

This ensures the client pool can properly rotate accounts when they hit rate limits, improving reliability when working with multiple Telegram accounts.

https://claude.ai/code/session_01Bta5e8kADEFDbQuowABJWS