### PR TITLE
refactor(web): finish template asset cleanup for issue 357

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ include = ["src*"]
 src = [
     "web/templates/*.html",
     "web/static/*.css",
+    "web/static/*.js",
+    "web/static/js/*.js",
     "cli/commands/*.tcss",
 ]
 

--- a/src/web/static/settings.js
+++ b/src/web/static/settings.js
@@ -363,13 +363,17 @@ function activateSettingsTab(tabId) {
     }
 }
 
+function settingsTabIdFromHash(hash) {
+    return (hash || '').replace('#', '').replace(/^pane-/, '');
+}
+
 function initSettingsTabs() {
     /* Determine which tab to show.
        base.html IIFE saves flash codes to window globals before clearing the URL,
        so we read from globals (reliable) with URL params as fallback. */
     var msg = window.__flashMsg || new URLSearchParams(window.location.search).get('msg');
     var err = window.__flashError || new URLSearchParams(window.location.search).get('error');
-    var hash = window.location.hash.replace('#', '');
+    var hash = settingsTabIdFromHash(window.location.hash);
 
     /* Priority: flash message tab > URL hash > default (accounts) */
     var targetTab = '';
@@ -391,6 +395,13 @@ function initSettingsTabs() {
             var id = btn.getAttribute('data-bs-target').replace('#pane-', '');
             history.replaceState(null, '', '#' + id);
         });
+    });
+
+    window.addEventListener('hashchange', function() {
+        var tabId = settingsTabIdFromHash(window.location.hash);
+        if (tabId) {
+            activateSettingsTab(tabId);
+        }
     });
 }
 

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -35,6 +35,15 @@ html { font-size: 14px; }
 .tga-table-striped-hover > tbody > tr:nth-of-type(odd) > * { --bs-table-accent-bg: var(--bs-table-striped-bg, rgba(0,0,0,0.05)); color: var(--bs-table-striped-color, var(--bs-table-color)); }
 .tga-table-striped-hover > tbody > tr:hover > * { --bs-table-accent-bg: var(--bs-table-hover-bg, rgba(0,0,0,0.075)); color: var(--bs-table-hover-color, var(--bs-table-color)); }
 
+/* TGConfirm shared confirm/alert dialog */
+.tgdlg-overlay { position: fixed; inset: 0; z-index: 10000; background: rgba(0,0,0,.5); display: flex; align-items: flex-end; justify-content: center; padding-bottom: 1.5rem; }
+.tgdlg-box { background: var(--bs-dark-bg-subtle,#1e1e2e); border: 1px solid var(--bs-primary); border-radius: 6px; padding: 1rem 1.5rem; min-width: 320px; max-width: 560px; font-family: var(--bs-font-monospace,monospace); }
+.tgdlg-message { color: var(--bs-body-color); margin-bottom: .75rem; font-size: .95rem; font-family: var(--bs-font-sans-serif,sans-serif); white-space: pre-wrap; }
+.tgdlg-item { padding: .2rem 0; cursor: pointer; white-space: pre; color: var(--bs-body-color); }
+.tgdlg-item.tgdlg-selected { color: var(--bs-primary); }
+.tgdlg-cursor { display: inline-block; width: 1ch; }
+.tgdlg-hint { margin-top: .75rem; color: var(--bs-secondary-color); font-size: .8rem; }
+
 /* Debug log coloring */
 .log-error td { color: var(--bs-danger); }
 .log-warning td { color: var(--bs-warning); }
@@ -322,4 +331,3 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
 .wizard-type-card input[type="radio"] {
     display: none;
 }
-

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -8,16 +8,6 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/style.css">
-    <style>
-    /* TGConfirm — shared confirm/alert dialog */
-    .tgdlg-overlay{position:fixed;inset:0;z-index:10000;background:rgba(0,0,0,.5);display:flex;align-items:flex-end;justify-content:center;padding-bottom:1.5rem}
-    .tgdlg-box{background:var(--bs-dark-bg-subtle,#1e1e2e);border:1px solid var(--bs-primary);border-radius:6px;padding:1rem 1.5rem;min-width:320px;max-width:560px;font-family:var(--bs-font-monospace,monospace)}
-    .tgdlg-message{color:var(--bs-body-color);margin-bottom:.75rem;font-size:.95rem;font-family:var(--bs-font-sans-serif,sans-serif);white-space:pre-wrap}
-    .tgdlg-item{padding:.2rem 0;cursor:pointer;white-space:pre;color:var(--bs-body-color)}
-    .tgdlg-item.tgdlg-selected{color:var(--bs-primary)}
-    .tgdlg-cursor{display:inline-block;width:1ch}
-    .tgdlg-hint{margin-top:.75rem;color:var(--bs-secondary-color);font-size:.8rem}
-    </style>
     <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
     <script src="/static/_theme_init.js"></script>
     {% block head_scripts %}{% endblock %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -173,35 +173,4 @@
 {% endblock %}
 {% block head_scripts %}
 <script src="/static/settings.js?v={{ app_version }}" defer></script>
-<script>
-(function() {
-    // Handle hash-based tab activation for /settings/#pane-name URLs
-    function activateTabFromHash() {
-        var hash = window.location.hash;
-        if (hash) {
-            var paneId = hash.replace('#', '');
-            // Find the corresponding tab button
-            var tab = document.querySelector('[data-bs-target="#' + paneId + '"]');
-            if (tab) {
-                // Remove active from all tabs and panes
-                document.querySelectorAll('#settings-tabs .nav-link').forEach(function(el) {
-                    el.classList.remove('active');
-                });
-                document.querySelectorAll('#settings-tab-content .tab-pane').forEach(function(el) {
-                    el.classList.remove('show', 'active');
-                });
-                // Activate selected tab and pane
-                tab.classList.add('active');
-                var pane = document.getElementById(paneId);
-                if (pane) {
-                    pane.classList.add('show', 'active');
-                }
-            }
-        }
-    }
-    // Activate on page load and hash change
-    window.addEventListener('hashchange', activateTabFromHash);
-    activateTabFromHash();
-})();
-</script>
 {% endblock %}

--- a/tests/test_packaging_release.py
+++ b/tests/test_packaging_release.py
@@ -15,5 +15,7 @@ def test_packaging_config_keeps_src_namespace_for_console_script() -> None:
     assert data["tool"]["setuptools"]["package-data"]["src"] == [
         "web/templates/*.html",
         "web/static/*.css",
+        "web/static/*.js",
+        "web/static/js/*.js",
         "cli/commands/*.tcss",
     ]

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -218,6 +218,17 @@ async def test_settings_page(client):
     assert "Режим разработчика" in resp.text
     assert "Я понимаю, что включаю потенциально опасные изменения" in resp.text
     assert "Backend override" not in resp.text
+    assert 'src="/static/settings.js' in resp.text
+    assert "activateTabFromHash" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_settings_static_js_handles_pane_hashes(client):
+    resp = await client.get("/static/settings.js")
+    assert resp.status_code == 200
+    assert "settingsTabIdFromHash" in resp.text
+    assert "replace(/^pane-/, '')" in resp.text
+    assert "hashchange" in resp.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #357

Summary:
- Moved TGConfirm `.tgdlg-*` CSS out of `base.html` into `src/web/static/style.css`.
- Removed duplicate settings inline hash-tab JS and kept tab behavior in `settings.js`.
- Preserved `#pane-*` settings hashes in external JS after removing the inline fallback.
- Packaged static JS assets via setuptools package-data and updated release coverage.

Validation:
- `ruff check src/ tests/ conftest.py`
- `pytest tests/test_packaging_release.py -q`
- `pytest tests/test_web.py -q -k "settings or static or flash"`
- `pytest tests/routes/test_moderation_routes.py tests/routes/test_pipelines_routes.py -q`
- `rg -n "<style>|tgdlg-" src/web/templates/base.html`
- `rg -n "activateTabFromHash" src/web/templates src/web/static`
- `rg -n "web/static/.*\\.js|web/static/js/.*\\.js" pyproject.toml tests/test_packaging_release.py`
