### PR TITLE
[codex] Centralize flood wait handling

### DIFF
--- a/src/telegram/account_lease_pool.py
+++ b/src/telegram/account_lease_pool.py
@@ -36,19 +36,11 @@ class AccountLeasePool:
                     await self._db.update_account_flood(account.phone, None)
                     account.flood_wait_until = None
 
-            n = len(accounts)
-            if n == 0:
+            ordered_accounts = self._round_robin_accounts(accounts)
+            if not ordered_accounts:
                 return None
 
-            start = 0
-            if self._last_phone is not None:
-                for i, acc in enumerate(accounts):
-                    if acc.phone == self._last_phone:
-                        start = (i + 1) % n
-                        break
-
-            for offset in range(n):
-                account = accounts[(start + offset) % n]
+            for account in ordered_accounts:
                 if account.phone not in connected_phones:
                     continue
                 if account.phone in self._in_use:
@@ -59,11 +51,12 @@ class AccountLeasePool:
                 self._last_phone = account.phone
                 return AccountLease(account=account, shared=False)
 
-            for account in accounts:
+            for account in ordered_accounts:
                 if account.phone not in connected_phones:
                     continue
                 if self._is_flood_waited(account, now):
                     continue
+                self._last_phone = account.phone
                 return AccountLease(account=account, shared=True)
 
             return None
@@ -149,6 +142,17 @@ class AccountLeasePool:
 
     async def _get_account(self, phone: str) -> Account | None:
         return await self.get_account(phone, active_only=True)
+
+    def _round_robin_accounts(self, accounts: list[Account]) -> list[Account]:
+        if not accounts:
+            return []
+        if self._last_phone is None:
+            return accounts
+        for i, account in enumerate(accounts):
+            if account.phone == self._last_phone:
+                start = (i + 1) % len(accounts)
+                return accounts[start:] + accounts[:start]
+        return accounts
 
     @classmethod
     def _is_flood_waited(cls, account: Account, now: datetime | None = None) -> bool:

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -13,6 +13,7 @@ from telethon_cli.errors import CLIError
 
 from src.models import Account
 from src.telegram.auth import TelegramAuth
+from src.telegram.flood_wait import HandledFloodWaitError, handle_flood_wait
 from src.telegram.session_materializer import SessionMaterializer
 
 logger = logging.getLogger(__name__)
@@ -29,38 +30,133 @@ class UnsupportedBackendOperationError(RuntimeError):
 class TelegramTransportSession:
     """Thin operation adapter that keeps raw Telethon calls inside backend code."""
 
-    def __init__(self, client: Any, *, disconnect_on_close: bool = True):
+    def __init__(
+        self,
+        client: Any,
+        *,
+        disconnect_on_close: bool = True,
+        phone: str | None = None,
+        pool: Any | None = None,
+        logger_: logging.Logger | None = None,
+        report_flood_wait: bool = True,
+    ):
         self._client = client
         self._disconnect_on_close = disconnect_on_close
+        self._phone = phone
+        self._pool = pool
+        self._logger = logger_ or logger
+        self._report_flood_wait = report_flood_wait
 
     @property
     def raw_client(self) -> Any:
         return self._client
+
+    def with_flood_context(
+        self,
+        *,
+        phone: str | None = None,
+        pool: Any | None = None,
+        logger_: logging.Logger | None = None,
+        report_flood_wait: bool = True,
+    ) -> TelegramTransportSession:
+        self._phone = phone
+        self._pool = pool
+        self._report_flood_wait = report_flood_wait
+        if logger_ is not None:
+            self._logger = logger_
+        return self
+
+    async def _run(self, operation: str, awaitable: Any) -> Any:
+        try:
+            return await awaitable
+        except HandledFloodWaitError:
+            raise
+        except Exception as exc:
+            from telethon.errors import FloodWaitError
+
+            if not isinstance(exc, FloodWaitError):
+                raise
+            if self._phone is None:
+                raise
+            info = await handle_flood_wait(
+                exc,
+                operation=operation,
+                phone=self._phone,
+                pool=self._pool if self._report_flood_wait else None,
+                logger_=self._logger,
+            )
+            raise HandledFloodWaitError(info) from exc
+
+    async def _stream(self, operation: str, iterator: AsyncIterator[Any]) -> AsyncIterator[Any]:
+        try:
+            async for item in iterator:
+                yield item
+        except HandledFloodWaitError:
+            raise
+        except Exception as exc:
+            from telethon.errors import FloodWaitError
+
+            if not isinstance(exc, FloodWaitError):
+                raise
+            if self._phone is None:
+                raise
+            info = await handle_flood_wait(
+                exc,
+                operation=operation,
+                phone=self._phone,
+                pool=self._pool if self._report_flood_wait else None,
+                logger_=self._logger,
+            )
+            raise HandledFloodWaitError(info) from exc
 
     async def close(self) -> None:
         if self._disconnect_on_close:
             await self._client.disconnect()
 
     async def fetch_me(self) -> Any:
-        return await self._client.get_me()
+        return await self._run("telegram_fetch_me", self._client.get_me())
 
     async def fetch_profile_photo(self, entity: Any, *, file: Any) -> Any:
-        return await self._client.download_profile_photo(entity, file=file)
+        return await self._run(
+            "telegram_fetch_profile_photo",
+            self._client.download_profile_photo(entity, file=file),
+        )
 
     async def resolve_entity(self, peer: Any) -> Any:
-        return await self._client.get_entity(peer)
+        return await self._run("telegram_resolve_entity", self._client.get_entity(peer))
+
+    async def get_entity(self, peer: Any) -> Any:
+        return await self.resolve_entity(peer)
 
     async def resolve_input_entity(self, peer: Any) -> Any:
-        return await self._client.get_input_entity(peer)
+        return await self._run(
+            "telegram_resolve_input_entity",
+            self._client.get_input_entity(peer),
+        )
+
+    async def get_input_entity(self, peer: Any) -> Any:
+        return await self.resolve_input_entity(peer)
 
     async def warm_dialog_cache(self) -> Any:
-        return await self._client.get_dialogs()
+        return await self._run("telegram_warm_dialog_cache", self._client.get_dialogs())
+
+    async def get_dialogs(self) -> Any:
+        return await self.warm_dialog_cache()
 
     def stream_dialogs(self) -> AsyncIterator[Any]:
-        return self._client.iter_dialogs()
+        return self._stream("telegram_stream_dialogs", self._client.iter_dialogs())
+
+    def iter_dialogs(self) -> AsyncIterator[Any]:
+        return self.stream_dialogs()
 
     def stream_messages(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        return self._client.iter_messages(entity, **kwargs)
+        return self._stream(
+            "telegram_stream_messages",
+            self._client.iter_messages(entity, **kwargs),
+        )
+
+    def iter_messages(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        return self.stream_messages(entity, **kwargs)
 
     async def publish_files(
         self,
@@ -70,25 +166,46 @@ class TelegramTransportSession:
         caption: str | None = None,
         schedule: Any = None,
     ) -> Any:
-        return await self._client.send_file(entity, files, caption=caption, schedule=schedule)
+        return await self._run(
+            "telegram_publish_files",
+            self._client.send_file(entity, files, caption=caption, schedule=schedule),
+        )
 
     async def send_message(self, entity: Any, message: Any, **kwargs: Any) -> Any:
-        return await self._client.send_message(entity, message, **kwargs)
+        return await self._run(
+            "telegram_send_message",
+            self._client.send_message(entity, message, **kwargs),
+        )
 
     async def forward_messages(self, entity: Any, messages: Any, from_peer: Any) -> Any:
-        return await self._client.forward_messages(entity, messages, from_peer)
+        return await self._run(
+            "telegram_forward_messages",
+            self._client.forward_messages(entity, messages, from_peer),
+        )
 
     async def edit_message(self, entity: Any, message: int, text: str, **kwargs: Any) -> Any:
-        return await self._client.edit_message(entity, message, text, **kwargs)
+        return await self._run(
+            "telegram_edit_message",
+            self._client.edit_message(entity, message, text, **kwargs),
+        )
 
     async def pin_message(self, entity: Any, message: Any, *, notify: bool = False) -> Any:
-        return await self._client.pin_message(entity, message, notify=notify)
+        return await self._run(
+            "telegram_pin_message",
+            self._client.pin_message(entity, message, notify=notify),
+        )
 
     async def unpin_message(self, entity: Any, message: Any = None) -> Any:
-        return await self._client.unpin_message(entity, message)
+        return await self._run(
+            "telegram_unpin_message",
+            self._client.unpin_message(entity, message),
+        )
 
     async def delete_messages(self, entity: Any, message_ids: list[int]) -> Any:
-        return await self._client.delete_messages(entity, message_ids)
+        return await self._run(
+            "telegram_delete_messages",
+            self._client.delete_messages(entity, message_ids),
+        )
 
     async def send_reaction(self, entity: Any, message_id: int, emoji: str) -> Any:
         """Send a reaction to a message using the Telethon raw API."""
@@ -96,19 +213,25 @@ class TelegramTransportSession:
             from telethon.tl.functions.messages import SendReactionRequest
             from telethon.tl.types import ReactionEmoji
 
-            return await self._client(
-                SendReactionRequest(
-                    peer=entity,
-                    msg_id=message_id,
-                    reaction=[ReactionEmoji(emoticon=emoji)],
-                )
+            return await self._run(
+                "telegram_send_reaction",
+                self._client(
+                    SendReactionRequest(
+                        peer=entity,
+                        msg_id=message_id,
+                        reaction=[ReactionEmoji(emoticon=emoji)],
+                    )
+                ),
             )
         except ImportError:
             # Telethon not available (e.g. test env with stub backend)
             return None
 
     async def download_media(self, message: Any, *, file: Any = None) -> Any:
-        return await self._client.download_media(message, file=file)
+        return await self._run(
+            "telegram_download_media",
+            self._client.download_media(message, file=file),
+        )
 
     async def get_participants(self, entity: Any, *, limit: int | None = None, search: str = "") -> Any:
         kwargs: dict[str, Any] = {}
@@ -116,30 +239,54 @@ class TelegramTransportSession:
             kwargs["limit"] = limit
         if search:
             kwargs["search"] = search
-        return await self._client.get_participants(entity, **kwargs)
+        return await self._run(
+            "telegram_get_participants",
+            self._client.get_participants(entity, **kwargs),
+        )
 
     def stream_participants(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        return self._client.iter_participants(entity, **kwargs)
+        return self._stream(
+            "telegram_stream_participants",
+            self._client.iter_participants(entity, **kwargs),
+        )
+
+    def iter_participants(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        return self.stream_participants(entity, **kwargs)
 
     async def edit_admin(self, entity: Any, user: Any, **kwargs: Any) -> Any:
-        return await self._client.edit_admin(entity, user, **kwargs)
+        return await self._run(
+            "telegram_edit_admin",
+            self._client.edit_admin(entity, user, **kwargs),
+        )
 
     async def edit_permissions(self, entity: Any, user: Any, until_date: Any = None, **kwargs: Any) -> Any:
         if until_date is not None:
             kwargs["until_date"] = until_date
-        return await self._client.edit_permissions(entity, user, **kwargs)
+        return await self._run(
+            "telegram_edit_permissions",
+            self._client.edit_permissions(entity, user, **kwargs),
+        )
 
     async def kick_participant(self, entity: Any, user: Any) -> Any:
-        return await self._client.kick_participant(entity, user)
+        return await self._run(
+            "telegram_kick_participant",
+            self._client.kick_participant(entity, user),
+        )
 
     async def edit_folder(self, entity: Any, folder: int) -> Any:
-        return await self._client.edit_folder(entity, folder)
+        return await self._run(
+            "telegram_edit_folder",
+            self._client.edit_folder(entity, folder),
+        )
 
     async def send_read_acknowledge(self, entity: Any, *, max_id: int | None = None) -> Any:
         kwargs: dict[str, Any] = {}
         if max_id is not None:
             kwargs["max_id"] = max_id
-        return await self._client.send_read_acknowledge(entity, **kwargs)
+        return await self._run(
+            "telegram_send_read_acknowledge",
+            self._client.send_read_acknowledge(entity, **kwargs),
+        )
 
     # --- base ---
 
@@ -149,23 +296,29 @@ class TelegramTransportSession:
     # --- uploads ---
 
     async def upload_file(self, file: Any, **kwargs: Any) -> Any:
-        return await self._client.upload_file(file, **kwargs)
+        return await self._run("telegram_upload_file", self._client.upload_file(file, **kwargs))
 
     # --- downloads ---
 
     async def download_file(self, input_location: Any, file: Any = None, **kwargs: Any) -> Any:
-        return await self._client.download_file(input_location, file, **kwargs)
+        return await self._run(
+            "telegram_download_file",
+            self._client.download_file(input_location, file, **kwargs),
+        )
 
     def stream_download(self, file: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        return self._client.iter_download(file, **kwargs)
+        return self._stream(
+            "telegram_stream_download",
+            self._client.iter_download(file, **kwargs),
+        )
 
     # --- dialogs ---
 
     def stream_drafts(self) -> AsyncIterator[Any]:
-        return self._client.iter_drafts()
+        return self._stream("telegram_stream_drafts", self._client.iter_drafts())
 
     async def get_drafts(self) -> Any:
-        return await self._client.get_drafts()
+        return await self._run("telegram_get_drafts", self._client.get_drafts())
 
     def conversation(self, entity: Any, **kwargs: Any) -> Any:
         return self._client.conversation(entity, **kwargs)
@@ -173,41 +326,62 @@ class TelegramTransportSession:
     # --- users ---
 
     async def is_bot(self) -> bool:
-        return await self._client.is_bot()
+        return await self._run("telegram_is_bot", self._client.is_bot())
 
     async def is_user_authorized(self) -> bool:
-        return await self._client.is_user_authorized()
+        return await self._run(
+            "telegram_is_user_authorized",
+            self._client.is_user_authorized(),
+        )
+
+    async def get_me(self) -> Any:
+        return await self.fetch_me()
 
     async def get_peer_id(self, peer: Any) -> int:
-        return await self._client.get_peer_id(peer)
+        return await self._run("telegram_get_peer_id", self._client.get_peer_id(peer))
 
     # --- chats ---
 
     def stream_admin_log(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        return self._client.iter_admin_log(entity, **kwargs)
+        return self._stream(
+            "telegram_stream_admin_log",
+            self._client.iter_admin_log(entity, **kwargs),
+        )
 
     async def get_admin_log(self, entity: Any, **kwargs: Any) -> Any:
-        return await self._client.get_admin_log(entity, **kwargs)
+        return await self._run(
+            "telegram_get_admin_log",
+            self._client.get_admin_log(entity, **kwargs),
+        )
 
     def stream_profile_photos(self, entity: Any, **kwargs: Any) -> AsyncIterator[Any]:
-        return self._client.iter_profile_photos(entity, **kwargs)
+        return self._stream(
+            "telegram_stream_profile_photos",
+            self._client.iter_profile_photos(entity, **kwargs),
+        )
 
     async def get_profile_photos(self, entity: Any, **kwargs: Any) -> Any:
-        return await self._client.get_profile_photos(entity, **kwargs)
+        return await self._run(
+            "telegram_get_profile_photos",
+            self._client.get_profile_photos(entity, **kwargs),
+        )
 
     def action(self, entity: Any, action: str, **kwargs: Any) -> Any:
         return self._client.action(entity, action, **kwargs)
 
     async def get_permissions(self, entity: Any, user: Any = None) -> Any:
-        return await self._client.get_permissions(entity, user)
+        return await self._run(
+            "telegram_get_permissions",
+            self._client.get_permissions(entity, user),
+        )
 
     # --- updates ---
 
     async def set_receive_updates(self, enabled: bool) -> None:
-        await self._client.set_receive_updates(enabled)
+        await self._run("telegram_set_receive_updates", self._client.set_receive_updates(enabled))
 
     async def run_until_disconnected(self) -> None:
-        await self._client.run_until_disconnected()
+        await self._run("telegram_run_until_disconnected", self._client.run_until_disconnected())
 
     def on(self, event: Any) -> Any:
         return self._client.on(event)
@@ -222,12 +396,15 @@ class TelegramTransportSession:
         return self._client.list_event_handlers()
 
     async def catch_up(self) -> None:
-        await self._client.catch_up()
+        await self._run("telegram_catch_up", self._client.catch_up())
 
     # --- bots ---
 
     async def inline_query(self, bot: Any, query: str, **kwargs: Any) -> Any:
-        return await self._client.inline_query(bot, query, **kwargs)
+        return await self._run(
+            "telegram_inline_query",
+            self._client.inline_query(bot, query, **kwargs),
+        )
 
     # --- buttons ---
 
@@ -240,15 +417,18 @@ class TelegramTransportSession:
         return self._client.takeout(**kwargs)
 
     async def end_takeout(self, success: bool) -> None:
-        await self._client.end_takeout(success)
+        await self._run("telegram_end_takeout", self._client.end_takeout(success))
 
     # --- existing ---
 
     async def remove_dialog(self, entity: Any) -> None:
-        await self._client.delete_dialog(entity)
+        await self._run("telegram_remove_dialog", self._client.delete_dialog(entity))
 
     async def invoke_request(self, request: Any) -> Any:
-        return await self._client(request)
+        return await self._run("telegram_invoke_request", self._client(request))
+
+    async def __call__(self, request: Any) -> Any:
+        return await self.invoke_request(request)
 
     async def lookup_search_posts_flood(self, query: str = "") -> Any:
         from telethon.tl.functions.channels import CheckSearchPostsFloodRequest

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -59,12 +59,14 @@ class TelegramTransportSession:
         logger_: logging.Logger | None = None,
         report_flood_wait: bool = True,
     ) -> TelegramTransportSession:
-        self._phone = phone
-        self._pool = pool
-        self._report_flood_wait = report_flood_wait
-        if logger_ is not None:
-            self._logger = logger_
-        return self
+        return TelegramTransportSession(
+            self._client,
+            disconnect_on_close=self._disconnect_on_close,
+            phone=phone,
+            pool=pool,
+            logger_=logger_ or self._logger,
+            report_flood_wait=report_flood_wait,
+        )
 
     async def _run(self, operation: str, awaitable: Any) -> Any:
         try:

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -91,8 +92,15 @@ class TelegramTransportSession:
 
     async def _stream(self, operation: str, iterator: AsyncIterator[Any]) -> AsyncIterator[Any]:
         try:
-            async for item in iterator:
-                yield item
+            try:
+                async for item in iterator:
+                    yield item
+            finally:
+                aclose = getattr(iterator, "aclose", None)
+                if aclose is not None:
+                    result = aclose()
+                    if inspect.isawaitable(result):
+                        await result
         except HandledFloodWaitError:
             raise
         except Exception as exc:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -690,7 +690,7 @@ class ClientPool:
         lease: BackendClientLease | None = None
         try:
             if direct_session is not None:
-                direct_session.with_flood_context(
+                context_session = direct_session.with_flood_context(
                     phone=phone,
                     pool=self,
                     logger_=logger,
@@ -698,7 +698,7 @@ class ClientPool:
                 )
                 lease = BackendClientLease(
                     phone=phone,
-                    session=direct_session,
+                    session=context_session,
                     backend_name="direct",
                     disconnect_on_release=False,
                 )
@@ -707,7 +707,7 @@ class ClientPool:
                     account_lease.account,
                     force_native=force_native,
                 )
-                lease.session.with_flood_context(
+                lease.session = lease.session.with_flood_context(
                     phone=phone,
                     pool=self,
                     logger_=logger,
@@ -722,7 +722,6 @@ class ClientPool:
                         phone=phone,
                         pool=self,
                         logger_=logger,
-                        report_flood_wait=report_generic_flood,
                     )
                     lease.disconnect_on_release = False
 
@@ -744,7 +743,7 @@ class ClientPool:
 
     async def _connect_account(self, account: Account) -> BackendClientLease:
         lease = await self._backend_router.acquire_client(account)
-        lease.session.with_flood_context(
+        lease.session = lease.session.with_flood_context(
             phone=account.phone,
             pool=self,
             logger_=logger,

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -398,16 +398,15 @@ class ClientPool:
     async def get_native_client_by_phone(
         self,
         phone: str,
-    ) -> tuple[object, str] | None:
-        """Get a specific client through the native backend for stateful flows."""
+    ) -> tuple[TelegramTransportSession, str] | None:
+        """Get a specific flood-aware client through the native backend for stateful flows."""
         lease = await self._acquire_phone_lease(phone)
         if lease is None:
             return None
         result = await self._acquire_from_lease(lease, force_native=True)
         if result is None:
             return None
-        session, acquired_phone = result
-        return session.raw_client, acquired_phone
+        return result
 
     async def get_premium_client(self) -> tuple[TelegramTransportSession, str] | None:
         """Get first available premium client.
@@ -422,7 +421,10 @@ class ClientPool:
             )
             if lease is None:
                 return None
-            result = await self._acquire_from_lease(lease)
+            result = await self._acquire_from_lease(
+                lease,
+                report_generic_flood=False,
+            )
             if result is not None:
                 return result
         return None
@@ -668,6 +670,7 @@ class ClientPool:
         account_lease: AccountLease,
         *,
         force_native: bool = False,
+        report_generic_flood: bool = True,
     ) -> tuple[TelegramTransportSession, str] | None:
         phone = account_lease.account.phone
         # force_native bypasses the persistent pool session — callers need a raw native client
@@ -687,6 +690,12 @@ class ClientPool:
         lease: BackendClientLease | None = None
         try:
             if direct_session is not None:
+                direct_session.with_flood_context(
+                    phone=phone,
+                    pool=self,
+                    logger_=logger,
+                    report_flood_wait=report_generic_flood,
+                )
                 lease = BackendClientLease(
                     phone=phone,
                     session=direct_session,
@@ -698,11 +707,22 @@ class ClientPool:
                     account_lease.account,
                     force_native=force_native,
                 )
+                lease.session.with_flood_context(
+                    phone=phone,
+                    pool=self,
+                    logger_=logger,
+                    report_flood_wait=report_generic_flood,
+                )
                 if not force_native:
                     # Store persistent session for future direct reuse.
                     # force_native sessions are short-lived and must not replace the pool session.
                     self.clients[phone] = TelegramTransportSession(
-                        lease.session.raw_client, disconnect_on_close=False
+                        lease.session.raw_client,
+                        disconnect_on_close=False,
+                        phone=phone,
+                        pool=self,
+                        logger_=logger,
+                        report_flood_wait=report_generic_flood,
                     )
                     lease.disconnect_on_release = False
 
@@ -724,9 +744,18 @@ class ClientPool:
 
     async def _connect_account(self, account: Account) -> BackendClientLease:
         lease = await self._backend_router.acquire_client(account)
+        lease.session.with_flood_context(
+            phone=account.phone,
+            pool=self,
+            logger_=logger,
+        )
         # Store persistent transport session so _direct_session() can reuse the connection
         self.clients[account.phone] = TelegramTransportSession(
-            lease.session.raw_client, disconnect_on_close=False
+            lease.session.raw_client,
+            disconnect_on_close=False,
+            phone=account.phone,
+            pool=self,
+            logger_=logger,
         )
         lease.disconnect_on_release = False
         return lease

--- a/tests/test_account_lease_pool.py
+++ b/tests/test_account_lease_pool.py
@@ -212,3 +212,24 @@ async def test_cursor_unchanged_when_all_flooded(db, pool):
     lease = await pool.acquire_available(connected)
     assert lease is not None
     assert lease.account.phone == "+76002"
+
+
+@pytest.mark.asyncio
+async def test_shared_fallback_uses_round_robin_order(db):
+    """When every account is in use, shared leases still rotate instead of preferring primary."""
+    phones = ["+77001", "+77002", "+77003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    pool = AccountLeasePool(db, set(phones))
+    connected = set(phones)
+
+    seen: list[str] = []
+    for _ in range(4):
+        lease = await pool.acquire_available(connected)
+        assert lease is not None
+        assert lease.shared is True
+        seen.append(lease.account.phone)
+
+    assert seen[:3] == phones
+    assert seen[3] == phones[0]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon.errors import FloodWaitError
 
 from src.models import Account
 from src.telegram.backends import (
@@ -13,6 +14,7 @@ from src.telegram.backends import (
     TelegramTransportSession,
     TelethonCliBackend,
 )
+from src.telegram.flood_wait import HandledFloodWaitError
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
 
 
@@ -79,6 +81,69 @@ async def test_download_media():
     result = await session.download_media(SimpleNamespace(id=1), file="/tmp/photo.jpg")
     assert result == "/tmp/photo.jpg"
     session.raw_client.download_media.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_transport_session_reports_flood_from_awaitable():
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 5
+    pool = AsyncMock()
+    session = TelegramTransportSession(
+        FakeCliTelethonClient(entity_resolver=lambda _arg: err),
+        phone="+7000",
+        pool=pool,
+    )
+
+    with pytest.raises(HandledFloodWaitError) as exc_info:
+        await session.get_entity("@channel")
+
+    assert exc_info.value.info.wait_seconds == 5
+    pool.report_flood.assert_awaited_once_with("+7000", 5)
+
+
+@pytest.mark.asyncio
+async def test_transport_session_reports_flood_from_stream():
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 7
+
+    class FloodingIterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise err
+
+    pool = AsyncMock()
+    session = TelegramTransportSession(
+        FakeCliTelethonClient(iter_messages_factory=lambda *a, **kw: FloodingIterator()),
+        phone="+7001",
+        pool=pool,
+    )
+
+    with pytest.raises(HandledFloodWaitError) as exc_info:
+        async for _msg in session.iter_messages("entity"):
+            pass
+
+    assert exc_info.value.info.wait_seconds == 7
+    pool.report_flood.assert_awaited_once_with("+7001", 7)
+
+
+@pytest.mark.asyncio
+async def test_transport_session_reports_flood_from_raw_request():
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 9
+    pool = AsyncMock()
+    session = TelegramTransportSession(
+        FakeCliTelethonClient(invoke_side_effect=err),
+        phone="+7002",
+        pool=pool,
+    )
+
+    with pytest.raises(HandledFloodWaitError) as exc_info:
+        await session(object())
+
+    assert exc_info.value.info.wait_seconds == 9
+    pool.report_flood.assert_awaited_once_with("+7002", 9)
 
 
 # --- Batch 3: Participants (#188, #189) ---

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -149,6 +149,39 @@ async def test_transport_session_reports_flood_from_stream():
 
 
 @pytest.mark.asyncio
+async def test_transport_session_closes_stream_iterator_on_flood():
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 7
+
+    class FloodingIterator:
+        closed = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise err
+
+        async def aclose(self):
+            self.closed = True
+
+    iterator = FloodingIterator()
+    pool = AsyncMock()
+    session = TelegramTransportSession(
+        FakeCliTelethonClient(iter_messages_factory=lambda *a, **kw: iterator),
+        phone="+7001",
+        pool=pool,
+    )
+
+    with pytest.raises(HandledFloodWaitError):
+        async for _msg in session.iter_messages("entity"):
+            pass
+
+    assert iterator.closed is True
+    pool.report_flood.assert_awaited_once_with("+7001", 7)
+
+
+@pytest.mark.asyncio
 async def test_transport_session_reports_flood_from_raw_request():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 9

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,6 +22,26 @@ def _session(**kwargs) -> TelegramTransportSession:
     return TelegramTransportSession(FakeCliTelethonClient(**kwargs))
 
 
+def test_with_flood_context_returns_distinct_session_without_mutating_original():
+    pool = object()
+    original = _session()
+
+    contextual = original.with_flood_context(
+        phone="+7000",
+        pool=pool,
+        report_flood_wait=False,
+    )
+
+    assert contextual is not original
+    assert contextual.raw_client is original.raw_client
+    assert original._phone is None
+    assert original._pool is None
+    assert original._report_flood_wait is True
+    assert contextual._phone == "+7000"
+    assert contextual._pool is pool
+    assert contextual._report_flood_wait is False
+
+
 # --- Batch 1: Messages (#184, #185, #186, #190) ---
 
 

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon.errors import FloodWaitError
 from telethon_cli.errors import CLIError
 
 from src.services.notification_target_service import NotificationTargetService
+from src.telegram.backends import TelegramTransportSession
+from src.telegram.flood_wait import HandledFloodWaitError
 from tests.helpers import FakeCliTelethonClient
 
 
@@ -91,6 +94,39 @@ async def test_shared_lease_keeps_phone_busy_until_last_release(
 
 @pytest.mark.asyncio
 @pytest.mark.native_backend_allowed
+async def test_native_client_by_phone_returns_flood_aware_session(
+    real_pool_harness_factory,
+):
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 11
+    harness = real_pool_harness_factory()
+    harness.queue_cli_client(phone="+70000000001", client=FakeCliTelethonClient())
+    harness.queue_native_client(
+        session_string="session-native",
+        client=FakeCliTelethonClient(entity_resolver=lambda _arg: err),
+    )
+    await harness.add_account(
+        "+70000000001",
+        session_string="session-native",
+        is_primary=True,
+    )
+    await harness.initialize_connected_accounts()
+
+    result = await harness.pool.get_native_client_by_phone("+70000000001")
+    assert result is not None
+    session, phone = result
+
+    assert phone == "+70000000001"
+    assert isinstance(session, TelegramTransportSession)
+    with pytest.raises(HandledFloodWaitError):
+        await session.get_entity("@flooded")
+
+    accounts = await harness.db.get_accounts()
+    assert accounts[0].flood_wait_until is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.native_backend_allowed
 async def test_auto_mode_falls_back_to_native_when_cli_acquire_fails(
     real_pool_harness_factory,
 ):
@@ -159,7 +195,11 @@ async def test_get_native_client_by_phone_uses_native_backend_and_disconnects(
 
     acquired = await harness.pool.get_native_client_by_phone("+70000000001")
 
-    assert acquired == (native_client, "+70000000001")
+    assert acquired is not None
+    session, phone = acquired
+    assert isinstance(session, TelegramTransportSession)
+    assert session.raw_client is native_client
+    assert phone == "+70000000001"
 
     await harness.pool.release_client("+70000000001")
     native_client.disconnect.assert_awaited_once()
@@ -187,7 +227,8 @@ async def test_notification_target_uses_real_pool_native_getter(
     service = NotificationTargetService(harness.db, harness.pool)
 
     async with service.use_client() as (acquired_client, phone):
-        assert acquired_client is native_client
+        assert isinstance(acquired_client, TelegramTransportSession)
+        assert acquired_client.raw_client is native_client
         assert phone == "+70000000001"
 
     native_client.disconnect.assert_awaited_once()

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -93,6 +93,37 @@ async def test_shared_lease_keeps_phone_busy_until_last_release(
 
 
 @pytest.mark.asyncio
+async def test_premium_client_does_not_disable_generic_flood_reporting_on_persistent_session(
+    real_pool_harness_factory,
+):
+    harness = real_pool_harness_factory()
+    cli_client = harness.queue_cli_client(
+        phone="+70000000001",
+        client=FakeCliTelethonClient(me=MagicMock(premium=True)),
+    )
+    await harness.add_account(
+        "+70000000001",
+        session_string="session-a",
+        is_primary=True,
+        is_premium=True,
+    )
+    await harness.initialize_connected_accounts()
+    persistent_session = harness.pool.clients["+70000000001"]
+
+    acquired = await harness.pool.get_premium_client()
+
+    assert acquired is not None
+    premium_session, phone = acquired
+    assert phone == "+70000000001"
+    assert premium_session is not persistent_session
+    assert premium_session.raw_client is cli_client
+    assert premium_session._report_flood_wait is False
+    assert persistent_session._report_flood_wait is True
+
+    await harness.pool.release_client("+70000000001")
+
+
+@pytest.mark.asyncio
 @pytest.mark.native_backend_allowed
 async def test_native_client_by_phone_returns_flood_aware_session(
     real_pool_harness_factory,

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -230,7 +230,9 @@ async def test_setup_bot_custom_prefix(db, real_pool_harness_factory):
         bot = await svc.setup_bot()
 
     assert bot.bot_username == "acme_bob_bot"
-    mock_create.assert_awaited_once_with(native_client, "Acme (bob)", "acme_bob_bot")
+    created_client = mock_create.await_args.args[0]
+    assert created_client.raw_client is native_client
+    assert mock_create.await_args.args[1:] == ("Acme (bob)", "acme_bob_bot")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- centralize FloodWaitError handling in TelegramTransportSession for calls, streams, and raw requests
- attach flood context from ClientPool while preserving premium-search-specific flood reporting
- apply round-robin ordering to shared account lease fallback for issue 496

## Validation
- ruff check src/ tests/ conftest.py
- pytest tests/ -v -m "not aiosqlite_serial" -n auto
- pytest tests/ -v -m aiosqlite_serial