### PR TITLE
test: fail on pytest warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,21 @@ jobs:
       - name: Ruff
         run: ruff check src tests conftest.py
 
+      - name: Enforce pytest warnings as errors
+        run: |
+          python - <<'PY'
+          import sys
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              config = tomllib.load(f)
+
+          actual = config["tool"]["pytest"]["ini_options"].get("filterwarnings")
+          expected = ["error"]
+          if actual != expected:
+              print(f"Expected tool.pytest.ini_options.filterwarnings = {expected!r}, got {actual!r}")
+              sys.exit(1)
+          PY
+
       - name: Pytest
         run: pytest tests -q -m "not aiosqlite_serial" -n auto && pytest tests -q -m aiosqlite_serial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,7 @@ asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
 timeout = 30
 addopts = "--dist=loadfile"
-filterwarnings = [
-    "ignore:Exception ignored in.*_SyncHttpxClientWrapper:pytest.PytestUnraisableExceptionWarning",
-    "ignore:unclosed event loop:ResourceWarning",
-    "ignore:Exception in thread.*_connection_worker_thread:pytest.PytestUnhandledThreadExceptionWarning",
-]
+filterwarnings = ["error"]
 markers = [
     "native_backend_allowed: test intentionally exercises explicit native Telethon allowlist flows",
     "real_tg_safe: opt-in real Telegram API test limited to read-only sandbox scenarios",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "langchain-core==1.2.19",
     "langchain-ollama==1.0.1",
     "pytest==9.0.2",
-    "pytest-asyncio==1.3.0",
     "pytest-timeout==2.4.0",
     "pytest-xdist==3.8.0",
     "httpx==0.28.1",
@@ -96,8 +95,7 @@ include = ["*.py"]
 select = ["E", "F", "I", "N", "W"]
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
+anyio_mode = "auto"
 testpaths = ["tests"]
 timeout = 30
 addopts = "--dist=loadfile"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,13 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.session_materializer import SessionMaterializer
 from tests.helpers import RealPoolHarness
 
+
+@pytest.fixture(scope="session")
+def anyio_backend() -> str:
+    """Force asyncio backend for the entire suite — no trio."""
+    return "asyncio"
+
+
 REAL_TG_SAFE_MARK = "real_tg_safe"
 REAL_TG_MANUAL_MARK = "real_tg_manual"
 REAL_TG_NEVER_MARK = "real_tg_never"
@@ -39,7 +46,7 @@ REAL_TG_OPTIONAL_ENV_VARS = (
 
 
 @pytest.fixture
-async def db():
+async def db(anyio_backend):
     """In-memory test database."""
     database = Database(":memory:")
     await database.initialize()
@@ -87,11 +94,13 @@ def cli_init_patch():
         fresh_database: bool = False,
     ):
         runtime_config = config or AppConfig()
+        fresh_databases: list[Database] = []
 
         async def fake_init_db(_config_path: str):
             if isinstance(db, Database) and fresh_database:
                 cmd_db = Database(db._db_path, session_encryption_secret=db._session_encryption_secret)
                 await cmd_db.initialize()
+                fresh_databases.append(cmd_db)
                 return runtime_config, cmd_db
             if isinstance(db, Database) and db._connection.db is None:
                 await db.initialize()
@@ -100,7 +109,11 @@ def cli_init_patch():
         with ExitStack() as stack:
             for target in targets:
                 stack.enter_context(patch(target, side_effect=fake_init_db))
-            yield runtime_config, db
+            try:
+                yield runtime_config, db
+            finally:
+                for cmd_db in fresh_databases:
+                    asyncio.run(cmd_db.close())
 
     return _patch
 

--- a/tests/e2e/test_collection_flow.py
+++ b/tests/e2e/test_collection_flow.py
@@ -138,7 +138,7 @@ async def _task_status(db_path: str, channel_id: int) -> str | None:
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_persists_messages_via_embedded_worker(tmp_path):
     """`serve` with the embedded worker must complete the full collect tract.
 
@@ -163,7 +163,7 @@ async def test_trigger_collection_persists_messages_via_embedded_worker(tmp_path
             assert status == CollectionTaskStatus.COMPLETED.value
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_stuck_without_worker(tmp_path):
     """Regression guard: if `serve` is started with `--no-worker`, the same
     click leaves the task in PENDING. This proves the happy-path test above
@@ -187,7 +187,7 @@ async def test_trigger_collection_stuck_without_worker(tmp_path):
             assert status == CollectionTaskStatus.PENDING.value
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedded_worker_publishes_heartbeat(tmp_path):
     """Sanity: the embedded worker writes a fresh `worker_heartbeat` snapshot.
 
@@ -218,7 +218,7 @@ async def test_embedded_worker_publishes_heartbeat(tmp_path):
                 await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_health_reflects_accounts_after_snapshot_publish(tmp_path):
     """Regression guard for the `/scheduler/` shows 0/0 bug.
 

--- a/tests/repositories/test_generated_images_repository.py
+++ b/tests/repositories/test_generated_images_repository.py
@@ -1,14 +1,14 @@
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_returns_id(db):
     repo = db.repos.generated_images
     img_id = await repo.save("a sunset", "together:flux", "https://img.example/1.png", None)
     assert img_id > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_id_found(db):
     repo = db.repos.generated_images
     img_id = await repo.save("a sunset", "together:flux", "https://img.example/1.png", "/tmp/img.png")
@@ -20,13 +20,13 @@ async def test_get_by_id_found(db):
     assert img.local_path == "/tmp/img.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_id_not_found(db):
     repo = db.repos.generated_images
     assert await repo.get_by_id(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_recent_default_limit(db):
     repo = db.repos.generated_images
     for i in range(60):
@@ -35,7 +35,7 @@ async def test_list_recent_default_limit(db):
     assert len(result) == 50
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_recent_custom_limit(db):
     repo = db.repos.generated_images
     for i in range(10):
@@ -44,7 +44,7 @@ async def test_list_recent_custom_limit(db):
     assert len(result) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_with_null_optional_fields(db):
     repo = db.repos.generated_images
     img_id = await repo.save("test", None, None, None)

--- a/tests/repositories/test_photo_loader_repository.py
+++ b/tests/repositories/test_photo_loader_repository.py
@@ -5,7 +5,7 @@ import pytest
 from src.models import PhotoAutoUploadJob, PhotoBatch, PhotoBatchItem, PhotoBatchStatus
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_and_get_batch(db):
     repo = db.repos.photo_loader
     batch = PhotoBatch(phone="+123", target_dialog_id=100, target_title="Chat", target_type="channel")
@@ -17,12 +17,12 @@ async def test_create_and_get_batch(db):
     assert fetched.target_dialog_id == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_batch_not_found(db):
     assert await db.repos.photo_loader.get_batch(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_batches(db):
     repo = db.repos.photo_loader
     await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -30,7 +30,7 @@ async def test_list_batches(db):
     assert len(await repo.list_batches()) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_batch_status(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -40,7 +40,7 @@ async def test_update_batch_status(db):
     assert b.error == "ok"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_batch_no_changes(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -49,7 +49,7 @@ async def test_update_batch_no_changes(db):
     assert b.status == PhotoBatchStatus.PENDING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_batch_last_run_at(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -59,7 +59,7 @@ async def test_update_batch_last_run_at(db):
     assert b.last_run_at is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_and_get_item(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -75,7 +75,7 @@ async def test_create_and_get_item(db):
     assert fetched.batch_id == bid
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_items(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -88,7 +88,7 @@ async def test_list_items(db):
     assert len(items) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_items_for_batch(db):
     repo = db.repos.photo_loader
     b1 = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -100,7 +100,7 @@ async def test_list_items_for_batch(db):
     assert len(await repo.list_items_for_batch(b2)) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_item_status(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -111,7 +111,7 @@ async def test_update_item_status(db):
     assert item.telegram_message_ids == [10, 20]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_item_no_changes(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -121,7 +121,7 @@ async def test_update_item_no_changes(db):
     assert item.status == PhotoBatchStatus.PENDING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_item(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -131,7 +131,7 @@ async def test_cancel_item(db):
     assert item.status == PhotoBatchStatus.CANCELLED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_item_already_completed(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -140,7 +140,7 @@ async def test_cancel_item_already_completed(db):
     assert await repo.cancel_item(iid) is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claim_next_due_item(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -155,14 +155,14 @@ async def test_claim_next_due_item(db):
     assert claimed.status == PhotoBatchStatus.RUNNING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claim_next_due_item_none(db):
     repo = db.repos.photo_loader
     now = datetime.now(timezone.utc)
     assert await repo.claim_next_due_item(now) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_running_items_on_startup(db):
     repo = db.repos.photo_loader
     bid = await repo.create_batch(PhotoBatch(phone="+1", target_dialog_id=1))
@@ -178,7 +178,7 @@ async def test_requeue_running_items_on_startup(db):
     assert item.status == PhotoBatchStatus.PENDING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_and_get_auto_job(db):
     repo = db.repos.photo_loader
     job = PhotoAutoUploadJob(phone="+1", target_dialog_id=100, folder_path="/tmp/photos", interval_minutes=30)
@@ -190,7 +190,7 @@ async def test_create_and_get_auto_job(db):
     assert fetched.interval_minutes == 30
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_auto_job(db):
     repo = db.repos.photo_loader
     job = PhotoAutoUploadJob(phone="+1", target_dialog_id=100, folder_path="/tmp/photos")
@@ -202,7 +202,7 @@ async def test_update_auto_job(db):
     assert updated.is_active is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_auto_jobs(db):
     repo = db.repos.photo_loader
     for i in range(3):
@@ -214,7 +214,7 @@ async def test_list_auto_jobs(db):
     assert len(await repo.list_auto_jobs(active_only=True)) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_auto_job(db):
     repo = db.repos.photo_loader
     job_id = await repo.create_auto_job(
@@ -224,7 +224,7 @@ async def test_delete_auto_job(db):
     assert await repo.get_auto_job(job_id) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auto_file_sent_tracking(db):
     repo = db.repos.photo_loader
     job_id = await repo.create_auto_job(

--- a/tests/repositories/test_pipeline_templates_repository.py
+++ b/tests/repositories/test_pipeline_templates_repository.py
@@ -14,7 +14,7 @@ def sample_template():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_and_get_by_id(db, sample_template):
     repo = db.repos.pipeline_templates
     tpl_id = await repo.add(sample_template)
@@ -27,13 +27,13 @@ async def test_add_and_get_by_id(db, sample_template):
     assert tpl.is_builtin is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_id_not_found(db):
     repo = db.repos.pipeline_templates
     assert await repo.get_by_id(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_name(db, sample_template):
     repo = db.repos.pipeline_templates
     await repo.add(sample_template)
@@ -42,13 +42,13 @@ async def test_get_by_name(db, sample_template):
     assert tpl.name == "Basic Pipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_name_not_found(db):
     repo = db.repos.pipeline_templates
     assert await repo.get_by_name("nonexistent") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_all(db, sample_template):
     repo = db.repos.pipeline_templates
     await repo.add(sample_template)
@@ -66,7 +66,7 @@ async def test_list_all(db, sample_template):
     assert "Other" in names
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_all_with_category_filter(db, sample_template):
     repo = db.repos.pipeline_templates
     await repo.add(sample_template)
@@ -82,7 +82,7 @@ async def test_list_all_with_category_filter(db, sample_template):
     assert filtered[0].name == "Basic Pipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete(db, sample_template):
     repo = db.repos.pipeline_templates
     tpl_id = await repo.add(sample_template)
@@ -90,7 +90,7 @@ async def test_delete(db, sample_template):
     assert await repo.get_by_id(tpl_id) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ensure_builtins_inserts_missing(db):
     repo = db.repos.pipeline_templates
     builtins = [
@@ -116,7 +116,7 @@ async def test_ensure_builtins_inserts_missing(db):
     assert "Builtin2" in names
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ensure_builtins_idempotent(db):
     repo = db.repos.pipeline_templates
     builtins = [

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -9,7 +9,7 @@ from src.database import Database
 from src.models import RuntimeSnapshot, TelegramCommand, TelegramCommandStatus
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_commands_repository_round_trip(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()
@@ -33,7 +33,7 @@ async def test_telegram_commands_repository_round_trip(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claim_next_command_rolls_back_on_error(tmp_path):
     """If an exception happens mid-claim, the DB must not stay locked."""
     db = Database(str(tmp_path / "test.db"))
@@ -71,7 +71,7 @@ async def test_claim_next_command_rolls_back_on_error(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claim_next_command_recovers_from_stale_transaction(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()
@@ -95,7 +95,7 @@ async def test_claim_next_command_recovers_from_stale_transaction(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_snapshots_repository_upsert_and_get(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()
@@ -119,7 +119,7 @@ async def test_runtime_snapshots_repository_upsert_and_get(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_snapshots_repository_handles_non_primitive_payload(tmp_path):
     """Regression for #473 tail: payload with datetime/bytes must round-trip
     via safe_json_dumps without raising TypeError.

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.agent.manager import AgentManager
@@ -26,7 +25,7 @@ from src.web.bootstrap import build_container_with_templates
 from src.web.log_handler import LogBuffer
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def base_app(tmp_path):
     """Create configured app + db with account and channel."""
     config = AppConfig()
@@ -99,7 +98,7 @@ async def base_app(tmp_path):
     await db.close()
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def route_client(base_app):
     """AsyncClient with Basic auth."""
     app, db, pool_mock = base_app

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -73,7 +73,7 @@ async def _web_mode_client(tmp_path):
         await container.db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_container_uses_snapshot_shims(tmp_path):
     """Verify runtime_mode="web" really produces the snapshot shims."""
     async with _web_mode_client(tmp_path) as (_, container):
@@ -85,7 +85,7 @@ async def test_web_container_uses_snapshot_shims(tmp_path):
         assert container.telegram_command_dispatcher is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_toggle_in_web_mode_enqueues_command(tmp_path):
     """POST /settings/{id}/toggle in real web bootstrap: no live pool, just a queued command."""
     async with _web_mode_client(tmp_path) as (client, container):
@@ -101,7 +101,7 @@ async def test_account_toggle_in_web_mode_enqueues_command(tmp_path):
         assert commands[0].payload == {"account_id": acc.id}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_delete_in_web_mode_enqueues_command(tmp_path):
     """POST /settings/{id}/delete in real web bootstrap: DB row untouched, command enqueued."""
     async with _web_mode_client(tmp_path) as (client, container):
@@ -119,7 +119,7 @@ async def test_account_delete_in_web_mode_enqueues_command(tmp_path):
         assert commands[0].command_type == "accounts.delete"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_chat_in_web_mode_returns_worker_only_error(tmp_path):
     """POST /agent/threads/{id}/chat in real web bootstrap returns a clear 503,
     not the old opaque 'AgentManager not initialized'."""
@@ -135,7 +135,7 @@ async def test_agent_chat_in_web_mode_returns_worker_only_error(tmp_path):
         assert "worker" in detail.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_permission_in_web_mode_returns_worker_only_error(tmp_path):
     """POST /agent/threads/{id}/permission/{req_id} in web returns the same 503 contract."""
     async with _web_mode_client(tmp_path) as (client, container):
@@ -150,7 +150,7 @@ async def test_agent_permission_in_web_mode_returns_worker_only_error(tmp_path):
         assert "worker" in detail.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_in_web_mode_renders_banner(tmp_path):
     """GET /agent in web mode renders the disabled banner but does not 500."""
     async with _web_mode_client(tmp_path) as (client, container):

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -8,7 +8,7 @@ import pytest
 from src.models import Account
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_account_enqueues_command(route_client, base_app):
     """Web toggle only enqueues `accounts.toggle`; worker reconciles the pool."""
     app, db, pool = base_app
@@ -31,7 +31,7 @@ async def test_toggle_account_enqueues_command(route_client, base_app):
     assert commands[0].payload == {"account_id": acc.id}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_account_enqueues_command(route_client, base_app):
     """Web delete only enqueues `accounts.delete`; the DB row survives until the worker runs."""
     app, db, pool = base_app
@@ -57,7 +57,7 @@ async def test_delete_account_enqueues_command(route_client, base_app):
     assert commands[0].payload == {"account_id": to_delete.id}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_status_empty(route_client, base_app):
     """Flood status returns JSON with no active floods."""
     app, db, pool = base_app
@@ -71,7 +71,7 @@ async def test_flood_status_empty(route_client, base_app):
         assert "remaining_seconds" in item
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_status_active_flood(route_client, base_app):
     """Flood status shows active flood wait."""
     app, db, pool = base_app
@@ -89,7 +89,7 @@ async def test_flood_status_active_flood(route_client, base_app):
     assert flooded[0]["remaining_seconds"] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_status_expired_flood(route_client, base_app):
     """Flood status shows ok for expired flood wait."""
     app, db, pool = base_app
@@ -107,7 +107,7 @@ async def test_flood_status_expired_flood(route_client, base_app):
     assert entry[0]["remaining_seconds"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_clear_success(route_client, base_app):
     """Flood clear resets flood wait."""
     app, db, pool = base_app
@@ -121,7 +121,7 @@ async def test_flood_clear_success(route_client, base_app):
     assert "/settings" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_clear_not_found(route_client, base_app):
     """Flood clear for non-existent account redirects."""
     resp = await route_client.post("/settings/99999/flood-clear", follow_redirects=False)

--- a/tests/routes/test_agent_channels_routes_regression.py
+++ b/tests/routes/test_agent_channels_routes_regression.py
@@ -30,7 +30,7 @@ async def db(base_app):
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_no_threads_creates_thread(client, db):
     """Covers auto-creating thread when none exist."""
     threads = await db.get_agent_threads()
@@ -42,7 +42,7 @@ async def test_agent_page_no_threads_creates_thread(client, db):
     assert "thread_id=" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_has_threads_no_thread_id(client, db):
     """Covers redirect to first thread when threads exist but no thread_id param."""
     tid = await db.create_agent_thread("First")
@@ -51,7 +51,7 @@ async def test_agent_page_has_threads_no_thread_id(client, db):
     assert f"thread_id={tid}" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_chat_whitespace_message(client, db):
     """Covers chat with whitespace-only message."""
     tid = await db.create_agent_thread("Chat")
@@ -63,7 +63,7 @@ async def test_agent_chat_whitespace_message(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_chat_invalid_model(client, db):
     """Covers chat with unrecognized model parameter."""
     tid = await db.create_agent_thread("Chat")
@@ -80,7 +80,7 @@ async def test_agent_chat_invalid_model(client, db):
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_list_tags_empty(client, db):
     """Covers GET /channels/tags with no tags."""
     resp = await client.get("/channels/tags")
@@ -89,7 +89,7 @@ async def test_channels_list_tags_empty(client, db):
     assert "tags" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_create_tag(client, db):
     """Covers POST /channels/tags creates a tag."""
     resp = await client.post(
@@ -101,7 +101,7 @@ async def test_channels_create_tag(client, db):
     assert "msg=tag_created" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_delete_tag(client, db):
     """Covers DELETE /channels/tags/{name}."""
     await db.repos.channels.create_tag("del-me")
@@ -111,7 +111,7 @@ async def test_channels_delete_tag(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_get_channel_tags(client, db):
     """Covers GET /channels/{pk}/tags."""
     from src.models import Channel
@@ -126,7 +126,7 @@ async def test_channels_get_channel_tags(client, db):
     assert "tags" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_set_channel_tags(client, db):
     """Covers POST /channels/{pk}/tags."""
     from src.models import Channel
@@ -144,7 +144,7 @@ async def test_channels_set_channel_tags(client, db):
     assert "msg=tags_updated" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_refresh_types(client, db):
     """Covers POST /channels/refresh-types."""
     with patch("src.web.routes.channels.deps.telegram_command_service") as mock_svc:
@@ -157,7 +157,7 @@ async def test_channels_refresh_types(client, db):
         assert "command_id=42" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_refresh_meta(client, db):
     """Covers POST /channels/refresh-meta."""
     with patch("src.web.routes.channels.deps.telegram_command_service") as mock_svc:
@@ -170,7 +170,7 @@ async def test_channels_refresh_meta(client, db):
         assert "command_id=43" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_add_empty_identifier(client, db):
     """Covers POST /channels/add with empty identifier."""
     resp = await client.post(
@@ -182,7 +182,7 @@ async def test_channels_add_empty_identifier(client, db):
     assert "error=resolve" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_show_all_view(client, db):
     """Covers channels list with view=all param."""
     resp = await client.get("/channels/?view=all")

--- a/tests/routes/test_agent_routes.py
+++ b/tests/routes/test_agent_routes.py
@@ -23,7 +23,7 @@ async def db(base_app):
     return db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_autocreates_thread(client, db):
     """Test agent page auto-creates first thread."""
     resp = await client.get("/agent", follow_redirects=False)
@@ -32,7 +32,7 @@ async def test_agent_page_autocreates_thread(client, db):
     assert "thread_id=" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_renders_with_thread(client, db):
     """Test agent page renders with existing thread."""
     thread_id = await db.create_agent_thread("Test Thread")
@@ -42,7 +42,7 @@ async def test_agent_page_renders_with_thread(client, db):
     assert "Test Thread" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_invalid_thread_redirects(client, db):
     """Test agent page with invalid thread redirects to existing."""
     thread_id = await db.create_agent_thread("Valid Thread")
@@ -52,7 +52,7 @@ async def test_agent_page_invalid_thread_redirects(client, db):
     assert f"thread_id={thread_id}" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_thread(client, db):
     """Test create new thread."""
     resp = await client.post("/agent/threads", follow_redirects=False)
@@ -61,7 +61,7 @@ async def test_create_thread(client, db):
     assert "thread_id=" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_thread(client, db):
     """Test delete thread."""
     thread_id = await db.create_agent_thread("To Delete")
@@ -72,7 +72,7 @@ async def test_delete_thread(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_thread_success(client, db):
     """Test rename thread success."""
     thread_id = await db.create_agent_thread("Original")
@@ -87,7 +87,7 @@ async def test_rename_thread_success(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_thread_empty_title(client, db):
     """Test rename thread with empty title."""
     thread_id = await db.create_agent_thread("Original")
@@ -100,7 +100,7 @@ async def test_rename_thread_empty_title(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channels_json(client, db):
     """Test get channels JSON."""
     resp = await client.get("/agent/channels-json")
@@ -109,7 +109,7 @@ async def test_get_channels_json(client, db):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_empty(client, db, pool_mock):
     """Test get forum topics returns empty list."""
     pool_mock.get_forum_topics = AsyncMock(return_value=[])
@@ -120,7 +120,7 @@ async def test_get_forum_topics_empty(client, db, pool_mock):
     assert "command_id" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_returns_data(client, db, pool_mock):
     """Test get forum topics returns data."""
     topics = [{"id": 1, "title": "Topic 1"}]
@@ -132,7 +132,7 @@ async def test_get_forum_topics_returns_data(client, db, pool_mock):
     assert "command_id" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_no_channel_id(client, db):
     """Test inject context without channel_id."""
     thread_id = await db.create_agent_thread("Context")
@@ -145,7 +145,7 @@ async def test_inject_context_no_channel_id(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_thread_not_found(client):
     """Test inject context with invalid thread."""
     resp = await client.post(
@@ -156,7 +156,7 @@ async def test_inject_context_thread_not_found(client):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_success(client, db):
     """Test inject context success."""
     thread_id = await db.create_agent_thread("Context")
@@ -171,7 +171,7 @@ async def test_inject_context_success(client, db):
     assert "content" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_chat(client, db):
     """Test stop chat."""
     thread_id = await db.create_agent_thread("Stop")
@@ -182,7 +182,7 @@ async def test_stop_chat(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_no_agent_manager(client, db):
     """Test chat without agent manager."""
     client._transport_app.state.agent_manager = None
@@ -196,7 +196,7 @@ async def test_chat_no_agent_manager(client, db):
     assert resp.status_code == 503
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_empty_message(client, db):
     """Test chat with empty message."""
     thread_id = await db.create_agent_thread("Chat")
@@ -209,7 +209,7 @@ async def test_chat_empty_message(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_thread_not_found(client):
     """Test chat with invalid thread."""
     resp = await client.post(
@@ -220,7 +220,7 @@ async def test_chat_thread_not_found(client):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_no_backend(client, db):
     """Test chat when no backend available."""
     thread_id = await db.create_agent_thread("Chat")
@@ -241,7 +241,7 @@ async def test_chat_no_backend(client, db):
     assert resp.status_code == 503
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming(client, db):
     """Test chat returns SSE stream."""
     thread_id = await db.create_agent_thread("Stream")
@@ -255,7 +255,7 @@ async def test_chat_streaming(client, db):
     assert "text/event-stream" in resp.headers.get("content-type", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_shows_status(client, db):
     """Test agent page shows agent status."""
     thread_id = await db.create_agent_thread("Status")
@@ -266,7 +266,7 @@ async def test_agent_page_shows_status(client, db):
     assert "agent" in resp.text.lower() or "backend" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_without_agent_manager(client, db):
     """Test agent page without agent manager."""
     client._transport_app.state.agent_manager = None
@@ -279,7 +279,7 @@ async def test_agent_page_without_agent_manager(client, db):
 # === Additional tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_chat_with_agent_manager(client, db):
     """Test stop chat with agent manager."""
     thread_id = await db.create_agent_thread("Stop")
@@ -290,7 +290,7 @@ async def test_stop_chat_with_agent_manager(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_with_topic(client, db):
     """Test inject context with topic_id."""
     thread_id = await db.create_agent_thread("Context")
@@ -305,7 +305,7 @@ async def test_inject_context_with_topic(client, db):
     assert "content" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_empty_topic(client, db):
     """Test inject context with empty topic_id."""
     thread_id = await db.create_agent_thread("Context")
@@ -320,7 +320,7 @@ async def test_inject_context_empty_topic(client, db):
     assert "content" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_with_limit(client, db):
     """Test inject context respects limit."""
     thread_id = await db.create_agent_thread("Context")
@@ -333,7 +333,7 @@ async def test_inject_context_with_limit(client, db):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_thread_not_found(client):
     """Test delete non-existent thread returns ok (idempotent)."""
     resp = await client.delete("/agent/threads/999999")
@@ -343,7 +343,7 @@ async def test_delete_thread_not_found(client):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_thread_not_found(client):
     """Test rename non-existent thread returns ok (idempotent)."""
     resp = await client.post(
@@ -357,7 +357,7 @@ async def test_rename_thread_not_found(client):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_fallback(client, db, pool_mock):
     """Test get forum topics fallback to cached when API fails."""
     # Simulate API returning empty (flood wait, etc.)

--- a/tests/routes/test_agent_routes_streaming.py
+++ b/tests/routes/test_agent_routes_streaming.py
@@ -24,7 +24,7 @@ async def db(base_app):
 # === inject_context: large context warning (line 181-185) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_large_context_warning(client, db):
     """Test inject context logs warning for very large content (>200K chars)."""
     thread_id = await db.create_agent_thread("Context")
@@ -43,7 +43,7 @@ async def test_inject_context_large_context_warning(client, db):
 # === chat: generate() — save assistant message on done (line 282-283) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_saves_assistant_message(client, db):
     """Test chat streaming saves assistant message when done."""
     thread_id = await db.create_agent_thread("Chat")
@@ -68,7 +68,7 @@ async def test_chat_streaming_saves_assistant_message(client, db):
 # === chat: generate() — IntegrityError on save (line 284-285) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_integrity_error_on_save(client, db):
     """Test chat streaming handles IntegrityError when saving assistant message."""
     thread_id = await db.create_agent_thread("Chat")
@@ -101,7 +101,7 @@ async def test_chat_streaming_integrity_error_on_save(client, db):
 # === chat: generate() — error in stream (line 286-290) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_error_in_stream(client, db):
     """Test chat streaming handles error chunk from agent."""
     thread_id = await db.create_agent_thread("Chat")
@@ -126,7 +126,7 @@ async def test_chat_streaming_error_in_stream(client, db):
 # === chat: generate() — IntegrityError on delete_last_exchange (line 289) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_error_integrity_delete(client, db):
     """Test chat streaming handles IntegrityError during error cleanup."""
     thread_id = await db.create_agent_thread("Chat")
@@ -152,7 +152,7 @@ async def test_chat_streaming_error_integrity_delete(client, db):
 # === chat: generate() — JSONDecodeError (line 291) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_malformed_chunk(client, db):
     """Test chat streaming skips malformed JSON chunks."""
     thread_id = await db.create_agent_thread("Chat")
@@ -178,7 +178,7 @@ async def test_chat_streaming_malformed_chunk(client, db):
 # === chat: generate() — generic exception (line 293) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_streaming_generic_exception(client, db):
     """Test chat streaming handles generic exceptions during message processing."""
     thread_id = await db.create_agent_thread("Chat")
@@ -211,7 +211,7 @@ async def test_chat_streaming_generic_exception(client, db):
 # === chat: no model parameter (line 232-233) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_with_invalid_model_ignored(client, db):
     """Test chat with invalid model string is ignored (model=None)."""
     thread_id = await db.create_agent_thread("Chat")
@@ -227,7 +227,7 @@ async def test_chat_with_invalid_model_ignored(client, db):
 # === forum-topics cached (line 130-131) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forum_topics_cached(client, db):
     """Test get forum topics returns cached data from DB."""
     # Insert topics via upsert_forum_topics (not RuntimeSnapshot)

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -26,7 +26,7 @@ async def db(base_app):
 # ── agent_page: lines 48-55 (redirects) ────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_no_threads_creates_thread(client, db):
     """Test agent page auto-creates thread when none exist (lines 57-58)."""
     # Ensure no threads
@@ -42,7 +42,7 @@ async def test_agent_page_no_threads_creates_thread(client, db):
     assert "/agent?thread_id=" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_no_thread_id_redirects_to_first(client, db):
     """Test agent page with no thread_id redirects to first thread (lines 53-55)."""
     thread_id = await db.create_agent_thread("First Thread")
@@ -53,7 +53,7 @@ async def test_agent_page_no_thread_id_redirects_to_first(client, db):
     assert f"thread_id={thread_id}" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_page_invalid_thread_id_redirects(client, db):
     """Test agent page with invalid thread_id redirects to first (lines 48-50)."""
     thread_id = await db.create_agent_thread("Valid")
@@ -67,7 +67,7 @@ async def test_agent_page_invalid_thread_id_redirects(client, db):
 # ── rename_thread: line 95-99 ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_thread_whitespace_title(client, db):
     """Test rename thread with whitespace-only title (line 96)."""
     thread_id = await db.create_agent_thread("Original")
@@ -83,7 +83,7 @@ async def test_rename_thread_whitespace_title(client, db):
 # ── get_forum_topics: lines 126-128, 132-136 ───────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_api_fails_falls_back_to_db(client, db, pool_mock):
     """Test get forum topics falls back to DB cache when API returns None (lines 131-136)."""
     pool_mock.get_forum_topics = AsyncMock(return_value=None)
@@ -94,7 +94,7 @@ async def test_get_forum_topics_api_fails_falls_back_to_db(client, db, pool_mock
     assert "command_id" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_api_returns_data_caches_to_db(client, db, pool_mock):
     """Test get forum topics caches fresh data to DB (lines 126-128)."""
     topics = [{"id": 1, "title": "Topic 1"}, {"id": 2, "title": "Topic 2"}]
@@ -109,7 +109,7 @@ async def test_get_forum_topics_api_returns_data_caches_to_db(client, db, pool_m
 # ── inject_context: line 134, 142-153 ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_with_topic_id_none_string(client, db):
     """Test inject context with topic_id as 'None' string (line 150)."""
     thread_id = await db.create_agent_thread("Context")
@@ -124,7 +124,7 @@ async def test_inject_context_with_topic_id_none_string(client, db):
     assert "content" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_large_limit_capped(client, db):
     """Test inject context with limit > 10000 is capped (line 147)."""
     thread_id = await db.create_agent_thread("Context")
@@ -139,7 +139,7 @@ async def test_inject_context_large_limit_capped(client, db):
     assert "content" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_context_zero_limit_uses_default(client, db):
     """Test inject context with limit=0 uses default 10000 (line 147)."""
     thread_id = await db.create_agent_thread("Context")
@@ -155,7 +155,7 @@ async def test_inject_context_zero_limit_uses_default(client, db):
 # ── resolve_permission: lines 196-204 ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_permission_invalid_choice(client, db):
     """Test resolve permission with invalid choice (line 198)."""
     thread_id = await db.create_agent_thread("Perm")
@@ -168,7 +168,7 @@ async def test_resolve_permission_invalid_choice(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_permission_no_agent_manager(client, db):
     """Test resolve permission when agent_manager is None (lines 200-202)."""
     thread_id = await db.create_agent_thread("Perm")
@@ -182,7 +182,7 @@ async def test_resolve_permission_no_agent_manager(client, db):
     assert resp.status_code == 503
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_permission_valid_choices(client, db):
     """Test resolve permission with all valid choices."""
     thread_id = await db.create_agent_thread("Perm")
@@ -205,7 +205,7 @@ async def test_resolve_permission_valid_choices(client, db):
 # ── stop_chat: lines 211-213 ───────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_chat_with_agent_manager_cancel(client, db):
     """Test stop chat calls cancel_stream on agent manager (lines 212-213)."""
     thread_id = await db.create_agent_thread("Stop")
@@ -219,7 +219,7 @@ async def test_stop_chat_with_agent_manager_cancel(client, db):
     mock_mgr.cancel_stream.assert_called_once_with(thread_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_chat_no_agent_manager(client, db):
     """Test stop chat without agent manager (line 211)."""
     thread_id = await db.create_agent_thread("Stop")
@@ -234,7 +234,7 @@ async def test_stop_chat_no_agent_manager(client, db):
 # ── chat: lines 221-241, 248, 264-282 ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_using_override_with_error(client, db):
     """Test chat when using_override is True with error (lines 237-238)."""
     thread_id = await db.create_agent_thread("Chat")
@@ -255,7 +255,7 @@ async def test_chat_using_override_with_error(client, db):
     assert resp.status_code == 503
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_prompt_too_large(client, db):
     """Test chat when estimated prompt exceeds 100K tokens (lines 247-251)."""
     thread_id = await db.create_agent_thread("Chat")
@@ -272,7 +272,7 @@ async def test_chat_prompt_too_large(client, db):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_auto_renames_thread(client, db):
     """Test chat auto-renames thread from first message (lines 257-258)."""
     thread_id = await db.create_agent_thread("Новый тред")
@@ -289,7 +289,7 @@ async def test_chat_auto_renames_thread(client, db):
     assert thread["title"] == "My first message"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_does_not_rename_custom_thread(client, db):
     """Test chat does not rename thread with custom title."""
     thread_id = await db.create_agent_thread("Custom Title")
@@ -306,7 +306,7 @@ async def test_chat_does_not_rename_custom_thread(client, db):
     assert thread["title"] == "Custom Title"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_with_model_parameter(client, db):
     """Test chat with explicit model parameter (line 225-226)."""
     thread_id = await db.create_agent_thread("Chat")
@@ -329,7 +329,7 @@ async def test_chat_with_model_parameter(client, db):
 # ── delete_thread: lines 86-88 (permission gate clearing) ──────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_thread_clears_permission_gate(client, db):
     """Test delete thread clears permission gate for session (lines 86-88)."""
     thread_id = await db.create_agent_thread("Perm")
@@ -343,7 +343,7 @@ async def test_delete_thread_clears_permission_gate(client, db):
     mock_gate.clear_session.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_thread_no_permission_gate(client, db):
     """Test delete thread with no permission_gate (line 87)."""
     thread_id = await db.create_agent_thread("Perm")
@@ -357,7 +357,7 @@ async def test_delete_thread_no_permission_gate(client, db):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_thread_no_agent_manager(client, db):
     """Test delete thread when agent_manager is None (line 86)."""
     thread_id = await db.create_agent_thread("Perm")
@@ -372,7 +372,7 @@ async def test_delete_thread_no_agent_manager(client, db):
 # ── get_channels_json: line 106 ────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channels_json_with_data(client, db):
     """Test get channels JSON with active channels."""
     from src.models import Channel

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_renders(route_client):
     """Test analytics page renders without errors."""
     resp = await route_client.get("/analytics")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_with_dates(route_client):
     """Test analytics page with date filters."""
     resp = await route_client.get(
@@ -21,14 +21,14 @@ async def test_analytics_page_with_dates(route_client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_limit_param(route_client):
     """Test analytics page with limit parameter."""
     resp = await route_client.get("/analytics?limit=20")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_invalid_limit(route_client):
     """Test analytics page with invalid limit returns 422."""
     resp = await route_client.get("/analytics?limit=abc")
@@ -36,21 +36,21 @@ async def test_analytics_page_invalid_limit(route_client):
     assert resp.status_code == 422
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_empty_db(route_client):
     """Test analytics page with empty database."""
     resp = await route_client.get("/analytics")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_analytics_page_renders(route_client):
     """Test content analytics page renders."""
     resp = await route_client.get("/analytics/content")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_content_summary_returns_json(route_client):
     """Test content summary API returns JSON."""
     resp = await route_client.get("/analytics/content/api/summary")
@@ -60,7 +60,7 @@ async def test_api_content_summary_returns_json(route_client):
     assert isinstance(data, dict)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_pipelines_returns_json(route_client):
     """Test pipeline stats API returns JSON."""
     resp = await route_client.get("/analytics/content/api/pipelines")
@@ -70,7 +70,7 @@ async def test_api_pipelines_returns_json(route_client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_pipelines_with_data(route_client):
     """Test pipeline stats API with created pipeline."""
     db = route_client._transport_app.state.db
@@ -110,7 +110,7 @@ async def test_api_pipelines_with_data(route_client):
     assert data[0]["pipeline_name"] == "Test Pipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_pipelines_filter_by_id(route_client):
     """Test pipeline stats API filtered by pipeline_id."""
     db = route_client._transport_app.state.db

--- a/tests/routes/test_analytics_routes_channel_trends.py
+++ b/tests/routes/test_analytics_routes_channel_trends.py
@@ -8,21 +8,21 @@ import pytest
 # ── Trends page ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trends_page_renders(route_client):
     """Test trends page renders."""
     resp = await route_client.get("/analytics/trends")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trends_page_with_days(route_client):
     """Test trends page with custom days param."""
     resp = await route_client.get("/analytics/trends?days=14")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trends_page_invalid_days(route_client):
     """Test trends page with invalid days falls back to 7."""
     resp = await route_client.get("/analytics/trends?days=99")
@@ -32,21 +32,21 @@ async def test_trends_page_invalid_days(route_client):
 # ── Channel analytics page ─────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_analytics_page_renders(route_client):
     """Test channel analytics page renders."""
     resp = await route_client.get("/analytics/channels")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_analytics_page_with_channel(route_client, base_app):
     """Test channel analytics page with channel_id param."""
     resp = await route_client.get("/analytics/channels?channel_id=100&days=30")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_analytics_page_invalid_days(route_client):
     """Test channel analytics page with invalid days falls back to 30."""
     resp = await route_client.get("/analytics/channels?days=99")
@@ -56,7 +56,7 @@ async def test_channel_analytics_page_invalid_days(route_client):
 # ── Channel API endpoints ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channel_overview(route_client):
     """Test channel overview API returns JSON."""
     from src.services.channel_analytics_service import ChannelOverview
@@ -79,7 +79,7 @@ async def test_api_channel_overview(route_client):
         assert data["title"] == "Test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_subscriber_history(route_client):
     """Test subscriber history API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -93,7 +93,7 @@ async def test_api_subscriber_history(route_client):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_views_timeseries(route_client):
     """Test views timeseries API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -107,7 +107,7 @@ async def test_api_views_timeseries(route_client):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_post_frequency(route_client):
     """Test post frequency API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -121,7 +121,7 @@ async def test_api_post_frequency(route_client):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_err(route_client):
     """Test ERR API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -135,7 +135,7 @@ async def test_api_err(route_client):
         assert data["err24"] == 3.1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_hourly_activity(route_client):
     """Test hourly activity API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -149,7 +149,7 @@ async def test_api_hourly_activity(route_client):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_citation_stats(route_client):
     """Test citation stats API returns JSON."""
     from src.services.channel_analytics_service import CitationStats
@@ -165,7 +165,7 @@ async def test_api_citation_stats(route_client):
         assert data["total_forwards"] == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_heatmap(route_client):
     """Test heatmap API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
@@ -179,7 +179,7 @@ async def test_api_heatmap(route_client):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_cross_citations(route_client):
     """Test cross-citations API returns JSON."""
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -65,14 +65,14 @@ async def client_unconfigured(base_app):
 
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_login_page(client):
     """Test login page renders."""
     resp = await client.get("/auth/login")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_login_page_shows_phone_step(client):
     """Test login page shows phone step when configured."""
     resp = await client.get("/auth/login")
@@ -81,7 +81,7 @@ async def test_login_page_shows_phone_step(client):
     assert "phone" in resp.text.lower() or "телефон" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_login_page_shows_credentials_step(client_unconfigured):
     """Test login page shows credentials step when not configured."""
     resp = await client_unconfigured.get("/auth/login")
@@ -90,7 +90,7 @@ async def test_login_page_shows_credentials_step(client_unconfigured):
     assert "api" in resp.text.lower() or "credential" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_redirect(client_unconfigured):
     """Test save credentials redirects to login."""
     resp = await client_unconfigured.post(
@@ -102,7 +102,7 @@ async def test_save_credentials_redirect(client_unconfigured):
     assert "/auth/login" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_updates_auth(client_unconfigured):
     """Test save credentials updates auth."""
     await client_unconfigured.post(
@@ -116,7 +116,7 @@ async def test_save_credentials_updates_auth(client_unconfigured):
     assert api_id == "12345"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_code_success(client):
     """Test send code is enqueued instead of executed inline."""
     db = client._transport.app.state.db
@@ -136,7 +136,7 @@ async def test_send_code_success(client):
     assert commands[0].payload["phone"] == "+1234567890"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_code_unconfigured(client_unconfigured):
     """Test send code when auth not configured."""
     resp = await client_unconfigured.post(
@@ -148,7 +148,7 @@ async def test_send_code_unconfigured(client_unconfigured):
     assert "error" in resp.text.lower() or "api" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_code_error(client):
     """Test send code route does not call TelegramAuth inline on web."""
     db = client._transport.app.state.db
@@ -168,7 +168,7 @@ async def test_send_code_error(client):
     assert commands[0].command_type == "auth.send_code"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resend_code_success(client):
     """Test resend code is enqueued instead of executed inline."""
     db = client._transport.app.state.db
@@ -187,7 +187,7 @@ async def test_resend_code_success(client):
     assert commands[0].payload["phone_code_hash"] == "old_hash"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resend_code_error(client):
     """Test resend code route does not call TelegramAuth inline on web."""
     db = client._transport.app.state.db
@@ -207,7 +207,7 @@ async def test_resend_code_error(client):
     assert commands[0].command_type == "auth.resend_code"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_success(client):
     """Test verify code is enqueued instead of executed inline."""
     auth = client._transport.app.state.auth
@@ -236,7 +236,7 @@ async def test_verify_code_success(client):
     assert commands[0].payload["password_2fa"] == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_2fa_required(client):
     """Test login page shows 2FA form for failed queued verify command."""
     db = client._transport.app.state.db
@@ -256,7 +256,7 @@ async def test_verify_code_2fa_required(client):
     assert "2fa" in resp.text.lower() or "password" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_with_2fa(client):
     """Test verify code enqueues 2FA password for worker processing."""
     db = client._transport.app.state.db
@@ -275,7 +275,7 @@ async def test_verify_code_with_2fa(client):
     assert commands[0].payload["password_2fa"] == "mypassword"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_invalid_code(client):
     """Test login page surfaces invalid-code error from failed queued command."""
     db = client._transport.app.state.db
@@ -302,7 +302,7 @@ async def test_verify_code_invalid_code(client):
     assert "Invalid code" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_generic_error(client):
     """Test login page surfaces generic verify error from failed queued command."""
     db = client._transport.app.state.db
@@ -322,7 +322,7 @@ async def test_verify_code_generic_error(client):
     assert "Connection lost" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_sets_primary(client):
     """Test verify_code command reflects existing DB primary-state context."""
     db = client._transport.app.state.db
@@ -340,7 +340,7 @@ async def test_verify_code_sets_primary(client):
     assert "is_primary" not in commands[0].payload  # worker recomputes from fresh DB state
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_detects_premium(client):
     """Test verify code route no longer mutates accounts synchronously."""
     db = client._transport.app.state.db
@@ -358,7 +358,7 @@ async def test_verify_code_detects_premium(client):
     assert len(accounts) == 1  # only the fixture account, new phone not added synchronously
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_timeout_parsing(client):
     """Test login page tolerates non-numeric timeout from failed queued command."""
     db = client._transport.app.state.db
@@ -379,7 +379,7 @@ async def test_verify_code_timeout_parsing(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_code_returns_code_info(client):
     """Test login page renders code-step data from successful queued command."""
     db = client._transport.app.state.db
@@ -403,7 +403,7 @@ async def test_send_code_returns_code_info(client):
     assert "code" in text_lower or "код" in text_lower
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_login_page_api_configured_flag(client):
     """Test login page correctly detects API configuration."""
     resp = await client.get("/auth/login")
@@ -412,7 +412,7 @@ async def test_login_page_api_configured_flag(client):
     assert "phone" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_validates_input(client_unconfigured):
     """Test save credentials accepts form data."""
     resp = await client_unconfigured.post(
@@ -423,7 +423,7 @@ async def test_save_credentials_validates_input(client_unconfigured):
     assert resp.status_code == 200 or resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_missing_phone_code_hash(client):
     """POST /auth/verify-code without phone_code_hash enqueues with empty hash → 303."""
     resp = await client.post(
@@ -434,7 +434,7 @@ async def test_verify_code_missing_phone_code_hash(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resend_code_missing_phone_code_hash(client):
     """POST /auth/resend-code without phone_code_hash enqueues with empty hash → 303."""
     resp = await client.post(
@@ -445,7 +445,7 @@ async def test_resend_code_missing_phone_code_hash(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_empty_password(client):
     """Test empty 2FA password is preserved as empty string in queued payload."""
     db = client._transport.app.state.db
@@ -463,7 +463,7 @@ async def test_verify_code_empty_password(client):
     assert commands[0].payload["password_2fa"] == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_verify_code_get_me_error(client):
     """Test verify_code route itself is unaffected by later worker-side premium refresh."""
     resp = await client.post(
@@ -479,14 +479,14 @@ async def test_verify_code_get_me_error(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_code_missing_phone(client):
     """POST /auth/send-code without phone renders login page (200)."""
     resp = await client.post("/auth/send-code", data={}, follow_redirects=False)
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_missing_api_id(client_unconfigured):
     """POST /auth/save-credentials without api_id returns 422."""
     resp = await client_unconfigured.post(
@@ -497,7 +497,7 @@ async def test_save_credentials_missing_api_id(client_unconfigured):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_missing_api_hash(client_unconfigured):
     """POST /auth/save-credentials without api_hash returns 422."""
     resp = await client_unconfigured.post(

--- a/tests/routes/test_calendar_routes.py
+++ b/tests/routes/test_calendar_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_calendar_page_renders(route_client):
     """Calendar page renders successfully and returns the calendar template."""
     resp = await route_client.get("/calendar/")
@@ -12,7 +12,7 @@ async def test_calendar_page_renders(route_client):
     assert "Календарь" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_calendar_page_with_days_param(route_client):
     """Calendar page echoes the requested days window back into the template."""
     resp = await route_client.get("/calendar/?days=14")
@@ -22,7 +22,7 @@ async def test_calendar_page_with_days_param(route_client):
     assert 'value="14"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_calendar_page_with_pipeline_filter(route_client):
     """Calendar page accepts pipeline_id filter and renders the form with that value."""
     resp = await route_client.get("/calendar/?pipeline_id=1")
@@ -30,7 +30,7 @@ async def test_calendar_page_with_pipeline_filter(route_client):
     assert "Календарь" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_calendar_empty(route_client):
     """Calendar JSON API returns empty list when no data."""
     resp = await route_client.get("/calendar/api/calendar")
@@ -39,7 +39,7 @@ async def test_api_calendar_empty(route_client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_calendar_with_days(route_client):
     """Calendar JSON API accepts days parameter."""
     resp = await route_client.get("/calendar/api/calendar?days=7")
@@ -48,7 +48,7 @@ async def test_api_calendar_with_days(route_client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_upcoming_empty(route_client):
     """Upcoming JSON API returns empty list."""
     resp = await route_client.get("/calendar/api/upcoming")
@@ -57,7 +57,7 @@ async def test_api_upcoming_empty(route_client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_upcoming_with_limit(route_client):
     """Upcoming JSON API accepts limit parameter."""
     resp = await route_client.get("/calendar/api/upcoming?limit=5")
@@ -66,7 +66,7 @@ async def test_api_upcoming_with_limit(route_client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_stats(route_client):
     """Calendar stats JSON API returns stats dict."""
     resp = await route_client.get("/calendar/api/stats")

--- a/tests/routes/test_channel_collection_routes.py
+++ b/tests/routes/test_channel_collection_routes.py
@@ -6,7 +6,7 @@ import pytest
 from tests.routes.conftest import _add_channel
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_channels_no_htmx(route_client, base_app):
     """POST collect-all without HTMX redirects."""
     app, db, pool = base_app
@@ -17,7 +17,7 @@ async def test_collect_all_channels_no_htmx(route_client, base_app):
     assert "/channels" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_channels_htmx(route_client, base_app):
     """POST collect-all with HTMX returns HTML fragment."""
     app, db, pool = base_app
@@ -31,7 +31,7 @@ async def test_collect_all_channels_htmx(route_client, base_app):
     assert "collect-all-btn" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_channels_empty(route_client, base_app):
     """POST collect-all with no active channels returns empty message."""
     app, db, pool = base_app
@@ -48,7 +48,7 @@ async def test_collect_all_channels_empty(route_client, base_app):
     assert "Нет активных каналов" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_channels_shutting_down(route_client, base_app):
     """POST collect-all during shutdown returns warning."""
     app, db, pool = base_app
@@ -64,7 +64,7 @@ async def test_collect_all_channels_shutting_down(route_client, base_app):
         app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_success(route_client, base_app):
     """POST stats/all starts stats collection."""
     app, db, pool = base_app
@@ -75,7 +75,7 @@ async def test_collect_all_stats_success(route_client, base_app):
     assert "/channels" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_already_running(route_client, base_app):
     """POST stats/all when already running redirects with error."""
     app, db, pool = base_app
@@ -92,7 +92,7 @@ async def test_collect_all_stats_already_running(route_client, base_app):
     assert "stats_running" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_htmx(route_client, base_app):
     """POST collect single channel with HTMX."""
     app, db, pool = base_app
@@ -106,7 +106,7 @@ async def test_collect_single_channel_htmx(route_client, base_app):
     assert f"collect-btn-{pk}" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_no_htmx(route_client, base_app):
     """POST collect single channel without HTMX redirects."""
     app, db, pool = base_app

--- a/tests/routes/test_channels_routes.py
+++ b/tests/routes/test_channels_routes.py
@@ -14,28 +14,28 @@ async def db(base_app):
     return db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_page_renders(route_client):
     """Test channels page renders."""
     resp = await route_client.get("/channels/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_page_with_message(route_client):
     """Test channels page with message param."""
     resp = await route_client.get("/channels/?msg=channel_added")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_page_with_error(route_client):
     """Test channels page with error param."""
     resp = await route_client.get("/channels/?error=resolve")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_success(route_client, pool_mock):
     """Test add channel success."""
     pool_mock.resolve_channel = AsyncMock(
@@ -56,7 +56,7 @@ async def test_add_channel_success(route_client, pool_mock):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_no_client(route_client):
     """Test add channel with no route_client available."""
     resp = await route_client.post(
@@ -68,7 +68,7 @@ async def test_add_channel_no_client(route_client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_resolve_fail(route_client):
     """Test add channel when resolve fails."""
     resp = await route_client.post(
@@ -80,7 +80,7 @@ async def test_add_channel_resolve_fail(route_client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_json(route_client, db):
     """Test get dialogs returns JSON."""
     await db.repos.dialog_cache.replace_dialogs(
@@ -99,7 +99,7 @@ async def test_get_dialogs_json(route_client, db):
         assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_bulk_channels(route_client):
     """Test add bulk channels."""
     with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
@@ -113,7 +113,7 @@ async def test_add_bulk_channels(route_client):
         assert "msg=channels_added" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_channel(route_client):
     """Test toggle channel."""
     with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
@@ -123,7 +123,7 @@ async def test_toggle_channel(route_client):
         assert "msg=channel_toggled" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_channel(route_client):
     """Test delete channel."""
     with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
@@ -133,7 +133,7 @@ async def test_delete_channel(route_client):
         assert "msg=channel_deleted" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_channel_in_pipeline(route_client):
     """Test delete channel that is in pipeline."""
     with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
@@ -147,7 +147,7 @@ async def test_delete_channel_in_pipeline(route_client):
         assert "error=channel_in_pipeline" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_redirect(route_client):
     """Test collect all redirects."""
     with patch("src.web.routes.channel_collection.deps.collection_service") as mock_svc:
@@ -163,7 +163,7 @@ async def test_collect_all_redirect(route_client):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_htmx(route_client):
     """Test collect all with HTMX header."""
     with patch("src.web.routes.channel_collection.deps.collection_service") as mock_svc:
@@ -183,7 +183,7 @@ async def test_collect_all_htmx(route_client):
         assert "collect-all-btn" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_shutting_down(route_client):
     """Test collect all when shutting down."""
     route_client._transport_app.state.shutting_down = True
@@ -193,7 +193,7 @@ async def test_collect_all_shutting_down(route_client):
     route_client._transport_app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_shutting_down_htmx(route_client):
     """Test collect all when shutting down with HTMX."""
     route_client._transport_app.state.shutting_down = True
@@ -206,7 +206,7 @@ async def test_collect_all_shutting_down_htmx(route_client):
     route_client._transport_app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel(route_client, db):
     """Test collect single channel."""
     with patch("src.web.routes.channel_collection.deps.collection_service") as mock_svc:
@@ -215,7 +215,7 @@ async def test_collect_channel(route_client, db):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_htmx(route_client, db):
     """Test collect single channel with HTMX."""
     with patch("src.web.routes.channel_collection.deps.collection_service") as mock_svc:
@@ -228,7 +228,7 @@ async def test_collect_channel_htmx(route_client, db):
         assert "collect-btn-1" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats(route_client):
     """Test collect stats for all channels."""
     with patch("src.web.routes.channel_collection.deps.get_collector") as mock_col:
@@ -240,14 +240,14 @@ async def test_collect_stats(route_client):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_missing_identifier(route_client):
     """POST /channels/add without identifier returns 422."""
     resp = await route_client.post("/channels/add", data={}, follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_tag_missing_name(route_client):
     """POST /channels/tags without name returns 422."""
     resp = await route_client.post("/channels/tags", data={}, follow_redirects=False)

--- a/tests/routes/test_dashboard_routes.py
+++ b/tests/routes/test_dashboard_routes.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_renders_with_data(route_client, base_app):
     """Dashboard renders with stats cards when auth configured and accounts exist."""
     app, db, pool = base_app
@@ -19,7 +19,7 @@ async def test_dashboard_renders_with_data(route_client, base_app):
     assert "Каналы" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_redirect_no_accounts(base_app):
     """Dashboard redirects to settings when no accounts exist."""
     from httpx import ASGITransport, AsyncClient
@@ -52,7 +52,7 @@ async def test_dashboard_redirect_no_accounts(base_app):
         assert "/settings" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_contains_stats(route_client, base_app):
     """Dashboard page renders the stats numbers from db.get_stats()."""
     app, db, pool = base_app
@@ -72,14 +72,14 @@ async def test_dashboard_contains_stats(route_client, base_app):
 # ── _time_ago helper tests ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_none():
     """Test _time_ago returns None for None input."""
     from src.web.routes.dashboard import _time_ago
     assert _time_ago(None) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_just_now():
     """Test _time_ago returns 'только что' for very recent."""
     from src.web.routes.dashboard import _time_ago
@@ -87,7 +87,7 @@ async def test_time_ago_just_now():
     assert _time_ago(now) == "только что"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_minutes():
     """Test _time_ago returns minutes ago."""
     from src.web.routes.dashboard import _time_ago
@@ -97,7 +97,7 @@ async def test_time_ago_minutes():
     assert "мин" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_hours():
     """Test _time_ago returns hours ago."""
     from src.web.routes.dashboard import _time_ago
@@ -107,7 +107,7 @@ async def test_time_ago_hours():
     assert "ч" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_days():
     """Test _time_ago returns days ago."""
     from src.web.routes.dashboard import _time_ago
@@ -117,7 +117,7 @@ async def test_time_ago_days():
     assert "д" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_time_ago_naive_datetime():
     """Test _time_ago handles naive datetime (no tzinfo)."""
     from src.web.routes.dashboard import _time_ago
@@ -130,7 +130,7 @@ async def test_time_ago_naive_datetime():
 # ── Dashboard redirect when auth not configured ──────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_redirect_auth_not_configured(base_app):
     """Dashboard redirects to /settings when auth is not configured."""
     import base64
@@ -160,7 +160,7 @@ async def test_dashboard_redirect_auth_not_configured(base_app):
 # ── Flood wait logic ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_with_active_flood_wait(route_client, base_app):
     """Dashboard surfaces flood-wait count on accounts card when accounts are flooded."""
     app, db, pool = base_app
@@ -176,7 +176,7 @@ async def test_dashboard_with_active_flood_wait(route_client, base_app):
     assert "flood-wait" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_with_expired_flood_wait(route_client, base_app):
     """Dashboard does NOT warn about flood-wait after it expires."""
     app, db, pool = base_app
@@ -191,7 +191,7 @@ async def test_dashboard_with_expired_flood_wait(route_client, base_app):
     assert "flood-wait" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_all_connected_flooded(route_client, base_app):
     """Dashboard shows collector_attention link when all connected accounts are flooded."""
     app, db, pool = base_app
@@ -206,7 +206,7 @@ async def test_dashboard_all_connected_flooded(route_client, base_app):
     assert "Коллектор ограничен" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_flood_wait_naive_datetime(route_client, base_app):
     """Dashboard handles flood_wait_until with naive datetime (no tzinfo)."""
     app, db, pool = base_app
@@ -220,7 +220,7 @@ async def test_dashboard_flood_wait_naive_datetime(route_client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_no_connected_clients(route_client, base_app):
     """Dashboard renders when no clients are connected (pool empty)."""
     app, db, pool = base_app
@@ -230,7 +230,7 @@ async def test_dashboard_no_connected_clients(route_client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard_with_pipeline_data(route_client, base_app):
     """Dashboard renders with pipeline statistics."""
     app, db, pool = base_app

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -92,7 +92,7 @@ def test_read_log_tail_respects_max_lines(tmp_path):
 
 # ─── route smoke tests ───────────────────────────────────────────────
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_page_renders(client):
     """Test debug page renders successfully."""
     resp = await client.get("/debug/")
@@ -100,7 +100,7 @@ async def test_debug_page_renders(client):
     assert "debug" in resp.text.lower() or "log" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_page_reads_from_file(client, tmp_path, monkeypatch):
     """Debug page shows records read from log file."""
     log = tmp_path / "app.log"
@@ -114,7 +114,7 @@ async def test_debug_page_reads_from_file(client, tmp_path, monkeypatch):
     assert "Hello from file" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_page_empty_when_no_file(client, tmp_path, monkeypatch):
     """Debug page renders without error when log file is absent."""
     monkeypatch.setattr("src.web.routes.debug.APP_LOG_PATH", tmp_path / "missing.log")
@@ -122,14 +122,14 @@ async def test_debug_page_empty_when_no_file(client, tmp_path, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_logs_partial(client):
     """Test debug logs partial endpoint."""
     resp = await client.get("/debug/logs")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_page_empty_buffer(client):
     """Kept for compatibility — debug page renders when buffer is empty."""
     client._transport.app.state.log_buffer._records.clear()
@@ -137,7 +137,7 @@ async def test_debug_page_empty_buffer(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_log_buffer_maxlen():
     """Test LogBuffer respects max length."""
     import logging
@@ -157,7 +157,7 @@ async def test_log_buffer_maxlen():
     assert "Message 4" in records[-1]["message"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_log_buffer_record_format():
     """Test LogBuffer record format."""
     import logging
@@ -180,7 +180,7 @@ async def test_log_buffer_record_format():
     assert records[0]["logger"] == "test_format"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_log_buffer_levels():
     """Test LogBuffer captures different log levels."""
     import logging
@@ -205,7 +205,7 @@ async def test_log_buffer_levels():
     assert "ERROR" in levels
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_log_buffer_exception():
     """Test LogBuffer handles exceptions in records."""
     import logging
@@ -229,14 +229,14 @@ async def test_log_buffer_exception():
 # ─── timing endpoint tests ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_timing_page(client):
     """Test timing page renders."""
     resp = await client.get("/debug/timing")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_timing_rows(client):
     """Test timing rows partial."""
     resp = await client.get("/debug/timing/rows")
@@ -246,7 +246,7 @@ async def test_debug_timing_rows(client):
 # ─── memory endpoint tests ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_memory_returns_json(client):
     """Test memory endpoint returns JSON with expected keys."""
     resp = await client.get("/debug/memory")
@@ -257,7 +257,7 @@ async def test_debug_memory_returns_json(client):
     assert "pool" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_memory_pool_info(client):
     """Test memory endpoint includes pool info."""
     resp = await client.get("/debug/memory")
@@ -266,7 +266,7 @@ async def test_debug_memory_pool_info(client):
     assert "dialogs_cache_entries" in data["pool"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_memory_uses_snapshot_in_web_mode(client, base_app):
     """In web-mode, pool counters must come from runtime_snapshots.pool_counters."""
     from datetime import datetime, timezone
@@ -298,7 +298,7 @@ async def test_debug_memory_uses_snapshot_in_web_mode(client, base_app):
     assert body["pool"]["session_overrides"] == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_memory_reports_empty_source_without_snapshot(client, base_app):
     """web-mode without a snapshot yet: source=empty and counters are zero."""
     app, _, _ = base_app
@@ -310,7 +310,7 @@ async def test_debug_memory_reports_empty_source_without_snapshot(client, base_a
     assert body["pool"]["dialogs_cache_entries"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_debug_memory_live_counters_in_worker_mode(client, base_app):
     """worker-mode: counters come from live pool, not snapshot."""
     app, _, pool = base_app

--- a/tests/routes/test_dialogs_routes.py
+++ b/tests/routes/test_dialogs_routes.py
@@ -63,7 +63,7 @@ async def client(base_app):
 
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_no_phone(client):
     """Test dialogs page without phone selection."""
     resp = await client.get("/dialogs/")
@@ -72,14 +72,14 @@ async def test_dialogs_page_no_phone(client):
     assert "+1234567890" in resp.text or "account" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_with_phone(client):
     """Test dialogs page with phone selection."""
     resp = await client.get("/dialogs/?phone=%2B1234567890")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_legacy_dialogs_route_redirects_to_dialogs(client):
     legacy_prefix = "/my" + "-telegram"
     resp = await client.get(f"{legacy_prefix}/?phone=%2B1234567890", follow_redirects=False)
@@ -87,7 +87,7 @@ async def test_legacy_dialogs_route_redirects_to_dialogs(client):
     assert resp.headers["location"] == "/dialogs/?phone=%2B1234567890"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_legacy_dialogs_post_route_redirects_to_dialogs(client):
     legacy_prefix = "/my" + "-telegram"
     resp = await client.post(
@@ -102,21 +102,21 @@ async def test_legacy_dialogs_post_route_redirects_to_dialogs(client):
     assert resp.headers["location"] == "/dialogs/leave"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_invalid_phone(client):
     """Test dialogs page with invalid phone."""
     resp = await client.get("/dialogs/?phone=invalid")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_shows_accounts(client):
     """Test dialogs page shows available accounts."""
     resp = await client.get("/dialogs/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_redirect(client):
     """Test leave dialogs redirects."""
     resp = await client.post(
@@ -131,7 +131,7 @@ async def test_leave_dialogs_redirect(client):
     assert "/dialogs/" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_empty(client):
     """Test leave dialogs with no selections."""
     resp = await client.post(
@@ -144,7 +144,7 @@ async def test_leave_dialogs_empty(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_malformed_channel_id(client):
     """Test leave dialogs handles malformed channel IDs."""
     resp = await client.post(
@@ -159,7 +159,7 @@ async def test_leave_dialogs_malformed_channel_id(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_negative_channel_id(client):
     """Test leave dialogs with negative channel IDs."""
     resp = await client.post(
@@ -173,7 +173,7 @@ async def test_leave_dialogs_negative_channel_id(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_no_colon(client):
     """Test leave dialogs with malformed ID (no colon)."""
     resp = await client.post(
@@ -188,28 +188,28 @@ async def test_leave_dialogs_no_colon(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_shows_left_count(client):
     """Test dialogs page shows left count from query param."""
     resp = await client.get("/dialogs/?left=2&failed=0")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_shows_failed_count(client):
     """Test dialogs page shows failed count from query param."""
     resp = await client.get("/dialogs/?left=0&failed=1")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_phone_url_encoded(client):
     """Test dialogs with URL-encoded phone number."""
     resp = await client.get("/dialogs/?phone=%2B1234567890")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_no_accounts(client):
     """Test dialogs with no connected accounts."""
     # Remove accounts
@@ -225,7 +225,7 @@ async def test_dialogs_no_accounts(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_preserves_phone(client):
     """Test leave dialogs preserves phone in redirect."""
     resp = await client.post(
@@ -242,7 +242,7 @@ async def test_leave_dialogs_preserves_phone(client):
     assert "phone=" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_logs_request(client, caplog):
     """Test dialogs logs request details."""
     import logging
@@ -252,7 +252,7 @@ async def test_dialogs_logs_request(client, caplog):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_shows_already_added(client):
     """Test dialogs shows already added flag."""
     # Add a channel that matches one of the dialogs
@@ -269,7 +269,7 @@ async def test_dialogs_shows_already_added(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_empty_dialogs(client):
     """Test dialogs with no dialogs."""
     client._transport.app.state.pool.get_dialogs_for_phone = AsyncMock(return_value=[])
@@ -278,7 +278,7 @@ async def test_dialogs_empty_dialogs(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_single(client):
     """Test leaving single dialog."""
     resp = await client.post(
@@ -292,7 +292,7 @@ async def test_leave_dialogs_single(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_multiple(client):
     """Test leaving multiple dialogs."""
     resp = await client.post(
@@ -309,7 +309,7 @@ async def test_leave_dialogs_multiple(client):
 # ─── refresh & cache ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_dialogs_redirects(client):
     """Test refresh dialogs redirects back."""
     resp = await client.post(
@@ -321,14 +321,14 @@ async def test_refresh_dialogs_redirects(client):
     assert "phone=" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_dialogs_missing_phone(client):
     """Test refresh without phone returns validation error."""
     resp = await client.post("/dialogs/refresh", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_missing_phone(client):
     """POST /dialogs/create-channel without phone returns 422."""
     resp = await client.post(
@@ -339,7 +339,7 @@ async def test_create_channel_missing_phone(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_missing_title(client):
     """POST /dialogs/create-channel without title returns 422."""
     resp = await client.post(
@@ -350,7 +350,7 @@ async def test_create_channel_missing_title(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cache_status_returns_json(client):
     """Test cache-status endpoint returns JSON list."""
     db = client._transport.app.state.db
@@ -364,7 +364,7 @@ async def test_cache_status_returns_json(client):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cache_clear_with_phone(client):
     """Test cache-clear with phone param."""
     resp = await client.post(
@@ -375,7 +375,7 @@ async def test_cache_clear_with_phone(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cache_clear_without_phone(client):
     """Test cache-clear without phone clears all."""
     resp = await client.post("/dialogs/cache-clear", follow_redirects=False)
@@ -385,14 +385,14 @@ async def test_cache_clear_without_phone(client):
 # ─── send / edit / delete messages ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_message_missing_fields(client):
     """Test send with missing required fields redirects."""
     resp = await client.post("/dialogs/send", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_message_no_client(client):
     """Test send when native client is unavailable."""
     pool = client._transport.app.state.pool
@@ -406,7 +406,7 @@ async def test_send_message_no_client(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_message_success(client):
     """Test successful send message."""
     native_mock = AsyncMock()
@@ -422,21 +422,21 @@ async def test_send_message_success(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_message_missing_fields(client):
     """Test edit-message with missing fields redirects."""
     resp = await client.post("/dialogs/edit-message", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_message_missing_fields(client):
     """Test delete-message with missing fields redirects."""
     resp = await client.post("/dialogs/delete-message", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_message_invalid_ids(client):
     """Test delete-message with non-numeric message_ids."""
     resp = await client.post(
@@ -448,7 +448,7 @@ async def test_delete_message_invalid_ids(client):
     assert "error=invalid_ids" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages_missing_fields(client):
     """Test forward-messages with missing fields redirects."""
     resp = await client.post("/dialogs/forward-messages", follow_redirects=False)
@@ -458,14 +458,14 @@ async def test_forward_messages_missing_fields(client):
 # ─── pin / unpin ────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pin_message_missing_fields(client):
     """Test pin-message with missing fields redirects."""
     resp = await client.post("/dialogs/pin-message", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message_missing_fields(client):
     """Test unpin-message with missing fields redirects."""
     resp = await client.post("/dialogs/unpin-message", follow_redirects=False)
@@ -475,28 +475,28 @@ async def test_unpin_message_missing_fields(client):
 # ─── participants / archive / unarchive / mark-read ─────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_missing_params(client):
     """Test participants with missing params returns 400."""
     resp = await client.get("/dialogs/participants")
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_dialog_missing_fields(client):
     """Test archive with missing fields redirects."""
     resp = await client.post("/dialogs/archive", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_dialog_missing_fields(client):
     """Test unarchive with missing fields redirects."""
     resp = await client.post("/dialogs/unarchive", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_missing_fields(client):
     """Test mark-read with missing fields redirects."""
     resp = await client.post("/dialogs/mark-read", follow_redirects=False)
@@ -506,7 +506,7 @@ async def test_mark_read_missing_fields(client):
 # ─── create-channel page ────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_page_renders(client):
     """Test create-channel page renders."""
     resp = await client.get("/dialogs/create-channel")
@@ -516,7 +516,7 @@ async def test_create_channel_page_renders(client):
 # ─── leave_dialogs with channel_service ─────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_calls_channel_service(client):
     """Test leave_dialogs queues a command."""
     resp = await client.post(
@@ -534,7 +534,7 @@ async def test_leave_dialogs_calls_channel_service(client):
 # ─── send_message success / error paths ─────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_message_exception(client):
     """Test send message handles exception."""
     native_mock = AsyncMock()
@@ -554,7 +554,7 @@ async def test_send_message_exception(client):
 # ─── edit_message success / no_client / error ───────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_message_no_client(client):
     """Test edit-message with no native client."""
     pool = client._transport.app.state.pool
@@ -569,7 +569,7 @@ async def test_edit_message_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_message_success(client):
     """Test successful edit message."""
     native_mock = AsyncMock()
@@ -586,7 +586,7 @@ async def test_edit_message_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_message_exception(client):
     """Test edit message handles exception."""
     native_mock = AsyncMock()
@@ -606,7 +606,7 @@ async def test_edit_message_exception(client):
 # ─── delete_message success / no_client / error ─────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_message_no_client(client):
     """Test delete-message with no native client."""
     pool = client._transport.app.state.pool
@@ -621,7 +621,7 @@ async def test_delete_message_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_message_success(client):
     """Test successful delete messages."""
     native_mock = AsyncMock()
@@ -638,7 +638,7 @@ async def test_delete_message_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_message_exception(client):
     """Test delete messages handles exception."""
     native_mock = AsyncMock()
@@ -658,7 +658,7 @@ async def test_delete_message_exception(client):
 # ─── forward_messages success / no_client / error / invalid_ids ──────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages_invalid_ids(client):
     """Test forward-messages with non-numeric ids."""
     resp = await client.post(
@@ -675,7 +675,7 @@ async def test_forward_messages_invalid_ids(client):
     assert "error=invalid_ids" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages_no_client(client):
     """Test forward-messages with no native client."""
     pool = client._transport.app.state.pool
@@ -695,7 +695,7 @@ async def test_forward_messages_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages_success(client):
     """Test successful forward messages."""
     native_mock = AsyncMock()
@@ -717,7 +717,7 @@ async def test_forward_messages_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages_exception(client):
     """Test forward messages handles exception."""
     native_mock = AsyncMock()
@@ -742,7 +742,7 @@ async def test_forward_messages_exception(client):
 # ─── pin_message success / no_client / error ────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pin_message_no_client(client):
     """Test pin-message with no native client."""
     pool = client._transport.app.state.pool
@@ -757,7 +757,7 @@ async def test_pin_message_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pin_message_success(client):
     """Test successful pin message."""
     native_mock = AsyncMock()
@@ -774,7 +774,7 @@ async def test_pin_message_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pin_message_exception(client):
     """Test pin message handles exception."""
     native_mock = AsyncMock()
@@ -794,7 +794,7 @@ async def test_pin_message_exception(client):
 # ─── unpin_message success / no_client / error ──────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message_no_client(client):
     """Test unpin-message with no native client."""
     pool = client._transport.app.state.pool
@@ -809,7 +809,7 @@ async def test_unpin_message_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message_success(client):
     """Test successful unpin message."""
     native_mock = AsyncMock()
@@ -826,7 +826,7 @@ async def test_unpin_message_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message_exception(client):
     """Test unpin message handles exception."""
     native_mock = AsyncMock()
@@ -846,7 +846,7 @@ async def test_unpin_message_exception(client):
 # ─── download-media ─────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_missing_fields(client):
     """Test download-media with missing fields."""
     resp = await client.post("/dialogs/download-media", follow_redirects=False)
@@ -854,7 +854,7 @@ async def test_download_media_missing_fields(client):
     assert "error=missing_fields" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_no_client(client):
     """Test download-media with no native client."""
     pool = client._transport.app.state.pool
@@ -869,7 +869,7 @@ async def test_download_media_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_message_not_found(client):
     """Test download-media when message is not found."""
     native_mock = AsyncMock()
@@ -886,7 +886,7 @@ async def test_download_media_message_not_found(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_no_media(client):
     """Test download-media when message has no media."""
 
@@ -908,7 +908,7 @@ async def test_download_media_no_media(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_exception(client):
     """Test download-media handles exception."""
     native_mock = AsyncMock()
@@ -928,7 +928,7 @@ async def test_download_media_exception(client):
 # ─── participants success / no_client / error ───────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_no_client(client):
     """Test participants with no native client returns 503."""
     pool = client._transport.app.state.pool
@@ -940,7 +940,7 @@ async def test_participants_no_client(client):
     assert resp.status_code == 202
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_success(client):
     """Test successful participants fetch."""
     participant = SimpleNamespace(id=1, first_name="Alice", last_name="Smith", username="alice")
@@ -956,7 +956,7 @@ async def test_participants_success(client):
     assert "command_id" in resp.json()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_exception(client):
     """Test participants handles exception."""
     native_mock = AsyncMock()
@@ -973,7 +973,7 @@ async def test_participants_exception(client):
 # ─── edit-admin ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_missing_fields(client):
     """Test edit-admin with missing fields."""
     resp = await client.post("/dialogs/edit-admin", follow_redirects=False)
@@ -981,7 +981,7 @@ async def test_edit_admin_missing_fields(client):
     assert "error=missing_fields" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_no_client(client):
     """Test edit-admin with no native client."""
     pool = client._transport.app.state.pool
@@ -996,7 +996,7 @@ async def test_edit_admin_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_success(client):
     """Test successful edit admin."""
     native_mock = AsyncMock()
@@ -1013,7 +1013,7 @@ async def test_edit_admin_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_exception(client):
     """Test edit admin handles exception."""
     native_mock = AsyncMock()
@@ -1033,7 +1033,7 @@ async def test_edit_admin_exception(client):
 # ─── edit-permissions ───────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_no_flags(client):
     """Test edit-permissions with no permission flags."""
     resp = await client.post(
@@ -1045,7 +1045,7 @@ async def test_edit_permissions_no_flags(client):
     assert "error=no_permission_flags" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_missing_fields(client):
     """Test edit-permissions with missing phone/chat/user."""
     resp = await client.post(
@@ -1057,7 +1057,7 @@ async def test_edit_permissions_missing_fields(client):
     assert "error=missing_fields" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_no_client(client):
     """Test edit-permissions with no native client."""
     pool = client._transport.app.state.pool
@@ -1072,7 +1072,7 @@ async def test_edit_permissions_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_success(client):
     """Test successful edit permissions."""
     native_mock = AsyncMock()
@@ -1096,7 +1096,7 @@ async def test_edit_permissions_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_exception(client):
     """Test edit permissions handles exception."""
     native_mock = AsyncMock()
@@ -1116,7 +1116,7 @@ async def test_edit_permissions_exception(client):
 # ─── kick ───────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_missing_fields(client):
     """Test kick with missing fields."""
     resp = await client.post("/dialogs/kick", follow_redirects=False)
@@ -1124,7 +1124,7 @@ async def test_kick_missing_fields(client):
     assert "error=missing_fields" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_no_client(client):
     """Test kick with no native client."""
     pool = client._transport.app.state.pool
@@ -1139,7 +1139,7 @@ async def test_kick_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_success(client):
     """Test successful kick participant."""
     native_mock = AsyncMock()
@@ -1156,7 +1156,7 @@ async def test_kick_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_exception(client):
     """Test kick handles exception."""
     native_mock = AsyncMock()
@@ -1176,14 +1176,14 @@ async def test_kick_exception(client):
 # ─── broadcast-stats ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_missing_params(client):
     """Test broadcast-stats with missing params returns 400."""
     resp = await client.get("/dialogs/broadcast-stats")
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_no_client(client):
     """Test broadcast-stats with no native client returns 503."""
     pool = client._transport.app.state.pool
@@ -1195,7 +1195,7 @@ async def test_broadcast_stats_no_client(client):
     assert resp.status_code == 202
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_success(client):
     """Test successful broadcast stats fetch."""
     stats = SimpleNamespace(
@@ -1222,7 +1222,7 @@ async def test_broadcast_stats_success(client):
     assert "command_id" in resp.json()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_empty(client):
     """Test broadcast stats with no available stats fields."""
     stats = SimpleNamespace(spec=[])
@@ -1238,7 +1238,7 @@ async def test_broadcast_stats_empty(client):
     assert "command_id" in resp.json()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_exception(client):
     """Test broadcast stats handles exception."""
     native_mock = AsyncMock()
@@ -1255,7 +1255,7 @@ async def test_broadcast_stats_exception(client):
 # ─── archive / unarchive success + error ────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_no_client(client):
     """Test archive with no native client."""
     pool = client._transport.app.state.pool
@@ -1270,7 +1270,7 @@ async def test_archive_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_success(client):
     """Test successful archive dialog."""
     native_mock = AsyncMock()
@@ -1287,7 +1287,7 @@ async def test_archive_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_exception(client):
     """Test archive handles exception."""
     native_mock = AsyncMock()
@@ -1304,7 +1304,7 @@ async def test_archive_exception(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_no_client(client):
     """Test unarchive with no native client."""
     pool = client._transport.app.state.pool
@@ -1319,7 +1319,7 @@ async def test_unarchive_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_success(client):
     """Test successful unarchive dialog."""
     native_mock = AsyncMock()
@@ -1336,7 +1336,7 @@ async def test_unarchive_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_exception(client):
     """Test unarchive handles exception."""
     native_mock = AsyncMock()
@@ -1356,7 +1356,7 @@ async def test_unarchive_exception(client):
 # ─── mark-read success / no_client / error ──────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_no_client(client):
     """Test mark-read with no native client."""
     pool = client._transport.app.state.pool
@@ -1371,7 +1371,7 @@ async def test_mark_read_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_success(client):
     """Test successful mark read."""
     native_mock = AsyncMock()
@@ -1388,7 +1388,7 @@ async def test_mark_read_success(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_exception(client):
     """Test mark read handles exception."""
     native_mock = AsyncMock()
@@ -1408,7 +1408,7 @@ async def test_mark_read_exception(client):
 # ─── create-channel POST ────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_post_no_client(client):
     """Test create channel POST with no matching client."""
     resp = await client.post(
@@ -1420,7 +1420,7 @@ async def test_create_channel_post_no_client(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_post_exception(client):
     """Test create channel POST handles exception."""
     from unittest.mock import MagicMock
@@ -1440,7 +1440,7 @@ async def test_create_channel_post_exception(client):
 # ─── download-media success path with file ───────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_success(client, tmp_path):
     """Test download-media returns file when media exists."""
     from tests.helpers import AsyncIterMessages
@@ -1470,7 +1470,7 @@ async def test_download_media_success(client, tmp_path):
 # ─── create-channel POST success ─────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_post_success(client):
     """Test successful create channel."""
     mock_result = MagicMock()
@@ -1492,7 +1492,7 @@ async def test_create_channel_post_success(client):
     assert "My New Channel" in resp.text or "created" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_channel_post_success_no_username(client):
     """Test create channel without username."""
     mock_result = MagicMock()
@@ -1516,7 +1516,7 @@ async def test_create_channel_post_success_no_username(client):
 # ─── broadcast-stats with non-standard fields ─────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_with_string_fields(client):
     """Test broadcast stats where stat fields are not SimpleNamespace."""
     stats = SimpleNamespace(

--- a/tests/routes/test_dialogs_routes_actions.py
+++ b/tests/routes/test_dialogs_routes_actions.py
@@ -9,13 +9,13 @@ import pytest
 # === participants ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_missing_fields(route_client):
     resp = await route_client.get("/dialogs/participants?phone=")
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_queues(route_client):
     resp = await route_client.get(
         "/dialogs/participants?phone=%2B1234567890&chat_id=-100123",
@@ -25,7 +25,7 @@ async def test_participants_queues(route_client):
     assert resp.json()["command_id"] is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_with_search_queues(route_client):
     resp = await route_client.get(
         "/dialogs/participants?phone=%2B1234567890&chat_id=-100123&search=test",
@@ -35,7 +35,7 @@ async def test_participants_with_search_queues(route_client):
     assert resp.json()["command_id"] is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_participants_cache_hit(route_client, monkeypatch):
     snapshot = SimpleNamespace(payload={"participants": [{"id": 1}]})
     mock_db = MagicMock()
@@ -49,7 +49,7 @@ async def test_participants_cache_hit(route_client, monkeypatch):
 # === edit-admin ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/edit-admin",
@@ -59,7 +59,7 @@ async def test_edit_admin_missing_fields(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin_success(route_client):
     resp = await route_client.post(
         "/dialogs/edit-admin",
@@ -78,7 +78,7 @@ async def test_edit_admin_success(route_client):
 # === edit-permissions ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_no_flags(route_client):
     resp = await route_client.post(
         "/dialogs/edit-permissions",
@@ -93,7 +93,7 @@ async def test_edit_permissions_no_flags(route_client):
     assert "no_permission_flags" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_success(route_client):
     resp = await route_client.post(
         "/dialogs/edit-permissions",
@@ -110,7 +110,7 @@ async def test_edit_permissions_success(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/edit-permissions",
@@ -124,7 +124,7 @@ async def test_edit_permissions_missing_fields(route_client):
 # === kick ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/kick",
@@ -134,7 +134,7 @@ async def test_kick_missing_fields(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_success(route_client):
     resp = await route_client.post(
         "/dialogs/kick",
@@ -151,13 +151,13 @@ async def test_kick_success(route_client):
 # === broadcast-stats ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_missing_fields(route_client):
     resp = await route_client.get("/dialogs/broadcast-stats?phone=")
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_broadcast_stats_queues(route_client):
     resp = await route_client.get(
         "/dialogs/broadcast-stats?phone=%2B1234567890&chat_id=-100123",
@@ -169,7 +169,7 @@ async def test_broadcast_stats_queues(route_client):
 # === archive ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/archive",
@@ -179,7 +179,7 @@ async def test_archive_missing_fields(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_archive_success(route_client):
     resp = await route_client.post(
         "/dialogs/archive",
@@ -195,7 +195,7 @@ async def test_archive_success(route_client):
 # === unarchive ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/unarchive",
@@ -205,7 +205,7 @@ async def test_unarchive_missing_fields(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unarchive_success(route_client):
     resp = await route_client.post(
         "/dialogs/unarchive",
@@ -221,7 +221,7 @@ async def test_unarchive_success(route_client):
 # === mark-read ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_missing_fields(route_client):
     resp = await route_client.post(
         "/dialogs/mark-read",
@@ -231,7 +231,7 @@ async def test_mark_read_missing_fields(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_success(route_client):
     resp = await route_client.post(
         "/dialogs/mark-read",
@@ -245,7 +245,7 @@ async def test_mark_read_success(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_mark_read_no_max_id(route_client):
     resp = await route_client.post(
         "/dialogs/mark-read",

--- a/tests/routes/test_filter_routes.py
+++ b/tests/routes/test_filter_routes.py
@@ -18,7 +18,7 @@ async def db(base_app):
     return db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_manage_renders_empty(route_client):
     """Test filter manage page renders empty."""
     resp = await route_client.get("/channels/filter/manage")
@@ -28,7 +28,7 @@ async def test_filter_manage_renders_empty(route_client):
     assert "Сейчас запустится только сбор статистики." in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_manage_shows_filtered(route_client, db):
     """Test filter manage shows filtered channels."""
     await _add_filtered_channel(db, channel_id=300, title="Filtered Channel")
@@ -38,7 +38,7 @@ async def test_filter_manage_shows_filtered(route_client, db):
     assert "Filtered Channel" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_selected_no_pks(route_client):
     """Test purge selected with no PKs returns error."""
     resp = await route_client.post("/channels/filter/purge-selected", follow_redirects=False)
@@ -46,7 +46,7 @@ async def test_purge_selected_no_pks(route_client):
     assert "error=no_filtered_channels" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_selected_success(route_client, db):
     """Test purge selected channels."""
     pk = await _add_filtered_channel(db, channel_id=400, title="To Purge")
@@ -62,7 +62,7 @@ async def test_purge_selected_success(route_client, db):
         assert "msg=purged_selected" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_selected_removes_messages(route_client, db):
     """Test purge selected removes messages from DB."""
     pk = await _add_filtered_channel(db, channel_id=500, title="Purge Messages")
@@ -75,7 +75,7 @@ async def test_purge_selected_removes_messages(route_client, db):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_all_no_filtered(route_client):
     """Test purge all with no filtered channels."""
     with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
@@ -88,7 +88,7 @@ async def test_purge_all_no_filtered(route_client):
         assert "error=no_filtered_channels" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_all_success(route_client, db):
     """Test purge all filtered channels."""
     await _add_filtered_channel(db, channel_id=600, title="Purge All")
@@ -103,7 +103,7 @@ async def test_purge_all_success(route_client, db):
         assert "msg=purged_all_filtered" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_blocked_without_dev_mode(route_client, db):
     """Test hard delete blocked without dev mode."""
     pk = await _add_filtered_channel(db, channel_id=700, title="Hard Delete")
@@ -116,7 +116,7 @@ async def test_hard_delete_blocked_without_dev_mode(route_client, db):
     assert "error=dev_mode_required_for_hard_delete" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_no_pks(route_client, db):
     """Test hard delete with no PKs."""
     await _enable_dev_mode(db)
@@ -125,7 +125,7 @@ async def test_hard_delete_no_pks(route_client, db):
     assert "error=no_filtered_channels" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_success(route_client, db):
     """Test hard delete channels."""
     pk = await _add_filtered_channel(db, channel_id=800, title="Hard Delete OK")
@@ -145,7 +145,7 @@ async def test_hard_delete_success(route_client, db):
         assert "msg=deleted_filtered" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analyze_redirects(route_client):
     """Test analyze channels redirects."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -160,7 +160,7 @@ async def test_analyze_redirects(route_client):
         assert "/channels/filter/manage" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analyze_ignores_with_stats_query(route_client):
     """Test analyze route no longer runs stats collection inline."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -177,7 +177,7 @@ async def test_analyze_ignores_with_stats_query(route_client):
         mock_collection.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_has_stats_true_when_no_active_channels(route_client, db):
     """Test has-stats returns true when there are no active channels to inspect."""
     channel = await db.get_channel_by_channel_id(100)
@@ -190,7 +190,7 @@ async def test_has_stats_true_when_no_active_channels(route_client, db):
     assert resp.json() == {"has_stats": True}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_has_stats_false_when_active_channel_lacks_stats(route_client):
     """Test has-stats returns false when any active channel has no stats yet."""
     resp = await route_client.get("/channels/filter/has-stats")
@@ -199,7 +199,7 @@ async def test_has_stats_false_when_active_channel_lacks_stats(route_client):
     assert resp.json() == {"has_stats": False}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_has_stats_true_when_all_active_channels_have_stats(route_client, db):
     """Test has-stats returns true when every active channel already has stats."""
     await db.save_channel_stats(ChannelStats(channel_id=100, subscriber_count=1))
@@ -213,7 +213,7 @@ async def test_has_stats_true_when_all_active_channels_have_stats(route_client, 
     assert resp.json() == {"has_stats": True}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_apply_missing_snapshot(route_client):
     """Test apply filters without snapshot."""
     resp = await route_client.post("/channels/filter/apply", follow_redirects=False)
@@ -221,7 +221,7 @@ async def test_apply_missing_snapshot(route_client):
     assert "error=filter_snapshot_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_apply_with_snapshot(route_client):
     """Test apply filters with snapshot."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -236,7 +236,7 @@ async def test_apply_with_snapshot(route_client):
         assert "msg=filter_applied" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_precheck_redirects(route_client):
     """Test precheck subscriber ratio redirects."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -247,7 +247,7 @@ async def test_precheck_redirects(route_client):
         assert "msg=precheck_done" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reset_redirects(route_client):
     """Test reset filters redirects."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -258,7 +258,7 @@ async def test_reset_redirects(route_client):
         assert "msg=filter_reset" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_messages_not_filtered(route_client):
     """Test purge messages for non-filtered channel."""
     resp = await route_client.post("/channels/900/purge-messages", follow_redirects=False)
@@ -266,7 +266,7 @@ async def test_purge_messages_not_filtered(route_client):
     assert "error=not_filtered" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_messages_success(route_client, db):
     """Test purge messages for filtered channel."""
     pk = await _add_filtered_channel(db, channel_id=950, title="Purge Msgs")
@@ -281,7 +281,7 @@ async def test_purge_messages_success(route_client, db):
         assert "msg=purged" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_toggle_not_found(route_client):
     """Test filter toggle with non-existent channel."""
     resp = await route_client.post("/channels/999999/filter-toggle", follow_redirects=False)
@@ -289,7 +289,7 @@ async def test_filter_toggle_not_found(route_client):
     assert "msg=channel_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_toggle_success(route_client, db):
     """Test filter toggle success."""
     pk = await _add_channel(db, channel_id=960, title="Toggle Filter")
@@ -301,7 +301,7 @@ async def test_filter_toggle_success(route_client, db):
 # === Additional tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_snapshot_valid(route_client, db):
     """Test apply filters with valid snapshot parsing."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -319,7 +319,7 @@ async def test_parse_snapshot_valid(route_client, db):
         assert "msg=filter_applied" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_snapshot_dedupes_by_channel_id(route_client, db):
     """Test snapshot parsing dedupes by channel_id."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -336,7 +336,7 @@ async def test_parse_snapshot_dedupes_by_channel_id(route_client, db):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_snapshot_invalid_channel_id(route_client, db):
     """Test snapshot parsing with invalid channel_id."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -353,7 +353,7 @@ async def test_parse_snapshot_invalid_channel_id(route_client, db):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_snapshot_no_separator(route_client, db):
     """Test snapshot parsing without separator."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -370,7 +370,7 @@ async def test_parse_snapshot_no_separator(route_client, db):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_snapshot_invalid_flag(route_client, db):
     """Test snapshot parsing with invalid flag."""
     with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
@@ -387,7 +387,7 @@ async def test_parse_snapshot_invalid_flag(route_client, db):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analyze_with_auto_delete(route_client, db):
     """Test analyze channels with auto_delete enabled."""
     await _add_filtered_channel(db, channel_id=3100, title="Auto Delete")
@@ -420,7 +420,7 @@ async def test_analyze_with_auto_delete(route_client, db):
         assert "msg=purged_all_filtered" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_selected_with_multiple_pks(route_client, db):
     """Test purge selected with multiple PKs."""
     pk1 = await _add_filtered_channel(db, channel_id=3200, title="Purge 1")

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_images_page(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.adapter_names = ["test_provider"]
@@ -20,7 +20,7 @@ async def test_images_page(route_client, monkeypatch):
     assert "text/html" in resp.headers["content-type"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_no_prompt(route_client, monkeypatch):
     resp = await route_client.post("/images/generate", data={})
     assert resp.status_code == 400
@@ -29,7 +29,7 @@ async def test_generate_no_prompt(route_client, monkeypatch):
     assert "Prompt" in body["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_no_providers(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=False)
@@ -43,7 +43,7 @@ async def test_generate_no_providers(route_client, monkeypatch):
     assert "No image providers" in body["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_success(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=True)
@@ -59,7 +59,7 @@ async def test_generate_success(route_client, monkeypatch):
     assert body["url"] == "https://img.example.com/1.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_failure(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=True)
@@ -75,7 +75,7 @@ async def test_generate_failure(route_client, monkeypatch):
     assert "Generation failed" in body["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_no_provider(route_client, monkeypatch):
     resp = await route_client.get("/images/models/search?provider=")
     assert resp.status_code == 400
@@ -83,7 +83,7 @@ async def test_search_models_no_provider(route_client, monkeypatch):
     assert "provider" in body["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_success(route_client, monkeypatch):
     monkeypatch.setattr(
         "src.web.routes.images._get_provider_api_key",
@@ -102,7 +102,7 @@ async def test_search_models_success(route_client, monkeypatch):
         assert len(body["models"]) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_no_api_key(route_client, monkeypatch):
     """Test search models when no API key is found."""
     monkeypatch.setattr(
@@ -115,7 +115,7 @@ async def test_search_models_no_api_key(route_client, monkeypatch):
     assert body["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_images_page_with_db_error(route_client, monkeypatch):
     """Test images page when DB provider loading fails."""
     with patch("src.services.image_provider_service.ImageProviderService", side_effect=Exception("DB error")):
@@ -123,7 +123,7 @@ async def test_images_page_with_db_error(route_client, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_with_model(route_client, monkeypatch):
     """Test generate with specific model selection."""
     mock_svc = MagicMock()
@@ -140,7 +140,7 @@ async def test_generate_with_model(route_client, monkeypatch):
     assert body["model"] == "test:model"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_api_key_from_db_config(monkeypatch):
     """API key returned from DB provider config."""
     mock_config = MagicMock(provider="together", api_key="db-key-123")
@@ -154,7 +154,7 @@ async def test_get_provider_api_key_from_db_config(monkeypatch):
     assert result == "db-key-123"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_api_key_env_fallback(monkeypatch):
     """Falls back to env var when DB config has no matching key."""
     mock_config = MagicMock(provider="other", api_key="other-key")
@@ -178,7 +178,7 @@ async def test_get_provider_api_key_env_fallback(monkeypatch):
     assert result == "env-key-456"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_api_key_exception_returns_empty():
     """Returns empty string on any exception."""
     from src.web.routes.images import _get_provider_api_key

--- a/tests/routes/test_import_channels_routes.py
+++ b/tests/routes/test_import_channels_routes.py
@@ -58,14 +58,14 @@ async def client_no_resolve(client):
     return client
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_page(client):
     """Test import page renders."""
     resp = await client.get("/channels/import")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_page_shows_form(client):
     """Test import page shows upload form."""
     resp = await client.get("/channels/import")
@@ -102,7 +102,7 @@ async def test_import_page_shows_form(client):
         "large-list",
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_text_variants(client, text_input):
     """Test supported text import variants."""
     resp = await client.post(
@@ -112,7 +112,7 @@ async def test_import_text_variants(client, text_input):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_deduplication(client):
     """Test duplicate channels are skipped."""
     # First import
@@ -130,7 +130,7 @@ async def test_import_deduplication(client):
     assert "queued" in resp.text.lower() or "очеред" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_file_txt(client):
     """Test importing from txt file."""
     content = b"@channel1\n@channel2\n@channel3"
@@ -143,7 +143,7 @@ async def test_import_file_txt(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_file_empty(client):
     """Test importing empty file."""
     file = ("empty.txt", io.BytesIO(b""), "text/plain")
@@ -155,7 +155,7 @@ async def test_import_file_empty(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_file_and_text_combined(client):
     """Test importing from both file and text."""
     content = b"@filechannel"
@@ -169,7 +169,7 @@ async def test_import_file_and_text_combined(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_results_structure(client):
     """Test import results contain expected fields."""
     resp = await client.post(
@@ -183,7 +183,7 @@ async def test_import_results_structure(client):
     assert "results" in text_lower or "результат" in text_lower
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_no_client_error(client, client_no_resolve):
     """Test import handles no_client error gracefully."""
     resp = await client.post(
@@ -195,7 +195,7 @@ async def test_import_no_client_error(client, client_no_resolve):
     assert "failed" in resp.text.lower() or "нет" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_resolve_failure(client):
     """Test import handles resolve failure."""
 
@@ -211,7 +211,7 @@ async def test_import_resolve_failure(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_mixed_success_failure(client):
     """Test import with mix of success and failures."""
     # First add a channel that will be skipped
@@ -228,7 +228,7 @@ async def test_import_mixed_success_failure(client):
     assert resp2.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_scam_channel(client):
     """Test import marks scam/fake channels as inactive."""
 
@@ -250,7 +250,7 @@ async def test_import_scam_channel(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_preserves_existing_channels(client):
     """Test import doesn't affect existing channels."""
     # Add a channel
@@ -275,7 +275,7 @@ async def test_import_preserves_existing_channels(client):
     assert any(c.channel_id == -1001111111111 for c in channels)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_results_total_count(client):
     """Test import shows total count."""
     resp = await client.post(
@@ -285,7 +285,7 @@ async def test_import_results_total_count(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_file_csv(client):
     """Test importing from CSV file."""
     content = b"channel\n@channel1\n@channel2"
@@ -298,7 +298,7 @@ async def test_import_file_csv(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_negative_id(client):
     """Test import with negative channel ID."""
 

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -60,7 +60,7 @@ async def _create_pipeline(db: Database, *, publish_mode: PipelinePublishMode) -
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_moderation_page_renders_empty_queue(client):
     resp = await client.get("/moderation/")
     assert resp.status_code == 200
@@ -68,7 +68,7 @@ async def test_moderation_page_renders_empty_queue(client):
     assert "request.query_params.get" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_run_uses_publish_service(client, monkeypatch):
     db = client._transport_app.state.db
     pipeline_id = await _create_pipeline(db, publish_mode=PipelinePublishMode.MODERATED)
@@ -81,7 +81,7 @@ async def test_publish_run_uses_publish_service(client, monkeypatch):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_run_rejects_unapproved_run(client, monkeypatch):
     db = client._transport_app.state.db
     pipeline_id = await _create_pipeline(db, publish_mode=PipelinePublishMode.MODERATED)
@@ -119,7 +119,7 @@ async def _create_pipeline_and_run(
     return pipeline_id, run_id
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_view_run_renders(client):
     """Test view run renders page."""
     db = client._transport_app.state.db
@@ -130,7 +130,7 @@ async def test_view_run_renders(client):
     assert "Generated content" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_view_run_not_found(client):
     """Test view run with invalid ID redirects."""
     resp = await client.get("/moderation/999999/view", follow_redirects=False)
@@ -138,7 +138,7 @@ async def test_view_run_not_found(client):
     assert "error=run_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_approve_run(client):
     """Test approve run sets status."""
     db = client._transport_app.state.db
@@ -152,7 +152,7 @@ async def test_approve_run(client):
     assert run.moderation_status == "approved"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_approve_run_not_found(client):
     """Test approve run with invalid ID redirects."""
     resp = await client.post("/moderation/999999/approve", follow_redirects=False)
@@ -160,7 +160,7 @@ async def test_approve_run_not_found(client):
     assert "error=run_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reject_run(client):
     """Test reject run sets status."""
     db = client._transport_app.state.db
@@ -174,7 +174,7 @@ async def test_reject_run(client):
     assert run.moderation_status == "rejected"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reject_run_not_found(client):
     """Test reject run with invalid ID redirects."""
     resp = await client.post("/moderation/999999/reject", follow_redirects=False)
@@ -182,7 +182,7 @@ async def test_reject_run_not_found(client):
     assert "error=run_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_bulk_approve(client):
     """Test bulk approve sets status for multiple runs."""
     db = client._transport_app.state.db
@@ -203,7 +203,7 @@ async def test_bulk_approve(client):
     assert run_2.moderation_status == "approved"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_bulk_reject(client):
     """Test bulk reject sets status for multiple runs."""
     db = client._transport_app.state.db
@@ -224,7 +224,7 @@ async def test_bulk_reject(client):
     assert run_2.moderation_status == "rejected"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_bulk_approve_empty(client):
     """Test bulk approve with no IDs doesn't crash."""
     resp = await client.post("/moderation/bulk-approve", follow_redirects=False)
@@ -232,7 +232,7 @@ async def test_bulk_approve_empty(client):
     assert "msg=runs_approved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_moderation_page_with_pipeline_filter(client):
     """Test moderation page with pipeline filter."""
     resp = await client.get("/moderation/?pipeline_id=1")

--- a/tests/routes/test_photo_loader_routes.py
+++ b/tests/routes/test_photo_loader_routes.py
@@ -22,21 +22,21 @@ async def pool_mock(base_app):
     return pool_mock
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_no_phone(route_client):
     """Test photo loader page without phone param."""
     resp = await route_client.get("/dialogs/photos")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_with_phone(route_client):
     """Test photo loader page with phone param."""
     resp = await route_client.get("/dialogs/photos?phone=%2B1234567890")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_legacy_photo_loader_route_redirects_to_dialogs(route_client):
     legacy_prefix = "/my" + "-telegram"
     resp = await route_client.get(
@@ -47,14 +47,14 @@ async def test_legacy_photo_loader_route_redirects_to_dialogs(route_client):
     assert resp.headers["location"] == "/dialogs/photos?phone=%2B1234567890"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_shows_no_jobs(route_client, db):
     """Test photo loader page shows no auto jobs."""
     resp = await route_client.get("/dialogs/photos?phone=%2B1234567890")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_refresh_redirects(route_client):
     """Test photo refresh redirects."""
     db = route_client._transport.app.state.db
@@ -72,7 +72,7 @@ async def test_photo_refresh_redirects(route_client):
     assert commands[0].command_type == "dialogs.refresh"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_missing_target(route_client):
     """Test photo send with missing target."""
     with patch(
@@ -94,7 +94,7 @@ async def test_photo_send_missing_target(route_client):
         assert "error=photo_target_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_invalid_target_id(route_client):
     """Test photo send with invalid target ID."""
     from io import BytesIO
@@ -118,7 +118,7 @@ async def test_photo_send_invalid_target_id(route_client):
         assert "error=photo_target_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_no_files(route_client):
     """Test photo send with empty persisted files."""
     from io import BytesIO
@@ -152,7 +152,7 @@ async def test_photo_send_no_files(route_client):
     assert commands[0].payload["file_paths"] == ["/tmp/one.jpg"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_schedule_missing_target(route_client):
     """Test photo schedule with missing target."""
     from io import BytesIO
@@ -174,7 +174,7 @@ async def test_photo_schedule_missing_target(route_client):
     assert "error=photo_target_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_run_due_redirects(route_client):
     """Test photo run due redirects."""
     db = route_client._transport.app.state.db
@@ -198,7 +198,7 @@ async def test_photo_run_due_redirects(route_client):
     assert commands[0].command_type == "photo.run_due"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_cancel_item_not_found(route_client):
     """Test photo cancel item not found."""
     with patch(
@@ -213,7 +213,7 @@ async def test_photo_cancel_item_not_found(route_client):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_toggle_auto_not_found(route_client):
     """Test photo toggle auto job not found."""
     with patch(
@@ -229,7 +229,7 @@ async def test_photo_toggle_auto_not_found(route_client):
         assert "error=photo_auto_failed" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_delete_auto(route_client):
     """Test photo delete auto job."""
     with patch(
@@ -245,7 +245,7 @@ async def test_photo_delete_auto(route_client):
         assert "msg=photo_auto_deleted" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_batch_missing_target(route_client):
     """Test photo batch with missing target."""
     resp = await route_client.post(
@@ -260,7 +260,7 @@ async def test_photo_batch_missing_target(route_client):
     assert "error=photo_target_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_missing_target(route_client):
     """Test photo auto with missing target."""
     resp = await route_client.post(
@@ -276,14 +276,14 @@ async def test_photo_auto_missing_target(route_client):
     assert "error=photo_target_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_refresh_missing_phone(route_client):
     """POST /dialogs/photos/refresh without phone returns 422."""
     resp = await route_client.post("/dialogs/photos/refresh", data={}, follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_send_missing_phone(route_client):
     """POST /dialogs/photos/send without phone returns redirect with error."""
     from io import BytesIO
@@ -296,7 +296,7 @@ async def test_photos_send_missing_phone(route_client):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_schedule_missing_phone(route_client):
     """POST /dialogs/photos/schedule without phone returns redirect with error."""
     from io import BytesIO
@@ -310,7 +310,7 @@ async def test_photos_schedule_missing_phone(route_client):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_schedule_missing_schedule_at(route_client):
     """POST /dialogs/photos/schedule without schedule_at returns redirect with error."""
     from io import BytesIO
@@ -324,14 +324,14 @@ async def test_photos_schedule_missing_schedule_at(route_client):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_batch_missing_phone(route_client):
     """POST /dialogs/photos/batch without phone returns 422."""
     resp = await route_client.post("/dialogs/photos/batch", data={}, follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_auto_missing_phone(route_client):
     """POST /dialogs/photos/auto without phone returns 422."""
     resp = await route_client.post(
@@ -342,7 +342,7 @@ async def test_photos_auto_missing_phone(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_auto_missing_folder_path(route_client):
     """POST /dialogs/photos/auto without folder_path returns 422."""
     resp = await route_client.post(
@@ -353,7 +353,7 @@ async def test_photos_auto_missing_folder_path(route_client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photos_auto_missing_interval_minutes(route_client):
     """POST /dialogs/photos/auto without interval_minutes returns 422."""
     resp = await route_client.post(

--- a/tests/routes/test_pipeline_run_cross_layer.py
+++ b/tests/routes/test_pipeline_run_cross_layer.py
@@ -17,7 +17,7 @@ from src.models import (
     PipelineRunTaskPayload,
 )
 
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 async def _seed_run_and_task(

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -43,14 +43,14 @@ async def client(base_app):
 
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_renders(client):
     resp = await client.get("/pipelines/")
     assert resp.status_code == 200
     assert "Пайплайны" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_warns_when_no_llm_provider(client):
     """LLM-requiring pipeline + no provider ⇒ pipeline_added_no_llm warning."""
     resp = await client.post(
@@ -62,7 +62,7 @@ async def test_add_pipeline_warns_when_no_llm_provider(client):
     assert "msg=pipeline_added_no_llm" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_with_provider(client):
     """With provider registered, redirect shows plain pipeline_added."""
     mock_provider_instance = MagicMock()
@@ -80,7 +80,7 @@ async def test_add_pipeline_with_provider(client):
     assert "pipeline_added_no_llm" not in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_lists_pipeline(client):
     await client.post(
         "/pipelines/add",
@@ -91,7 +91,7 @@ async def test_pipelines_page_lists_pipeline(client):
     assert "Listed Pipeline" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_shows_pipeline_id(client):
     await client.post(
         "/pipelines/add",
@@ -102,7 +102,7 @@ async def test_pipelines_page_shows_pipeline_id(client):
     assert "ID: 1" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_pipeline(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     resp = await client.post("/pipelines/1/toggle", follow_redirects=False)
@@ -110,7 +110,7 @@ async def test_toggle_pipeline(client):
     assert "msg=pipeline_toggled" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_pipeline(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     resp = await client.post("/pipelines/1/delete", follow_redirects=False)
@@ -118,7 +118,7 @@ async def test_delete_pipeline(client):
     assert "msg=pipeline_deleted" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     resp = await client.post(
@@ -130,7 +130,7 @@ async def test_edit_pipeline(client):
     assert "msg=pipeline_edited" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_edit_page_loads(client):
     """GET /pipelines/<id>/edit returns 200 with edit form."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -139,7 +139,7 @@ async def test_pipeline_edit_page_loads(client):
     assert "Редактировать" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_edit_page_not_found(client):
     """GET /pipelines/<id>/edit redirects for invalid ID."""
     resp = await client.get("/pipelines/999999/edit", follow_redirects=False)
@@ -150,7 +150,7 @@ async def test_pipeline_edit_page_not_found(client):
 # === New tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_pipeline_not_found(client):
     """Test run pipeline with invalid ID."""
     from unittest.mock import patch
@@ -161,7 +161,7 @@ async def test_run_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_pipeline_enqueues(client):
     """Test run pipeline enqueues generation."""
     from unittest.mock import patch
@@ -180,7 +180,7 @@ async def test_run_pipeline_enqueues(client):
                 assert "msg=pipeline_run_enqueued" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_pipeline_blocked_when_needs_llm_and_no_provider(client):
     """Default chain pipeline needs LLM: without provider, run is blocked."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -190,7 +190,7 @@ async def test_run_pipeline_blocked_when_needs_llm_and_no_provider(client):
     assert "error=llm_not_configured" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_pipeline_allowed_for_non_llm_dag_without_provider(client):
     """A DAG with only SOURCE→PUBLISH nodes runs without an LLM provider."""
     from unittest.mock import patch
@@ -231,7 +231,7 @@ async def test_run_pipeline_allowed_for_non_llm_dag_without_provider(client):
             assert "msg=pipeline_run_enqueued" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_pipeline_failure(client):
     """Test run pipeline handles failure."""
     from unittest.mock import patch
@@ -252,7 +252,7 @@ async def test_run_pipeline_failure(client):
                 assert "error=pipeline_run_failed" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_page_renders(client):
     """Test generate page renders."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -261,7 +261,7 @@ async def test_generate_page_renders(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_page_not_found(client):
     """Test generate page with invalid pipeline."""
     resp = await client.get("/pipelines/999999/generate", follow_redirects=False)
@@ -272,7 +272,7 @@ async def test_generate_page_not_found(client):
 # === SSE Streaming tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_stream_success(client):
     """Test SSE streaming generation."""
     from unittest.mock import patch
@@ -300,7 +300,7 @@ async def test_generate_stream_success(client):
         assert "text/event-stream" in resp.headers["content-type"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_stream_pipeline_not_found(client):
     """Test SSE streaming with invalid pipeline."""
     resp = await client.get("/pipelines/999999/generate-stream", follow_redirects=False)
@@ -308,7 +308,7 @@ async def test_generate_stream_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_pipeline_success(client):
     """Test non-streaming generation success."""
     from unittest.mock import patch
@@ -336,7 +336,7 @@ async def test_generate_pipeline_success(client):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_pipeline_failure(client):
     """Test non-streaming generation failure."""
     from unittest.mock import patch
@@ -363,7 +363,7 @@ async def test_generate_pipeline_failure(client):
         assert "Generation failed" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_pipeline_not_found(client):
     """Test non-streaming generation with invalid pipeline."""
     resp = await client.post(
@@ -375,7 +375,7 @@ async def test_generate_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_pipeline_success(client):
     """Test publishing a generation run."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -397,7 +397,7 @@ async def test_publish_pipeline_success(client):
     assert "msg=pipeline_published" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_pipeline_invalid_run(client):
     """Test publishing with wrong pipeline_id."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -420,7 +420,7 @@ async def test_publish_pipeline_invalid_run(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_pipeline_run_not_found(client):
     """Test publishing a non-existent run."""
     await client.post("/pipelines/add", data=_ADD_DATA)
@@ -434,7 +434,7 @@ async def test_publish_pipeline_run_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_not_found(client):
     """Test edit with invalid pipeline_id."""
     resp = await client.post(
@@ -446,7 +446,7 @@ async def test_edit_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_pipeline_not_found(client):
     """Test toggle with invalid pipeline_id."""
     resp = await client.post("/pipelines/999999/toggle", follow_redirects=False)

--- a/tests/routes/test_pipelines_routes_dag_and_templates.py
+++ b/tests/routes/test_pipelines_routes_dag_and_templates.py
@@ -90,7 +90,7 @@ def _make_pipeline(pipeline_id=1, *, name="Test", dag=None, backend=PipelineGene
 # ── api_channels_search ─────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channels_search_short_query(route_client, base_app):
     """Short query (< 2 chars) returns top 50 channels."""
     _, db, _ = base_app
@@ -101,7 +101,7 @@ async def test_api_channels_search_short_query(route_client, base_app):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channels_search_empty_query(route_client, base_app):
     """Empty q returns top 50 channels."""
     resp = await route_client.get("/pipelines/api/channels/search")
@@ -110,7 +110,7 @@ async def test_api_channels_search_empty_query(route_client, base_app):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channels_search_with_query(route_client, base_app):
     """Query >= 2 chars searches by title/username/channel_id."""
     _, db, _ = base_app
@@ -123,7 +123,7 @@ async def test_api_channels_search_with_query(route_client, base_app):
     assert any(item["title"] == "UniqueSearchTerm" for item in data)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channels_search_by_channel_id(route_client, base_app):
     """Search by numeric channel_id substring."""
     _, db, _ = base_app
@@ -136,7 +136,7 @@ async def test_api_channels_search_by_channel_id(route_client, base_app):
     assert len(data) >= 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_channels_search_result_fields(route_client, base_app):
     """Each result has value, title, username, group keys."""
     _, db, _ = base_app
@@ -158,7 +158,7 @@ async def test_api_channels_search_result_fields(route_client, base_app):
 # ── create_wizard_submit ────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_submit_success(client_with_dialog, base_app):
     """POST /pipelines/create-wizard creates a DAG pipeline."""
     app, db, _ = base_app
@@ -201,7 +201,7 @@ async def test_create_wizard_submit_success(client_with_dialog, base_app):
     assert "msg=pipeline_added" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_submit_with_run_after(client_with_dialog, base_app):
     """POST /pipelines/create-wizard with run_after triggers pipeline run."""
     app, db, _ = base_app
@@ -235,7 +235,7 @@ async def test_create_wizard_submit_with_run_after(client_with_dialog, base_app)
     assert "msg=pipeline_run_with_since" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_submit_validation_error(route_client, base_app):
     """POST /pipelines/create-wizard with invalid data redirects with error."""
     app, db, _ = base_app
@@ -258,7 +258,7 @@ async def test_create_wizard_submit_validation_error(route_client, base_app):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_submit_inactive(client_with_dialog, base_app):
     """POST /pipelines/create-wizard without is_active checkbox creates inactive pipeline."""
     app, db, _ = base_app
@@ -286,7 +286,7 @@ async def test_create_wizard_submit_inactive(client_with_dialog, base_app):
 # ── create_wizard_page ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_page_renders(route_client, base_app):
     """GET /pipelines/create renders the wizard page."""
     app, _, _ = base_app
@@ -295,7 +295,7 @@ async def test_create_wizard_page_renders(route_client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_wizard_missing_pipeline_json(route_client, base_app):
     """POST /pipelines/create-wizard without pipeline_json returns 422."""
     app, _, _ = base_app
@@ -311,7 +311,7 @@ async def test_create_wizard_missing_pipeline_json(route_client, base_app):
 # ── add_pipeline validation error ───────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_validation_error(route_client, base_app):
     """POST /pipelines/add with validation error redirects with error."""
     app, _, _ = base_app
@@ -328,7 +328,7 @@ async def test_add_pipeline_validation_error(route_client, base_app):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_missing_name(route_client, base_app):
     """POST /pipelines/add without name returns 422."""
     app, _, _ = base_app
@@ -341,7 +341,7 @@ async def test_add_pipeline_missing_name(route_client, base_app):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_missing_prompt_template(route_client, base_app):
     """POST /pipelines/add without prompt_template returns 422."""
     app, _, _ = base_app
@@ -357,7 +357,7 @@ async def test_add_pipeline_missing_prompt_template(route_client, base_app):
 # ── edit_pipeline DAG preservation ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_dag_preserves_backend(client_with_dialog, base_app):
     """Edit a DAG pipeline preserves existing backend when CHAIN default is submitted."""
     app, db, _ = base_app
@@ -390,7 +390,7 @@ async def test_edit_pipeline_dag_preserves_backend(client_with_dialog, base_app)
     assert "msg=pipeline_edited" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_dag_preserves_prompt(client_with_dialog, base_app):
     """Edit a DAG pipeline preserves existing prompt_template when empty is submitted."""
     app, db, _ = base_app
@@ -430,7 +430,7 @@ async def test_edit_pipeline_dag_preserves_prompt(client_with_dialog, base_app):
     assert "msg=pipeline_edited" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_missing_name(route_client, base_app):
     """POST /pipelines/<id>/edit without name returns 422."""
     app, _, _ = base_app
@@ -443,7 +443,7 @@ async def test_edit_pipeline_missing_name(route_client, base_app):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_pipeline_missing_run_id(route_client, base_app):
     """POST /pipelines/<id>/publish without run_id returns 422."""
     app, _, _ = base_app
@@ -456,7 +456,7 @@ async def test_publish_pipeline_missing_run_id(route_client, base_app):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_validation_error(route_client, base_app):
     """POST /pipelines/<id>/edit with validation error redirects with error."""
     app, _, _ = base_app
@@ -486,7 +486,7 @@ async def test_edit_pipeline_validation_error(route_client, base_app):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_update_returns_false(route_client, base_app):
     """POST /pipelines/<id>/edit when update returns False redirects with error."""
     app, _, _ = base_app
@@ -516,7 +516,7 @@ async def test_edit_pipeline_update_returns_false(route_client, base_app):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_pipeline_with_phone_query_param(route_client, base_app):
     """POST /pipelines/<id>/edit with phone query param passes it to redirect."""
     app, _, _ = base_app
@@ -547,7 +547,7 @@ async def test_edit_pipeline_with_phone_query_param(route_client, base_app):
 # ── generate_stream SSE ─────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_stream_no_llm_nodes(route_client, base_app):
     """GET /pipelines/<id>/generate-stream for pipeline with no LLM nodes redirects."""
     app, db, _ = base_app
@@ -568,7 +568,7 @@ async def test_generate_stream_no_llm_nodes(route_client, base_app):
     assert "error=pipeline_no_llm_nodes" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_stream_llm_not_configured(client_with_dialog, base_app):
     """GET /pipelines/<id>/generate-stream with no provider redirects."""
     app, db, _ = base_app
@@ -586,7 +586,7 @@ async def test_generate_stream_llm_not_configured(client_with_dialog, base_app):
 # ── generate_pipeline POST ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_pipeline_no_llm_nodes_runs_graph(route_client, base_app):
     """POST /pipelines/<id>/generate on a pipeline WITHOUT LLM nodes (pure
     action/publish graph) must NOT be rejected — it's a legitimate use case.
@@ -632,7 +632,7 @@ async def test_generate_pipeline_no_llm_nodes_runs_graph(route_client, base_app)
     assert "pipeline_no_llm_nodes" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_pipeline_llm_not_configured(client_with_dialog, base_app):
     """POST /pipelines/<id>/generate with no provider redirects."""
     app, db, _ = base_app
@@ -653,7 +653,7 @@ async def test_generate_pipeline_llm_not_configured(client_with_dialog, base_app
 # ── dry_run_pipeline ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_pipeline_success(client_with_dialog, base_app):
     """POST /pipelines/<id>/dry-run enqueues dry run."""
     app, db, _ = base_app
@@ -669,7 +669,7 @@ async def test_dry_run_pipeline_success(client_with_dialog, base_app):
     assert "msg=pipeline_dry_run_enqueued" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_pipeline_not_found(route_client, base_app):
     """POST /pipelines/<id>/dry-run with invalid ID redirects."""
     app, _, _ = base_app
@@ -682,7 +682,7 @@ async def test_dry_run_pipeline_not_found(route_client, base_app):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_pipeline_llm_not_configured(client_with_dialog, base_app):
     """POST /pipelines/<id>/dry-run with no LLM provider redirects."""
     app, db, _ = base_app
@@ -695,7 +695,7 @@ async def test_dry_run_pipeline_llm_not_configured(client_with_dialog, base_app)
     assert "error=llm_not_configured" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_pipeline_enqueue_failure(client_with_dialog, base_app):
     """POST /pipelines/<id>/dry-run handles enqueue failure."""
     app, db, _ = base_app
@@ -714,7 +714,7 @@ async def test_dry_run_pipeline_enqueue_failure(client_with_dialog, base_app):
 # ── dry_run_count ───────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_not_found(route_client, base_app):
     """GET /pipelines/<id>/dry-run-count for missing pipeline returns 404."""
     app, _, _ = base_app
@@ -726,7 +726,7 @@ async def test_dry_run_count_not_found(route_client, base_app):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_legacy_pipeline(route_client, base_app):
     """GET /pipelines/<id>/dry-run-count for legacy pipeline uses source IDs."""
     app, db, _ = base_app
@@ -742,7 +742,7 @@ async def test_dry_run_count_legacy_pipeline(route_client, base_app):
     assert "after_filter" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_dag_pipeline(route_client, base_app):
     """GET /pipelines/<id>/dry-run-count for DAG pipeline uses source node IDs."""
     app, db, _ = base_app
@@ -768,7 +768,7 @@ async def test_dry_run_count_dag_pipeline(route_client, base_app):
     assert "total" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_dag_pipeline_falls_back_to_sidecar_sources(route_client, base_app):
     """Broken DAG source config should still use persisted pipeline_sources."""
     app, db, _ = base_app
@@ -811,7 +811,7 @@ async def test_dry_run_count_dag_pipeline_falls_back_to_sidecar_sources(route_cl
 # ── dry_run_count_new ───────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_new(route_client, base_app):
     """GET /pipelines/dry-run-count returns total and after_filter."""
     app, _, _ = base_app
@@ -823,7 +823,7 @@ async def test_dry_run_count_new(route_client, base_app):
     assert "after_filter" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_count_new_empty_ids(route_client, base_app):
     """GET /pipelines/dry-run-count with empty source_ids."""
     app, _, _ = base_app
@@ -963,7 +963,7 @@ def test_apply_pipeline_filter_unknown_type():
 # ── export_pipeline ─────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_pipeline_success(client_with_dialog, base_app):
     """GET /pipelines/<id>/export returns JSON file."""
     app, db, _ = base_app
@@ -979,7 +979,7 @@ async def test_export_pipeline_success(client_with_dialog, base_app):
     assert data["name"] == "Test Pipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_pipeline_not_found(route_client, base_app):
     """GET /pipelines/<id>/export for missing pipeline redirects."""
     app, _, _ = base_app
@@ -995,7 +995,7 @@ async def test_export_pipeline_not_found(route_client, base_app):
 # ── import_pipeline ─────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_pipeline_from_text(route_client, base_app):
     """POST /pipelines/import with json_text creates a pipeline."""
     app, db, _ = base_app
@@ -1019,7 +1019,7 @@ async def test_import_pipeline_from_text(route_client, base_app):
     assert "/generate" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_pipeline_from_file(route_client, base_app):
     """POST /pipelines/import with json_file creates a pipeline."""
     app, db, _ = base_app
@@ -1044,7 +1044,7 @@ async def test_import_pipeline_from_file(route_client, base_app):
     assert "/generate" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_pipeline_no_data(route_client, base_app):
     """POST /pipelines/import without file or text redirects with error."""
     app, _, _ = base_app
@@ -1059,7 +1059,7 @@ async def test_import_pipeline_no_data(route_client, base_app):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_pipeline_validation_error(route_client, base_app):
     """POST /pipelines/import with bad JSON redirects with error."""
     app, _, _ = base_app
@@ -1076,7 +1076,7 @@ async def test_import_pipeline_validation_error(route_client, base_app):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_pipeline_general_exception(route_client, base_app):
     """POST /pipelines/import with unexpected error redirects with error."""
     app, _, _ = base_app
@@ -1096,7 +1096,7 @@ async def test_import_pipeline_general_exception(route_client, base_app):
 # ── create_from_template ────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_success(route_client, base_app):
     """POST /pipelines/from-template creates pipeline from template."""
     app, db, _ = base_app
@@ -1121,7 +1121,7 @@ async def test_create_from_template_success(route_client, base_app):
     assert "/pipelines/42/edit" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_validation_error(route_client, base_app):
     """POST /pipelines/from-template with bad data redirects with error."""
     app, db, _ = base_app
@@ -1146,7 +1146,7 @@ async def test_create_from_template_validation_error(route_client, base_app):
     assert "error=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_missing_template_id(route_client, base_app):
     """POST /pipelines/from-template without template_id returns 422."""
     app, _, _ = base_app
@@ -1162,7 +1162,7 @@ async def test_create_from_template_missing_template_id(route_client, base_app):
 # ── templates_json ──────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_templates_json(route_client, base_app):
     """GET /pipelines/templates/json returns template list."""
     app, db, _ = base_app
@@ -1191,7 +1191,7 @@ async def test_templates_json(route_client, base_app):
 # ── templates_page ──────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_templates_page_renders(route_client, base_app):
     """GET /pipelines/templates renders the templates page."""
     app, db, _ = base_app
@@ -1211,7 +1211,7 @@ async def test_templates_page_renders(route_client, base_app):
 # ── ai_edit_pipeline ────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_edit_pipeline_no_provider(route_client, base_app):
     """POST /pipelines/<id>/ai-edit without provider returns 400."""
     app, _, _ = base_app
@@ -1225,7 +1225,7 @@ async def test_ai_edit_pipeline_no_provider(route_client, base_app):
     assert resp.json()["ok"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_edit_pipeline_no_instruction(route_client, base_app):
     """POST /pipelines/<id>/ai-edit without instruction returns 400."""
     app, _, _ = base_app
@@ -1239,7 +1239,7 @@ async def test_ai_edit_pipeline_no_instruction(route_client, base_app):
     assert "instruction is required" in resp.json()["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_edit_pipeline_success(route_client, base_app):
     """POST /pipelines/<id>/ai-edit with valid instruction returns updated JSON."""
     app, db, _ = base_app
@@ -1258,7 +1258,7 @@ async def test_ai_edit_pipeline_success(route_client, base_app):
     assert data["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_edit_pipeline_exception(route_client, base_app):
     """POST /pipelines/<id>/ai-edit handles service exception."""
     app, db, _ = base_app
@@ -1277,7 +1277,7 @@ async def test_ai_edit_pipeline_exception(route_client, base_app):
 # ── get/set_refinement_steps ────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_refinement_steps_not_found(route_client, base_app):
     """GET /pipelines/<id>/refinement-steps for missing pipeline redirects."""
     app, db, _ = base_app
@@ -1288,7 +1288,7 @@ async def test_get_refinement_steps_not_found(route_client, base_app):
     assert "error=pipeline_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_refinement_steps_success(client_with_dialog, base_app):
     """GET /pipelines/<id>/refinement-steps returns steps list."""
     app, db, _ = base_app
@@ -1302,7 +1302,7 @@ async def test_get_refinement_steps_success(client_with_dialog, base_app):
     assert isinstance(data["steps"], list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_refinement_steps_not_found(route_client, base_app):
     """POST /pipelines/<id>/refinement-steps for missing pipeline redirects."""
     app, db, _ = base_app
@@ -1317,7 +1317,7 @@ async def test_set_refinement_steps_not_found(route_client, base_app):
     assert "error=pipeline_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_refinement_steps_success(client_with_dialog, base_app):
     """POST /pipelines/<id>/refinement-steps saves steps and returns them."""
     app, db, _ = base_app
@@ -1338,7 +1338,7 @@ async def test_set_refinement_steps_success(client_with_dialog, base_app):
     assert len(data["steps"]) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_refinement_steps_invalid_steps(client_with_dialog, base_app):
     """POST /pipelines/<id>/refinement-steps with invalid steps returns 400."""
     app, db, _ = base_app
@@ -1353,7 +1353,7 @@ async def test_set_refinement_steps_invalid_steps(client_with_dialog, base_app):
     assert resp.json()["ok"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_refinement_steps_empty_prompt_filtered(client_with_dialog, base_app):
     """Steps with empty prompts are filtered out."""
     app, db, _ = base_app
@@ -1386,7 +1386,7 @@ async def test_set_refinement_steps_empty_prompt_filtered(client_with_dialog, ba
 # ── _page_context branches ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_with_no_llm_provider(route_client, base_app):
     """Pipelines page renders when no LLM provider is configured."""
     app, db, _ = base_app
@@ -1396,7 +1396,7 @@ async def test_pipelines_page_with_no_llm_provider(route_client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_with_dialog_refresh(route_client, base_app):
     """Pipelines page handles dialog refresh with ?refresh=1."""
     app, db, pool_mock = base_app
@@ -1409,7 +1409,7 @@ async def test_pipelines_page_with_dialog_refresh(route_client, base_app):
 # ── edit_page with refresh ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_page_with_refresh(client_with_dialog, base_app):
     """GET /pipelines/<id>/edit?refresh=1 triggers dialog cache refresh."""
     app, db, _ = base_app
@@ -1423,7 +1423,7 @@ async def test_edit_page_with_refresh(client_with_dialog, base_app):
 # ── Toggle with scheduler sync failure ──────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_pipeline_scheduler_sync_failure(client_with_dialog, base_app):
     """Toggle pipeline handles scheduler sync failure gracefully."""
     app, db, _ = base_app
@@ -1440,7 +1440,7 @@ async def test_toggle_pipeline_scheduler_sync_failure(client_with_dialog, base_a
 # ── Delete with scheduler sync failure ──────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_pipeline_handles_scheduler(client_with_dialog, base_app):
     """Delete pipeline handles scheduler sync failure gracefully."""
     app, db, _ = base_app

--- a/tests/routes/test_rss_routes.py
+++ b/tests/routes/test_rss_routes.py
@@ -14,7 +14,7 @@ NOW = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 # --- _rfc822 / _iso8601 unit tests ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rfc822_none():
     from src.web.routes.rss import _rfc822
 
@@ -23,7 +23,7 @@ async def test_rfc822_none():
     assert len(result) > 10  # e.g. "Fri, 01 Jan 2026 00:00:00 +0000"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rfc822_naive_datetime():
     from src.web.routes.rss import _rfc822
 
@@ -32,7 +32,7 @@ async def test_rfc822_naive_datetime():
     assert "+0000" in result or "GMT" in result or "UTC" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rfc822_aware_datetime():
     from src.web.routes.rss import _rfc822
 
@@ -41,7 +41,7 @@ async def test_rfc822_aware_datetime():
     assert "Jun" in result or "15" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_iso8601_none():
     from src.web.routes.rss import _iso8601
 
@@ -53,7 +53,7 @@ async def test_iso8601_none():
 # --- RSS feed route tests ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rss_feed_empty(route_client):
     resp = await route_client.get("/rss.xml")
     assert resp.status_code == 200
@@ -64,7 +64,7 @@ async def test_rss_feed_empty(route_client):
     assert "<item>" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rss_feed_with_messages(route_client, base_app):
     _, db, _ = base_app
 
@@ -87,7 +87,7 @@ async def test_rss_feed_with_messages(route_client, base_app):
 # --- Atom feed route tests ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_atom_feed_empty(route_client):
     resp = await route_client.get("/atom.xml")
     assert resp.status_code == 200
@@ -97,7 +97,7 @@ async def test_atom_feed_empty(route_client):
     assert "<entry>" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_atom_feed_with_messages(route_client, base_app):
     _, db, _ = base_app
 

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -40,14 +40,14 @@ async def client(base_app):
 
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page(client):
     """Test scheduler page renders."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_status(client):
     """Test scheduler page shows scheduler status."""
     resp = await client.get("/scheduler/")
@@ -56,21 +56,21 @@ async def test_scheduler_page_shows_status(client):
     assert "scheduler" in resp.text.lower() or "планировщик" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_message(client):
     """Test scheduler page with message query param."""
     resp = await client.get("/scheduler/?msg=test_message")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_error(client):
     """Test scheduler page with error query param."""
     resp = await client.get("/scheduler/?error=shutting_down")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_scheduler_redirect(client):
     """Test start scheduler redirects."""
     with patch("src.web.routes.scheduler.deps.scheduler_service") as mock_svc:
@@ -80,7 +80,7 @@ async def test_start_scheduler_redirect(client):
         assert "/scheduler" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_scheduler_shutting_down(client):
     """Test start scheduler when shutting down."""
     client._transport.app.state.shutting_down = True
@@ -90,7 +90,7 @@ async def test_start_scheduler_shutting_down(client):
     assert "error=shutting_down" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_scheduler_redirect(client):
     """Test stop scheduler redirects."""
     with patch("src.web.routes.scheduler.deps.scheduler_service") as mock_svc:
@@ -100,7 +100,7 @@ async def test_stop_scheduler_redirect(client):
         assert "/scheduler" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_redirect(client):
     """Test trigger collection redirects."""
     with patch("src.web.routes.scheduler.deps.scheduler_service") as mock_svc:
@@ -110,7 +110,7 @@ async def test_trigger_collection_redirect(client):
         assert "/scheduler" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_shutting_down(client):
     """Test trigger collection when shutting down."""
     client._transport.app.state.shutting_down = True
@@ -120,7 +120,7 @@ async def test_trigger_collection_shutting_down(client):
     assert "error=shutting_down" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_enqueues(client):
     """Test trigger collection enqueues channels."""
     resp = await client.post("/scheduler/trigger", follow_redirects=False)
@@ -129,7 +129,7 @@ async def test_trigger_collection_enqueues(client):
     assert "/scheduler" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_redirect(client):
     """Test cancel task redirects."""
     # Create a task first
@@ -144,7 +144,7 @@ async def test_cancel_task_redirect(client):
     assert "/scheduler" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_nonexistent(client):
     """Test cancel nonexistent task."""
     resp = await client.post("/scheduler/tasks/999999/cancel", follow_redirects=False)
@@ -152,7 +152,7 @@ async def test_cancel_task_nonexistent(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_tasks(client):
     """Test scheduler page shows collection tasks."""
     db = client._transport.app.state.db
@@ -167,7 +167,7 @@ async def test_scheduler_page_shows_tasks(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_processed_message_label_for_pipeline_runs(client):
     db = client._transport.app.state.db
 
@@ -201,7 +201,7 @@ async def test_scheduler_page_shows_processed_message_label_for_pipeline_runs(cl
     assert "Обработано" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_search_log(client):
     """Test scheduler page shows search log."""
     db = client._transport.app.state.db
@@ -213,7 +213,7 @@ async def test_scheduler_page_shows_search_log(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_shows_collector_status(client):
     """Test scheduler page shows collector running status."""
     resp = await client.get("/scheduler/")
@@ -223,7 +223,7 @@ async def test_scheduler_shows_collector_status(client):
     assert "running" in text_lower or "остановлен" in text_lower or "запущен" in text_lower
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_shows_collector_health_card_when_all_accounts_flooded(client):
     db = client._transport.app.state.db
     accounts = await db.get_accounts(active_only=False)
@@ -238,28 +238,28 @@ async def test_scheduler_shows_collector_health_card_when_all_accounts_flooded(c
     assert "Что делать" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_shows_interval(client):
     """Test scheduler page shows collection interval."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_empty_tasks(client):
     """Test scheduler page with no tasks."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_empty_search_log(client):
     """Test scheduler page with no search log."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_has_active_tasks_flag(client):
     """Test scheduler page has active tasks detection."""
     db = client._transport.app.state.db
@@ -274,7 +274,7 @@ async def test_scheduler_has_active_tasks_flag(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_last_run_display(client):
     """Test scheduler displays last run time."""
     # Set last_run on scheduler
@@ -286,7 +286,7 @@ async def test_scheduler_last_run_display(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_last_stats_display(client):
     """Test scheduler displays last stats."""
     client._transport.app.state.scheduler._last_stats = {"collected": 100}
@@ -295,7 +295,7 @@ async def test_scheduler_last_stats_display(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_last_search_run_display(client):
     """Test scheduler displays last search run time."""
     from datetime import datetime
@@ -306,7 +306,7 @@ async def test_scheduler_last_search_run_display(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_last_search_stats_display(client):
     """Test scheduler displays last search stats."""
     client._transport.app.state.scheduler._last_search_stats = {"queries": 5}
@@ -315,21 +315,21 @@ async def test_scheduler_last_search_stats_display(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_interval_minutes(client):
     """Test scheduler displays interval minutes."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_search_interval_minutes(client):
     """Test scheduler displays search interval minutes."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_scheduler_calls_service(client):
     """Test start scheduler enqueues reconcile command."""
     db = client._transport.app.state.db
@@ -338,7 +338,7 @@ async def test_start_scheduler_calls_service(client):
     assert commands[0].command_type == "scheduler.reconcile"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_scheduler_calls_service(client):
     """Test stop scheduler enqueues reconcile command."""
     db = client._transport.app.state.db
@@ -347,7 +347,7 @@ async def test_stop_scheduler_calls_service(client):
     assert commands[0].command_type == "scheduler.reconcile"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_scheduler_sets_autostart_flag(client):
     """POST /scheduler/start persists scheduler_autostart=1 to DB."""
     db = client._transport.app.state.db
@@ -357,7 +357,7 @@ async def test_start_scheduler_sets_autostart_flag(client):
     assert value == "1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_scheduler_clears_autostart_flag(client):
     """POST /scheduler/stop persists scheduler_autostart=0 to DB."""
     db = client._transport.app.state.db
@@ -368,7 +368,7 @@ async def test_stop_scheduler_clears_autostart_flag(client):
     assert value == "0"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_calls_service(client):
     """Test trigger collection calls collection service."""
     mock_service = MagicMock()
@@ -386,7 +386,7 @@ async def test_trigger_collection_calls_service(client):
         mock_service.enqueue_all_channels.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_calls_queue(client):
     """Test cancel task calls queue cancel."""
     db = client._transport.app.state.db
@@ -400,7 +400,7 @@ async def test_cancel_task_calls_queue(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_tasks_redirects_and_deletes_only_pending_channel_tasks(client):
     db = client._transport.app.state.db
 
@@ -426,7 +426,7 @@ async def test_clear_pending_collect_tasks_redirects_and_deletes_only_pending_ch
     assert (await db.get_collection_task(running_id)).status == CollectionTaskStatus.RUNNING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_tasks_empty_queue_redirects(client):
     resp = await client.post(
         "/scheduler/tasks/clear-pending-collect",
@@ -437,7 +437,7 @@ async def test_clear_pending_collect_tasks_empty_queue_redirects(client):
     assert "msg=pending_collect_tasks_empty" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_clear_pending_collect_button(client):
     db = client._transport.app.state.db
     await db.create_collection_task(
@@ -451,14 +451,14 @@ async def test_scheduler_page_shows_clear_pending_collect_button(client):
     assert "Очистить очередь загрузки" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_hides_clear_button_when_no_pending(client):
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
     assert 'action="/scheduler/tasks/clear-pending-collect"' not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_completed_task(client):
     """Test scheduler page shows completed task status."""
     db = client._transport.app.state.db
@@ -473,7 +473,7 @@ async def test_scheduler_page_with_completed_task(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_failed_task(client):
     """Test scheduler page shows failed task status."""
     db = client._transport.app.state.db
@@ -488,7 +488,7 @@ async def test_scheduler_page_with_failed_task(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_cancelled_task(client):
     """Test scheduler page shows cancelled task status."""
     db = client._transport.app.state.db
@@ -503,7 +503,7 @@ async def test_scheduler_page_with_cancelled_task(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_then_get_scheduler_with_pending_tasks(client):
     """Trigger collect-all then follow redirect to scheduler page with pending tasks.
 
@@ -527,7 +527,7 @@ async def test_trigger_then_get_scheduler_with_pending_tasks(client):
     assert "Планировщик" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_many_pending_tasks(client):
     """Scheduler page renders correctly with many pending tasks."""
     db = client._transport.app.state.db
@@ -547,7 +547,7 @@ async def test_scheduler_page_with_many_pending_tasks(client):
 # ── Dry-run notification tests ──────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_no_queries(client):
     """Dry-run with no notification queries shows empty state."""
     resp = await client.post("/scheduler/dry-run-notifications")
@@ -555,7 +555,7 @@ async def test_dry_run_no_queries(client):
     assert "Нет активных запросов" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_excludes_inactive_queries(client):
     """Dry-run excludes queries with is_active=False."""
     db = client._transport.app.state.db
@@ -570,7 +570,7 @@ async def test_dry_run_excludes_inactive_queries(client):
     assert "inactive_query" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_excludes_disabled_scheduler_job(client):
     """Dry-run excludes queries whose scheduler job is disabled."""
     db = client._transport.app.state.db
@@ -687,7 +687,7 @@ def _non_pipeline_rows(soup):
     ]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_renders_processed_label_for_action_only_run(base_app, route_client):
     """Action-only pipeline run should render «Обработано» label + action count."""
     from bs4 import BeautifulSoup
@@ -719,7 +719,7 @@ async def test_scheduler_renders_processed_label_for_action_only_run(base_app, r
     assert "5" in result_cell_text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_renders_generation_label_for_generation_run(base_app, route_client):
     from bs4 import BeautifulSoup
 
@@ -749,7 +749,7 @@ async def test_scheduler_renders_generation_label_for_generation_run(base_app, r
     assert "3" in result_cell_text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_shows_warning_badge_when_run_has_node_errors(base_app, route_client):
     """Issue #463: when metadata.node_errors is non-empty, scheduler must render
     a warning badge with count next to result_count, so users see why 0.
@@ -781,7 +781,7 @@ async def test_scheduler_shows_warning_badge_when_run_has_node_errors(base_app, 
     assert "⚠" in cell_html or "pipe-run-warning" in cell_html
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_mixed_page_non_pipeline_tasks_unaffected(base_app, route_client):
     """When a pipeline_run coexists with a plain non-pipeline task on /scheduler,
     the non-pipeline row must keep its plain messages_collected display
@@ -844,7 +844,7 @@ async def test_scheduler_mixed_page_non_pipeline_tasks_unaffected(base_app, rout
     assert "42" in plain_text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_shows_flood_wait_countdown(client):
     """Test that scheduler page shows flood wait countdown in hours and minutes."""
     db = client._transport.app.state.db
@@ -865,7 +865,7 @@ async def test_scheduler_shows_flood_wait_countdown(client):
     assert " ч " in resp.text or " мин)" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_hides_countdown_if_too_short(client):
     """Test that countdown is hidden if less than 60 seconds remain."""
     db = client._transport.app.state.db

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -47,7 +47,7 @@ async def client(base_app):
 # ── cancel_task: line 179 (shutting_down) ──────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_shutting_down(client):
     """Test cancel task when shutting down (line 179)."""
     client._transport.app.state.shutting_down = True
@@ -61,7 +61,7 @@ async def test_cancel_task_shutting_down(client):
 # ── clear_pending_collect_tasks: line 188 (shutting_down) ──────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_shutting_down(client):
     """Test clear pending collect when shutting down (line 188)."""
     client._transport.app.state.shutting_down = True
@@ -78,35 +78,35 @@ async def test_clear_pending_collect_shutting_down(client):
 # ── scheduler_page: lines 223, 256-258 ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_status_filter_completed(client):
     """Test scheduler page with completed status filter (line 271)."""
     resp = await client.get("/scheduler/?status=completed")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_status_filter_active(client):
     """Test scheduler page with active status filter."""
     resp = await client.get("/scheduler/?status=active")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_status_filter_invalid(client):
     """Test scheduler page with invalid status filter falls back to 'all'."""
     resp = await client.get("/scheduler/?status=invalid_status")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_pagination(client):
     """Test scheduler page with pagination parameters (line 256-258)."""
     resp = await client.get("/scheduler/?page=2&limit=10")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_page_exceeds_total(client):
     """Test scheduler page when page exceeds total pages (lines 282-286)."""
     db = client._transport.app.state.db
@@ -124,7 +124,7 @@ async def test_scheduler_page_page_exceeds_total(client):
 # ── toggle_scheduler_job: line 338 (shutting_down), 348 ────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_scheduler_job_shutting_down(client):
     """Test toggle job when shutting down (line 338)."""
     client._transport.app.state.shutting_down = True
@@ -138,7 +138,7 @@ async def test_toggle_scheduler_job_shutting_down(client):
     client._transport.app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_scheduler_job_invalid(client):
     """Test toggle job with invalid job_id (line 339-340)."""
     resp = await client.post(
@@ -150,7 +150,7 @@ async def test_toggle_scheduler_job_invalid(client):
     assert "error=invalid_job" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_scheduler_job_syncs_running(client, base_app):
     """Test toggle job syncs when scheduler is running (line 348)."""
     app, db, _ = base_app
@@ -173,7 +173,7 @@ async def test_toggle_scheduler_job_syncs_running(client, base_app):
 # ── set_job_interval: lines 355, 359, 361-369, 371-385 ────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_shutting_down(client):
     """Test set interval when shutting down (line 355)."""
     client._transport.app.state.shutting_down = True
@@ -188,7 +188,7 @@ async def test_set_job_interval_shutting_down(client):
     client._transport.app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_invalid_job(client):
     """Test set interval with invalid job_id (line 357-358)."""
     resp = await client.post(
@@ -201,7 +201,7 @@ async def test_set_job_interval_invalid_job(client):
     assert "error=invalid_job" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_photo_due_blocked(client):
     """Test set interval for photo_due is blocked (line 358-359)."""
     resp = await client.post(
@@ -214,7 +214,7 @@ async def test_set_job_interval_photo_due_blocked(client):
     assert "error=invalid_job" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_photo_auto_blocked(client):
     """Test set interval for photo_auto is blocked."""
     resp = await client.post(
@@ -227,7 +227,7 @@ async def test_set_job_interval_photo_auto_blocked(client):
     assert "error=invalid_job" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_missing_value(client):
     """Test set interval with missing value (line 364)."""
     resp = await client.post(
@@ -240,7 +240,7 @@ async def test_set_job_interval_missing_value(client):
     assert "error=invalid_interval" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_collect_all(client, base_app):
     """Test set interval for collect_all (lines 368-370)."""
     app, db, _ = base_app
@@ -258,7 +258,7 @@ async def test_set_job_interval_collect_all(client, base_app):
     assert saved == "45"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_search_query(client, base_app):
     """Test set interval for search query job (lines 371-377)."""
     app, db, _ = base_app
@@ -277,7 +277,7 @@ async def test_set_job_interval_search_query(client, base_app):
     assert "msg=interval_updated" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_pipeline(client, base_app):
     """Test set interval for pipeline_run job (lines 378-385)."""
     app, db, _ = base_app
@@ -296,7 +296,7 @@ async def test_set_job_interval_pipeline(client, base_app):
     assert "msg=interval_updated" in location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_content_generate(client, base_app):
     """Test set interval for content_generate job (lines 378-385)."""
     app, db, _ = base_app
@@ -318,7 +318,7 @@ async def test_set_job_interval_content_generate(client, base_app):
 # ── test_notification: lines 418, 427 ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_shutting_down(client):
     """Test test notification when shutting down (line 418)."""
     client._transport.app.state.shutting_down = True
@@ -329,7 +329,7 @@ async def test_test_notification_shutting_down(client):
     client._transport.app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_bot_not_configured(client):
     """Test notification route now queues a worker command."""
     db = client._transport.app.state.db
@@ -344,7 +344,7 @@ async def test_test_notification_bot_not_configured(client):
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_with_search_query(client, base_app):
     """Test notification route queues command even when queries exist."""
     app, db, _ = base_app
@@ -364,7 +364,7 @@ async def test_test_notification_with_search_query(client, base_app):
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_no_messages(client, base_app):
     """Test notification route queues command when there are no matches."""
     app, db, _ = base_app
@@ -387,7 +387,7 @@ async def test_test_notification_no_messages(client, base_app):
 # ── dry-run-notifications: lines 490-492 ────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_with_completed_task_and_matches(client, base_app):
     """Test dry-run with completed task and matching messages (lines 460-507)."""
     app, db, _ = base_app
@@ -412,7 +412,7 @@ async def test_dry_run_with_completed_task_and_matches(client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dry_run_search_error(client, base_app, caplog):
     """Test dry-run handles search error for a query (lines 489-492)."""
     app, db, _ = base_app
@@ -442,7 +442,7 @@ async def test_dry_run_search_error(client, base_app, caplog):
 # ── _build_collector_health_context: lines 103-109 ─────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_health_with_naive_flood_wait(client, base_app):
     """Test health context handles flood_wait_until without tzinfo (lines 103-104)."""
     app, db, _ = base_app
@@ -462,7 +462,7 @@ async def test_scheduler_health_with_naive_flood_wait(client, base_app):
 # ── _build_jobs_context: lines 202-244 ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_disabled_job(client, base_app):
     """Test scheduler page shows disabled job (lines 220-228)."""
     app, db, _ = base_app
@@ -472,7 +472,7 @@ async def test_scheduler_page_with_disabled_job(client, base_app):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_with_sq_job(client, base_app):
     """Test scheduler page shows search query job."""
     app, db, _ = base_app
@@ -491,7 +491,7 @@ async def test_scheduler_page_with_sq_job(client, base_app):
 # ── trigger: line 410-412 ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_collection_uses_bulk_enqueue_msg(client, base_app):
     """Test trigger collection uses bulk_enqueue_msg for flash message."""
     from src.services.collection_service import BulkEnqueueResult
@@ -515,7 +515,7 @@ async def test_trigger_collection_uses_bulk_enqueue_msg(client, base_app):
 # ── _is_worker_alive / state=worker_down (fix for #457) ────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_worker_alive_fresh_heartbeat(base_app):
     """Fresh heartbeat → worker is alive."""
     from src.web.routes.scheduler import _is_worker_alive
@@ -525,7 +525,7 @@ async def test_is_worker_alive_fresh_heartbeat(base_app):
     assert await _is_worker_alive(db) is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_worker_alive_missing_heartbeat(tmp_path):
     """No heartbeat snapshot → worker is considered down.
 
@@ -542,7 +542,7 @@ async def test_is_worker_alive_missing_heartbeat(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_worker_alive_stale_heartbeat(base_app):
     """Heartbeat older than threshold → worker is considered down."""
     from src.models import RuntimeSnapshot
@@ -560,7 +560,7 @@ async def test_is_worker_alive_stale_heartbeat(base_app):
     assert await _is_worker_alive(db) is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_worker_alive_naive_datetime(base_app):
     """Heartbeat with a naive datetime must still be comparable (UTC assumed)."""
     from src.models import RuntimeSnapshot
@@ -579,7 +579,7 @@ async def test_is_worker_alive_naive_datetime(base_app):
     assert await _is_worker_alive(db) is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_renders_worker_down_banner(client, base_app):
     """/scheduler/ surfaces the `worker_down` banner when the heartbeat is stale.
 
@@ -607,7 +607,7 @@ async def test_scheduler_page_renders_worker_down_banner(client, base_app):
     assert "python -m src.main worker" in body
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_no_worker_banner_when_heartbeat_fresh(client, base_app):
     """Fresh heartbeat must NOT render the worker_down banner."""
     resp = await client.get("/scheduler/")
@@ -618,7 +618,7 @@ async def test_scheduler_page_no_worker_banner_when_heartbeat_fresh(client, base
 # ── web_mode fixture sanity (#457 round 3) ─────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_mode_app_has_snapshot_shims(web_mode_app):
     """Sanity check — the new fixture must really produce the web-mode wiring."""
     from src.web.runtime_shims import (
@@ -641,7 +641,7 @@ async def test_web_mode_app_has_snapshot_shims(web_mode_app):
     assert isinstance(container.pool, SnapshotClientPool)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_mode_scheduler_page_renders(web_mode_client):
     """/scheduler/ must render a 200 OK under the real web-mode wiring, no 500."""
     resp = await web_mode_client.get("/scheduler/", follow_redirects=True)
@@ -651,7 +651,7 @@ async def test_web_mode_scheduler_page_renders(web_mode_client):
 # ── web-mode fallback: collection_queue=None must not 500 (fix for #457 round 2) ─
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_web_mode_falls_back_to_db(client, base_app):
     """POST /scheduler/tasks/clear-pending-collect must NOT 500 in web-mode.
 
@@ -687,7 +687,7 @@ async def test_clear_pending_collect_web_mode_falls_back_to_db(client, base_app)
     assert not any(t.id == task_id for t in remaining)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_web_mode_falls_back_to_db(client, base_app):
     """POST /scheduler/tasks/{id}/cancel must NOT 500 in web-mode.
 
@@ -745,7 +745,7 @@ async def _assert_filter_preserved(resp, expected_msg_or_error: str) -> str:
     return location
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/trigger?{_filter_qs}")
     # On empty DB there are no active channels → bulk_enqueue_msg returns
@@ -757,31 +757,31 @@ async def test_trigger_preserves_filter(web_mode_client, _filter_qs):
     assert "limit=25" in loc
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_scheduler_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/start?{_filter_qs}")
     await _assert_filter_preserved(resp, "msg=scheduler_started")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_scheduler_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/stop?{_filter_qs}")
     await _assert_filter_preserved(resp, "msg=scheduler_stopped")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_trigger_warm_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/trigger-warm?{_filter_qs}")
     await _assert_filter_preserved(resp, "msg=warm_dialogs_started")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/test-notification?{_filter_qs}")
     await _assert_filter_preserved(resp, "msg=test_notification_queued")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(
         f"/scheduler/tasks/clear-pending-collect?{_filter_qs}"
@@ -789,7 +789,7 @@ async def test_clear_pending_collect_preserves_filter(web_mode_client, _filter_q
     await _assert_filter_preserved(resp, "msg=pending_collect_tasks_empty")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_preserves_filter(web_mode_client, web_mode_app, _filter_qs):
     _, container = web_mode_app
     task_id = await container.db.repos.tasks.create_collection_task_if_not_active(
@@ -799,13 +799,13 @@ async def test_cancel_task_preserves_filter(web_mode_client, web_mode_app, _filt
     await _assert_filter_preserved(resp, "msg=task_cancelled")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_scheduler_job_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/jobs/collect_all/toggle?{_filter_qs}")
     await _assert_filter_preserved(resp, "msg=job_toggled")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_job_interval_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(
         f"/scheduler/jobs/collect_all/set-interval?{_filter_qs}",
@@ -818,13 +818,13 @@ async def test_set_job_interval_preserves_filter(web_mode_client, _filter_qs):
 # the user to status=all on top of the error, which was the actual bad UX.
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_invalid_job_toggle_preserves_filter(web_mode_client, _filter_qs):
     resp = await web_mode_client.post(f"/scheduler/jobs/not-a-real-job/toggle?{_filter_qs}")
     await _assert_filter_preserved(resp, "error=invalid_job")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_shutting_down_preserves_filter(web_mode_app, web_mode_client, _filter_qs):
     app, _ = web_mode_app
     app.state.shutting_down = True
@@ -835,7 +835,7 @@ async def test_shutting_down_preserves_filter(web_mode_app, web_mode_client, _fi
         app.state.shutting_down = False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_default_filter_omitted_from_url(web_mode_client):
     """When user is already on default filters, the redirect URL stays clean."""
     resp = await web_mode_client.post("/scheduler/start")
@@ -853,7 +853,7 @@ async def test_default_filter_omitted_from_url(web_mode_client):
 # nullable service) automatically.
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "method, path, form",
     [

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -14,14 +14,14 @@ async def db(base_app):
     return db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_queries_page_renders_empty(route_client):
     """Test search queries page renders empty."""
     resp = await route_client.get("/search-queries/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_queries_page_lists_items(route_client):
     """Test search queries page lists items after add."""
     await route_client.post(
@@ -33,7 +33,7 @@ async def test_search_queries_page_lists_items(route_client):
     assert "test query" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_search_query_redirects(route_client):
     """Test add search query redirects."""
     resp = await route_client.post(
@@ -45,7 +45,7 @@ async def test_add_search_query_redirects(route_client):
     assert "msg=sq_added" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_search_query_with_all_fields(route_client):
     """Test add search query with all fields."""
     resp = await route_client.post(
@@ -66,7 +66,7 @@ async def test_add_search_query_with_all_fields(route_client):
     assert "msg=sq_added" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_search_query(route_client):
     """Test toggle search query."""
     await route_client.post(
@@ -78,7 +78,7 @@ async def test_toggle_search_query(route_client):
     assert "msg=sq_toggled" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_search_query(route_client):
     """Test edit search query."""
     await route_client.post(
@@ -94,7 +94,7 @@ async def test_edit_search_query(route_client):
     assert "msg=sq_edited" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_search_query(route_client, db):
     """Test delete search query."""
     await route_client.post(
@@ -106,7 +106,7 @@ async def test_delete_search_query(route_client, db):
     assert "msg=sq_deleted" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_search_query(route_client):
     """Test run search query."""
     await route_client.post(
@@ -121,7 +121,7 @@ async def test_run_search_query(route_client):
         assert "msg=sq_run" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_synced_after_add(route_client):
     """Test scheduler syncs after add when running."""
     route_client._transport_app.state.scheduler._running = True
@@ -143,7 +143,7 @@ async def test_scheduler_synced_after_add(route_client):
         mock_scheduler.sync_search_query_jobs.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_synced_after_toggle(route_client):
     """Test scheduler syncs after toggle when running."""
     await route_client.post(
@@ -164,21 +164,21 @@ async def test_scheduler_synced_after_toggle(route_client):
         mock_scheduler.sync_search_query_jobs.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_nonexistent_no_crash(route_client):
     """Test delete nonexistent query doesn't crash."""
     resp = await route_client.post("/search-queries/999999/delete", follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_search_query_missing_query(route_client):
     """POST /search-queries/add without query returns 422."""
     resp = await route_client.post("/search-queries/add", data={}, follow_redirects=False)
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_search_query_missing_query(route_client):
     """POST /search-queries/{id}/edit without query returns 422."""
     resp = await route_client.post("/search-queries/1/edit", data={}, follow_redirects=False)

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -9,7 +9,7 @@ import pytest
 from src.models import SearchResult
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_root_redirects_to_search_when_no_agent(route_client):
     """Test root redirects to /search when agent unavailable."""
     resp = await route_client.get("/", follow_redirects=False)
@@ -17,7 +17,7 @@ async def test_root_redirects_to_search_when_no_agent(route_client):
     assert "/search" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_root_redirects_to_agent_when_available(route_client):
     """Test root redirects to /agent when agent manager available."""
     from src.agent.manager import AgentManager
@@ -32,21 +32,21 @@ async def test_root_redirects_to_agent_when_available(route_client):
     assert "/agent" in resp.headers.get("location", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_page_renders(route_client):
     """Test search page renders with account."""
     resp = await route_client.get("/search")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_page_with_message(route_client):
     """Test search page with message param."""
     resp = await route_client.get("/search?msg=test_message")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_query(route_client, monkeypatch):
     """Test search with query executes search."""
     mock_result = SearchResult(messages=[], total=0, query="test")
@@ -63,7 +63,7 @@ async def test_search_with_query(route_client, monkeypatch):
     mock_svc.search.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_invalid_channel_id(route_client, monkeypatch):
     """Test search with invalid channel_id shows error."""
     mock_svc = MagicMock()
@@ -81,7 +81,7 @@ async def test_search_invalid_channel_id(route_client, monkeypatch):
     assert "Некорректный ID" in resp.text or "invalid" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_pagination(route_client, monkeypatch):
     """Test search with pagination parameter."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -97,7 +97,7 @@ async def test_search_pagination(route_client, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_fts_mode(route_client, monkeypatch):
     """Test search with FTS mode."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -113,7 +113,7 @@ async def test_search_fts_mode(route_client, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_hybrid_mode(route_client, monkeypatch):
     """Test search with hybrid mode."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -129,7 +129,7 @@ async def test_search_hybrid_mode(route_client, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_error_rendered(route_client, monkeypatch):
     """Test search error is rendered in page."""
     mock_svc = MagicMock()
@@ -145,7 +145,7 @@ async def test_search_error_rendered(route_client, monkeypatch):
     assert "ошибка" in resp.text.lower() or "error" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_date_filters(route_client, monkeypatch):
     """Test search with date filters."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -163,7 +163,7 @@ async def test_search_date_filters(route_client, monkeypatch):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_length_filter(route_client, monkeypatch):
     """Test search with length filter syntax."""
     mock_result = SearchResult(messages=[], total=0, query="test")
@@ -182,7 +182,7 @@ async def test_search_length_filter(route_client, monkeypatch):
 # --- Browse mode tests ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_browse_mode_with_channel_id(route_client, monkeypatch, base_app):
     """Browse mode: channel_id without query shows latest messages from that channel."""
     app, db, pool = base_app
@@ -208,7 +208,7 @@ async def test_browse_mode_with_channel_id(route_client, monkeypatch, base_app):
     assert call_kwargs.kwargs.get("channel_id") == 200 or call_kwargs[1].get("channel_id") == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_browse_mode_no_channel_id(route_client, monkeypatch):
     """Browse mode without channel_id just shows empty search page."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -226,7 +226,7 @@ async def test_browse_mode_no_channel_id(route_client, monkeypatch):
     mock_svc.search.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_browse_mode_with_query(route_client, monkeypatch, base_app):
     """Browse mode is NOT active when query is present - normal search instead."""
     mock_result = SearchResult(messages=[], total=0, query="test")
@@ -244,7 +244,7 @@ async def test_browse_mode_with_query(route_client, monkeypatch, base_app):
     mock_svc.search.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_browse_mode_error_handling(route_client, monkeypatch, base_app):
     """Browse mode error is handled gracefully."""
     app, db, pool = base_app
@@ -266,7 +266,7 @@ async def test_browse_mode_error_handling(route_client, monkeypatch, base_app):
     assert "error" in resp.text.lower() or "ошибка" in resp.text.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_length_filter():
     """Test _extract_length helper function."""
     from src.web.routes.search import _extract_length
@@ -290,7 +290,7 @@ async def test_extract_length_filter():
 # ── Onboarding redirect paths ────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_redirects_when_auth_not_configured(base_app):
     """Test search page redirects to /settings when auth is not configured."""
     import base64
@@ -317,7 +317,7 @@ async def test_search_redirects_when_auth_not_configured(base_app):
     app.state.auth.update_credentials(12345, "test_hash")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_redirects_when_no_accounts(base_app):
     """Test search page redirects to /settings when no accounts exist."""
     import base64
@@ -347,7 +347,7 @@ async def test_search_redirects_when_no_accounts(base_app):
 # ── check_quota failure path ─────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_quota_failure(route_client, monkeypatch):
     """Test search page handles check_quota failure gracefully."""
     mock_result = SearchResult(messages=[], total=0, query="")
@@ -388,7 +388,7 @@ async def _insert_message_get_id(db, channel_id, message_id, text, date=None):
     return rows[0]["id"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_not_found(route_client, base_app):
     """Test translate endpoint with non-existent message."""
     resp = await route_client.post(
@@ -402,7 +402,7 @@ async def test_translate_message_not_found(route_client, base_app):
     assert "not found" in data["error"].lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_no_text(route_client, base_app):
     """Test translate endpoint with message that has no text."""
     app, db, _ = base_app
@@ -419,7 +419,7 @@ async def test_translate_message_no_text(route_client, base_app):
     assert data["ok"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_cached(route_client, base_app):
     """Test translate endpoint returns cached translation."""
     app, db, _ = base_app
@@ -441,7 +441,7 @@ async def test_translate_message_cached(route_client, base_app):
     assert data["translation"] == "Hello world"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_same_language(route_client, base_app):
     """Test translate endpoint when detected lang matches target."""
     app, db, _ = base_app
@@ -460,7 +460,7 @@ async def test_translate_message_same_language(route_client, base_app):
     assert data.get("same_lang") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_service_not_configured(route_client, base_app, monkeypatch):
     """Test translate endpoint when translation service is not available."""
     app, db, _ = base_app
@@ -480,7 +480,7 @@ async def test_translate_message_service_not_configured(route_client, base_app, 
     assert data["ok"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_with_service(route_client, base_app, monkeypatch):
     """Test translate endpoint with a working translation service."""
     app, db, _ = base_app
@@ -513,7 +513,7 @@ async def test_translate_message_with_service(route_client, base_app, monkeypatc
     app.state.container = None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_non_en_target(route_client, base_app):
     """Test translate endpoint with non-en target language and cached translation."""
     app, db, _ = base_app

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -18,7 +18,7 @@ async def db(base_app):
     return db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_renders(route_client):
     """Test settings page renders."""
     with patch(
@@ -32,7 +32,7 @@ async def test_settings_page_renders(route_client):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_shows_accounts(route_client):
     """Test settings page shows accounts."""
     with patch(
@@ -47,7 +47,7 @@ async def test_settings_shows_accounts(route_client):
         assert "+1234567890" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_shows_flood_banner_and_account_availability(route_client, db):
     accounts = await db.get_accounts(active_only=False)
     future = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -68,7 +68,7 @@ async def test_settings_shows_flood_banner_and_account_availability(route_client
         assert "Flood" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_msg_param(route_client):
     """Test settings page with message param."""
     with patch(
@@ -82,7 +82,7 @@ async def test_settings_msg_param(route_client):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler(route_client, db):
     """Test save scheduler settings."""
     resp = await route_client.post(
@@ -94,7 +94,7 @@ async def test_save_scheduler(route_client, db):
     assert "msg=scheduler_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_invalid(route_client):
     """Test save scheduler with invalid value."""
     resp = await route_client.post(
@@ -106,7 +106,7 @@ async def test_save_scheduler_invalid(route_client):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_valid(route_client, db):
     """Test save credentials with valid values."""
     resp = await route_client.post(
@@ -118,7 +118,7 @@ async def test_save_credentials_valid(route_client, db):
     assert "msg=credentials_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_invalid_id(route_client):
     """Test save credentials with invalid api_id."""
     resp = await route_client.post(
@@ -130,7 +130,7 @@ async def test_save_credentials_invalid_id(route_client):
     assert "error=invalid_api_id" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_account_enqueues_command(route_client):
     """Web route only enqueues a telegram command; worker flips is_active and reconciles the pool."""
     resp = await route_client.post("/settings/1/toggle", follow_redirects=False)
@@ -144,7 +144,7 @@ async def test_toggle_account_enqueues_command(route_client):
     assert commands[0].payload == {"account_id": 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_account_enqueues_command(route_client):
     """Web route only enqueues a telegram command; worker removes the route_client and deletes the row."""
     resp = await route_client.post("/settings/1/delete", follow_redirects=False)
@@ -158,7 +158,7 @@ async def test_delete_account_enqueues_command(route_client):
     assert commands[0].payload == {"account_id": 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters(route_client, db):
     """Test save filter settings."""
     resp = await route_client.post(
@@ -174,7 +174,7 @@ async def test_save_filters(route_client, db):
     assert "msg=filters_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters_invalid(route_client):
     """Test save filters with invalid value."""
     resp = await route_client.post(
@@ -186,7 +186,7 @@ async def test_save_filters_invalid(route_client):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search(route_client, db):
     """Test save semantic search settings."""
     resp = await route_client.post(
@@ -202,7 +202,7 @@ async def test_save_semantic_search(route_client, db):
     assert "msg=semantic_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_backend(route_client, db):
     """Test save agent backend settings."""
     resp = await route_client.post(
@@ -217,7 +217,7 @@ async def test_save_agent_backend(route_client, db):
     assert "msg=agent_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_notification_account(route_client, db):
     """Test save notification account."""
     with patch(
@@ -236,7 +236,7 @@ async def test_save_notification_account(route_client, db):
         assert "msg=notification_account_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_notification_account_invalid(route_client, db):
     """Test save notification account with invalid phone."""
     resp = await route_client.post(
@@ -251,7 +251,7 @@ async def test_save_notification_account_invalid(route_client, db):
 # === Semantic Search Settings tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_invalid_batch_size(route_client, db):
     """Test save semantic search with invalid batch size."""
     resp = await route_client.post(
@@ -267,7 +267,7 @@ async def test_save_semantic_search_invalid_batch_size(route_client, db):
     assert "error=semantic_invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_empty_provider(route_client, db):
     """Test save semantic search with empty provider."""
     resp = await route_client.post(
@@ -283,7 +283,7 @@ async def test_save_semantic_search_empty_provider(route_client, db):
     assert "error=semantic_invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_empty_model(route_client, db):
     """Test save semantic search with empty model."""
     resp = await route_client.post(
@@ -299,7 +299,7 @@ async def test_save_semantic_search_empty_model(route_client, db):
     assert "error=semantic_invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_reset_index(route_client, db):
     """Test save semantic search with reset index flag."""
     # First set some initial values
@@ -320,7 +320,7 @@ async def test_save_semantic_search_reset_index(route_client, db):
     assert "msg=semantic_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_semantic_index(route_client, db):
     """Test running semantic index."""
     with patch(
@@ -337,7 +337,7 @@ async def test_run_semantic_index(route_client, db):
         assert "indexed=5" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_semantic_index_with_reset(route_client, db):
     """Test running semantic index with reset."""
     with patch(
@@ -356,7 +356,7 @@ async def test_run_semantic_index_with_reset(route_client, db):
 # === Agent Settings tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_prompt_template_invalid(route_client, db):
     """Test save agent with invalid prompt template."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -373,7 +373,7 @@ async def test_save_agent_prompt_template_invalid(route_client, db):
     assert "error=agent_prompt_template_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_prompt_template_valid(route_client, db):
     """Test save agent with valid prompt template."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -390,7 +390,7 @@ async def test_save_agent_prompt_template_valid(route_client, db):
     assert "msg=agent_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_dev_mode_with_disclaimer(route_client, db):
     """Test enabling dev mode with disclaimer."""
     resp = await route_client.post(
@@ -410,7 +410,7 @@ async def test_save_agent_dev_mode_with_disclaimer(route_client, db):
     assert enabled == "1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_dev_mode_without_disclaimer(route_client, db):
     """Test enabling dev mode without disclaimer (should not enable)."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -432,7 +432,7 @@ async def test_save_agent_dev_mode_without_disclaimer(route_client, db):
     assert enabled == "0"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_logs_rejected_deepagents_override(route_client, db, caplog):
     """Rejected deepagents override should be written to logs."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -455,7 +455,7 @@ async def test_save_agent_logs_rejected_deepagents_override(route_client, db, ca
 # === Agent Provider tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_agent_provider_writes_disabled(route_client, db):
     """Test add agent provider when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -475,7 +475,7 @@ async def test_add_agent_provider_writes_disabled(route_client, db):
         assert "error=agent_provider_secret_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_agent_provider_dev_mode_required(route_client, db):
     """Test add agent provider requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -496,7 +496,7 @@ async def test_add_agent_provider_dev_mode_required(route_client, db):
         assert "error=agent_dev_mode_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_providers_writes_disabled(route_client, db):
     """Test save agent providers when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -516,7 +516,7 @@ async def test_save_agent_providers_writes_disabled(route_client, db):
         assert "error=agent_provider_secret_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_agent_provider_writes_disabled(route_client, db):
     """Test delete agent provider when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -535,7 +535,7 @@ async def test_delete_agent_provider_writes_disabled(route_client, db):
         assert "error=agent_provider_secret_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_agent_provider_models_writes_disabled(route_client, db):
     """Test refresh agent provider models when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -548,7 +548,7 @@ async def test_refresh_agent_provider_models_writes_disabled(route_client, db):
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_all_agent_provider_models_writes_disabled(route_client, db):
     """Test refresh all provider models when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -560,7 +560,7 @@ async def test_refresh_all_agent_provider_models_writes_disabled(route_client, d
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_probe_agent_provider_model_writes_disabled(route_client, db):
     """Test probe agent provider model when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -575,7 +575,7 @@ async def test_probe_agent_provider_model_writes_disabled(route_client, db):
 # === Test All Agent Provider Models ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_all_agent_provider_models_writes_disabled(route_client, db):
     """Test test all agent provider models when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -587,7 +587,7 @@ async def test_test_all_agent_provider_models_writes_disabled(route_client, db):
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_all_agent_provider_models_dev_mode_required(route_client, db):
     """Test test all requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -604,7 +604,7 @@ async def test_test_all_agent_provider_models_dev_mode_required(route_client, db
         assert resp.status_code == 403
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_all_status_writes_disabled(route_client, db):
     """Test test all status when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -613,7 +613,7 @@ async def test_test_all_status_writes_disabled(route_client, db):
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_all_status_dev_mode_required(route_client, db):
     """Test test all status requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -630,7 +630,7 @@ async def test_test_all_status_dev_mode_required(route_client, db):
 # === Notification tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_json_response(route_client, db):
     """Test notification setup with JSON accept header."""
     resp = await route_client.post(
@@ -646,7 +646,7 @@ async def test_notification_setup_json_response(route_client, db):
     assert command.command_type == "notifications.setup_bot"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_runtime_error(route_client, db):
     """Test notification setup is queued instead of running inline."""
     resp = await route_client.post(
@@ -657,7 +657,7 @@ async def test_notification_setup_runtime_error(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_runtime_error_json(route_client, db):
     """Test notification setup JSON response returns queued command."""
     resp = await route_client.post(
@@ -670,7 +670,7 @@ async def test_notification_setup_runtime_error_json(route_client, db):
     assert data["status"] == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_bot_status(route_client, db):
     """Test notification bot status endpoint."""
     await db.repos.runtime_snapshots.upsert_snapshot(
@@ -685,7 +685,7 @@ async def test_notification_bot_status(route_client, db):
     assert data["configured"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete(route_client, db):
     """Test notification bot deletion."""
     resp = await route_client.post(
@@ -698,7 +698,7 @@ async def test_notification_delete(route_client, db):
     assert commands[0].command_type == "notifications.delete_bot"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete_json(route_client, db):
     """Test notification bot deletion JSON response returns queued command."""
     resp = await route_client.post(
@@ -714,7 +714,7 @@ async def test_notification_delete_json(route_client, db):
 # === Test notification ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_success(route_client, db):
     """Test test notification success."""
     resp = await route_client.post(

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -20,7 +20,7 @@ async def db(base_app):
 # ── settings_page: edge-case branches ──────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_flood_wait_naive_tz(route_client, db):
     """Test settings page when flood_wait_until has no tzinfo (line 424)."""
     accounts = await db.get_accounts(active_only=False)
@@ -39,7 +39,7 @@ async def test_settings_page_flood_wait_naive_tz(route_client, db):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_expired_flood_cleared(route_client, db):
     """Test settings page clears expired flood waits (lines 424-427)."""
     accounts = await db.get_accounts(active_only=False)
@@ -63,7 +63,7 @@ async def test_settings_page_expired_flood_cleared(route_client, db):
         assert acc.flood_wait_until is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_inactive_account(route_client, db):
     """Test settings page with inactive account (line 434)."""
     accounts = await db.get_accounts(active_only=False)
@@ -85,7 +85,7 @@ async def test_settings_page_inactive_account(route_client, db):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_notification_bot_error(route_client, db):
     """Test settings page renders without inline notification bot fetch."""
     with patch(
@@ -107,7 +107,7 @@ async def test_settings_page_notification_bot_error(route_client, db):
 # ── save_scheduler: line 560-566 (interval update via scheduler) ───────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_updates_running_scheduler(route_client, db):
     """Test save scheduler updates interval on running scheduler (lines 567-569)."""
     mock_scheduler = MagicMock()
@@ -124,7 +124,7 @@ async def test_save_scheduler_updates_running_scheduler(route_client, db):
     mock_scheduler.update_interval.assert_called_once_with(45)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_clamps_interval(route_client, db):
     """Test save scheduler clamps interval to 1..1440."""
     resp = await route_client.post(
@@ -141,7 +141,7 @@ async def test_save_scheduler_clamps_interval(route_client, db):
 # ── save_semantic_search: lines 576-591 (branch coverage) ──────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_saves_api_key(route_client, db):
     """Test save semantic search saves API key when not masked (lines 610-613)."""
     resp = await route_client.post(
@@ -160,7 +160,7 @@ async def test_save_semantic_search_saves_api_key(route_client, db):
     assert saved_key == "sk-test-key-123"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_preserves_masked_api_key(route_client, db):
     """Test that masked API key is preserved (lines 611-612)."""
     await db.set_setting("semantic_embeddings_api_key", "original-key")
@@ -179,7 +179,7 @@ async def test_save_semantic_search_preserves_masked_api_key(route_client, db):
     assert saved_key == "original-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_semantic_search_no_api_key_field(route_client, db):
     """Test save semantic search with no api_key field at all (line 610)."""
     resp = await route_client.post(
@@ -198,7 +198,7 @@ async def test_save_semantic_search_no_api_key_field(route_client, db):
 # ── semantic-index: lines 624, 628 ─────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_semantic_index_unavailable(route_client, db):
     """Test running semantic index when not available (line 624)."""
     with patch(
@@ -214,7 +214,7 @@ async def test_run_semantic_index_unavailable(route_client, db):
         assert "error=semantic_unavailable" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_semantic_index_with_reset_flag(route_client, db):
     """Test semantic index with reset flag (line 628)."""
     with patch(
@@ -239,7 +239,7 @@ async def test_run_semantic_index_with_reset_flag(route_client, db):
 # ── save_agent: lines 641-652 (tool_permissions scope) ─────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_tool_permissions(route_client, db):
     """Test save agent with tool_permissions scope (lines 645-653)."""
     resp = await route_client.post(
@@ -255,7 +255,7 @@ async def test_save_agent_tool_permissions(route_client, db):
     assert "msg=tool_permissions_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_tool_permissions_with_phone(route_client, db):
     """Test save agent tool_permissions with phone (line 648)."""
     resp = await route_client.post(
@@ -274,7 +274,7 @@ async def test_save_agent_tool_permissions_with_phone(route_client, db):
 # ── save_agent: lines 655-669 (backend_override branches) ──────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_backend_override_invalid(route_client, db):
     """Test save agent with invalid backend override (line 669)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -296,7 +296,7 @@ async def test_save_agent_backend_override_invalid(route_client, db):
     assert saved == "auto"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_dev_mode_no_disclaimer_keeps_current(route_client, db):
     """Test dev_mode scope without disclaimer keeps current state (line 679)."""
     # Start with dev mode enabled; request wants to enable but no disclaimer
@@ -318,7 +318,7 @@ async def test_save_agent_dev_mode_no_disclaimer_keeps_current(route_client, db)
     assert saved == "1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_prompt_template_empty_falls_back(route_client, db):
     """Test empty prompt template falls back to default (lines 683-684)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -338,7 +338,7 @@ async def test_save_agent_prompt_template_empty_falls_back(route_client, db):
 # ── save_agent: lines 714-723 (claude override no credentials) ─────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_claude_override_no_credentials(route_client, db, caplog):
     """Test claude override rejected without API key (lines 714-723)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -367,7 +367,7 @@ async def test_save_agent_claude_override_no_credentials(route_client, db, caplo
 # ── save_agent: line 730 (agent_manager refresh) ───────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_refreshes_agent_manager(route_client, db):
     """Test save agent refreshes agent_manager settings cache (line 730)."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -392,7 +392,7 @@ async def test_save_agent_refreshes_agent_manager(route_client, db):
 # ── agent-providers/add: lines 746-749, 751, 757 ──────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_agent_provider_invalid_name(route_client, db):
     """Test add agent provider with invalid name (lines 746-749)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -416,7 +416,7 @@ async def test_add_agent_provider_invalid_name(route_client, db):
         assert "error=agent_provider_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_agent_provider_already_exists(route_client, db):
     """Test add agent provider when it already exists (line 751)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -443,7 +443,7 @@ async def test_add_agent_provider_already_exists(route_client, db):
         assert "msg=agent_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_agent_provider_refreshes_manager(route_client, db):
     """Test add agent provider refreshes agent manager (line 757)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -477,7 +477,7 @@ async def test_add_agent_provider_refreshes_manager(route_client, db):
 # ── agent-providers/save: lines 771, 773, 801 ──────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_providers_dev_mode_required(route_client, db):
     """Test save agent providers requires dev mode (line 771)."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -498,7 +498,7 @@ async def test_save_agent_providers_dev_mode_required(route_client, db):
         assert "error=agent_dev_mode_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_providers_probes_enabled(route_client, db):
     """Test save agent providers probes enabled providers (lines 777-801)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -539,7 +539,7 @@ async def test_save_agent_providers_probes_enabled(route_client, db):
 # ── agent-providers/{name}/delete: lines 813-825 ───────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_agent_provider_dev_mode_required(route_client, db):
     """Test delete agent provider requires dev mode (lines 813-815)."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -561,7 +561,7 @@ async def test_delete_agent_provider_dev_mode_required(route_client, db):
         assert "error=agent_dev_mode_required" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_agent_provider_refreshes_manager(route_client, db):
     """Test delete provider refreshes agent manager (lines 821-824)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -593,7 +593,7 @@ async def test_delete_agent_provider_refreshes_manager(route_client, db):
 # ── agent-providers/{name}/refresh: lines 837, 839 ─────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_agent_provider_dev_mode_required_json(route_client, db):
     """Test refresh provider requires dev mode (JSON) (line 837)."""
     await db.set_setting("agent_dev_mode_enabled", "0")
@@ -612,7 +612,7 @@ async def test_refresh_agent_provider_dev_mode_required_json(route_client, db):
         assert resp.status_code == 403
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_agent_provider_unknown(route_client, db):
     """Test refresh unknown provider (line 839)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -637,7 +637,7 @@ async def test_refresh_agent_provider_unknown(route_client, db):
 # ── agent-providers/{name}/probe: lines 902, 904, 907, 911-917 ────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_probe_agent_provider_unknown(route_client, db):
     """Test probe unknown provider (line 904)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -659,7 +659,7 @@ async def test_probe_agent_provider_unknown(route_client, db):
         assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_probe_agent_provider_validation_blocked(route_client, db):
     """Test probe provider when validation fails (lines 910-917)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -690,7 +690,7 @@ async def test_probe_agent_provider_validation_blocked(route_client, db):
         assert data["reason"] == "Missing API key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_probe_agent_provider_success(route_client, db):
     """Test probe provider with successful probe (lines 929-960)."""
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -736,7 +736,7 @@ async def test_probe_agent_provider_success(route_client, db):
 # ── save-filters: lines 1020-1024, 1048-1049 ──────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters_zero_subs_no_auto_delete(route_client, db):
     """Test save filters with zero min_subscribers and no auto_delete (lines 1020-1042)."""
     resp = await route_client.post(
@@ -750,7 +750,7 @@ async def test_save_filters_zero_subs_no_auto_delete(route_client, db):
     assert "msg=filters_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters_with_auto_delete_on_collect(route_client, db):
     """Test save filters with auto_delete_on_collect checked."""
     resp = await route_client.post(
@@ -768,7 +768,7 @@ async def test_save_filters_with_auto_delete_on_collect(route_client, db):
 # ── save-notification-account: lines 1048-1049, 1058 ───────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_notification_account_with_notifier(route_client, db):
     """Test save notification account invalidates notifier cache (line 1058)."""
     mock_notifier = MagicMock()
@@ -792,7 +792,7 @@ async def test_save_notification_account_with_notifier(route_client, db):
         mock_notifier.invalidate_me_cache.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_notification_account_empty_phone(route_client, db):
     """Test save notification account with empty phone clears setting."""
     with patch(
@@ -816,7 +816,7 @@ async def test_save_notification_account_empty_phone(route_client, db):
 # ── save-credentials: lines 1065-1078, 1087 ────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_only_hash(route_client, db):
     """Test save credentials with only api_hash changed (lines 1079-1080)."""
     await db.set_setting("tg_api_id", "99999")
@@ -830,7 +830,7 @@ async def test_save_credentials_only_hash(route_client, db):
     assert "msg=credentials_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_no_changes(route_client, db):
     """Test save credentials when nothing changed."""
     resp = await route_client.post(
@@ -845,7 +845,7 @@ async def test_save_credentials_no_changes(route_client, db):
 # ── notifications/setup: lines 1098-1099, 1107, 1117 ──────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_general_exception(route_client, db):
     """Test notification setup redirect is queued."""
     resp = await route_client.post(
@@ -856,7 +856,7 @@ async def test_notification_setup_general_exception(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_general_exception_json(route_client, db):
     """Test notification setup JSON response is queued."""
     resp = await route_client.post(
@@ -869,7 +869,7 @@ async def test_notification_setup_general_exception_json(route_client, db):
     assert data["status"] == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_success_redirect(route_client, db):
     """Test notification setup success path is queued."""
     resp = await route_client.post(
@@ -883,7 +883,7 @@ async def test_notification_setup_success_redirect(route_client, db):
 # ── notifications/delete: lines 1142-1153 ──────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete_runtime_error_account(route_client, db):
     """Test notification delete is queued."""
     resp = await route_client.post(
@@ -894,7 +894,7 @@ async def test_notification_delete_runtime_error_account(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete_runtime_error_other(route_client, db):
     """Test notification delete keeps queued contract regardless of runtime outcome."""
     resp = await route_client.post(
@@ -905,7 +905,7 @@ async def test_notification_delete_runtime_error_other(route_client, db):
     assert "msg=notification_delete_queued" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete_general_exception(route_client, db):
     """Test notification delete redirect remains queued."""
     resp = await route_client.post(
@@ -916,7 +916,7 @@ async def test_notification_delete_general_exception(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_delete_general_exception_json(route_client, db):
     """Test notification delete JSON response is queued."""
     resp = await route_client.post(
@@ -932,7 +932,7 @@ async def test_notification_delete_general_exception_json(route_client, db):
 # ── notifications/test: lines 1167, 1169-1170, 1175-1184, 1192 ────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_no_notifier_no_bot(route_client, db):
     """Test notification test is queued even without cached notifier state."""
     resp = await route_client.post(
@@ -943,7 +943,7 @@ async def test_test_notification_no_notifier_no_bot(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_bot_sends_start(route_client, db):
     """Test notification test success path is queued."""
     resp = await route_client.post(
@@ -954,7 +954,7 @@ async def test_test_notification_bot_sends_start(route_client, db):
     assert "msg=notification_test_queued" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_notify_fails(route_client, db):
     """Test notification test retains queued redirect contract."""
     resp = await route_client.post(
@@ -968,7 +968,7 @@ async def test_test_notification_notify_fails(route_client, db):
 # ── Image Providers: lines 1202-1262 ───────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_image_provider_invalid(route_client, db):
     """Test add image provider with invalid name (lines 1204-1207)."""
     with patch(
@@ -990,7 +990,7 @@ async def test_add_image_provider_invalid(route_client, db):
         assert "error=image_provider_invalid" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_image_provider_already_exists(route_client, db):
     """Test add image provider when it already exists (lines 1208-1209)."""
     with patch(
@@ -1015,7 +1015,7 @@ async def test_add_image_provider_already_exists(route_client, db):
         assert "msg=image_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_image_providers_missing_key(route_client, db):
     """Test save image providers with missing API key (lines 1226-1233)."""
     with patch(
@@ -1048,7 +1048,7 @@ async def test_save_image_providers_missing_key(route_client, db):
         assert "error=image_provider_missing_key" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_image_providers_success(route_client, db):
     """Test save image providers success (lines 1236-1239)."""
     with patch(
@@ -1072,7 +1072,7 @@ async def test_save_image_providers_success(route_client, db):
         assert "msg=image_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_image_provider(route_client, db):
     """Test delete image provider (lines 1246-1250)."""
     with patch(
@@ -1097,7 +1097,7 @@ async def test_delete_image_provider(route_client, db):
 # ── Translation settings: lines 1255-1262, 1267-1269 ──────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_translation_settings(route_client, db):
     """Test save translation settings (lines 1255-1262)."""
     resp = await route_client.post(
@@ -1120,7 +1120,7 @@ async def test_save_translation_settings(route_client, db):
     assert saved_lang == "en"  # .lower() applied
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translation_backfill(route_client, db):
     """Test translation backfill (lines 1267-1269)."""
     resp = await route_client.post(
@@ -1134,7 +1134,7 @@ async def test_translation_backfill(route_client, db):
 # ── translation-run: lines 1276-1293 ───────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translation_run_batch(route_client, db):
     """Test translation run batch (lines 1276-1293)."""
     await db.set_setting("translation_source_filter", "ru,ua")
@@ -1151,7 +1151,7 @@ async def test_translation_run_batch(route_client, db):
 # ── _reload_llm_providers: lines 80-83 ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_reload_llm_providers_failure(route_client, db, caplog):
     """Test _reload_llm_providers handles exception (lines 80-83)."""
     mock_llm_svc = MagicMock()

--- a/tests/routes/test_telegram_commands_routes.py
+++ b/tests/routes/test_telegram_commands_routes.py
@@ -24,7 +24,7 @@ async def client(base_app):
         yield c
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_command_status_redacts_sensitive_payload(client, base_app):
     app, db, _ = base_app
     cmd = TelegramCommand(
@@ -45,7 +45,7 @@ async def test_get_command_status_redacts_sensitive_payload(client, base_app):
     assert body["result_payload"]["is_premium"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_command_status_404(client):
     resp = await client.get("/telegram-commands/999999")
     assert resp.status_code == 404

--- a/tests/test_ab_testing_service.py
+++ b/tests/test_ab_testing_service.py
@@ -27,7 +27,7 @@ class FakeQualityScoringService:
         return payload, score >= 0.7
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_save_and_get_variants(db):
     repo = db.repos.generation_runs
     service = ABTestingService(db)
@@ -45,7 +45,7 @@ async def test_ab_testing_service_save_and_get_variants(db):
     assert run.variants == ["base", "variant 2", "variant 3"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_select_variant_updates_generated_text(db):
     repo = db.repos.generation_runs
     service = ABTestingService(db)
@@ -61,7 +61,7 @@ async def test_ab_testing_service_select_variant_updates_generated_text(db):
     assert run.selected_variant == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_auto_select_best_uses_scoring_service(db):
     repo = db.repos.generation_runs
     service = ABTestingService(db)
@@ -81,7 +81,7 @@ async def test_ab_testing_service_auto_select_best_uses_scoring_service(db):
     assert run.selected_variant == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_generate_variants_includes_base_text(db, monkeypatch):
     pipeline = ContentPipeline(
         id=1,
@@ -110,7 +110,7 @@ async def test_ab_testing_service_generate_variants_includes_base_text(db, monke
     assert len(variants) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_select_variant_invalid_index(db):
     """Invalid index raises ValueError."""
     repo = db.repos.generation_runs
@@ -123,7 +123,7 @@ async def test_ab_testing_service_select_variant_invalid_index(db):
         await service.select_variant(run_id, 5)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_select_variant_missing_run(db):
     """Missing run raises ValueError."""
     service = ABTestingService(db)
@@ -132,7 +132,7 @@ async def test_ab_testing_service_select_variant_missing_run(db):
         await service.select_variant(999, 0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_get_variants_missing_run(db):
     """get_variants returns None for missing run."""
     service = ABTestingService(db)
@@ -142,7 +142,7 @@ async def test_ab_testing_service_get_variants_missing_run(db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_get_variants_no_variants_returns_base(db):
     """get_variants returns generated_text when no variants stored."""
     repo = db.repos.generation_runs
@@ -157,7 +157,7 @@ async def test_ab_testing_service_get_variants_no_variants_returns_base(db):
     assert result.variants[0].text == "base text only"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_auto_select_single_variant_returns_zero(db):
     """Auto-select with single variant returns 0."""
     repo = db.repos.generation_runs
@@ -171,7 +171,7 @@ async def test_ab_testing_service_auto_select_single_variant_returns_zero(db):
     assert best_index == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ab_testing_service_auto_select_without_scoring_picks_longest(db):
     """Auto-select without scoring picks longest text."""
     repo = db.repos.generation_runs

--- a/tests/test_account_lease_pool.py
+++ b/tests/test_account_lease_pool.py
@@ -13,7 +13,7 @@ async def pool(db):
     return AccountLeasePool(db, set())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_available_skips_active_flood(db, pool):
     """Account with future flood_wait_until is not returned."""
     await db.add_account(Account(phone="+70001", session_string="s1", is_active=True))
@@ -24,7 +24,7 @@ async def test_acquire_available_skips_active_flood(db, pool):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_available_clears_expired_flood(db, pool):
     """Expired flood_wait_until is cleared from DB and account is returned."""
     await db.add_account(Account(phone="+70002", session_string="s2", is_active=True))
@@ -43,7 +43,7 @@ async def test_acquire_available_clears_expired_flood(db, pool):
     assert acc.flood_wait_until is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_available_returns_non_flooded_when_one_flooded(db):
     """With two accounts, the flooded one is skipped and the other returned."""
     pool = AccountLeasePool(db, set())
@@ -59,7 +59,7 @@ async def test_acquire_available_returns_non_flooded_when_one_flooded(db):
     assert result.account.phone == "+70004"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_flood_waited_returns_false_for_expired(db):
     """_is_flood_waited correctly ignores expired timestamps."""
     past = datetime.now(timezone.utc) - timedelta(seconds=1)
@@ -67,7 +67,7 @@ async def test_is_flood_waited_returns_false_for_expired(db):
     assert not AccountLeasePool._is_flood_waited(account)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_flood_waited_returns_true_for_future(db):
     """_is_flood_waited correctly detects active flood wait."""
     future = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -75,7 +75,7 @@ async def test_is_flood_waited_returns_true_for_future(db):
     assert AccountLeasePool._is_flood_waited(account)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_available_round_robin_distributes(db, pool):
     """Sequential acquire/release calls cycle through all available accounts."""
     phones = ["+71001", "+71002", "+71003"]
@@ -96,7 +96,7 @@ async def test_acquire_available_round_robin_distributes(db, pool):
     assert seen[3] == seen[0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_round_robin_skips_in_use(db):
     """Phones already in_use are skipped by the round-robin walk."""
     phones = ["+72001", "+72002", "+72003"]
@@ -118,7 +118,7 @@ async def test_round_robin_skips_in_use(db):
     assert lease2.account.phone == "+72003"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_round_robin_skips_flood_waited(db, pool):
     """Flood-waited accounts are skipped during round-robin selection."""
     phones = ["+73001", "+73002", "+73003"]
@@ -140,7 +140,7 @@ async def test_round_robin_skips_flood_waited(db, pool):
     assert "+73002" not in seen
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_round_robin_skips_disconnected(db, pool):
     """Phones missing from connected_phones are skipped."""
     phones = ["+74001", "+74002", "+74003"]
@@ -159,7 +159,7 @@ async def test_round_robin_skips_disconnected(db, pool):
     assert set(seen) == {"+74001", "+74003"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_round_robin_survives_account_change(db, pool):
     """Cursor based on phone (not index) survives account list mutations."""
     a_id = await db.add_account(Account(phone="+75001", session_string="A", is_active=True))
@@ -183,7 +183,7 @@ async def test_round_robin_survives_account_change(db, pool):
     assert lease2.account.phone == "+75003"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cursor_unchanged_when_all_flooded(db, pool):
     """When no exclusive account is available, cursor must not advance."""
     phones = ["+76001", "+76002", "+76003"]
@@ -214,7 +214,7 @@ async def test_cursor_unchanged_when_all_flooded(db, pool):
     assert lease.account.phone == "+76002"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_shared_fallback_uses_round_robin_order(db):
     """When every account is in use, shared leases still rotate instead of preferring primary."""
     phones = ["+77001", "+77002", "+77003"]

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -23,7 +23,7 @@ def mock_pool():
     return pool
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_list(mock_bundle):
     mock_bundle.list_accounts.return_value = [Account(id=1, phone="+7999", session_string="sess")]
     svc = AccountService(mock_bundle)
@@ -32,7 +32,7 @@ async def test_account_service_list(mock_bundle):
     assert results[0].phone == "+7999"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_toggle_no_pool(mock_bundle):
     acc = Account(id=1, phone="+7999", session_string="sess", is_active=True)
     mock_bundle.list_accounts.return_value = [acc]
@@ -42,7 +42,7 @@ async def test_account_service_toggle_no_pool(mock_bundle):
     mock_bundle.set_active.assert_called_once_with(1, False)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_toggle_activate_with_pool(mock_bundle, mock_pool):
     acc = Account(id=1, phone="+7999", session_string="sess", is_active=False)
     mock_bundle.list_accounts.return_value = [acc]
@@ -53,7 +53,7 @@ async def test_account_service_toggle_activate_with_pool(mock_bundle, mock_pool)
     mock_pool.add_client.assert_called_once_with("+7999", "sess")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_toggle_deactivate_with_pool(mock_bundle, mock_pool):
     acc = Account(id=1, phone="+7999", session_string="sess", is_active=True)
     mock_bundle.list_accounts.return_value = [acc]
@@ -64,7 +64,7 @@ async def test_account_service_toggle_deactivate_with_pool(mock_bundle, mock_poo
     mock_pool.remove_client.assert_called_once_with("+7999")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_toggle_add_client_error(mock_bundle, mock_pool):
     acc = Account(id=1, phone="+7999", session_string="sess", is_active=False)
     mock_bundle.list_accounts.return_value = [acc]
@@ -76,7 +76,7 @@ async def test_account_service_toggle_add_client_error(mock_bundle, mock_pool):
     mock_bundle.set_active.assert_called_once_with(1, True)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_toggle_not_found(mock_bundle):
     mock_bundle.list_accounts.return_value = []
     svc = AccountService(mock_bundle)
@@ -84,7 +84,7 @@ async def test_account_service_toggle_not_found(mock_bundle):
     mock_bundle.set_active.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_delete_with_pool(mock_bundle, mock_pool):
     acc = Account(id=1, phone="+7999", session_string="sess")
     mock_bundle.list_accounts.return_value = [acc]
@@ -95,14 +95,14 @@ async def test_account_service_delete_with_pool(mock_bundle, mock_pool):
     mock_bundle.delete_account.assert_called_once_with(1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_delete_no_pool(mock_bundle):
     svc = AccountService(mock_bundle)
     await svc.delete(1)
     mock_bundle.delete_account.assert_called_once_with(1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_service_init_with_db():
     from src.database import Database
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -28,20 +28,20 @@ def _default_agent_env(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-claude-key")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_make_mcp_server_returns_server(db):
     server = make_mcp_server(db)
     assert server is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_initialize(db):
     mgr = AgentManager(db)
     mgr.initialize()
     assert mgr._claude_backend._server is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_chat_stream_mocked(db):
     thread_id = await db.create_agent_thread("test thread")
     await db.save_agent_message(thread_id, "user", "test")
@@ -72,7 +72,7 @@ async def test_agent_chat_stream_mocked(db):
     assert "done" in last_chunk or "full_text" in last_chunk or "hello" in last_chunk
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_stream_events_yield_incremental_chunks(db):
     """StreamEvent content_block_delta/text_delta chunks are forwarded as SSE data."""
     thread_id = await db.create_agent_thread("stream-event thread")
@@ -124,7 +124,7 @@ async def test_chat_stream_stream_events_yield_incremental_chunks(db):
     assert done_payloads[0]["full_text"] == "привет мир"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_fallback_to_assistant_message_when_no_stream_events(db):
     """When no StreamEvents arrive, AssistantMessage text is used as fallback."""
     thread_id = await db.create_agent_thread("fallback thread")
@@ -155,7 +155,7 @@ async def test_chat_stream_fallback_to_assistant_message_when_no_stream_events(d
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_emits_tool_start_and_tool_end_events(db):
     """StreamEvent content_block_start (tool_use) and content_block_stop emit tool_start/tool_end SSE."""
     thread_id = await db.create_agent_thread("tool-visibility thread")
@@ -220,7 +220,7 @@ async def test_chat_stream_emits_tool_start_and_tool_end_events(db):
     assert "query" in tool_end["summary"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_emits_tool_start_end_from_assistant_message(db):
     """ToolUseBlock inside AssistantMessage emits tool_start and tool_end SSE events.
 
@@ -267,7 +267,7 @@ async def test_chat_stream_emits_tool_start_end_from_assistant_message(db):
     assert "limit" in tool_end["summary"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_passes_prompt_as_async_iterable(db):
     """query() receives an AsyncIterable prompt, not a plain string.
 
@@ -307,7 +307,7 @@ async def test_chat_stream_passes_prompt_as_async_iterable(db):
     assert not isinstance(captured_prompt, str), "prompt must not be a plain string"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_options_have_can_use_tool(db):
     """ClaudeAgentOptions must include can_use_tool to auto-approve CLI permissions.
 
@@ -344,7 +344,7 @@ async def test_chat_stream_options_have_can_use_tool(db):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_closes_sdk_generator(db):
     """aiter.aclose() must be called to kill the Claude CLI subprocess."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
@@ -378,7 +378,7 @@ async def test_chat_stream_closes_sdk_generator(db):
     assert aclose_called, "aiter.aclose() was never called — subprocess may leak"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_closes_sdk_generator_on_timeout(db):
     """aiter.aclose() must be called even when timeout fires."""
     thread_id = await db.create_agent_thread("aclose-timeout thread")
@@ -406,7 +406,7 @@ async def test_chat_stream_closes_sdk_generator_on_timeout(db):
     assert aclose_called, "aiter.aclose() not called on timeout — subprocess may leak"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stderr_errors_surfaced_as_warnings(db):
     """Errors from claude-cli stderr are emitted as warning events to the user."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
@@ -449,7 +449,7 @@ async def test_stderr_errors_surfaced_as_warnings(db):
     assert any("connection refused" in t for t in warning_texts), f"Missing 'connection refused' in {warning_texts}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stderr_debug_lines_not_surfaced(db):
     """DEBUG/TRACE stderr lines must NOT be shown to the user."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
@@ -483,7 +483,7 @@ async def test_stderr_debug_lines_not_surfaced(db):
     assert len(warnings) == 0, f"DEBUG/TRACE should not produce warnings: {warnings}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stderr_stage_keywords_not_duplicated_as_warnings(db):
     """stderr lines matching stage keywords should emit status, not warning."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
@@ -522,7 +522,7 @@ async def test_stderr_stage_keywords_not_duplicated_as_warnings(db):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stderr_api_request_counter_not_deduped(db):
     """Each [api:request] event gets a unique counter, not deduped."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
@@ -564,7 +564,7 @@ async def test_stderr_api_request_counter_not_deduped(db):
     assert "API #3" in api_statuses[2]["text"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_user_message_does_not_break_stream(db):
     """UserMessage (tool results sent to Claude) should not break the stream."""
     from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, UserMessage
@@ -598,7 +598,7 @@ async def test_user_message_does_not_break_stream(db):
     assert any(p.get("done") for p in payloads), "Stream should complete with done"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_emits_tool_result_from_assistant_message(db):
     """ToolResultBlock in AssistantMessage emits tool_result SSE event."""
     thread_id = await db.create_agent_thread("tool-result thread")
@@ -641,7 +641,7 @@ async def test_chat_stream_emits_tool_result_from_assistant_message(db):
     assert "Found 5 channels" in tool_results[0]["summary"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_retry_emits_status_event(db):
     """When Claude SDK retries after timeout, a status SSE event is emitted."""
     thread_id = await db.create_agent_thread("retry thread")
@@ -677,7 +677,7 @@ async def test_chat_stream_retry_emits_status_event(db):
     assert retry_events, f"retry status event not found, status_events: {status_events}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_text_delta_not_broken_by_tool_tracking(db):
     """Existing text streaming still works correctly with tool tracking in place."""
     thread_id = await db.create_agent_thread("text-delta thread")
@@ -718,7 +718,7 @@ async def test_chat_stream_text_delta_not_broken_by_tool_tracking(db):
     assert done_payloads[0]["full_text"] == "привет мир"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_multiple_tools_sequence(db):
     """Multiple tool calls in sequence emit correct tool_start/tool_end pairs."""
     thread_id = await db.create_agent_thread("multi-tool thread")
@@ -776,7 +776,7 @@ async def test_chat_stream_multiple_tools_sequence(db):
     assert tool_ends[1]["tool"] == "list_channels"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_emits_initial_connection_status(db):
     """First SSE event is always a status event with backend connection info."""
     thread_id = await db.create_agent_thread("init-status thread")
@@ -806,7 +806,7 @@ async def test_chat_stream_emits_initial_connection_status(db):
     assert "Подключение" in first_payload["text"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_emits_stderr_stage_status(db):
     """Stderr lines with stage keywords emit status events to the stream."""
     thread_id = await db.create_agent_thread("stderr-status")
@@ -843,7 +843,7 @@ async def test_chat_stream_emits_stderr_stage_status(db):
     assert any("API" in t for t in status_texts), f"missing stderr-derived status: {status_texts}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_renders_saved_prompt_template_variables(db):
     await db.set_setting(
         AGENT_PROMPT_TEMPLATE_SETTING,
@@ -894,7 +894,7 @@ async def test_chat_stream_renders_saved_prompt_template_variables(db):
     assert chunks
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_prefers_claude_when_available(db, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
     monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
@@ -908,7 +908,7 @@ async def test_runtime_status_prefers_claude_when_available(db, monkeypatch):
     assert status.deepagents_available is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_prefers_db_backed_deepagents_over_claude(db, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
     config = AppConfig()
@@ -936,7 +936,7 @@ async def test_runtime_status_prefers_db_backed_deepagents_over_claude(db, monke
     assert status.deepagents_available is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_falls_back_to_deepagents_when_claude_missing(db, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -952,7 +952,7 @@ async def test_runtime_status_falls_back_to_deepagents_when_claude_missing(db, m
     assert status.error is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_respects_dev_override(db, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
     monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
@@ -978,7 +978,7 @@ def test_deepagents_tools_can_be_converted_to_structured_tools(db):
     assert "channels" in channels_tool.description.lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_deepagents_search_tool_returns_friendly_error_inside_running_loop(db):
     mgr = AgentManager(db)
 
@@ -1036,7 +1036,7 @@ def test_deepagents_backend_requires_explicit_key_for_anthropic_fallback(db):
     assert mgr._deepagents_backend.init_error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_reports_failed_deepagents_initialization(db, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -1052,7 +1052,7 @@ async def test_runtime_status_reports_failed_deepagents_initialization(db, monke
     assert status.error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_treats_valid_legacy_fallback_as_available(db, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -1074,7 +1074,7 @@ async def test_runtime_status_treats_valid_legacy_fallback_as_available(db, monk
     assert status.error is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_treats_invalid_legacy_fallback_as_unavailable(db, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -1089,7 +1089,7 @@ async def test_runtime_status_treats_invalid_legacy_fallback_as_unavailable(db, 
     assert "provider:model" in status.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claude_backend_uses_model_from_config(db):
     thread_id = await db.create_agent_thread("test thread")
     await db.save_agent_message(thread_id, "user", "test")
@@ -1120,7 +1120,7 @@ async def test_claude_backend_uses_model_from_config(db):
 # ── DB round-trip tests ───────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_thread_crud(db):
     tid = await db.create_agent_thread("My Thread")
     assert isinstance(tid, int)
@@ -1140,7 +1140,7 @@ async def test_agent_thread_crud(db):
     assert await db.get_agent_thread(tid) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_messages_cascade_delete(db):
     tid = await db.create_agent_thread("cascade test")
     await db.save_agent_message(tid, "user", "hello")
@@ -1158,7 +1158,7 @@ async def test_agent_messages_cascade_delete(db):
 # ── build_prompt tests ────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_prompt_empty_history(db):
     mgr = AgentManager(db)
     prompt, stats = mgr._build_prompt([], "hello")
@@ -1169,7 +1169,7 @@ async def test_build_prompt_empty_history(db):
     assert stats["prompt_chars"] == len(prompt)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_prompt_multi_turn(db):
     mgr = AgentManager(db)
     history = [
@@ -1240,7 +1240,7 @@ def test_build_prompt_edge(db, name, text):
 
 
 @pytest.mark.parametrize("name,text", EDGE_CASES, ids=[c[0] for c in EDGE_CASES])
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_edge(db, name, text):
     """chat_stream with mocked query correctly handles special characters."""
     thread_id = await db.create_agent_thread(f"edge-{name}")
@@ -1273,7 +1273,7 @@ async def test_chat_stream_edge(db, name, text):
         assert isinstance(payload, dict)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_chat_stream_edge_history_mix(db):
     """Multiple edge-case messages in a single conversation history."""
     thread_id = await db.create_agent_thread("multi-edge")
@@ -1464,7 +1464,7 @@ def test_deepagents_backend_configured_flag(db, monkeypatch):
 # ── Runtime status extended tests ──────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_dev_mode_override_respects_backend_override(db, monkeypatch):
     """Runtime status respects dev mode backend override even when other backend is available."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
@@ -1480,7 +1480,7 @@ async def test_runtime_status_dev_mode_override_respects_backend_override(db, mo
     assert status.using_override is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_reports_error_when_override_backend_unavailable(db, monkeypatch):
     """Runtime status reports error when overridden backend is unavailable."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1499,7 +1499,7 @@ async def test_runtime_status_reports_error_when_override_backend_unavailable(db
     assert "claude-agent-sdk" in status.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_fallback_info_includes_provider_details(db, monkeypatch):
     """Runtime status includes fallback provider/model info."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
@@ -1516,7 +1516,7 @@ async def test_runtime_status_fallback_info_includes_provider_details(db, monkey
 # ── DeepagentsBackend streaming tests ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_deepagents_backend_chat_stream_handles_exception(db, monkeypatch):
     """DeepagentsBackend.chat_stream handles and propagates exceptions."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1728,7 +1728,7 @@ def test_build_agent_tools_import_error_shows_details(db, monkeypatch):
 # ── Refresh re-init tests ─────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_reinitializes_on_preflight_true(db, monkeypatch):
     """refresh_settings_cache(preflight=True) re-inits even when preflight_available is not None."""
     monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
@@ -1746,7 +1746,7 @@ async def test_refresh_reinitializes_on_preflight_true(db, monkeypatch):
         mock_init.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_selected_backend_deepagents_override(db, monkeypatch):
     """When override=deepagents, selected_backend is deepagents even if claude_available=True."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "claude-key")
@@ -1781,7 +1781,7 @@ def test_agent_config_timeout_defaults():
     assert config.agent.total_timeout == 300
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_await_with_countdown_normal():
     """_await_with_countdown returns result when coro completes within timeout."""
     from src.agent.manager import _await_with_countdown
@@ -1795,7 +1795,7 @@ async def test_await_with_countdown_normal():
     assert result == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_await_with_countdown_timeout_fires():
     """_await_with_countdown raises TimeoutError when coro exceeds timeout."""
     from src.agent.manager import _await_with_countdown
@@ -1809,7 +1809,7 @@ async def test_await_with_countdown_timeout_fires():
         await _await_with_countdown(slow_coro(), timeout=0.2, queue=queue, label="test", countdown_interval=1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_await_with_countdown_emits_status():
     """_await_with_countdown pushes countdown status events to queue."""
     from src.agent.manager import _await_with_countdown
@@ -1832,7 +1832,7 @@ async def test_await_with_countdown_emits_status():
     assert len(countdown_items) >= 1, f"ожидали хотя бы один countdown event, получили: {items}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_first_event_timeout_fires(db):
     """When query() yields no events, first_event_timeout triggers with error."""
     thread_id = await db.create_agent_thread("timeout thread")
@@ -1863,7 +1863,7 @@ async def test_first_event_timeout_fires(db):
     assert "90" not in errors[0]["error"], "должен использовать конфиг first_event_timeout=1, не дефолт 90"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_idle_timeout_fires(db):
     """When query() stops yielding mid-stream, idle_timeout triggers."""
     thread_id = await db.create_agent_thread("idle-timeout thread")
@@ -1899,7 +1899,7 @@ async def test_idle_timeout_fires(db):
     assert "замолчал" in errors[0]["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_permission_timeout_from_config(db):
     """permission_timeout from AgentConfig is passed to AgentRequestContext."""
     from src.agent.permission_gate import AgentRequestContext
@@ -1917,7 +1917,7 @@ async def test_permission_timeout_from_config(db):
     assert ctx.permission_timeout == 77
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_close_timeout_from_config(db, monkeypatch):
     """stream_close_timeout from config is used for CLAUDE_CODE_STREAM_CLOSE_TIMEOUT env var."""
     monkeypatch.delenv("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", raising=False)

--- a/tests/test_agent_errors.py
+++ b/tests/test_agent_errors.py
@@ -7,7 +7,7 @@ from claude_agent_sdk import CLIConnectionError, CLINotFoundError, ProcessError
 from src.agent.manager import AgentManager, ClaudeSdkBackend, DeepagentsBackend
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_handles_ollama_500_error(db, monkeypatch):
     """Test that Ollama 500 errors are translated to friendly messages."""
 
@@ -46,7 +46,7 @@ async def test_agent_manager_handles_ollama_500_error(db, monkeypatch):
         assert "Возможно, модель не загрузилась" in error_msg
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_handles_ollama_connection_error(db, monkeypatch):
     """Test that Ollama connection errors are translated to friendly messages."""
 
@@ -81,7 +81,7 @@ async def test_agent_manager_handles_ollama_connection_error(db, monkeypatch):
         assert "Проверьте, что сервис запущен" in error_msg
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_handles_generic_error(db, monkeypatch):
     """Test that generic errors are passed through (with prefix)."""
 
@@ -147,7 +147,7 @@ async def _collect_claude_error(db, monkeypatch, exc):
     raise AssertionError(f"No error payload in chunks: {chunks}")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claude_backend_process_error(db, monkeypatch):
     """ProcessError from claude-agent-sdk should surface with details."""
     exc = ProcessError("CLI crashed", exit_code=1, stderr="segfault in libfoo")
@@ -158,7 +158,7 @@ async def test_claude_backend_process_error(db, monkeypatch):
     assert "segfault" in payload["error"] or "CLI crashed" in payload["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claude_backend_cli_not_found(db, monkeypatch):
     """CLINotFoundError should tell the user to install Claude Code."""
     exc = CLINotFoundError("Claude Code not found", cli_path="/usr/bin/claude")
@@ -168,7 +168,7 @@ async def test_claude_backend_cli_not_found(db, monkeypatch):
     assert "claude" in payload["error"].lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_claude_backend_cli_connection_error(db, monkeypatch):
     """CLIConnectionError should report connection failure."""
     exc = CLIConnectionError("Connection refused")

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -90,7 +90,7 @@ def mock_db():
 
 
 class TestAwaitWithCountdown:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_extends_deadline_on_activity(self):
         """Deadline is extended when activity_ts indicates fresh SDK activity."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -113,7 +113,7 @@ class TestAwaitWithCountdown:
         )
         assert result == "done"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_thinking_status_after_api_request_delay(self):
         """Shows 'thinking' status when api_request_ts is stale (>15s)."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -138,7 +138,7 @@ class TestAwaitWithCountdown:
         thinking_items = [i for i in items if "thinking" in i]
         assert len(thinking_items) >= 1, f"Expected thinking event, got: {items}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_max_timeout_caps_deadline(self):
         """max_timeout prevents deadline from extending beyond hard ceiling."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -159,7 +159,7 @@ class TestAwaitWithCountdown:
                 max_timeout=0.8,
             )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancelled_error_propagation(self):
         """CancelledError from outer scope propagates correctly."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -184,7 +184,7 @@ class TestAwaitWithCountdown:
 
 
 class TestToolTracker:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_first_event_idempotent(self):
         """on_first_event only emits once."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -193,7 +193,7 @@ class TestToolTracker:
         await tracker.on_first_event()  # second call should be no-op
         assert queue.qsize() == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_block_stop_with_invalid_json(self):
         """Accumulated input that is not valid JSON produces empty summary."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -209,7 +209,7 @@ class TestToolTracker:
         assert len(tool_end_events) == 1
         assert tool_end_events[0]["is_error"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_block_stop_ignores_mismatched_index(self):
         """on_block_stop with non-matching index does not emit tool_end."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -221,7 +221,7 @@ class TestToolTracker:
         await tracker.on_block_stop(99)  # different index — should be ignored
         assert queue.empty()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_tool_result_unknown_id(self):
         """Tool result with unknown tool_use_id defaults to 'tool'."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -234,7 +234,7 @@ class TestToolTracker:
         results = [json.loads(i.removeprefix("data: ")) for i in items]
         assert results[0]["tool"] == "tool"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_tool_result_with_error(self):
         """Tool result with is_error=True is correctly emitted."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -249,7 +249,7 @@ class TestToolTracker:
         tool_result = [r for r in results if r.get("type") == "tool_result"][0]
         assert tool_result["is_error"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_tool_result_none_content(self):
         """Tool result with None content produces empty summary."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -262,7 +262,7 @@ class TestToolTracker:
         results = [json.loads(i.removeprefix("data: ")) for i in items]
         assert results[0]["summary"] == ""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_on_status_emits_status_event(self):
         """on_status pushes a status event to the queue."""
         queue: asyncio.Queue = asyncio.Queue()
@@ -337,7 +337,7 @@ class TestEmbedHistoryInPrompt:
 
 
 class TestClaudeSdkBackendChatStreamErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_total_timeout_exceeded(self, db):
         """When total timeout is exceeded during stream, error is emitted."""
         thread_id = await db.create_agent_thread("total-timeout")
@@ -379,7 +379,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors, f"Expected timeout error, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cli_not_found_error(self, db):
         """CLINotFoundError produces user-friendly error message."""
         thread_id = await db.create_agent_thread("cli-not-found")
@@ -404,7 +404,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert errors, f"Expected error, got: {payloads}"
         assert "Claude CLI" in errors[0]["error"] or "npm install" in errors[0].get("error", "")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_process_error(self, db):
         """ProcessError produces error with captured stderr details."""
         thread_id = await db.create_agent_thread("process-error")
@@ -428,7 +428,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors, f"Expected error, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_process_error_with_long_stderr_truncated(self, db):
         """ProcessError with long stderr truncates the details."""
         thread_id = await db.create_agent_thread("long-stderr")
@@ -457,7 +457,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         if details:
             assert len(details) <= 503  # 500 + "..."
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cli_connection_error_retries_then_fails(self, db):
         """CLIConnectionError retries once then fails with user message."""
         thread_id = await db.create_agent_thread("conn-error")
@@ -481,7 +481,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors, f"Expected error, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cli_connection_error_overloaded_message(self, db):
         """CLIConnectionError with 'overloaded' uses specific message."""
         thread_id = await db.create_agent_thread("overloaded")
@@ -510,7 +510,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert errors
         assert call_count == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sdk_error_produces_error_payload(self, db):
         """ClaudeSDKError produces error with SDK details."""
         thread_id = await db.create_agent_thread("sdk-error")
@@ -535,7 +535,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert errors
         assert "SDK" in errors[0]["error"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_base_exception_group_with_retryable_error(self, db):
         """ExceptionGroup with retryable error retries once then fails."""
         thread_id = await db.create_agent_thread("exc-group")
@@ -565,7 +565,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         done_or_error = [p for p in payloads if p.get("done") or "error" in p]
         assert done_or_error, f"Expected done or error, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_base_exception_group_with_timeout_no_retry(self, db):
         """ExceptionGroup containing TimeoutError does NOT retry."""
         thread_id = await db.create_agent_thread("exc-group-timeout")
@@ -592,7 +592,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert errors
         assert call_count == 1, "Should not retry on timeout"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generic_exception_with_control_request_timeout_retries(self, db):
         """Generic Exception with 'Control request timeout' retries once."""
         thread_id = await db.create_agent_thread("ctrl-timeout")
@@ -619,7 +619,7 @@ class TestClaudeSdkBackendChatStreamErrors:
 
         assert call_count >= 2, f"Expected retry, got {call_count} calls"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generic_exception_no_retry(self, db):
         """Generic Exception without retry keywords fails immediately."""
         thread_id = await db.create_agent_thread("generic-fail")
@@ -641,7 +641,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rate_limit_event_rejected(self, db):
         """RateLimitEvent with 'rejected' status surfaces as warning."""
         thread_id = await db.create_agent_thread("rate-limit")
@@ -673,7 +673,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         warnings = [p for p in payloads if p.get("type") == "warning"]
         assert warnings, f"Expected warning for rejected rate limit, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rate_limit_event_non_rejected(self, db):
         """RateLimitEvent with non-rejected status emits status event."""
         thread_id = await db.create_agent_thread("rate-limit-ok")
@@ -707,7 +707,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         ]
         assert status_events, f"Expected Rate limit status, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rate_limit_event_with_none_info(self, db):
         """RateLimitEvent with None rate_limit_info uses 'unknown' status."""
         thread_id = await db.create_agent_thread("rl-none-info")
@@ -738,7 +738,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert status_events
         assert "unknown" in status_events[0]["text"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stream_event_error_overloaded(self, db):
         """StreamEvent with error type 'overloaded_error' raises CLIConnectionError."""
         thread_id = await db.create_agent_thread("overload-error")
@@ -766,7 +766,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stream_event_error_generic(self, db):
         """StreamEvent with generic error type raises ClaudeSDKError."""
         thread_id = await db.create_agent_thread("api-error")
@@ -794,7 +794,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_content_block_start_non_tool_use(self, db):
         """content_block_start with non-tool_use type is logged but doesn't crash."""
         thread_id = await db.create_agent_thread("block-start")
@@ -826,7 +826,7 @@ class TestClaudeSdkBackendChatStreamErrors:
 
         assert chunks
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_result_message_with_cost_and_turns(self, db):
         """ResultMessage with total_cost_usd and num_turns fields."""
         thread_id = await db.create_agent_thread("result-msg")
@@ -859,7 +859,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         assert done_events[0]["num_turns"] == 3
         assert done_events[0]["session_id"] == "test-session-id"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unhandled_message_type_logs_warning(self, db):
         """Unknown SDK message type logs a warning without crashing."""
         thread_id = await db.create_agent_thread("unhandled-msg")
@@ -881,7 +881,7 @@ class TestClaudeSdkBackendChatStreamErrors:
 
         assert chunks  # should not crash
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancelled_error_sets_draining(self, db):
         """CancelledError during stream sets draining=True and continues."""
         thread_id = await db.create_agent_thread("cancel-drain")
@@ -902,7 +902,7 @@ class TestClaudeSdkBackendChatStreamErrors:
 
         assert chunks
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_idle_timeout_with_rate_limit_info(self, db):
         """Idle timeout includes rate limit info in error message."""
         thread_id = await db.create_agent_thread("idle-rl")
@@ -944,7 +944,7 @@ class TestClaudeSdkBackendChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stderr_debug_lines_dumped_after_error(self, db):
         """Debug and stderr lines are dumped to log after error in chat_stream."""
         thread_id = await db.create_agent_thread("debug-dump")
@@ -1465,7 +1465,7 @@ class TestDeepagentsProbeAndRun:
             with pytest.raises(RuntimeError, match="get_channels"):
                 backend._run_probe(cfg)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_probe_config_supported(self, mock_db):
         """probe_config returns 'supported' on successful probe."""
         config = AppConfig()
@@ -1486,7 +1486,7 @@ class TestDeepagentsProbeAndRun:
         assert result.status == "supported"
         assert result.model == "gpt-4"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_probe_config_timeout(self, mock_db):
         """probe_config returns 'unknown' on timeout."""
         config = AppConfig()
@@ -1517,7 +1517,7 @@ class TestDeepagentsProbeAndRun:
         assert result.status == "unknown"
         assert "timed out" in (result.reason or "").lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_probe_config_exception(self, mock_db):
         """probe_config returns appropriate status on exception."""
         config = AppConfig()
@@ -1539,7 +1539,7 @@ class TestDeepagentsProbeAndRun:
 
 
 class TestDeepagentsChatStream:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_empty_response(self, mock_db):
         """chat_stream handles empty response from agent."""
         config = AppConfig()
@@ -1585,7 +1585,7 @@ class TestDeepagentsChatStream:
         assert done_events
         assert done_events[0]["full_text"] == ""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_multiple_providers_fallback(self, mock_db):
         """chat_stream tries next provider when first fails."""
         config = AppConfig()
@@ -1649,7 +1649,7 @@ class TestDeepagentsChatStream:
         assert done_events
         assert done_events[0]["full_text"] == "provider 2 response"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_all_providers_fail(self, mock_db):
         """chat_stream raises RuntimeError when all providers fail."""
         config = AppConfig()
@@ -1682,7 +1682,7 @@ class TestDeepagentsChatStream:
 
 
 class TestDeepagentsResearcherWriter:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_researcher_writer_success(self, mock_db):
         """run_researcher_writer completes research and writer phases."""
         config = AppConfig()
@@ -1706,7 +1706,7 @@ class TestDeepagentsResearcherWriter:
                     assert result == "research done"
                     assert mock_run.call_count == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_researcher_writer_all_fail(self, mock_db):
         """run_researcher_writer raises when all providers fail."""
         config = AppConfig()
@@ -1736,7 +1736,7 @@ class TestDeepagentsResearcherWriter:
 
 
 class TestAgentManagerChatStreamErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_with_no_backend_selected(self, db, monkeypatch):
         """chat_stream yields error when no backend is selected."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1759,7 +1759,7 @@ class TestAgentManagerChatStreamErrors:
         errors = [p for p in payloads if "error" in p]
         assert errors, f"Expected error for no backend, got: {payloads}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_deepagents_backend_selected(self, db, monkeypatch):
         """chat_stream works when deepagents backend is selected."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1789,7 +1789,7 @@ class TestAgentManagerChatStreamErrors:
         assert done_events
         assert done_events[0]["backend"] == "deepagents"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_cancel_stream(self, db):
         """cancel_stream cancels active stream."""
         mgr = AgentManager(db)
@@ -1797,7 +1797,7 @@ class TestAgentManagerChatStreamErrors:
         result = await mgr.cancel_stream(999)
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_with_invalid_model_for_claude(self, db):
         """chat_stream ignores invalid model for Claude backend."""
         thread_id = await db.create_agent_thread("invalid-model")
@@ -1818,7 +1818,7 @@ class TestAgentManagerChatStreamErrors:
             ]
             assert chunks
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_backend_exception_with_ollama_500(self, db, monkeypatch):
         """chat_stream shows Ollama 500 error with helpful message."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1849,7 +1849,7 @@ class TestAgentManagerChatStreamErrors:
         assert errors
         assert any("Ollama" in e.get("error", "") for e in errors)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_backend_exception_with_ollama_connection_refused(
         self, db, monkeypatch
     ):
@@ -1908,14 +1908,14 @@ class TestAgentManagerPermissionGate:
 
 
 class TestAgentManagerCloseAll:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_close_all_with_no_tasks(self, db):
         """close_all completes immediately with no active tasks."""
         mgr = AgentManager(db)
         await mgr.close_all()
         assert len(mgr._active_tasks) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_close_all_cancels_active_tasks(self, db):
         """close_all cancels and waits for active tasks."""
         mgr = AgentManager(db)
@@ -1932,7 +1932,7 @@ class TestAgentManagerCloseAll:
 
 
 class TestAgentManagerEstimateTokens:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_estimate_prompt_tokens(self, db):
         """estimate_prompt_tokens returns reasonable estimate."""
         mgr = AgentManager(db)
@@ -1944,7 +1944,7 @@ class TestAgentManagerEstimateTokens:
 
 
 class TestAgentManagerRuntimeStatusEdgeCases:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime_status_with_dev_override_unavailable_deepagents(
         self, db, monkeypatch
     ):
@@ -1962,7 +1962,7 @@ class TestAgentManagerRuntimeStatusEdgeCases:
         assert status.selected_backend == "deepagents"
         assert status.error is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime_status_with_invalid_override(self, db, monkeypatch):
         """Runtime status falls back to auto for invalid override values."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
@@ -1974,7 +1974,7 @@ class TestAgentManagerRuntimeStatusEdgeCases:
 
         assert status.backend_override == "auto"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime_status_no_backends_available(self, db, monkeypatch):
         """Runtime status reports error when no backend is available."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -1987,7 +1987,7 @@ class TestAgentManagerRuntimeStatusEdgeCases:
         assert status.selected_backend is None
         assert status.error is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime_status_deepagents_without_db_configs(self, db, monkeypatch):
         """Runtime status selects claude when deepagents has no usable DB configs."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
@@ -2002,7 +2002,7 @@ class TestAgentManagerRuntimeStatusEdgeCases:
 
         assert status.selected_backend == "claude"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_runtime_status_deepagents_has_db_configs(self, db, monkeypatch):
         """Runtime status selects deepagents when it has usable DB configs."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
@@ -2037,7 +2037,7 @@ class TestAgentManagerRuntimeStatusEdgeCases:
 
 
 class TestAgentManagerCachedSettings:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_cache_hit(self, db):
         """Cached settings are used on subsequent calls."""
         mgr = AgentManager(db)
@@ -2049,7 +2049,7 @@ class TestAgentManagerCachedSettings:
         val2 = await mgr._get_setting_cached("test_key")
         assert val2 == "test_value"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_cache_default(self, db):
         """Default value is used when setting is not found."""
         mgr = AgentManager(db)
@@ -2058,7 +2058,7 @@ class TestAgentManagerCachedSettings:
 
 
 class TestAgentManagerProbeProvider:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_probe_provider_config_delegates(self, db):
         """probe_provider_config delegates to deepagents backend."""
         mgr = AgentManager(db)
@@ -2105,7 +2105,7 @@ class TestDeepagentsRunDbToolSync:
 
 
 class TestDeepagentsRefreshSettingsCache:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_resets_state_on_change(self, mock_db):
         """refresh_settings_cache resets state when configs change."""
         config = AppConfig()
@@ -2137,7 +2137,7 @@ class TestDeepagentsRefreshSettingsCache:
         assert backend._last_used_model == ""
         assert backend._preflight_available is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_keeps_state_when_no_change(self, mock_db):
         """refresh_settings_cache keeps state when configs haven't changed."""
         config = AppConfig()
@@ -2167,7 +2167,7 @@ class TestDeepagentsRefreshSettingsCache:
         assert backend._last_used_provider == "openai"
         assert backend._last_used_model == "gpt-4"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_clears_state_when_no_configs(self, mock_db):
         """refresh_settings_cache clears state when no configs returned."""
         config = AppConfig()
@@ -2290,7 +2290,7 @@ class TestTruncate:
 
 
 class TestAsPromptStream:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_yields_single_message(self):
         from src.agent.manager import _as_prompt_stream
 
@@ -2304,7 +2304,7 @@ class TestAsPromptStream:
 
 
 class TestAutoApproveTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_allow(self):
         from claude_agent_sdk import PermissionResultAllow
 

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -19,7 +19,7 @@ from src.services.agent_provider_service import (
 )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_provider_configs_are_encrypted_in_settings(db):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -47,7 +47,7 @@ async def test_provider_configs_are_encrypted_in_settings(db):
     assert loaded[0].secret_fields["api_key"] == "sk-test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_provider_configs_tolerates_undecryptable_secrets(db):
     write_config = AppConfig()
     write_config.security.session_encryption_key = "provider-secret"
@@ -76,7 +76,7 @@ async def test_load_provider_configs_tolerates_undecryptable_secrets(db):
     assert "could not be decrypted" in loaded[0].last_validation_error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_models_uses_static_cache_on_live_fetch_failure(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -95,7 +95,7 @@ async def test_refresh_models_uses_static_cache_on_live_fetch_failure(db, monkey
     assert saved["openai"]["source"] == "static cache"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_models_uses_live_source_on_success(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -112,7 +112,7 @@ async def test_refresh_models_uses_live_source_on_success(db, monkeypatch):
     assert entry.models == ["gpt-4.1", "gpt-4.1-mini"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_google_genai_models_uses_api_key_header(db, monkeypatch):
     service = AgentProviderService(db, AppConfig())
     captured: dict[str, object] = {}
@@ -131,7 +131,7 @@ async def test_fetch_google_genai_models_uses_api_key_header(db, monkeypatch):
     assert captured["headers"] == {"x-goog-api-key": "google-api-key"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_all_models_only_refreshes_configured_providers(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -176,7 +176,7 @@ def test_validate_provider_config_returns_error_for_unknown_provider(db):
     assert service.validate_provider_config(cfg) == "Unknown provider: unknown"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_model_cache_supports_legacy_entries_without_compatibility(db):
     await db.set_setting(
         MODEL_CACHE_SETTINGS_KEY,
@@ -200,7 +200,7 @@ async def test_load_model_cache_supports_legacy_entries_without_compatibility(db
     assert cache["openai"].compatibility == {}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ensure_model_compatibility_reuses_fresh_cached_result(db):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -241,7 +241,7 @@ async def test_ensure_model_compatibility_reuses_fresh_cached_result(db):
     assert result.config_fingerprint == fingerprint
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ensure_model_compatibility_force_bypasses_cached_result(db):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -346,7 +346,7 @@ def test_config_fingerprint_depends_on_routing_fields(db):
     assert service.config_fingerprint(cfg_local) != service.config_fingerprint(cfg_cloud)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_ollama_models_supports_cloud_api_key(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -367,7 +367,7 @@ async def test_fetch_ollama_models_supports_cloud_api_key(db, monkeypatch):
     assert captured["headers"] == {"Authorization": "Bearer ollama-key"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_ollama_models_normalizes_cloud_api_base_url(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -388,7 +388,7 @@ async def test_fetch_ollama_models_normalizes_cloud_api_base_url(db, monkeypatch
     assert captured["headers"] == {"Authorization": "Bearer ollama-key"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_ollama_models_normalizes_local_api_base_url(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -409,7 +409,7 @@ async def test_fetch_ollama_models_normalizes_local_api_base_url(db, monkeypatch
     assert captured["headers"] is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_prefers_db_provider_configs_over_legacy_env(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -454,7 +454,7 @@ async def test_agent_manager_prefers_db_provider_configs_over_legacy_env(db, mon
     assert any('"provider": "openai"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_falls_back_to_legacy_env_when_db_provider_is_unsupported(
     db, monkeypatch
 ):
@@ -528,7 +528,7 @@ async def test_agent_manager_falls_back_to_legacy_env_when_db_provider_is_unsupp
     assert any('"provider": "anthropic"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_fails_over_to_next_provider_on_init_error(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -577,7 +577,7 @@ async def test_agent_manager_fails_over_to_next_provider_on_init_error(db, monke
     assert any('"provider": "anthropic"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_fails_over_to_next_provider_on_run_error(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -626,7 +626,7 @@ async def test_agent_manager_fails_over_to_next_provider_on_run_error(db, monkey
     assert any('"provider": "groq"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_cloud_provider_uses_bearer_headers(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -669,7 +669,7 @@ async def test_ollama_cloud_provider_uses_bearer_headers(db, monkeypatch):
     assert any('"provider": "ollama"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_provider_normalizes_api_suffix_for_runtime(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -713,7 +713,7 @@ async def test_ollama_provider_normalizes_api_suffix_for_runtime(db, monkeypatch
     assert any('"provider": "ollama"' in chunk for chunk in chunks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_runtime_status_reports_db_provider_preflight_failure(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -746,7 +746,7 @@ async def test_runtime_status_reports_db_provider_preflight_failure(db, monkeypa
     assert "provider init failed" in (status.error or "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_manager_skips_cached_unsupported_provider_and_fails_over(db, monkeypatch):
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
@@ -820,7 +820,7 @@ async def test_agent_manager_skips_cached_unsupported_provider_and_fails_over(db
 # === _fetch_live_models HTTP error handling tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_live_models_http_error_fallback_to_static(db, monkeypatch):
     """_fetch_live_models propagates exception, caller handles fallback."""
     import aiohttp
@@ -852,7 +852,7 @@ async def test_fetch_live_models_http_error_fallback_to_static(db, monkeypatch):
         await service._fetch_live_models(spec, cfg)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_live_models_success_updates_cache(db, monkeypatch):
     """_fetch_live_models returns live models on success."""
     config = AppConfig()
@@ -881,7 +881,7 @@ async def test_fetch_live_models_success_updates_cache(db, monkeypatch):
     assert "gpt-4.1-mini" in models
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
     """Z.AI live model fetch uses native API endpoint with Bearer auth."""
     config = AppConfig()
@@ -917,7 +917,7 @@ async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
 # === save_provider_configs encryption tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_provider_configs_requires_encryption_key(db):
     """save_provider_configs requires encryption key."""
     service = AgentProviderService(db, AppConfig())  # No encryption key
@@ -1087,7 +1087,7 @@ def test_build_provider_views_keeps_empty_plain_field_value(db):
 # === export_compatibility_catalog tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_compatibility_catalog_creates_file(db, tmp_path):
     """export_compatibility_catalog creates catalog file."""
     config = AppConfig()
@@ -1192,7 +1192,7 @@ def test_canonical_endpoint_fingerprint_for_ollama_cloud(db):
 # === Z.AI edge case tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_zai_fetch_models_http_error_propagates(db, monkeypatch):
     """Z.AI model fetch propagates HTTP errors (caller handles fallback)."""
     config = AppConfig()
@@ -1217,7 +1217,7 @@ async def test_zai_fetch_models_http_error_propagates(db, monkeypatch):
         await service._fetch_live_models(spec, cfg)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_zai_fetch_models_empty_response(db, monkeypatch):
     """Z.AI model fetch handles empty response gracefully."""
     config = AppConfig()
@@ -1242,7 +1242,7 @@ async def test_zai_fetch_models_empty_response(db, monkeypatch):
     assert models == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_zai_fetch_models_missing_api_key(db, monkeypatch):
     """Z.AI model fetch handles missing api_key gracefully."""
     config = AppConfig()

--- a/tests/test_agent_threads_moderation_runtime_paths.py
+++ b/tests/test_agent_threads_moderation_runtime_paths.py
@@ -45,14 +45,14 @@ def _text(result: dict) -> str:
 
 
 class TestListAgentThreads:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_agent_threads = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_agent_threads"]({})
         assert "Треды не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_threads(self, mock_db):
         mock_db.get_agent_threads = AsyncMock(
             return_value=[{"id": 1, "title": "Test Chat", "created_at": "2025-01-01"}]
@@ -62,7 +62,7 @@ class TestListAgentThreads:
         assert "Test Chat" in _text(result)
         assert "Треды (1)" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         mock_db.get_agent_threads = AsyncMock(side_effect=Exception("db error"))
         handlers = _get_tool_handlers(mock_db)
@@ -71,7 +71,7 @@ class TestListAgentThreads:
 
 
 class TestCreateAgentThread:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_creates_with_title(self, mock_db):
         mock_db.create_agent_thread = AsyncMock(return_value=42)
         handlers = _get_tool_handlers(mock_db)
@@ -79,14 +79,14 @@ class TestCreateAgentThread:
         assert "id=42" in _text(result)
         assert "My Thread" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_creates_with_default_title(self, mock_db):
         mock_db.create_agent_thread = AsyncMock(return_value=1)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_agent_thread"]({})
         assert "id=1" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.create_agent_thread = AsyncMock(side_effect=Exception("fail"))
         handlers = _get_tool_handlers(mock_db)
@@ -95,20 +95,20 @@ class TestCreateAgentThread:
 
 
 class TestDeleteAgentThread:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_thread_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_agent_thread"]({})
         assert "thread_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         mock_db.get_agent_thread = AsyncMock(return_value={"title": "My Thread"})
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_agent_thread"]({"thread_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_thread_not_found_uses_fallback_name(self, mock_db):
         """When thread is None, name should be 'id=X' fallback."""
         mock_db.get_agent_thread = AsyncMock(return_value=None)
@@ -118,7 +118,7 @@ class TestDeleteAgentThread:
         assert "id=99" in _text(result)
         mock_db.delete_agent_thread.assert_awaited_once_with(99)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_success(self, mock_db):
         mock_db.get_agent_thread = AsyncMock(return_value={"title": "Chat 1"})
         mock_db.delete_agent_thread = AsyncMock()
@@ -127,7 +127,7 @@ class TestDeleteAgentThread:
         assert "Chat 1" in _text(result)
         assert "удалён" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_exception(self, mock_db):
         mock_db.get_agent_thread = AsyncMock(return_value={"title": "Chat"})
         mock_db.delete_agent_thread = AsyncMock(side_effect=Exception("boom"))
@@ -137,20 +137,20 @@ class TestDeleteAgentThread:
 
 
 class TestRenameAgentThread:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_both_params(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["rename_agent_thread"]({"thread_id": 1})
         assert "обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rename_success(self, mock_db):
         mock_db.rename_agent_thread = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["rename_agent_thread"]({"thread_id": 3, "title": "New Name"})
         assert "New Name" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rename_exception(self, mock_db):
         mock_db.rename_agent_thread = AsyncMock(side_effect=Exception("fail"))
         handlers = _get_tool_handlers(mock_db)
@@ -159,20 +159,20 @@ class TestRenameAgentThread:
 
 
 class TestGetThreadMessages:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_thread_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_thread_messages"]({})
         assert "thread_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_agent_messages = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_thread_messages"]({"thread_id": 1})
         assert "Нет сообщений" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_messages(self, mock_db):
         msgs = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
         mock_db.get_agent_messages = AsyncMock(return_value=msgs)
@@ -182,7 +182,7 @@ class TestGetThreadMessages:
         assert "[user]: hello" in text
         assert "[assistant]: hi" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_limit_applied(self, mock_db):
         """Only last N messages should be returned when limit is small."""
         msgs = [{"role": "user", "content": f"msg{i}"} for i in range(10)]
@@ -195,7 +195,7 @@ class TestGetThreadMessages:
         assert "msg9" in text
         assert "msg0" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.get_agent_messages = AsyncMock(side_effect=Exception("fail"))
         handlers = _get_tool_handlers(mock_db)
@@ -209,7 +209,7 @@ class TestGetThreadMessages:
 
 
 class TestListPendingModeration:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
@@ -217,7 +217,7 @@ class TestListPendingModeration:
         result = await handlers["list_pending_moderation"]({})
         assert "Нет черновиков" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs(self, mock_db):
         run = SimpleNamespace(
             id=1,
@@ -231,7 +231,7 @@ class TestListPendingModeration:
         result = await handlers["list_pending_moderation"]({"pipeline_id": 2, "limit": 5})
         assert "На модерации (1 шт.)" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(side_effect=Exception("db"))
@@ -241,13 +241,13 @@ class TestListPendingModeration:
 
 
 class TestApproveRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_run_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["approve_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
@@ -255,7 +255,7 @@ class TestApproveRun:
         result = await handlers["approve_run"]({"run_id": 99})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approve_success(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(
@@ -266,7 +266,7 @@ class TestApproveRun:
         result = await handlers["approve_run"]({"run_id": 1})
         assert "одобрен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(side_effect=Exception("boom"))
@@ -276,13 +276,13 @@ class TestApproveRun:
 
 
 class TestRejectRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_run_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["reject_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reject_success(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(
@@ -295,25 +295,25 @@ class TestRejectRun:
 
 
 class TestBulkApproveRuns:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_ids_format(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "a,b,c", "confirm": True})
         assert "числами через запятую" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_ids(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "", "confirm": True})
         assert "пуст" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "1,2,3"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approves_multiple(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
@@ -323,7 +323,7 @@ class TestBulkApproveRuns:
         assert "Одобрено 3 run(s)" in text
         assert mock_db.repos.generation_runs.set_moderation_status.await_count == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.set_moderation_status = AsyncMock(side_effect=Exception("fail"))
@@ -333,7 +333,7 @@ class TestBulkApproveRuns:
 
 
 class TestBulkRejectRuns:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rejects_multiple(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
@@ -342,19 +342,19 @@ class TestBulkRejectRuns:
         text = _text(result)
         assert "Отклонено 2 run(s)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_ids(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_reject_runs"]({"run_ids": "x", "confirm": True})
         assert "числами через запятую" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_ids(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_reject_runs"]({"run_ids": "", "confirm": True})
         assert "пуст" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_reject_runs"]({"run_ids": "1"})
@@ -376,13 +376,13 @@ def _make_pool_with_account(phone="+79001234567"):
 
 
 class TestSearchMyTelegram:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["search_dialogs"]({"phone": "+79001234567"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_data(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -399,7 +399,7 @@ class TestSearchMyTelegram:
         text = _text(result)
         assert "Диалоги (2)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_dialogs(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -411,7 +411,7 @@ class TestSearchMyTelegram:
             result = await handlers["search_dialogs"]({"phone": "+79001234567"})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_dialogs_shown_without_limit(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -428,7 +428,7 @@ class TestSearchMyTelegram:
         assert "Диалоги (105)" in text
         assert "и ещё" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filter_empty_distinguishes_from_no_dialogs(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -446,7 +446,7 @@ class TestSearchMyTelegram:
         assert "Всего диалогов" in text
         assert "не найдены" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_limit_param(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -462,7 +462,7 @@ class TestSearchMyTelegram:
         text = _text(result)
         assert "Диалоги (3)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_param(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -483,7 +483,7 @@ class TestSearchMyTelegram:
         assert "Python Weekly" in text
         assert "Golang Daily" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_type_alias_channels(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -503,7 +503,7 @@ class TestSearchMyTelegram:
         assert "Chan" in text
         assert "Group" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_type_alias_groups(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -522,7 +522,7 @@ class TestSearchMyTelegram:
         assert "Диалоги (2)" in text
         assert "Chan" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_type_exact(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -540,7 +540,7 @@ class TestSearchMyTelegram:
         assert "Диалоги (1)" in text
         assert "Bot1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -554,13 +554,13 @@ class TestSearchMyTelegram:
 
 
 class TestLeaveDialogs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["leave_dialogs"]({"phone": "+7999", "dialog_ids": "1,2"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_dialog_ids(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -570,7 +570,7 @@ class TestLeaveDialogs:
         result = await handlers["leave_dialogs"]({"phone": "+79001234567", "dialog_ids": ""})
         assert "dialog_ids обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -580,7 +580,7 @@ class TestLeaveDialogs:
         result = await handlers["leave_dialogs"]({"phone": "+79001234567", "dialog_ids": "1,2"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_leave_success(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -594,7 +594,7 @@ class TestLeaveDialogs:
             )
         assert "2/2" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_leave_exception(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -610,7 +610,7 @@ class TestLeaveDialogs:
 
 
 class TestGetCacheStatus:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_cache(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=[])
@@ -618,7 +618,7 @@ class TestGetCacheStatus:
         result = await handlers["get_cache_status"]({})
         assert "Кеш диалогов пуст" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_phones(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=["+79001234567"])
@@ -632,7 +632,7 @@ class TestGetCacheStatus:
         assert "+79001234567" in text
         assert "42 записей" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_no_cached_at(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=["+7999"])
@@ -642,7 +642,7 @@ class TestGetCacheStatus:
         result = await handlers["get_cache_status"]({})
         assert "—" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(side_effect=Exception("oops"))
@@ -652,13 +652,13 @@ class TestGetCacheStatus:
 
 
 class TestCreateTelegramChannel:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["create_telegram_channel"]({"phone": "+7999", "title": "My Chan"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_title(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -668,7 +668,7 @@ class TestCreateTelegramChannel:
         result = await handlers["create_telegram_channel"]({"phone": "+79001234567", "title": ""})
         assert "title обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         pool = _make_pool_with_account()
         mock_db.get_accounts = AsyncMock(
@@ -680,7 +680,7 @@ class TestCreateTelegramChannel:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_client_not_found(self, mock_db):
         pool = _make_pool_with_account()
         pool.get_native_client_by_phone = AsyncMock(return_value=None)
@@ -726,19 +726,19 @@ def _photo_patches(photo_task_svc, auto_upload_svc):
 
 
 class TestCancelPhotoItem:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_item_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["cancel_photo_item"]({})
         assert "item_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["cancel_photo_item"]({"item_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_success(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         photo_task_svc.cancel_item = AsyncMock(return_value=True)
@@ -750,7 +750,7 @@ class TestCancelPhotoItem:
             result = await handlers["cancel_photo_item"]({"item_id": 5, "confirm": True})
         assert "отменено" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_item_not_found(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         photo_task_svc.cancel_item = AsyncMock(return_value=False)
@@ -763,7 +763,7 @@ class TestCancelPhotoItem:
         text = _text(result)
         assert "Не удалось отменить" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         photo_task_svc.cancel_item = AsyncMock(side_effect=Exception("db"))
@@ -777,13 +777,13 @@ class TestCancelPhotoItem:
 
 
 class TestToggleAutoUpload:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_job_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_auto_upload"]({})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_job_not_found(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         auto_upload_svc.get_job = AsyncMock(return_value=None)
@@ -795,7 +795,7 @@ class TestToggleAutoUpload:
             result = await handlers["toggle_auto_upload"]({"job_id": 1})
         assert "не найдена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_active_to_paused(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         job = MagicMock()
@@ -810,7 +810,7 @@ class TestToggleAutoUpload:
             result = await handlers["toggle_auto_upload"]({"job_id": 1})
         assert "приостановлена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_paused_to_active(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         job = MagicMock()
@@ -825,7 +825,7 @@ class TestToggleAutoUpload:
             result = await handlers["toggle_auto_upload"]({"job_id": 1})
         assert "активирована" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         auto_upload_svc.get_job = AsyncMock(side_effect=Exception("fail"))
@@ -839,20 +839,20 @@ class TestToggleAutoUpload:
 
 
 class TestRunPhotoDue:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["run_photo_due"]({})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         pool = _make_pool_with_account()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["run_photo_due"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_due_success(self, mock_db):
         pool = _make_pool_with_account()
         photo_task_svc, auto_upload_svc = _make_photo_services()
@@ -868,7 +868,7 @@ class TestRunPhotoDue:
         assert "items=3" in text
         assert "auto_jobs=1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         pool = _make_pool_with_account()
         with patch("src.database.bundles.PhotoLoaderBundle"):
@@ -900,14 +900,14 @@ class TestImageGenerationService:
         svc = ImageGenerationService(adapters={})
         assert svc.adapter_names == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_available_false_no_adapters(self):
         from src.services.image_generation_service import ImageGenerationService
 
         svc = ImageGenerationService(adapters={})
         assert not await svc.is_available()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_available_true_with_adapter(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -942,7 +942,7 @@ class TestImageGenerationService:
         assert provider is None
         assert model_id == ""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_no_text_returns_none(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -950,7 +950,7 @@ class TestImageGenerationService:
         result = await svc.generate("together:model", "")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_no_adapters_returns_none(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -958,7 +958,7 @@ class TestImageGenerationService:
         result = await svc.generate("together:model", "some text")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_success(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -967,7 +967,7 @@ class TestImageGenerationService:
         result = await svc.generate("together:FLUX.1-schnell", "test prompt")
         assert result == "http://img.example.com/x.png"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_unknown_provider_uses_fallback(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -977,7 +977,7 @@ class TestImageGenerationService:
         result = await svc.generate("replicate:some-model", "text")
         assert result == "http://fallback.example.com/img.png"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_os_error_returns_none(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -986,7 +986,7 @@ class TestImageGenerationService:
         result = await svc.generate("x:model", "text")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_unexpected_error_returns_none(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -995,7 +995,7 @@ class TestImageGenerationService:
         result = await svc.generate("x:model", "text")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_models_together(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -1004,7 +1004,7 @@ class TestImageGenerationService:
         assert len(models) > 0
         assert models[0]["id"].startswith("black-forest-labs")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_models_openai(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -1013,7 +1013,7 @@ class TestImageGenerationService:
         ids = [m["id"] for m in models]
         assert "dall-e-3" in ids
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_models_with_query_filter(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -1021,7 +1021,7 @@ class TestImageGenerationService:
         models = await svc.search_models("openai", query="dall-e-3")
         assert all("dall-e-3" in m["id"] for m in models)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_models_unknown_provider_empty(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -1029,7 +1029,7 @@ class TestImageGenerationService:
         models = await svc.search_models("unknown_provider")
         assert models == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_models_replicate_no_token(self):
         from src.services.image_generation_service import ImageGenerationService
 
@@ -1047,7 +1047,7 @@ class TestImageGenerationService:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_and_count_embeddings(db):
     """Test insert_message + count_embeddings basic flow."""
     from datetime import datetime
@@ -1064,7 +1064,7 @@ async def test_messages_insert_and_count_embeddings(db):
     assert inserted
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_duplicate_returns_false(db):
     """Duplicate inserts should return False."""
     from datetime import datetime
@@ -1083,7 +1083,7 @@ async def test_messages_insert_duplicate_returns_false(db):
     assert not second
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_with_reactions(db):
     """Messages with reactions_json should populate message_reactions."""
     from datetime import datetime
@@ -1102,7 +1102,7 @@ async def test_messages_insert_with_reactions(db):
     assert inserted
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_batch(db):
     """insert_messages_batch should return count of inserted rows."""
     from datetime import datetime
@@ -1122,39 +1122,39 @@ async def test_messages_insert_batch(db):
     assert count == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_empty_batch(db):
     count = await db.repos.messages.insert_messages_batch([])
     assert count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_get_embedding_dimensions_none(db):
     dims = await db.repos.messages.get_embedding_dimensions()
     assert dims is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_ensure_embeddings_table(db):
     await db.repos.messages.ensure_embeddings_table(128)
     dims = await db.repos.messages.get_embedding_dimensions()
     assert dims == 128
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_ensure_embeddings_table_invalid(db):
     with pytest.raises(ValueError):
         await db.repos.messages.ensure_embeddings_table(0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_ensure_embeddings_table_dimension_mismatch(db):
     await db.repos.messages.ensure_embeddings_table(128)
     with pytest.raises(RuntimeError):
         await db.repos.messages.ensure_embeddings_table(256)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_upsert_embeddings(db):
     from datetime import datetime
 
@@ -1182,7 +1182,7 @@ async def test_messages_upsert_embeddings(db):
     assert total >= 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_upsert_embedding_json(db):
     from datetime import datetime
 
@@ -1209,14 +1209,14 @@ async def test_messages_upsert_embedding_json(db):
     assert loaded[0][1] == pytest.approx([0.5, 0.6, 0.7], abs=1e-6)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_no_query(db):
     msgs, total = await db.repos.messages.search_messages()
     assert isinstance(msgs, list)
     assert isinstance(total, int)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_normalize_date_to_date_only():
     from src.database.repositories.messages import MessagesRepository
 
@@ -1225,7 +1225,7 @@ async def test_messages_normalize_date_to_date_only():
     assert val == "2025-01-16"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_normalize_date_to_datetime():
     from src.database.repositories.messages import MessagesRepository
 
@@ -1234,7 +1234,7 @@ async def test_messages_normalize_date_to_datetime():
     assert val == "2025-01-15T12:00:00"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_normalize_date_to_none():
     from src.database.repositories.messages import MessagesRepository
 
@@ -1248,7 +1248,7 @@ async def test_messages_normalize_date_to_none():
 # ===========================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_idempotent(db):
     """Running migrations again on an initialized DB should not raise."""
     import aiosqlite
@@ -1269,7 +1269,7 @@ async def test_migrations_idempotent(db):
         assert isinstance(result2, bool)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_adds_missing_columns():
     """If columns are missing, migrations should add them."""
     import aiosqlite
@@ -1293,7 +1293,7 @@ async def test_migrations_adds_missing_columns():
         assert "reactions_json" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_renames_legacy_dialog_search_permission_key():
     import json
 
@@ -1324,7 +1324,7 @@ async def test_migrations_renames_legacy_dialog_search_permission_key():
         assert legacy_key not in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_skips_without_table():
     """_migrate_vec_to_portable should return early if vec_messages table doesn't exist."""
     import aiosqlite
@@ -1367,7 +1367,7 @@ def _make_task_enqueuer():
     return enqueuer
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_start_with_task_enqueuer():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1390,7 +1390,7 @@ async def test_scheduler_start_with_task_enqueuer():
     await mgr.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_stop_without_start():
     """Stop on non-running scheduler should not raise."""
     from src.config import SchedulerConfig
@@ -1400,7 +1400,7 @@ async def test_scheduler_stop_without_start():
     await mgr.stop()  # Should be a no-op
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_stop_cancels_bg_task():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1414,7 +1414,7 @@ async def test_scheduler_stop_cancels_bg_task():
     assert mgr._bg_task is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_trigger_background_idempotent():
     """Second trigger_background call should not create another task if first is running."""
     import asyncio
@@ -1443,7 +1443,7 @@ async def test_scheduler_trigger_background_idempotent():
     await mgr._bg_task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_photo_due_no_enqueuer():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1453,7 +1453,7 @@ async def test_scheduler_run_photo_due_no_enqueuer():
     assert "processed" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_photo_auto_no_enqueuer():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1463,7 +1463,7 @@ async def test_scheduler_run_photo_auto_no_enqueuer():
     assert "jobs" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_photo_due_with_enqueuer():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1475,7 +1475,7 @@ async def test_scheduler_run_photo_due_with_enqueuer():
     enqueuer.enqueue_photo_due.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_photo_auto_with_enqueuer():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1487,7 +1487,7 @@ async def test_scheduler_run_photo_auto_with_enqueuer():
     enqueuer.enqueue_photo_auto.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_photo_due_exception():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1500,7 +1500,7 @@ async def test_scheduler_run_photo_due_exception():
     assert isinstance(result, dict)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_pipeline_job():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1511,7 +1511,7 @@ async def test_scheduler_run_pipeline_job():
     enqueuer.enqueue_pipeline_run.assert_awaited_once_with(42)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_content_generate_job():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1522,7 +1522,7 @@ async def test_scheduler_run_content_generate_job():
     enqueuer.enqueue_content_generate.assert_awaited_once_with(7)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_run_search_query():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1533,7 +1533,7 @@ async def test_scheduler_run_search_query():
     enqueuer.enqueue_sq_stats.assert_awaited_once_with(5)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_get_job_next_run_no_scheduler():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1543,7 +1543,7 @@ async def test_scheduler_get_job_next_run_no_scheduler():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_get_all_jobs_no_scheduler():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1553,7 +1553,7 @@ async def test_scheduler_get_all_jobs_no_scheduler():
     assert result == {}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_get_potential_jobs_no_bundles():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1563,7 +1563,7 @@ async def test_scheduler_get_potential_jobs_no_bundles():
     assert any(j["job_id"] == "collect_all" for j in jobs)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_load_settings_no_bundle():
     """load_settings with no bundle should be a no-op."""
     from src.config import SchedulerConfig
@@ -1574,7 +1574,7 @@ async def test_scheduler_load_settings_no_bundle():
     assert mgr.interval_minutes == 45
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_is_job_enabled_no_bundle():
     from src.config import SchedulerConfig
     from src.scheduler.service import SchedulerManager
@@ -1583,7 +1583,7 @@ async def test_scheduler_is_job_enabled_no_bundle():
     assert await mgr.is_job_enabled("collect_all")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_sync_job_state_not_running():
     """sync_job_state should be a no-op when scheduler is not running."""
     from src.config import SchedulerConfig
@@ -1593,7 +1593,7 @@ async def test_scheduler_sync_job_state_not_running():
     await mgr.sync_job_state("collect_all", True)  # Should not raise
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_update_interval_no_job():
     """update_interval when job is disabled should just store the value."""
     from src.config import SchedulerConfig
@@ -1613,7 +1613,7 @@ async def test_scheduler_update_interval_no_job():
 # ===========================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_no_pool():
     from src.search.telegram_search import TelegramSearch
 
@@ -1625,7 +1625,7 @@ async def test_telegram_search_no_pool():
     assert "аккаунтов" in result.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_no_premium_client():
     from src.search.telegram_search import TelegramSearch
 
@@ -1643,7 +1643,7 @@ async def test_telegram_search_no_premium_client():
     assert result.error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_my_chats_no_pool():
     from src.search.telegram_search import TelegramSearch
 
@@ -1654,7 +1654,7 @@ async def test_telegram_search_my_chats_no_pool():
     assert result.error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_my_chats_no_client():
     from src.search.telegram_search import TelegramSearch
 
@@ -1669,7 +1669,7 @@ async def test_telegram_search_my_chats_no_client():
     assert "доступных" in result.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_in_channel_no_pool():
     from src.search.telegram_search import TelegramSearch
 
@@ -1680,7 +1680,7 @@ async def test_telegram_search_in_channel_no_pool():
     assert result.error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telegram_search_in_channel_no_client():
     from src.search.telegram_search import TelegramSearch
 
@@ -1694,7 +1694,7 @@ async def test_telegram_search_in_channel_no_client():
     assert result.error is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_search_quota_no_pool():
     from src.search.telegram_search import TelegramSearch
 
@@ -1705,7 +1705,7 @@ async def test_check_search_quota_no_pool():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_search_quota_no_premium():
     from src.search.telegram_search import TelegramSearch
 
@@ -1719,7 +1719,7 @@ async def test_check_search_quota_no_premium():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_unavailability_reason_no_pool():
     from src.search.telegram_search import TelegramSearch
 
@@ -1730,7 +1730,7 @@ async def test_get_premium_unavailability_reason_no_pool():
     assert "аккаунтов" in reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_unavailability_reason_no_method():
     from src.search.telegram_search import TelegramSearch
 
@@ -1782,7 +1782,7 @@ def _make_task(task_type, payload=None, task_id=1):
     return task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_start_recovers_tasks():
     from src.services.unified_dispatcher import UnifiedDispatcher
 
@@ -1799,7 +1799,7 @@ async def test_dispatcher_start_recovers_tasks():
     tasks_repo.requeue_running_generic_tasks_on_startup.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_start_idempotent():
     from src.services.unified_dispatcher import UnifiedDispatcher
 
@@ -1818,7 +1818,7 @@ async def test_dispatcher_start_idempotent():
     await dispatcher.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_photo_due_no_service():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1837,7 +1837,7 @@ async def test_dispatcher_handle_photo_due_no_service():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_photo_due_with_service():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1858,7 +1858,7 @@ async def test_dispatcher_handle_photo_due_with_service():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_photo_auto_no_service():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1877,7 +1877,7 @@ async def test_dispatcher_handle_photo_auto_no_service():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_photo_auto_with_service():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1898,7 +1898,7 @@ async def test_dispatcher_handle_photo_auto_with_service():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_sq_stats_no_bundle():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1919,7 +1919,7 @@ async def test_dispatcher_handle_sq_stats_no_bundle():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_sq_stats_invalid_payload():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1941,7 +1941,7 @@ async def test_dispatcher_handle_sq_stats_invalid_payload():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_dispatch_unknown_task_type():
     from src.models import CollectionTaskStatus
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1964,7 +1964,7 @@ async def test_dispatcher_dispatch_unknown_task_type():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_photo_due_exception():
     from src.models import CollectionTaskStatus, CollectionTaskType
     from src.services.unified_dispatcher import UnifiedDispatcher
@@ -1985,7 +1985,7 @@ async def test_dispatcher_handle_photo_due_exception():
     assert any(CollectionTaskStatus.FAILED in c.args for c in calls)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatcher_handle_stats_all_empty_channels():
     from src.models import CollectionTaskStatus, CollectionTaskType, StatsAllTaskPayload
     from src.services.unified_dispatcher import UnifiedDispatcher

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -49,7 +49,7 @@ def _text(result: dict) -> str:
 class TestSearchMessagesTool:
     """Tests for the search_messages tool handler."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_result(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
         handlers = _get_tool_handlers(mock_db)
@@ -61,7 +61,7 @@ class TestSearchMessagesTool:
         assert "nonexistent" in _text(result)
         mock_db.search_messages.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db):
         mock_messages = [
             SimpleNamespace(
@@ -88,7 +88,7 @@ class TestSearchMessagesTool:
         assert "channel_id=200" in text
         mock_db.search_messages.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_text_truncation(self, mock_db):
         """Tool truncates message text to 300 chars."""
         long_text = "x" * 500
@@ -105,7 +105,7 @@ class TestSearchMessagesTool:
         assert "x" * 300 in text
         assert "x" * 301 not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_none_text_handled(self, mock_db):
         """Tool handles messages with None text without crashing."""
         mock_messages = [
@@ -119,7 +119,7 @@ class TestSearchMessagesTool:
         text = _text(result)
         assert "channel_id=100" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_default_limit(self, mock_db):
         """Tool applies default limit=20 when not provided."""
         mock_db.search_messages = AsyncMock(return_value=([], 0))
@@ -129,7 +129,7 @@ class TestSearchMessagesTool:
 
         mock_db.search_messages.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_custom_limit(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
         handlers = _get_tool_handlers(mock_db)
@@ -141,7 +141,7 @@ class TestSearchMessagesTool:
         assert call_kwargs["query"] == "test"
         assert call_kwargs["limit"] == 50
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text_not_exception(self, mock_db):
         """Tool catches DB errors and returns error text (no exception raised)."""
         mock_db.search_messages = AsyncMock(side_effect=Exception("DB connection error"))
@@ -155,7 +155,7 @@ class TestSearchMessagesTool:
 
 
 class TestSemanticSearchTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db):
         mock_messages = [
             SimpleNamespace(
@@ -187,7 +187,7 @@ class TestSemanticSearchTool:
         assert "Semantic result" in text
         mock_db.search_semantic_messages.assert_awaited_once_with([1.0, 0.0], limit=5)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text_not_exception(self, mock_db):
         class BrokenEmbeddingService:
             def __init__(self, _db, **_kwargs):
@@ -213,7 +213,7 @@ class TestSemanticSearchTool:
 class TestGetChannelsTool:
     """Tests for the get_channels tool handler."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_channels = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -222,7 +222,7 @@ class TestGetChannelsTool:
 
         assert "Каналы не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_channels(self, mock_db):
         mock_channels = [
             SimpleNamespace(
@@ -254,7 +254,7 @@ class TestGetChannelsTool:
         assert "неактивен" in text
         assert "[отфильтрован]" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_none_username(self, mock_db):
         """Channel with username=None renders @None (known pre-existing issue)."""
         mock_channels = [
@@ -277,7 +277,7 @@ class TestGetChannelsTool:
         # Known issue: renders @None for channels without username
         assert "@None" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text_not_exception(self, mock_db):
         """Tool catches DB errors and returns error text."""
         mock_db.get_channels = AsyncMock(side_effect=Exception("DB query failed"))
@@ -296,7 +296,7 @@ class TestGetChannelsTool:
 
 
 class TestListPipelinesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list = AsyncMock(return_value=[])
@@ -305,7 +305,7 @@ class TestListPipelinesTool:
 
         assert "Пайплайны не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipelines(self, mock_db):
         pipeline = SimpleNamespace(
             id=1,
@@ -333,7 +333,7 @@ class TestListPipelinesTool:
 
 
 class TestListPendingModerationTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
@@ -342,7 +342,7 @@ class TestListPendingModerationTool:
         result = await handlers["list_pending_moderation"]({})
         assert "Нет черновиков на модерации" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs(self, mock_db):
         run = SimpleNamespace(
             id=42, pipeline_id=1, generated_text="Draft content here", created_at="2026-01-01"
@@ -363,7 +363,7 @@ class TestListPendingModerationTool:
 
 
 class TestApproveRejectRunTools:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approve_success(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(
@@ -376,7 +376,7 @@ class TestApproveRejectRunTools:
         assert "одобрен" in _text(result)
         mock_db.repos.generation_runs.set_moderation_status.assert_awaited_once_with(1, "approved")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reject_success(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(
@@ -389,7 +389,7 @@ class TestApproveRejectRunTools:
         assert "отклонён" in _text(result)
         mock_db.repos.generation_runs.set_moderation_status.assert_awaited_once_with(1, "rejected")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approve_missing_run_id(self, mock_db):
         mock_db.repos = MagicMock()
         handlers = _get_tool_handlers(mock_db)
@@ -397,7 +397,7 @@ class TestApproveRejectRunTools:
         result = await handlers["approve_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approve_not_found(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
@@ -413,7 +413,7 @@ class TestApproveRejectRunTools:
 
 
 class TestAnalyticsSummaryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_summary(self, mock_db):
         summary = {
             "total_generations": 50,
@@ -439,7 +439,7 @@ class TestAnalyticsSummaryTool:
 
 
 class TestTrendingTopicsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_topics(self, mock_db):
         topics = [
             SimpleNamespace(keyword="AI", count=100),
@@ -454,7 +454,7 @@ class TestTrendingTopicsTool:
         assert "AI" in text
         assert "100 упоминаний" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_trending_topics = AsyncMock(return_value=[])
@@ -470,7 +470,7 @@ class TestTrendingTopicsTool:
 
 
 class TestCalendarTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_events(self, mock_db):
         event = SimpleNamespace(
             run_id=1,
@@ -490,7 +490,7 @@ class TestCalendarTool:
         assert "News" in text
         assert "run_id=1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
             mock_svc.return_value.get_upcoming = AsyncMock(return_value=[])
@@ -506,7 +506,7 @@ class TestCalendarTool:
 
 
 class TestPipelineStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_stats(self, mock_db):
         stat = SimpleNamespace(
             pipeline_id=1,
@@ -534,7 +534,7 @@ class TestPipelineStatsTool:
 
 
 class TestChannelStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_stats(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(
@@ -547,7 +547,7 @@ class TestChannelStatsTool:
         assert "channel_id=100" in text
         assert "5000" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
@@ -563,13 +563,13 @@ class TestChannelStatsTool:
 
 
 class TestRunPipelineTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["run_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(return_value=None)
@@ -578,7 +578,7 @@ class TestRunPipelineTool:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_inactive(self, mock_db):
         pipeline = SimpleNamespace(id=1, name="Inactive", is_active=False)
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -760,20 +760,20 @@ class TestConfigPropagation:
 
 
 class TestRefreshChannelMetaTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["refresh_channel_meta"]({"confirm": True})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         mock_pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["refresh_channel_meta"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_single_channel(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.fetch_channel_meta = AsyncMock(return_value={
@@ -791,7 +791,7 @@ class TestRefreshChannelMetaTool:
         assert "News" in text
         mock_db.update_channel_full_meta.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_not_found(self, mock_db):
         mock_pool = MagicMock()
         mock_db.get_channels = AsyncMock(return_value=[])
@@ -806,13 +806,13 @@ class TestRefreshChannelMetaTool:
 
 
 class TestGetAccountInfoTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["get_account_info"]({})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_info(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.get_users_info = AsyncMock(return_value=[
@@ -829,7 +829,7 @@ class TestGetAccountInfoTool:
         assert "@johndoe" in text
         assert "premium=да" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_accounts(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.get_users_info = AsyncMock(return_value=[])
@@ -844,19 +844,19 @@ class TestGetAccountInfoTool:
 
 
 class TestSetSchedulerIntervalTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_scheduler_interval"]({"job_id": "collect_all", "minutes": 30})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_job_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_scheduler_interval"]({"minutes": 30, "confirm": True})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sets_interval(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.settings.set_setting = AsyncMock()
@@ -867,7 +867,7 @@ class TestSetSchedulerIntervalTool:
         assert "60 мин" in _text(result)
         mock_db.repos.settings.set_setting.assert_awaited_once_with("collect_interval_minutes", "60")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clamps_minutes(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.settings.set_setting = AsyncMock()
@@ -877,7 +877,7 @@ class TestSetSchedulerIntervalTool:
         )
         assert "1440 мин" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_rejects_non_collect_all(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_scheduler_interval"](
@@ -887,13 +887,13 @@ class TestSetSchedulerIntervalTool:
 
 
 class TestCancelSchedulerTaskTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["cancel_scheduler_task"]({"task_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancels_task(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.cancel_collection_task = AsyncMock(return_value=True)
@@ -901,7 +901,7 @@ class TestCancelSchedulerTaskTool:
         result = await handlers["cancel_scheduler_task"]({"task_id": 42, "confirm": True})
         assert "отменена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_task_not_found(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.cancel_collection_task = AsyncMock(return_value=False)
@@ -911,13 +911,13 @@ class TestCancelSchedulerTaskTool:
 
 
 class TestClearPendingTasksTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["clear_pending_tasks"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clears_tasks(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.delete_pending_channel_tasks = AsyncMock(return_value=5)
@@ -932,7 +932,7 @@ class TestClearPendingTasksTool:
 
 
 class TestGetSearchQueryStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_stats(self, mock_db):
         fake_stats = [
             SimpleNamespace(day="2025-01-01", count=10),
@@ -949,13 +949,13 @@ class TestGetSearchQueryStatsTool:
         assert "2025-01-02" in text
         assert "25" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_search_query_stats"]({})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_stats(self, mock_db):
         with patch("src.services.search_query_service.SearchQueryService") as mock_svc_cls:
             mock_svc_cls.return_value.get_daily_stats = AsyncMock(return_value=[])
@@ -971,7 +971,7 @@ class TestGetSearchQueryStatsTool:
 
 
 class TestNotificationDryRunTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_active_queries(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=None)
@@ -980,7 +980,7 @@ class TestNotificationDryRunTool:
         result = await handlers["notification_dry_run"]({})
         assert "Нет активных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_zero_when_no_since(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.tasks.get_last_completed_collect_task = AsyncMock(return_value=None)
@@ -993,7 +993,7 @@ class TestNotificationDryRunTool:
         assert "Test Query" in text
         assert "0 совпадений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_actual_match_counts(self, mock_db):
         from datetime import datetime, timezone
 
@@ -1019,13 +1019,13 @@ class TestNotificationDryRunTool:
 
 
 class TestListPhotoDialogsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["list_photo_dialogs"]({})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_dialogs(self, mock_db):
         mock_pool = MagicMock()
         mock_db.get_accounts = AsyncMock(return_value=[
@@ -1051,7 +1051,7 @@ class TestListPhotoDialogsTool:
 
 
 class TestRefreshPhotoDialogsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         mock_pool = MagicMock()
         mock_db.get_accounts = AsyncMock(return_value=[
@@ -1062,7 +1062,7 @@ class TestRefreshPhotoDialogsTool:
         result = await handlers["refresh_photo_dialogs"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refreshes(self, mock_db):
         mock_pool = MagicMock()
         mock_db.get_accounts = AsyncMock(return_value=[

--- a/tests/test_agent_tools_accounts.py
+++ b/tests/test_agent_tools_accounts.py
@@ -25,14 +25,14 @@ def _make_account(
 
 
 class TestListAccountsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_accounts"]({})
         assert "Аккаунты не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_accounts_shows_phone_and_status(self, mock_db):
         acc = _make_account(phone="+71112223344", is_active=True)
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -43,7 +43,7 @@ class TestListAccountsTool:
         assert "активен" in text
         assert "Аккаунты (1)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_account_shows_inactive(self, mock_db):
         acc = _make_account(phone="+70000000000", is_active=False)
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -51,7 +51,7 @@ class TestListAccountsTool:
         result = await handlers["list_accounts"]({})
         assert "неактивен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flood_wait_shown(self, mock_db):
         acc = _make_account(flood_wait_until="2025-01-01 12:00:00")
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -59,7 +59,7 @@ class TestListAccountsTool:
         result = await handlers["list_accounts"]({})
         assert "flood_wait" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_accounts = AsyncMock(side_effect=Exception("conn error"))
         handlers = _get_tool_handlers(mock_db)
@@ -69,13 +69,13 @@ class TestListAccountsTool:
 
 
 class TestToggleAccountTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_account_id_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_account"]({})
         assert "account_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_account_not_found_returns_error(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -83,7 +83,7 @@ class TestToggleAccountTool:
         assert "не найден" in _text(result)
         assert "999" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_account_gets_deactivated(self, mock_db):
         acc = _make_account(acc_id=1, phone="+71111111111", is_active=True)
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -94,7 +94,7 @@ class TestToggleAccountTool:
         assert "деактивирован" in text
         mock_db.set_account_active.assert_awaited_once_with(1, False)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_account_gets_activated(self, mock_db):
         acc = _make_account(acc_id=2, phone="+72222222222", is_active=False)
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -105,7 +105,7 @@ class TestToggleAccountTool:
         assert "активирован" in text
         mock_db.set_account_active.assert_awaited_once_with(2, True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_accounts = AsyncMock(side_effect=Exception("db fail"))
         handlers = _get_tool_handlers(mock_db)
@@ -114,20 +114,20 @@ class TestToggleAccountTool:
 
 
 class TestDeleteAccountTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_account_id_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_account"]({})
         assert "account_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_account"]({"account_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deletes_account(self, mock_db):
         acc = _make_account(acc_id=5, phone="+75555555555")
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -137,7 +137,7 @@ class TestDeleteAccountTool:
         assert "удалён" in _text(result)
         mock_db.delete_account.assert_awaited_once_with(5)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         mock_db.delete_account = AsyncMock(side_effect=Exception("constraint"))
@@ -147,14 +147,14 @@ class TestDeleteAccountTool:
 
 
 class TestGetFloodStatusTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_accounts_returns_not_found(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_flood_status"]({})
         assert "Аккаунты не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_flood_shows_no_restrictions(self, mock_db):
         acc = _make_account(phone="+71234567890", flood_wait_until=None)
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -162,7 +162,7 @@ class TestGetFloodStatusTool:
         result = await handlers["get_flood_status"]({})
         assert "нет ограничений" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flood_wait_until_shown(self, mock_db):
         acc = _make_account(phone="+70001112233", flood_wait_until="2025-06-01 10:00")
         mock_db.get_accounts = AsyncMock(return_value=[acc])
@@ -171,7 +171,7 @@ class TestGetFloodStatusTool:
         assert "заблокирован" in _text(result)
         assert "2025-06-01 10:00" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_accounts = AsyncMock(side_effect=RuntimeError("oops"))
         handlers = _get_tool_handlers(mock_db)
@@ -180,21 +180,21 @@ class TestGetFloodStatusTool:
 
 
 class TestClearFloodStatusTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account(phone="+71111111111")])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["clear_flood_status"]({"phone": "+71111111111"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_account_not_found_returns_error(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["clear_flood_status"]({"phone": "+79999999999", "confirm": True})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_clears_flood(self, mock_db):
         acc = _make_account(phone="+71111111111", flood_wait_until="2025-01-01")
         mock_db.get_accounts = AsyncMock(return_value=[acc])

--- a/tests/test_agent_tools_analytics.py
+++ b/tests/test_agent_tools_analytics.py
@@ -10,7 +10,7 @@ from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 class TestAnalyticsToolGetAnalyticsSummary:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_summary(self, mock_db):
         summary = {
             "total_generations": 100,
@@ -29,7 +29,7 @@ class TestAnalyticsToolGetAnalyticsSummary:
         assert "Аналитика контента" in text
         assert "Пайплайнов: 5" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_summary = AsyncMock(side_effect=Exception("analytics down"))
@@ -39,7 +39,7 @@ class TestAnalyticsToolGetAnalyticsSummary:
 
 
 class TestAnalyticsToolGetPipelineStats:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_pipeline_stats = AsyncMock(return_value=[])
@@ -47,7 +47,7 @@ class TestAnalyticsToolGetPipelineStats:
             result = await handlers["get_pipeline_stats"]({})
         assert "не найдена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_stats(self, mock_db):
         stat = SimpleNamespace(
             pipeline_id=1,
@@ -67,7 +67,7 @@ class TestAnalyticsToolGetPipelineStats:
         assert "генераций=50" in text
         assert "80%" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_pipeline_stats = AsyncMock(side_effect=Exception("err"))
@@ -77,7 +77,7 @@ class TestAnalyticsToolGetPipelineStats:
 
 
 class TestAnalyticsToolGetTrendingTopics:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_trending_topics = AsyncMock(return_value=[])
@@ -85,7 +85,7 @@ class TestAnalyticsToolGetTrendingTopics:
             result = await handlers["get_trending_topics"]({"days": 7, "limit": 10})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_topics(self, mock_db):
         topics = [
             SimpleNamespace(keyword="Python", count=500),
@@ -100,7 +100,7 @@ class TestAnalyticsToolGetTrendingTopics:
         assert "500 упоминаний" in text
         assert "AI" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_trending_topics = AsyncMock(side_effect=Exception("trend err"))
@@ -110,7 +110,7 @@ class TestAnalyticsToolGetTrendingTopics:
 
 
 class TestAnalyticsToolGetTrendingChannels:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_trending_channels = AsyncMock(return_value=[])
@@ -118,7 +118,7 @@ class TestAnalyticsToolGetTrendingChannels:
             result = await handlers["get_trending_channels"]({})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_channels(self, mock_db):
         channels = [
             SimpleNamespace(title="TechChannel", channel_id=100, count=200),
@@ -135,7 +135,7 @@ class TestAnalyticsToolGetTrendingChannels:
 
 
 class TestAnalyticsToolGetMessageVelocity:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_message_velocity = AsyncMock(return_value=[])
@@ -143,7 +143,7 @@ class TestAnalyticsToolGetMessageVelocity:
             result = await handlers["get_message_velocity"]({"days": 30})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_velocity(self, mock_db):
         velocity = [
             SimpleNamespace(date="2026-01-01", count=1000),
@@ -157,7 +157,7 @@ class TestAnalyticsToolGetMessageVelocity:
         assert "2026-01-01" in text
         assert "1000 сообщений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_message_velocity = AsyncMock(side_effect=Exception("err"))
@@ -167,7 +167,7 @@ class TestAnalyticsToolGetMessageVelocity:
 
 
 class TestAnalyticsToolGetPeakHours:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_peak_hours = AsyncMock(return_value=[])
@@ -175,7 +175,7 @@ class TestAnalyticsToolGetPeakHours:
             result = await handlers["get_peak_hours"]({})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_hours(self, mock_db):
         hours = [
             SimpleNamespace(hour=9, count=500),
@@ -190,7 +190,7 @@ class TestAnalyticsToolGetPeakHours:
         assert "500 сообщений" in text
         assert "18:00" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_peak_hours = AsyncMock(side_effect=Exception("err"))
@@ -200,7 +200,7 @@ class TestAnalyticsToolGetPeakHours:
 
 
 class TestAnalyticsToolGetCalendar:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
             mock_svc.return_value.get_upcoming = AsyncMock(return_value=[])
@@ -208,7 +208,7 @@ class TestAnalyticsToolGetCalendar:
             result = await handlers["get_calendar"]({"limit": 10})
         assert "Нет запланированных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_events(self, mock_db):
         event = SimpleNamespace(
             run_id=7,
@@ -228,7 +228,7 @@ class TestAnalyticsToolGetCalendar:
         assert "Content Pipe" in text
         assert "Preview of upcoming post" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.content_calendar_service.ContentCalendarService") as mock_svc:
             mock_svc.return_value.get_upcoming = AsyncMock(side_effect=Exception("cal err"))
@@ -238,7 +238,7 @@ class TestAnalyticsToolGetCalendar:
 
 
 class TestAnalyticsToolGetDailyStats:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_daily_stats = AsyncMock(return_value=[])
@@ -246,7 +246,7 @@ class TestAnalyticsToolGetDailyStats:
             result = await handlers["get_daily_stats"]({"days": 7})
         assert "Нет данных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_data(self, mock_db):
         rows = [
             {"date": "2026-01-01", "count": 10, "published": 8},
@@ -261,7 +261,7 @@ class TestAnalyticsToolGetDailyStats:
         assert "генераций=10" in text
         assert "опубл.=8" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_default_days(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_daily_stats = AsyncMock(return_value=[])
@@ -270,7 +270,7 @@ class TestAnalyticsToolGetDailyStats:
             # Should call with days=30 by default
             mock_svc.return_value.get_daily_stats.assert_awaited_once_with(days=30, pipeline_id=None)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_daily_stats = AsyncMock(side_effect=Exception("stats err"))
@@ -280,14 +280,14 @@ class TestAnalyticsToolGetDailyStats:
 
 
 class TestAnalyticsToolGetTopMessages:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_top_messages = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_top_messages"]({})
         assert "не найдены" in _text(result) or "Нет" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_messages(self, mock_db):
         msgs = [
             {
@@ -302,7 +302,7 @@ class TestAnalyticsToolGetTopMessages:
         assert "TestChannel" in text
         assert "50" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_date_range(self, mock_db):
         mock_db.get_top_messages = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -311,7 +311,7 @@ class TestAnalyticsToolGetTopMessages:
         })
         mock_db.get_top_messages.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.get_top_messages = AsyncMock(side_effect=Exception("db err"))
         handlers = _get_tool_handlers(mock_db)
@@ -320,7 +320,7 @@ class TestAnalyticsToolGetTopMessages:
 
 
 class TestAnalyticsToolGetContentTypeStats:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_engagement_by_media_type = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -329,7 +329,7 @@ class TestAnalyticsToolGetContentTypeStats:
         })
         assert "не найдены" in _text(result) or "Нет данных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_data(self, mock_db):
         rows = [
             {"content_type": "text", "message_count": 100, "avg_reactions": 5.0},
@@ -344,7 +344,7 @@ class TestAnalyticsToolGetContentTypeStats:
         assert "text" in text
         assert "100" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.get_engagement_by_media_type = AsyncMock(side_effect=Exception("err"))
         handlers = _get_tool_handlers(mock_db)
@@ -355,14 +355,14 @@ class TestAnalyticsToolGetContentTypeStats:
 
 
 class TestAnalyticsToolGetHourlyActivity:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.get_hourly_activity = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_hourly_activity"]({})
         assert "не найдены" in _text(result) or "Нет" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_data(self, mock_db):
         hours = [
             {"hour": 9, "message_count": 500, "avg_reactions": 5.0},
@@ -375,7 +375,7 @@ class TestAnalyticsToolGetHourlyActivity:
         assert "09:00" in text
         assert "500" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.get_hourly_activity = AsyncMock(side_effect=Exception("err"))
         handlers = _get_tool_handlers(mock_db)

--- a/tests/test_agent_tools_channels.py
+++ b/tests/test_agent_tools_channels.py
@@ -29,19 +29,19 @@ def _make_channel(
 
 
 class TestAddChannelTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_identifier_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_channel"]({})
         assert "identifier обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_channel"]({"identifier": "@testchan"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_adds_channel(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.add_by_identifier = AsyncMock(return_value=True)
@@ -49,7 +49,7 @@ class TestAddChannelTool:
             result = await handlers["add_channel"]({"identifier": "@mychan", "confirm": True})
         assert "успешно добавлен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_already_exists_returns_message(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.add_by_identifier = AsyncMock(return_value=False)
@@ -57,7 +57,7 @@ class TestAddChannelTool:
             result = await handlers["add_channel"]({"identifier": "@existing", "confirm": True})
         assert "уже существует" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.add_by_identifier = AsyncMock(side_effect=Exception("API error"))
@@ -67,20 +67,20 @@ class TestAddChannelTool:
 
 
 class TestDeleteChannelTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_channel"]({})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel())
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_channel"]({"pk": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deletes_channel(self, mock_db):
         ch = _make_channel(title="DeleteMe")
         mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
@@ -91,7 +91,7 @@ class TestDeleteChannelTool:
         assert "удалён" in _text(result)
         assert "DeleteMe" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel())
         with patch("src.services.channel_service.ChannelService") as mock_svc:
@@ -102,13 +102,13 @@ class TestDeleteChannelTool:
 
 
 class TestToggleChannelTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_channel"]({})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_channel_gets_deactivated(self, mock_db):
         ch_after = _make_channel(is_active=False, title="MyChan")
         with patch("src.services.channel_service.ChannelService") as mock_svc:
@@ -119,7 +119,7 @@ class TestToggleChannelTool:
         assert "неактивен" in _text(result)
         assert "MyChan" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.toggle = AsyncMock(side_effect=Exception("not found"))
@@ -129,25 +129,25 @@ class TestToggleChannelTool:
 
 
 class TestImportChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_text_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["import_channels"]({})
         assert "text обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_identifiers_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["import_channels"]({"text": "hello world nothing here"})
         assert "Не удалось распознать" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["import_channels"]({"text": "@chan1 @chan2"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_imports_channels(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.add_by_identifier = AsyncMock(return_value=True)
@@ -157,7 +157,7 @@ class TestImportChannelsTool:
         assert "Импорт завершён" in text
         assert "2/2" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_partial_failure_reported(self, mock_db):
         call_count = 0
 
@@ -182,14 +182,14 @@ class TestImportChannelsTool:
 
 
 class TestListTagsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         mock_db.repos.channels.list_all_tags = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_tags"]({})
         assert "Теги не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_tags(self, mock_db):
         mock_db.repos.channels.list_all_tags = AsyncMock(return_value=["news", "tech", "fun"])
         handlers = _get_tool_handlers(mock_db)
@@ -200,19 +200,19 @@ class TestListTagsTool:
 
 
 class TestCreateTagTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_name(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_tag"]({})
         assert "name обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_tag"]({"name": "newtag"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_creates_tag(self, mock_db):
         mock_db.repos.channels.create_tag = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -222,13 +222,13 @@ class TestCreateTagTool:
 
 
 class TestDeleteTagTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_tag"]({"name": "oldtag"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_deletes_tag(self, mock_db):
         mock_db.repos.channels.delete_tag = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -238,20 +238,20 @@ class TestDeleteTagTool:
 
 
 class TestSetChannelTagsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_channel_tags"]({"tags": "news,tech"})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_not_found(self, mock_db):
         mock_db.get_channel_by_pk = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_channel_tags"]({"pk": 999, "tags": "news"})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sets_tags(self, mock_db):
         ch = _make_channel(pk=1, title="TestChan")
         mock_db.get_channel_by_pk = AsyncMock(return_value=ch)
@@ -261,7 +261,7 @@ class TestSetChannelTagsTool:
         assert "обновлены" in _text(result)
         mock_db.repos.channels.set_channel_tags.assert_called_once_with(1, ["news", "tech"])
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clears_tags(self, mock_db):
         ch = _make_channel(pk=1, title="TestChan")
         mock_db.get_channel_by_pk = AsyncMock(return_value=ch)

--- a/tests/test_agent_tools_collection.py
+++ b/tests/test_agent_tools_collection.py
@@ -29,20 +29,20 @@ def _make_channel(
 
 
 class TestCollectChannelTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["collect_channel"]({"pk": 1})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk_returns_error(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["collect_channel"]({})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_not_found_returns_error(self, mock_db):
         pool = MagicMock()
         mock_db.get_channel_by_pk = AsyncMock(return_value=None)
@@ -50,7 +50,7 @@ class TestCollectChannelTool:
         result = await handlers["collect_channel"]({"pk": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filtered_channel_without_force_returns_warning(self, mock_db):
         pool = MagicMock()
         ch = _make_channel(is_filtered=True, title="SpamChan")
@@ -60,7 +60,7 @@ class TestCollectChannelTool:
         assert "отфильтрован" in _text(result)
         assert "force=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filtered_channel_with_force_enqueues(self, mock_db):
         pool = MagicMock()
         ch = _make_channel(is_filtered=True, title="SpamChan")
@@ -70,7 +70,7 @@ class TestCollectChannelTool:
         result = await handlers["collect_channel"]({"pk": 1, "force": True})
         assert "поставлен в очередь" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_normal_channel_enqueues(self, mock_db):
         pool = MagicMock()
         ch = _make_channel(title="GoodChan")
@@ -84,13 +84,13 @@ class TestCollectChannelTool:
 
 
 class TestCollectAllChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["collect_all_channels"]({})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_channels_returns_message(self, mock_db):
         pool = MagicMock()
         mock_db.get_channels = AsyncMock(return_value=[])
@@ -98,7 +98,7 @@ class TestCollectAllChannelsTool:
         result = await handlers["collect_all_channels"]({})
         assert "Нет активных каналов" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enqueues_all_active_channels(self, mock_db):
         pool = MagicMock()
         channels = [_make_channel(pk=i, channel_id=i * 100, title=f"Chan{i}") for i in range(3)]
@@ -112,20 +112,20 @@ class TestCollectAllChannelsTool:
 
 
 class TestCollectChannelStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["collect_channel_stats"]({"pk": 1})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk_returns_error(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["collect_channel_stats"]({})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_not_found_returns_error(self, mock_db):
         pool = MagicMock()
         mock_db.get_channel_by_pk = AsyncMock(return_value=None)
@@ -133,7 +133,7 @@ class TestCollectChannelStatsTool:
         result = await handlers["collect_channel_stats"]({"pk": 99})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enqueues_stats_task(self, mock_db):
         pool = MagicMock()
         ch = _make_channel(title="StatsChan")
@@ -147,13 +147,13 @@ class TestCollectChannelStatsTool:
 
 
 class TestCollectAllStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["collect_all_stats"]({})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_channels_returns_message(self, mock_db):
         pool = MagicMock()
         mock_db.get_channels = AsyncMock(return_value=[])
@@ -161,7 +161,7 @@ class TestCollectAllStatsTool:
         result = await handlers["collect_all_stats"]({})
         assert "Нет активных каналов" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enqueues_stats_for_all(self, mock_db):
         pool = MagicMock()
         channels = [_make_channel(pk=i, channel_id=i * 100) for i in range(5)]

--- a/tests/test_agent_tools_dialogs.py
+++ b/tests/test_agent_tools_dialogs.py
@@ -10,13 +10,13 @@ from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 class TestDialogsToolSearchDialogs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["search_dialogs"]({"phone": "+7123456"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_dialogs(self, mock_db):
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -30,7 +30,7 @@ class TestDialogsToolSearchDialogs:
             result = await handlers["search_dialogs"]({"phone": "+79001234567"})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_dialogs(self, mock_db):
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -52,13 +52,13 @@ class TestDialogsToolSearchDialogs:
 
 
 class TestDialogsToolRefreshDialogs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["refresh_dialogs"]({"phone": "+7123456"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_success(self, mock_db):
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -78,13 +78,13 @@ class TestDialogsToolRefreshDialogs:
 
 
 class TestDialogsToolLeaveDialogs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["leave_dialogs"]({"phone": "+7123456", "dialog_ids": "1,2"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_dialog_ids(self, mock_db):
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -97,7 +97,7 @@ class TestDialogsToolLeaveDialogs:
         )
         assert "dialog_ids обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
@@ -112,20 +112,20 @@ class TestDialogsToolLeaveDialogs:
 
 
 class TestDialogsToolGetForumTopics:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_channel_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_forum_topics"]({})
         assert "channel_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_topics(self, mock_db):
         mock_db.get_forum_topics = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_forum_topics"]({"channel_id": 123})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_topics(self, mock_db):
         topics = [
             {"topic_id": 1, "title": "General"},
@@ -139,7 +139,7 @@ class TestDialogsToolGetForumTopics:
         assert "Off-topic" in text
         assert "id=1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.get_forum_topics = AsyncMock(side_effect=Exception("no access"))
         handlers = _get_tool_handlers(mock_db)
@@ -148,14 +148,14 @@ class TestDialogsToolGetForumTopics:
 
 
 class TestDialogsToolClearDialogCache:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["clear_dialog_cache"]({"phone": "+79001234567", "confirm": False})
         assert "Подтвердите" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clears_for_phone(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=None)
         mock_db.repos = MagicMock()
@@ -167,7 +167,7 @@ class TestDialogsToolClearDialogCache:
         assert "очищен" in _text(result)
         mock_db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+79001234567")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clears_all_when_no_phone(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.clear_all_dialogs = AsyncMock()
@@ -178,7 +178,7 @@ class TestDialogsToolClearDialogCache:
 
 
 class TestDialogsToolGetCacheStatus:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_cache(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(return_value=[])
@@ -186,7 +186,7 @@ class TestDialogsToolGetCacheStatus:
         result = await handlers["get_cache_status"]({})
         assert "пуст" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_cache_entries(self, mock_db):
         from datetime import datetime, timezone
 
@@ -203,7 +203,7 @@ class TestDialogsToolGetCacheStatus:
         assert "42" in text
         assert "2026-01-01" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.dialog_cache.get_all_phones = AsyncMock(side_effect=Exception("cache err"))

--- a/tests/test_agent_tools_filters.py
+++ b/tests/test_agent_tools_filters.py
@@ -16,7 +16,7 @@ def _make_purge_result(purged=2, deleted=50):
 
 
 class TestAnalyzeFiltersTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_report(self, mock_db):
         """Empty report returns appropriate message."""
         report = MagicMock()
@@ -27,7 +27,7 @@ class TestAnalyzeFiltersTool:
             result = await handlers["analyze_filters"]({})
         assert "Нет каналов для анализа" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_with_flagged_channels(self, mock_db):
         """Flagged channels are listed with their flags."""
         r = MagicMock()
@@ -47,7 +47,7 @@ class TestAnalyzeFiltersTool:
         assert "spam" in text
         assert "1 рекомендовано" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_shows_all_beyond_30(self, mock_db):
         """More than 30 flagged channels are all shown without truncation."""
 
@@ -69,7 +69,7 @@ class TestAnalyzeFiltersTool:
         assert "35 рекомендовано" in text
         assert "и ещё" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_non_flagged_not_listed(self, mock_db):
         """Non-flagged channels don't appear in the flagged list."""
         ok = MagicMock()
@@ -87,7 +87,7 @@ class TestAnalyzeFiltersTool:
         assert "GoodChan" not in text
         assert "0 рекомендовано" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
             mock_analyzer.return_value.analyze_all = AsyncMock(side_effect=RuntimeError("DB fail"))
@@ -98,13 +98,13 @@ class TestAnalyzeFiltersTool:
 
 
 class TestApplyFiltersTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["apply_filters"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_applies_and_returns_count(self, mock_db):
         report = MagicMock()
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
@@ -117,7 +117,7 @@ class TestApplyFiltersTool:
         assert "3 каналов" in text
         assert "Фильтры применены" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
             mock_analyzer.return_value.analyze_all = AsyncMock(side_effect=Exception("oops"))
@@ -127,13 +127,13 @@ class TestApplyFiltersTool:
 
 
 class TestResetFiltersTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["reset_filters"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_resets_and_returns_count(self, mock_db):
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
             mock_analyzer.return_value.reset_filters = AsyncMock(return_value=7)
@@ -143,7 +143,7 @@ class TestResetFiltersTool:
         assert "7 каналов" in text
         assert "разблокированы" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
             mock_analyzer.return_value.reset_filters = AsyncMock(side_effect=Exception("nope"))
@@ -153,13 +153,13 @@ class TestResetFiltersTool:
 
 
 class TestToggleChannelFilterTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pk_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_channel_filter"]({})
         assert "pk обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_not_found(self, mock_db):
         mock_db.get_channel_by_pk = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
@@ -167,7 +167,7 @@ class TestToggleChannelFilterTool:
         assert "не найден" in _text(result)
         assert "999" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filtered_false_becomes_filtered(self, mock_db):
         ch = MagicMock()
         ch.is_filtered = False
@@ -181,7 +181,7 @@ class TestToggleChannelFilterTool:
         assert "отфильтрован" in text
         mock_db.set_channel_filtered.assert_awaited_once_with(1, True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filtered_true_becomes_unblocked(self, mock_db):
         ch = MagicMock()
         ch.is_filtered = True
@@ -195,7 +195,7 @@ class TestToggleChannelFilterTool:
         assert "разблокирован" in text
         mock_db.set_channel_filtered.assert_awaited_once_with(2, False)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_channel_by_pk = AsyncMock(side_effect=Exception("db error"))
         handlers = _get_tool_handlers(mock_db)
@@ -204,13 +204,13 @@ class TestToggleChannelFilterTool:
 
 
 class TestPurgeFilteredChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["purge_filtered_channels"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pks_and_confirm_purges_by_pks(self, mock_db):
         purge_result = _make_purge_result(purged=2, deleted=40)
         with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
@@ -222,7 +222,7 @@ class TestPurgeFilteredChannelsTool:
         assert "40 сообщений" in text
         mock_svc.return_value.purge_channels_by_pks.assert_awaited_once_with([1, 2])
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_pks_and_confirm_purges_all(self, mock_db):
         purge_result = _make_purge_result(purged=5, deleted=200)
         with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
@@ -234,7 +234,7 @@ class TestPurgeFilteredChannelsTool:
         assert "200 сообщений" in text
         mock_svc.return_value.purge_all_filtered.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
             mock_svc.return_value.purge_all_filtered = AsyncMock(side_effect=Exception("disk full"))
@@ -244,19 +244,19 @@ class TestPurgeFilteredChannelsTool:
 
 
 class TestHardDeleteChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_pks_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["hard_delete_channels"]({})
         assert "pks обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["hard_delete_channels"]({"pks": "1,2"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pks_and_confirm_deletes(self, mock_db):
         del_result = _make_purge_result(purged=2, deleted=0)
         with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
@@ -268,7 +268,7 @@ class TestHardDeleteChannelsTool:
         assert "безвозвратно" in text
         mock_svc.return_value.hard_delete_channels_by_pks.assert_awaited_once_with([3, 4])
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.filter_deletion_service.FilterDeletionService") as mock_svc:
             mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(side_effect=Exception("err"))

--- a/tests/test_agent_tools_images.py
+++ b/tests/test_agent_tools_images.py
@@ -10,13 +10,13 @@ from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 class TestImagesToolGenerateImage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_prompt(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["generate_image"]({"prompt": ""})
         assert "prompt обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_available(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=False)
@@ -24,7 +24,7 @@ class TestImagesToolGenerateImage:
             result = await handlers["generate_image"]({"prompt": "a cat"})
         assert "не настроена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_local_path_result(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
@@ -34,7 +34,7 @@ class TestImagesToolGenerateImage:
         text = _text(result)
         assert "/local/path/image.png" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_result(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
@@ -43,7 +43,7 @@ class TestImagesToolGenerateImage:
             result = await handlers["generate_image"]({"prompt": "something"})
         assert "не вернула результат" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(side_effect=Exception("provider down"))
@@ -53,13 +53,13 @@ class TestImagesToolGenerateImage:
 
 
 class TestImagesToolListImageModels:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_provider(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_image_models"]({"provider": ""})
         assert "provider обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_models(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.search_models = AsyncMock(return_value=[])
@@ -67,7 +67,7 @@ class TestImagesToolListImageModels:
             result = await handlers["list_image_models"]({"provider": "together"})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_models(self, mock_db):
         models = [
             {"id": "flux-schnell", "run_count": 10000, "rank": 1},
@@ -84,7 +84,7 @@ class TestImagesToolListImageModels:
 
 
 class TestImagesToolListImageProviders:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_providers(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.adapter_names = []
@@ -92,7 +92,7 @@ class TestImagesToolListImageProviders:
             result = await handlers["list_image_providers"]({})
         assert "не настроены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_providers(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.adapter_names = ["together", "hf", "replicate"]
@@ -104,7 +104,7 @@ class TestImagesToolListImageProviders:
         assert "replicate" in text
         assert "Провайдеры изображений (3)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.side_effect = Exception("provider fail")
@@ -114,7 +114,7 @@ class TestImagesToolListImageProviders:
 
 
 class TestImagesToolListGeneratedImages:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generated_images.list_recent = AsyncMock(return_value=[])
@@ -122,7 +122,7 @@ class TestImagesToolListGeneratedImages:
         result = await handlers["list_generated_images"]({})
         assert "Нет сгенерированных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_images(self, mock_db):
         img = SimpleNamespace(
             id=1,
@@ -140,7 +140,7 @@ class TestImagesToolListGeneratedImages:
         assert "together:flux" in text
         assert "/data/img/abc.png" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_long_prompt_truncated(self, mock_db):
         long_prompt = "x" * 100
         img = SimpleNamespace(
@@ -160,7 +160,7 @@ class TestImagesToolListGeneratedImages:
         assert "x" * 60 in text
         assert "x" * 61 not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generated_images.list_recent = AsyncMock(side_effect=Exception("db err"))

--- a/tests/test_agent_tools_init.py
+++ b/tests/test_agent_tools_init.py
@@ -9,7 +9,7 @@ import pytest
 
 
 class TestAdaptSdkTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_extracts_text_from_mcp_response(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -29,7 +29,7 @@ class TestAdaptSdkTool:
         result = await adapted()
         assert result == "hello world"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_joins_multiple_text_parts(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -48,7 +48,7 @@ class TestAdaptSdkTool:
         result = await adapted()
         assert result == "part1\npart2"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_non_text_parts_ignored(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -67,7 +67,7 @@ class TestAdaptSdkTool:
         result = await adapted()
         assert result == "only this"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_non_dict_result_str(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -81,7 +81,7 @@ class TestAdaptSdkTool:
         result = await adapted()
         assert result == "plain string"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_dict_without_content_key(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -95,7 +95,7 @@ class TestAdaptSdkTool:
         result = await adapted()
         assert "error" in result
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_passes_kwargs_as_args_dict(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -112,7 +112,7 @@ class TestAdaptSdkTool:
         await adapted(query="test", limit=5)
         assert captured == {"query": "test", "limit": 5}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_docstring_preserved(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -125,7 +125,7 @@ class TestAdaptSdkTool:
         adapted = _adapt_sdk_tool(tool)
         assert adapted.__doc__ == "My description"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_text_parts_returns_str(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -145,7 +145,7 @@ class TestAdaptSdkTool:
 
 
 class TestWrapWithSessionGate:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_gate_passes_through(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -163,7 +163,7 @@ class TestWrapWithSessionGate:
             result = await wrapped.handler()
         assert result["content"][0]["text"] == "ok"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_gate_none_context_passes_through(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -184,7 +184,7 @@ class TestWrapWithSessionGate:
             result = await wrapped.handler()
         assert result["content"][0]["text"] == "passed"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_gate_tool_disabled_returns_gate_result(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -210,7 +210,7 @@ class TestWrapWithSessionGate:
             result = await wrapped.handler()
         assert result["content"][0]["text"] == "blocked"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_gate_tool_enabled_passes_through(self):
         from claude_agent_sdk import SdkMcpTool
 
@@ -310,7 +310,7 @@ class TestBuildAgentToolsDict:
         for tool_name in tools_dict:
             assert tool_name in _PIPELINE_SAFE_TOOLS, f"build_agent_tools_dict included unsafe tool: {tool_name}"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_tool_functions_are_async_callable(self):
         from claude_agent_sdk import SdkMcpTool
 

--- a/tests/test_agent_tools_messaging.py
+++ b/tests/test_agent_tools_messaging.py
@@ -45,7 +45,7 @@ def _make_mock_pool():
 
 
 class TestSendMessage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         await assert_tool_text(
@@ -54,7 +54,7 @@ class TestSendMessage:
             "CLI-режиме",
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -65,7 +65,7 @@ class TestSendMessage:
             "confirm=true",
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -76,7 +76,7 @@ class TestSendMessage:
         text = _text(result)
         assert "отправлено" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_recipient_or_text_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -85,7 +85,7 @@ class TestSendMessage:
 
 
 class TestEditMessage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["edit_message"](
@@ -93,7 +93,7 @@ class TestEditMessage:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -103,7 +103,7 @@ class TestEditMessage:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -114,7 +114,7 @@ class TestEditMessage:
         text = _text(result)
         assert "отредактировано" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_message_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -125,13 +125,13 @@ class TestEditMessage:
 
 
 class TestDeleteMessage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["delete_message"]({"phone": "+79001234567", "chat_id": "123", "message_ids": "1,2"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_message_ids_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -141,7 +141,7 @@ class TestDeleteMessage:
         )
         assert "валидные message_ids" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -151,7 +151,7 @@ class TestDeleteMessage:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -164,7 +164,7 @@ class TestDeleteMessage:
 
 
 class TestForwardMessages:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["forward_messages"](
@@ -172,7 +172,7 @@ class TestForwardMessages:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_ids_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -182,7 +182,7 @@ class TestForwardMessages:
         )
         assert "валидные message_ids" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -192,7 +192,7 @@ class TestForwardMessages:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -210,13 +210,13 @@ class TestForwardMessages:
 
 
 class TestPinMessage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["pin_message"]({"phone": "+79001234567", "chat_id": "chat", "message_id": 1})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -224,7 +224,7 @@ class TestPinMessage:
         result = await handlers["pin_message"]({"phone": "+79001234567", "chat_id": "chat", "message_id": 10})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -236,13 +236,13 @@ class TestPinMessage:
 
 
 class TestUnpinMessage:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["unpin_message"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -250,7 +250,7 @@ class TestUnpinMessage:
         result = await handlers["unpin_message"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -260,13 +260,13 @@ class TestUnpinMessage:
 
 
 class TestGetParticipants:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["get_participants"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_participants(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -275,7 +275,7 @@ class TestGetParticipants:
         result = await handlers["get_participants"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_participants(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -291,7 +291,7 @@ class TestGetParticipants:
         assert "111" in text
         assert "John" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -301,13 +301,13 @@ class TestGetParticipants:
 
 
 class TestKickParticipant:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["kick_participant"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -315,7 +315,7 @@ class TestKickParticipant:
         result = await handlers["kick_participant"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -327,13 +327,13 @@ class TestKickParticipant:
 
 
 class TestArchiveChat:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["archive_chat"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -341,7 +341,7 @@ class TestArchiveChat:
         result = await handlers["archive_chat"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -351,13 +351,13 @@ class TestArchiveChat:
 
 
 class TestMarkRead:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["mark_read"]({"phone": "+79001234567", "chat_id": "chat"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -365,7 +365,7 @@ class TestMarkRead:
         result = await handlers["mark_read"]({"phone": "+79001234567"})
         assert "chat_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pool_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -375,13 +375,13 @@ class TestMarkRead:
 
 
 class TestEditAdmin:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["edit_admin"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -389,7 +389,7 @@ class TestEditAdmin:
         result = await handlers["edit_admin"]({"phone": "+79001234567", "chat_id": "chat", "user_id": "111"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_promote_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -401,7 +401,7 @@ class TestEditAdmin:
 
 
 class TestEditPermissions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["edit_permissions"](
@@ -409,7 +409,7 @@ class TestEditPermissions:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_flags_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -418,7 +418,7 @@ class TestEditPermissions:
         text = _text(result)
         assert "флаг" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -63,7 +63,7 @@ def _setup_resolve_entity(pool, client, entity=None):
 
 
 class TestSendMessageExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -88,7 +88,7 @@ class TestSendMessageExceptions:
 
 
 class TestEditMessageExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -114,7 +114,7 @@ class TestEditMessageExceptions:
 
 
 class TestDeleteMessageValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_valid_ids(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["delete_message"]({
@@ -125,7 +125,7 @@ class TestDeleteMessageValidation:
         })
         assert "не указаны валидные message_ids" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -150,7 +150,7 @@ class TestDeleteMessageValidation:
 
 
 class TestForwardMessagesErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_to_entity_resolve_error(self, mock_db, mock_pool):
         client = _make_client()
         # First resolve (from_chat) succeeds, second (to_chat) fails
@@ -178,7 +178,7 @@ class TestForwardMessagesErrors:
         text = _text(result)
         assert "не удалось найти" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_forward_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -204,7 +204,7 @@ class TestForwardMessagesErrors:
 
 
 class TestPinMessageExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pin_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -229,7 +229,7 @@ class TestPinMessageExceptions:
 
 
 class TestUnpinMessageExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unpin_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -252,7 +252,7 @@ class TestUnpinMessageExceptions:
 
 
 class TestDownloadMediaErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_message_not_found(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -272,7 +272,7 @@ class TestDownloadMediaErrors:
 
         assert "не найдено" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_media_in_message(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -294,7 +294,7 @@ class TestDownloadMediaErrors:
 
         assert "нет медиа" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_download_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -324,7 +324,7 @@ class TestDownloadMediaErrors:
 
 
 class TestGetParticipantsExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -339,7 +339,7 @@ class TestGetParticipantsExceptions:
         text = _text(result)
         assert "Ошибка получения участников" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_participants(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -361,7 +361,7 @@ class TestGetParticipantsExceptions:
         assert "John Doe" in text
         assert "@johndoe" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_participants(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -382,7 +382,7 @@ class TestGetParticipantsExceptions:
 
 
 class TestEditAdminErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_user_resolve_error(self, mock_db, mock_pool):
         client = _make_client()
         call_count = 0
@@ -409,7 +409,7 @@ class TestEditAdminErrors:
         text = _text(result)
         assert "не удалось найти" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_admin_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -427,7 +427,7 @@ class TestEditAdminErrors:
         text = _text(result)
         assert "Ошибка изменения прав администратора" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_demote_user(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -456,7 +456,7 @@ class TestEditAdminErrors:
 
 
 class TestEditPermissionsErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_and_user_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_permissions"]({
@@ -466,7 +466,7 @@ class TestEditPermissionsErrors:
         })
         assert "chat_id и user_id обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_user_resolve_error(self, mock_db, mock_pool):
         client = _make_client()
         call_count = 0
@@ -493,7 +493,7 @@ class TestEditPermissionsErrors:
         text = _text(result)
         assert "не удалось найти" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_permissions_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -511,7 +511,7 @@ class TestEditPermissionsErrors:
         text = _text(result)
         assert "Ошибка изменения ограничений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_flags_set_returns_error(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_permissions"]({
@@ -522,7 +522,7 @@ class TestEditPermissionsErrors:
         })
         assert "укажите хотя бы один флаг" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_until_date(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -547,7 +547,7 @@ class TestEditPermissionsErrors:
 
 
 class TestKickParticipantErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_user_resolve_error(self, mock_db, mock_pool):
         client = _make_client()
         call_count = 0
@@ -573,7 +573,7 @@ class TestKickParticipantErrors:
         text = _text(result)
         assert "не удалось найти" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_kick_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -597,7 +597,7 @@ class TestKickParticipantErrors:
 
 
 class TestGetBroadcastStatsErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -612,7 +612,7 @@ class TestGetBroadcastStatsErrors:
         text = _text(result)
         assert "Ошибка получения статистики" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_stats(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -640,7 +640,7 @@ class TestGetBroadcastStatsErrors:
         assert "800" in text
         assert "period" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stats_no_fields_falls_to_raw(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -672,7 +672,7 @@ class TestGetBroadcastStatsErrors:
 
 
 class TestArchiveChatExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_archive_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -695,7 +695,7 @@ class TestArchiveChatExceptions:
 
 
 class TestUnarchiveChatExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unarchive_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -718,7 +718,7 @@ class TestUnarchiveChatExceptions:
 
 
 class TestMarkReadExceptions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_read_exception(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -734,7 +734,7 @@ class TestMarkReadExceptions:
         text = _text(result)
         assert "Ошибка отметки сообщений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_read_success(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -756,13 +756,13 @@ class TestMarkReadExceptions:
 
 
 class TestReadMessagesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["read_messages"]({"chat_id": "@test"})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["read_messages"]({
@@ -770,7 +770,7 @@ class TestReadMessagesTool:
         })
         assert "chat_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_messages(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -795,7 +795,7 @@ class TestReadMessagesTool:
         assert "Hello world" in text
         assert "1 сообщений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_text_messages(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -815,7 +815,7 @@ class TestReadMessagesTool:
 
         assert "Сообщений с текстом не найдено" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_date_and_sender(self, mock_db, mock_pool):
         from datetime import datetime
 
@@ -845,7 +845,7 @@ class TestReadMessagesTool:
         assert "2025-06-15 12:30" in text
         assert "[id:42]" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -864,7 +864,7 @@ class TestReadMessagesTool:
         text = _text(result)
         assert "Ошибка чтения сообщений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_limit_defaults_to_100(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -887,7 +887,7 @@ class TestReadMessagesTool:
         # Should still work with default limit=100
         assert "1 сообщений" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_character_budget_truncation(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -924,7 +924,7 @@ class TestReadMessagesTool:
 
 
 class TestSendValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_recipient(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["send_message"]({
@@ -934,7 +934,7 @@ class TestSendValidation:
         })
         assert "recipient и text обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_text(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["send_message"]({
@@ -946,7 +946,7 @@ class TestSendValidation:
 
 
 class TestEditValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_message"]({
@@ -957,7 +957,7 @@ class TestEditValidation:
 
 
 class TestDeleteValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["delete_message"]({
@@ -968,7 +968,7 @@ class TestDeleteValidation:
 
 
 class TestForwardValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["forward_messages"]({
@@ -977,7 +977,7 @@ class TestForwardValidation:
         })
         assert "from_chat, to_chat и message_ids обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_valid_ids(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["forward_messages"]({
@@ -991,7 +991,7 @@ class TestForwardValidation:
 
 
 class TestPinValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["pin_message"]({
@@ -1002,7 +1002,7 @@ class TestPinValidation:
 
 
 class TestUnpinValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["unpin_message"]({
@@ -1013,7 +1013,7 @@ class TestUnpinValidation:
 
 
 class TestDownloadValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["download_media"]({
@@ -1024,7 +1024,7 @@ class TestDownloadValidation:
 
 
 class TestParticipantsValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["get_participants"]({
@@ -1034,7 +1034,7 @@ class TestParticipantsValidation:
 
 
 class TestEditAdminValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_admin"]({
@@ -1045,7 +1045,7 @@ class TestEditAdminValidation:
 
 
 class TestKickValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["kick_participant"]({
@@ -1056,7 +1056,7 @@ class TestKickValidation:
 
 
 class TestBroadcastStatsValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["get_broadcast_stats"]({
@@ -1066,7 +1066,7 @@ class TestBroadcastStatsValidation:
 
 
 class TestArchiveValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["archive_chat"]({
@@ -1077,7 +1077,7 @@ class TestArchiveValidation:
 
 
 class TestUnarchiveValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["unarchive_chat"]({
@@ -1088,7 +1088,7 @@ class TestUnarchiveValidation:
 
 
 class TestMarkReadValidation:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["mark_read"]({
@@ -1103,7 +1103,7 @@ class TestMarkReadValidation:
 
 
 class TestConfirmationGates:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["send_message"]({
@@ -1113,7 +1113,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_message"]({
@@ -1124,7 +1124,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["delete_message"]({
@@ -1134,7 +1134,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_forward_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["forward_messages"]({
@@ -1145,7 +1145,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pin_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["pin_message"]({
@@ -1155,7 +1155,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unpin_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["unpin_message"]({
@@ -1164,7 +1164,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_archive_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["archive_chat"]({
@@ -1173,7 +1173,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unarchive_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["unarchive_chat"]({
@@ -1182,7 +1182,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_admin_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_admin"]({
@@ -1192,7 +1192,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_permissions_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["edit_permissions"]({
@@ -1203,7 +1203,7 @@ class TestConfirmationGates:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_kick_requires_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["kick_participant"]({

--- a/tests/test_agent_tools_moderation.py
+++ b/tests/test_agent_tools_moderation.py
@@ -21,14 +21,14 @@ def _make_run(run_id=1, pipeline_id=1, status="pending", moderation_status="pend
 
 
 class TestListPendingModerationTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_pending_moderation"]({})
         assert "Нет черновиков на модерации" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs_shows_preview(self, mock_db):
         run = _make_run(run_id=1, text="Sample generated text for preview")
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[run])
@@ -38,7 +38,7 @@ class TestListPendingModerationTool:
         assert "На модерации (1 шт.)" in text
         assert "run_id=1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipeline_filter(self, mock_db):
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -47,7 +47,7 @@ class TestListPendingModerationTool:
             pipeline_id=5, limit=10
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(
             side_effect=Exception("db error")
@@ -58,20 +58,20 @@ class TestListPendingModerationTool:
 
 
 class TestViewModerationRunTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_run_id_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["view_moderation_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_not_found(self, mock_db):
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["view_moderation_run"]({"run_id": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_found_shows_text(self, mock_db):
         run = _make_run(run_id=1, text="Full text content")
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -83,20 +83,20 @@ class TestViewModerationRunTool:
 
 
 class TestApproveRunTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_run_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["approve_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_not_found(self, mock_db):
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["approve_run"]({"run_id": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_approve_success(self, mock_db):
         run = _make_run(run_id=1)
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -108,7 +108,7 @@ class TestApproveRunTool:
 
 
 class TestRejectRunTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reject_success(self, mock_db):
         run = _make_run(run_id=2)
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -120,25 +120,25 @@ class TestRejectRunTool:
 
 
 class TestBulkApproveRunsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "1,2,3"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_run_ids(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "a,b,c", "confirm": True})
         assert "должны быть числами" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_run_ids(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "", "confirm": True})
         assert "run_ids пуст" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_bulk_approve_success(self, mock_db):
         mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -147,7 +147,7 @@ class TestBulkApproveRunsTool:
 
 
 class TestBulkRejectRunsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_bulk_reject_success(self, mock_db):
         mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
         handlers = _get_tool_handlers(mock_db)

--- a/tests/test_agent_tools_notifications.py
+++ b/tests/test_agent_tools_notifications.py
@@ -35,7 +35,7 @@ def _make_mock_pool():
 
 
 class TestGetNotificationStatusTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_configured_returns_message(self, mock_db):
         with (
             patch("src.services.notification_service.NotificationService") as mock_ns,
@@ -46,7 +46,7 @@ class TestGetNotificationStatusTool:
             result = await handlers["get_notification_status"]({})
         assert "не настроен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_configured_shows_bot_info(self, mock_db):
         bot = SimpleNamespace(bot_username="mybot", chat_id=12345, created_at="2025-01-01")
         with (
@@ -60,7 +60,7 @@ class TestGetNotificationStatusTool:
         assert "@mybot" in text
         assert "12345" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with (
             patch("src.services.notification_service.NotificationService") as mock_ns,
@@ -71,7 +71,7 @@ class TestGetNotificationStatusTool:
             result = await handlers["get_notification_status"]({})
         assert "Ошибка получения статуса бота" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_configured_with_pool(self, mock_db):
         notif_svc = MagicMock()
         notif_svc.get_status = AsyncMock(return_value=None)
@@ -82,7 +82,7 @@ class TestGetNotificationStatusTool:
             result = await handlers["get_notification_status"]({})
         assert "не настроен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_configured_shows_bot_details_with_pool(self, mock_db):
         notif_svc = MagicMock()
         bot = MagicMock()
@@ -101,20 +101,20 @@ class TestGetNotificationStatusTool:
 
 
 class TestSetupNotificationBotTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["setup_notification_bot"]({"confirm": True})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["setup_notification_bot"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_creates_bot(self, mock_db):
         pool = MagicMock()
         bot = SimpleNamespace(bot_username="newbot", chat_id=99999)
@@ -129,13 +129,13 @@ class TestSetupNotificationBotTool:
         assert "создан" in text
         assert "@newbot" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate_cli_check(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["setup_notification_bot"]({"confirm": True})
         assert "CLI-режиме" in _text(result) or "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pool_and_confirm_success(self, mock_db):
         notif_svc = MagicMock()
         bot = MagicMock()
@@ -152,20 +152,20 @@ class TestSetupNotificationBotTool:
 
 
 class TestDeleteNotificationBotTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["delete_notification_bot"]({"confirm": True})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["delete_notification_bot"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deletes_bot(self, mock_db):
         pool = MagicMock()
         with (
@@ -177,7 +177,7 @@ class TestDeleteNotificationBotTool:
             result = await handlers["delete_notification_bot"]({"confirm": True})
         assert "удалён" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deleted_via_ctx(self, mock_db):
         notif_svc = MagicMock()
         notif_svc.teardown_bot = AsyncMock()
@@ -190,13 +190,13 @@ class TestDeleteNotificationBotTool:
 
 
 class TestTestNotificationTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["test_notification"]({})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_configured_returns_message(self, mock_db):
         pool = MagicMock()
         with (
@@ -208,7 +208,7 @@ class TestTestNotificationTool:
             result = await handlers["test_notification"]({})
         assert "не настроен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sends_notification(self, mock_db):
         pool = MagicMock()
         bot = SimpleNamespace(bot_username="testbot", chat_id=1)
@@ -224,7 +224,7 @@ class TestTestNotificationTool:
         assert "отправлено" in _text(result)
         inst.send_notification.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_configured_sends_test_via_ctx(self, mock_db):
         notif_svc = MagicMock()
         bot = MagicMock()

--- a/tests/test_agent_tools_permissions.py
+++ b/tests/test_agent_tools_permissions.py
@@ -104,7 +104,7 @@ class TestIsPerPhoneFormat:
 
 
 class TestLoadToolPermissions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_setting_returns_all_enabled(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
@@ -112,7 +112,7 @@ class TestLoadToolPermissions:
         assert all(perms.values())
         assert len(perms) == len(TOOL_CATEGORIES)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flat_format(self):
         db = MagicMock()
         raw = json.dumps({"search_messages": False, "send_message": True})
@@ -123,7 +123,7 @@ class TestLoadToolPermissions:
         # Non-specified tools default to True
         assert perms["list_channels"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_format_with_matching_phone(self):
         db = MagicMock()
         raw = json.dumps({"+7900": {"search_messages": False, "list_channels": False}})
@@ -134,7 +134,7 @@ class TestLoadToolPermissions:
         # Non-specified tools for this phone default to True
         assert perms["send_message"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_phone_not_in_saved(self):
         db = MagicMock()
         raw = json.dumps({"+7900": {"search_messages": False}})
@@ -143,7 +143,7 @@ class TestLoadToolPermissions:
         # Phone not in saved → defaults (all enabled)
         assert all(perms.values())
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_none_defaults_to_primary(self):
         primary = SimpleNamespace(phone="+111", is_primary=True)
         db = MagicMock()
@@ -153,7 +153,7 @@ class TestLoadToolPermissions:
         perms = await load_tool_permissions(db, phone=None)
         assert perms["search_messages"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_corrupted_json_returns_defaults(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value="not valid json{{{")
@@ -165,7 +165,7 @@ class TestLoadToolPermissions:
 
 
 class TestLoadToolPermissionsAllPhones:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_setting_returns_defaults(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
@@ -174,7 +174,7 @@ class TestLoadToolPermissionsAllPhones:
         assert "+7900" in result
         assert all(result["+7900"].values())
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flat_applies_to_all_phones(self):
         db = MagicMock()
         raw = json.dumps({"search_messages": False})
@@ -185,7 +185,7 @@ class TestLoadToolPermissionsAllPhones:
         assert result["+7900"]["search_messages"] is False
         assert result["+7800"]["search_messages"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_isolation(self):
         db = MagicMock()
         raw = json.dumps({
@@ -199,7 +199,7 @@ class TestLoadToolPermissionsAllPhones:
         assert result["+7900"]["search_messages"] is False
         assert result["+7800"]["search_messages"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_phone_not_in_saved_gets_defaults(self):
         db = MagicMock()
         raw = json.dumps({"+7900": {"search_messages": False}})
@@ -214,7 +214,7 @@ class TestLoadToolPermissionsAllPhones:
 
 
 class TestSaveToolPermissions:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flat_save(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
@@ -225,7 +225,7 @@ class TestSaveToolPermissions:
         saved_json = db.set_setting.call_args[0][1]
         assert json.loads(saved_json) == perms
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_save(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
@@ -239,7 +239,7 @@ class TestSaveToolPermissions:
         assert "+7900" in parsed
         assert parsed["+7900"]["search_messages"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_migrates_legacy_flat(self):
         """Saving per-phone when existing is flat should migrate to per-phone."""
         db = MagicMock()
@@ -255,7 +255,7 @@ class TestSaveToolPermissions:
         assert isinstance(parsed["+7900"], dict)
         assert parsed["+7900"]["search_messages"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_per_phone_does_not_touch_other_phones(self):
         db = MagicMock()
         existing = json.dumps({
@@ -280,14 +280,14 @@ class TestSaveToolPermissions:
 
 
 class TestLoadToolPermissionsUnion:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_setting_all_enabled(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
         result = await load_tool_permissions_union(db)
         assert all(result.values())
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flat_format(self):
         db = MagicMock()
         raw = json.dumps({"search_messages": False, "send_message": True})
@@ -296,7 +296,7 @@ class TestLoadToolPermissionsUnion:
         assert result["search_messages"] is False
         assert result["send_message"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_union_across_phones(self):
         """Union: True if ANY phone allows the tool."""
         db = MagicMock()
@@ -308,7 +308,7 @@ class TestLoadToolPermissionsUnion:
         result = await load_tool_permissions_union(db)
         assert result["search_messages"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_phones_disable_means_disabled(self):
         db = MagicMock()
         raw = json.dumps({
@@ -319,7 +319,7 @@ class TestLoadToolPermissionsUnion:
         result = await load_tool_permissions_union(db)
         assert result["search_messages"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cache_returns_same_result(self):
         import src.agent.tools.permissions as perm_mod
         # Clear the module-level cache so we get a fresh start

--- a/tests/test_agent_tools_photo_loader.py
+++ b/tests/test_agent_tools_photo_loader.py
@@ -85,7 +85,7 @@ def _photo_ctx(photo_task_svc, auto_upload_svc):
 
 
 class TestListPhotoBatches:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -95,7 +95,7 @@ class TestListPhotoBatches:
             result = await handlers["list_photo_batches"]({})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_batches_shows_info(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -118,7 +118,7 @@ class TestListPhotoBatches:
 
 
 class TestListPhotoItems:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -128,7 +128,7 @@ class TestListPhotoItems:
             result = await handlers["list_photo_items"]({})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_items_shows_info(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -149,7 +149,7 @@ class TestListPhotoItems:
 
 
 class TestSendPhotosNow:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["send_photos_now"](
@@ -157,7 +157,7 @@ class TestSendPhotosNow:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -167,7 +167,7 @@ class TestSendPhotosNow:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -186,7 +186,7 @@ class TestSendPhotosNow:
 
 
 class TestSchedulePhotos:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["schedule_photos"](
@@ -194,7 +194,7 @@ class TestSchedulePhotos:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -204,7 +204,7 @@ class TestSchedulePhotos:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_success(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -229,21 +229,21 @@ class TestSchedulePhotos:
 
 
 class TestCancelPhotoItem:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_item_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["cancel_photo_item"]({})
         assert "item_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["cancel_photo_item"]({"item_id": 5})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_found_item_cancelled(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -254,7 +254,7 @@ class TestCancelPhotoItem:
             result = await handlers["cancel_photo_item"]({"item_id": 5, "confirm": True})
         assert "отменено" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_message(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -267,7 +267,7 @@ class TestCancelPhotoItem:
 
 
 class TestListAutoUploads:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_configured(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -277,7 +277,7 @@ class TestListAutoUploads:
             result = await handlers["list_auto_uploads"]({})
         assert "не настроены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_jobs_shows_info(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -300,14 +300,14 @@ class TestListAutoUploads:
 
 
 class TestToggleAutoUpload:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_job_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["toggle_auto_upload"]({})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_error(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -318,7 +318,7 @@ class TestToggleAutoUpload:
             result = await handlers["toggle_auto_upload"]({"job_id": 999})
         assert "не найдена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_job_gets_paused(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -331,7 +331,7 @@ class TestToggleAutoUpload:
             result = await handlers["toggle_auto_upload"]({"job_id": 3})
         assert "приостановлена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_job_gets_activated(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -346,21 +346,21 @@ class TestToggleAutoUpload:
 
 
 class TestDeleteAutoUpload:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_job_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["delete_auto_upload"]({})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["delete_auto_upload"]({"job_id": 5})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deleted(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -372,7 +372,7 @@ class TestDeleteAutoUpload:
 
 
 class TestCreatePhotoBatch:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["create_photo_batch"](
@@ -380,7 +380,7 @@ class TestCreatePhotoBatch:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -388,7 +388,7 @@ class TestCreatePhotoBatch:
         result = await handlers["create_photo_batch"]({"phone": "+79001234567"})
         assert "обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -398,7 +398,7 @@ class TestCreatePhotoBatch:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_batch_created(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -417,20 +417,20 @@ class TestCreatePhotoBatch:
 
 
 class TestRunPhotoDue:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["run_photo_due"]({"confirm": True})
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["run_photo_due"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_processes_items_and_jobs(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -444,7 +444,7 @@ class TestRunPhotoDue:
 
 
 class TestCreateAutoUpload:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["create_auto_upload"](
@@ -452,7 +452,7 @@ class TestCreateAutoUpload:
         )
         assert "CLI-режиме" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_fields_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -460,7 +460,7 @@ class TestCreateAutoUpload:
         result = await handlers["create_auto_upload"]({"phone": "+79001234567"})
         assert "обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -470,7 +470,7 @@ class TestCreateAutoUpload:
         )
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_job_created(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -493,21 +493,21 @@ class TestCreateAutoUpload:
 
 
 class TestUpdateAutoUpload:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_job_id_returns_error(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["update_auto_upload"]({})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_mock_pool()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["update_auto_upload"]({"job_id": 1, "folder_path": "/new"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_error(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()
@@ -518,7 +518,7 @@ class TestUpdateAutoUpload:
             result = await handlers["update_auto_upload"]({"job_id": 999, "confirm": True})
         assert "не найдена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_updated(self, mock_db):
         photo_task_svc, auto_upload_svc = _make_photo_services()
         mock_pool, _ = _make_mock_pool()

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -44,7 +44,7 @@ def _make_run(run_id=1, pipeline_id=1, status="pending", moderation_status="pend
 
 
 class TestPipelinesToolListPipelines:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list = AsyncMock(return_value=[])
@@ -52,7 +52,7 @@ class TestPipelinesToolListPipelines:
             result = await handlers["list_pipelines"]({"active_only": False})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipeline(self, mock_db):
         p = SimpleNamespace(
             id=5,
@@ -72,7 +72,7 @@ class TestPipelinesToolListPipelines:
         assert "id=5" in text
         assert "gpt-4" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list = AsyncMock(side_effect=Exception("db err"))
@@ -80,14 +80,14 @@ class TestPipelinesToolListPipelines:
             result = await handlers["list_pipelines"]({})
         assert "Ошибка" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService.list", AsyncMock(return_value=[])):
             handlers = _get_tool_handlers(mock_db, config=MagicMock())
             result = await handlers["list_pipelines"]({})
             assert "Пайплайны не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipelines(self, mock_db):
         p = _make_pipeline(pk=1, name="NewsPipeline")
         with patch("src.services.pipeline_service.PipelineService.list", AsyncMock(return_value=[p])):
@@ -99,13 +99,13 @@ class TestPipelinesToolListPipelines:
 
 
 class TestPipelinesToolGetPipelineDetail:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_pipeline_detail"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(return_value=None)
@@ -113,7 +113,7 @@ class TestPipelinesToolGetPipelineDetail:
             result = await handlers["get_pipeline_detail"]({"pipeline_id": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_found(self, mock_db):
         p = SimpleNamespace(
             id=2,
@@ -139,13 +139,13 @@ class TestPipelinesToolGetPipelineDetail:
         assert "Detail Pipeline" in text
         assert "Channel A" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["get_pipeline_detail"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         with patch(
             "src.services.pipeline_service.PipelineService.get_detail", AsyncMock(return_value=None)
@@ -154,7 +154,7 @@ class TestPipelinesToolGetPipelineDetail:
             result = await handlers["get_pipeline_detail"]({"pipeline_id": 999})
             assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_detail(self, mock_db):
         p = _make_pipeline(pk=1, name="TestPipeline")
         detail = {
@@ -175,14 +175,14 @@ class TestPipelinesToolGetPipelineDetail:
 
 
 class TestGetPipelineQueueTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_queue(self, mock_db):
         mock_db.repos.generation_runs.list_by_status = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["get_pipeline_queue"]({})
         assert "Очередь генерации пуста" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs(self, mock_db):
         run = _make_run(run_id=1, status="pending", text="Generated content preview")
         mock_db.repos.generation_runs.list_by_status = AsyncMock(return_value=[run])
@@ -194,7 +194,7 @@ class TestGetPipelineQueueTool:
 
 
 class TestPipelinesToolAddPipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({
@@ -206,13 +206,13 @@ class TestPipelinesToolAddPipeline:
         })
         assert "Подтвердите" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_required_fields(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({"confirm": True, "name": "only name"})
         assert "обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_target_ref_format(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({
@@ -224,7 +224,7 @@ class TestPipelinesToolAddPipeline:
         })
         assert "Неверный формат" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_creates_pipeline(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             with patch("src.services.pipeline_service.PipelineTargetRef"):
@@ -243,13 +243,13 @@ class TestPipelinesToolAddPipeline:
         assert "id=10" in text
         assert "My Pipeline" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm_new(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["add_pipeline"]({"name": "Test"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_required_fields_new(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["add_pipeline"]({"name": "Test", "confirm": True})
@@ -257,13 +257,13 @@ class TestPipelinesToolAddPipeline:
 
 
 class TestPipelinesToolTogglePipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.toggle = AsyncMock(return_value=False)
@@ -271,7 +271,7 @@ class TestPipelinesToolTogglePipeline:
             result = await handlers["toggle_pipeline"]({"pipeline_id": 99})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggled(self, mock_db):
         p = SimpleNamespace(id=1, name="P1", is_active=True)
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -283,20 +283,20 @@ class TestPipelinesToolTogglePipeline:
         assert "P1" in text
         assert "активирован" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["toggle_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService.toggle", AsyncMock(return_value=False)):
             handlers = _get_tool_handlers(mock_db, config=MagicMock())
             result = await handlers["toggle_pipeline"]({"pipeline_id": 999})
             assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_activates(self, mock_db):
         p = _make_pipeline(pk=1, name="Test", is_active=True)
         with patch(
@@ -308,13 +308,13 @@ class TestPipelinesToolTogglePipeline:
 
 
 class TestPipelinesToolDeletePipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         p = SimpleNamespace(id=1, name="PipeX")
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -323,7 +323,7 @@ class TestPipelinesToolDeletePipeline:
             result = await handlers["delete_pipeline"]({"pipeline_id": 1, "confirm": False})
         assert "Подтвердите" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_deletes_with_confirmation(self, mock_db):
         p = SimpleNamespace(id=1, name="PipeToDelete")
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -335,7 +335,7 @@ class TestPipelinesToolDeletePipeline:
         assert "PipeToDelete" in text
         assert "удалён" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm_new(self, mock_db):
         p = _make_pipeline(pk=1, name="Test")
         with patch("src.services.pipeline_service.PipelineService.get", AsyncMock(return_value=p)):
@@ -343,7 +343,7 @@ class TestPipelinesToolDeletePipeline:
             result = await handlers["delete_pipeline"]({"pipeline_id": 1})
             assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["delete_pipeline"]({})
@@ -351,13 +351,13 @@ class TestPipelinesToolDeletePipeline:
 
 
 class TestPipelinesToolListPipelineRuns:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_pipeline_runs"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[])
@@ -365,7 +365,7 @@ class TestPipelinesToolListPipelineRuns:
         result = await handlers["list_pipeline_runs"]({"pipeline_id": 1})
         assert "Нет генераций" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs(self, mock_db):
         run = SimpleNamespace(
             id=10,
@@ -382,14 +382,14 @@ class TestPipelinesToolListPipelineRuns:
         assert "run_id=10" in text
         assert "approved" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_runs(self, mock_db):
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["list_pipeline_runs"]({"pipeline_id": 1})
         assert "Нет генераций" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_runs_new(self, mock_db):
         run = _make_run(run_id=1, text="Preview text")
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[run])
@@ -401,13 +401,13 @@ class TestPipelinesToolListPipelineRuns:
 
 
 class TestPipelinesToolGetPipelineRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_run_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_pipeline_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
@@ -415,7 +415,7 @@ class TestPipelinesToolGetPipelineRun:
         result = await handlers["get_pipeline_run"]({"run_id": 99})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_found(self, mock_db):
         run = SimpleNamespace(
             id=5,
@@ -436,14 +436,14 @@ class TestPipelinesToolGetPipelineRun:
         assert "Full content text" in text
         assert "approved" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_not_found_new(self, mock_db):
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["get_pipeline_run"]({"run_id": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_run_text(self, mock_db):
         run = _make_run(run_id=1, text="Full generated text content")
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -455,20 +455,20 @@ class TestPipelinesToolGetPipelineRun:
 
 
 class TestGetRefinementStepsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["get_refinement_steps"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["get_refinement_steps"]({"pipeline_id": 999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_steps(self, mock_db):
         p = MagicMock()
         p.refinement_steps = []
@@ -477,7 +477,7 @@ class TestGetRefinementStepsTool:
         result = await handlers["get_refinement_steps"]({"pipeline_id": 1})
         assert "не имеет шагов рефайнмента" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_steps(self, mock_db):
         p = MagicMock()
         p.refinement_steps = [
@@ -493,19 +493,19 @@ class TestGetRefinementStepsTool:
 
 
 class TestSetRefinementStepsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["set_refinement_steps"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["set_refinement_steps"]({"pipeline_id": 1, "steps_json": "[]"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_json(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["set_refinement_steps"](
@@ -513,7 +513,7 @@ class TestSetRefinementStepsTool:
         )
         assert "парсинга" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_a_list(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["set_refinement_steps"](
@@ -521,7 +521,7 @@ class TestSetRefinementStepsTool:
         )
         assert "JSON-массивом" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_steps_missing_prompt(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["set_refinement_steps"](
@@ -529,7 +529,7 @@ class TestSetRefinementStepsTool:
         )
         assert "не содержат поле 'prompt'" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sets_valid_steps(self, mock_db):
         p = MagicMock()
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=p)
@@ -547,13 +547,13 @@ class TestSetRefinementStepsTool:
 
 
 class TestEditPipelineTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["edit_pipeline"]({"pipeline_id": 1})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
         result = await handlers["edit_pipeline"]({"confirm": True})
@@ -564,7 +564,7 @@ class TestEditPipelineTool:
 
 
 class TestPipelineRunsToolResultSemantics:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_runs_shows_result_kind_and_count(self, mock_db):
         from tests.factories.pipeline_runs import make_action_only_run, make_generation_run
 
@@ -586,7 +586,7 @@ class TestPipelineRunsToolResultSemantics:
         assert "run_id=11" in text
         assert "processed_messages:5" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_run_shows_semantic_fields_for_empty_text_run(self, mock_db):
         """Regression #463: action-only run with empty text must still show
         result_kind/result_count (not just «(пусто)»).
@@ -605,7 +605,7 @@ class TestPipelineRunsToolResultSemantics:
         assert "processed_messages:8" in text
         assert "Run id=12" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_run_generation_shows_text_and_label(self, mock_db):
         from tests.factories.pipeline_runs import make_generation_run
 

--- a/tests/test_agent_tools_pipelines_write_paths.py
+++ b/tests/test_agent_tools_pipelines_write_paths.py
@@ -58,7 +58,7 @@ def _make_pipeline(
 
 
 class TestGetPipelineQueueErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         mock_db.repos.generation_runs.list_by_status = AsyncMock(
             side_effect=Exception("DB error")
@@ -77,7 +77,7 @@ class TestGetPipelineQueueErrors:
 
 
 class TestGetRefinementStepsErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(
             side_effect=Exception("corrupt data")
@@ -88,7 +88,7 @@ class TestGetRefinementStepsErrors:
         text = _text(result)
         assert "Ошибка получения шагов рефайнмента" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
@@ -96,7 +96,7 @@ class TestGetRefinementStepsErrors:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_steps(self, mock_db):
         pipeline = _make_pipeline(refinement_steps=[])
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=pipeline)
@@ -105,7 +105,7 @@ class TestGetRefinementStepsErrors:
 
         assert "не имеет шагов рефайнмента" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_steps(self, mock_db):
         pipeline = _make_pipeline(refinement_steps=[
             {"name": "Improve", "prompt": "Make this better: {text}"},
@@ -125,7 +125,7 @@ class TestGetRefinementStepsErrors:
 
 
 class TestGetPipelineDetailErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(side_effect=Exception("fail"))
@@ -142,7 +142,7 @@ class TestGetPipelineDetailErrors:
 
 
 class TestAddPipelineErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.add = AsyncMock(side_effect=Exception("constraint"))
@@ -158,7 +158,7 @@ class TestAddPipelineErrors:
         text = _text(result)
         assert "Ошибка создания пайплайна" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_required_fields(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({
@@ -167,7 +167,7 @@ class TestAddPipelineErrors:
         })
         assert "обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_target_ref_format(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({
@@ -179,7 +179,7 @@ class TestAddPipelineErrors:
         })
         assert "Неверный формат target_ref" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["add_pipeline"]({
@@ -190,7 +190,7 @@ class TestAddPipelineErrors:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_add(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.add = AsyncMock(return_value=42)
@@ -216,7 +216,7 @@ class TestAddPipelineErrors:
 
 
 class TestEditPipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["edit_pipeline"]({
@@ -224,13 +224,13 @@ class TestEditPipeline:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["edit_pipeline"]({"confirm": True})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(return_value=None)
@@ -242,7 +242,7 @@ class TestEditPipeline:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_edit_with_source_ids(self, mock_db):
         pipeline = _make_pipeline()
         detail = {
@@ -266,7 +266,7 @@ class TestEditPipeline:
         text = _text(result)
         assert "обновлён" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_with_new_target_refs(self, mock_db):
         pipeline = _make_pipeline()
         detail = {
@@ -290,7 +290,7 @@ class TestEditPipeline:
         text = _text(result)
         assert "обновлён" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_invalid_target_ref(self, mock_db):
         pipeline = _make_pipeline()
         detail = {
@@ -312,7 +312,7 @@ class TestEditPipeline:
 
         assert "Неверный формат target_ref" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_returns_false(self, mock_db):
         pipeline = _make_pipeline()
         detail = {
@@ -334,7 +334,7 @@ class TestEditPipeline:
 
         assert "Не удалось обновить" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(side_effect=Exception("boom"))
@@ -353,13 +353,13 @@ class TestEditPipeline:
 
 
 class TestTogglePipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.toggle = AsyncMock(return_value=False)
@@ -368,7 +368,7 @@ class TestTogglePipeline:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_activated(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.toggle = AsyncMock(return_value=True)
@@ -382,7 +382,7 @@ class TestTogglePipeline:
         assert "активирован" in text
         assert "MyPipe" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.toggle = AsyncMock(side_effect=Exception("error"))
@@ -398,13 +398,13 @@ class TestTogglePipeline:
 
 
 class TestDeletePipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["delete_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(
@@ -415,7 +415,7 @@ class TestDeletePipeline:
 
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_delete(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(
@@ -432,7 +432,7 @@ class TestDeletePipeline:
         assert "удалён" in text
         assert "DelMe" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(side_effect=Exception("fk error"))
@@ -451,13 +451,13 @@ class TestDeletePipeline:
 
 
 class TestListPipelineRunsErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_pipeline_runs"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_runs(self, mock_db):
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db)
@@ -465,7 +465,7 @@ class TestListPipelineRunsErrors:
 
         assert "Нет генераций" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_status_filter(self, mock_db):
         runs = [
             SimpleNamespace(
@@ -490,7 +490,7 @@ class TestListPipelineRunsErrors:
         assert "text A" in text
         assert "text B" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(
             side_effect=Exception("fail")
@@ -507,13 +507,13 @@ class TestListPipelineRunsErrors:
 
 
 class TestGetPipelineRunErrors:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_run_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_pipeline_run"]({})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
@@ -521,7 +521,7 @@ class TestGetPipelineRunErrors:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos.generation_runs.get = AsyncMock(side_effect=Exception("err"))
         handlers = _get_tool_handlers(mock_db)
@@ -529,7 +529,7 @@ class TestGetPipelineRunErrors:
 
         assert "Ошибка получения run" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_get(self, mock_db):
         run = SimpleNamespace(
             id=1, pipeline_id=1, status="completed",
@@ -552,7 +552,7 @@ class TestGetPipelineRunErrors:
 
 
 class TestPublishPipelineRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["publish_pipeline_run"]({
@@ -561,19 +561,19 @@ class TestPublishPipelineRun:
         })
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["publish_pipeline_run"]({"run_id": 1})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_run_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["publish_pipeline_run"]({"confirm": True})
         assert "run_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_not_found(self, mock_db, mock_pool):
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
@@ -584,7 +584,7 @@ class TestPublishPipelineRun:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db, mock_pool):
         run = SimpleNamespace(id=1, pipeline_id=99, generated_text="x")
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -599,7 +599,7 @@ class TestPublishPipelineRun:
 
         assert "Пайплайн id=99 не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_publish_with_failures(self, mock_db, mock_pool):
         run = SimpleNamespace(id=1, pipeline_id=1, generated_text="x")
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -627,7 +627,7 @@ class TestPublishPipelineRun:
         assert "1 ошибок" in text
         assert "Flood wait" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_publish_exception(self, mock_db, mock_pool):
         run = SimpleNamespace(id=1, pipeline_id=1, generated_text="x")
         mock_db.repos.generation_runs.get = AsyncMock(return_value=run)
@@ -657,19 +657,19 @@ class TestPublishPipelineRun:
 
 
 class TestSetRefinementSteps:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_refinement_steps"]({"confirm": True})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_refinement_steps"]({"pipeline_id": 1})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_json(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_refinement_steps"]({
@@ -679,7 +679,7 @@ class TestSetRefinementSteps:
         })
         assert "Ошибка парсинга steps_json" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_a_list(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_refinement_steps"]({
@@ -689,7 +689,7 @@ class TestSetRefinementSteps:
         })
         assert "должен быть JSON-массивом" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_dropped_steps_with_missing_prompt(self, mock_db):
         steps = [
             {"name": "Step1", "prompt": "Do something: {text}"},
@@ -703,7 +703,7 @@ class TestSetRefinementSteps:
         })
         assert "1 из 2 шагов не содержат" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
@@ -714,7 +714,7 @@ class TestSetRefinementSteps:
         })
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_set(self, mock_db):
         pipeline = _make_pipeline()
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=pipeline)
@@ -731,7 +731,7 @@ class TestSetRefinementSteps:
         assert "1 шт" in text
         mock_db.repos.content_pipelines.set_refinement_steps.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(
             side_effect=Exception("db fail")
@@ -745,7 +745,7 @@ class TestSetRefinementSteps:
 
         assert "Ошибка обновления шагов рефайнмента" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_steps_clears(self, mock_db):
         pipeline = _make_pipeline()
         mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=pipeline)
@@ -768,13 +768,13 @@ class TestSetRefinementSteps:
 
 
 class TestExportPipelineJson:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["export_pipeline_json"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.export_json = AsyncMock(return_value=None)
@@ -783,7 +783,7 @@ class TestExportPipelineJson:
 
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_export(self, mock_db):
         export_data = {"name": "MyPipe", "prompt_template": "test"}
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -796,7 +796,7 @@ class TestExportPipelineJson:
         parsed = json.loads(text)
         assert parsed["name"] == "MyPipe"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.export_json = AsyncMock(
@@ -814,7 +814,7 @@ class TestExportPipelineJson:
 
 
 class TestImportPipelineJson:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["import_pipeline_json"]({
@@ -822,13 +822,13 @@ class TestImportPipelineJson:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_json_text(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["import_pipeline_json"]({"confirm": True})
         assert "json_text обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_import(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.import_json = AsyncMock(return_value=5)
@@ -842,7 +842,7 @@ class TestImportPipelineJson:
         assert "импортирован" in text
         assert "5" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_import_with_name_override(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.import_json = AsyncMock(return_value=6)
@@ -857,7 +857,7 @@ class TestImportPipelineJson:
         call_kwargs = mock_svc.return_value.import_json.await_args.kwargs
         assert call_kwargs["name_override"] == "New Name"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.import_json = AsyncMock(
@@ -878,7 +878,7 @@ class TestImportPipelineJson:
 
 
 class TestListPipelineTemplates:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list_templates = AsyncMock(return_value=[])
@@ -887,7 +887,7 @@ class TestListPipelineTemplates:
 
         assert "Шаблонов не найдено" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_templates(self, mock_db):
         from enum import Enum
 
@@ -919,7 +919,7 @@ class TestListPipelineTemplates:
         assert "fetch" in text
         assert "generate" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_category_filter(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list_templates = AsyncMock(return_value=[])
@@ -932,7 +932,7 @@ class TestListPipelineTemplates:
             category="automation"
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.list_templates = AsyncMock(
@@ -950,7 +950,7 @@ class TestListPipelineTemplates:
 
 
 class TestCreatePipelineFromTemplate:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_pipeline_from_template"]({
@@ -959,7 +959,7 @@ class TestCreatePipelineFromTemplate:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_template_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_pipeline_from_template"]({
@@ -968,7 +968,7 @@ class TestCreatePipelineFromTemplate:
         })
         assert "template_id и name обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_name(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["create_pipeline_from_template"]({
@@ -977,7 +977,7 @@ class TestCreatePipelineFromTemplate:
         })
         assert "template_id и name обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_create(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.create_from_template = AsyncMock(return_value=10)
@@ -995,7 +995,7 @@ class TestCreatePipelineFromTemplate:
         assert "создан из шаблона" in text
         assert "10" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_target_ref_without_pipe_skipped(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.create_from_template = AsyncMock(return_value=11)
@@ -1011,7 +1011,7 @@ class TestCreatePipelineFromTemplate:
         text = _text(result)
         assert "создан из шаблона" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.create_from_template = AsyncMock(
@@ -1033,7 +1033,7 @@ class TestCreatePipelineFromTemplate:
 
 
 class TestAiEditPipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["ai_edit_pipeline"]({
@@ -1041,7 +1041,7 @@ class TestAiEditPipeline:
         })
         assert "pipeline_id и instruction обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_instruction(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["ai_edit_pipeline"]({
@@ -1049,7 +1049,7 @@ class TestAiEditPipeline:
         })
         assert "pipeline_id и instruction обязательны" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["ai_edit_pipeline"]({
@@ -1058,7 +1058,7 @@ class TestAiEditPipeline:
         })
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_edit(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.edit_via_llm = AsyncMock(return_value={
@@ -1076,7 +1076,7 @@ class TestAiEditPipeline:
         assert "обновлён через AI" in text
         assert "Updated" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_llm_returns_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.edit_via_llm = AsyncMock(return_value={
@@ -1094,7 +1094,7 @@ class TestAiEditPipeline:
         assert "Ошибка AI-редактирования" in text
         assert "Could not parse instruction" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.edit_via_llm = AsyncMock(
@@ -1118,7 +1118,7 @@ class TestAiEditPipeline:
 
 
 class TestBuildImageServiceFallback:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_image_service_builds_without_config(self, mock_db):
         """When config is None, _build_image_service should return a bare ImageGenerationService."""
         pipeline = _make_pipeline()
@@ -1149,7 +1149,7 @@ class TestBuildImageServiceFallback:
 
 
 class TestGenerateDraftTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -1171,7 +1171,7 @@ class TestGenerateDraftTool:
         text = _text(result)
         assert "Ошибка генерации" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_successful_draft(self, mock_db):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -1197,7 +1197,7 @@ class TestGenerateDraftTool:
         assert "Draft content" in text
         assert "ChanA" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipeline_id_uses_template(self, mock_db):
         pipeline = _make_pipeline(prompt_template="Write about {topic}")
         with (

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -100,21 +100,21 @@ class TestRequirePool:
 
 
 class TestResolvePhone:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_non_empty_phone_passed_through(self):
         db = MagicMock()
         phone, err = await resolve_phone(db, "+79001234567")
         assert phone == "+79001234567"
         assert err is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_normalizes_phone_without_plus(self):
         db = MagicMock()
         phone, err = await resolve_phone(db, "79001234567")
         assert phone == "+79001234567"
         assert err is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_phone_defaults_to_primary(self):
         primary = SimpleNamespace(phone="+11111111111", is_primary=True)
         secondary = SimpleNamespace(phone="+22222222222", is_primary=False)
@@ -125,7 +125,7 @@ class TestResolvePhone:
         assert phone == "+11111111111"
         assert err is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_phone_no_primary_picks_first(self):
         acc1 = SimpleNamespace(phone="+111", is_primary=False)
         acc2 = SimpleNamespace(phone="+222", is_primary=False)
@@ -136,7 +136,7 @@ class TestResolvePhone:
         assert phone == "+111"
         assert err is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_phone_no_accounts(self):
         db = MagicMock()
         db.get_accounts = AsyncMock(return_value=[])
@@ -145,7 +145,7 @@ class TestResolvePhone:
         assert err is not None
         assert "нет подключённых" in err["content"][0]["text"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_db_exception_returns_error(self):
         db = MagicMock()
         db.get_accounts = AsyncMock(side_effect=Exception("DB down"))
@@ -159,21 +159,21 @@ class TestResolvePhone:
 
 
 class TestRequirePhonePermission:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_setting_allows_all(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value=None)
         result = await require_phone_permission(db, "+7900", "search_messages")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_setting_allows_all(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value="")
         result = await require_phone_permission(db, "+7900", "search_messages")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_malformed_json_blocks(self):
         db = MagicMock()
         db.get_setting = AsyncMock(return_value="not-json")
@@ -181,7 +181,7 @@ class TestRequirePhonePermission:
         assert result is not None
         assert "заблокировано" in result["content"][0]["text"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_db_exception_blocks(self):
         db = MagicMock()
         db.get_setting = AsyncMock(side_effect=Exception("err"))
@@ -189,7 +189,7 @@ class TestRequirePhonePermission:
         assert result is not None
         assert "заблокировано" in result["content"][0]["text"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_phone_in_allowed_list(self):
         db = MagicMock()
         perms = {"+7900": {"search_messages": True}}
@@ -197,7 +197,7 @@ class TestRequirePhonePermission:
         result = await require_phone_permission(db, "+7900", "search_messages")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_phone_not_allowed(self):
         """Phone is in perms dict but tool is disabled for it → blocked."""
         db = MagicMock()
@@ -213,7 +213,7 @@ class TestRequirePhonePermission:
         assert "не разрешён" in text
         assert "+7900" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_phone_not_in_perms_defaults_allowed(self):
         """Phone not in perms dict at all → defaults to allowed."""
         db = MagicMock()
@@ -224,7 +224,7 @@ class TestRequirePhonePermission:
         # Phone not in perms dict → allowed (returns None)
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_phone_shows_phone_list(self):
         db = MagicMock()
         perms = {"+7900": {"search_messages": True}}
@@ -235,7 +235,7 @@ class TestRequirePhonePermission:
         text = result["content"][0]["text"]
         assert "укажи параметр phone" in text or "Разрешённые" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_tool_not_restricted_for_any_phone(self):
         """If no phone has this tool enabled, tool is not restricted → allow."""
         db = MagicMock()

--- a/tests/test_agent_tools_scheduler.py
+++ b/tests/test_agent_tools_scheduler.py
@@ -24,14 +24,14 @@ def _make_scheduler_mgr():
 
 
 class TestGetSchedulerStatusTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_manager_returns_error(self, mock_db):
         """Without a scheduler_manager the tool catches RuntimeError and returns text."""
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_scheduler_status"]({})
         assert "Ошибка получения статуса планировщика" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_manager_shows_running_state(self, mock_db):
         mgr = _make_scheduler_mgr()
         handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
@@ -40,7 +40,7 @@ class TestGetSchedulerStatusTool:
         assert "запущен" in text
         assert "60 мин" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_manager_lists_jobs(self, mock_db):
         mgr = _make_scheduler_mgr()
         handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
@@ -50,7 +50,7 @@ class TestGetSchedulerStatusTool:
         assert "вкл" in text
         assert "2025-01-01 12:00" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_manager_stopped(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.is_running = False
@@ -60,20 +60,20 @@ class TestGetSchedulerStatusTool:
 
 
 class TestStartSchedulerTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["start_scheduler"]({"confirm": True})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["start_scheduler"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pool_and_confirm_starts(self, mock_db):
         mgr = _make_scheduler_mgr()
         mock_pool = MagicMock()
@@ -82,7 +82,7 @@ class TestStartSchedulerTool:
         assert "Планировщик запущен" in _text(result)
         mgr.start.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.start = AsyncMock(side_effect=Exception("already running"))
@@ -93,13 +93,13 @@ class TestStartSchedulerTool:
 
 
 class TestStopSchedulerTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["stop_scheduler"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_stops(self, mock_db):
         mgr = _make_scheduler_mgr()
         handlers = _get_tool_handlers(mock_db, scheduler_manager=mgr)
@@ -107,7 +107,7 @@ class TestStopSchedulerTool:
         assert "Планировщик остановлен" in _text(result)
         mgr.stop.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.stop = AsyncMock(side_effect=Exception("not running"))
@@ -117,20 +117,20 @@ class TestStopSchedulerTool:
 
 
 class TestTriggerCollectionTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_pool_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["trigger_collection"]({"confirm": True})
         assert "Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["trigger_collection"]({})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pool_and_confirm_triggers(self, mock_db):
         mgr = _make_scheduler_mgr()
         mock_pool = MagicMock()
@@ -140,7 +140,7 @@ class TestTriggerCollectionTool:
         assert "Сбор запущен" in text
         mgr.trigger_now.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.trigger_now = AsyncMock(side_effect=Exception("busy"))
@@ -151,13 +151,13 @@ class TestTriggerCollectionTool:
 
 
 class TestToggleSchedulerJobTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_job_id_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_scheduler_job"]({})
         assert "job_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_enabled_job_becomes_disabled(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.is_job_enabled = AsyncMock(return_value=True)
@@ -168,7 +168,7 @@ class TestToggleSchedulerJobTool:
         assert "выключена" in text
         mgr.sync_job_state.assert_awaited_once_with("collect", False)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_disabled_job_becomes_enabled(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.is_job_enabled = AsyncMock(return_value=False)
@@ -179,13 +179,13 @@ class TestToggleSchedulerJobTool:
         assert "включена" in text
         mgr.sync_job_state.assert_awaited_once_with("notify", True)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_manager_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["toggle_scheduler_job"]({"job_id": "collect"})
         assert "Ошибка переключения задачи" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mgr = _make_scheduler_mgr()
         mgr.is_job_enabled = AsyncMock(side_effect=Exception("unknown job"))

--- a/tests/test_agent_tools_search_queries.py
+++ b/tests/test_agent_tools_search_queries.py
@@ -24,12 +24,12 @@ async def _add_query(db, query="test query", interval_minutes=30, is_active=True
 
 
 class TestListSearchQueriesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, sq_handlers):
         result = await sq_handlers["list_search_queries"]({"active_only": False})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_lists_all_when_active_only_false(self, db, sq_handlers):
         await _add_query(db, "query1", is_active=True)
         await _add_query(db, "query2", is_active=False)
@@ -39,7 +39,7 @@ class TestListSearchQueriesTool:
         assert "query2" in text
         assert "Поисковые запросы (2)" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_only_filters_inactive(self, db, sq_handlers):
         await _add_query(db, "active_query", is_active=True)
         await _add_query(db, "inactive_query", is_active=False)
@@ -48,7 +48,7 @@ class TestListSearchQueriesTool:
         assert "active_query" in text
         assert "inactive_query" not in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_status_labels(self, db, sq_handlers):
         await _add_query(db, "myquery", is_active=True)
         result = await sq_handlers["list_search_queries"]({})
@@ -57,18 +57,18 @@ class TestListSearchQueriesTool:
 
 
 class TestGetSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id_returns_error(self, sq_handlers):
         result = await sq_handlers["get_search_query"]({})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_error(self, sq_handlers):
         result = await sq_handlers["get_search_query"]({"sq_id": 9999})
         assert "не найден" in _text(result)
         assert "9999" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_found_shows_fields(self, db, sq_handlers):
         sq_id = await _add_query(db, "find this")
         result = await sq_handlers["get_search_query"]({"sq_id": sq_id})
@@ -80,24 +80,24 @@ class TestGetSearchQueryTool:
 
 
 class TestAddSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_query_returns_error(self, sq_handlers):
         result = await sq_handlers["add_search_query"]({"confirm": True})
         assert "query обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, sq_handlers):
         result = await sq_handlers["add_search_query"]({"query": "hello"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_query_and_confirm_creates(self, sq_handlers):
         result = await sq_handlers["add_search_query"]({"query": "new query", "confirm": True})
         text = _text(result)
         assert "создан" in text
         assert "id=" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_custom_interval_creates(self, sq_handlers):
         result = await sq_handlers["add_search_query"](
             {"query": "custom interval", "interval_minutes": 120, "confirm": True}
@@ -106,22 +106,22 @@ class TestAddSearchQueryTool:
 
 
 class TestEditSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id_returns_error(self, sq_handlers):
         result = await sq_handlers["edit_search_query"]({"confirm": True})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, sq_handlers):
         result = await sq_handlers["edit_search_query"]({"sq_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_error(self, sq_handlers):
         result = await sq_handlers["edit_search_query"]({"sq_id": 9999, "confirm": True})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_found_updates_query(self, db, sq_handlers):
         sq_id = await _add_query(db, "original")
         result = await sq_handlers["edit_search_query"](
@@ -129,7 +129,7 @@ class TestEditSearchQueryTool:
         )
         assert "обновлён" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_updates_interval(self, db, sq_handlers):
         sq_id = await _add_query(db, "some query")
         result = await sq_handlers["edit_search_query"](
@@ -139,17 +139,17 @@ class TestEditSearchQueryTool:
 
 
 class TestDeleteSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id_returns_error(self, sq_handlers):
         result = await sq_handlers["delete_search_query"]({})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, sq_handlers):
         result = await sq_handlers["delete_search_query"]({"sq_id": 1})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_confirm_deletes(self, db, sq_handlers):
         sq_id = await _add_query(db, "to delete")
         result = await sq_handlers["delete_search_query"]({"sq_id": sq_id, "confirm": True})
@@ -159,17 +159,17 @@ class TestDeleteSearchQueryTool:
 
 
 class TestToggleSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id_returns_error(self, sq_handlers):
         result = await sq_handlers["toggle_search_query"]({})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found_returns_error(self, sq_handlers):
         result = await sq_handlers["toggle_search_query"]({"sq_id": 9999})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_query_gets_deactivated(self, db, sq_handlers):
         sq_id = await _add_query(db, "active one", is_active=True)
         result = await sq_handlers["toggle_search_query"]({"sq_id": sq_id})
@@ -177,7 +177,7 @@ class TestToggleSearchQueryTool:
         assert "деактивирован" in text
         assert str(sq_id) in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_query_gets_activated(self, db, sq_handlers):
         sq_id = await _add_query(db, "inactive one", is_active=False)
         result = await sq_handlers["toggle_search_query"]({"sq_id": sq_id})
@@ -187,12 +187,12 @@ class TestToggleSearchQueryTool:
 
 
 class TestRunSearchQueryTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_sq_id_returns_error(self, sq_handlers):
         result = await sq_handlers["run_search_query"]({})
         assert "sq_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_returns_count(self, db, sq_handlers):
         sq_id = await _add_query(db, "search term")
         result = await sq_handlers["run_search_query"]({"sq_id": sq_id})
@@ -201,7 +201,7 @@ class TestRunSearchQueryTool:
         assert "совпадений" in text
         assert str(sq_id) in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_nonexistent_returns_zero_matches(self, sq_handlers):
         """run_search_query with a nonexistent id returns 0 matches (service is lenient)."""
         result = await sq_handlers["run_search_query"]({"sq_id": 9999})

--- a/tests/test_agent_tools_search_telegram.py
+++ b/tests/test_agent_tools_search_telegram.py
@@ -28,7 +28,7 @@ def mock_pool():
 
 
 class TestIndexMessagesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         with patch(
             "src.services.embedding_service.EmbeddingService"
@@ -43,7 +43,7 @@ class TestIndexMessagesTool:
         text = _text(result)
         assert "42" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch(
             "src.services.embedding_service.EmbeddingService"
@@ -68,13 +68,13 @@ class TestIndexMessagesTool:
 
 
 class TestSearchTelegramTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["search_telegram"]({"query": "test"})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="cats",
@@ -99,7 +99,7 @@ class TestSearchTelegramTool:
         assert "Найдено 1" in text
         assert "Cats are great" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_result(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="nothing",
@@ -121,7 +121,7 @@ class TestSearchTelegramTool:
         text = _text(result)
         assert "Ничего не найдено" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_result_with_error_field(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="fail",
@@ -143,7 +143,7 @@ class TestSearchTelegramTool:
         text = _text(result)
         assert "Premium required" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error_text(self, mock_db, mock_pool):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -166,13 +166,13 @@ class TestSearchTelegramTool:
 
 
 class TestSearchMyChatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["search_my_chats"]({"query": "test"})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="hello",
@@ -197,7 +197,7 @@ class TestSearchMyChatsTool:
         assert "Найдено 1" in text
         assert "Hello world" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_field_rendered(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="x",
@@ -219,7 +219,7 @@ class TestSearchMyChatsTool:
         text = _text(result)
         assert "Not authenticated" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error_text(self, mock_db, mock_pool):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -241,19 +241,19 @@ class TestSearchMyChatsTool:
 
 
 class TestSearchInChannelTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
         result = await handlers["search_in_channel"]({"channel_id": 100, "query": "test"})
         assert "требует Telegram-клиент" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_channel_id(self, mock_db, mock_pool):
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["search_in_channel"]({"query": "test"})
         assert "channel_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="news",
@@ -279,7 +279,7 @@ class TestSearchInChannelTool:
         text = _text(result)
         assert "Breaking news" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_field_rendered(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="x",
@@ -303,7 +303,7 @@ class TestSearchInChannelTool:
         text = _text(result)
         assert "Channel not found" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error_text(self, mock_db, mock_pool):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -327,7 +327,7 @@ class TestSearchInChannelTool:
 
 
 class TestSearchHybridTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_results(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="ai",
@@ -358,7 +358,7 @@ class TestSearchHybridTool:
         assert call_kwargs["channel_id"] == 100
         assert call_kwargs["limit"] == 5
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_result(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="nothing",
@@ -380,7 +380,7 @@ class TestSearchHybridTool:
         text = _text(result)
         assert "Ничего не найдено" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_field_rendered(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="x",
@@ -402,7 +402,7 @@ class TestSearchHybridTool:
         text = _text(result)
         assert "Index not built" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_returns_error_text(self, mock_db, mock_pool):
         with (
             patch("src.services.embedding_service.EmbeddingService"),
@@ -418,7 +418,7 @@ class TestSearchHybridTool:
         assert "Ошибка гибридного поиска" in text
         assert "OOM" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_optional_filters_passed(self, mock_db, mock_pool):
         fake_result = SimpleNamespace(
             query="test",
@@ -452,7 +452,7 @@ class TestSearchHybridTool:
         assert call_kwargs["min_length"] == 50
         assert call_kwargs["max_length"] == 500
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_client_pool_hybrid_still_works(self, mock_db):
         """search_hybrid does not require client_pool (local DB only)."""
         fake_result = SimpleNamespace(
@@ -482,7 +482,7 @@ class TestSearchHybridTool:
 
 
 class TestSearchMessagesOptionalFilters:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_optional_filters_passed(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
         handlers = _get_tool_handlers(mock_db)
@@ -505,7 +505,7 @@ class TestSearchMessagesOptionalFilters:
         assert call_kwargs["max_length"] == 100
         assert call_kwargs["limit"] == 5
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_id_as_string_converted(self, mock_db):
         mock_db.search_messages = AsyncMock(return_value=([], 0))
         handlers = _get_tool_handlers(mock_db)

--- a/tests/test_agent_tools_settings.py
+++ b/tests/test_agent_tools_settings.py
@@ -9,7 +9,7 @@ from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 class TestGetSettingsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_all_settings_keys(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=None)
         handlers = _get_tool_handlers(mock_db)
@@ -19,7 +19,7 @@ class TestGetSettingsTool:
         assert "agent_prompt_template" in text
         assert "Настройки системы" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_set_values(self, mock_db):
         async def fake_get(key):
             return "60" if key == "collect_interval_minutes" else None
@@ -29,14 +29,14 @@ class TestGetSettingsTool:
         result = await handlers["get_settings"]({})
         assert "60" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_setting = AsyncMock(side_effect=Exception("no table"))
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_settings"]({})
         assert "Ошибка получения настроек" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_settings(self, mock_db):
         mock_db.get_setting = AsyncMock(side_effect=lambda k: {"collect_interval_minutes": "60"}.get(k))
         handlers = _get_tool_handlers(mock_db)
@@ -45,7 +45,7 @@ class TestGetSettingsTool:
         assert "Настройки системы" in text
         assert "collect_interval_minutes" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
         mock_db.get_setting = AsyncMock(side_effect=Exception("db error"))
         handlers = _get_tool_handlers(mock_db)
@@ -54,13 +54,13 @@ class TestGetSettingsTool:
 
 
 class TestSaveAgentSettingsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_agent_settings"]({"backend": "claude"})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_prompt_template(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -70,7 +70,7 @@ class TestSaveAgentSettingsTool:
         assert "сохранены" in _text(result)
         mock_db.set_setting.assert_any_await("agent_prompt_template", "You are a helpful bot.")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_backend_override(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -78,13 +78,13 @@ class TestSaveAgentSettingsTool:
         assert "сохранены" in _text(result)
         mock_db.set_setting.assert_any_await("agent_backend_override", "deepagents")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_agent_settings"]({"prompt_template": "new template"})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_prompt_template_via_call(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -94,7 +94,7 @@ class TestSaveAgentSettingsTool:
         assert "сохранены" in _text(result)
         mock_db.set_setting.assert_any_call("agent_prompt_template", "new template")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_backend(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -106,13 +106,13 @@ class TestSaveAgentSettingsTool:
 
 
 class TestSaveFilterSettingsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_filter_settings"]({"low_uniqueness_threshold": 0.5})
         assert "confirm=true" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_thresholds(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -123,13 +123,13 @@ class TestSaveFilterSettingsTool:
         mock_db.set_setting.assert_any_await("low_uniqueness_threshold", "0.3")
         mock_db.set_setting.assert_any_await("low_subscriber_ratio_threshold", "0.1")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_filter_settings"]({"low_uniqueness_threshold": 0.3})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_thresholds_via_call(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -141,13 +141,13 @@ class TestSaveFilterSettingsTool:
 
 
 class TestSaveSchedulerSettingsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_scheduler_settings"]({"collect_interval_minutes": 30})
         assert "confirm=true" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_saves_interval(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -157,7 +157,7 @@ class TestSaveSchedulerSettingsTool:
         assert "30 мин" in _text(result)
         mock_db.set_setting.assert_called_with("collect_interval_minutes", "30")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clamps_interval_to_range(self, mock_db):
         mock_db.set_setting = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
@@ -175,7 +175,7 @@ class TestSaveSchedulerSettingsTool:
 
 
 class TestGetSystemInfoTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_shows_stats(self, mock_db):
         mock_db.get_stats = AsyncMock(return_value={"channels": 10, "messages": 1000})
         handlers = _get_tool_handlers(mock_db)
@@ -185,14 +185,14 @@ class TestGetSystemInfoTool:
         assert "10" in text
         assert "Системная информация" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         mock_db.get_stats = AsyncMock(side_effect=Exception("no stats"))
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_system_info"]({})
         assert "Ошибка получения системной информации" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_stats(self, mock_db):
         mock_db.get_stats = AsyncMock(return_value={"channels": 10, "messages": 5000})
         handlers = _get_tool_handlers(mock_db)
@@ -201,7 +201,7 @@ class TestGetSystemInfoTool:
         assert "Системная информация" in text
         assert "channels" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
         mock_db.get_stats = AsyncMock(side_effect=Exception("stats error"))
         handlers = _get_tool_handlers(mock_db)

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -174,7 +174,7 @@ def app_factory(db):
     return _factory
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_mounts_and_shows_threads(db, app_factory):
     """App mounts, auto-creates a thread, sidebar renders it."""
     app = app_factory()
@@ -186,7 +186,7 @@ async def test_tui_mounts_and_shows_threads(db, app_factory):
         assert len(items) >= 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_shows_existing_thread_messages(db, app_factory):
     """Existing messages are rendered when thread loads."""
     tid = await db.create_agent_thread("my thread")
@@ -204,7 +204,7 @@ async def test_tui_shows_existing_thread_messages(db, app_factory):
         assert "assistant" in roles
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_send_message_calls_chat_stream(db, app_factory):
     """Sending a message triggers chat_stream on the AgentManager."""
     config = AppConfig()
@@ -230,7 +230,7 @@ async def test_tui_send_message_calls_chat_stream(db, app_factory):
     assert "test message" in str(call_args)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_send_message_saves_to_db(db, app_factory):
     """User message and assistant response are saved to DB."""
     config = AppConfig()
@@ -257,7 +257,7 @@ async def test_tui_send_message_saves_to_db(db, app_factory):
     assert "my question" in contents
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_new_thread_action(db, app_factory):
     """Ctrl+N creates a new thread."""
     app = app_factory()
@@ -270,7 +270,7 @@ async def test_tui_new_thread_action(db, app_factory):
         assert len(threads_after) == len(threads_before) + 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_delete_thread_action(db, app_factory):
     """Ctrl+D deletes the active thread and auto-creates a new one if needed."""
     app = app_factory()
@@ -286,7 +286,7 @@ async def test_tui_delete_thread_action(db, app_factory):
         assert active_id not in remaining_ids
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_toggle_sidebar(db, app_factory):
     """Ctrl+T toggles sidebar visibility."""
     app = app_factory()
@@ -304,7 +304,7 @@ async def test_tui_toggle_sidebar(db, app_factory):
         assert sidebar.display is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_thread_auto_rename(db, app_factory):
     """First message auto-renames 'Новый тред'."""
     config = AppConfig()
@@ -328,7 +328,7 @@ async def test_tui_thread_auto_rename(db, app_factory):
     assert thread["title"] == "Hello world!"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_error_chunk_cleans_up(db, app_factory):
     """SSE error chunk triggers cleanup via delete_last_agent_exchange."""
     config = AppConfig()
@@ -371,7 +371,7 @@ def test_ctrl_c_not_bound():
     assert "ctrl+c" not in bound_keys
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_copy_to_clipboard_called(db, app_factory, monkeypatch):
     """action_copy_text() delegates to copy_to_clipboard()."""
     app = app_factory()
@@ -557,7 +557,7 @@ class TestAgentChatInteractiveMode:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_button_toggles_to_stop_during_streaming(db, app_factory):
     """Button must show '■ Стоп (esc)' with error variant while streaming."""
     gate = asyncio.Event()
@@ -596,7 +596,7 @@ async def test_button_toggles_to_stop_during_streaming(db, app_factory):
         assert btn.variant == "success"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_button_reverts_after_cancel(db, app_factory):
     """Pressing ESC during streaming cancels and reverts button to Отправить."""
     gate = asyncio.Event()
@@ -635,7 +635,7 @@ async def test_button_reverts_after_cancel(db, app_factory):
     gate.set()  # cleanup
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_button_click_cancels_streaming(db, app_factory):
     """Clicking the stop button during streaming cancels the stream."""
     gate = asyncio.Event()
@@ -676,7 +676,7 @@ async def test_stop_button_click_cancels_streaming(db, app_factory):
     gate.set()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_no_race_condition_button_set_before_worker_runs(db, app_factory):
     """Verify _set_button_streaming(True) executes before worker starts.
 
@@ -760,7 +760,7 @@ class TestAgentChatParser:
         assert args.thread_id == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tui_stream_shows_tool_status(db, app_factory):
     """Tool SSE events update the streaming widget status label."""
     config = AppConfig()

--- a/tests/test_ai_search.py
+++ b/tests/test_ai_search.py
@@ -30,7 +30,7 @@ def fake_deepagents():
         yield create_deep_agent
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_disabled(mock_search_bundle):
     config = LLMConfig(enabled=False)
     engine = AISearchEngine(config, mock_search_bundle)
@@ -41,7 +41,7 @@ async def test_ai_search_disabled(mock_search_bundle):
     assert "AI search is not available" in res.ai_summary
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_initialization_success(llm_config, mock_search_bundle):
     mock_create = MagicMock()
     mock_agent = MagicMock()
@@ -56,7 +56,7 @@ async def test_ai_search_initialization_success(llm_config, mock_search_bundle):
     mock_create.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_initialization_import_error(llm_config, mock_search_bundle):
     with patch.dict(sys.modules, {"deepagents": None}):
         engine = AISearchEngine(llm_config, mock_search_bundle)
@@ -64,7 +64,7 @@ async def test_ai_search_initialization_import_error(llm_config, mock_search_bun
         assert engine._agent is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_initialization_general_error(llm_config, mock_search_bundle):
     mock_create = MagicMock(side_effect=Exception("unexpected"))
     module = types.SimpleNamespace(create_deep_agent=mock_create)
@@ -76,7 +76,7 @@ async def test_ai_search_initialization_general_error(llm_config, mock_search_bu
     assert engine._agent is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_run_success(llm_config, mock_search_bundle, fake_deepagents):
     mock_agent = MagicMock()
     mock_agent.run.return_value = "AI Summary Result"
@@ -95,7 +95,7 @@ async def test_ai_search_run_success(llm_config, mock_search_bundle, fake_deepag
     assert res.total == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagents):
     mock_agent = MagicMock()
     mock_agent.run.side_effect = Exception("AI Fail")
@@ -108,7 +108,7 @@ async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagen
     assert "AI search error: AI Fail" in res.ai_summary
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_posts_tool_logic(llm_config, mock_search_bundle, fake_deepagents):
     # This tests the tool function defined inside initialize
     mock_search_bundle.search_messages.return_value = (
@@ -130,7 +130,7 @@ async def test_search_posts_tool_logic(llm_config, mock_search_bundle, fake_deep
     assert "content" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_posts_tool_no_results(llm_config, mock_search_bundle, fake_deepagents):
     mock_search_bundle.search_messages.return_value = ([], 0)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -56,7 +56,7 @@ class TestDescribeNextType:
 
 
 class TestSendCode:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_code_returns_dict(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         fake_type = FakeSentCodeTypeApp()
@@ -87,7 +87,7 @@ class TestSendCode:
         assert info["timeout"] == 60
         assert "+1234567890" in auth._pending
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_code_disconnects_previous_pending_client(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         old_client = MagicMock()
@@ -117,13 +117,13 @@ class TestSendCode:
 
 
 class TestResendCode:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resend_code_no_pending(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         with pytest.raises(ValueError, match="No pending auth"):
             await auth.resend_code("+1234567890")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resend_code_calls_resend_request(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         mock_client = AsyncMock()
@@ -153,7 +153,7 @@ class TestResendCode:
 
 
 class TestVerifyCode:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_disconnects_temporary_client(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         mock_client = AsyncMock()

--- a/tests/test_auth_flow_cli.py
+++ b/tests/test_auth_flow_cli.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @pytest.mark.telegram_unit
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cli_send_code_saves_hash_to_db(tmp_path):
     """account send-code saves phone_code_hash to DB under auth_pending:{phone}."""
     import json
@@ -47,7 +47,7 @@ async def test_cli_send_code_saves_hash_to_db(tmp_path):
 
 
 @pytest.mark.telegram_unit
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sign_in_fresh_success():
     """sign_in_fresh() passes session_str to StringSession and signs in."""
     from src.telegram.auth import TelegramAuth
@@ -77,7 +77,7 @@ async def test_sign_in_fresh_success():
 
 
 @pytest.mark.telegram_unit
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sign_in_fresh_2fa_required():
     """sign_in_fresh raises ValueError('2FA') when SessionPasswordNeededError and no password given."""
     from telethon.errors import SessionPasswordNeededError
@@ -94,7 +94,7 @@ async def test_sign_in_fresh_2fa_required():
 
 
 @pytest.mark.telegram_unit
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sign_in_fresh_2fa_with_password():
     """sign_in_fresh with password succeeds after SessionPasswordNeededError."""
     from telethon.errors import SessionPasswordNeededError
@@ -118,7 +118,7 @@ async def test_sign_in_fresh_2fa_with_password():
 
 
 @pytest.mark.telegram_unit
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sign_in_fresh_does_not_require_pending():
     """sign_in_fresh works without prior send_code in same process (no _pending check)."""
     from src.telegram.auth import TelegramAuth

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -45,7 +45,7 @@ def test_with_flood_context_returns_distinct_session_without_mutating_original()
 # --- Batch 1: Messages (#184, #185, #186, #190) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_messages():
     result = SimpleNamespace(id=99)
     session = _session(forward_messages_side_effect=lambda *a: result)
@@ -54,7 +54,7 @@ async def test_forward_messages():
     session.raw_client.forward_messages.assert_awaited_once_with("target", [1, 2], "source")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_message():
     result = SimpleNamespace(id=1, message="edited")
     session = _session(edit_message_side_effect=lambda *a, **kw: result)
@@ -63,28 +63,28 @@ async def test_edit_message():
     session.raw_client.edit_message.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pin_message():
     session = _session(pin_message_side_effect=lambda *a, **kw: None)
     await session.pin_message("chat", 42, notify=True)
     session.raw_client.pin_message.assert_awaited_once_with("chat", 42, notify=True)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message():
     session = _session(unpin_message_side_effect=lambda *a: None)
     await session.unpin_message("chat", 42)
     session.raw_client.unpin_message.assert_awaited_once_with("chat", 42)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unpin_message_all():
     session = _session(unpin_message_side_effect=lambda *a: None)
     await session.unpin_message("chat")
     session.raw_client.unpin_message.assert_awaited_once_with("chat", None)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_messages():
     session = _session(delete_messages_side_effect=lambda *a: [SimpleNamespace(pts_count=2)])
     result = await session.delete_messages("chat", [1, 2])
@@ -95,7 +95,7 @@ async def test_delete_messages():
 # --- Batch 2: Media (#187) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media():
     session = _session(download_media_side_effect=lambda *a, **kw: "/tmp/photo.jpg")
     result = await session.download_media(SimpleNamespace(id=1), file="/tmp/photo.jpg")
@@ -103,7 +103,7 @@ async def test_download_media():
     session.raw_client.download_media.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_transport_session_reports_flood_from_awaitable():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 5
@@ -121,7 +121,7 @@ async def test_transport_session_reports_flood_from_awaitable():
     pool.report_flood.assert_awaited_once_with("+7000", 5)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_transport_session_reports_flood_from_stream():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 7
@@ -148,7 +148,7 @@ async def test_transport_session_reports_flood_from_stream():
     pool.report_flood.assert_awaited_once_with("+7001", 7)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_transport_session_closes_stream_iterator_on_flood():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 7
@@ -181,7 +181,7 @@ async def test_transport_session_closes_stream_iterator_on_flood():
     pool.report_flood.assert_awaited_once_with("+7001", 7)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_transport_session_reports_flood_from_raw_request():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 9
@@ -202,7 +202,7 @@ async def test_transport_session_reports_flood_from_raw_request():
 # --- Batch 3: Participants (#188, #189) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_participants():
     users = [SimpleNamespace(id=1, username="alice"), SimpleNamespace(id=2, username="bob")]
     session = _session(get_participants_side_effect=lambda *a, **kw: users)
@@ -211,7 +211,7 @@ async def test_get_participants():
     session.raw_client.get_participants.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_participants():
     users = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
     session = _session(iter_participants_factory=lambda *a, **kw: AsyncIterMessages(users))
@@ -221,21 +221,21 @@ async def test_stream_participants():
     assert len(collected) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_admin():
     session = _session(edit_admin_side_effect=lambda *a, **kw: None)
     await session.edit_admin("chat", "user", is_admin=True)
     session.raw_client.edit_admin.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_permissions():
     session = _session(edit_permissions_side_effect=lambda *a, **kw: None)
     await session.edit_permissions("chat", "user", view_messages=False)
     session.raw_client.edit_permissions.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kick_participant():
     session = _session(kick_participant_side_effect=lambda *a: None)
     await session.kick_participant("chat", "user")
@@ -245,14 +245,14 @@ async def test_kick_participant():
 # --- Batch 4: Stats, Folder, Read Acknowledge (#191, #192, #193) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_folder():
     session = _session(edit_folder_side_effect=lambda *a: None)
     await session.edit_folder("chat", 1)
     session.raw_client.edit_folder.assert_awaited_once_with("chat", 1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_read_acknowledge():
     session = _session(send_read_acknowledge_side_effect=lambda *a, **kw: True)
     result = await session.send_read_acknowledge("chat", max_id=100)
@@ -260,7 +260,7 @@ async def test_send_read_acknowledge():
     session.raw_client.send_read_acknowledge.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_send_read_acknowledge_no_max_id():
     session = _session(send_read_acknowledge_side_effect=lambda *a, **kw: True)
     await session.send_read_acknowledge("chat")
@@ -279,7 +279,7 @@ def test_set_proxy():
 # --- uploads ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_upload_file():
     result = SimpleNamespace(id=42)
     session = _session(upload_file_side_effect=lambda *a, **kw: result)
@@ -291,14 +291,14 @@ async def test_upload_file():
 # --- downloads ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_file():
     session = _session(download_file_side_effect=lambda *a, **kw: b"data")
     result = await session.download_file(SimpleNamespace(id=1), "/tmp/out.bin")
     assert result == b"data"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_download():
     chunks = [b"chunk1", b"chunk2"]
     session = _session(iter_download_factory=lambda *a, **kw: AsyncIterMessages(chunks))
@@ -311,7 +311,7 @@ async def test_stream_download():
 # --- dialogs ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_drafts():
     drafts = [SimpleNamespace(text="draft1")]
     session = _session(iter_drafts_factory=lambda: AsyncIterMessages(drafts))
@@ -321,7 +321,7 @@ async def test_stream_drafts():
     assert len(collected) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_drafts():
     drafts = [SimpleNamespace(text="hi")]
     session = _session(get_drafts_side_effect=lambda: drafts)
@@ -339,21 +339,21 @@ def test_conversation():
 # --- users ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_bot():
     session = _session(is_bot_result=False)
     result = await session.is_bot()
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_user_authorized():
     session = _session(authorized=True)
     result = await session.is_user_authorized()
     assert result is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_peer_id():
     session = _session(get_peer_id_side_effect=lambda p: 123456)
     result = await session.get_peer_id("@username")
@@ -363,7 +363,7 @@ async def test_get_peer_id():
 # --- chats ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_admin_log():
     events = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
     session = _session(iter_admin_log_factory=lambda *a, **kw: AsyncIterMessages(events))
@@ -373,7 +373,7 @@ async def test_stream_admin_log():
     assert len(collected) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_admin_log():
     events = [SimpleNamespace(id=1)]
     session = _session(get_admin_log_side_effect=lambda *a, **kw: events)
@@ -381,7 +381,7 @@ async def test_get_admin_log():
     assert len(result) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stream_profile_photos():
     photos = [SimpleNamespace(id=1)]
     session = _session(iter_profile_photos_factory=lambda *a, **kw: AsyncIterMessages(photos))
@@ -391,7 +391,7 @@ async def test_stream_profile_photos():
     assert len(collected) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_profile_photos():
     photos = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
     session = _session(get_profile_photos_side_effect=lambda *a, **kw: photos)
@@ -405,7 +405,7 @@ def test_action():
     assert result is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_permissions():
     perms = SimpleNamespace(send_messages=True, send_media=False)
     session = _session(get_permissions_side_effect=lambda *a: perms)
@@ -416,14 +416,14 @@ async def test_get_permissions():
 # --- updates ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_receive_updates():
     session = _session(set_receive_updates_side_effect=lambda *a: None)
     await session.set_receive_updates(True)
     session.raw_client.set_receive_updates.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_until_disconnected():
     session = _session(run_until_disconnected_side_effect=lambda: None)
     await session.run_until_disconnected()
@@ -463,7 +463,7 @@ def test_list_event_handlers():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_catch_up():
     session = _session(catch_up_side_effect=lambda: None)
     await session.catch_up()
@@ -473,7 +473,7 @@ async def test_catch_up():
 # --- bots ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inline_query():
     results = [SimpleNamespace(id="1", title="result")]
     session = _session(inline_query_side_effect=lambda *a, **kw: results)
@@ -501,7 +501,7 @@ def test_takeout():
     assert result is ctx
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_end_takeout():
     session = _session(end_takeout_side_effect=lambda s: None)
     await session.end_takeout(True)
@@ -511,7 +511,7 @@ async def test_end_takeout():
 # --- stats (invoke_request) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_broadcast_stats():
     stats = SimpleNamespace(period=SimpleNamespace(min_date=0, max_date=0))
     session = _session(invoke_side_effect=lambda req: stats)
@@ -523,7 +523,7 @@ async def test_get_broadcast_stats():
 # --- flood_sleep_threshold (#495) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_native_backend_disables_flood_auto_sleep():
     """NativeTelethonBackend.acquire_client must set flood_sleep_threshold=0
     so Telethon raises FloodWaitError instead of sleeping silently (#495)."""
@@ -540,7 +540,7 @@ async def test_native_backend_disables_flood_auto_sleep():
     assert lease.backend_name == "native"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_telethon_cli_backend_disables_flood_auto_sleep(monkeypatch, tmp_path):
     """TelethonCliBackend.acquire_client must also set flood_sleep_threshold=0 (#495)."""
     fake_client = FakeCliTelethonClient()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -32,7 +32,7 @@ def _make_container(db: Database) -> MagicMock:
     return container
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_autostarts_scheduler_when_flag_set(tmp_path):
     """start_container calls scheduler.start() when scheduler_autostart=1 is in DB."""
     db = Database(str(tmp_path / "test.db"))
@@ -51,7 +51,7 @@ async def test_start_container_autostarts_scheduler_when_flag_set(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_no_autostart_when_flag_absent(tmp_path):
     """start_container does not call scheduler.start() when flag is not set."""
     db = Database(str(tmp_path / "test.db"))
@@ -70,7 +70,7 @@ async def test_start_container_no_autostart_when_flag_absent(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_no_autostart_when_flag_zero(tmp_path):
     """start_container does not call scheduler.start() when scheduler_autostart=0."""
     db = Database(str(tmp_path / "test.db"))
@@ -89,7 +89,7 @@ async def test_start_container_no_autostart_when_flag_zero(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_calls_load_settings(tmp_path):
     """start_container always calls scheduler.load_settings() on startup."""
     db = Database(str(tmp_path / "test.db"))
@@ -107,7 +107,7 @@ async def test_start_container_calls_load_settings(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_web_mode_skips_telegram_runtime(tmp_path):
     """Web runtime should not initialize Telegram pool or worker dispatchers."""
     db = Database(str(tmp_path / "test.db"))
@@ -132,7 +132,7 @@ async def test_start_container_web_mode_skips_telegram_runtime(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_container_worker_mode_initializes_runtime(tmp_path):
     """Worker runtime should initialize Telegram pool and dispatcher startup paths."""
     db = Database(str(tmp_path / "test.db"))
@@ -157,7 +157,7 @@ async def test_start_container_worker_mode_initializes_runtime(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_engine_accepts_none_pool(tmp_path):
     """SearchEngine built with pool=None (web-mode) must not raise on check_search_quota."""
     db = Database(str(tmp_path / "test.db"))
@@ -171,7 +171,7 @@ async def test_search_engine_accepts_none_pool(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_web_container_does_not_connect_telethon(tmp_path, monkeypatch):
     """Regression for #444 Test Plan: web startup without internet must not
     initiate a single Telegram connect/reconnect.

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -63,7 +63,7 @@ async def _seed_messages_batch(db, channel_id, messages):
 # ─── tests ───────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_active_channels(db):
     await _seed_channel(db, channel_id=100111, title="Active 1", username="active1")
     await _seed_channel(db, channel_id=100222, title="Active 2", username="active2")
@@ -80,14 +80,14 @@ async def test_get_active_channels(db):
     assert all(isinstance(c, ChannelListItem) for c in channels)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_active_channels_empty(db):
     svc = ChannelAnalyticsService(db)
     channels = await svc.get_active_channels()
     assert channels == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_overview_basic(db):
     await _seed_channel(db, channel_id=100123, title="Overview Chan", username="ov_chan")
     svc = ChannelAnalyticsService(db)
@@ -104,7 +104,7 @@ async def test_get_channel_overview_basic(db):
     assert overview.err24 is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_overview_with_subscribers(db):
     await _seed_channel(db, channel_id=100123, title="Sub Chan")
     # Two stats entries for delta calculation
@@ -120,7 +120,7 @@ async def test_get_channel_overview_with_subscribers(db):
     assert overview.avg_reactions == 25.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_overview_with_posts(db):
     await _seed_channel(db, channel_id=100123, title="Post Chan")
     await _seed_stats(db, 100123, subscriber_count=500, avg_views=200.0)
@@ -175,7 +175,7 @@ async def test_get_channel_overview_with_posts(db):
     assert overview1.posts_month == 5  # 5 within last day
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_overview_missing_channel(db):
     svc = ChannelAnalyticsService(db)
     overview = await svc.get_channel_overview(999999)
@@ -184,7 +184,7 @@ async def test_get_channel_overview_missing_channel(db):
     assert overview.username is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_subscriber_history(db):
     await _seed_channel(db, channel_id=100123, title="Hist Chan")
     for i in range(5):
@@ -202,7 +202,7 @@ async def test_get_subscriber_history(db):
     assert counts[-1] == 300
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_views_timeseries(db):
     await _seed_channel(db, channel_id=100123, title="Views Chan")
     now = datetime.now(timezone.utc)
@@ -227,7 +227,7 @@ async def test_get_views_timeseries(db):
         assert "avg_views" in entry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_post_frequency(db):
     await _seed_channel(db, channel_id=100123, title="Freq Chan")
     now = datetime.now(timezone.utc)
@@ -264,7 +264,7 @@ async def test_get_post_frequency(db):
     assert yesterday_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_citation_stats(db):
     await _seed_channel(db, channel_id=100123, title="Cite Chan")
     messages = []
@@ -287,7 +287,7 @@ async def test_get_citation_stats(db):
     assert stats.avg_forwards == 20.0  # 100 / 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_err(db):
     await _seed_channel(db, channel_id=100123, title="ERR Chan")
     await _seed_stats(db, 100123, subscriber_count=1000, avg_views=200.0)
@@ -314,7 +314,7 @@ async def test_get_err(db):
     assert abs(err - 10.7) < 0.1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_err_no_subscribers(db):
     await _seed_channel(db, channel_id=100123, title="No Sub Chan")
     svc = ChannelAnalyticsService(db)
@@ -322,7 +322,7 @@ async def test_get_err_no_subscribers(db):
     assert err is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_err24(db):
     await _seed_channel(db, channel_id=100123, title="ERR24 Chan")
     await _seed_stats(db, 100123, subscriber_count=500)
@@ -346,7 +346,7 @@ async def test_get_err24(db):
     assert abs(err24 - 43.0) < 0.1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_err24_no_recent_posts(db):
     await _seed_channel(db, channel_id=100123, title="Empty ERR24")
     await _seed_stats(db, 100123, subscriber_count=500)
@@ -364,7 +364,7 @@ async def test_get_err24_no_recent_posts(db):
     assert err24 is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_hourly_activity(db):
     await _seed_channel(db, channel_id=100123, title="Hourly Chan")
     now = datetime.now(timezone.utc)
@@ -387,7 +387,7 @@ async def test_get_hourly_activity(db):
     assert hour_counts.get(20) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_ranked_channels_by_err(db):
     await _seed_channel(db, channel_id=100111, title="Low ERR", username="low_err")
     await _seed_channel(db, channel_id=100222, title="High ERR", username="high_err")
@@ -429,7 +429,7 @@ async def test_get_ranked_channels_by_err(db):
     assert rankings[1].rank == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_ranked_channels_by_subscriber_count(db):
     await _seed_channel(db, channel_id=100111, title="Small", username="small")
     await _seed_channel(db, channel_id=100222, title="Big", username="big")
@@ -445,7 +445,7 @@ async def test_get_ranked_channels_by_subscriber_count(db):
     assert rankings[1].score == 100.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_ranked_channels_limit(db):
     for i in range(5):
         await _seed_channel(db, channel_id=-100100 - i, title=f"Ch {i}")
@@ -457,7 +457,7 @@ async def test_get_ranked_channels_limit(db):
     assert all(r.rank <= 3 for r in rankings)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_comparison(db):
     await _seed_channel(db, channel_id=100111, title="Chan A", username="chan_a")
     await _seed_channel(db, channel_id=100222, title="Chan B", username="chan_b")
@@ -476,7 +476,7 @@ async def test_get_channel_comparison(db):
     assert "err" in comparison.metrics
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_comparison_empty(db):
     svc = ChannelAnalyticsService(db)
     comparison = await svc.get_channel_comparison([])
@@ -484,7 +484,7 @@ async def test_get_channel_comparison_empty(db):
     assert comparison.channels == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_ranked_channels_unknown_metric(db):
     await _seed_channel(db, channel_id=100111, title="Unknown Metric Chan")
     await _seed_stats(db, 100111, subscriber_count=500)
@@ -495,7 +495,7 @@ async def test_get_ranked_channels_unknown_metric(db):
     assert rankings[0].score == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_overview_to_dict(db):
     """Verify dataclass serialization works for template rendering."""
     await _seed_channel(db, channel_id=100123, title="Dict Chan")
@@ -513,7 +513,7 @@ async def test_overview_to_dict(db):
 # ── heatmap tests ────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_heatmap_empty(db):
     await _seed_channel(db, channel_id=100123, title="Heatmap Empty")
     svc = ChannelAnalyticsService(db)
@@ -521,7 +521,7 @@ async def test_get_heatmap_empty(db):
     assert data == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_heatmap_basic(db):
     await _seed_channel(db, channel_id=100123, title="Heatmap Chan")
     now = datetime.now(timezone.utc)
@@ -564,7 +564,7 @@ async def test_get_heatmap_basic(db):
     assert total_count == 5  # 3 Monday + 2 Wednesday
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_heatmap_days_filter(db):
     await _seed_channel(db, channel_id=100123, title="Heatmap Days")
     now = datetime.now(timezone.utc)
@@ -591,7 +591,7 @@ async def test_get_heatmap_days_filter(db):
 # ── cross-channel citation tests ─────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_cross_channel_citations_empty(db):
     await _seed_channel(db, channel_id=100123, title="Cite Empty")
     svc = ChannelAnalyticsService(db)
@@ -599,7 +599,7 @@ async def test_get_cross_channel_citations_empty(db):
     assert data == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_cross_channel_citations_basic(db):
     # Source channel
     await _seed_channel(db, channel_id=100500, title="Source Chan", username="src_chan")
@@ -635,7 +635,7 @@ async def test_get_cross_channel_citations_basic(db):
     assert data[0]["latest_date"] is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_cross_channel_citations_multiple_sources(db):
     await _seed_channel(db, channel_id=100111, title="Source A", username="src_a")
     await _seed_channel(db, channel_id=100222, title="Source B", username="src_b")
@@ -667,7 +667,7 @@ async def test_get_cross_channel_citations_multiple_sources(db):
     assert data[1]["citation_count"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_cross_channel_citations_limit(db):
     await _seed_channel(db, channel_id=100123, title="Target Limit")
     now = datetime.now(timezone.utc)
@@ -687,7 +687,7 @@ async def test_get_cross_channel_citations_limit(db):
 # ── repo-level tests for new methods ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_hour_weekday_heatmap(db):
     await _seed_channel(db, channel_id=100123, title="Repo Heatmap")
     now = datetime.now(timezone.utc)
@@ -710,7 +710,7 @@ async def test_repo_hour_weekday_heatmap(db):
         assert r["count"] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_cross_channel_citations_no_forward(db):
     await _seed_channel(db, channel_id=100123, title="No Fwd")
     await db.insert_message(Message(
@@ -725,7 +725,7 @@ async def test_repo_cross_channel_citations_no_forward(db):
 # ── web API route tests ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_heatmap_route(db):
     """Verify heatmap service returns list (route requires full app state)."""
     await _seed_channel(db, channel_id=100123, title="API Heat")
@@ -734,7 +734,7 @@ async def test_api_heatmap_route(db):
     assert isinstance(data, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_api_cross_citations_route(db):
     """Verify cross-citations service returns list (route requires full app state)."""
     await _seed_channel(db, channel_id=100123, title="API Cross")
@@ -746,7 +746,7 @@ async def test_api_cross_citations_route(db):
 # ── heatmap: weekday / hour precision tests ────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_heatmap_specific_weekday_hour_values(db):
     """Verify heatmap returns correct weekday (%w) and hour values."""
     await _seed_channel(db, channel_id=100123, title="Heatmap Precise")
@@ -779,7 +779,7 @@ async def test_heatmap_specific_weekday_hour_values(db):
     assert (0, 0) not in lookup or lookup.get((0, 0)) is None  # Sunday midnight unlikely
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_heatmap_aggregation_multiple_same_slot(db):
     """Multiple messages in the same (weekday, hour) slot aggregate."""
     await _seed_channel(db, channel_id=100123, title="Heatmap Agg")
@@ -806,7 +806,7 @@ async def test_heatmap_aggregation_multiple_same_slot(db):
 # ── cross-channel citation edge cases ─────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cross_citations_date_filtering(db):
     """Messages outside the days window are excluded from cross-citations."""
     await _seed_channel(db, channel_id=100500, title="Source")
@@ -840,7 +840,7 @@ async def test_cross_citations_date_filtering(db):
     assert data_90d[0]["citation_count"] == 2  # both
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cross_citations_unknown_source(db):
     """Cross-citations work even when source channel is not in channels table."""
     await _seed_channel(db, channel_id=100123, title="Target Only")
@@ -863,7 +863,7 @@ async def test_cross_citations_unknown_source(db):
     assert data[0]["citation_count"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cross_citations_respects_limit(db):
     """Limit parameter caps the number of returned source channels."""
     await _seed_channel(db, channel_id=100123, title="Target")
@@ -881,7 +881,7 @@ async def test_cross_citations_respects_limit(db):
     assert len(data) == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cross_citations_only_includes_forwards(db):
     """Regular messages (no forward_from_channel_id) are not counted."""
     await _seed_channel(db, channel_id=100123, title="No Fwd Target")
@@ -901,7 +901,7 @@ async def test_cross_citations_only_includes_forwards(db):
 # ── service-level heatmap / citation integration ──────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_heatmap_service_delegates_to_repo(db):
     """Service get_heatmap delegates correctly and returns repo output."""
     await _seed_channel(db, channel_id=100123, title="Delegator")
@@ -917,7 +917,7 @@ async def test_heatmap_service_delegates_to_repo(db):
     assert svc_data == repo_data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cross_citations_service_delegates_to_repo(db):
     """Service get_cross_channel_citations delegates correctly."""
     await _seed_channel(db, channel_id=100123, title="Delegator")
@@ -930,7 +930,7 @@ async def test_cross_citations_service_delegates_to_repo(db):
 # ── repo-level heatmap edge cases ─────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_heatmap_all_hours_covered(db):
     """Messages spanning many hours produce correct hour range."""
     await _seed_channel(db, channel_id=100123, title="All Hours")
@@ -949,7 +949,7 @@ async def test_repo_heatmap_all_hours_covered(db):
         assert h in hours_seen
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_heatmap_no_messages_returns_empty(db):
     """Heatmap for a channel with no messages returns empty list."""
     await _seed_channel(db, channel_id=100123, title="Empty Heat")
@@ -957,7 +957,7 @@ async def test_repo_heatmap_no_messages_returns_empty(db):
     assert rows == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_cross_citations_multiple_from_same_source(db):
     """Multiple forwarded messages from the same source are aggregated."""
     await _seed_channel(db, channel_id=100500, title="Agg Source")
@@ -977,7 +977,7 @@ async def test_repo_cross_citations_multiple_from_same_source(db):
     assert rows[0]["citation_count"] == 7
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repo_cross_citations_latest_date(db):
     """latest_date is the most recent forwarded message date."""
     await _seed_channel(db, channel_id=100500, title="Src Latest")

--- a/tests/test_channel_renames_routes.py
+++ b/tests/test_channel_renames_routes.py
@@ -79,7 +79,7 @@ async def _create_channel_with_flags(db, channel_id: int, *, filter_flags: str =
 # ---------- keep endpoint ----------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_keep_accepted_clean(tmp_path):
     """Channel has only rename-related flags → unfilter → flash rename_accepted."""
     app, db = await _build_app_with_db(tmp_path)
@@ -106,7 +106,7 @@ async def test_keep_accepted_clean(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_keep_accepted_still_filtered(tmp_path):
     """Channel has other flags → stays filtered with non-rename flags, honest flash."""
     app, db = await _build_app_with_db(tmp_path)
@@ -128,7 +128,7 @@ async def test_keep_accepted_still_filtered(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_keep_already_decided(tmp_path):
     """Second POST on the same event is a no-op and returns rename_already_decided."""
     app, db = await _build_app_with_db(tmp_path)
@@ -154,7 +154,7 @@ async def test_keep_already_decided(tmp_path):
 # ---------- filter endpoint ----------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_ensures_state_even_after_manual_unfilter(tmp_path):
     """Admin manually unfiltered a channel between detection and the filter click.
     The filter endpoint must still leave it filtered with the correct flags."""
@@ -184,7 +184,7 @@ async def test_filter_ensures_state_even_after_manual_unfilter(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_already_decided(tmp_path):
     app, db = await _build_app_with_db(tmp_path)
     try:
@@ -203,7 +203,7 @@ async def test_filter_already_decided(tmp_path):
 # ---------- rename_events_page ----------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_events_page_renders(tmp_path):
     """Test rename events page renders with events list."""
     app, db = await _build_app_with_db(tmp_path)
@@ -226,7 +226,7 @@ async def test_rename_events_page_renders(tmp_path):
 # ---------- rename_events_count ----------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_events_count_zero(tmp_path):
     """Test rename events count returns empty when zero."""
     app, db = await _build_app_with_db(tmp_path)
@@ -244,7 +244,7 @@ async def test_rename_events_count_zero(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rename_events_count_nonzero(tmp_path):
     """Test rename events count returns badge when nonzero."""
     app, db = await _build_app_with_db(tmp_path)
@@ -309,7 +309,7 @@ def test_rename_required_flags_no_change():
 # ---------- keep endpoint — channel removed ----------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_keep_channel_removed(tmp_path):
     """Channel was deleted while event was pending — event closed."""
     app, db = await _build_app_with_db(tmp_path)

--- a/tests/test_channel_service_new.py
+++ b/tests/test_channel_service_new.py
@@ -15,7 +15,7 @@ def _make_channel(pk=1, channel_id=100, title="Test", is_active=True, username="
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_for_page():
     ch = _make_channel()
     channels = MagicMock()
@@ -30,7 +30,7 @@ async def test_list_for_page():
     assert result[2] == {}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_by_identifier_success():
     channels = MagicMock()
     channels.add_channel = AsyncMock(return_value=1)
@@ -61,7 +61,7 @@ async def test_add_by_identifier_success():
     assert added.about == "Test about"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_by_identifier_not_found():
     channels = MagicMock()
     pool = MagicMock()
@@ -72,7 +72,7 @@ async def test_add_by_identifier_not_found():
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_with_added_flags():
     existing = [_make_channel(pk=1, channel_id=100)]
     channels = MagicMock()
@@ -90,7 +90,7 @@ async def test_get_dialogs_with_added_flags():
     assert result[1]["already_added"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_bulk_by_dialog_ids():
     channels = MagicMock()
     channels.add_channel = AsyncMock(return_value=1)
@@ -108,7 +108,7 @@ async def test_add_bulk_by_dialog_ids():
     assert added.channel_id == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_my_dialogs():
     existing = [_make_channel(pk=1, channel_id=100)]
     channels = MagicMock()
@@ -126,7 +126,7 @@ async def test_get_my_dialogs():
     assert result[1]["already_added"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_deactivates():
     ch = _make_channel(is_active=True)
     channels = MagicMock()
@@ -139,7 +139,7 @@ async def test_toggle_deactivates():
     channels.set_active.assert_called_once_with(1, False)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_activates():
     ch = _make_channel(is_active=False)
     channels = MagicMock()
@@ -152,7 +152,7 @@ async def test_toggle_activates():
     channels.set_active.assert_called_once_with(1, True)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_not_found():
     channels = MagicMock()
     channels.get_by_pk = AsyncMock(return_value=None)
@@ -162,7 +162,7 @@ async def test_toggle_not_found():
     await svc.toggle(pk=999)  # Should not raise
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_cancels_tasks():
     ch = _make_channel()
     channels = MagicMock()
@@ -178,7 +178,7 @@ async def test_delete_cancels_tasks():
     channels.delete_channel.assert_called_once_with(1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_pk_found():
     ch = _make_channel()
     channels = MagicMock()
@@ -189,7 +189,7 @@ async def test_get_by_pk_found():
     assert result == ch
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_by_pk_not_found():
     channels = MagicMock()
     channels.get_by_pk = AsyncMock(return_value=None)
@@ -199,7 +199,7 @@ async def test_get_by_pk_not_found():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_channel_meta_success():
     ch = _make_channel()
     channels = MagicMock()
@@ -218,7 +218,7 @@ async def test_refresh_channel_meta_success():
     channels.update_channel_full_meta.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_channel_meta_not_found():
     channels = MagicMock()
     channels.get_by_pk = AsyncMock(return_value=None)
@@ -230,7 +230,7 @@ async def test_refresh_channel_meta_not_found():
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_channel_meta_no_meta():
     ch = _make_channel()
     channels = MagicMock()
@@ -243,7 +243,7 @@ async def test_refresh_channel_meta_no_meta():
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_all_channel_meta():
     ch1 = _make_channel(pk=1, channel_id=100)
     ch2 = _make_channel(pk=2, channel_id=200)
@@ -264,7 +264,7 @@ async def test_refresh_all_channel_meta():
     assert failed == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs():
     pool = MagicMock()
     pool.leave_channels = AsyncMock(return_value={100: True, 200: False})

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -11,7 +11,7 @@ from src.telegram.collector import Collector
 from tests.helpers import make_mock_pool
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_and_get_channel_stats(db):
     ch = Channel(channel_id=-100123, title="Test")
     await db.add_channel(ch)
@@ -35,7 +35,7 @@ async def test_save_and_get_channel_stats(db):
     assert result[0].collected_at is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_channel_removes_stats(db):
     ch = Channel(channel_id=-100123, title="Test")
     await db.add_channel(ch)
@@ -50,7 +50,7 @@ async def test_delete_channel_removes_stats(db):
     assert len(await db.get_channel_stats(-100123)) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_latest_stats_for_all(db):
     ch1 = Channel(channel_id=-100111, title="Ch1")
     ch2 = Channel(channel_id=-100222, title="Ch2")
@@ -67,7 +67,7 @@ async def test_get_latest_stats_for_all(db):
     assert latest[-100222].subscriber_count == 300
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_previous_subscriber_counts(db):
     ch1 = Channel(channel_id=-100111, title="Ch1")
     ch2 = Channel(channel_id=-100222, title="Ch2")
@@ -204,7 +204,7 @@ async def _create_stats_web_test_context(tmp_path, collector):
     return app, db, pk
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_success(db):
     ch = Channel(channel_id=-100123, title="Test", username="test_chan")
     await db.add_channel(ch)
@@ -238,7 +238,7 @@ async def test_collect_channel_stats_success(db):
     assert mock_client.iter_messages.call_args.kwargs["wait_time"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_rotates_on_flood_wait(db):
     ch = Channel(channel_id=-100321, title="Rotate", username="rotate_chan")
     await db.add_channel(ch)
@@ -270,7 +270,7 @@ async def test_collect_channel_stats_rotates_on_flood_wait(db):
     client2.get_entity.assert_awaited_once_with("rotate_chan")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_releases_client(db):
     ch = Channel(channel_id=-100123, title="Test", username="test_chan")
     await db.add_channel(ch)
@@ -290,7 +290,7 @@ async def test_collect_channel_stats_releases_client(db):
     pool.release_client.assert_awaited_once_with("+7000")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_fallback_on_stale_username(db):
     """Stale username in DB → resolve via numeric ID and mark channel filtered."""
     from telethon.errors import UsernameNotOccupiedError
@@ -333,7 +333,7 @@ async def test_collect_channel_stats_fallback_on_stale_username(db):
     assert "title_changed" in updated.filter_flags
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_no_client(db):
     ch = Channel(channel_id=-100123, title="Test")
     await db.add_channel(ch)
@@ -345,7 +345,7 @@ async def test_collect_channel_stats_no_client(db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_web_endpoint_enqueues_command(tmp_path):
     """Web route only enqueues a telegram command; worker executes it."""
     import base64
@@ -381,7 +381,7 @@ async def test_stats_web_endpoint_enqueues_command(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats(db):
     ch1 = Channel(channel_id=-100111, title="Ch1", username="ch1")
     ch2 = Channel(channel_id=-100222, title="Ch2", username="ch2")

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -39,7 +39,7 @@ def _make_mgr(**overrides) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_escaping_agent_not_available(capsys):
     """When agent is not available, prints skip message and returns."""
     db = make_cli_db()
@@ -52,7 +52,7 @@ async def test_escaping_agent_not_available(capsys):
     assert "пропуск" in out or "не настроены" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_escaping_stream_ok(capsys):
     """Successful escaping test streams responses and counts passed."""
     db = make_cli_db()
@@ -79,7 +79,7 @@ async def test_escaping_stream_ok(capsys):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tools_agent_not_available(capsys):
     """When agent is not available, prints skip message."""
     db = make_cli_db()
@@ -92,7 +92,7 @@ async def test_tools_agent_not_available(capsys):
     assert "пропуск" in out or "не настроен" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tools_stream_with_tool_events(capsys):
     """Successful tools test receives tool_start/tool_end events."""
     db = make_cli_db()
@@ -658,7 +658,7 @@ def test_run_chat_with_model(capsys):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_tools_exits_on_failure():
     db = make_cli_db()
     config = make_cli_config()

--- a/tests/test_cli_channel_commands.py
+++ b/tests/test_cli_channel_commands.py
@@ -17,14 +17,14 @@ from tests.helpers import cli_ns as _ns
 
 
 class TestHandleTag:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_tag_action_prints_usage(self, capsys):
         args = argparse.Namespace(tag_action=None)
         db = MagicMock()
         await _handle_tag(args, db)
         assert "Usage: channel tag" in capsys.readouterr().out
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_tags_empty(self, capsys):
         args = argparse.Namespace(tag_action="list")
         db = MagicMock()
@@ -32,7 +32,7 @@ class TestHandleTag:
         await _handle_tag(args, db)
         assert "No tags found." in capsys.readouterr().out
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_list_tags(self, capsys):
         args = argparse.Namespace(tag_action="list")
         db = MagicMock()
@@ -42,7 +42,7 @@ class TestHandleTag:
         assert "news" in out
         assert "tech" in out
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_add_tag(self, capsys):
         args = argparse.Namespace(tag_action="add", name="sports")
         db = MagicMock()
@@ -51,7 +51,7 @@ class TestHandleTag:
         assert "Tag 'sports' created." in capsys.readouterr().out
         db.repos.channels.create_tag.assert_awaited_once_with("sports")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_tag(self, capsys):
         args = argparse.Namespace(tag_action="delete", name="old")
         db = MagicMock()
@@ -60,7 +60,7 @@ class TestHandleTag:
         assert "Tag 'old' deleted." in capsys.readouterr().out
         db.repos.channels.delete_tag.assert_awaited_once_with("old")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_set_channel_tags(self, capsys):
         args = argparse.Namespace(tag_action="set", pk=5, tags="a, b, c")
         db = MagicMock()
@@ -70,7 +70,7 @@ class TestHandleTag:
         assert "pk=5" in out
         db.repos.channels.set_channel_tags.assert_awaited_once_with(5, ["a", "b", "c"])
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_channel_tags_empty(self, capsys):
         args = argparse.Namespace(tag_action="get", pk=10)
         db = MagicMock()
@@ -78,7 +78,7 @@ class TestHandleTag:
         await _handle_tag(args, db)
         assert "No tags for channel pk=10" in capsys.readouterr().out
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_channel_tags(self, capsys):
         args = argparse.Namespace(tag_action="get", pk=10)
         db = MagicMock()

--- a/tests/test_cli_channel_pipeline_route_paths.py
+++ b/tests/test_cli_channel_pipeline_route_paths.py
@@ -991,7 +991,7 @@ async def _route_client_b3(_base_app_b3):
 # --- Channel routes ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_refresh_types_redirect(_route_client_b3):
     """POST /channels/refresh-types enqueues a channels.refresh_types command."""
     client = _route_client_b3
@@ -1007,7 +1007,7 @@ async def test_channels_refresh_types_redirect(_route_client_b3):
     assert commands[0].command_type == "channels.refresh_types"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_refresh_types_enqueues_single_command(_route_client_b3):
     """A second invocation enqueues another command; web path never calls pool."""
     client = _route_client_b3
@@ -1024,7 +1024,7 @@ async def test_channels_refresh_types_enqueues_single_command(_route_client_b3):
 # removed: replaced by queued-command model — web no longer runs resolve inline
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_refresh_meta_success(_route_client_b3):
     """POST /channels/refresh-meta enqueues a channels.refresh_meta command."""
     client = _route_client_b3
@@ -1062,14 +1062,14 @@ def _settings_patch():
         yield
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_renders_b3(_route_client_b3, _settings_patch):
     client = _route_client_b3
     resp = await client.get("/settings/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_scheduler_valid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1081,7 +1081,7 @@ async def test_settings_save_scheduler_valid_b3(_route_client_b3):
     assert "msg=scheduler_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_scheduler_invalid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1093,7 +1093,7 @@ async def test_settings_save_scheduler_invalid_b3(_route_client_b3):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_credentials_valid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1105,7 +1105,7 @@ async def test_settings_save_credentials_valid_b3(_route_client_b3):
     assert "msg=credentials_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_credentials_invalid_api_id_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1117,7 +1117,7 @@ async def test_settings_save_credentials_invalid_api_id_b3(_route_client_b3):
     assert "error=invalid_api_id" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_filters_valid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1129,7 +1129,7 @@ async def test_settings_save_filters_valid_b3(_route_client_b3):
     assert "msg=filters_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_filters_invalid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1141,7 +1141,7 @@ async def test_settings_save_filters_invalid_b3(_route_client_b3):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_backend_override_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1153,7 +1153,7 @@ async def test_settings_save_agent_backend_override_b3(_route_client_b3):
     assert "msg=agent_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_tool_permissions_b3(_route_client_b3):
     """save-agent with tool_permissions scope saves permissions."""
     client = _route_client_b3
@@ -1166,7 +1166,7 @@ async def test_settings_save_agent_tool_permissions_b3(_route_client_b3):
     assert "tool_permissions_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_notification_account_empty_b3(_route_client_b3):
     """Saving empty notification phone clears it."""
     client = _route_client_b3
@@ -1184,7 +1184,7 @@ async def test_settings_save_notification_account_empty_b3(_route_client_b3):
     assert "msg=notification_account_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_semantic_search_valid_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1200,7 +1200,7 @@ async def test_settings_save_semantic_search_valid_b3(_route_client_b3):
     assert "msg=semantic_saved" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_semantic_search_invalid_batch_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(
@@ -1216,7 +1216,7 @@ async def test_settings_save_semantic_search_invalid_batch_b3(_route_client_b3):
     assert "error=semantic_invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_semantic_search_empty_provider_b3(_route_client_b3):
     client = _route_client_b3
     resp = await client.post(

--- a/tests/test_cli_image_scheduler_web_routes.py
+++ b/tests/test_cli_image_scheduler_web_routes.py
@@ -17,7 +17,6 @@ import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.collection_queue import CollectionQueue
@@ -421,7 +420,7 @@ class TestCLISchedulerCommand:
 # ---------------------------------------------------------------------------
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def base_app(tmp_path):
     """Minimal app with one account and channel for web route tests."""
     config = AppConfig()
@@ -471,7 +470,7 @@ async def base_app(tmp_path):
     await db.close()
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def route_client(base_app):
     """AsyncClient with Basic auth for web route tests."""
     app, db, pool_mock = base_app
@@ -497,7 +496,7 @@ async def route_client(base_app):
 class TestWebImagesRoutes:
     """Tests for src/web/routes/images.py"""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_images_page_renders(self, route_client):
         """GET /images/ returns 200."""
         with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
@@ -507,7 +506,7 @@ class TestWebImagesRoutes:
             resp = await route_client.get("/images/")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_no_prompt(self, route_client):
         """POST /images/generate without prompt returns 400."""
         with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
@@ -519,7 +518,7 @@ class TestWebImagesRoutes:
         data = resp.json()
         assert data["ok"] is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_no_providers(self, route_client):
         """POST /images/generate when no providers returns 409."""
         with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
@@ -529,7 +528,7 @@ class TestWebImagesRoutes:
             resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
         assert resp.status_code == 409
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_success(self, route_client):
         """POST /images/generate with valid prompt and provider returns 200 with url."""
         with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
@@ -546,7 +545,7 @@ class TestWebImagesRoutes:
         assert data["ok"] is True
         assert "url" in data
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_provider_failure(self, route_client):
         """POST /images/generate when generation fails returns 500."""
         with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
@@ -557,13 +556,13 @@ class TestWebImagesRoutes:
             resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
         assert resp.status_code == 500
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_models_search_no_provider(self, route_client):
         """GET /images/models/search without provider returns 400."""
         resp = await route_client.get("/images/models/search")
         assert resp.status_code == 400
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_models_search_with_provider(self, route_client):
         """GET /images/models/search with provider returns model list."""
         with (
@@ -588,7 +587,7 @@ class TestWebImagesRoutes:
 class TestWebAccountsRoutes:
     """Tests for src/web/routes/accounts.py"""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flood_status_empty(self, route_client, base_app):
         """GET /settings/flood-status returns list of accounts."""
         resp = await route_client.get("/settings/flood-status")
@@ -599,7 +598,7 @@ class TestWebAccountsRoutes:
         assert "phone" in data[0]
         assert "flood_wait_until" in data[0]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flood_status_ok_field(self, route_client, base_app):
         """GET /settings/flood-status returns ok status for accounts with no flood."""
         resp = await route_client.get("/settings/flood-status")
@@ -609,13 +608,13 @@ class TestWebAccountsRoutes:
         assert acc["flood_wait_until"] == "ok"
         assert acc["remaining_seconds"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_flood_clear_not_found(self, route_client):
         """POST /settings/999/flood-clear with non-existent account redirects with error."""
         resp = await route_client.post("/settings/999/flood-clear", follow_redirects=False)
         assert resp.status_code in (303, 200)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_account(self, route_client, base_app):
         """POST /settings/{id}/toggle redirects to settings."""
         _, db, _ = base_app
@@ -625,7 +624,7 @@ class TestWebAccountsRoutes:
         assert resp.status_code == 303
         assert "settings" in resp.headers["location"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_account(self, route_client, base_app):
         """POST /settings/{id}/delete redirects to settings."""
         _, db, _ = base_app
@@ -644,25 +643,25 @@ class TestWebAccountsRoutes:
 class TestWebCalendarRoutes:
     """Tests for src/web/routes/calendar.py"""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_calendar_page_renders(self, route_client):
         """GET /calendar/ returns 200."""
         resp = await route_client.get("/calendar/")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_calendar_page_with_days_param(self, route_client):
         """GET /calendar/?days=14 returns 200."""
         resp = await route_client.get("/calendar/?days=14")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_calendar_page_invalid_days(self, route_client):
         """GET /calendar/?days=0 returns 422 (out of range)."""
         resp = await route_client.get("/calendar/?days=0")
         assert resp.status_code == 422
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_calendar_returns_json(self, route_client):
         """GET /calendar/api/calendar returns JSON list."""
         resp = await route_client.get("/calendar/api/calendar")
@@ -670,7 +669,7 @@ class TestWebCalendarRoutes:
         data = resp.json()
         assert isinstance(data, list)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_calendar_with_days(self, route_client):
         """GET /calendar/api/calendar?days=3 returns JSON."""
         resp = await route_client.get("/calendar/api/calendar?days=3")
@@ -678,7 +677,7 @@ class TestWebCalendarRoutes:
         data = resp.json()
         assert isinstance(data, list)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_upcoming_returns_json(self, route_client):
         """GET /calendar/api/upcoming returns JSON list."""
         resp = await route_client.get("/calendar/api/upcoming")
@@ -686,7 +685,7 @@ class TestWebCalendarRoutes:
         data = resp.json()
         assert isinstance(data, list)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_upcoming_with_limit(self, route_client):
         """GET /calendar/api/upcoming?limit=5 returns list."""
         resp = await route_client.get("/calendar/api/upcoming?limit=5")
@@ -694,7 +693,7 @@ class TestWebCalendarRoutes:
         data = resp.json()
         assert isinstance(data, list)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_stats_returns_json(self, route_client):
         """GET /calendar/api/stats returns JSON dict."""
         resp = await route_client.get("/calendar/api/stats")
@@ -702,7 +701,7 @@ class TestWebCalendarRoutes:
         data = resp.json()
         assert isinstance(data, dict)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_calendar_pipeline_filter(self, route_client):
         """GET /calendar/api/calendar?pipeline_id=999 returns empty list."""
         resp = await route_client.get("/calendar/api/calendar?pipeline_id=999")

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -98,7 +98,7 @@ class TestIsPremiumFlood:
 
 
 class TestGetLiveFloodAvailability:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_premium_flood_uses_premium_getter(self):
         from src.cli.commands.test import _get_live_flood_availability
 
@@ -109,7 +109,7 @@ class TestGetLiveFloodAvailability:
         result = await _get_live_flood_availability(pool, info)
         assert result is avail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_non_premium_uses_regular_getter(self):
         from src.cli.commands.test import _get_live_flood_availability
 
@@ -120,7 +120,7 @@ class TestGetLiveFloodAvailability:
         result = await _get_live_flood_availability(pool, info)
         assert result is avail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_none_when_no_getter(self):
         from src.cli.commands.test import _get_live_flood_availability
 
@@ -131,7 +131,7 @@ class TestGetLiveFloodAvailability:
 
 
 class TestDecideLiveTestFloodAction:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_availability_returns_skip(self):
         from src.cli.commands.test import _decide_live_test_flood_action
 
@@ -140,7 +140,7 @@ class TestDecideLiveTestFloodAction:
         decision = await _decide_live_test_flood_action(pool, info)
         assert decision.action == "skip"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_all_flooded_returns_rotate(self):
         from src.cli.commands.test import _decide_live_test_flood_action
 
@@ -152,7 +152,7 @@ class TestDecideLiveTestFloodAction:
         decision = await _decide_live_test_flood_action(pool, info)
         assert decision.action == "rotate"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_flooded_short_retry_returns_wait_retry(self):
         from src.cli.commands.test import _decide_live_test_flood_action
 
@@ -167,7 +167,7 @@ class TestDecideLiveTestFloodAction:
         assert decision.action == "wait_retry"
         assert decision.retry_after_sec == 10
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_flooded_long_retry_returns_skip(self):
         from src.cli.commands.test import _decide_live_test_flood_action
 
@@ -238,7 +238,7 @@ class TestSkipRemainingChecks:
 
 
 class TestRunChecks:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_get_stats_fail(self):
         from src.cli.commands.test import Status, _check_get_stats
 
@@ -248,7 +248,7 @@ class TestRunChecks:
         assert result.status == Status.FAIL
         assert "stats error" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_account_list_fail(self):
         from src.cli.commands.test import Status, _check_account_list
 
@@ -257,7 +257,7 @@ class TestRunChecks:
         result = await _check_account_list(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_channel_list_fail(self):
         from src.cli.commands.test import Status, _check_channel_list
 
@@ -266,7 +266,7 @@ class TestRunChecks:
         result = await _check_channel_list(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_queries_with_data(self):
         from src.cli.commands.test import Status, _check_notification_queries
 
@@ -276,7 +276,7 @@ class TestRunChecks:
         assert result.status == Status.PASS
         assert "2 queries" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_queries_fail(self):
         from src.cli.commands.test import Status, _check_notification_queries
 
@@ -285,7 +285,7 @@ class TestRunChecks:
         result = await _check_notification_queries(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_local_search_fail(self):
         from src.cli.commands.test import Status, _check_local_search
 
@@ -294,7 +294,7 @@ class TestRunChecks:
         result = await _check_local_search(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_collection_tasks_fail(self):
         from src.cli.commands.test import Status, _check_collection_tasks
 
@@ -303,7 +303,7 @@ class TestRunChecks:
         result = await _check_collection_tasks(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_recent_searches_with_data(self):
         from src.cli.commands.test import Status, _check_recent_searches
 
@@ -313,7 +313,7 @@ class TestRunChecks:
         assert result.status == Status.PASS
         assert "1 entries" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_recent_searches_fail(self):
         from src.cli.commands.test import Status, _check_recent_searches
 
@@ -322,7 +322,7 @@ class TestRunChecks:
         result = await _check_recent_searches(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_pipeline_list_fail(self):
         from src.cli.commands.test import Status, _check_pipeline_list
 
@@ -333,7 +333,7 @@ class TestRunChecks:
         result = await _check_pipeline_list(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_bot_fail(self):
         from src.cli.commands.test import Status, _check_notification_bot
 
@@ -344,7 +344,7 @@ class TestRunChecks:
         result = await _check_notification_bot(db)
         assert result.status == Status.FAIL
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_bot_configured(self):
         from src.cli.commands.test import Status, _check_notification_bot
 
@@ -356,7 +356,7 @@ class TestRunChecks:
         assert result.status == Status.PASS
         assert "2 configured" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_photo_tasks_fail(self):
         from src.cli.commands.test import Status, _check_photo_tasks
 
@@ -461,7 +461,7 @@ class TestCLITestRunEntry:
 
 
 class TestDisableFloodAutoSleep:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sets_threshold_to_zero(self):
         from src.cli.commands.test import _disable_flood_auto_sleep
 
@@ -481,7 +481,7 @@ class TestDisableFloodAutoSleep:
 
         assert raw_client.flood_sleep_threshold == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_skips_when_no_raw_client(self):
         from src.cli.commands.test import _disable_flood_auto_sleep
 
@@ -632,7 +632,7 @@ class TestProcessControlAdditional:
 
 
 class TestDBConnectionAdditional:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_execute_method_works(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -645,7 +645,7 @@ class TestDBConnectionAdditional:
         finally:
             await conn.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_connect_sets_row_factory(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -657,7 +657,7 @@ class TestDBConnectionAdditional:
         finally:
             await conn.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_connect_sets_foreign_keys(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -670,7 +670,7 @@ class TestDBConnectionAdditional:
         finally:
             await conn.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_execute_without_profiler(self, tmp_path):
         from src.database.connection import ProfilingConnection
 
@@ -681,7 +681,7 @@ class TestDBConnectionAdditional:
             row = await cur.fetchone()
             assert row[0] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_execute_fetchall(self, tmp_path):
         from src.database.connection import ProfilingConnection
 
@@ -691,7 +691,7 @@ class TestDBConnectionAdditional:
             rows = await pc.execute_fetchall("SELECT 1 AS n UNION SELECT 2")
             assert len(rows) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_executemany(self, tmp_path):
         from src.database.connection import ProfilingConnection
 
@@ -703,7 +703,7 @@ class TestDBConnectionAdditional:
             rows = await raw.execute_fetchall("SELECT * FROM t")
             assert len(rows) == 3
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_executescript(self, tmp_path):
         from src.database.connection import ProfilingConnection
 
@@ -712,7 +712,7 @@ class TestDBConnectionAdditional:
             pc = ProfilingConnection(raw)
             await pc.executescript("CREATE TABLE x (id INTEGER PRIMARY KEY)")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_getattr_delegates(self, tmp_path):
         from src.database.connection import ProfilingConnection
 
@@ -722,7 +722,7 @@ class TestDBConnectionAdditional:
             # row_factory attribute should delegate to underlying connection
             assert pc.row_factory is aiosqlite.Row
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_profiling_connection_with_profiler(self, tmp_path):
         """ProfilingConnection records timing when profiler is active."""
         from src.database.connection import ProfilingConnection
@@ -749,7 +749,7 @@ class TestDBConnectionAdditional:
 # ===========================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_with_query_and_date_from(db):
     """search_messages with query + date_from filter should work."""
     msg = _make_msg(channel_id=10, message_id=1, text="important news")
@@ -764,7 +764,7 @@ async def test_messages_search_with_query_and_date_from(db):
     assert isinstance(total, int)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_with_query_and_date_to(db):
     """search_messages with query + date_to filter should work."""
     msg = _make_msg(channel_id=11, message_id=2, text="date filter test")
@@ -778,7 +778,7 @@ async def test_messages_search_with_query_and_date_to(db):
     assert isinstance(msgs, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_with_channel_id_filter(db):
     """search_messages with channel_id filter."""
     msg = _make_msg(channel_id=42, message_id=3, text="channel specific")
@@ -791,7 +791,7 @@ async def test_messages_search_with_channel_id_filter(db):
     assert all(m.channel_id == 42 for m in msgs)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_with_min_max_length(db):
     """search_messages with min/max length filters."""
     msg = _make_msg(channel_id=50, message_id=4, text="A" * 100)
@@ -805,7 +805,7 @@ async def test_messages_search_with_min_max_length(db):
     assert isinstance(msgs, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_with_offset(db):
     """search_messages with offset should skip rows."""
     for i in range(5):
@@ -817,7 +817,7 @@ async def test_messages_search_with_offset(db):
     assert len(msgs_all) - 2 == len(msgs_offset)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_fts_mode(db):
     """search_messages with is_fts=True."""
     msg = _make_msg(channel_id=70, message_id=1, text="fts mode test phrase")
@@ -831,7 +831,7 @@ async def test_messages_search_fts_mode(db):
     assert isinstance(msgs, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_date_to_date_only_normalization(db):
     """date_to with a date-only string gets normalized to next day."""
     msg = _make_msg(channel_id=80, message_id=1, text="date norm test")
@@ -845,7 +845,7 @@ async def test_messages_search_date_to_date_only_normalization(db):
     assert isinstance(msgs, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_get_by_id_existing(db):
     """get_by_id returns message for existing id."""
     msg = _make_msg(channel_id=90, message_id=1, text="by id test")
@@ -858,14 +858,14 @@ async def test_messages_get_by_id_existing(db):
     assert fetched.channel_id == 90
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_get_by_id_nonexistent(db):
     """get_by_id returns None for unknown id."""
     result = await db.repos.messages.get_by_id(999999)
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_build_fts_match_fts_mode():
     """_build_fts_match returns raw query in FTS mode."""
     from src.database.repositories.messages import MessagesRepository
@@ -874,7 +874,7 @@ async def test_messages_build_fts_match_fts_mode():
     assert result == "my query"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_build_fts_match_phrase_mode():
     """_build_fts_match wraps query in quotes for phrase mode."""
     from src.database.repositories.messages import MessagesRepository
@@ -884,7 +884,7 @@ async def test_messages_build_fts_match_phrase_mode():
     assert result.endswith('"')
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_build_fts_match_escapes_quotes():
     """_build_fts_match escapes internal quotes."""
     from src.database.repositories.messages import MessagesRepository
@@ -893,7 +893,7 @@ async def test_messages_build_fts_match_escapes_quotes():
     assert '""' in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_build_extra_conditions_with_max_length():
     """_build_extra_conditions adds max_length and exclude patterns."""
     from src.database.repositories.messages import MessagesRepository
@@ -910,21 +910,21 @@ async def test_messages_build_extra_conditions_with_max_length():
     assert any("NOT LIKE" in c for c in conds)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_upsert_embeddings_empty(db):
     """upsert_message_embeddings with empty list returns 0."""
     count = await db.repos.messages.upsert_message_embeddings([])
     assert count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_upsert_embedding_json_empty(db):
     """upsert_message_embedding_json with empty list returns 0."""
     count = await db.repos.messages.upsert_message_embedding_json([])
     assert count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_upsert_embeddings_mismatch_dims(db):
     """upsert_message_embeddings raises ValueError on mismatched dimensions."""
     with pytest.raises(ValueError, match="dimensions"):
@@ -933,7 +933,7 @@ async def test_messages_upsert_embeddings_mismatch_dims(db):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_reset_embeddings_index(db):
     """reset_embeddings_index should complete without error."""
     await db.repos.messages.reset_embeddings_index()
@@ -941,7 +941,7 @@ async def test_messages_reset_embeddings_index(db):
     assert dims is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_get_embedding_dimensions_invalid_value(db):
     """get_embedding_dimensions returns None for invalid setting value."""
     await db.repos.messages._set_setting("semantic_embedding_dimensions", "not_a_number")
@@ -949,7 +949,7 @@ async def test_messages_get_embedding_dimensions_invalid_value(db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_insert_batch_with_reactions(db):
     """insert_messages_batch handles messages with reactions."""
     import json as _json
@@ -966,7 +966,7 @@ async def test_messages_insert_batch_with_reactions(db):
     assert count >= 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_parse_reactions_json_valid():
     from src.database.repositories.messages import _parse_reactions_json
 
@@ -975,7 +975,7 @@ async def test_messages_parse_reactions_json_valid():
     assert result[0]["emoji"] == "👍"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_parse_reactions_json_invalid():
     from src.database.repositories.messages import _parse_reactions_json
 
@@ -983,7 +983,7 @@ async def test_messages_parse_reactions_json_invalid():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_parse_reactions_json_none():
     from src.database.repositories.messages import _parse_reactions_json
 
@@ -991,7 +991,7 @@ async def test_messages_parse_reactions_json_none():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_search_topic_id_filter(db):
     """search_messages with topic_id filter."""
     msg = _make_msg(channel_id=300, message_id=1, text="topic test")
@@ -1005,7 +1005,7 @@ async def test_messages_search_topic_id_filter(db):
     assert isinstance(msgs, list)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_messages_like_fallback_search(db):
     """MessagesRepository with fts_available=False uses LIKE search."""
     from src.database.repositories.messages import MessagesRepository
@@ -1024,7 +1024,7 @@ async def test_messages_like_fallback_search(db):
 # ===========================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_from_scratch_creates_all_tables():
     """run_migrations on fresh schema creates expected tables."""
     from src.database.migrations import run_migrations
@@ -1048,7 +1048,7 @@ async def test_migrations_from_scratch_creates_all_tables():
         assert "generation_runs" in tables
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_notification_bots_table_created():
     """notification_bots table is created during migration."""
     from src.database.migrations import run_migrations
@@ -1065,7 +1065,7 @@ async def test_migrations_notification_bots_table_created():
         assert "bot_username" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_photo_tables_created():
     """Photo tables are created during migration."""
     from src.database.migrations import run_migrations
@@ -1083,7 +1083,7 @@ async def test_migrations_photo_tables_created():
         assert "photo_batches" in tables or "collection_tasks" in tables
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_collection_tasks_index():
     """Collection tasks index is created during migration."""
     from src.database.migrations import run_migrations
@@ -1101,7 +1101,7 @@ async def test_migrations_collection_tasks_index():
         assert "idx_collection_tasks_type_status_run_after" in indices
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrations_search_queries_columns():
     """search_queries gets all expected columns."""
     from src.database.migrations import run_migrations
@@ -1119,7 +1119,7 @@ async def test_migrations_search_queries_columns():
         assert "is_fts" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_with_table_no_dims():
     """_migrate_vec_to_portable skips when dimensions setting is missing."""
     from src.database.migrations import _migrate_vec_to_portable
@@ -1138,7 +1138,7 @@ async def test_migrate_vec_to_portable_with_table_no_dims():
         await _migrate_vec_to_portable(conn)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_invalid_dims():
     """_migrate_vec_to_portable skips when dimensions value is invalid."""
     from src.database.migrations import _migrate_vec_to_portable
@@ -1216,7 +1216,7 @@ def _make_auto_job():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_create_and_get_batch(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1228,13 +1228,13 @@ async def test_photo_loader_create_and_get_batch(db):
     assert fetched.phone == "+1234567890"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_get_batch_nonexistent(db):
     result = await db.repos.photo_loader.get_batch(999999)
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_batches(db):
     for i in range(3):
         batch = _make_photo_batch()
@@ -1244,7 +1244,7 @@ async def test_photo_loader_list_batches(db):
     assert len(batches) >= 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_batches_with_limit(db):
     for i in range(5):
         batch = _make_photo_batch()
@@ -1254,7 +1254,7 @@ async def test_photo_loader_list_batches_with_limit(db):
     assert len(batches) <= 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_batch_status(db):
     from src.models import PhotoBatchStatus
 
@@ -1266,7 +1266,7 @@ async def test_photo_loader_update_batch_status(db):
     assert fetched.status == PhotoBatchStatus.RUNNING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_batch_error(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1276,7 +1276,7 @@ async def test_photo_loader_update_batch_error(db):
     assert fetched.error == "Some error occurred"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_batch_last_run_at(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1287,7 +1287,7 @@ async def test_photo_loader_update_batch_last_run_at(db):
     assert fetched.last_run_at is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_batch_no_sets(db):
     """update_batch with no args is a no-op."""
     batch = _make_photo_batch()
@@ -1296,7 +1296,7 @@ async def test_photo_loader_update_batch_no_sets(db):
     await db.repos.photo_loader.update_batch(batch_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_create_and_get_item(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1311,13 +1311,13 @@ async def test_photo_loader_create_and_get_item(db):
     assert "/tmp/photo1.jpg" in fetched.file_paths
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_get_item_nonexistent(db):
     result = await db.repos.photo_loader.get_item(999999)
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_items(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1330,7 +1330,7 @@ async def test_photo_loader_list_items(db):
     assert len(items) >= 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_items_for_batch(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1344,7 +1344,7 @@ async def test_photo_loader_list_items_for_batch(db):
     assert all(it.batch_id == batch_id for it in items)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_item_status(db):
     from src.models import PhotoBatchStatus
 
@@ -1358,7 +1358,7 @@ async def test_photo_loader_update_item_status(db):
     assert fetched.status == PhotoBatchStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_item_error(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1370,7 +1370,7 @@ async def test_photo_loader_update_item_error(db):
     assert fetched.error == "upload failed"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_item_telegram_ids(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1382,7 +1382,7 @@ async def test_photo_loader_update_item_telegram_ids(db):
     assert fetched.telegram_message_ids == [111, 222]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_item_timestamps(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1400,7 +1400,7 @@ async def test_photo_loader_update_item_timestamps(db):
     assert fetched.completed_at is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_item_no_sets(db):
     """update_item with no args is a no-op."""
     batch = _make_photo_batch()
@@ -1411,7 +1411,7 @@ async def test_photo_loader_update_item_no_sets(db):
     await db.repos.photo_loader.update_item(item_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_cancel_item(db):
     batch = _make_photo_batch()
     batch_id = await db.repos.photo_loader.create_batch(batch)
@@ -1426,13 +1426,13 @@ async def test_photo_loader_cancel_item(db):
     assert fetched.status == PhotoBatchStatus.CANCELLED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_cancel_item_nonexistent(db):
     result = await db.repos.photo_loader.cancel_item(999999)
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_claim_next_due_item(db):
     """claim_next_due_item returns pending item."""
     batch = _make_photo_batch()
@@ -1448,7 +1448,7 @@ async def test_photo_loader_claim_next_due_item(db):
     assert claimed.status == PhotoBatchStatus.RUNNING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_claim_next_due_item_none(db):
     """claim_next_due_item returns None when no pending items."""
     now = datetime.now(timezone.utc)
@@ -1456,7 +1456,7 @@ async def test_photo_loader_claim_next_due_item_none(db):
     assert claimed is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_requeue_running_items(db):
     """requeue_running_items_on_startup requeues RUNNING items."""
     from src.models import PhotoBatchStatus
@@ -1477,7 +1477,7 @@ async def test_photo_loader_requeue_running_items(db):
     assert fetched.status == PhotoBatchStatus.PENDING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_create_and_get_auto_job(db):
     job = _make_auto_job()
     job_id = await db.repos.photo_loader.create_auto_job(job)
@@ -1490,13 +1490,13 @@ async def test_photo_loader_create_and_get_auto_job(db):
     assert fetched.is_active is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_get_auto_job_nonexistent(db):
     result = await db.repos.photo_loader.get_auto_job(999999)
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_auto_jobs(db):
     for i in range(3):
         job = _make_auto_job()
@@ -1506,7 +1506,7 @@ async def test_photo_loader_list_auto_jobs(db):
     assert len(jobs) >= 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_list_auto_jobs_active_only(db):
 
     # Active job
@@ -1524,7 +1524,7 @@ async def test_photo_loader_list_auto_jobs_active_only(db):
     assert inactive_id not in job_ids
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_auto_job_all_fields(db):
     job = _make_auto_job()
     job_id = await db.repos.photo_loader.create_auto_job(job)
@@ -1553,7 +1553,7 @@ async def test_photo_loader_update_auto_job_all_fields(db):
     assert fetched.last_seen_marker == "file_001.jpg"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_update_auto_job_no_sets(db):
     """update_auto_job with no args is a no-op."""
     job = _make_auto_job()
@@ -1562,7 +1562,7 @@ async def test_photo_loader_update_auto_job_no_sets(db):
     await db.repos.photo_loader.update_auto_job(job_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_delete_auto_job(db):
     job = _make_auto_job()
     job_id = await db.repos.photo_loader.create_auto_job(job)
@@ -1572,7 +1572,7 @@ async def test_photo_loader_delete_auto_job(db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_has_sent_auto_file(db):
     job = _make_auto_job()
     job_id = await db.repos.photo_loader.create_auto_job(job)
@@ -1586,7 +1586,7 @@ async def test_photo_loader_has_sent_auto_file(db):
     assert result_after is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_mark_auto_file_sent_idempotent(db):
     """mark_auto_file_sent is idempotent (INSERT OR IGNORE)."""
     job = _make_auto_job()
@@ -1601,7 +1601,7 @@ async def test_photo_loader_mark_auto_file_sent_idempotent(db):
     assert result is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_json_loads_list_valid():
     from src.database.repositories.photo_loader import _json_loads_list
 
@@ -1609,7 +1609,7 @@ async def test_photo_loader_json_loads_list_valid():
     assert result == [1, 2, 3]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_json_loads_list_invalid():
     from src.database.repositories.photo_loader import _json_loads_list
 
@@ -1617,7 +1617,7 @@ async def test_photo_loader_json_loads_list_invalid():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_json_loads_list_not_list():
     from src.database.repositories.photo_loader import _json_loads_list
 
@@ -1625,7 +1625,7 @@ async def test_photo_loader_json_loads_list_not_list():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_json_loads_list_empty():
     from src.database.repositories.photo_loader import _json_loads_list
 
@@ -1633,7 +1633,7 @@ async def test_photo_loader_json_loads_list_empty():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_dt_helper():
     from src.database.repositories.photo_loader import _dt
 

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -202,7 +202,7 @@ class TestPrintResult:
 
 
 class TestDecideLiveFloodAction:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_availability_returns_skip(self):
         from src.cli.commands.test import _decide_live_test_flood_action
         from src.telegram.flood_wait import FloodWaitInfo
@@ -219,7 +219,7 @@ class TestDecideLiveFloodAction:
         decision = await _decide_live_test_flood_action(pool, info)
         assert decision.action == "skip"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_flooded_returns_rotate(self):
         from src.cli.commands.test import _decide_live_test_flood_action
         from src.telegram.client_pool import StatsClientAvailability
@@ -240,7 +240,7 @@ class TestDecideLiveFloodAction:
 
 
 class TestTgCallWrapper:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_timeout_raises(self):
         from src.cli.commands.test import _tg_call
 
@@ -303,7 +303,7 @@ class TestTelegramLiveFloodDecision:
 
 
 class TestClientPoolDialogsCache:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalidate_all(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -315,7 +315,7 @@ class TestClientPoolDialogsCache:
         pool.invalidate_dialogs_cache()
         assert len(pool._dialogs_cache) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalidate_by_phone(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -327,7 +327,7 @@ class TestClientPoolDialogsCache:
         assert ("+7", "full") not in pool._dialogs_cache
         assert ("+8", "full") in pool._dialogs_cache
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_expired(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -339,7 +339,7 @@ class TestClientPoolDialogsCache:
         result = pool._get_cached_dialogs("+7", "full")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_channels_only_from_full(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -353,7 +353,7 @@ class TestClientPoolDialogsCache:
         assert len(result) == 1
         assert result[0]["channel_id"] == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_channels_only_full_expired(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -366,7 +366,7 @@ class TestClientPoolDialogsCache:
 
 
 class TestClientPoolPremiumFlood:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_premium_flood(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -375,7 +375,7 @@ class TestClientPoolPremiumFlood:
         await pool.report_premium_flood("+7", 60)
         assert "+7" in pool._premium_flood_wait_until
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clear_premium_flood(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -385,7 +385,7 @@ class TestClientPoolPremiumFlood:
         pool.clear_premium_flood("+7")
         assert "+7" not in pool._premium_flood_wait_until
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_premium_flood_expires_stale_entries(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -400,7 +400,7 @@ class TestClientPoolPremiumFlood:
 
 
 class TestClientPoolStatsAvailability:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_stats_availability(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -409,7 +409,7 @@ class TestClientPoolStatsAvailability:
         result = await pool.get_stats_availability()
         assert result.state in ("available", "no_connected_active", "all_flooded")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_premium_stats_no_premium(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -420,7 +420,7 @@ class TestClientPoolStatsAvailability:
 
 
 class TestClientPoolDialogsFetched:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_and_check(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -432,7 +432,7 @@ class TestClientPoolDialogsFetched:
 
 
 class TestClientPoolPremiumUnavailabilityReason:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_premium_accounts(self, db):
         from src.telegram.auth import TelegramAuth
         from src.telegram.client_pool import ClientPool
@@ -663,7 +663,7 @@ class TestAgentManager:
         manager.initialize()
         manager._claude_backend.initialize.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_settings_cache(self):
         from src.agent.manager import AgentManager
 
@@ -873,7 +873,7 @@ class TestCollectorGetMediaType:
 
 
 class TestCollectorProperties:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_cancelled(self, db):
         from tests.helpers import make_mock_pool
 
@@ -883,7 +883,7 @@ class TestCollectorProperties:
         await collector.cancel()
         assert collector.is_cancelled
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delay_between_channels(self, db):
         from tests.helpers import make_mock_pool
 
@@ -894,7 +894,7 @@ class TestCollectorProperties:
 
 
 class TestCollectorAutoDelete:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_not_enabled(self, db):
         from tests.helpers import make_mock_pool
 
@@ -903,7 +903,7 @@ class TestCollectorAutoDelete:
         result = await collector._maybe_auto_delete(100)
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_enabled(self, db):
         from tests.helpers import make_mock_pool
 
@@ -914,7 +914,7 @@ class TestCollectorAutoDelete:
         result = await collector._maybe_auto_delete(100)
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_cached(self, db):
         from tests.helpers import make_mock_pool
 
@@ -930,7 +930,7 @@ class TestCollectorAutoDelete:
 
 
 class TestAgentProviderServiceRefresh:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_models_for_provider_live_fail(self, db):
         from src.services.agent_provider_service import AgentProviderService
 
@@ -942,7 +942,7 @@ class TestAgentProviderServiceRefresh:
         assert entry.error == "network"
         assert entry.source == "static cache"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_all_models(self, db):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.services.agent_provider_service import AgentProviderService
@@ -960,7 +960,7 @@ class TestAgentProviderServiceRefresh:
 
 
 class TestAgentProviderServiceSaveLoad:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_and_load_round_trip(self, db):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.security import SessionCipher
@@ -1086,7 +1086,7 @@ class TestRunSync:
         result = _run_sync("test_tool", _op)
         assert result == 42
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inside_event_loop_raises(self):
         from src.agent.tools.deepagents_sync import _run_sync
 
@@ -1198,28 +1198,28 @@ class TestDeepagentsSyncTools:
 
 
 class TestSchedulerManager:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_running_false(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         assert sm.is_running is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_interval_minutes(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig(collect_interval_minutes=30))
         assert sm.interval_minutes == 30
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_job_enabled_no_bundle(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         assert await sm.is_job_enabled("collect_all") is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_update_interval_no_scheduler(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1227,28 +1227,28 @@ class TestSchedulerManager:
         sm.update_interval(15)
         assert sm._current_interval_minutes == 15
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_job_next_run_no_scheduler(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         assert sm.get_job_next_run("collect_all") is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_all_jobs_no_scheduler(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         assert sm.get_all_jobs_next_run() == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stop_not_running(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm.stop()  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_now_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1256,7 +1256,7 @@ class TestSchedulerManager:
         result = await sm.trigger_now()
         assert result["enqueued"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_background_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1266,7 +1266,7 @@ class TestSchedulerManager:
         if sm._bg_task:
             await sm._bg_task
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_due_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1274,7 +1274,7 @@ class TestSchedulerManager:
         result = await sm._run_photo_due()
         assert result == {"processed": 0}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_auto_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1282,42 +1282,42 @@ class TestSchedulerManager:
         result = await sm._run_photo_auto()
         assert result == {"jobs": 0}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_pipeline_job_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm._run_pipeline_job(1)  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_content_generate_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm._run_content_generate_job(1)  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_search_query_no_enqueuer(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm._run_search_query(1)  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_settings_no_bundle(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm.load_settings()  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_job_state_not_running(self):
         from src.scheduler.service import SchedulerManager
 
         sm = SchedulerManager(SchedulerConfig())
         await sm.sync_job_state("collect_all", True)  # Should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_potential_jobs(self):
         from src.scheduler.service import SchedulerManager
 
@@ -1359,7 +1359,7 @@ def _make_dispatcher(**overrides):
 
 
 class TestUnifiedDispatcherDispatch:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unknown_task_type(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1372,7 +1372,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_photo_due_no_service(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1385,7 +1385,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_photo_auto_no_service(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1396,7 +1396,7 @@ class TestUnifiedDispatcherDispatch:
         await dispatcher._handle_photo_auto(task)
         tasks_repo.update_collection_task.assert_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sq_stats_no_bundle(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1408,7 +1408,7 @@ class TestUnifiedDispatcherDispatch:
         await dispatcher._handle_sq_stats(task)
         tasks_repo.update_collection_task.assert_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sq_stats_invalid_payload(self):
         dispatcher, tasks_repo, _ = _make_dispatcher(sq_bundle=MagicMock())
         task = CollectionTask.model_construct(
@@ -1421,7 +1421,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_run_no_env(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1435,7 +1435,7 @@ class TestUnifiedDispatcherDispatch:
         assert call_args[0][1] == CollectionTaskStatus.FAILED
         assert "not configured" in str(call_args)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_run_invalid_payload(self):
         dispatcher, tasks_repo, _ = _make_dispatcher(
             pipeline_bundle=MagicMock(), search_engine=MagicMock(), db=MagicMock()
@@ -1450,7 +1450,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_content_generate_no_env(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1463,7 +1463,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_content_generate_invalid_payload(self):
         dispatcher, tasks_repo, _ = _make_dispatcher(
             pipeline_bundle=MagicMock(), search_engine=MagicMock(), db=MagicMock()
@@ -1478,7 +1478,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_content_publish_no_id(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1489,7 +1489,7 @@ class TestUnifiedDispatcherDispatch:
         await dispatcher._handle_content_publish(task)
         tasks_repo.update_collection_task.assert_not_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stats_all_no_id(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask(
@@ -1500,7 +1500,7 @@ class TestUnifiedDispatcherDispatch:
         await dispatcher._handle_stats_all(task)
         tasks_repo.update_collection_task.assert_not_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stats_all_invalid_payload(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         task = CollectionTask.model_construct(
@@ -1513,7 +1513,7 @@ class TestUnifiedDispatcherDispatch:
         call_args = tasks_repo.update_collection_task.call_args
         assert call_args[0][1] == CollectionTaskStatus.FAILED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stats_all_completed_all_done(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         payload = StatsAllTaskPayload(
@@ -1532,7 +1532,7 @@ class TestUnifiedDispatcherDispatch:
 
 
 class TestUnifiedDispatcherStartStop:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_start_and_stop(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         await dispatcher.start()
@@ -1540,7 +1540,7 @@ class TestUnifiedDispatcherStartStop:
         await dispatcher.stop()
         assert dispatcher._task is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_start_already_running(self):
         dispatcher, tasks_repo, _ = _make_dispatcher()
         await dispatcher.start()

--- a/tests/test_cli_test_commands.py
+++ b/tests/test_cli_test_commands.py
@@ -263,7 +263,7 @@ class TestRunBenchmarkStep:
 
 
 class TestCheckGetStats:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_stats = AsyncMock(return_value={"channels": 5})
@@ -271,7 +271,7 @@ class TestCheckGetStats:
         assert result.status == Status.PASS
         assert "channels=5" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fail(self):
         db = MagicMock()
         db.get_stats = AsyncMock(side_effect=RuntimeError("no db"))
@@ -281,7 +281,7 @@ class TestCheckGetStats:
 
 
 class TestCheckAccountList:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_accounts = AsyncMock(return_value=[MagicMock()])
@@ -289,7 +289,7 @@ class TestCheckAccountList:
         assert result.status == Status.PASS
         assert "1 accounts" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fail(self):
         db = MagicMock()
         db.get_accounts = AsyncMock(side_effect=Exception("fail"))
@@ -298,7 +298,7 @@ class TestCheckAccountList:
 
 
 class TestCheckChannelList:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_channels_with_counts = AsyncMock(return_value=[MagicMock(), MagicMock()])
@@ -308,14 +308,14 @@ class TestCheckChannelList:
 
 
 class TestCheckNotificationQueries:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_skip_when_empty(self):
         db = MagicMock()
         db.get_notification_queries = AsyncMock(return_value=[])
         result = await _check_notification_queries(db)
         assert result.status == Status.SKIP
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_notification_queries = AsyncMock(return_value=[MagicMock()])
@@ -325,7 +325,7 @@ class TestCheckNotificationQueries:
 
 
 class TestCheckLocalSearch:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.search_messages = AsyncMock(return_value=([], 0))
@@ -335,7 +335,7 @@ class TestCheckLocalSearch:
 
 
 class TestCheckCollectionTasks:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_collection_tasks = AsyncMock(return_value=[MagicMock()])
@@ -345,14 +345,14 @@ class TestCheckCollectionTasks:
 
 
 class TestCheckRecentSearches:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_skip_when_empty(self):
         db = MagicMock()
         db.get_recent_searches = AsyncMock(return_value=[])
         result = await _check_recent_searches(db)
         assert result.status == Status.SKIP
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.get_recent_searches = AsyncMock(return_value=[MagicMock(), MagicMock()])
@@ -362,7 +362,7 @@ class TestCheckRecentSearches:
 
 
 class TestCheckPipelineList:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.repos.content_pipelines.get_all = AsyncMock(return_value=[MagicMock()])
@@ -370,7 +370,7 @@ class TestCheckPipelineList:
         assert result.status == Status.PASS
         assert "1 pipelines" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fail(self):
         db = MagicMock()
         db.repos.content_pipelines.get_all = AsyncMock(side_effect=Exception("err"))
@@ -379,7 +379,7 @@ class TestCheckPipelineList:
 
 
 class TestCheckNotificationBot:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_none_configured(self):
         db = MagicMock()
         db.repos.notification_bots.count = AsyncMock(return_value=0)
@@ -387,7 +387,7 @@ class TestCheckNotificationBot:
         assert result.status == Status.PASS
         assert "none configured" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_configured(self):
         db = MagicMock()
         db.repos.notification_bots.count = AsyncMock(return_value=2)
@@ -397,7 +397,7 @@ class TestCheckNotificationBot:
 
 
 class TestCheckPhotoTasks:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
         db.repos.photo_loader.list_batches = AsyncMock(return_value=[MagicMock()])
@@ -405,7 +405,7 @@ class TestCheckPhotoTasks:
         assert result.status == Status.PASS
         assert "1 batches" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_fail(self):
         db = MagicMock()
         db.repos.photo_loader.list_batches = AsyncMock(side_effect=Exception("err"))

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -18,14 +18,14 @@ def _channel_entity(
     return make_channel_entity(channel_id, title=title, username=username)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_initialize_no_accounts(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await harness.initialize_connected_accounts()
     assert len(harness.pool.clients) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_initialize_completes_with_accounts(real_pool_harness_factory):
     """initialize() with working accounts completes quickly."""
     import time
@@ -42,7 +42,7 @@ async def test_pool_initialize_completes_with_accounts(real_pool_harness_factory
     assert elapsed < 5.0, f"initialize took {elapsed:.1f}s, expected < 5s"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_initialize_skips_hanging_connect(real_pool_harness_factory, caplog):
     """Account whose _connect_account hangs is skipped after timeout."""
     import asyncio
@@ -76,7 +76,7 @@ async def test_pool_initialize_skips_hanging_connect(real_pool_harness_factory, 
     assert elapsed < 5.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_initialize_handles_fetch_me_error(real_pool_harness_factory, caplog):
     """Account whose get_me raises an error is handled gracefully."""
     from unittest.mock import AsyncMock
@@ -93,14 +93,14 @@ async def test_pool_initialize_handles_fetch_me_error(real_pool_harness_factory,
     assert "Failed to fetch premium status" in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_get_available_no_clients(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     result = await harness.pool.get_available_client()
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_availability_no_connected_active(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await harness.add_account("+70000000001", session_string="s1", is_primary=True)
@@ -110,7 +110,7 @@ async def test_stats_availability_no_connected_active(real_pool_harness_factory)
     assert availability.retry_after_sec is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_availability_all_flooded(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(phone="+70000000002", client=FakeCliTelethonClient())
@@ -127,7 +127,7 @@ async def test_stats_availability_all_flooded(real_pool_harness_factory):
     assert availability.next_available_at_utc is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_report_flood(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await harness.add_account("+71234567890", session_string="session1", is_primary=True)
@@ -138,7 +138,7 @@ async def test_pool_report_flood(real_pool_harness_factory):
     assert accounts[0].flood_wait_until is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_disconnect_all_releases_active_leases(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     cli_client = harness.queue_cli_client(
@@ -158,7 +158,7 @@ async def test_pool_disconnect_all_releases_active_leases(real_pool_harness_fact
     assert cli_client.disconnect.await_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pool_skips_flooded_returns_next(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(phone="+70001111111", client=FakeCliTelethonClient())
@@ -174,7 +174,7 @@ async def test_pool_skips_flooded_returns_next(real_pool_harness_factory):
     assert result[1] == "+70002222222"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_returns_raw_id(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     client = harness.queue_cli_client(
@@ -195,7 +195,7 @@ async def test_resolve_channel_returns_raw_id(real_pool_harness_factory):
     client.get_entity.assert_awaited_with("@test_chan")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_no_client_raises(real_pool_harness_factory):
     harness = real_pool_harness_factory()
 
@@ -203,7 +203,7 @@ async def test_resolve_channel_no_client_raises(real_pool_harness_factory):
         await harness.pool.resolve_channel("@test_chan")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_entity_not_found_returns_none(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(
@@ -219,7 +219,7 @@ async def test_resolve_channel_entity_not_found_returns_none(real_pool_harness_f
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_flood_rotates(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     flood_err = FloodWaitError(request=None, capture=0)
@@ -246,7 +246,7 @@ async def test_resolve_channel_flood_rotates(real_pool_harness_factory):
     assert result["channel_id"] == 123456
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_user_returns_none(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(
@@ -262,7 +262,7 @@ async def test_resolve_channel_user_returns_none(real_pool_harness_factory):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_client_fallback_when_in_use(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(
@@ -286,7 +286,7 @@ async def test_get_premium_client_fallback_when_in_use(real_pool_harness_factory
     assert second[1] == "+70001111111"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_strips_post_id_from_url(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     client = harness.queue_cli_client(

--- a/tests/test_client_pool_extended.py
+++ b/tests/test_client_pool_extended.py
@@ -32,7 +32,7 @@ def mock_auth():
     return auth
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_client_pool_initialize_success(mock_db, mock_auth, telethon_cli_spy):
     acc = Account(
         phone="+7999",
@@ -55,7 +55,7 @@ async def test_client_pool_initialize_success(mock_db, mock_auth, telethon_cli_s
     mock_db.update_account_premium.assert_called_once_with("+7999", True)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_available_client_rotation(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, session_string="s1")
     acc2 = Account(phone="+7002", is_active=True, session_string="s2")
@@ -81,7 +81,7 @@ async def test_get_available_client_rotation(mock_db, mock_auth):
     assert res3 is not None  # Should return one of them even if in use
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_available_client_flood_waited(mock_db, mock_auth):
     future = datetime.now(timezone.utc) + timedelta(minutes=10)
     acc1 = Account(phone="+7001", is_active=True, session_string="s1", flood_wait_until=future)
@@ -95,7 +95,7 @@ async def test_get_available_client_flood_waited(mock_db, mock_auth):
     assert res[1] == "+7002"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_client_unavailable(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, is_premium=False, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -108,7 +108,7 @@ async def test_get_premium_client_unavailable(mock_db, mock_auth):
     assert "Нет аккаунтов с Telegram Premium" in reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_client_skips_premium_flood_waited(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, is_premium=True, session_string="s1")
     acc2 = Account(phone="+7002", is_active=True, is_premium=True, session_string="s2")
@@ -124,7 +124,7 @@ async def test_get_premium_client_skips_premium_flood_waited(mock_db, mock_auth)
     mock_db.update_account_flood.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_unavailability_reason_reports_premium_flood(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, is_premium=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -137,7 +137,7 @@ async def test_get_premium_unavailability_reason_reports_premium_flood(mock_db, 
     assert "Flood Wait" in reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_stats_availability_all_flooded(mock_db, mock_auth):
     future = datetime.now(timezone.utc) + timedelta(seconds=100)
     acc = Account(phone="+7001", is_active=True, session_string="s1", flood_wait_until=future)
@@ -151,7 +151,7 @@ async def test_get_stats_availability_all_flooded(mock_db, mock_auth):
     assert stats.retry_after_sec >= 99
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_premium_stats_availability_all_flooded(mock_db, mock_auth):
     premium = Account(phone="+7001", is_active=True, is_premium=True, session_string="s1")
     regular = Account(phone="+7002", is_active=True, is_premium=False, session_string="s2")
@@ -166,7 +166,7 @@ async def test_get_premium_stats_availability_all_flooded(mock_db, mock_auth):
     assert stats.retry_after_sec >= 24
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_flood_rotation(mock_db, mock_auth):
     acc1 = Account(phone="+7001", is_active=True, session_string="s1")
     acc2 = Account(phone="+7002", is_active=True, session_string="s2")
@@ -187,7 +187,7 @@ async def test_resolve_channel_flood_rotation(mock_db, mock_auth):
         mock_db.update_account_flood.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_errors(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -211,7 +211,7 @@ async def test_resolve_channel_errors(mock_db, mock_auth):
         await pool.resolve_channel("@t")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_users_info_with_avatar(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, is_primary=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -230,7 +230,7 @@ async def test_get_users_info_with_avatar(mock_db, mock_auth):
         assert "data:image/jpeg;base64" in info[0].avatar_base64
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_users_info_avatar_flood_does_not_mark_generic_account(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, is_primary=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -252,7 +252,7 @@ async def test_get_users_info_avatar_flood_does_not_mark_generic_account(mock_db
     mock_db.update_account_flood.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_flood(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -270,7 +270,7 @@ async def test_leave_channels_flood(mock_db, mock_auth):
     mock_db.update_account_flood.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_cache_hit_and_miss(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -293,7 +293,7 @@ async def test_get_forum_topics_cache_hit_and_miss(mock_db, mock_auth):
     assert len(topics) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_timeout(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -313,7 +313,7 @@ async def test_get_dialogs_timeout(mock_db, mock_auth):
         assert res == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_sets_is_own(mock_db, mock_auth):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -12,7 +12,7 @@ from src.telegram.flood_wait import HandledFloodWaitError
 from tests.helpers import FakeCliTelethonClient
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_initialize_uses_runtime_backend_without_persistent_clients(
     real_pool_harness_factory,
 ):
@@ -40,7 +40,7 @@ async def test_initialize_uses_runtime_backend_without_persistent_clients(
     assert len(harness.telethon_cli_spy.created) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_client_supports_session_override_before_db_write(
     real_pool_harness_factory,
 ):
@@ -65,7 +65,7 @@ async def test_add_client_supports_session_override_before_db_write(
     assert len(harness.telethon_cli_spy.created) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_shared_lease_keeps_phone_busy_until_last_release(
     real_pool_harness_factory,
 ):
@@ -92,7 +92,7 @@ async def test_shared_lease_keeps_phone_busy_until_last_release(
     assert third[1] == "+70000000002"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_premium_client_does_not_disable_generic_flood_reporting_on_persistent_session(
     real_pool_harness_factory,
 ):
@@ -123,7 +123,7 @@ async def test_premium_client_does_not_disable_generic_flood_reporting_on_persis
     await harness.pool.release_client("+70000000001")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.native_backend_allowed
 async def test_native_client_by_phone_returns_flood_aware_session(
     real_pool_harness_factory,
@@ -156,7 +156,7 @@ async def test_native_client_by_phone_returns_flood_aware_session(
     assert accounts[0].flood_wait_until is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.native_backend_allowed
 async def test_auto_mode_falls_back_to_native_when_cli_acquire_fails(
     real_pool_harness_factory,
@@ -183,7 +183,7 @@ async def test_auto_mode_falls_back_to_native_when_cli_acquire_fails(
     assert harness.native_auth_spy.created == [("session-auto", native_client)]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.native_backend_allowed
 async def test_auto_mode_falls_back_to_native_for_subprocess_transport(
     real_pool_harness_factory,
@@ -205,7 +205,7 @@ async def test_auto_mode_falls_back_to_native_for_subprocess_transport(
     assert harness.native_auth_spy.created == [("session-subprocess", native_client)]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.native_backend_allowed
 async def test_get_native_client_by_phone_uses_native_backend_and_disconnects(
     real_pool_harness_factory,
@@ -236,7 +236,7 @@ async def test_get_native_client_by_phone_uses_native_backend_and_disconnects(
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.native_backend_allowed
 async def test_notification_target_uses_real_pool_native_getter(
     real_pool_harness_factory,
@@ -265,7 +265,7 @@ async def test_notification_target_uses_real_pool_native_getter(
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_reconnects_disconnected_client(
     real_pool_harness_factory,
 ):
@@ -289,7 +289,7 @@ async def test_acquire_reconnects_disconnected_client(
     cli_client.connect.assert_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_acquire_falls_back_to_backend_when_reconnect_fails(
     real_pool_harness_factory,
 ):

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -41,7 +41,7 @@ async def _create_pending_task(db: Database, channel_id: int = -1001) -> int:
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_pull_picks_up_pending_task_added_after_startup(tmp_path):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -73,7 +73,7 @@ async def test_db_pull_picks_up_pending_task_added_after_startup(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_pull_does_not_double_ingest(tmp_path):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -102,7 +102,7 @@ async def test_db_pull_does_not_double_ingest(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_pull_swallows_errors(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -141,7 +141,7 @@ async def test_db_pull_swallows_errors(tmp_path, monkeypatch):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_db_pull_is_idempotent(tmp_path):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -164,7 +164,7 @@ async def test_stop_db_pull_is_idempotent(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delayed_requeue_queue_full_releases_known_task_id(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -196,7 +196,7 @@ async def test_delayed_requeue_queue_full_releases_known_task_id(tmp_path, monke
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_tasks_clears_known_task_ids(tmp_path):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()

--- a/tests/test_collection_service_new.py
+++ b/tests/test_collection_service_new.py
@@ -13,7 +13,7 @@ def _make_channel(pk=1, channel_id=100, title="Test", is_filtered=False):
     return Channel(id=pk, channel_id=channel_id, title=title, is_filtered=is_filtered)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_channel_by_pk_not_found():
     channels = MagicMock()
     channels.get_by_pk = AsyncMock(return_value=None)
@@ -24,7 +24,7 @@ async def test_enqueue_channel_by_pk_not_found():
     assert result == "not_found"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_channel_by_pk_filtered():
     ch = _make_channel(is_filtered=True)
     channels = MagicMock()
@@ -36,7 +36,7 @@ async def test_enqueue_channel_by_pk_filtered():
     assert result == "filtered"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_channel_by_pk_force_filtered():
     ch = _make_channel(is_filtered=True)
     channels = MagicMock()
@@ -49,7 +49,7 @@ async def test_enqueue_channel_by_pk_force_filtered():
     assert result == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_channel_by_pk_success():
     ch = _make_channel()
     channels = MagicMock()
@@ -62,7 +62,7 @@ async def test_enqueue_channel_by_pk_success():
     assert result == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_channel_by_pk_already_active():
     ch = _make_channel()
     channels = MagicMock()
@@ -75,7 +75,7 @@ async def test_enqueue_channel_by_pk_already_active():
     assert result == "already_active"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_empty():
     channels = MagicMock()
     channels.list_channels = AsyncMock(return_value=[])
@@ -87,7 +87,7 @@ async def test_enqueue_all_channels_empty():
     assert result.queued_count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_success():
     ch1 = _make_channel(pk=1, channel_id=100)
     ch2 = _make_channel(pk=2, channel_id=200)
@@ -103,7 +103,7 @@ async def test_enqueue_all_channels_success():
     assert result.skipped_existing_count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_mixed():
     ch1 = _make_channel(pk=1, channel_id=100)
     ch2 = _make_channel(pk=2, channel_id=200)
@@ -119,7 +119,7 @@ async def test_enqueue_all_channels_mixed():
     assert result.skipped_existing_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_with_queue():
     ch = _make_channel()
     queue = MagicMock()
@@ -135,7 +135,7 @@ async def test_enqueue_with_queue():
     queue.enqueue.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_with_queue_already_active():
     ch = _make_channel()
     queue = MagicMock()
@@ -150,7 +150,7 @@ async def test_enqueue_with_queue_already_active():
     assert result == "already_active"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats():
     ch = _make_channel()
     collector = MagicMock()
@@ -162,7 +162,7 @@ async def test_collect_channel_stats():
     collector.collect_channel_stats.assert_called_once_with(ch)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_full():
     ch = _make_channel()
     collector = MagicMock()
@@ -178,7 +178,7 @@ async def test_collect_single_channel_full():
 # ── cancel_task / clear_pending_collect_tasks fallback (fix for #457) ─────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_with_live_queue_delegates():
     """With a live queue the service must delegate so RUNNING tasks get interrupted."""
     channels = MagicMock()
@@ -203,7 +203,7 @@ async def test_cancel_task_with_live_queue_delegates():
     channels.cancel_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_without_queue_falls_back_to_db():
     """In web-mode (queue=None) the DB path must keep the route from 500'ing (#457)."""
     channels = MagicMock()
@@ -225,7 +225,7 @@ async def test_cancel_task_without_queue_falls_back_to_db():
     channels.cancel_collection_task.assert_awaited_once_with(77, note=None)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_stats_all_bypasses_queue_and_cancels_collector():
     channels = MagicMock()
     channels.get_collection_task = AsyncMock(
@@ -251,7 +251,7 @@ async def test_cancel_task_stats_all_bypasses_queue_and_cancels_collector():
     queue.cancel_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_task_returns_false_when_task_missing():
     channels = MagicMock()
     channels.get_collection_task = AsyncMock(return_value=None)
@@ -270,7 +270,7 @@ async def test_cancel_task_returns_false_when_task_missing():
     queue.cancel_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_tasks_with_live_queue_delegates():
     """With a queue the service must delegate to drain memory + cancel requeue timers."""
     channels = MagicMock()
@@ -284,7 +284,7 @@ async def test_clear_pending_collect_tasks_with_live_queue_delegates():
     queue.clear_pending_tasks.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_pending_collect_tasks_without_queue_falls_back_to_db():
     """Without a queue the service just deletes PENDING rows — memory lives in the worker."""
     channels = MagicMock()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -20,7 +20,7 @@ from tests.helpers import AsyncIterMessages as _AsyncIterMessages
 from tests.helpers import FakeTelethonClient, make_mock_message, make_mock_pool, make_mock_reactions
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_no_channels(db):
     pool = make_mock_pool()
     config = SchedulerConfig()
@@ -30,7 +30,7 @@ async def test_collect_no_channels(db):
     assert stats["messages"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_no_clients(db):
     ch = Channel(channel_id=-100123, title="Test")
     await db.add_channel(ch)
@@ -45,7 +45,7 @@ async def test_collect_no_clients(db):
     assert stats["errors"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_skips_filtered_channels(db):
     await db.add_channel(Channel(channel_id=-100124, title="Filtered"))
     await db.add_channel(Channel(channel_id=-100125, title="Normal"))
@@ -60,7 +60,7 @@ async def test_collect_all_skips_filtered_channels(db):
     assert stats["errors"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_invalid_min_subscribers_setting_falls_back_to_zero(db):
     await db.set_setting("min_subscribers_filter", "broken")
     ch = Channel(channel_id=-100124, title="Normal")
@@ -74,7 +74,7 @@ async def test_collect_all_invalid_min_subscribers_setting_falls_back_to_zero(db
     assert stats["errors"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_raises_all_clients_flooded(db):
     ch = Channel(channel_id=-100124, title="Flooded")
     await db.add_channel(ch)
@@ -100,7 +100,7 @@ async def test_collect_single_channel_raises_all_clients_flooded(db):
     assert exc.value.next_available_at == next_available_at
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_raises_no_active_clients(db):
     ch = Channel(channel_id=-100125, title="No Clients")
     await db.add_channel(ch)
@@ -122,7 +122,7 @@ async def test_collect_single_channel_raises_no_active_clients(db):
         await collector.collect_single_channel(ch)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_skips_filtered(db):
     """collect_single_channel returns 0 immediately for filtered channels."""
     ch = Channel(
@@ -140,7 +140,7 @@ async def test_collect_single_channel_skips_filtered(db):
     pool.get_available_client.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_uses_peer_channel_without_username(db):
     """_collect_channel falls back to PeerChannel when no username."""
     ch = Channel(channel_id=1970788983, title="Test Channel")
@@ -160,7 +160,7 @@ async def test_collect_channel_uses_peer_channel_without_username(db):
     assert call_arg.channel_id == 1970788983
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_uses_username_when_available(db):
     """_collect_channel resolves by username when it is stored."""
     ch = Channel(channel_id=1970788983, title="Test Channel", username="test_chan")
@@ -179,7 +179,7 @@ async def test_collect_channel_uses_username_when_available(db):
     assert call_arg == "test_chan"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_positive_id_end_to_end(db):
     """End-to-end: collect_all_channels with username resolves by username."""
     ch = Channel(channel_id=1970788983, title="Positive ID Channel", username="my_chan")
@@ -199,7 +199,7 @@ async def test_collect_positive_id_end_to_end(db):
     assert call_arg == "my_chan"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_rotation(db):
     ch = Channel(
         channel_id=1970788984,
@@ -249,7 +249,7 @@ async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_
     assert 3500 < remaining <= 3600
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_short_username_resolve_flood_still_rotates(db):
     ch = Channel(
         channel_id=1970788985,
@@ -298,7 +298,7 @@ async def test_collect_channel_short_username_resolve_flood_still_rotates(db):
     assert collector._get_resolve_username_backoff_remaining_sec() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
     ch = Channel(
         channel_id=1970788986,
@@ -320,7 +320,7 @@ async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
     pool.get_available_client.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_no_username_channel_fetches_dialogs_once(db):
     """For no-username channels get_dialogs() is called once per process to warm entity cache."""
     ch = Channel(channel_id=123, title="No Username")
@@ -344,7 +344,7 @@ async def test_collect_no_username_channel_fetches_dialogs_once(db):
     mock_client.get_dialogs.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_falls_back_to_username_on_cache_miss(db):
     """When PeerChannel fails (entity not cached), fall back to username."""
     ch = Channel(channel_id=1970788983, title="Test", username="agipdoom")
@@ -370,7 +370,7 @@ async def test_collect_channel_falls_back_to_username_on_cache_miss(db):
     mock_client.get_entity.assert_awaited_once_with("agipdoom")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_marks_username_changed_when_numeric_fallback_succeeds(db):
     ch = Channel(channel_id=1970788983, title="Old Title", username="old_name")
     channel_id = await db.add_channel(ch)
@@ -398,7 +398,7 @@ async def test_collect_channel_marks_username_changed_when_numeric_fallback_succ
     assert "username_changed" in updated.filter_flags
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_no_username_no_cache_reports_error(db):
     """Channel with no username and empty cache -> error logged, 0 messages."""
     ch = Channel(channel_id=1970788983, title="Private Group")
@@ -416,7 +416,7 @@ async def test_collect_channel_no_username_no_cache_reports_error(db):
     assert stats["messages"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_private_group_uses_map_phone(db):
     """When channel→phone map has an entry, get_client_by_phone is used directly."""
     ch = Channel(channel_id=1877929309, title="Private Group")
@@ -440,7 +440,7 @@ async def test_collect_private_group_uses_map_phone(db):
     pool.get_client_by_phone.assert_awaited_once_with("+7001")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_private_group_discovers_access_phone(db):
     """When channel not in map, _discover_phone_for_channel finds the right phone
     and registers it so the next iteration uses it directly."""
@@ -479,7 +479,7 @@ async def test_collect_private_group_discovers_access_phone(db):
     assert pool._channel_phone_map.get(1877929309) == "+7001"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_dialogs_timeout(db):
     """Hanging get_dialogs() must not block collection (30s timeout)."""
     ch = Channel(channel_id=123, title="Test", username="test")
@@ -505,7 +505,7 @@ def _make_mock_message(msg_id, text=None, media=None, sender_id=None):
     return make_mock_message(msg_id, text=text, media=media, sender_id=sender_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_photo():
     from telethon.tl.types import MessageMediaPhoto
 
@@ -513,13 +513,13 @@ async def test_get_media_type_photo():
     assert Collector._get_media_type(msg) == "photo"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_none():
     msg = SimpleNamespace(media=None)
     assert Collector._get_media_type(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_document_video():
     from telethon.tl.types import DocumentAttributeVideo, MessageMediaDocument
 
@@ -531,7 +531,7 @@ async def test_get_media_type_document_video():
     assert Collector._get_media_type(msg) == "video"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_sticker():
     from telethon.tl.types import (
         DocumentAttributeSticker,
@@ -547,7 +547,7 @@ async def test_get_media_type_sticker():
     assert Collector._get_media_type(msg) == "sticker"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_voice():
     from telethon.tl.types import DocumentAttributeAudio, MessageMediaDocument
 
@@ -559,7 +559,7 @@ async def test_get_media_type_voice():
     assert Collector._get_media_type(msg) == "voice"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_poll():
     from telethon.tl.types import MessageMediaPoll
 
@@ -570,21 +570,21 @@ async def test_get_media_type_poll():
 # --- _extract_reactions tests ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_none():
     """No reactions attr → None."""
     msg = SimpleNamespace(reactions=None)
     assert Collector._extract_reactions(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_empty_results():
     """reactions exists but results is empty → None."""
     msg = SimpleNamespace(reactions=SimpleNamespace(results=[]))
     assert Collector._extract_reactions(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_single_emoji():
     import json
 
@@ -595,7 +595,7 @@ async def test_extract_reactions_single_emoji():
     assert parsed == [{"emoji": "👍", "count": 5}]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_multiple():
     import json
 
@@ -607,7 +607,7 @@ async def test_extract_reactions_multiple():
     assert parsed[1] == {"emoji": "❤️", "count": 3}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_custom_emoji():
     import json
 
@@ -617,7 +617,7 @@ async def test_extract_reactions_custom_emoji():
     assert parsed == [{"emoji": "custom:12345678", "count": 2}]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_message_service_joined_by_link():
     from telethon.tl.types import MessageActionChatJoinedByLink
 
@@ -633,7 +633,7 @@ async def test_classify_message_service_joined_by_link():
     assert Collector._get_sender_kind(msg) == "user"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_collects_media_without_text(db):
     """Collector should collect messages without text (media-only)."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=5)
@@ -657,7 +657,7 @@ async def test_collect_channel_collects_media_without_text(db):
     assert count == 2  # Both messages collected
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_backfill_uses_no_limit(db):
     """First run (last_collected_id==0) should use limit=None."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=0)
@@ -678,7 +678,7 @@ async def test_backfill_uses_no_limit(db):
     assert call_kwargs[1].get("limit") is None or call_kwargs.kwargs.get("limit") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_incremental_uses_no_limit(db):
     """Subsequent runs (last_collected_id>0) should use limit=None (all new messages)."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=50)
@@ -698,7 +698,7 @@ async def test_incremental_uses_no_limit(db):
     assert call_kwargs[1].get("limit") is None or call_kwargs.kwargs.get("limit") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_backfill_batch_flush(db):
     """During backfill, messages should be flushed in batches of 500."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=0)
@@ -727,7 +727,7 @@ async def test_backfill_batch_flush(db):
     assert total == 600
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_progress_callback_invoked_on_batch_flush(db):
     """progress_callback is called after each batch flush and final flush."""
     ch = Channel(channel_id=-100123, title="Test", username="test", last_collected_id=0)
@@ -757,7 +757,7 @@ async def test_progress_callback_invoked_on_batch_flush(db):
     progress_cb.assert_any_await(600)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_does_not_advance_last_id_when_flush_fails(db):
     ch = Channel(channel_id=-100126, title="Test", username="test", last_collected_id=5)
     await db.add_channel(ch)
@@ -782,7 +782,7 @@ async def test_collect_channel_does_not_advance_last_id_when_flush_fails(db):
     assert updated.last_collected_id == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_backfill_does_not_send_notification_queries(db):
     from src.models import SearchQuery
 
@@ -809,7 +809,7 @@ async def test_backfill_does_not_send_notification_queries(db):
     notifier.notify.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_incremental_collection_sends_notification_queries(db):
     from src.models import SearchQuery
 
@@ -834,7 +834,7 @@ async def test_incremental_collection_sends_notification_queries(db):
     notifier.notify.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_retries_after_short_flood_wait(db):
     ch = Channel(channel_id=-100171, title="Retry", username="retry", last_collected_id=5)
     ch_id = await db.add_channel(ch)
@@ -875,7 +875,7 @@ async def test_collect_channel_retries_after_short_flood_wait(db):
     pool.report_flood.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_rotates_on_long_flood_wait(db):
     """FloodWait > max_flood_wait_sec still rotates to the next available account."""
     ch = Channel(channel_id=-100172, title="LongFlood", username="longflood", last_collected_id=5)
@@ -931,7 +931,7 @@ async def test_collect_channel_rotates_on_long_flood_wait(db):
     assert "rotating" in notifier.notify.call_args[0][0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_long_flood_all_accounts_flooded_returns(db):
     """FloodWait > max_flood_wait_sec with no other account available surfaces unavailability."""
     ch = Channel(channel_id=-100173, title="AllFlood", username="allflood", last_collected_id=5)
@@ -987,7 +987,7 @@ async def test_collect_channel_long_flood_all_accounts_flooded_returns(db):
     pool.report_flood.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_skips_filtered_channel(db):
     """CollectionQueue worker skips channels that become filtered after enqueue."""
     from src.collection_queue import CollectionQueue
@@ -1018,7 +1018,7 @@ async def test_collection_queue_skips_filtered_channel(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_connection_error_triggers_reconnect_and_requeue(db):
     """ConnectionError during collection triggers reconnect and re-enqueues the task."""
     from src.collection_queue import CollectionQueue
@@ -1056,7 +1056,7 @@ async def test_connection_error_triggers_reconnect_and_requeue(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_connection_error_no_retry_after_max(db):
     """Second ConnectionError after retry marks task as FAILED."""
     from src.collection_queue import CollectionQueue
@@ -1085,7 +1085,7 @@ async def test_connection_error_no_retry_after_max(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_connection_error_reconnect_fails(db):
     """When reconnect fails, task is marked as FAILED immediately."""
     from src.collection_queue import CollectionQueue
@@ -1114,7 +1114,7 @@ async def test_connection_error_reconnect_fails(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_uses_incremental_queue_tasks(db):
     from src.collection_queue import CollectionQueue
     from src.services.collection_service import CollectionService
@@ -1153,7 +1153,7 @@ async def test_enqueue_all_channels_uses_incremental_queue_tasks(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_force_tasks_keep_full_collection(db):
     from src.collection_queue import CollectionQueue
 
@@ -1182,7 +1182,7 @@ async def test_collection_queue_force_tasks_keep_full_collection(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_reschedules_when_all_clients_flooded(db):
     from src.collection_queue import CollectionQueue
 
@@ -1214,7 +1214,7 @@ async def test_collection_queue_reschedules_when_all_clients_flooded(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_fails_when_no_active_clients(db):
     from src.collection_queue import CollectionQueue
 
@@ -1241,7 +1241,7 @@ async def test_collection_queue_fails_when_no_active_clients(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_startup_tasks(db):
     """requeue_startup_tasks re-enqueues pending tasks that survived a restart."""
     from src.collection_queue import CollectionQueue
@@ -1271,7 +1271,7 @@ async def test_requeue_startup_tasks(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_startup_tasks_preserves_incremental_flag(db):
     from src.collection_queue import CollectionQueue
 
@@ -1314,7 +1314,7 @@ async def test_requeue_startup_tasks_preserves_incremental_flag(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_startup_tasks_cancels_orphaned(db):
     """requeue_startup_tasks cancels tasks whose channel was deleted."""
     from src.collection_queue import CollectionQueue
@@ -1333,7 +1333,7 @@ async def test_requeue_startup_tasks_cancels_orphaned(db):
     assert task.status == "cancelled"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_startup_tasks_defers_future_run_after(db):
     """Startup tasks with run_after in the future go to _delayed_requeues, not the main queue."""
     from datetime import datetime, timedelta, timezone
@@ -1361,7 +1361,7 @@ async def test_requeue_startup_tasks_defers_future_run_after(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_cancels_deleted_channel(db):
     from src.collection_queue import CollectionQueue
 
@@ -1389,7 +1389,7 @@ async def test_collection_queue_cancels_deleted_channel(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_clear_pending_tasks_removes_db_rows_and_queue_items(db):
     from src.collection_queue import CollectionQueue
 
@@ -1422,7 +1422,7 @@ async def test_collection_queue_clear_pending_tasks_removes_db_rows_and_queue_it
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collection_queue_skips_task_deleted_after_dequeue(db):
     from src.collection_queue import CollectionQueue
 
@@ -1448,7 +1448,7 @@ async def test_collection_queue_skips_task_deleted_after_dequeue(db):
     await queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_skips_filtered(db):
     """collect_all_stats should skip filtered channels."""
     await db.add_channel(Channel(channel_id=-100150, title="Filtered"))
@@ -1469,7 +1469,7 @@ async def test_collect_all_stats_skips_filtered(db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_broadcast_low_ratio(db):
     """Broadcast channel with ratio < 1.0 is filtered before iter_messages."""
     ch = Channel(
@@ -1514,7 +1514,7 @@ async def test_prefilter_broadcast_low_ratio(db):
     assert "low_subscriber_ratio" in stored.filter_flags
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_supergroup_low_ratio(db):
     """Supergroup with ratio < 0.02 is filtered before iter_messages."""
     ch = Channel(
@@ -1555,7 +1555,7 @@ async def test_prefilter_supergroup_low_ratio(db):
     assert stored.is_filtered is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_supergroup_pass_ratio(db):
     """Supergroup with ratio >= 0.02 continues collection."""
     ch = Channel(
@@ -1597,7 +1597,7 @@ async def test_prefilter_supergroup_pass_ratio(db):
     assert stored.is_filtered is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_no_stats_skips_check(db):
     """No stats (subscriber_count=None) → collection continues without filtering."""
     ch = Channel(
@@ -1627,7 +1627,7 @@ async def test_prefilter_no_stats_skips_check(db):
     assert stored.is_filtered is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_uses_message_count(db):
     """Pre-filter uses real COUNT(*) from DB, not last_collected_id."""
     ch = Channel(
@@ -1665,7 +1665,7 @@ async def test_prefilter_uses_message_count(db):
     mock_client.iter_messages.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_skips_when_no_messages(db):
     """First run (message_count=0) → pre-filter skipped, collection proceeds."""
     ch = Channel(
@@ -1692,7 +1692,7 @@ async def test_prefilter_skips_when_no_messages(db):
     assert mock_client.iter_messages.call_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_prefilter_skipped_when_force(db):
     """force=True → pre-filter skipped; channel filter state not changed."""
     ch = Channel(
@@ -1734,7 +1734,7 @@ async def test_prefilter_skipped_when_force(db):
     assert stored.is_filtered is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_precheck_skipped_when_force_and_first_run(db):
     """force=True + first_run (last_collected_id=0) → precheck пропускается."""
     ch = Channel(
@@ -1758,7 +1758,7 @@ async def test_precheck_skipped_when_force_and_first_run(db):
     assert mock_client.iter_messages.call_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_entity_timeout_returns_zero(db):
     """get_entity hanging → TimeoutError → _collect_channel returns 0."""
     ch = Channel(channel_id=-100400, title="Hanging Channel", username="hang_chan")
@@ -1774,7 +1774,7 @@ async def test_get_entity_timeout_returns_zero(db):
     assert count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_precheck_timeout_skips_check(db):
     """Precheck hanging → TimeoutError → collection continues with 0 precheck sample."""
     ch = Channel(
@@ -1800,7 +1800,7 @@ async def test_precheck_timeout_skips_check(db):
     mock_client.iter_messages.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_post_collection_low_uniqueness_marks_filtered(db):
     """First run with 100 identical messages → channel marked is_filtered=True, messages kept."""
     ch = Channel(channel_id=-100300, title="Spam Channel", username="spam", last_collected_id=0)
@@ -1841,7 +1841,7 @@ async def test_post_collection_low_uniqueness_marks_filtered(db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_precheck_detects_cross_channel_spam(db):
     """Precheck marks a first-run channel as cross_channel_spam on 80%+ sample overlap."""
     # Existing channel with known messages in DB
@@ -1893,7 +1893,7 @@ async def test_precheck_detects_cross_channel_spam(db):
     assert "cross_channel_spam" in stored.filter_flags
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_username_changed_marks_filtered(db):
     """Username lookup fails, PeerChannel fallback succeeds → filtered with username_changed."""
     ch = Channel(channel_id=3645212410, title="Old Title", username="raketa_nanobanana4")
@@ -1924,7 +1924,7 @@ async def test_username_changed_marks_filtered(db):
     assert "username_changed" in stored.filter_flags
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_username_not_found_deactivates(db):
     """Both username and PeerChannel lookups fail → channel deactivated, returns 0."""
     ch = Channel(channel_id=3645212410, title="Old Title", username="gone_username")

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -57,7 +57,7 @@ def collector(mock_pool, mock_db):
     return Collector(mock_pool, mock_db, SchedulerConfig())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_flood_wait_retry(collector, mock_pool, mock_db):
     channel = Channel(id=1, channel_id=123, title="Ch", last_collected_id=10)
     mock_db.get_channel_by_pk.return_value = channel
@@ -86,7 +86,7 @@ async def test_collect_channel_flood_wait_retry(collector, mock_pool, mock_db):
     mock_pool.report_flood.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_pre_filter_min_subs(collector, mock_pool, mock_db):
     channel = Channel(channel_id=123, title="Ch")
     mock_db.get_setting.return_value = "100"  # min_subscribers_filter
@@ -100,7 +100,7 @@ async def test_collect_channel_pre_filter_min_subs(collector, mock_pool, mock_db
     mock_db.set_channels_filtered_bulk.assert_called_with([(123, "low_subscriber_manual")])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_pre_filter_ratio(collector, mock_pool, mock_db):
     channel = Channel(channel_id=123, title="Ch", channel_type="channel")
     mock_db.get_channel_stats.return_value = [ChannelStats(channel_id=123, subscriber_count=10)]
@@ -114,7 +114,7 @@ async def test_collect_channel_pre_filter_ratio(collector, mock_pool, mock_db):
     mock_db.set_channels_filtered_bulk.assert_called_with([(123, "low_subscriber_ratio")])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flush_batch_persistence_error(collector, mock_pool, mock_db):
     channel = Channel(channel_id=123, title="Ch")
     client = AsyncMock()
@@ -136,7 +136,7 @@ async def test_flush_batch_persistence_error(collector, mock_pool, mock_db):
     assert res == 0  # persisted_max_msg_id not updated, stop_due_to_persistence_error = True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_queries_logic(collector, mock_db):
     notifier = AsyncMock()
     collector._notifier = notifier
@@ -157,7 +157,7 @@ async def test_notification_queries_logic(collector, mock_db):
     assert "https://t.me/mychan/42" in call_text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_queries_private_channel_link(collector, mock_db):
     """Private channel (no username) should produce t.me/c/ link."""
     notifier = AsyncMock()
@@ -175,7 +175,7 @@ async def test_notification_queries_private_channel_link(collector, mock_db):
     assert "https://t.me/c/1234567890/99" in call_text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fts_query_matches_logic():
     from src.services.notification_matcher import _fts_query_matches
 
@@ -189,7 +189,7 @@ async def test_fts_query_matches_logic():
     assert not _fts_query_matches("apple*", "I love bananas")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_flooded_error(collector, mock_pool):
     channel = Channel(channel_id=123)
     mock_pool.get_available_client.return_value = None
@@ -206,7 +206,7 @@ async def test_collect_channel_stats_flooded_error(collector, mock_pool):
         await collector._collect_channel_stats(channel)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_no_clients(collector, mock_db):
     mock_db.get_channels.return_value = [Channel(channel_id=123)]
     with patch.object(collector, "_collect_channel_stats", side_effect=NoActiveStatsClientsError):
@@ -214,7 +214,7 @@ async def test_collect_all_stats_no_clients(collector, mock_db):
         assert res["errors"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_entity_timeout(collector, mock_pool):
     channel = Channel(channel_id=123, username="user")
     client = AsyncMock()
@@ -225,7 +225,7 @@ async def test_collect_channel_entity_timeout(collector, mock_pool):
     assert res == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_username_changed(collector, mock_pool, mock_db):
     channel = Channel(channel_id=123, username="old_user")
     client = AsyncMock()
@@ -249,7 +249,7 @@ async def test_collect_channel_username_changed(collector, mock_pool, mock_db):
 # --- Tests for Collector._handle_meta_change_review (the unified helper) ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_meta_change_review_no_change(collector, mock_db):
     channel = Channel(channel_id=777, username="same", title="Same", filter_flags="")
     changed = await collector._handle_meta_change_review(
@@ -261,7 +261,7 @@ async def test_handle_meta_change_review_no_change(collector, mock_db):
     mock_db.create_rename_event.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_meta_change_review_username_only(collector, mock_db):
     channel = Channel(channel_id=777, username="old", title="Same", filter_flags="")
     changed = await collector._handle_meta_change_review(
@@ -273,7 +273,7 @@ async def test_handle_meta_change_review_username_only(collector, mock_db):
     mock_db.create_rename_event.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_meta_change_review_title_only(collector, mock_db):
     channel = Channel(channel_id=777, username="same", title="Old", filter_flags="")
     changed = await collector._handle_meta_change_review(
@@ -284,7 +284,7 @@ async def test_handle_meta_change_review_title_only(collector, mock_db):
     mock_db.create_rename_event.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_meta_change_review_preserves_existing_flags(collector, mock_db):
     # Channel already has an unrelated filter reason; the helper must preserve it.
     channel = Channel(

--- a/tests/test_collector_runtime.py
+++ b/tests/test_collector_runtime.py
@@ -43,7 +43,7 @@ def _message(msg_id: int, text: str = "msg"):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_single_channel_retries_on_flood_with_second_account(
     db,
     real_pool_harness_factory,
@@ -85,7 +85,7 @@ async def test_collect_single_channel_retries_on_flood_with_second_account(
     assert flooded.flood_wait_until is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_stats_uses_transport_session_and_persists_stats(
     db,
     real_pool_harness_factory,

--- a/tests/test_content_analytics_service.py
+++ b/tests/test_content_analytics_service.py
@@ -50,7 +50,7 @@ async def _set_run_times(
     await db.db.commit()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_analytics_summary_and_pipeline_stats(db):
     analytics = ContentAnalyticsService(db)
     pipeline_a = await _create_pipeline(db, "Pipeline A")
@@ -89,7 +89,7 @@ async def test_content_analytics_summary_and_pipeline_stats(db):
     assert stats[1].success_rate == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_analytics_daily_stats_aggregate_all_pipelines(db):
     analytics = ContentAnalyticsService(db)
     pipeline_a = await _create_pipeline(db, "Pipeline A")

--- a/tests/test_content_calendar_service.py
+++ b/tests/test_content_calendar_service.py
@@ -38,7 +38,7 @@ def service(mock_db):
 # === get_calendar tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_calendar_empty_db(service, mock_db):
     """get_calendar returns empty days when no runs exist."""
     result = await service.get_calendar(days=3)
@@ -49,7 +49,7 @@ async def test_get_calendar_empty_db(service, mock_db):
         assert day.events == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_calendar_with_events_filters_by_date(service, mock_db):
     """get_calendar filters events by date range."""
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -81,7 +81,7 @@ async def test_get_calendar_with_events_filters_by_date(service, mock_db):
     assert result[0].events[0].pipeline_name == "Test Pipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_calendar_filters_by_pipeline(service, mock_db):
     """get_calendar filters by pipeline_id when provided."""
     mock_pipeline = MagicMock()
@@ -97,7 +97,7 @@ async def test_get_calendar_filters_by_pipeline(service, mock_db):
     mock_db.repos.generation_runs.list_runs_for_calendar.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_calendar_skips_runs_without_pipeline(service, mock_db):
     """get_calendar skips runs without pipeline_id."""
     mock_run = MagicMock()
@@ -115,7 +115,7 @@ async def test_get_calendar_skips_runs_without_pipeline(service, mock_db):
 # === get_upcoming tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_upcoming_empty_db(service, mock_db):
     """get_upcoming returns empty list when no pending runs."""
     result = await service.get_upcoming(limit=10)
@@ -123,7 +123,7 @@ async def test_get_upcoming_empty_db(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_upcoming_filters_by_status(service, mock_db):
     """get_upcoming only includes pending or approved runs."""
     mock_pipeline = MagicMock()
@@ -151,7 +151,7 @@ async def test_get_upcoming_filters_by_status(service, mock_db):
     assert result[0].moderation_status == "pending"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_upcoming_respects_limit(service, mock_db):
     """get_upcoming respects the limit parameter."""
     mock_pipeline = MagicMock()
@@ -181,7 +181,7 @@ async def test_get_upcoming_respects_limit(service, mock_db):
     assert len(result) == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_upcoming_filters_by_pipeline(service, mock_db):
     """get_upcoming filters by pipeline_id when provided."""
     await service.get_upcoming(limit=10, pipeline_id=1)
@@ -192,7 +192,7 @@ async def test_get_upcoming_filters_by_pipeline(service, mock_db):
 # === get_stats tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_stats_delegates_to_repo(service, mock_db):
     """get_stats delegates to generation_runs repository."""
     mock_db.repos.generation_runs.get_calendar_stats = AsyncMock(
@@ -205,7 +205,7 @@ async def test_get_stats_delegates_to_repo(service, mock_db):
     assert result == {"total": 10, "approved": 5}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_stats_empty(service, mock_db):
     """get_stats returns empty dict when no data."""
     mock_db.repos.generation_runs.get_calendar_stats = AsyncMock(return_value={})

--- a/tests/test_content_generation_service_edge_cases.py
+++ b/tests/test_content_generation_service_edge_cases.py
@@ -173,7 +173,7 @@ def _restore_provider(original):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_set_status_failure_marks_run_failed():
     """If set_status('running') raises, run should be marked 'failed'."""
     engine = DummySearchEngine([_make_msg()])
@@ -213,7 +213,7 @@ async def test_generate_set_status_failure_marks_run_failed():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_publish_reply_and_reply_to_id():
     """publish_reply and reply_to_message_id should be stored in metadata."""
     engine = DummySearchEngine([_make_msg()])
@@ -256,7 +256,7 @@ async def test_generate_publish_reply_and_reply_to_id():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_image_url_from_graph_executor():
     """When graph executor returns image_url, it should be saved to the run."""
     engine = DummySearchEngine([_make_msg()])
@@ -311,7 +311,7 @@ async def test_generate_image_url_from_graph_executor():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_legacy_image_with_image_service():
     """Legacy pipeline with image_model and image_service generates image."""
     engine = DummySearchEngine([_make_msg()])
@@ -350,7 +350,7 @@ async def test_generate_legacy_image_with_image_service():
         _restore_provider(orig)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_legacy_image_with_default_model():
     """Legacy pipeline uses default_image_model from settings when image_model not set."""
     engine = DummySearchEngine([_make_msg()])
@@ -379,7 +379,7 @@ async def test_generate_legacy_image_with_default_model():
         _restore_provider(orig)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_no_image_without_service():
     """No image generation when image_service is None and image_model is set."""
     engine = DummySearchEngine([_make_msg()])
@@ -410,7 +410,7 @@ async def test_generate_no_image_without_service():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_refinement_steps_applied_metadata():
     """Refinement steps count is stored in metadata."""
     engine = DummySearchEngine([_make_msg()])
@@ -445,7 +445,7 @@ async def test_generate_refinement_steps_applied_metadata():
         _restore_provider(orig)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_refinement_steps_skipped_for_graph_pipeline():
     """Refinement steps are NOT applied when pipeline has pipeline_json (graph-based)."""
     engine = DummySearchEngine([_make_msg()])
@@ -480,7 +480,7 @@ async def test_generate_refinement_steps_skipped_for_graph_pipeline():
             pipeline_executor.PipelineExecutor.execute = original_execute
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refinement_returns_empty_string_keeps_previous():
     """If refinement step returns empty, previous text is kept."""
     engine = DummySearchEngine([_make_msg()])
@@ -514,7 +514,7 @@ async def test_refinement_returns_empty_string_keeps_previous():
         _restore_provider(orig)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refinement_returns_dict():
     """Refinement step that returns dict with 'text' key."""
     engine = DummySearchEngine([_make_msg()])
@@ -548,7 +548,7 @@ async def test_refinement_returns_dict():
         _restore_provider(orig)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refinement_returns_dict_generated_text():
     """Refinement step that returns dict with 'generated_text' key."""
     engine = DummySearchEngine([_make_msg()])
@@ -587,7 +587,7 @@ async def test_refinement_returns_dict_generated_text():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_deep_agents_no_manager():
     """DEEP_AGENTS backend without agent_manager raises RuntimeError."""
     engine = DummySearchEngine([_make_msg()])
@@ -607,7 +607,7 @@ async def test_deep_agents_no_manager():
         await service._run_deep_agents(pipeline, None, 512, 0.7)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_deep_agents_with_manager():
     """DEEP_AGENTS backend calls agent_manager.chat_stream and returns text."""
     engine = DummySearchEngine([_make_msg()])
@@ -637,7 +637,7 @@ async def test_deep_agents_with_manager():
     assert result["citations"] == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_deep_agents_invalid_json_chunk():
     """Invalid JSON chunks in stream are ignored."""
     engine = DummySearchEngine([_make_msg()])
@@ -671,7 +671,7 @@ async def test_deep_agents_invalid_json_chunk():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_graph_passes_services():
     """_run_graph builds PipelineExecutor with correct service dict."""
     engine = DummySearchEngine([_make_msg()])
@@ -735,7 +735,7 @@ async def test_run_graph_passes_services():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_rag_returns_generated_text():
     """_run_rag calls GenerationService and returns result dict."""
     engine = DummySearchEngine([_make_msg()])
@@ -764,7 +764,7 @@ async def test_run_rag_returns_generated_text():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_run_not_found_after_save():
     """If generation_runs.get returns None after save, raise RuntimeError."""
     engine = DummySearchEngine([_make_msg()])
@@ -809,7 +809,7 @@ async def test_generate_run_not_found_after_save():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_exception_sets_failed():
     """Any exception during generation should mark run as failed."""
     engine = DummySearchEngine([_make_msg()])
@@ -848,7 +848,7 @@ async def test_generate_exception_sets_failed():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_image_no_service():
     """_generate_image returns None when no image_service."""
     engine = DummySearchEngine([_make_msg()])
@@ -866,7 +866,7 @@ async def test_generate_image_no_service():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_image_with_service():
     """_generate_image delegates to image_service.generate."""
     engine = DummySearchEngine([_make_msg()])
@@ -886,7 +886,7 @@ async def test_generate_image_with_service():
     assert image_svc.calls == [("override-model", "test text")]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_image_uses_pipeline_model_when_no_model_arg():
     """_generate_image uses pipeline.image_model when model arg is None."""
     engine = DummySearchEngine([_make_msg()])
@@ -911,7 +911,7 @@ async def test_generate_image_uses_pipeline_model_when_no_model_arg():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_generation_selects_graph():
     """_run_generation selects _run_graph when pipeline_json is set."""
     engine = DummySearchEngine([_make_msg()])
@@ -944,7 +944,7 @@ async def test_run_generation_selects_graph():
             pipeline_executor.PipelineExecutor.execute = original_execute
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_generation_selects_deep_agents():
     """_run_generation selects _run_deep_agents when backend is DEEP_AGENTS."""
     engine = DummySearchEngine([_make_msg()])

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -204,7 +204,7 @@ def test_is_same_origin_url_alias():
 # === OriginCSRFMiddleware tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_safe_method_get():
     """GET requests pass through."""
     request = MagicMock()
@@ -222,7 +222,7 @@ async def test_csrf_safe_method_get():
     call_next.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_safe_method_head():
     """HEAD requests pass through."""
     request = MagicMock()
@@ -239,7 +239,7 @@ async def test_csrf_safe_method_head():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_exempt_path_login():
     """Login path is exempt from CSRF."""
     request = MagicMock()
@@ -256,7 +256,7 @@ async def test_csrf_exempt_path_login():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_exempt_path_static():
     """Static paths are exempt from CSRF."""
     request = MagicMock()
@@ -273,7 +273,7 @@ async def test_csrf_exempt_path_static():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_with_valid_origin():
     """POST with valid Origin passes."""
     request = make_mock_request(scheme="http", netloc="localhost:8000")
@@ -290,7 +290,7 @@ async def test_csrf_post_with_valid_origin():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_with_invalid_origin():
     """POST with invalid Origin is rejected."""
     request = make_mock_request(scheme="http", netloc="localhost:8000")
@@ -308,7 +308,7 @@ async def test_csrf_post_with_invalid_origin():
     assert b"CSRF" in response.body
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_with_null_origin():
     """POST with 'null' Origin is rejected."""
     request = MagicMock()
@@ -325,7 +325,7 @@ async def test_csrf_post_with_null_origin():
     assert response.status_code == 403
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_with_valid_referer():
     """POST with valid Referer passes."""
     request = make_mock_request(scheme="http", netloc="localhost:8000")
@@ -342,7 +342,7 @@ async def test_csrf_post_with_valid_referer():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_with_invalid_referer():
     """POST with invalid Referer is rejected."""
     request = make_mock_request(scheme="http", netloc="localhost:8000")
@@ -359,7 +359,7 @@ async def test_csrf_post_with_invalid_referer():
     assert response.status_code == 403
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_no_origin_no_referer_no_cookie():
     """POST without Origin/Referer but no session cookie passes."""
     request = MagicMock()
@@ -376,7 +376,7 @@ async def test_csrf_post_no_origin_no_referer_no_cookie():
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_post_no_origin_with_session_cookie():
     """POST without Origin/Referer but with session cookie is rejected."""
     from src.web.session import COOKIE_NAME

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,7 +25,7 @@ def _encrypt_v1(secret: str, plaintext: str) -> str:
     return f"enc:v1:{token}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_and_get_accounts(db):
     acc = Account(phone="+71234567890", session_string="session1", is_primary=True)
     await db.add_account(acc)
@@ -36,7 +36,7 @@ async def test_add_and_get_accounts(db):
     assert accounts[0].is_primary is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_upsert(db):
     acc = Account(phone="+71234567890", session_string="session1")
     await db.add_account(acc)
@@ -48,7 +48,7 @@ async def test_account_upsert(db):
     assert accounts[0].session_string == "session2"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_upsert_reactivates_without_overwriting_primary(db):
     await db.add_account(
         Account(
@@ -75,7 +75,7 @@ async def test_account_upsert_reactivates_without_overwriting_primary(db):
     assert accounts[0].is_primary is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_session_encrypted_at_rest(tmp_path):
     db_path = str(tmp_path / "encrypted.db")
     database = Database(db_path, session_encryption_secret="test-encryption-secret")
@@ -97,7 +97,7 @@ async def test_account_session_encrypted_at_rest(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_plaintext_sessions_migrate_on_init(tmp_path):
     """Plaintext sessions are encrypted during initialize(), not get_accounts()."""
     db_path = str(tmp_path / "plaintext_migration.db")
@@ -126,7 +126,7 @@ async def test_plaintext_sessions_migrate_on_init(tmp_path):
     await encrypted_db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_legacy_v1_sessions_migrate_to_v2_on_init(tmp_path):
     db_path = str(tmp_path / "v1_migration.db")
     legacy_secret = "legacy-key"
@@ -158,7 +158,7 @@ async def test_legacy_v1_sessions_migrate_to_v2_on_init(tmp_path):
     await encrypted_db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_sessions_rollback_on_bad_row(tmp_path):
     """Migration rolls back when a row has an unsupported encryption version."""
     db_path = str(tmp_path / "rollback_migration.db")
@@ -191,7 +191,7 @@ async def test_migrate_sessions_rollback_on_bad_row(tmp_path):
         assert rows[1]["session_string"] == "enc:v99:garbage"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_initialize_fails_without_key_when_encrypted_sessions_exist(tmp_path):
     db_path = str(tmp_path / "no_key_fail_fast.db")
 
@@ -208,7 +208,7 @@ async def test_initialize_fails_without_key_when_encrypted_sessions_exist(tmp_pa
         await db_without_key.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_and_get_channels(db):
     ch = Channel(channel_id=-1001234567890, title="Test Channel", username="@test")
     await db.add_channel(ch)
@@ -218,7 +218,7 @@ async def test_add_and_get_channels(db):
     assert channels[0].channel_id == -1001234567890
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_by_pk(db):
     ch = Channel(channel_id=-1002233445566, title="Lookup Channel", username="@lookup")
     await db.add_channel(ch)
@@ -230,13 +230,13 @@ async def test_get_channel_by_pk(db):
     assert found.title == "Lookup Channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_by_pk_returns_none_for_unknown_id(db):
     found = await db.get_channel_by_pk(999999)
     assert found is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_channels_filtered_bulk_and_reset(db):
     await db.add_channel(Channel(channel_id=-1007001, title="One", username="one"))
     await db.add_channel(Channel(channel_id=-1007002, title="Two", username="two"))
@@ -264,7 +264,7 @@ async def test_set_channels_filtered_bulk_and_reset(db):
     assert by_channel_id[-1007002].filter_flags == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_insert_message_deduplication(db):
     msg = Message(
         channel_id=-1001234567890,
@@ -281,7 +281,7 @@ async def test_insert_message_deduplication(db):
     assert total == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_batch_insert(db):
     messages = [
         Message(
@@ -299,7 +299,7 @@ async def test_batch_insert(db):
     assert total == 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_messages(db):
     messages = [
         Message(
@@ -328,7 +328,7 @@ async def test_search_messages(db):
     assert all("Bitcoin" in (m.text or "") for m in results)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_messages_date_to_includes_entire_day(db):
     await db.insert_messages_batch(
         [
@@ -359,7 +359,7 @@ async def test_search_messages_date_to_includes_entire_day(db):
     assert {message.message_id for message in results} == {1, 2}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_messages_full_iso_date_to_remains_precise(db):
     await db.insert_messages_batch(
         [
@@ -384,7 +384,7 @@ async def test_search_messages_full_iso_date_to_remains_precise(db):
     assert results[0].message_id == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_queries_crud(db):
     sq = SearchQuery(query="bitcoin", is_regex=False, notify_on_collect=True)
     repo = db.repos.search_queries
@@ -400,7 +400,7 @@ async def test_notification_queries_crud(db):
     assert len(queries) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats(db):
     stats = await db.get_stats()
     assert stats["accounts"] == 0
@@ -409,7 +409,7 @@ async def test_stats(db):
     assert stats["search_queries"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_set_setting(db):
     assert await db.get_setting("nonexistent") is None
     await db.set_setting("tg_api_id", "12345")
@@ -418,7 +418,7 @@ async def test_get_set_setting(db):
     assert await db.get_setting("tg_api_id") == "99999"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_with_data(db):
     acc = Account(phone="+71234567890", session_string="s1", is_primary=True)
     await db.add_account(acc)
@@ -444,7 +444,7 @@ async def test_stats_with_data(db):
     assert stats["search_queries"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_premium_field(db):
     acc = Account(phone="+71234567890", session_string="s1", is_premium=True)
     await db.add_account(acc)
@@ -454,7 +454,7 @@ async def test_account_premium_field(db):
     assert accounts[0].is_premium is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_account_premium(db):
     acc = Account(phone="+71234567890", session_string="s1", is_premium=False)
     await db.add_account(acc)
@@ -468,7 +468,7 @@ async def test_update_account_premium(db):
     assert accounts[0].is_premium is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_account_upsert_updates_premium(db):
     acc = Account(phone="+71234567890", session_string="s1", is_premium=False)
     await db.add_account(acc)
@@ -482,7 +482,7 @@ async def test_account_upsert_updates_premium(db):
     assert accounts[0].session_string == "s2"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_insert_message_with_media_type(db):
     msg = Message(
         channel_id=-100123,
@@ -500,7 +500,7 @@ async def test_insert_message_with_media_type(db):
     assert messages[0].text is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_batch_insert_with_media_type(db):
     messages = [
         Message(
@@ -536,7 +536,7 @@ async def test_batch_insert_with_media_type(db):
     assert media_types[3] == "photo"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_adds_media_type_column(tmp_path):
     """Migration adds media_type column to existing DB without it."""
     db_path = str(tmp_path / "migrate_test.db")
@@ -611,7 +611,7 @@ async def test_migrate_adds_media_type_column(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_with_channel_type(db):
     ch = Channel(channel_id=-100123, title="Test", username="test", channel_type="channel")
     await db.add_channel(ch)
@@ -621,7 +621,7 @@ async def test_add_channel_with_channel_type(db):
     assert channels[0].channel_type == "channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_type_upsert(db):
     ch = Channel(channel_id=-100123, title="Test", username="test", channel_type=None)
     await db.add_channel(ch)
@@ -635,7 +635,7 @@ async def test_channel_type_upsert(db):
     assert channels[0].title == "Test Updated"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_upsert_reactivates_existing_channel(db):
     await db.add_channel(
         Channel(channel_id=-100124, title="Test", username="test", is_active=False)
@@ -650,7 +650,7 @@ async def test_channel_upsert_reactivates_existing_channel(db):
     assert channels[0].is_active is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_adds_channel_type_column(tmp_path):
     """Migration adds channel_type column to existing channels table."""
     db_path = str(tmp_path / "migrate_channel_type_test.db")
@@ -728,7 +728,7 @@ async def test_migrate_adds_channel_type_column(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_filter_columns_idempotent(tmp_path):
     db_path = str(tmp_path / "migrate_filter_columns_idempotent.db")
 
@@ -792,7 +792,7 @@ async def test_migrate_filter_columns_idempotent(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_adds_is_premium_column(tmp_path):
     """Migration adds is_premium column to existing accounts table without it."""
     db_path = str(tmp_path / "migrate_premium_test.db")
@@ -861,7 +861,7 @@ async def test_migrate_adds_is_premium_column(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_task_claim_and_continuation(db):
     now = datetime.now(timezone.utc)
     payload = StatsAllTaskPayload(channel_ids=[-1001, -1002])
@@ -896,7 +896,7 @@ async def test_stats_task_claim_and_continuation(db):
     assert rescheduled.payload.next_index == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_requeue_running_stats_tasks_on_startup(db):
     tid = await db.create_stats_task(StatsAllTaskPayload(channel_ids=[]))
     await db.update_collection_task(tid, CollectionTaskStatus.RUNNING)
@@ -912,7 +912,7 @@ async def test_requeue_running_stats_tasks_on_startup(db):
     assert task.run_after is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_payload_round_trip_serialization(db):
     payload = StatsAllTaskPayload(channel_ids=[-1001], next_index=3, channels_ok=2, channels_err=1)
     task_id = await db.create_stats_task(payload)
@@ -924,7 +924,7 @@ async def test_stats_payload_round_trip_serialization(db):
     assert task.payload.model_dump() == payload.model_dump()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_collection_task_preserves_typed_status(db):
     task_id = await db.create_collection_task(-100123, "Channel")
     cancelled = await db.cancel_collection_task(task_id, note="cancelled in test")
@@ -937,7 +937,7 @@ async def test_cancel_collection_task_preserves_typed_status(db):
     assert task.note == "cancelled in test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migration_backfills_collection_task_type(tmp_path):
     db_path = tmp_path / "legacy_tasks.db"
     stats_payload = (
@@ -994,7 +994,7 @@ async def test_migration_backfills_collection_task_type(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_messages_for_channel(db):
     ch1 = Channel(channel_id=-100301, title="Channel 1")
     ch2 = Channel(channel_id=-100302, title="Channel 2")
@@ -1027,7 +1027,7 @@ async def test_delete_messages_for_channel(db):
     assert all(m.channel_id == -100302 for m in results)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_excludes_filtered_channels(db):
     ch_ok = Channel(channel_id=-100311, title="Good Channel")
     ch_bad = Channel(channel_id=-100312, title="Filtered Channel")
@@ -1065,7 +1065,7 @@ async def test_search_excludes_filtered_channels(db):
     assert results_fts[0].channel_id == -100311
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_channel_meta(db):
     """update_channel_meta updates username and title, leaving other fields intact."""
     ch = Channel(channel_id=9999001, title="Original Title", username="original_user")
@@ -1083,7 +1083,7 @@ async def test_update_channel_meta(db):
 
 
 @pytest.mark.aiosqlite_serial
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_adds_reactions_json_column(tmp_path):
     """Migration adds reactions_json column to existing DB without it."""
     db_path = str(tmp_path / "migrate_reactions.db")
@@ -1153,7 +1153,7 @@ async def test_migrate_adds_reactions_json_column(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reactions_json_roundtrip(db):
     """reactions_json is persisted and retrieved via search_messages."""
     await db.add_channel(Channel(channel_id=-100999, title="ReactTest"))
@@ -1171,7 +1171,7 @@ async def test_reactions_json_roundtrip(db):
     assert messages[0].reactions_json == '[{"emoji": "❤️", "count": 3}]'
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reactions_json_null_when_absent(db):
     """reactions_json is None when message has no reactions."""
     await db.add_channel(Channel(channel_id=-100998, title="NoReact"))
@@ -1192,7 +1192,7 @@ async def test_reactions_json_null_when_absent(db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_message_reactions_populated_on_insert(db):
     """insert_message populates message_reactions from reactions_json."""
     await db.add_channel(Channel(channel_id=-100111, title="ReactNorm"))
@@ -1214,7 +1214,7 @@ async def test_message_reactions_populated_on_insert(db):
     assert result == {"👍": 5, "❤️": 2}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_message_reactions_not_populated_when_no_reactions(db):
     """insert_message does not create message_reactions rows when reactions_json is None."""
     await db.add_channel(Channel(channel_id=-100112, title="NoReactNorm"))
@@ -1233,7 +1233,7 @@ async def test_message_reactions_not_populated_when_no_reactions(db):
     assert row["cnt"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_message_reactions_batch_insert(db):
     """insert_messages_batch populates message_reactions for all messages with reactions."""
     await db.add_channel(Channel(channel_id=-100113, title="BatchReact"))
@@ -1257,7 +1257,7 @@ async def test_message_reactions_batch_insert(db):
     assert row["total"] == 10 + 20 + 30
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_emojis(db):
     """get_trending_emojis returns emojis sorted by total count."""
     await db.add_channel(Channel(channel_id=-100114, title="Trending"))
@@ -1289,7 +1289,7 @@ async def test_get_trending_emojis(db):
     assert trending[1]["count"] == 15
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_top_reacted_messages(db):
     """get_top_reacted_messages returns messages ordered by total reactions."""
     await db.add_channel(Channel(channel_id=-100115, title="TopReact"))
@@ -1325,14 +1325,14 @@ async def test_get_top_reacted_messages(db):
     assert top[1].message_id == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_top_messages_empty(db):
     """get_top_messages returns empty list when no messages with reactions exist."""
     result = await db.get_top_messages(limit=10)
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_top_messages_sorted_by_reactions(db):
     """get_top_messages returns messages sorted by total reaction count descending."""
     await db.add_channel(Channel(channel_id=-100500, title="TopTest"))
@@ -1369,7 +1369,7 @@ async def test_get_top_messages_sorted_by_reactions(db):
     assert result[1]["total_reactions"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_top_messages_date_filter(db):
     """get_top_messages respects date_from/date_to filters."""
     await db.add_channel(Channel(channel_id=-100501, title="DateFilter"))
@@ -1397,7 +1397,7 @@ async def test_get_top_messages_date_filter(db):
     assert result[0]["message_id"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_engagement_by_media_type(db):
     """get_engagement_by_media_type groups messages by media type with counts."""
     await db.add_channel(Channel(channel_id=-100502, title="MediaTypes"))
@@ -1437,7 +1437,7 @@ async def test_get_engagement_by_media_type(db):
     assert content_types["photo"]["message_count"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_hourly_activity(db):
     """get_hourly_activity groups messages by hour with correct counts."""
     await db.add_channel(Channel(channel_id=-100503, title="Hourly"))
@@ -1473,7 +1473,7 @@ async def test_get_hourly_activity(db):
 
 
 @pytest.mark.aiosqlite_serial
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migration_backfills_message_reactions(tmp_path):
     """Migration backfills message_reactions from existing reactions_json data."""
     db_path = str(tmp_path / "migrate_reactions_norm.db")
@@ -1543,7 +1543,7 @@ async def test_migration_backfills_message_reactions(tmp_path):
 
 
 @pytest.mark.aiosqlite_serial
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_adds_engagement_columns(tmp_path):
     """Migration adds views, forwards, reply_count columns to existing DB without them."""
     db_path = str(tmp_path / "migrate_engagement.db")
@@ -1604,7 +1604,7 @@ async def test_migrate_adds_engagement_columns(tmp_path):
     await database.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_engagement_stats_roundtrip(db):
     """views, forwards, reply_count are persisted and retrieved via search_messages."""
     await db.add_channel(Channel(channel_id=-100777, title="EngageTest"))
@@ -1626,7 +1626,7 @@ async def test_engagement_stats_roundtrip(db):
     assert messages[0].reply_count == 7
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_engagement_stats_null_when_absent(db):
     """views, forwards, reply_count are None when not provided."""
     await db.add_channel(Channel(channel_id=-100776, title="NoEngageTest"))

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -5,7 +5,7 @@ import pytest
 from src.database.connection import DBConnection, ProfilingConnection
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_connection_connect_and_close(tmp_path):
     db_path = str(tmp_path / "test_conn.db")
     conn = DBConnection(db_path)
@@ -18,7 +18,7 @@ async def test_db_connection_connect_and_close(tmp_path):
     assert conn.db is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_connection_memory():
     conn = DBConnection(":memory:")
     db = await conn.connect()
@@ -26,7 +26,7 @@ async def test_db_connection_memory():
     await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_connection_execute():
     conn = DBConnection(":memory:")
     await conn.connect()
@@ -40,7 +40,7 @@ async def test_db_connection_execute():
     await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_db_connection_execute_fetchall():
     conn = DBConnection(":memory:")
     await conn.connect()
@@ -52,7 +52,7 @@ async def test_db_connection_execute_fetchall():
     await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_profiling_connection_execute():
     inner = AsyncMock()
     mock_cursor = MagicMock()
@@ -65,7 +65,7 @@ async def test_profiling_connection_execute():
         assert result == mock_cursor
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_profiling_connection_execute_with_profiler():
     from src.web.timing import RequestProfiler
 
@@ -84,7 +84,7 @@ async def test_profiling_connection_execute_with_profiler():
         profiler.deactivate()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_profiling_connection_execute_fetchall():
     from src.web.timing import RequestProfiler
 
@@ -102,7 +102,7 @@ async def test_profiling_connection_execute_fetchall():
         profiler.deactivate()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_profiling_connection_executemany():
     from src.web.timing import RequestProfiler
 
@@ -119,7 +119,7 @@ async def test_profiling_connection_executemany():
         profiler.deactivate()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_profiling_connection_executescript():
     from src.web.timing import RequestProfiler
 

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -872,19 +872,19 @@ class TestDeepagentsSyncGenerateImage:
 
 
 class TestPipelinesToolEditPipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["edit_pipeline"]({"pipeline_id": 1, "confirm": False})
         assert "Подтвердите" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_pipeline_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["edit_pipeline"]({"confirm": True})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(return_value=None)
@@ -892,7 +892,7 @@ class TestPipelinesToolEditPipeline:
             result = await handlers["edit_pipeline"]({"pipeline_id": 99, "confirm": True})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_target_ref_format(self, mock_db):
         p = SimpleNamespace(
             id=1,
@@ -918,7 +918,7 @@ class TestPipelinesToolEditPipeline:
             )
         assert "Неверный формат" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         p = SimpleNamespace(
             id=1,
@@ -948,7 +948,7 @@ class TestPipelinesToolEditPipeline:
         assert "NewName" in _text(result)
         assert "обновлён" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_update_fails(self, mock_db):
         p = SimpleNamespace(
             id=1,
@@ -965,7 +965,7 @@ class TestPipelinesToolEditPipeline:
             result = await handlers["edit_pipeline"]({"pipeline_id": 1, "confirm": True})
         assert "Не удалось обновить" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get_detail = AsyncMock(side_effect=Exception("db err"))
@@ -980,13 +980,13 @@ class TestPipelinesToolEditPipeline:
 
 
 class TestPipelinesToolRunPipeline:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_id(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["run_pipeline"]({})
         assert "pipeline_id обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_not_found(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(return_value=None)
@@ -994,7 +994,7 @@ class TestPipelinesToolRunPipeline:
             result = await handlers["run_pipeline"]({"pipeline_id": 99})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_pipeline(self, mock_db):
         p = SimpleNamespace(id=1, name="InactivePipe", is_active=False)
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
@@ -1003,7 +1003,7 @@ class TestPipelinesToolRunPipeline:
             result = await handlers["run_pipeline"]({"pipeline_id": 1})
         assert "неактивен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         p = SimpleNamespace(id=1, name="ActivePipe", is_active=True)
         run = SimpleNamespace(id=10, generated_text="Generated content", moderation_status="pending")
@@ -1020,7 +1020,7 @@ class TestPipelinesToolRunPipeline:
         assert "run id=10" in text
         assert "Generated content" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.services.pipeline_service.PipelineService") as mock_svc:
             mock_svc.return_value.get = AsyncMock(side_effect=Exception("db err"))
@@ -1035,7 +1035,7 @@ class TestPipelinesToolRunPipeline:
 
 
 class TestPipelinesToolGenerateDraft:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success_with_query(self, mock_db):
         gen_result = {
             "generated_text": "Draft text",
@@ -1052,7 +1052,7 @@ class TestPipelinesToolGenerateDraft:
         assert "Draft text" in text
         assert "Chan" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_pipeline_id(self, mock_db):
         p = SimpleNamespace(id=1, name="P", prompt_template="Write about {topic}", llm_model="gpt-4")
         gen_result = {"generated_text": "Pipeline draft", "citations": []}
@@ -1073,7 +1073,7 @@ class TestPipelinesToolGenerateDraft:
         text = _text(result)
         assert "Pipeline draft" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error(self, mock_db):
         with patch("src.search.engine.SearchEngine", side_effect=Exception("search fail")):
             handlers = _get_tool_handlers(mock_db)
@@ -1087,7 +1087,7 @@ class TestPipelinesToolGenerateDraft:
 
 
 class TestPipelinesToolPublishPipelineRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool(self, mock_db):
         # No client_pool passed → require_pool gate should trigger
         handlers = _get_tool_handlers(mock_db, client_pool=None)
@@ -1095,14 +1095,14 @@ class TestPipelinesToolPublishPipelineRun:
         txt = _text(result)
         assert "недоступен" in txt or "Подтвердите" in txt or "pool" in txt.lower() or "Telegram" in txt
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
         result = await handlers["publish_pipeline_run"]({"run_id": 1, "confirm": False})
         assert "Подтвердите" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_not_found(self, mock_db):
         pool = MagicMock()
         mock_db.repos.generation_runs.get = AsyncMock(return_value=None)
@@ -1110,7 +1110,7 @@ class TestPipelinesToolPublishPipelineRun:
         result = await handlers["publish_pipeline_run"]({"run_id": 99, "confirm": True})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_not_found(self, mock_db):
         pool = MagicMock()
         run = SimpleNamespace(id=1, pipeline_id=5)
@@ -1121,7 +1121,7 @@ class TestPipelinesToolPublishPipelineRun:
             result = await handlers["publish_pipeline_run"]({"run_id": 1, "confirm": True})
         assert "не найден" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         pool = MagicMock()
         run = SimpleNamespace(id=1, pipeline_id=2)
@@ -1145,7 +1145,7 @@ class TestPipelinesToolPublishPipelineRun:
 
 
 class TestAgentProviderServiceLoadConfigs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_empty_on_no_setting(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import AgentProviderService
@@ -1155,7 +1155,7 @@ class TestAgentProviderServiceLoadConfigs:
         result = await svc.load_provider_configs()
         assert result == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_empty_on_invalid_json(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import PROVIDER_SETTINGS_KEY, AgentProviderService
@@ -1166,7 +1166,7 @@ class TestAgentProviderServiceLoadConfigs:
         result = await svc.load_provider_configs()
         assert result == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_empty_on_non_list_json(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import PROVIDER_SETTINGS_KEY, AgentProviderService
@@ -1177,7 +1177,7 @@ class TestAgentProviderServiceLoadConfigs:
         result = await svc.load_provider_configs()
         assert result == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_skips_unknown_provider(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import PROVIDER_SETTINGS_KEY, AgentProviderService
@@ -1189,7 +1189,7 @@ class TestAgentProviderServiceLoadConfigs:
         result = await svc.load_provider_configs()
         assert result == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_requires_cipher(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import AgentProviderService
@@ -1208,7 +1208,7 @@ class TestAgentProviderServiceLoadConfigs:
 
 
 class TestAgentProviderServiceLoadModelCache:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_on_no_setting(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import AgentProviderService
@@ -1218,7 +1218,7 @@ class TestAgentProviderServiceLoadModelCache:
         result = await svc.load_model_cache()
         assert result == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_on_invalid_json(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import MODEL_CACHE_SETTINGS_KEY, AgentProviderService
@@ -1229,7 +1229,7 @@ class TestAgentProviderServiceLoadModelCache:
         result = await svc.load_model_cache()
         assert result == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_on_non_dict_json(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import MODEL_CACHE_SETTINGS_KEY, AgentProviderService
@@ -1240,7 +1240,7 @@ class TestAgentProviderServiceLoadModelCache:
         result = await svc.load_model_cache()
         assert result == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_and_load_model_cache(self, db):
         from src.config import AppConfig
         from src.services.agent_provider_service import AgentProviderService, ProviderModelCacheEntry
@@ -1265,7 +1265,7 @@ class TestAgentProviderServiceLoadModelCache:
 
 
 class TestAgentProviderServiceBuildProviderViews:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_builds_view_for_openai(self, db):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.config import AppConfig
@@ -1295,7 +1295,7 @@ class TestAgentProviderServiceBuildProviderViews:
         assert "gpt-4o" in view["models"]
         assert view["enabled"] is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_builds_view_with_empty_cache(self, db):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.config import AppConfig
@@ -1361,7 +1361,7 @@ class TestAgentProviderServiceValidateConfig:
 
 
 class TestAgentProviderServiceRefreshAllModels:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_all_empty_configs(self, db, monkeypatch):
         from src.config import AppConfig
         from src.services.agent_provider_service import AgentProviderService
@@ -1376,7 +1376,7 @@ class TestAgentProviderServiceRefreshAllModels:
         results = await svc.refresh_all_models(configs=[])
         assert results == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_all_with_config(self, db, monkeypatch):
         from src.agent.provider_registry import ProviderRuntimeConfig
         from src.config import AppConfig
@@ -1569,7 +1569,7 @@ class TestDeepagentsBackendProperties:
 
 
 class TestAgentManagerCancelStream:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_nonexistent_stream_returns_false(self, db):
         from src.agent.manager import AgentManager
 
@@ -1580,7 +1580,7 @@ class TestAgentManagerCancelStream:
         result = await mgr.cancel_stream(thread_id)
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_active_stream_returns_true(self, db):
         import asyncio
 

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -147,7 +147,7 @@ async def client(db, real_pool_harness_factory):
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_renders(client):
     resp = await client.get("/dialogs/")
     assert resp.status_code == 200
@@ -158,7 +158,7 @@ async def test_dialogs_page_renders(client):
     assert "загрузить список диалогов" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_shows_dialogs(db, real_pool_harness_factory):
     # Under the queued-command model, the dialogs page reads from dialog_cache;
     # seed the cache so it has something to render.
@@ -183,7 +183,7 @@ async def test_dialogs_page_shows_dialogs(db, real_pool_harness_factory):
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_requires_auth(db, real_pool_harness_factory):
     app, db, harness = await _build_dialogs_app(
         db,
@@ -198,7 +198,7 @@ async def test_dialogs_page_requires_auth(db, real_pool_harness_factory):
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_success():
     """All dialogs → True; PeerChannel for channels/groups, PeerUser for dm/bot."""
     from telethon.tl.types import PeerChannel, PeerUser
@@ -236,7 +236,7 @@ async def test_leave_channels_success():
     pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_partial_failure():
     """One delete_dialog raises RuntimeError → that id is False, others True."""
     from src.telegram.client_pool import ClientPool
@@ -273,7 +273,7 @@ async def test_leave_channels_partial_failure():
     pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_flood_breaks_loop():
     """FloodWaitError → reports flood, marks all remaining ids as False, stops loop."""
     from telethon.errors import FloodWaitError
@@ -311,7 +311,7 @@ async def test_leave_channels_flood_breaks_loop():
     pool._db.repos.dialog_cache.clear_dialogs.assert_awaited_once_with("+1234567890")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_post(client):
     """POST /dialogs/leave enqueues a dialogs.leave command."""
     resp = await client.post(
@@ -324,7 +324,7 @@ async def test_leave_dialogs_post(client):
     assert "phone=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_refresh_dialogs_post_enqueues_command(db, real_pool_harness_factory):
     """POST /dialogs/refresh enqueues a dialogs.refresh command (queued model)."""
     app, db, harness = await _build_dialogs_app(db, real_pool_harness_factory)
@@ -346,7 +346,7 @@ async def test_refresh_dialogs_post_enqueues_command(db, real_pool_harness_facto
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_dialogs_flash_message(client):
     """GET with left/failed params shows flash banner."""
     resp = await client.get("/dialogs/?phone=%2B1234567890&left=2&failed=1")
@@ -356,7 +356,7 @@ async def test_leave_dialogs_flash_message(client):
     assert "<strong>1</strong>" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_my_dialogs_enriches_already_added(db):
     """get_my_dialogs() marks dialogs already in the channel DB.
 
@@ -392,7 +392,7 @@ async def test_get_my_dialogs_enriches_already_added(db):
     assert by_id[888]["already_added"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_my_dialogs_passes_refresh_flag(db):
     pool = MagicMock()
     pool.get_dialogs_for_phone = AsyncMock(return_value=list(_FAKE_DIALOGS))
@@ -409,7 +409,7 @@ async def test_get_my_dialogs_passes_refresh_flag(db):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_my_dialogs_bot_type():
     """entity with bot=True → channel_type='bot'."""
     from src.telegram.client_pool import ClientPool
@@ -453,7 +453,7 @@ async def test_get_my_dialogs_bot_type():
     assert result[0]["channel_id"] == 777
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_partial_on_timeout():
     """When iter_dialogs times out, partial accumulated results are returned."""
     from src.telegram.client_pool import ClientPool
@@ -506,7 +506,7 @@ async def test_get_dialogs_for_phone_partial_on_timeout():
     assert result[0]["channel_id"] == -100999
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_without_phone_does_not_fetch_dialogs(
     db,
     real_pool_harness_factory,
@@ -524,7 +524,7 @@ async def test_dialogs_page_without_phone_does_not_fetch_dialogs(
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_page_without_accounts_shows_disabled_photo_loader(
     db,
     real_pool_harness_factory,
@@ -546,7 +546,7 @@ async def test_dialogs_page_without_accounts_shows_disabled_photo_loader(
     await app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_uses_manual_cache():
     from src.telegram.client_pool import ClientPool
 
@@ -573,7 +573,7 @@ async def test_get_dialogs_for_phone_uses_manual_cache():
     assert mock_client.iter_dialogs.call_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_refresh_bypasses_cache():
     from src.telegram.client_pool import ClientPool
 
@@ -599,7 +599,7 @@ async def test_get_dialogs_for_phone_refresh_bypasses_cache():
     assert mock_client.iter_dialogs.call_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_refetches_after_ttl_expiry():
     from src.telegram.client_pool import ClientPool
 
@@ -626,7 +626,7 @@ async def test_get_dialogs_for_phone_refetches_after_ttl_expiry():
     assert mock_client.iter_dialogs.call_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_uses_db_cache_across_pool_instances(db):
     from src.telegram.client_pool import ClientPool
 
@@ -649,7 +649,7 @@ async def test_get_dialogs_for_phone_uses_db_cache_across_pool_instances(db):
     pool.get_client_by_phone.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_refresh_replaces_db_cache(db):
     from src.telegram.client_pool import ClientPool
 
@@ -685,7 +685,7 @@ async def test_get_dialogs_for_phone_refresh_replaces_db_cache(db):
     assert cached[0]["title"] == "Fresh Title"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_failed_refresh_keeps_existing_db_cache(db):
     from src.telegram.client_pool import ClientPool
 
@@ -710,7 +710,7 @@ async def test_get_dialogs_for_phone_failed_refresh_keeps_existing_db_cache(db):
     assert _strip_extra_dialog_fields(cached) == _strip_extra_dialog_fields(_FAKE_DIALOGS)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_for_phone_partial_timeout_keeps_existing_db_cache(db):
     from src.telegram.client_pool import ClientPool
 

--- a/tests/test_dialogs_cli_and_web_actions.py
+++ b/tests/test_dialogs_cli_and_web_actions.py
@@ -908,20 +908,20 @@ async def web_client(db, real_pool_harness_factory):
 class TestWebPage:
     """GET /dialogs/."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_page_renders(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_page_with_phone(self, web_client):
         c, app = web_client
         phone_encoded = "%2B79001234567"
         resp = await c.get(f"/dialogs/?phone={phone_encoded}")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_page_invalid_phone_shows_no_dialogs(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/?phone=%2B00000")
@@ -931,7 +931,7 @@ class TestWebPage:
 class TestWebRefresh:
     """POST /dialogs/refresh."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_ok(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/refresh", data={"phone": _PHONE})
@@ -941,7 +941,7 @@ class TestWebRefresh:
 class TestWebCacheStatus:
     """GET /dialogs/cache-status."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cache_status_empty(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/cache-status")
@@ -953,13 +953,13 @@ class TestWebCacheStatus:
 class TestWebCacheClear:
     """POST /dialogs/cache-clear."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cache_clear_all(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/cache-clear", data={"phone": ""})
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cache_clear_single(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/cache-clear", data={"phone": _PHONE})
@@ -985,14 +985,14 @@ async def _assert_enqueued(app, expected_type: str, expected_payload_subset: dic
 class TestWebSend:
     """POST /dialogs/send — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/send", data={"phone": _PHONE, "recipient": "", "text": ""})
         assert resp.status_code == 200
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1008,7 +1008,7 @@ class TestWebSend:
 class TestWebEditMessage:
     """POST /dialogs/edit-message — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/edit-message", data={
@@ -1016,7 +1016,7 @@ class TestWebEditMessage:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1032,7 +1032,7 @@ class TestWebEditMessage:
 class TestWebDeleteMessage:
     """POST /dialogs/delete-message — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/delete-message", data={
@@ -1040,7 +1040,7 @@ class TestWebDeleteMessage:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_invalid_ids(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/delete-message", data={
@@ -1048,7 +1048,7 @@ class TestWebDeleteMessage:
         })
         assert "error=invalid_ids" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1064,7 +1064,7 @@ class TestWebDeleteMessage:
 class TestWebForwardMessages:
     """POST /dialogs/forward-messages — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_forward_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/forward-messages", data={
@@ -1072,7 +1072,7 @@ class TestWebForwardMessages:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_forward_invalid_ids(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/forward-messages", data={
@@ -1080,7 +1080,7 @@ class TestWebForwardMessages:
         })
         assert "error=invalid_ids" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_forward_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1096,7 +1096,7 @@ class TestWebForwardMessages:
 class TestWebPinMessage:
     """POST /dialogs/pin-message — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pin_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/pin-message", data={
@@ -1104,7 +1104,7 @@ class TestWebPinMessage:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pin_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1120,7 +1120,7 @@ class TestWebPinMessage:
 class TestWebUnpinMessage:
     """POST /dialogs/unpin-message — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unpin_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/unpin-message", data={
@@ -1128,7 +1128,7 @@ class TestWebUnpinMessage:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unpin_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1140,7 +1140,7 @@ class TestWebUnpinMessage:
         assert "command_id=" in resp.headers["location"]
         await _assert_enqueued(app, "dialogs.unpin_message", {"phone": _PHONE, "chat_id": "@ch"})
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unpin_all_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1159,13 +1159,13 @@ class TestWebParticipants:
     responds 202.
     """
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_participants_missing_params(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/participants")
         assert resp.status_code == 400
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_participants_enqueues_when_no_snapshot(self, web_client):
         c, app = web_client
         phone_enc = _PHONE.replace("+", "%2B")
@@ -1181,13 +1181,13 @@ class TestWebParticipants:
 class TestWebArchive:
     """POST /dialogs/archive and /unarchive — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_archive_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/archive", data={"phone": "", "chat_id": ""})
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_archive_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1199,7 +1199,7 @@ class TestWebArchive:
         assert "command_id=" in resp.headers["location"]
         await _assert_enqueued(app, "dialogs.archive", {"phone": _PHONE, "chat_id": "@ch"})
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unarchive_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1211,7 +1211,7 @@ class TestWebArchive:
         assert "command_id=" in resp.headers["location"]
         await _assert_enqueued(app, "dialogs.unarchive", {"phone": _PHONE, "chat_id": "@ch"})
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_unarchive_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/unarchive", data={"phone": "", "chat_id": ""})
@@ -1221,13 +1221,13 @@ class TestWebArchive:
 class TestWebMarkRead:
     """POST /dialogs/mark-read — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_read_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/mark-read", data={"phone": "", "chat_id": ""})
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_read_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1239,7 +1239,7 @@ class TestWebMarkRead:
         assert "command_id=" in resp.headers["location"]
         await _assert_enqueued(app, "dialogs.mark_read", {"phone": _PHONE, "chat_id": "@ch"})
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mark_read_with_max_id_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1254,7 +1254,7 @@ class TestWebMarkRead:
 class TestWebEditAdmin:
     """POST /dialogs/edit-admin — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_admin_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/edit-admin", data={
@@ -1262,7 +1262,7 @@ class TestWebEditAdmin:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_admin_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1281,7 +1281,7 @@ class TestWebEditAdmin:
 class TestWebEditPermissions:
     """POST /dialogs/edit-permissions — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_permissions_no_flags(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/edit-permissions", data={
@@ -1289,7 +1289,7 @@ class TestWebEditPermissions:
         })
         assert "error=no_permission_flags" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_permissions_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/edit-permissions", data={
@@ -1297,7 +1297,7 @@ class TestWebEditPermissions:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_edit_permissions_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1316,7 +1316,7 @@ class TestWebEditPermissions:
 class TestWebKick:
     """POST /dialogs/kick — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_kick_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/kick", data={
@@ -1324,7 +1324,7 @@ class TestWebKick:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_kick_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1340,13 +1340,13 @@ class TestWebKick:
 class TestWebBroadcastStats:
     """GET /dialogs/broadcast-stats — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_broadcast_stats_missing_params(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/broadcast-stats")
         assert resp.status_code == 400
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_broadcast_stats_enqueues_when_no_snapshot(self, web_client):
         c, app = web_client
         phone_enc = _PHONE.replace("+", "%2B")
@@ -1362,7 +1362,7 @@ class TestWebBroadcastStats:
 class TestWebLeave:
     """POST /dialogs/leave — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_leave_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1378,7 +1378,7 @@ class TestWebLeave:
 class TestWebDownloadMedia:
     """POST /dialogs/download-media — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_download_missing_fields(self, web_client):
         c, app = web_client
         resp = await c.post("/dialogs/download-media", data={
@@ -1386,7 +1386,7 @@ class TestWebDownloadMedia:
         })
         assert "error=missing_fields" in str(resp.url)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_download_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(
@@ -1402,13 +1402,13 @@ class TestWebDownloadMedia:
 class TestWebCreateChannel:
     """GET and POST /dialogs/create-channel — queued-command model."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_channel_page(self, web_client):
         c, app = web_client
         resp = await c.get("/dialogs/create-channel")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_channel_enqueues(self, web_client):
         c, app = web_client
         resp = await c.post(

--- a/tests/test_draft_notification_service.py
+++ b/tests/test_draft_notification_service.py
@@ -74,7 +74,7 @@ def mock_auto_pipeline():
 # === notify_new_draft tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_without_notifier(mock_db, mock_run, mock_moderated_pipeline):
     """Returns False when notifier is None."""
     service = DraftNotificationService(mock_db, notifier=None)
@@ -82,7 +82,7 @@ async def test_notify_new_draft_without_notifier(mock_db, mock_run, mock_moderat
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_auto_mode(
     mock_db, mock_notifier, mock_run, mock_auto_pipeline
 ):
@@ -93,7 +93,7 @@ async def test_notify_new_draft_auto_mode(
     mock_notifier.notify.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_moderated_success(
     mock_db, mock_notifier, mock_run, mock_moderated_pipeline
 ):
@@ -108,7 +108,7 @@ async def test_notify_new_draft_moderated_success(
     assert "#123" in call_args
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_truncates_long_content(
     mock_db, mock_notifier, mock_long_run, mock_moderated_pipeline
 ):
@@ -121,7 +121,7 @@ async def test_notify_new_draft_truncates_long_content(
     assert "A" * 200 in call_args
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_short_content(
     mock_db, mock_notifier, mock_short_run, mock_moderated_pipeline
 ):
@@ -135,7 +135,7 @@ async def test_notify_new_draft_short_content(
     assert call_args.count("...") == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_notifier_exception(
     mock_db, mock_notifier, mock_run, mock_moderated_pipeline
 ):
@@ -146,7 +146,7 @@ async def test_notify_new_draft_notifier_exception(
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_notifier_returns_false(
     mock_db, mock_notifier, mock_run, mock_moderated_pipeline
 ):
@@ -157,7 +157,7 @@ async def test_notify_new_draft_notifier_returns_false(
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_new_draft_with_none_generated_text(
     mock_db, mock_notifier, mock_moderated_pipeline
 ):
@@ -173,7 +173,7 @@ async def test_notify_new_draft_with_none_generated_text(
 # === notify_bulk_drafts tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_without_notifier(mock_db, mock_moderated_pipeline):
     """Returns 0 when notifier is None."""
     service = DraftNotificationService(mock_db, notifier=None)
@@ -182,7 +182,7 @@ async def test_notify_bulk_drafts_without_notifier(mock_db, mock_moderated_pipel
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_auto_mode(mock_db, mock_notifier, mock_auto_pipeline):
     """Returns 0 for auto mode pipelines."""
     service = DraftNotificationService(mock_db, notifier=mock_notifier)
@@ -191,7 +191,7 @@ async def test_notify_bulk_drafts_auto_mode(mock_db, mock_notifier, mock_auto_pi
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_single_run(
     mock_db, mock_notifier, mock_run, mock_moderated_pipeline
 ):
@@ -202,7 +202,7 @@ async def test_notify_bulk_drafts_single_run(
     mock_notifier.notify.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_multiple_runs(
     mock_db, mock_notifier, mock_moderated_pipeline
 ):
@@ -216,7 +216,7 @@ async def test_notify_bulk_drafts_multiple_runs(
     assert "5 новых черновиков" in call_args
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_limits_displayed_runs(
     mock_db, mock_notifier, mock_moderated_pipeline
 ):
@@ -229,7 +229,7 @@ async def test_notify_bulk_drafts_limits_displayed_runs(
     assert "и ещё 5" in call_args
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_notifier_exception(
     mock_db, mock_notifier, mock_moderated_pipeline
 ):
@@ -241,7 +241,7 @@ async def test_notify_bulk_drafts_notifier_exception(
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_notifier_returns_false(
     mock_db, mock_notifier, mock_moderated_pipeline
 ):
@@ -253,7 +253,7 @@ async def test_notify_bulk_drafts_notifier_returns_false(
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_bulk_drafts_empty_list(mock_db, mock_notifier, mock_moderated_pipeline):
     """Handles empty list gracefully."""
     service = DraftNotificationService(mock_db, notifier=mock_notifier)

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -30,7 +30,7 @@ class FakeEmbeddings:
         return [0.5, 0.5]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_indexes_pending_messages_incrementally(db, monkeypatch):
 
     await db.insert_messages_batch(
@@ -78,7 +78,7 @@ async def test_embedding_service_indexes_pending_messages_incrementally(db, monk
     assert messages[0].text == "Crypto market update"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hybrid_search_fuses_keyword_and_semantic_candidates(db):
 
     await db.insert_messages_batch(
@@ -149,7 +149,7 @@ def test_embedding_runtime_config_model_ref_without_colon():
     assert config.model_ref == "cohere:embed-english-v3.0"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_get_embeddings_langchain_not_installed(db):
     """Test _get_embeddings when LangChain is not installed."""
     service = EmbeddingService(db)
@@ -162,7 +162,7 @@ async def test_embedding_service_get_embeddings_langchain_not_installed(db):
             await service._get_embeddings()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_get_embeddings_provider_not_installed(db):
     """Test _get_embeddings when provider package is not installed."""
     service = EmbeddingService(db)
@@ -181,7 +181,7 @@ async def test_embedding_service_get_embeddings_provider_not_installed(db):
             await service._get_embeddings()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_get_embeddings_init_exception(db):
     """Test _get_embeddings when initialization fails with non-import error."""
     _service = EmbeddingService(db)
@@ -206,7 +206,7 @@ async def test_embedding_service_get_embeddings_init_exception(db):
             pytest.skip("Cannot easily mock dynamic import inside function")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_embed_documents_sync_fallback(db):
     """Test _embed_documents uses sync fallback when async not available."""
 
@@ -227,7 +227,7 @@ async def test_embedding_service_embed_documents_sync_fallback(db):
         assert result[0] == [0.1, 0.2]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_embed_query_sync_fallback(db):
     """Test embed_query uses sync fallback when async not available."""
 
@@ -247,7 +247,7 @@ async def test_embedding_service_embed_query_sync_fallback(db):
         assert result == [0.3, 0.4]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_embedding_service_index_pending_messages_empty(db, monkeypatch):
     """Test index_pending_messages with no pending messages."""
     service = EmbeddingService(db)

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -12,7 +12,7 @@ from src.services.error_recovery_service import (
 )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_awaits_async_fallback():
     service = ErrorRecoveryService(retry_policy=RetryPolicy(max_retries=0, jitter=False))
 
@@ -27,7 +27,7 @@ async def test_execute_with_recovery_awaits_async_fallback():
     assert result == "fallback-value"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_circuit_breaker_enforces_half_open_limit():
     breaker = CircuitBreaker(
         CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=1)
@@ -44,7 +44,7 @@ async def test_circuit_breaker_enforces_half_open_limit():
     assert state == "half_open_limit"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_half_open_success_closes_circuit():
     breaker = CircuitBreaker(
         CircuitBreakerConfig(failure_threshold=1, recovery_timeout=0.0, half_open_max_calls=1)
@@ -70,7 +70,7 @@ def test_error_classifier_detects_rate_limit():
 # === Additional tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_success():
     """Test execute_with_recovery with successful function."""
     service = ErrorRecoveryService()
@@ -82,7 +82,7 @@ async def test_execute_with_recovery_success():
     assert result == "success-value"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_retries():
     """Test execute_with_recovery retries on transient error."""
     call_count = 0
@@ -100,7 +100,7 @@ async def test_execute_with_recovery_retries():
     assert call_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_circuit_open():
     """Test execute_with_recovery when circuit is open."""
     service = ErrorRecoveryService(
@@ -120,7 +120,7 @@ async def test_execute_with_recovery_circuit_open():
     assert result == "fallback"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_circuit_open_no_fallback():
     """Test execute_with_recovery when circuit is open without fallback."""
     service = ErrorRecoveryService(
@@ -136,7 +136,7 @@ async def test_execute_with_recovery_circuit_open_no_fallback():
         await service.execute_with_recovery(lambda: None)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_error_stats():
     """Test get_error_stats returns statistics."""
     service = ErrorRecoveryService()
@@ -153,7 +153,7 @@ async def test_error_stats():
     assert len(stats["recent"]) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_error_stats_empty():
     """Test get_error_stats when no errors recorded."""
     service = ErrorRecoveryService()
@@ -189,7 +189,7 @@ def test_error_classifier_unknown():
     assert ErrorClassifier.classify(err) == ErrorCategory.UNKNOWN
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_circuit_breaker_closed_state():
     """Test circuit breaker starts in closed state."""
     breaker = CircuitBreaker(CircuitBreakerConfig())
@@ -197,7 +197,7 @@ async def test_circuit_breaker_closed_state():
     assert state["state"] == "closed"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_circuit_breaker_opens_after_threshold():
     """Test circuit breaker opens after failure threshold."""
     breaker = CircuitBreaker(
@@ -212,7 +212,7 @@ async def test_circuit_breaker_opens_after_threshold():
     assert state == "open"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retry_policy_with_jitter():
     """Test retry policy calculates delay with jitter."""
     policy = RetryPolicy(max_retries=3, base_delay=1.0, jitter=True)
@@ -226,7 +226,7 @@ async def test_retry_policy_with_jitter():
 # === New tests for improved coverage ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_error_history_trims_at_max():
     """Error history is trimmed to _max_history=100 entries."""
     service = ErrorRecoveryService()
@@ -238,7 +238,7 @@ async def test_error_history_trims_at_max():
     assert len(service._error_history) == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_fatal_error_no_retries():
     """Fatal errors raise immediately without retries."""
     service = ErrorRecoveryService(
@@ -258,7 +258,7 @@ async def test_execute_with_recovery_fatal_error_no_retries():
     assert call_count == 1  # No retries
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_recovery_fatal_error_with_fallback():
     """Fatal error with fallback returns fallback value."""
     service = ErrorRecoveryService(
@@ -276,7 +276,7 @@ async def test_execute_with_recovery_fatal_error_with_fallback():
     assert result == "fallback-value"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_circuit_breaker_recovery_timeout_transition(monkeypatch):
     """Circuit breaker transitions from open to half_open after recovery timeout."""
     current_time = {"value": 100.0}
@@ -299,7 +299,7 @@ async def test_circuit_breaker_recovery_timeout_transition(monkeypatch):
     assert state == "half_open"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_circuit_breaker_half_open_failure_reopens(monkeypatch):
     """Failure in half_open state transitions back to open."""
     current_time = {"value": 100.0}

--- a/tests/test_filter_deletion_service.py
+++ b/tests/test_filter_deletion_service.py
@@ -40,7 +40,7 @@ async def _add_filtered_channel(db: Database, channel_id: int, title: str | None
     return pk
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_empty_list(db):
     """Test purge with empty list returns empty result."""
     service = FilterDeletionService(db)
@@ -50,7 +50,7 @@ async def test_purge_channels_by_pks_empty_list(db):
     assert result.purged_titles == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_channel_not_found(db):
     """Test purge skips non-existent channels."""
     service = FilterDeletionService(db)
@@ -59,7 +59,7 @@ async def test_purge_channels_by_pks_channel_not_found(db):
     assert result.skipped_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_not_filtered(db):
     """Test purge skips channels that are not filtered."""
     await db.add_channel(Channel(channel_id=100, title="Test"))
@@ -70,7 +70,7 @@ async def test_purge_channels_by_pks_not_filtered(db):
     assert result.skipped_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_success(db):
     """Test successful purge of filtered channel."""
     pk = await _add_filtered_channel(db, channel_id=100, title="Filtered Channel")
@@ -92,7 +92,7 @@ async def test_purge_channels_by_pks_success(db):
     assert result.total_messages_deleted == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_no_title(db):
     """Test purge with channel that has no title."""
     pk = await _add_filtered_channel(db, channel_id=100, title=None)
@@ -103,7 +103,7 @@ async def test_purge_channels_by_pks_no_title(db):
     assert f"pk={pk}" in result.purged_titles[0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_channels_by_pks_exception_handling(db):
     """Test purge handles exceptions gracefully."""
     # Create a mock db that raises exception
@@ -116,7 +116,7 @@ async def test_purge_channels_by_pks_exception_handling(db):
     assert result.skipped_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_all_filtered_no_channels(db):
     """Test purge all when no filtered channels exist."""
     await db.add_channel(Channel(channel_id=100, title="Active"))
@@ -126,7 +126,7 @@ async def test_purge_all_filtered_no_channels(db):
     assert result.purged_count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_purge_all_filtered_with_channels(db):
     """Test purge all with filtered channels."""
     _pk1 = await _add_filtered_channel(db, channel_id=100, title="Filtered 1")
@@ -156,7 +156,7 @@ async def test_purge_all_filtered_with_channels(db):
     assert result.total_messages_deleted == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_requires_channel_service(db):
     """Test hard delete raises error without channel service."""
     service = FilterDeletionService(db, channel_service=None)
@@ -165,7 +165,7 @@ async def test_hard_delete_requires_channel_service(db):
         await service.hard_delete_channels_by_pks([1])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_channel_not_found(db, channel_service):
     """Test hard delete skips non-existent channels."""
     channel_service.get_by_pk = AsyncMock(return_value=None)
@@ -176,7 +176,7 @@ async def test_hard_delete_channel_not_found(db, channel_service):
     assert result.skipped_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_not_filtered(db, channel_service):
     """Test hard delete skips channels that are not filtered."""
     channel = Channel(channel_id=100, title="Test", is_filtered=False)
@@ -188,7 +188,7 @@ async def test_hard_delete_not_filtered(db, channel_service):
     assert result.skipped_count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_success(db, channel_service):
     """Test successful hard delete of filtered channel."""
     channel = Channel(channel_id=100, title="To Delete", is_filtered=True)
@@ -202,7 +202,7 @@ async def test_hard_delete_success(db, channel_service):
     channel_service.delete.assert_called_once_with(1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_no_title(db, channel_service):
     """Test hard delete with channel that has no title."""
     channel = Channel(channel_id=100, title=None, is_filtered=True)
@@ -215,7 +215,7 @@ async def test_hard_delete_no_title(db, channel_service):
     assert "pk=1" in result.purged_titles[0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hard_delete_exception_handling(db, channel_service):
     """Test hard delete handles exceptions gracefully."""
     channel_service.get_by_pk = AsyncMock(side_effect=Exception("DB error"))

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -13,7 +13,7 @@ from src.telegram.flood_wait import (
 )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_with_flood_wait_returns_success_value():
     result = await run_with_flood_wait(
         AsyncMock(return_value="ok")(),
@@ -23,7 +23,7 @@ async def test_run_with_flood_wait_returns_success_value():
     assert result == "ok"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_flood_wait_reports_pool_and_builds_info():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 33
@@ -43,7 +43,7 @@ async def test_handle_flood_wait_reports_pool_and_builds_info():
     pool.report_flood.assert_awaited_once_with("+7000", 33)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_with_flood_wait_raises_handled_error_with_info():
     err = FloodWaitError(request=None, capture=0)
     err.seconds = 17
@@ -105,7 +105,7 @@ def test_format_flood_wait_detail_with_phone():
 # === handle_flood_wait edge cases ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_flood_wait_zero_seconds_clamped_to_one():
     """Zero seconds is clamped to 1."""
     err = FloodWaitError(request=None, capture=0)
@@ -119,7 +119,7 @@ async def test_handle_flood_wait_zero_seconds_clamped_to_one():
     assert info.wait_seconds == 1  # Clamped
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_flood_wait_none_seconds_clamped_to_one():
     """None seconds is clamped to 1."""
     err = FloodWaitError(request=None, capture=0)
@@ -133,7 +133,7 @@ async def test_handle_flood_wait_none_seconds_clamped_to_one():
     assert info.wait_seconds == 1  # Clamped
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_flood_wait_without_pool():
     """No pool means no report_flood call."""
     err = FloodWaitError(request=None, capture=0)
@@ -149,7 +149,7 @@ async def test_handle_flood_wait_without_pool():
     assert info.wait_seconds == 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_with_flood_wait_reports_short_floods():
     """Short FloodWait (≤60s) must still trigger pool.report_flood. Regression
     guard for #495: previously Telethon's flood_sleep_threshold=60 swallowed
@@ -172,7 +172,7 @@ async def test_run_with_flood_wait_reports_short_floods():
     pool.report_flood.assert_awaited_once_with("+7000", 5)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_with_flood_wait_with_timeout(monkeypatch):
     """Timeout parameter is forwarded to asyncio.wait_for."""
     captured: dict[str, float] = {}

--- a/tests/test_forward_citations_repo.py
+++ b/tests/test_forward_citations_repo.py
@@ -41,7 +41,7 @@ async def _plain_msg(db, target_ch: int, msg_id: int, text: str = "plain") -> No
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_positive_ids(db):
     """After fix, forward_from_channel_id stores positive values matching channels.channel_id."""
     await _seed(db, 100500, "Source Chan", "src")
@@ -56,7 +56,7 @@ async def test_citation_positive_ids(db):
     assert rows[0]["citation_count"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_multiple_sources(db):
     """Multiple source channels are correctly identified."""
     await _seed(db, 100111, "Source A", "a")
@@ -76,7 +76,7 @@ async def test_citation_multiple_sources(db):
     assert rows[1]["citation_count"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_null_source(db):
     """Messages without forward_from_channel_id are excluded."""
     await _seed(db, 100123, "Target")
@@ -87,7 +87,7 @@ async def test_citation_null_source(db):
     assert len(rows) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_unknown_source(db):
     """Forward from unknown channel returns citation with NULL title."""
     await _seed(db, 100123, "Target")
@@ -101,7 +101,7 @@ async def test_citation_unknown_source(db):
     assert rows[0]["citation_count"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_limit(db):
     """Limit parameter works correctly."""
     await _seed(db, 100123, "Target")
@@ -113,7 +113,7 @@ async def test_citation_limit(db):
     assert len(rows) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_date_filtering(db):
     """Only messages within the date window are included."""
     await _seed(db, 100500, "Source")
@@ -133,7 +133,7 @@ async def test_citation_date_filtering(db):
     assert rows_90d[0]["citation_count"] == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_citation_ordering(db):
     """Results ordered by citation_count DESC."""
     await _seed(db, 100111, "Less")

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generation_runs_repo(db):
     repo = db.repos.generation_runs
     run_id = await repo.create_run(42, "prompt-template")
@@ -24,7 +24,7 @@ async def test_generation_runs_repo(db):
     assert any(r.id == run_id for r in rows)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generation_runs_repo_hydrates_moderation_fields(db):
     repo = db.repos.generation_runs
     run_id = await repo.create_run(42, "prompt-template")
@@ -43,7 +43,7 @@ async def test_generation_runs_repo_hydrates_moderation_fields(db):
     assert rows[0].published_at is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_pending_moderation_returns_runs(db):
     repo = db.repos.generation_runs
     pending_id = await repo.create_run(42, "pending-prompt")
@@ -61,7 +61,7 @@ async def test_list_pending_moderation_returns_runs(db):
     assert statuses[approved_id] == "approved"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generation_runs_repo_hydrates_quality_fields(db):
     repo = db.repos.generation_runs
     run_id = await repo.create_run(42, "quality-prompt")
@@ -78,7 +78,7 @@ async def test_generation_runs_repo_hydrates_quality_fields(db):
     assert rows[0].quality_issues == ["too long", "weak ending"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generation_runs_repo_hydrates_variant_fields(db):
     repo = db.repos.generation_runs
     run_id = await repo.create_run(42, "variant-prompt")

--- a/tests/test_image_adapters.py
+++ b/tests/test_image_adapters.py
@@ -51,7 +51,7 @@ def _mock_session(responses: list):
 # ── Together AI ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_together_image_adapter_success():
     adapter = make_together_image_adapter("test-key")
     resp = _mock_response(json_data={"data": [{"url": "https://img.together.xyz/abc.png"}]})
@@ -63,7 +63,7 @@ async def test_together_image_adapter_success():
     assert url == "https://img.together.xyz/abc.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_together_image_adapter_error():
     adapter = make_together_image_adapter("test-key")
     resp = _mock_response(status=429, json_data={})
@@ -77,7 +77,7 @@ async def test_together_image_adapter_error():
 # ── HuggingFace ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_huggingface_image_adapter_saves_binary(tmp_path):
     adapter = make_huggingface_image_adapter("test-token", output_dir=str(tmp_path))
     fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
@@ -99,7 +99,7 @@ async def test_huggingface_image_adapter_saves_binary(tmp_path):
 # ── OpenAI ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_image_adapter_success():
     adapter = make_openai_image_adapter("test-key")
     resp = _mock_response(json_data={"data": [{"url": "https://oaidalleapi.blob/img.png"}]})
@@ -114,7 +114,7 @@ async def test_openai_image_adapter_success():
 # ── Replicate ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_polls_until_complete():
     adapter = make_replicate_image_adapter("test-token", timeout=5.0)
 
@@ -141,7 +141,7 @@ async def test_replicate_image_adapter_polls_until_complete():
     assert url == "https://replicate.delivery/img.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_failed_prediction():
     adapter = make_replicate_image_adapter("test-token", timeout=5.0)
 

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -17,7 +17,7 @@ def _make_clean_service():
 # ── search_models() huggingface ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_huggingface_with_token(monkeypatch):
     """Test HuggingFace model search with API token."""
     monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
@@ -61,7 +61,7 @@ async def test_search_models_huggingface_with_token(monkeypatch):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_huggingface_no_token_returns_empty(monkeypatch):
     """Test HuggingFace search returns empty list when no token available."""
     monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
@@ -73,7 +73,7 @@ async def test_search_models_huggingface_no_token_returns_empty(monkeypatch):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_huggingface_exception_returns_empty():
     """Test HuggingFace search handles exceptions gracefully."""
     svc = _make_clean_service()
@@ -94,7 +94,7 @@ async def test_search_models_huggingface_exception_returns_empty():
 # ── generate() ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_returns_url_with_adapter():
     svc = _make_clean_service()
 
@@ -106,14 +106,14 @@ async def test_generate_returns_url_with_adapter():
     assert result == "https://img.example.com/my-model.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_returns_none_no_adapters():
     svc = _make_clean_service()
     result = await svc.generate("some-model", "A sunset")
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_empty_text_returns_none():
     svc = _make_clean_service()
 
@@ -125,7 +125,7 @@ async def test_generate_empty_text_returns_none():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_catches_adapter_error():
     svc = _make_clean_service()
 
@@ -140,13 +140,13 @@ async def test_generate_catches_adapter_error():
 # ── is_available() ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_available_false_when_empty():
     svc = _make_clean_service()
     assert await svc.is_available() is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_available_true_with_adapter():
     svc = _make_clean_service()
 
@@ -189,7 +189,7 @@ def test_parse_model_string_with_slashes():
 # ── fallback ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fallback_to_first_adapter():
     svc = _make_clean_service()
     calls = []
@@ -227,7 +227,7 @@ def test_adapter_names():
 # ── constructor with adapters param ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_init_with_prebuilt_adapters():
     async def fake(prompt: str, model: str) -> str:
         return "prebuilt-url"
@@ -310,7 +310,7 @@ def test_resolve_adapter_returns_none_when_no_adapters():
 # ── generate() S3 upload ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_uploads_to_s3_when_local_path():
     """When adapter returns a non-http path and S3 is configured, uploads to S3."""
     svc = _make_clean_service()
@@ -329,7 +329,7 @@ async def test_generate_uploads_to_s3_when_local_path():
     svc._s3.upload_file.assert_called_once_with("/tmp/image.png")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_skips_s3_when_adapter_returns_url():
     """When adapter returns a URL, S3 upload is skipped."""
     svc = _make_clean_service()
@@ -347,7 +347,7 @@ async def test_generate_skips_s3_when_adapter_returns_url():
     svc._s3.upload_file.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_s3_upload_fails_returns_local_path():
     """When S3 upload fails, returns local path as fallback."""
     svc = _make_clean_service()
@@ -367,7 +367,7 @@ async def test_generate_s3_upload_fails_returns_local_path():
 # ── generate() OSError and TimeoutError ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_catches_os_error():
     svc = _make_clean_service()
 
@@ -379,7 +379,7 @@ async def test_generate_catches_os_error():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_catches_timeout_error():
     svc = _make_clean_service()
 
@@ -394,7 +394,7 @@ async def test_generate_catches_timeout_error():
 # ── generate() no adapter for provider ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_no_adapter_for_named_provider():
     """When no adapters are registered at all, returns None."""
     svc = _make_clean_service()
@@ -448,7 +448,7 @@ def test_register_from_env_replicate(monkeypatch):
 # ── search_models static catalogs ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_together_catalog():
     svc = _make_clean_service()
     models = await svc.search_models("together", query="flux")
@@ -456,7 +456,7 @@ async def test_search_models_together_catalog():
     assert all("together:" in m["model_string"] for m in models)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_openai_catalog():
     svc = _make_clean_service()
     models = await svc.search_models("openai")
@@ -464,14 +464,14 @@ async def test_search_models_openai_catalog():
     assert any("dall-e-3" in m["id"] for m in models)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_unknown_provider():
     svc = _make_clean_service()
     models = await svc.search_models("unknown_provider")
     assert models == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_with_query_filter():
     svc = _make_clean_service()
     models = await svc.search_models("together", query="dev")
@@ -482,7 +482,7 @@ async def test_search_models_with_query_filter():
 # ── search_models Replicate (mocked HTTP) ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_replicate_no_token(monkeypatch):
     monkeypatch.delenv("REPLICATE_API_TOKEN", raising=False)
     svc = _make_clean_service()
@@ -490,7 +490,7 @@ async def test_search_models_replicate_no_token(monkeypatch):
     assert models == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_models_replicate_with_token(monkeypatch):
     class FakeAiohttpSession:
         async def __aenter__(self):

--- a/tests/test_image_provider_service.py
+++ b/tests/test_image_provider_service.py
@@ -24,14 +24,14 @@ def _make_readonly_service(db) -> ImageProviderService:
 # ── load / save ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_empty(db):
     svc = _make_service(db)
     configs = await svc.load_provider_configs()
     assert configs == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_and_load_roundtrip(db):
     svc = _make_service(db)
     cfg = ImageProviderConfig(provider="together", enabled=True, api_key="sk-test-key")
@@ -43,7 +43,7 @@ async def test_save_and_load_roundtrip(db):
     assert loaded[0].api_key == "sk-test-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_multiple_providers(db):
     svc = _make_service(db)
     configs = [
@@ -57,7 +57,7 @@ async def test_save_multiple_providers(db):
     assert providers == {"together", "openai"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_without_key_omits_encrypted_field(db):
     svc = _make_service(db)
     cfg = ImageProviderConfig(provider="replicate", enabled=True, api_key="")
@@ -67,7 +67,7 @@ async def test_save_without_key_omits_encrypted_field(db):
     assert loaded[0].api_key == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_preserves_encrypted_on_decrypt_failure(db):
     """When api_key is empty but _api_key_enc_preserved has a value, it's written to DB."""
     svc = _make_service(db)
@@ -92,7 +92,7 @@ async def test_save_preserves_encrypted_on_decrypt_failure(db):
     assert reloaded[0].api_key == "real-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_writes_disabled_without_cipher(db):
     svc = _make_readonly_service(db)
     assert svc.writes_enabled is False
@@ -100,7 +100,7 @@ async def test_writes_disabled_without_cipher(db):
         await svc.save_provider_configs([])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_ignores_unknown_providers(db):
     svc = _make_service(db)
     cfg = ImageProviderConfig(provider="together", enabled=True, api_key="key")
@@ -120,7 +120,7 @@ async def test_load_ignores_unknown_providers(db):
 # ── parse_provider_form ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_provider_form_new_key(db):
     svc = _make_service(db)
     form = {
@@ -134,7 +134,7 @@ async def test_parse_provider_form_new_key(db):
     assert configs[0].enabled is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_provider_form_keep_old_key(db):
     svc = _make_service(db)
     existing = [ImageProviderConfig(provider="together", enabled=True, api_key="old-key")]
@@ -147,7 +147,7 @@ async def test_parse_provider_form_keep_old_key(db):
     assert configs[0].api_key == "old-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_provider_form_preserves_enc(db):
     svc = _make_service(db)
     existing = [
@@ -188,7 +188,7 @@ def test_build_provider_views():
 # ── build_adapters ──
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_adapters_from_db(db):
     svc = _make_service(db)
     configs = [ImageProviderConfig(provider="together", enabled=True, api_key="test-key")]
@@ -197,7 +197,7 @@ async def test_build_adapters_from_db(db):
     assert callable(adapters["together"])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_adapters_disabled_provider_skipped(db):
     svc = _make_service(db)
     configs = [ImageProviderConfig(provider="together", enabled=False, api_key="test-key")]
@@ -205,7 +205,7 @@ async def test_build_adapters_disabled_provider_skipped(db):
     assert "together" not in adapters
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_adapters_env_fallback(db, monkeypatch):
     svc = _make_service(db)
     monkeypatch.setenv("REPLICATE_API_TOKEN", "env-token")
@@ -216,7 +216,7 @@ async def test_build_adapters_env_fallback(db, monkeypatch):
     assert "replicate" in adapters  # from env
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_adapters_disabled_blocks_env(db, monkeypatch):
     """Disabled DB config should block env-var fallback for that provider."""
     svc = _make_service(db)

--- a/tests/test_import_web.py
+++ b/tests/test_import_web.py
@@ -34,7 +34,7 @@ async def client(tmp_path, real_pool_harness_factory):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_page_get(client):
     resp = await client.get("/channels/import")
     assert resp.status_code == 200
@@ -42,7 +42,7 @@ async def test_import_page_get(client):
     assert "Импортировать" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_textarea(client):
     resp = await client.post(
         "/channels/import",
@@ -54,7 +54,7 @@ async def test_import_textarea(client):
     assert "channel2" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_empty_input(client):
     resp = await client.post(
         "/channels/import",
@@ -65,7 +65,7 @@ async def test_import_empty_input(client):
     assert "Всего" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_skips_duplicates(client):
     # First import
     await client.post(
@@ -81,7 +81,7 @@ async def test_import_skips_duplicates(client):
     assert "Пропущен" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_button_on_channels_page(client):
     resp = await client.get("/channels/")
     assert resp.status_code == 200
@@ -102,7 +102,7 @@ async def client_no_accounts(tmp_path, real_pool_harness_factory):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_no_client_still_enqueues(client_no_accounts):
     """Under queued model, web just enqueues a channels.import_batch command.
 
@@ -119,7 +119,7 @@ async def test_import_no_client_still_enqueues(client_no_accounts):
     assert "chan3" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_file_upload(client):
     file_content = b"@filech1\n@filech2\n@filech3"
     resp = await client.post(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -100,19 +100,19 @@ async def test_db(app_with_db):
 class TestAuthFlow:
     """Full authentication cycle: no auth → 401, with auth → 200, health → 200."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_auth_returns_401(self, noauth_client):
         resp = await noauth_client.get("/", follow_redirects=False)
         assert resp.status_code == 401
         assert "WWW-Authenticate" in resp.headers
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_auth_returns_200(self, auth_client):
         resp = await auth_client.get("/")
         assert resp.status_code == 200
         assert resp.url.path == "/search"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_health_no_auth_returns_200(self, noauth_client):
         resp = await noauth_client.get("/health")
         assert resp.status_code == 200
@@ -120,7 +120,7 @@ class TestAuthFlow:
         assert data["status"] in ("healthy", "degraded")
         assert "db" in data
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_wrong_credentials_returns_401(self, app_with_db):
         app, _ = app_with_db
         transport = ASGITransport(app=app)
@@ -133,7 +133,7 @@ class TestAuthFlow:
             resp = await c.get("/")
             assert resp.status_code == 401
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_all_protected_pages_require_auth(self, noauth_client):
         for path in [
             "/settings/",
@@ -151,7 +151,7 @@ class TestAuthFlow:
 class TestChannelCRUD:
     """Add channel → list → toggle active → delete."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_full_channel_lifecycle(self, auth_client, test_db):
         """Add is now queued; toggle/delete remain synchronous."""
         # 1. POST /channels/add enqueues a channels.add_identifier command
@@ -197,7 +197,7 @@ class TestChannelCRUD:
         channels = await test_db.get_channels()
         assert len(channels) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_add_channel_enqueues_regardless_of_resolve(self, auth_client, app_with_db, test_db):
         """Under queued model, web just enqueues the command; resolve failure
         is the worker's concern. Web always redirects with command_id=."""
@@ -218,7 +218,7 @@ class TestChannelCRUD:
         assert commands[0].command_type == "channels.add_identifier"
         assert commands[0].payload.get("identifier") == "@nonexistent"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channels_page_lists_channels(self, auth_client, test_db):
         ch = Channel(channel_id=-100999, title="Visible Channel")
         await test_db.add_channel(ch)
@@ -231,7 +231,7 @@ class TestChannelCRUD:
 class TestSearchQueryCRUD:
     """Add search query → list → delete."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_add_plain_query(self, auth_client, test_db):
         resp = await auth_client.post(
             "/search-queries/add",
@@ -249,7 +249,7 @@ class TestSearchQueryCRUD:
         assert queries[0].query == "bitcoin"
         assert queries[0].is_regex is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_add_regex_query(self, auth_client, test_db):
         resp = await auth_client.post(
             "/search-queries/add",
@@ -267,7 +267,7 @@ class TestSearchQueryCRUD:
         assert len(queries) == 1
         assert queries[0].is_regex is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_delete_query(self, auth_client, test_db):
         repo = test_db.repos.search_queries
         sq = SearchQuery(query="delete_me")
@@ -279,7 +279,7 @@ class TestSearchQueryCRUD:
         queries = await repo.get_all()
         assert len(queries) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_query_appears_on_page(self, auth_client, test_db):
         repo = test_db.repos.search_queries
         await repo.add(SearchQuery(query="ethereum"))
@@ -291,12 +291,12 @@ class TestSearchQueryCRUD:
 class TestSearchModes:
     """Search local with results and without."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_local_no_results(self, auth_client):
         resp = await auth_client.get("/search?q=nonexistent&mode=local")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_local_with_results(self, auth_client, test_db):
         msgs = [
             Message(
@@ -318,7 +318,7 @@ class TestSearchModes:
         assert resp.status_code == 200
         assert "Bitcoin" in resp.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_empty_query_shows_form(self, auth_client):
         resp = await auth_client.get("/search")
         assert resp.status_code == 200
@@ -388,13 +388,13 @@ class TestConfigEnvChain:
 class TestSchedulerStartStop:
     """Start/stop scheduler through web routes."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_scheduler_page_shows_status(self, auth_client):
         resp = await auth_client.get("/scheduler/")
         assert resp.status_code == 200
         assert "Остановлен" in resp.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_start_and_stop_scheduler(self, auth_client, app_with_db):
         app, db = app_with_db
         sched = app.state.scheduler
@@ -427,7 +427,7 @@ class TestSchedulerStartStop:
             assert "scheduler_stopped" in resp.headers["location"]
         assert await db.get_setting("scheduler_autostart") == "0"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_double_start_is_safe(self, auth_client, app_with_db):
         app, _ = app_with_db
 
@@ -444,7 +444,7 @@ class TestSchedulerStartStop:
             resp2 = await c.post("/scheduler/start")  # should not crash
             assert resp2.status_code == 303
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_enqueues_channels(self, app_with_db):
         """POST /scheduler/trigger enqueues collection tasks via the queue."""
         app, db = app_with_db
@@ -473,7 +473,7 @@ class TestSchedulerStartStop:
         assert len(tasks) == 2
         assert all(task.status == "pending" for task in tasks)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_empty_returns_collect_all_empty(self, app_with_db):
         """POST /scheduler/trigger with no channels returns collect_all_empty."""
         app, _ = app_with_db
@@ -494,7 +494,7 @@ class TestSchedulerStartStop:
 class TestCollectorIncremental:
     """Collector passes min_id from DB to iter_messages on incremental run."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_incremental_passes_min_id(self, test_db):
         from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 
@@ -524,7 +524,7 @@ class TestCollectorIncremental:
 class TestSearchPagination:
     """Search with pagination (page=1, page=2)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_paginated_search(self, auth_client, test_db):
         # Insert 60 messages containing "crypto"
         msgs = [
@@ -547,7 +547,7 @@ class TestSearchPagination:
         resp2 = await auth_client.get("/search?q=Crypto&mode=local&page=2")
         assert resp2.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_engine_pagination_offsets(self, test_db):
         msgs = [
             Message(
@@ -584,7 +584,7 @@ class TestSearchPagination:
 class TestFloodWaitRotation:
     """ClientPool switches to another account on FloodWaitError."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_flood_marks_account(self, test_db):
         from src.models import Account
 
@@ -604,7 +604,7 @@ class TestFloodWaitRotation:
         healthy = [a for a in accounts if a.phone == "+70002222222"]
         assert healthy[0].flood_wait_until is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_collector_handles_flood_with_rotation(self, test_db):
         """FloodWaitError on client1 → report_flood → retry with client2."""
         from telethon.errors import FloodWaitError
@@ -645,7 +645,7 @@ class TestFloodWaitRotation:
 class TestNotificationQueryMatch:
     """Notification query patterns match correctly during collection check."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_plain_query_case_insensitive(self, test_db):
         repo = test_db.repos.search_queries
         await repo.add(
@@ -684,7 +684,7 @@ class TestNotificationQueryMatch:
         call_text = notifier.notify.call_args[0][0]
         assert "BITCOIN" in call_text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_regex_query_matches(self, test_db):
         repo = test_db.repos.search_queries
         await repo.add(
@@ -730,7 +730,7 @@ class TestNotificationQueryMatch:
         call_text = notifier.notify.call_args[0][0]
         assert "2 times" in call_text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_regex_does_not_crash(self, test_db):
         repo = test_db.repos.search_queries
         await repo.add(
@@ -764,7 +764,7 @@ class TestNotificationQueryMatch:
 class TestGracefulShutdown:
     """SchedulerManager cancels background task on stop."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_task_cancelled_on_stop(self, test_db):
         """trigger_background -> stop -> background task is cancelled."""
         started_event = asyncio.Event()
@@ -795,7 +795,7 @@ class TestGracefulShutdown:
         assert manager._bg_task is None
         assert cancelled_event.is_set()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stop_without_bg_task_is_safe(self, test_db):
         """stop() with no background task does not raise."""
         config = SchedulerConfig()
@@ -805,7 +805,7 @@ class TestGracefulShutdown:
         await manager.stop()
         assert manager._bg_task is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_background_deduplicates_racing_calls(self, test_db):
         started_event = asyncio.Event()
         release_event = asyncio.Event()
@@ -838,7 +838,7 @@ class TestGracefulShutdown:
 class TestAPICredentialsFallback:
     """When config has no API creds, lifespan loads them from DB settings."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_api_credentials_fallback_via_lifespan(self, tmp_path):
         from src.web.app import lifespan
 
@@ -863,7 +863,7 @@ class TestAPICredentialsFallback:
                 assert app.state.auth._api_id == 99999
                 assert app.state.auth._api_hash == "hash_from_db"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_api_id_in_db_does_not_crash_lifespan(self, tmp_path):
         from src.web.app import lifespan
 
@@ -883,7 +883,7 @@ class TestAPICredentialsFallback:
                 assert app.state.auth.is_configured is False
                 initialize.assert_not_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_invalid_api_id_in_db_does_not_crash_cli_pool_init(self, tmp_path):
         db_path = str(tmp_path / "bad-cli.db")
         db = Database(db_path)

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -53,7 +53,7 @@ async def pipeline_client(tmp_path, real_pool_harness_factory):
     await built_db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
     # Mock LLM provider service so the Generate button is shown in the template
     from unittest.mock import MagicMock
@@ -138,7 +138,7 @@ async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
     assert run_after.metadata and run_after.metadata.get("published") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_generate_action_only_runs_graph(pipeline_client, monkeypatch):
     """Regression: POST /pipelines/{id}/generate on an action-only pipeline
     (with pipeline_json graph) must exercise PipelineExecutor — not the legacy

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -44,7 +44,7 @@ def make_message(**kwargs) -> Message:
 # === search tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_basic(mock_search_bundle):
     """Basic search returns SearchResult."""
     msg = make_message(text="test message", channel_id=1, message_id=1)
@@ -59,7 +59,7 @@ async def test_search_basic(mock_search_bundle):
     mock_search_bundle.search_messages.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_channel_filter(mock_search_bundle):
     """Search with channel_id filter."""
     mock_search_bundle.search_messages.return_value = ([], 0)
@@ -71,7 +71,7 @@ async def test_search_with_channel_filter(mock_search_bundle):
     assert kwargs["channel_id"] == 123
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_date_range(mock_search_bundle):
     """Search with date range."""
     mock_search_bundle.search_messages.return_value = ([], 0)
@@ -84,7 +84,7 @@ async def test_search_with_date_range(mock_search_bundle):
     assert kwargs["date_to"] == "2024-12-31"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_length_filters(mock_search_bundle):
     """Search with min/max length filters."""
     mock_search_bundle.search_messages.return_value = ([], 0)
@@ -97,7 +97,7 @@ async def test_search_with_length_filters(mock_search_bundle):
     assert kwargs["max_length"] == 500
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_fts_flag(mock_search_bundle):
     """Search with FTS flag."""
     mock_search_bundle.search_messages.return_value = ([], 0)
@@ -109,7 +109,7 @@ async def test_search_with_fts_flag(mock_search_bundle):
     assert kwargs["is_fts"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_pagination(mock_search_bundle):
     """Search with limit and offset."""
     mock_search_bundle.search_messages.return_value = ([], 0)
@@ -125,7 +125,7 @@ async def test_search_with_pagination(mock_search_bundle):
 # === search_semantic tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_basic(mock_search_bundle, mock_embedding_service):
     """Basic semantic search returns SearchResult."""
     msg = make_message(text="semantic match")
@@ -139,7 +139,7 @@ async def test_search_semantic_basic(mock_search_bundle, mock_embedding_service)
     mock_embedding_service.embed_query.assert_called_once_with("test")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_with_filters(mock_search_bundle, mock_embedding_service):
     """Semantic search with filters."""
     mock_search_bundle.messages.search_semantic_messages.return_value = ([], 0)
@@ -166,7 +166,7 @@ async def test_search_semantic_with_filters(mock_search_bundle, mock_embedding_s
     assert kwargs["max_length"] == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_no_embedding_service(mock_search_bundle):
     """Semantic search without embedding service raises."""
     local_search = LocalSearch(mock_search_bundle, embedding_service=None)
@@ -180,7 +180,7 @@ async def test_search_semantic_no_embedding_service(mock_search_bundle):
 # === search_hybrid tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_hybrid_basic(mock_search_bundle, mock_embedding_service):
     """Basic hybrid search returns SearchResult."""
     msg = make_message(text="hybrid match")
@@ -194,7 +194,7 @@ async def test_search_hybrid_basic(mock_search_bundle, mock_embedding_service):
     mock_embedding_service.embed_query.assert_called_once_with("test")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_hybrid_with_filters(mock_search_bundle, mock_embedding_service):
     """Hybrid search with filters."""
     mock_search_bundle.messages.search_hybrid_messages.return_value = ([], 0)
@@ -224,7 +224,7 @@ async def test_search_hybrid_with_filters(mock_search_bundle, mock_embedding_ser
     assert kwargs["max_length"] == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_hybrid_no_embedding_service(mock_search_bundle):
     """Hybrid search without embedding service raises."""
     local_search = LocalSearch(mock_search_bundle, embedding_service=None)

--- a/tests/test_main_client_pool_collector_paths.py
+++ b/tests/test_main_client_pool_collector_paths.py
@@ -231,7 +231,7 @@ class TestClientPoolCachedDialogs:
 class TestClientPoolFlood:
     """Cover flood wait tracking (report_flood, clear_flood, premium_flood)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_flood(self):
         from src.telegram.client_pool import ClientPool
 
@@ -241,7 +241,7 @@ class TestClientPoolFlood:
         await pool.report_flood("+1", 60)
         pool._db.update_account_flood.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_premium_flood(self):
         from src.telegram.client_pool import ClientPool
 
@@ -250,7 +250,7 @@ class TestClientPoolFlood:
         await pool.report_premium_flood("+1", 60)
         assert "+1" in pool._premium_flood_wait_until
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_report_premium_flood_cleans_expired(self):
         from src.telegram.client_pool import ClientPool
 
@@ -262,7 +262,7 @@ class TestClientPoolFlood:
         assert "+old" not in pool._premium_flood_wait_until
         assert "+1" in pool._premium_flood_wait_until
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clear_flood(self):
         from src.telegram.client_pool import ClientPool
 
@@ -291,7 +291,7 @@ class TestClientPoolFlood:
 class TestClientPoolDisconnect:
     """Cover disconnect_all."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_disconnect_all_empty(self):
         from src.telegram.client_pool import ClientPool
 
@@ -300,7 +300,7 @@ class TestClientPoolDisconnect:
         await pool.disconnect_all()
         assert len(pool.clients) == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_disconnect_all_with_clients(self):
         from src.telegram.client_pool import ClientPool
 
@@ -384,7 +384,7 @@ class TestClientPoolProperties:
         pool._dialogs_fetched = set()
         assert pool.is_dialogs_fetched("+2") is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reconnect_phone_not_found(self):
         from src.telegram.client_pool import ClientPool
 
@@ -393,7 +393,7 @@ class TestClientPoolProperties:
         result = await pool.reconnect_phone("+1")
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reconnect_phone_already_connected(self):
         from src.telegram.client_pool import ClientPool
 
@@ -405,7 +405,7 @@ class TestClientPoolProperties:
         result = await pool.reconnect_phone("+1")
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reconnect_phone_disconnected(self):
         from src.telegram.client_pool import ClientPool
 
@@ -420,7 +420,7 @@ class TestClientPoolProperties:
         mock_client.connect.assert_called_once()
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reconnect_phone_exception(self):
         from src.telegram.client_pool import ClientPool
 
@@ -432,7 +432,7 @@ class TestClientPoolProperties:
         result = await pool.reconnect_phone("+1")
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_remove_client(self):
         from src.telegram.client_pool import ClientPool
 
@@ -451,7 +451,7 @@ class TestClientPoolProperties:
         assert "+1" not in pool._session_overrides
         assert "+1" not in pool.clients
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_db_cached_dialogs_empty(self):
         from src.telegram.client_pool import ClientPool
 
@@ -465,7 +465,7 @@ class TestClientPoolProperties:
         result = await pool._get_db_cached_dialogs("+1", "full")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_db_cached_dialogs_full(self):
         from src.telegram.client_pool import ClientPool
 
@@ -484,7 +484,7 @@ class TestClientPoolProperties:
         assert result is not None
         assert len(result) == 2
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_db_cached_dialogs_channels_only(self):
         from src.telegram.client_pool import ClientPool
 
@@ -503,7 +503,7 @@ class TestClientPoolProperties:
         assert result is not None
         assert len(result) == 1  # dm filtered out
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_dialog_found(self):
         from src.telegram.client_pool import ClientPool
 
@@ -515,7 +515,7 @@ class TestClientPoolProperties:
         assert result is not None
         assert result["channel_id"] == 100
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_dialog_not_found(self):
         from src.telegram.client_pool import ClientPool
 
@@ -530,7 +530,7 @@ class TestClientPoolProperties:
         result = await pool._get_cached_dialog("+1", 999)
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_cached_dialog_no_cache(self):
         from src.telegram.client_pool import ClientPool
 
@@ -568,7 +568,7 @@ class TestCollectorProperties:
         c._cancel_event.set()
         assert c.is_cancelled is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel(self):
         from src.telegram.collector import Collector
 
@@ -589,7 +589,7 @@ class TestCollectorProperties:
 class TestCollectorAutoDelete:
     """Cover _is_auto_delete_enabled (reads DB setting, caches result)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_not_enabled(self):
         from src.telegram.collector import Collector
 
@@ -603,7 +603,7 @@ class TestCollectorAutoDelete:
         result = await c._is_auto_delete_enabled()
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_enabled(self):
         from src.telegram.collector import Collector
 
@@ -616,7 +616,7 @@ class TestCollectorAutoDelete:
         result = await c._is_auto_delete_enabled()
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_auto_delete_cached(self):
         from src.telegram.collector import Collector
 
@@ -625,7 +625,7 @@ class TestCollectorAutoDelete:
         result = await c._is_auto_delete_enabled()
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_maybe_auto_delete_disabled(self):
         from src.telegram.collector import Collector
 
@@ -634,7 +634,7 @@ class TestCollectorAutoDelete:
         result = await c._maybe_auto_delete(100)
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_maybe_auto_delete_success(self):
         from src.telegram.collector import Collector
 
@@ -645,7 +645,7 @@ class TestCollectorAutoDelete:
         result = await c._maybe_auto_delete(100)
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_maybe_auto_delete_exception(self):
         from src.telegram.collector import Collector
 
@@ -719,7 +719,7 @@ class TestTelegramAuth:
         auth = TelegramAuth(0, "")
         assert auth.api_id == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_no_pending(self):
         """Line 165: no pending auth raises ValueError."""
         from src.telegram.auth import TelegramAuth
@@ -787,7 +787,7 @@ class TestTelegramAuth:
 class TestClientPoolResolveChannel:
     """Cover resolve_channel (lines 689-759)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_no_client(self):
         from src.telegram.client_pool import ClientPool
 
@@ -796,7 +796,7 @@ class TestClientPoolResolveChannel:
         with pytest.raises(RuntimeError, match="no_client"):
             await pool.resolve_channel("@test_channel")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_numeric_id(self):
         from src.telegram.client_pool import ClientPool
 
@@ -828,7 +828,7 @@ class TestClientPoolResolveChannel:
         assert result is not None
         assert result["channel_id"] == 12345
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_user_not_channel(self):
         from src.telegram.client_pool import ClientPool
 
@@ -848,7 +848,7 @@ class TestClientPoolResolveChannel:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_timeout(self):
         from src.telegram.client_pool import ClientPool
 
@@ -868,7 +868,7 @@ class TestClientPoolResolveChannel:
 class TestClientPoolGetAccountForPhone:
     """Cover _get_account_for_phone (lines 530-539)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_account_from_db(self):
         from src.models import Account
         from src.telegram.client_pool import ClientPool
@@ -882,7 +882,7 @@ class TestClientPoolGetAccountForPhone:
         assert result is not None
         assert result.phone == "+1"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_account_from_overrides(self):
         from src.telegram.client_pool import ClientPool
 
@@ -894,7 +894,7 @@ class TestClientPoolGetAccountForPhone:
         assert result is not None
         assert result.session_string == "override_session"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_account_not_found(self):
         from src.telegram.client_pool import ClientPool
 
@@ -909,7 +909,7 @@ class TestClientPoolGetAccountForPhone:
 class TestClientPoolAcquirePhoneLease:
     """Cover _acquire_phone_lease (lines 541-558)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_lease_from_pool(self):
         from src.telegram.client_pool import ClientPool
 
@@ -921,7 +921,7 @@ class TestClientPoolAcquirePhoneLease:
         result = await pool._acquire_phone_lease("+1")
         assert result is lease
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_not_connected(self):
         from src.telegram.client_pool import ClientPool
 
@@ -932,7 +932,7 @@ class TestClientPoolAcquirePhoneLease:
         result = await pool._acquire_phone_lease("+1")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_no_account(self):
         from src.telegram.client_pool import ClientPool
 
@@ -944,7 +944,7 @@ class TestClientPoolAcquirePhoneLease:
         result = await pool._acquire_phone_lease("+1")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_flood_waited(self):
         from src.models import Account
         from src.telegram.client_pool import ClientPool
@@ -961,7 +961,7 @@ class TestClientPoolAcquirePhoneLease:
         result = await pool._acquire_phone_lease("+1")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_exclusive(self):
         from src.models import Account
         from src.telegram.client_pool import ClientPool
@@ -978,7 +978,7 @@ class TestClientPoolAcquirePhoneLease:
         assert result is not None
         assert result.shared is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_phone_shared(self):
         from src.models import Account
         from src.telegram.client_pool import ClientPool
@@ -1084,7 +1084,7 @@ class TestClientPoolClassifyEntity:
 class TestCollectorCollectSingle:
     """Cover collect_single_channel entry point."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_collect_filtered_no_force(self):
         """Line 154-159: filtered channel without force → skip."""
         from src.telegram.collector import Collector
@@ -1101,7 +1101,7 @@ class TestCollectorCollectSingle:
         result = await c.collect_single_channel(channel, force=False)
         assert result == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_collect_full_resets_min_id(self):
         """Line 165-166: full=True resets last_collected_id."""
         from src.telegram.collector import Collector
@@ -1128,7 +1128,7 @@ class TestCollectorCollectSingle:
 class TestCollectorLoadMinSubs:
     """Cover _load_min_subscribers_filter."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_min_subs_default(self):
         from src.telegram.collector import Collector
 
@@ -1138,7 +1138,7 @@ class TestCollectorLoadMinSubs:
         result = await c._load_min_subscribers_filter()
         assert result == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_min_subs_from_db(self):
         from src.telegram.collector import Collector
 
@@ -1152,7 +1152,7 @@ class TestCollectorLoadMinSubs:
 class TestCollectorMaybeAutoDelete:
     """Cover _maybe_auto_delete deeper paths."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_maybe_auto_delete_with_count(self):
         from src.telegram.collector import Collector
 
@@ -1168,7 +1168,7 @@ class TestCollectorMaybeAutoDelete:
 class TestClientPoolGetStatsAvail:
     """Cover get_stats_availability methods (lines 475-492)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_premium_stats_avail_has_premium(self):
         from src.telegram.client_pool import ClientPool
 
@@ -1245,7 +1245,7 @@ class TestSessionMaterializerCacheHit:
 class TestBackendsAbstract:
     """Cover abstract method raise (line 314) and unauthorized path (372-373)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_client_abstract(self):
         from src.telegram.backends import TelegramBackend
 
@@ -1263,7 +1263,7 @@ class TestBackendsAbstract:
 class TestLeasePoolEdge:
     """Cover remaining lines in account_lease_pool."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_available_no_active(self):
         from src.telegram.account_lease_pool import AccountLeasePool
 
@@ -1273,7 +1273,7 @@ class TestLeasePoolEdge:
         result = await pool.acquire_available(connected_phones=set())
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_by_phone_not_found(self):
         from src.telegram.account_lease_pool import AccountLeasePool
 
@@ -1283,7 +1283,7 @@ class TestLeasePoolEdge:
         result = await pool.acquire_by_phone("+999", connected_phones=set())
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_acquire_available_all_in_use_flood_waited(self):
         """Line 45: in-use account but flood-waited → skip, return None."""
         from src.models import Account

--- a/tests/test_messaging_deepagents_provider_paths.py
+++ b/tests/test_messaging_deepagents_provider_paths.py
@@ -70,7 +70,7 @@ def _build_sync_tools(mock_db, config=None, client_pool=None):
 
 
 class TestEditAdminTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -81,7 +81,7 @@ class TestEditAdminTool:
         text = _text(result).lower()
         assert "pool" in text or "недоступен" in text or "изменение прав" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -90,7 +90,7 @@ class TestEditAdminTool:
         result = await handlers["edit_admin"]({"phone": "+79001234567", "chat_id": "chan", "user_id": "user1"})
         assert "confirm" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id_returns_error(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -99,7 +99,7 @@ class TestEditAdminTool:
         result = await handlers["edit_admin"]({"phone": "+79001234567", "user_id": "user1", "confirm": True})
         assert "обязательн" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_promote_success(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -112,7 +112,7 @@ class TestEditAdminTool:
         )
         assert "обновлены" in _text(result).lower() or "администратора" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_title(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -128,7 +128,7 @@ class TestEditAdminTool:
         )
         assert "обновлены" in _text(result).lower() or "администратора" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("permission denied"))
@@ -140,7 +140,7 @@ class TestEditAdminTool:
         )
         assert "Ошибка" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_client_not_found(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.get_native_client_by_phone = AsyncMock(return_value=None)
@@ -159,7 +159,7 @@ class TestEditAdminTool:
 
 
 class TestEditPermissionsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -169,7 +169,7 @@ class TestEditPermissionsTool:
         )
         assert "недоступен" in _text(result).lower() or "pool" in _text(result).lower() or "Изменение" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -180,7 +180,7 @@ class TestEditPermissionsTool:
         )
         assert "confirm" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_flags_returns_error(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -191,7 +191,7 @@ class TestEditPermissionsTool:
         )
         assert "флаг" in _text(result).lower() or "ограничени" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success_path(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -204,7 +204,7 @@ class TestEditPermissionsTool:
         )
         assert "обновлены" in _text(result).lower() or "ограничени" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_until_date(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -220,7 +220,7 @@ class TestEditPermissionsTool:
         )
         assert "обновлены" in _text(result).lower() or "ограничени" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("forbidden"))
@@ -239,7 +239,7 @@ class TestEditPermissionsTool:
 
 
 class TestGetBroadcastStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -248,7 +248,7 @@ class TestGetBroadcastStatsTool:
         text = _text(result).lower()
         assert "недоступен" in text or "pool" in text or "статистик" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -257,7 +257,7 @@ class TestGetBroadcastStatsTool:
         result = await handlers["get_broadcast_stats"]({"phone": "+79001234567"})
         assert "обязателен" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success_with_stats_fields(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         stats_mock = MagicMock()
@@ -284,7 +284,7 @@ class TestGetBroadcastStatsTool:
         assert "Статистика" in text
         assert "followers" in text or "1000" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stats_without_current_field(self, mock_db):
         """Branch: val.current is None → use str(val)."""
         mock_pool, mock_client = _make_pool_with_client()
@@ -306,7 +306,7 @@ class TestGetBroadcastStatsTool:
         result = await handlers["get_broadcast_stats"]({"phone": "+79001234567", "chat_id": "chan"})
         assert "Статистика" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_stats_falls_back_to_raw(self, mock_db):
         """Branch: no fields parsed → fields['raw'] = str(stats)."""
         mock_pool, mock_client = _make_pool_with_client()
@@ -326,7 +326,7 @@ class TestGetBroadcastStatsTool:
         result = await handlers["get_broadcast_stats"]({"phone": "+79001234567", "chat_id": "chan"})
         assert "raw" in _text(result) or "Статистика" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("chan error"))
@@ -336,7 +336,7 @@ class TestGetBroadcastStatsTool:
         result = await handlers["get_broadcast_stats"]({"phone": "+79001234567", "chat_id": "chan"})
         assert "Ошибка" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_client_not_found(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.get_native_client_by_phone = AsyncMock(return_value=None)
@@ -353,7 +353,7 @@ class TestGetBroadcastStatsTool:
 
 
 class TestUnarchiveChatTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -362,7 +362,7 @@ class TestUnarchiveChatTool:
         text = _text(result).lower()
         assert "недоступен" in text or "pool" in text or "разархивирование" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_confirm_returns_gate(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -371,7 +371,7 @@ class TestUnarchiveChatTool:
         result = await handlers["unarchive_chat"]({"phone": "+79001234567", "chat_id": "chan"})
         assert "confirm" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -380,7 +380,7 @@ class TestUnarchiveChatTool:
         result = await handlers["unarchive_chat"]({"phone": "+79001234567", "confirm": True})
         assert "обязателен" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -392,7 +392,7 @@ class TestUnarchiveChatTool:
         assert "разархивирован" in _text(result).lower()
         mock_client.edit_folder.assert_awaited_once_with(mock_client.get_entity.return_value, 0)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("fail"))
@@ -409,7 +409,7 @@ class TestUnarchiveChatTool:
 
 
 class TestDownloadMediaTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -417,7 +417,7 @@ class TestDownloadMediaTool:
         result = await handlers["download_media"]({"phone": "+79001234567", "chat_id": "me", "message_id": 1})
         assert "недоступен" in _text(result).lower() or "pool" in _text(result).lower() or "Загрузка" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -426,7 +426,7 @@ class TestDownloadMediaTool:
         result = await handlers["download_media"]({"phone": "+79001234567", "message_id": 1})
         assert "обязательн" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_message_not_found(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -442,7 +442,7 @@ class TestDownloadMediaTool:
         result = await handlers["download_media"]({"phone": "+79001234567", "chat_id": "me", "message_id": 42})
         assert "не найдено" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_media_in_message(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -459,7 +459,7 @@ class TestDownloadMediaTool:
         result = await handlers["download_media"]({"phone": "+79001234567", "chat_id": "me", "message_id": 42})
         assert "нет медиа" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("network error"))
@@ -469,7 +469,7 @@ class TestDownloadMediaTool:
         result = await handlers["download_media"]({"phone": "+79001234567", "chat_id": "me", "message_id": 1})
         assert "Ошибка" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_client_not_found(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.get_native_client_by_phone = AsyncMock(return_value=None)
@@ -486,7 +486,7 @@ class TestDownloadMediaTool:
 
 
 class TestMarkReadTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
         mock_db.get_setting = AsyncMock(return_value=None)
@@ -495,7 +495,7 @@ class TestMarkReadTool:
         text = _text(result).lower()
         assert "недоступен" in text or "pool" in text or "прочитанн" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_chat_id(self, mock_db):
         mock_pool, _ = _make_pool_with_client()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
@@ -504,7 +504,7 @@ class TestMarkReadTool:
         result = await handlers["mark_read"]({"phone": "+79001234567"})
         assert "обязателен" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_success(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(return_value=MagicMock())
@@ -515,7 +515,7 @@ class TestMarkReadTool:
         result = await handlers["mark_read"]({"phone": "+79001234567", "chat_id": "chan", "max_id": 100})
         assert "прочитанны" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_propagates(self, mock_db):
         mock_pool, mock_client = _make_pool_with_client()
         mock_client.get_entity = AsyncMock(side_effect=Exception("flood"))
@@ -948,33 +948,33 @@ class TestAgentProviderService:
             **kwargs,
         )
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_provider_configs_empty(self):
         svc, db = self._make_service()
         configs = await svc.load_provider_configs()
         assert configs == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_provider_configs_invalid_json(self):
         svc, db = self._make_service()
         db.get_setting = AsyncMock(return_value="not-json{{{")
         configs = await svc.load_provider_configs()
         assert configs == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_provider_configs_not_list(self):
         svc, db = self._make_service()
         db.get_setting = AsyncMock(return_value=json.dumps({"key": "value"}))
         configs = await svc.load_provider_configs()
         assert configs == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_model_cache_empty(self):
         svc, db = self._make_service()
         cache = await svc.load_model_cache()
         assert cache == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_model_cache_invalid_json(self):
         svc, db = self._make_service()
         db.get_setting = AsyncMock(return_value="{{broken")
@@ -1201,7 +1201,7 @@ class TestAgentProviderService:
         # No encryption key → cipher is None
         assert svc.writes_enabled is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_provider_configs_raises_without_encryption(self):
         svc, _ = self._make_service()
         cfg = self._make_cfg()
@@ -1243,7 +1243,7 @@ class TestAgentProviderService:
         views = svc.build_provider_views([cfg], cache)
         assert "gpt-custom-model" in views[0]["models"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_and_load_model_cache(self):
         from src.services.agent_provider_service import ProviderModelCacheEntry
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -9,7 +9,7 @@ import pytest
 from src.database.migrations import _migrate_vec_to_portable
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.aiosqlite_serial
 async def test_migrate_vec_to_portable_converts_json_to_blob(tmp_path):
     db_path = str(tmp_path / "test.db")
@@ -43,7 +43,7 @@ async def test_migrate_vec_to_portable_converts_json_to_blob(tmp_path):
         await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.aiosqlite_serial
 async def test_migrate_vec_skips_when_no_vec_table(tmp_path):
     db_path = str(tmp_path / "test.db")
@@ -65,7 +65,7 @@ async def test_migrate_vec_skips_when_no_vec_table(tmp_path):
         await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.aiosqlite_serial
 async def test_migrate_vec_is_idempotent_with_existing_data(tmp_path):
     """Migration adds missing rows from vec_messages even if message_embeddings already has data."""
@@ -101,7 +101,7 @@ async def test_migrate_vec_is_idempotent_with_existing_data(tmp_path):
         await conn.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.aiosqlite_serial
 async def test_migrate_vec_skips_empty_vec_table(tmp_path):
     db_path = str(tmp_path / "test.db")

--- a/tests/test_migrations_schema_paths.py
+++ b/tests/test_migrations_schema_paths.py
@@ -101,7 +101,7 @@ async def _init_schema(db):
     await db.commit()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_missing_columns(fresh_db):
     await _init_schema(fresh_db)
     result = await run_migrations(fresh_db)
@@ -113,7 +113,7 @@ async def test_run_migrations_adds_missing_columns(fresh_db):
         assert expected in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_idempotent(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -123,7 +123,7 @@ async def test_run_migrations_idempotent(fresh_db):
     assert cols.count("media_type") == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_search_queries_table(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -131,7 +131,7 @@ async def test_run_migrations_creates_search_queries_table(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_photo_tables(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -140,7 +140,7 @@ async def test_run_migrations_creates_photo_tables(fresh_db):
         assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_generation_runs(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -148,7 +148,7 @@ async def test_run_migrations_creates_generation_runs(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_agent_tables(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -157,7 +157,7 @@ async def test_run_migrations_creates_agent_tables(fresh_db):
         assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_pipeline_templates(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -165,7 +165,7 @@ async def test_run_migrations_creates_pipeline_templates(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_generated_images(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -173,7 +173,7 @@ async def test_run_migrations_creates_generated_images(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_flat(fresh_db):
     await _init_schema(fresh_db)
     perms = {"list_dialogs": True, "other_tool": False}
@@ -191,7 +191,7 @@ async def test_migrate_tool_permission_flat(fresh_db):
     assert data["search_dialogs"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_per_phone(fresh_db):
     await _init_schema(fresh_db)
     perms = {"+123456": {"list_dialogs": True}, "+789": {"list_dialogs": False}}
@@ -208,7 +208,7 @@ async def test_migrate_tool_permission_per_phone(fresh_db):
     assert "list_dialogs" not in data["+123456"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_no_existing_setting(fresh_db):
     await _init_schema(fresh_db)
     await _migrate_tool_permission_key(fresh_db, "list_dialogs", "search_dialogs")
@@ -216,7 +216,7 @@ async def test_migrate_tool_permission_no_existing_setting(fresh_db):
     assert await cur.fetchone() is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_invalid_json(fresh_db):
     await _init_schema(fresh_db)
     await fresh_db.execute(
@@ -229,13 +229,13 @@ async def test_migrate_tool_permission_invalid_json(fresh_db):
     assert row["value"] == "not-json"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_no_table(fresh_db):
     await _init_schema(fresh_db)
     await _migrate_vec_to_portable(fresh_db)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_message_reactions(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -243,7 +243,7 @@ async def test_run_migrations_creates_message_reactions(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_tags_tables(fresh_db):
     await _init_schema(fresh_db)
     await run_migrations(fresh_db)
@@ -255,7 +255,7 @@ async def test_run_migrations_creates_tags_tables(fresh_db):
 # === Additional tests for edge-case paths ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_with_data(fresh_db):
     """Test actual vec_messages migration with embedding data."""
     import struct
@@ -298,7 +298,7 @@ async def test_migrate_vec_to_portable_with_data(fresh_db):
     assert row["message_id"] == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_json_vector(fresh_db):
     """Test vec migration with JSON-encoded vector."""
     await _init_schema(fresh_db)
@@ -330,7 +330,7 @@ async def test_migrate_vec_to_portable_json_vector(fresh_db):
     assert row["cnt"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_no_dimension_setting(fresh_db):
     """Test vec migration skips when no dimension setting."""
     await _init_schema(fresh_db)
@@ -347,7 +347,7 @@ async def test_migrate_vec_to_portable_no_dimension_setting(fresh_db):
     # No crash, nothing migrated
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_invalid_dimension(fresh_db):
     """Test vec migration skips when dimension is invalid."""
     await _init_schema(fresh_db)
@@ -365,7 +365,7 @@ async def test_migrate_vec_to_portable_invalid_dimension(fresh_db):
     await _migrate_vec_to_portable(fresh_db)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_missing_message_columns(fresh_db):
     """Test that migrations add missing message columns."""
     # Create messages table WITHOUT the extra columns
@@ -437,7 +437,7 @@ async def test_run_migrations_adds_missing_message_columns(fresh_db):
     assert "translation_en" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_keywords_to_search_queries(fresh_db):
     """Test migration of keywords table to search_queries."""
     await _init_schema(fresh_db)
@@ -470,7 +470,7 @@ async def test_run_migrations_keywords_to_search_queries(fresh_db):
     assert row["name"] == "test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_notification_bots_drop_notnull(fresh_db):
     """Test notification_bots migration drops NOT NULL from bot_id."""
     await _init_schema(fresh_db)
@@ -499,7 +499,7 @@ async def test_run_migrations_notification_bots_drop_notnull(fresh_db):
     assert row["bot_id"] == 456
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_collection_tasks_rebuild(fresh_db):
     """Test collection_tasks migration rebuilds table with proper schema."""
     await _init_schema(fresh_db)
@@ -536,7 +536,7 @@ async def test_run_migrations_collection_tasks_rebuild(fresh_db):
     assert row["channel_title"] == "Test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_no_matching_key(fresh_db):
     """Test tool permission migration when old key doesn't exist."""
     await _init_schema(fresh_db)
@@ -556,7 +556,7 @@ async def test_migrate_tool_permission_no_matching_key(fresh_db):
     assert "new_name" not in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_resets_agent_prompt(fresh_db):
     """Test one-time agent prompt reset migration."""
     await _init_schema(fresh_db)

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -133,7 +133,7 @@ async def _init_minimal_schema(db):
     await db.commit()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_dialog_cache(fresh_db):
     """Covers dialog_cache table creation."""
     await _init_minimal_schema(fresh_db)
@@ -144,7 +144,7 @@ async def test_run_migrations_creates_dialog_cache(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_channel_rename_events(fresh_db):
     """Covers channel_rename_events table creation."""
     await _init_minimal_schema(fresh_db)
@@ -155,7 +155,7 @@ async def test_run_migrations_creates_channel_rename_events(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_runtime_snapshots(fresh_db):
     """Covers runtime_snapshots table creation."""
     await _init_minimal_schema(fresh_db)
@@ -166,7 +166,7 @@ async def test_run_migrations_creates_runtime_snapshots(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_telegram_commands(fresh_db):
     """Covers telegram_commands table creation."""
     await _init_minimal_schema(fresh_db)
@@ -177,7 +177,7 @@ async def test_run_migrations_creates_telegram_commands(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_message_embeddings_json(fresh_db):
     """Covers message_embeddings_json table creation."""
     await _init_minimal_schema(fresh_db)
@@ -188,7 +188,7 @@ async def test_run_migrations_creates_message_embeddings_json(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_dialog_cache_index(fresh_db):
     """Covers dialog_cache phone index creation."""
     await _init_minimal_schema(fresh_db)
@@ -199,7 +199,7 @@ async def test_run_migrations_creates_dialog_cache_index(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_creates_channel_stats_index(fresh_db):
     """Covers channel_stats lookup index creation."""
     await _init_minimal_schema(fresh_db)
@@ -210,7 +210,7 @@ async def test_run_migrations_creates_channel_stats_index(fresh_db):
     assert await cur.fetchone() is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_notification_search_cleanup(fresh_db):
     """Covers updating notification_search tasks to failed."""
     await _init_minimal_schema(fresh_db)
@@ -229,7 +229,7 @@ async def test_run_migrations_notification_search_cleanup(fresh_db):
     assert "removed" in row["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_channel_type_normalization(fresh_db):
     """Covers channel_type normalization: supergroup->group, chat->group."""
     await _init_minimal_schema(fresh_db)
@@ -257,7 +257,7 @@ async def test_run_migrations_channel_type_normalization(fresh_db):
     assert rows[3] == "group"  # 'chat' becomes 'group'
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_last_collected_id_fixup(fresh_db):
     """Covers last_collected_id=0 fixup with existing messages."""
     await _init_minimal_schema(fresh_db)
@@ -277,7 +277,7 @@ async def test_run_migrations_last_collected_id_fixup(fresh_db):
     assert row["last_collected_id"] == 99
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_search_query_columns(fresh_db):
     """Covers search_queries column additions (is_regex, notify_on_collect, etc.)."""
     await _init_minimal_schema(fresh_db)
@@ -292,7 +292,7 @@ async def test_run_migrations_adds_search_query_columns(fresh_db):
     assert "max_length" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_pipeline_target_columns(fresh_db):
     """Covers pipeline_targets target_title, target_type column additions."""
     await _init_minimal_schema(fresh_db)
@@ -303,7 +303,7 @@ async def test_run_migrations_adds_pipeline_target_columns(fresh_db):
     assert "target_type" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_pipeline_json_and_refinement(fresh_db):
     """Covers content_pipelines refinement_steps and pipeline_json columns."""
     await _init_minimal_schema(fresh_db)
@@ -315,7 +315,7 @@ async def test_run_migrations_adds_pipeline_json_and_refinement(fresh_db):
     assert "publish_times" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_forward_from_channel_id(fresh_db):
     """Covers forward_from_channel_id column addition on messages."""
     await _init_minimal_schema(fresh_db)
@@ -325,7 +325,7 @@ async def test_run_migrations_forward_from_channel_id(fresh_db):
     assert "forward_from_channel_id" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_fwd_abs_normalization(fresh_db):
     """Covers _migration_fwd_abs_v1: negative forward_from_channel_id abs normalization."""
     await _init_minimal_schema(fresh_db)
@@ -346,7 +346,7 @@ async def test_run_migrations_fwd_abs_normalization(fresh_db):
     assert row["forward_from_channel_id"] == 100123456
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_channel_preferred_phone(fresh_db):
     """Covers preferred_phone column on channels."""
     await _init_minimal_schema(fresh_db)
@@ -356,7 +356,7 @@ async def test_run_migrations_adds_channel_preferred_phone(fresh_db):
     assert "preferred_phone" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_message_translation_columns(fresh_db):
     """Covers translation_en and translation_custom columns."""
     await _init_minimal_schema(fresh_db)
@@ -367,7 +367,7 @@ async def test_run_migrations_adds_message_translation_columns(fresh_db):
     assert "translation_custom" in cols
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_vec_to_portable_invalid_type_row(fresh_db):
     """Covers the `else: continue` branch when embedding type is not str/bytes/bytearray."""
     await _init_minimal_schema(fresh_db)
@@ -398,7 +398,7 @@ async def test_migrate_vec_to_portable_invalid_type_row(fresh_db):
     assert row["cnt"] == 1  # bytes blob should be migrated
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_empty_value(fresh_db):
     """Covers the case where the setting value is empty string."""
     await _init_minimal_schema(fresh_db)
@@ -412,7 +412,7 @@ async def test_migrate_tool_permission_empty_value(fresh_db):
     assert row["value"] == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_migrate_tool_permission_non_dict_value(fresh_db):
     """Covers the case where the JSON value is a list (not dict)."""
     await _init_minimal_schema(fresh_db)
@@ -427,7 +427,7 @@ async def test_migrate_tool_permission_non_dict_value(fresh_db):
     assert row["value"] == "[1,2,3]"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_prompt_reset_already_done(fresh_db):
     """Covers the path where _migration_reset_prompt_v2 already exists."""
     await _init_minimal_schema(fresh_db)
@@ -443,7 +443,7 @@ async def test_run_migrations_prompt_reset_already_done(fresh_db):
     assert await cur.fetchone() is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_migrations_adds_translation_columns_on_bare_messages(fresh_db):
     """Test adding translation columns on a bare messages table that lacks them."""
     await fresh_db.execute("""
@@ -503,7 +503,7 @@ async def test_run_migrations_adds_translation_columns_on_bare_messages(fresh_db
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_snapshots_basic():
     """Covers _publish_snapshots happy path with mocked container."""
     from src.runtime.worker import _publish_snapshots
@@ -553,7 +553,7 @@ async def test_publish_snapshots_basic():
     assert mock_runtime_snapshots.upsert_snapshot.call_count >= 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_snapshots_with_available_notification():
     """Covers the notification bot snapshot path when target is available."""
     from src.runtime.worker import _publish_snapshots
@@ -595,7 +595,7 @@ async def test_publish_snapshots_with_available_notification():
     assert mock_runtime_snapshots.upsert_snapshot.call_count >= 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_snapshots_notification_exception():
     """Covers the exception path when NotificationService.get_status() fails."""
     from src.runtime.worker import _publish_snapshots
@@ -648,7 +648,7 @@ async def test_publish_snapshots_notification_exception():
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generate_image_url_result(mock_db, tmp_path):
     """Covers the URL download path in generate_image (lines 58-93)."""
 
@@ -726,7 +726,7 @@ def clean_provider_env():
             os.environ[var] = val
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_no_db():
     """Covers load_db_providers when db is None."""
     svc = AgentProviderService(db=None, config=None)
@@ -734,7 +734,7 @@ async def test_load_db_providers_no_db():
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_db_exception():
     """Covers load_db_providers exception path."""
     mock_db = MagicMock()
@@ -754,7 +754,7 @@ async def test_load_db_providers_db_exception():
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reload_db_providers():
     """Covers reload_db_providers: removes stale providers."""
     svc = AgentProviderService()
@@ -772,7 +772,7 @@ async def test_reload_db_providers():
     assert "db_only" not in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_no_db():
     """Covers get_provider_status_list when db is None."""
     svc = AgentProviderService(db=None, config=None)
@@ -780,7 +780,7 @@ async def test_get_provider_status_list_no_db():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_with_configs():
     """Covers get_provider_status_list with active/disabled/invalid providers."""
     mock_db = MagicMock()
@@ -807,7 +807,7 @@ async def test_get_provider_status_list_with_configs():
     assert any(s["provider"] == "disabled_prov" and s["status"] == "disabled" for s in statuses)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_has_providers_true_and_false():
     """Covers has_providers with and without real providers."""
     svc = AgentProviderService()
@@ -833,7 +833,7 @@ def test_get_provider_callable_returns_first_non_default():
     assert result == "custom"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_provider_service():
     """Covers build_provider_service factory function."""
     svc = await build_provider_service(db=None, config=None)
@@ -945,7 +945,7 @@ def test_has_valid_secrets_with_empty_secrets():
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_telegram_credentials_from_config():
     """Covers load_telegram_credentials with config values."""
     from src.web.bootstrap import load_telegram_credentials
@@ -961,7 +961,7 @@ async def test_load_telegram_credentials_from_config():
     assert api_hash == "test_hash"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_telegram_credentials_from_db():
     """Covers load_telegram_credentials falling back to DB settings."""
     from src.web.bootstrap import load_telegram_credentials
@@ -977,7 +977,7 @@ async def test_load_telegram_credentials_from_db():
     assert api_hash == "db_hash"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_telegram_credentials_no_db_fallback():
     """Covers load_telegram_credentials with no DB values."""
     from src.web.bootstrap import load_telegram_credentials
@@ -1137,7 +1137,7 @@ def test_invalidate_numpy_index():
     assert local_search._numpy_index_loaded is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_no_vec_no_numpy():
     """Covers semantic search fallback when vec and numpy are unavailable."""
     mock_bundle = MagicMock()
@@ -1156,7 +1156,7 @@ async def test_search_semantic_no_vec_no_numpy():
     assert "unavailable" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_numpy_empty_index():
     """Covers semantic search with numpy fallback but empty index."""
     mock_bundle = MagicMock()
@@ -1181,7 +1181,7 @@ async def test_search_semantic_numpy_empty_index():
         assert result.messages == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_vec_path():
     """Covers semantic search using the vec (sqlite-vec) path."""
     mock_bundle = MagicMock()
@@ -1198,7 +1198,7 @@ async def test_search_semantic_vec_path():
     assert result.messages[0].text == "test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_passes_offset_and_limit(mock_search_bundle_for_local):
     """Covers search with offset parameter."""
     local_search = LocalSearch(mock_search_bundle_for_local)
@@ -1224,7 +1224,7 @@ def mock_search_bundle_for_local():
 # ============================================================================
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_bg_tasks_empty():
     """Covers _cancel_bg_tasks with empty set."""
     from src.web.bootstrap import _cancel_bg_tasks
@@ -1234,7 +1234,7 @@ async def test_cancel_bg_tasks_empty():
     assert len(tasks) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_bg_tasks_with_tasks():
     """Covers _cancel_bg_tasks cancelling active tasks."""
     from src.web.bootstrap import _cancel_bg_tasks

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -174,7 +174,7 @@ async def test_delete_bot_success():
     confirm_msg.click.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_setup_bot_success(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     native_client = await _connect_notification_account(
@@ -204,7 +204,7 @@ async def test_setup_bot_success(db, real_pool_harness_factory):
     assert saved.bot_username == "leadhunter_alice_bot"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_setup_bot_custom_prefix(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     native_client = await _connect_notification_account(
@@ -235,7 +235,7 @@ async def test_setup_bot_custom_prefix(db, real_pool_harness_factory):
     assert mock_create.await_args.args[1:] == ("Acme (bob)", "acme_bob_bot")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_setup_bot_slug_truncated(db, real_pool_harness_factory):
     long_username = "averylongusernamethatexceeds17"
     harness = real_pool_harness_factory()
@@ -261,7 +261,7 @@ async def test_setup_bot_slug_truncated(db, real_pool_harness_factory):
     assert len(bot.bot_username) <= 32
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_setup_bot_no_client(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     svc = NotificationService(db, NotificationTargetService(db, harness.pool))
@@ -270,7 +270,7 @@ async def test_setup_bot_no_client(db, real_pool_harness_factory):
         await svc.setup_bot()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_setup_bot_bot_id_none_if_entity_fails(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     harness.queue_cli_client(phone="+70001111111", client=FakeCliTelethonClient())
@@ -300,7 +300,7 @@ async def test_setup_bot_bot_id_none_if_entity_fails(db, real_pool_harness_facto
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_status_no_bot(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await _connect_notification_account(
@@ -316,7 +316,7 @@ async def test_get_status_no_bot(db, real_pool_harness_factory):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_status_returns_bot(db, real_pool_harness_factory):
     saved = NotificationBot(
         tg_user_id=666,
@@ -344,7 +344,7 @@ async def test_get_status_returns_bot(db, real_pool_harness_factory):
     assert result.bot_username == "leadhunter_dave_bot"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_teardown_bot_success(db, real_pool_harness_factory):
     saved = NotificationBot(
         tg_user_id=777,
@@ -376,7 +376,7 @@ async def test_teardown_bot_success(db, real_pool_harness_factory):
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_teardown_bot_no_bot_raises(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     native_client = await _connect_notification_account(
@@ -395,7 +395,7 @@ async def test_teardown_bot_no_bot_raises(db, real_pool_harness_factory):
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notifier_uses_primary_account_by_default(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     native_client = await _connect_notification_account(
@@ -415,7 +415,7 @@ async def test_notifier_uses_primary_account_by_default(db, real_pool_harness_fa
     native_client.disconnect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notifier_does_not_fallback_from_selected_account(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     primary_client = await _connect_notification_account(
@@ -453,7 +453,7 @@ async def test_notifier_does_not_fallback_from_selected_account(db, real_pool_ha
     primary_client.send_message.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_service_uses_selected_account(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await _connect_notification_account(

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -50,7 +50,7 @@ def make_query(
 # === match_and_notify tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_empty_messages():
     """Empty message list returns {}."""
     notifier = AsyncMock()
@@ -62,7 +62,7 @@ async def test_match_and_notify_empty_messages():
     notifier.notify.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_empty_queries():
     """Empty query list returns {}."""
     notifier = AsyncMock()
@@ -74,7 +74,7 @@ async def test_match_and_notify_empty_queries():
     notifier.notify.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_plain_text_match():
     """Plain text query matches message text."""
     notifier = AsyncMock()
@@ -89,7 +89,7 @@ async def test_match_and_notify_plain_text_match():
     notifier.notify.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_case_insensitive():
     """Matching is case-insensitive."""
     notifier = AsyncMock()
@@ -103,7 +103,7 @@ async def test_match_and_notify_case_insensitive():
     assert result == {1: 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_regex_query():
     """Regex query matches via re.search."""
     notifier = AsyncMock()
@@ -117,7 +117,7 @@ async def test_match_and_notify_regex_query():
     assert result == {1: 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_regex_error_falls_through():
     """Invalid regex in query does not crash."""
     notifier = AsyncMock()
@@ -132,7 +132,7 @@ async def test_match_and_notify_regex_error_falls_through():
     assert result == {}  # No match due to regex error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_fts_query_and():
     """FTS5 AND logic - both terms required."""
     notifier = AsyncMock()
@@ -151,7 +151,7 @@ async def test_match_and_notify_fts_query_and():
     assert result == {1: 1}  # Only one message matched
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_fts_query_or():
     """FTS5 OR logic - any term matches."""
     notifier = AsyncMock()
@@ -171,7 +171,7 @@ async def test_match_and_notify_fts_query_or():
     assert result.get(1, 0) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_excludes_by_pattern():
     """Messages matching exclude patterns are skipped."""
     notifier = AsyncMock()
@@ -188,7 +188,7 @@ async def test_match_and_notify_excludes_by_pattern():
     assert result == {1: 1}  # Only non-spam message
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_max_length_filter():
     """Messages at/above max_length are skipped."""
     notifier = AsyncMock()
@@ -209,7 +209,7 @@ async def test_match_and_notify_max_length_filter():
     assert result == {1: 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_message_no_text():
     """Messages with None text are skipped."""
     notifier = AsyncMock()
@@ -223,7 +223,7 @@ async def test_match_and_notify_message_no_text():
     assert result == {1: 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_counts_multiple_matches():
     """One query matching multiple messages counts correctly."""
     notifier = AsyncMock()
@@ -244,7 +244,7 @@ async def test_match_and_notify_counts_multiple_matches():
     assert "3 times" in call_args
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_match_and_notify_multiple_queries():
     """Multiple queries each produce separate counts."""
     notifier = AsyncMock()

--- a/tests/test_notification_target_service.py
+++ b/tests/test_notification_target_service.py
@@ -40,28 +40,28 @@ def _make_service(accounts=None, clients=None, configured_phone=None):
     return svc, notifications
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_configured_phone_set():
     svc, notifications = _make_service(configured_phone="+70001112233")
     result = await svc.get_configured_phone()
     assert result == "+70001112233"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_configured_phone_empty():
     svc, _ = _make_service(configured_phone="")
     result = await svc.get_configured_phone()
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_set_configured_phone():
     svc, notifications = _make_service()
     await svc.set_configured_phone("+70001112233")
     notifications.set_setting.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_selected_account_available():
     acc = _make_account(phone="+70001112233", is_primary=False)
     svc, _ = _make_service(
@@ -75,7 +75,7 @@ async def test_describe_target_selected_account_available():
     assert status.effective_phone == "+70001112233"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_selected_account_missing():
     svc, _ = _make_service(
         accounts=[],
@@ -86,7 +86,7 @@ async def test_describe_target_selected_account_missing():
     assert status.state == "missing"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_selected_account_inactive():
     acc = _make_account(phone="+70001112233", is_active=False)
     svc, _ = _make_service(
@@ -97,7 +97,7 @@ async def test_describe_target_selected_account_inactive():
     assert status.state == "inactive"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_selected_account_flood_wait():
     until = datetime.now(timezone.utc) + timedelta(seconds=300)
     acc = _make_account(phone="+70001112233", flood_wait_until=until)
@@ -109,7 +109,7 @@ async def test_describe_target_selected_account_flood_wait():
     assert status.state == "flood_wait"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_selected_account_disconnected():
     acc = _make_account(phone="+70001112233")
     svc, _ = _make_service(
@@ -121,7 +121,7 @@ async def test_describe_target_selected_account_disconnected():
     assert status.state == "disconnected"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_primary_fallback():
     acc = _make_account(phone="+70001112233", is_primary=True)
     svc, _ = _make_service(
@@ -133,7 +133,7 @@ async def test_describe_target_primary_fallback():
     assert status.state == "available"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_describe_target_primary_missing():
     svc, _ = _make_service(accounts=[], clients={})
     status = await svc.describe_target()
@@ -141,7 +141,7 @@ async def test_describe_target_primary_missing():
     assert status.state == "missing"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_use_client_success():
     acc = _make_account(phone="+70001112233")
     svc, _ = _make_service(
@@ -160,7 +160,7 @@ async def test_use_client_success():
     svc._pool.release_client.assert_called_once_with("+70001112233")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_use_client_not_available():
     svc, _ = _make_service(accounts=[], clients={})
     with pytest.raises(RuntimeError):

--- a/tests/test_notifier_delivery_paths.py
+++ b/tests/test_notifier_delivery_paths.py
@@ -32,7 +32,7 @@ def mock_notification_bundle():
 class TestNotifierFastPath:
     """Tests for Notifier fast path with cached me.id and bot."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_with_cached_me_id_and_bot(
         self,
         mock_target_service,
@@ -68,7 +68,7 @@ class TestNotifierFastPath:
         # Should not use client since fast path succeeded
         mock_target_service.use_client.assert_not_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_with_cached_me_id_but_no_bot_falls_back(
         self, mock_target_service, mock_notification_bundle
     ):
@@ -100,7 +100,7 @@ class TestNotifierFastPath:
 class TestNotifierSlowPath:
     """Tests for Notifier slow path that requires client connection."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_without_cached_me_id_fetches_it(
         self, mock_target_service, mock_notification_bundle
     ):
@@ -143,7 +143,7 @@ class TestNotifierSlowPath:
         assert notifier._cached_me_id == 123
         mock_client.get_me.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_fallback_to_client_when_no_bot(
         self, mock_target_service, mock_notification_bundle
     ):
@@ -170,7 +170,7 @@ class TestNotifierSlowPath:
         assert result is True
         mock_client.send_message.assert_awaited_once_with(789, "Test message")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_admin_chat_id_me(self, mock_target_service, mock_notification_bundle):
         """Test sending to 'me' when admin_chat_id is None."""
         mock_notification_bundle.get_bot = AsyncMock(return_value=None)
@@ -199,7 +199,7 @@ class TestNotifierSlowPath:
 class TestNotifierWithoutBundle:
     """Tests for Notifier when notification_bundle is None."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_without_bundle_uses_client_directly(self, mock_target_service):
         """Test that without bundle, notifier uses client.send_message directly."""
         mock_client = MagicMock()
@@ -225,7 +225,7 @@ class TestNotifierWithoutBundle:
 class TestNotifierErrorHandling:
     """Tests for Notifier error handling."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_cancelled_error_propagates(
         self,
         mock_target_service,
@@ -249,7 +249,7 @@ class TestNotifierErrorHandling:
         with pytest.raises(asyncio.CancelledError):
             await notifier.notify("Test message")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_notify_general_exception_returns_false(
         self,
         mock_target_service,
@@ -305,7 +305,7 @@ class TestNotifierInvalidateCache:
 class TestSendViaBotApi:
     """Tests for _send_via_bot_api helper function."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_via_bot_api_success(self):
         """Test successful bot API call."""
         mock_response = AsyncMock()
@@ -326,7 +326,7 @@ class TestSendViaBotApi:
 
         assert result is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_via_bot_api_error_response(self):
         """Test bot API call when response has ok=false."""
         mock_response = AsyncMock()
@@ -349,7 +349,7 @@ class TestSendViaBotApi:
 
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_via_bot_api_network_error(self):
         """Test bot API call when network error occurs during ClientSession creation."""
         # The error happens inside the async with ClientSession() block
@@ -363,7 +363,7 @@ class TestSendViaBotApi:
 
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_via_bot_api_cancelled_error_propagates(self):
         """Test that CancelledError in bot API call is re-raised."""
         mock_session = MagicMock()
@@ -374,7 +374,7 @@ class TestSendViaBotApi:
             with pytest.raises(asyncio.CancelledError):
                 await _send_via_bot_api("123456:ABC-DEF", 789, "Test message")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_via_bot_api_timeout_error(self):
         """Test bot API call when timeout occurs during session creation."""
         mock_session = MagicMock()

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -49,7 +49,7 @@ def test_is_session_approved_missing_session():
 # ── resolve() ───────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_sets_future_result():
     gate = PermissionGate()
     request_id = "test-req-1"
@@ -61,13 +61,13 @@ async def test_resolve_sets_future_result():
     assert future.result() == "once"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_unknown_request_returns_false():
     gate = PermissionGate()
     assert gate.resolve("nonexistent-id", "once") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_already_done_future_still_returns_true():
     gate = PermissionGate()
     request_id = "test-req-2"
@@ -97,7 +97,7 @@ def test_clear_session_nonexistent():
 # ── check() with no context ────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_returns_none_without_context():
     """When no request context is set, check returns None (fall through)."""
     gate = PermissionGate()
@@ -108,7 +108,7 @@ async def test_check_returns_none_without_context():
 # ── check() with session already approved ──────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_returns_none_when_session_approved():
     gate = PermissionGate()
     gate._session_overrides["session-1"] = {"my_tool"}
@@ -131,7 +131,7 @@ async def test_check_returns_none_when_session_approved():
 # ── check() — user grants "once" ───────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_user_grants_once():
     gate = PermissionGate()
     ctx = AgentRequestContext(
@@ -167,7 +167,7 @@ async def test_check_user_grants_once():
 # ── check() — user grants "session" ────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_user_grants_session():
     gate = PermissionGate()
     ctx = AgentRequestContext(
@@ -198,7 +198,7 @@ async def test_check_user_grants_session():
 # ── check() — user denies ──────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_user_denies():
     gate = PermissionGate()
     ctx = AgentRequestContext(
@@ -229,7 +229,7 @@ async def test_check_user_denies():
 # ── check() — timeout ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_timeout():
     gate = PermissionGate()
     ctx = AgentRequestContext(
@@ -251,7 +251,7 @@ async def test_check_timeout():
 # ── check() — cancellation ─────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_cancelled_error_propagates():
     gate = PermissionGate()
     ctx = AgentRequestContext(

--- a/tests/test_photo_loader.py
+++ b/tests/test_photo_loader.py
@@ -123,7 +123,7 @@ async def _build_photo_loader_app(
     return app, db
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_task_send_now_uses_send_file(db, tmp_path, real_pool_harness_factory):
     image = tmp_path / "one.jpg"
     image.write_bytes(b"x")
@@ -163,7 +163,7 @@ async def test_photo_task_send_now_uses_send_file(db, tmp_path, real_pool_harnes
     assert client.send_file.await_args.kwargs["schedule"] is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_task_schedule_send_passes_schedule(db, tmp_path, real_pool_harness_factory):
     image = tmp_path / "one.jpg"
     image.write_bytes(b"x")
@@ -195,7 +195,7 @@ async def test_photo_task_schedule_send_passes_schedule(db, tmp_path, real_pool_
     assert client.send_file.await_args.kwargs["schedule"] == schedule_at
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_task_run_due_processes_pending_items(db, tmp_path, real_pool_harness_factory):
     image = tmp_path / "one.jpg"
     image.write_bytes(b"x")
@@ -233,7 +233,7 @@ async def test_photo_task_run_due_processes_pending_items(db, tmp_path, real_poo
     assert item.status == PhotoBatchStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_upload_sends_only_new_files(db, tmp_path, real_pool_harness_factory):
     folder = tmp_path / "photos"
     folder.mkdir()
@@ -280,7 +280,7 @@ async def test_photo_auto_upload_sends_only_new_files(db, tmp_path, real_pool_ha
     client.send_file.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_registers_photo_jobs():
     collector = MagicMock()
     collector.collect_all_channels = AsyncMock(return_value={"channels": 0})
@@ -309,7 +309,7 @@ async def test_scheduler_registers_photo_jobs():
     await manager.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_renders(tmp_path, telethon_cli_spy, native_auth_spy):
     config = AppConfig()
     config.database.path = str(tmp_path / "test.db")
@@ -404,7 +404,7 @@ async def test_photo_loader_page_renders(tmp_path, telethon_cli_spy, native_auth
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("query", "expected_title", "expected_text", "highlight_kind"),
     [
@@ -531,7 +531,7 @@ async def test_photo_loader_page_feedback_panel_and_highlight_hooks(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_without_phone_selects_first_account(
     tmp_path,
     telethon_cli_spy,
@@ -600,7 +600,7 @@ async def test_photo_loader_page_without_phone_selects_first_account(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_without_selectable_targets_disables_forms(
     tmp_path,
     telethon_cli_spy,
@@ -656,7 +656,7 @@ async def test_photo_loader_page_without_selectable_targets_disables_forms(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_page_without_accounts_renders_empty_state(
     tmp_path,
     telethon_cli_spy,
@@ -703,7 +703,7 @@ async def test_photo_loader_page_without_accounts_renders_empty_state(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_loader_refresh_warms_dialog_cache(
     tmp_path,
     telethon_cli_spy,
@@ -835,7 +835,7 @@ def test_photo_loader_cli_send_command(tmp_path, cli_init_patch, capsys):
     asyncio.run(db.close())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_schedule_logs_exception(tmp_path, caplog, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -872,7 +872,7 @@ async def test_photo_schedule_logs_exception(tmp_path, caplog, telethon_cli_spy,
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_schedule_redirects_when_target_validation_raises(
     tmp_path,
     caplog,
@@ -919,7 +919,7 @@ async def test_photo_schedule_redirects_when_target_validation_raises(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_schedule_requires_target_selection(
     tmp_path,
     telethon_cli_spy,
@@ -958,7 +958,7 @@ async def test_photo_schedule_requires_target_selection(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_schedule_rejects_unknown_target(tmp_path, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -993,7 +993,7 @@ async def test_photo_schedule_rejects_unknown_target(tmp_path, telethon_cli_spy,
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_logs_exception(tmp_path, caplog, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -1029,7 +1029,7 @@ async def test_photo_send_logs_exception(tmp_path, caplog, telethon_cli_spy, nat
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_redirects_when_target_validation_raises(
     tmp_path,
     caplog,
@@ -1075,7 +1075,7 @@ async def test_photo_send_redirects_when_target_validation_raises(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_requires_target_selection(tmp_path, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -1109,7 +1109,7 @@ async def test_photo_send_requires_target_selection(tmp_path, telethon_cli_spy, 
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_batch_logs_exception(tmp_path, caplog, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -1143,7 +1143,7 @@ async def test_photo_batch_logs_exception(tmp_path, caplog, telethon_cli_spy, na
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_batch_redirects_when_target_validation_raises(
     tmp_path,
     caplog,
@@ -1188,7 +1188,7 @@ async def test_photo_batch_redirects_when_target_validation_raises(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_batch_rejects_unknown_target(tmp_path, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(
@@ -1221,7 +1221,7 @@ async def test_photo_batch_rejects_unknown_target(tmp_path, telethon_cli_spy, na
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_send_rejects_bot_target(tmp_path, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(
         tmp_path,
@@ -1263,7 +1263,7 @@ async def test_photo_send_rejects_bot_target(tmp_path, telethon_cli_spy, native_
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_logs_exception(tmp_path, caplog, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_auto_upload_service = SimpleNamespace(
@@ -1299,7 +1299,7 @@ async def test_photo_auto_logs_exception(tmp_path, caplog, telethon_cli_spy, nat
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_redirects_when_target_validation_raises(
     tmp_path,
     caplog,
@@ -1346,7 +1346,7 @@ async def test_photo_auto_redirects_when_target_validation_raises(
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_requires_target_selection(tmp_path, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_auto_upload_service = SimpleNamespace(
@@ -1381,7 +1381,7 @@ async def test_photo_auto_requires_target_selection(tmp_path, telethon_cli_spy, 
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_run_due_logs_exception(tmp_path, caplog, telethon_cli_spy, native_auth_spy):
     app, db = await _build_photo_loader_app(tmp_path, telethon_cli_spy, native_auth_spy)
     app.state.photo_task_service = SimpleNamespace(

--- a/tests/test_photo_publish_runtime.py
+++ b/tests/test_photo_publish_runtime.py
@@ -12,7 +12,7 @@ from src.telegram.flood_wait import HandledFloodWaitError
 from tests.helpers import FakeCliTelethonClient
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_publish_service_sends_album_via_transport_session(
     real_pool_harness_factory,
 ):
@@ -46,7 +46,7 @@ async def test_photo_publish_service_sends_album_via_transport_session(
     client.send_file.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_publish_service_reports_flood_from_transport_session(
     real_pool_harness_factory,
 ):
@@ -81,7 +81,7 @@ async def test_photo_publish_service_reports_flood_from_transport_session(
     assert accounts[0].flood_wait_until is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_publish_service_does_not_wrap_dialog_resolver_with_short_timeout(
     real_pool_harness_factory,
     monkeypatch,

--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -174,7 +174,7 @@ class TestDownstreamNodesNoEdges:
 # ---------------------------------------------------------------------------
 
 class TestExecuteHappyPath:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_execute_sets_context_from_handlers(self):
         graph = PipelineGraph(
             nodes=[_node("n1"), _node("n2")],
@@ -208,7 +208,7 @@ class TestExecuteHappyPath:
 # ---------------------------------------------------------------------------
 
 class TestExecuteConditionSkip:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_condition_false_skips_downstream(self):
         graph = PipelineGraph(
             nodes=[
@@ -257,7 +257,7 @@ class TestExecuteConditionSkip:
 # ---------------------------------------------------------------------------
 
 class TestExecuteNodeFailure:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_exception_propagates(self):
         graph = PipelineGraph(
             nodes=[_node("bad")],
@@ -285,7 +285,7 @@ class TestExecuteNodeFailure:
 # ---------------------------------------------------------------------------
 
 class TestExecuteSeedsContext:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_pipeline_fields_seeded_into_context(self):
         graph = PipelineGraph(
             nodes=[_node("n1")],
@@ -331,7 +331,7 @@ class TestExecutorResultSemantics:
     each pipeline shape: generation-only, action-only, mixed, empty-success.
     """
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generation_only_graph_returns_generated_items(self):
         graph = PipelineGraph(
             nodes=[
@@ -361,7 +361,7 @@ class TestExecutorResultSemantics:
         assert result["result_count"] == 2
         assert result["generated_text"] == "draft text"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mixed_graph_generation_wins_but_action_counts_preserved(self):
         from src.services.pipeline_result import increment_action_count
 
@@ -398,7 +398,7 @@ class TestExecutorResultSemantics:
         # But action counts remain visible for UI/metadata consumers.
         assert result["action_counts"] == {"react": 3}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_action_only_graph_with_empty_text_is_not_zero_result(self):
         """Regression: empty generated_text MUST NOT collapse result_count to 0."""
         from src.services.pipeline_result import increment_action_count
@@ -430,7 +430,7 @@ class TestExecutorResultSemantics:
         assert result["result_count"] == 5
         assert (result.get("generated_text") or "") == ""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_successful_graph_returns_zero_processed(self):
         graph = PipelineGraph(
             nodes=[_node("src", PipelineNodeType.SOURCE)],
@@ -450,7 +450,7 @@ class TestExecutorResultSemantics:
         assert result["result_kind"] == "processed_messages"
         assert result["result_count"] == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_executor_propagates_node_errors_from_context(self):
         """Issue #463: errors recorded via ctx.record_error() must appear in result['node_errors']."""
         graph = PipelineGraph(
@@ -484,7 +484,7 @@ class TestExecutorResultSemantics:
             }
         ]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_executor_node_errors_default_empty(self):
         graph = PipelineGraph(nodes=[_node("src", PipelineNodeType.SOURCE)], edges=[])
         pipeline = _pipeline()
@@ -499,7 +499,7 @@ class TestExecutorResultSemantics:
 
         assert result["node_errors"] == []
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mixed_action_types_all_preserved(self):
         """Multiple action types (react + forward + delete) all surface in action_counts."""
         from src.services.pipeline_result import increment_action_count

--- a/tests/test_pipeline_graph.py
+++ b/tests/test_pipeline_graph.py
@@ -135,7 +135,7 @@ def test_node_context_get_last():
 # ── Handler tests ─────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_source_handler():
     handler = SourceHandler()
     ctx = NodeContext()
@@ -143,7 +143,7 @@ async def test_source_handler():
     assert ctx.get_global("source_channel_ids") == [1, 2, 3]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_handler_keywords():
     from unittest.mock import MagicMock
 
@@ -160,7 +160,7 @@ async def test_filter_handler_keywords():
     assert filtered[0] is m1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_handler_anonymous():
     from unittest.mock import MagicMock
 
@@ -181,7 +181,7 @@ async def test_filter_handler_anonymous():
     assert filtered[0] is m1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_handler_not_empty():
     handler = ConditionHandler()
     ctx = NodeContext()
@@ -190,7 +190,7 @@ async def test_condition_handler_not_empty():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_handler_empty():
     handler = ConditionHandler()
     ctx = NodeContext()
@@ -199,7 +199,7 @@ async def test_condition_handler_empty():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delay_handler_zero():
     handler = DelayHandler()
     ctx = NodeContext()
@@ -207,7 +207,7 @@ async def test_delay_handler_zero():
     await handler.execute({"min_seconds": 0, "max_seconds": 0}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_handler():
     handler = LlmGenerateHandler()
     ctx = NodeContext()
@@ -228,7 +228,7 @@ async def test_llm_generate_handler():
 # ── PipelineExecutor integration ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_executor_linear_pipeline():
     graph = PipelineGraph(
         nodes=[
@@ -258,7 +258,7 @@ async def test_executor_linear_pipeline():
     assert result["generated_text"] == "Hello from LLM"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_executor_condition_stops_on_false():
     graph = PipelineGraph(
         nodes=[
@@ -281,7 +281,7 @@ async def test_executor_condition_stops_on_false():
     assert result["context"].get_global("publish_targets") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_handler_tracks_successful_reactions():
     class FakeSession:
         def __init__(self):
@@ -316,7 +316,7 @@ async def test_react_handler_tracks_successful_reactions():
     assert ctx.get_global("action_counts") == {"react": 1}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_executor_returns_processed_message_result_for_action_only_pipeline(monkeypatch):
     class FakeHandler:
         async def execute(self, node_config, context, services):

--- a/tests/test_pipeline_nodes_handler_edge_cases.py
+++ b/tests/test_pipeline_nodes_handler_edge_cases.py
@@ -50,14 +50,14 @@ def _msg(
 # ── SourceHandler extras ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_source_handler_empty_channel_ids():
     ctx = NodeContext()
     await SourceHandler().execute({"channel_ids": []}, ctx, {})
     assert ctx.get_global("source_channel_ids") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_source_handler_missing_channel_ids_key():
     ctx = NodeContext()
     await SourceHandler().execute({}, ctx, {})
@@ -67,7 +67,7 @@ async def test_source_handler_missing_channel_ids_key():
 # ── FetchMessagesHandler extras ───────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_messages_no_db_service():
     """When db is None in services, sets empty context_messages and records the error."""
     ctx = NodeContext()
@@ -80,7 +80,7 @@ async def test_fetch_messages_no_db_service():
     assert "db" in errors[0]["detail"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_messages_no_channel_ids():
     """When no source_channel_ids set, passes empty list to DB query."""
     ctx = NodeContext()
@@ -90,7 +90,7 @@ async def test_fetch_messages_no_channel_ids():
     mock_db.repos.messages.get_recent_for_channels.assert_awaited_once_with([], 24.0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_messages_limit_zero_returns_empty():
     """limit=0 should produce 0 messages (slice [:0])."""
     ctx = NodeContext()
@@ -106,7 +106,7 @@ async def test_fetch_messages_limit_zero_returns_empty():
 # ── LlmGenerateHandler extras ─────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_empty_prompt_template():
     """Empty prompt_template should still work (renders with empty source_messages)."""
     ctx = NodeContext()
@@ -120,7 +120,7 @@ async def test_llm_generate_empty_prompt_template():
     assert ctx.get_global("generated_text") == "generated"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_messages_with_empty_text_skipped():
     """Messages with empty/None text are not included in source_parts."""
     ctx = NodeContext()
@@ -142,7 +142,7 @@ async def test_llm_generate_messages_with_empty_text_skipped():
     assert "[None]" not in captured["prompt"] or "id:" not in captured["prompt"].split("actual content")[0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_provider_returns_dict_with_generated_text_key():
     """Provider returns dict with 'generated_text' key instead of 'text'."""
     ctx = NodeContext()
@@ -156,7 +156,7 @@ async def test_llm_generate_provider_returns_dict_with_generated_text_key():
     assert ctx.get_global("generated_text") == "from gen key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_default_model_from_services():
     """Model falls back to services['default_model'] when not in config."""
     ctx = NodeContext()
@@ -176,7 +176,7 @@ async def test_llm_generate_default_model_from_services():
 # ── LlmRefineHandler extras ──────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_no_generated_text_uses_context_messages():
     """When generated_text is empty and context_messages exist, uses first 3 messages."""
     ctx = NodeContext()
@@ -199,7 +199,7 @@ async def test_llm_refine_no_generated_text_uses_context_messages():
     assert "msg3" not in captured["prompt"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_no_text_no_messages():
     """When both generated_text and context_messages are empty, prompt has empty {text}."""
     ctx = NodeContext()
@@ -222,7 +222,7 @@ async def test_llm_refine_no_text_no_messages():
 # ── ImageGenerateHandler extras ───────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_no_generated_text():
     """When generated_text is empty, still attempts generation with empty prompt."""
     ctx = NodeContext()
@@ -232,7 +232,7 @@ async def test_image_generate_no_generated_text():
     svc.generate.assert_awaited_once_with("test", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_service_returns_none_url():
     """When image service returns None URL, image_url stays None."""
     ctx = NodeContext()
@@ -243,7 +243,7 @@ async def test_image_generate_service_returns_none_url():
     assert ctx.get_global("image_url") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_default_model_from_services():
     """Model falls back to services['default_image_model'] when not in config."""
     ctx = NodeContext()
@@ -259,14 +259,14 @@ async def test_image_generate_default_model_from_services():
 # ── PublishHandler extras ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_default_mode_is_moderated():
     ctx = NodeContext()
     await PublishHandler().execute({"targets": []}, ctx, {})
     assert ctx.get_global("publish_mode") == "moderated"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_empty_targets():
     ctx = NodeContext()
     await PublishHandler().execute({}, ctx, {})
@@ -277,7 +277,7 @@ async def test_publish_empty_targets():
 # ── NotifyHandler extras ──────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_no_text_uses_trigger_text():
     """When generated_text is empty but trigger_text exists, uses trigger_text."""
     ctx = NodeContext()
@@ -287,7 +287,7 @@ async def test_notify_no_text_uses_trigger_text():
     svc.send_text.assert_awaited_once_with("triggered content")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_no_text_no_trigger():
     """When both generated_text and trigger_text are empty, sends empty string."""
     ctx = NodeContext()
@@ -296,7 +296,7 @@ async def test_notify_no_text_no_trigger():
     svc.send_text.assert_awaited_once_with("")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_template_with_channel_title():
     ctx = NodeContext()
     ctx.set_global("generated_text", "news")
@@ -311,7 +311,7 @@ async def test_notify_template_with_channel_title():
 # ── FilterHandler extras ──────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_empty_keywords_list():
     """Empty keywords list and no match_links → all messages filtered out."""
     ctx = NodeContext()
@@ -323,7 +323,7 @@ async def test_filter_empty_keywords_list():
     assert ctx.get_global("context_messages") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_empty_context_messages():
     """No context messages → result is empty."""
     ctx = NodeContext()
@@ -332,7 +332,7 @@ async def test_filter_empty_context_messages():
     assert ctx.get_global("context_messages") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_keywords_strips_empty_entries():
     """Keywords list with empty strings should be filtered out."""
     ctx = NodeContext()
@@ -344,7 +344,7 @@ async def test_filter_keywords_strips_empty_entries():
     assert len(ctx.get_global("context_messages")) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_keywords_case_insensitive():
     ctx = NodeContext()
     m1 = _msg(text="Crypto is great")
@@ -355,7 +355,7 @@ async def test_filter_keywords_case_insensitive():
     assert len(ctx.get_global("context_messages")) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_service_message_default_types():
     ctx = NodeContext()
     m1 = _msg(text="user_joined the chat")
@@ -365,7 +365,7 @@ async def test_filter_service_message_default_types():
     assert len(ctx.get_global("context_messages")) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_regex_empty_pattern():
     """Empty regex pattern string → no matches, result empty."""
     ctx = NodeContext()
@@ -375,7 +375,7 @@ async def test_filter_regex_empty_pattern():
     assert ctx.get_global("context_messages") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_sets_filtered_messages_also():
     """FilterHandler sets both filtered_messages and context_messages."""
     ctx = NodeContext()
@@ -390,7 +390,7 @@ async def test_filter_sets_filtered_messages_also():
 # ── DelayHandler extras ───────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @patch("asyncio.sleep", new_callable=AsyncMock)
 async def test_delay_negative_min_seconds(mock_sleep):
     """Negative min_seconds → treated as negative float, no sleep."""
@@ -400,7 +400,7 @@ async def test_delay_negative_min_seconds(mock_sleep):
     mock_sleep.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @patch("asyncio.sleep", new_callable=AsyncMock)
 async def test_delay_max_less_than_min(mock_sleep):
     """max_seconds < min_seconds → uses min_seconds as delay."""
@@ -412,7 +412,7 @@ async def test_delay_max_less_than_min(mock_sleep):
 # ── ReactHandler extras ──────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_empty_messages():
     ctx = NodeContext()
     ctx.set_global("context_messages", [])
@@ -421,7 +421,7 @@ async def test_react_empty_messages():
     pool.get_available_client.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_exception_continues():
     """React exception on one message should not crash the loop."""
     ctx = NodeContext()
@@ -443,7 +443,7 @@ async def test_react_exception_continues():
 # ── ForwardHandler extras ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_empty_messages():
     ctx = NodeContext()
     ctx.set_global("context_messages", [])
@@ -458,7 +458,7 @@ async def test_forward_empty_messages():
     pool.release_client.assert_awaited_once_with("+123")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_exception_continues():
     """Forward exception for one target should not prevent others."""
     ctx = NodeContext()
@@ -480,7 +480,7 @@ async def test_forward_exception_continues():
     assert pool.get_client_by_phone.await_count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_empty_targets():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -492,7 +492,7 @@ async def test_forward_empty_targets():
 # ── ConditionHandler extras ───────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_missing_field_in_context():
     """Field not in context → get_global returns '' → not_empty is False."""
     ctx = NodeContext()
@@ -502,7 +502,7 @@ async def test_condition_missing_field_in_context():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_eq_mismatch():
     ctx = NodeContext()
     ctx.set_global("status", "active")
@@ -512,7 +512,7 @@ async def test_condition_eq_mismatch():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_gt_equal_values():
     ctx = NodeContext()
     ctx.set_global("count", "5")
@@ -522,7 +522,7 @@ async def test_condition_gt_equal_values():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_lt_not_supported():
     """Unsupported operator → result stays False."""
     ctx = NodeContext()
@@ -533,7 +533,7 @@ async def test_condition_lt_not_supported():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_contains_case_insensitive():
     ctx = NodeContext()
     ctx.set_global("text", "Hello WORLD")
@@ -546,7 +546,7 @@ async def test_condition_contains_case_insensitive():
 # ── AgentLoopHandler extras ──────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_default_system_prompt():
     """When no system_prompt in config, uses default."""
     ctx = NodeContext()
@@ -562,7 +562,7 @@ async def test_agent_loop_default_system_prompt():
     assert "полезный ассистент" in captured["prompt"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_provider_returns_dict():
     """Provider returns dict with 'text' key."""
     ctx = NodeContext()
@@ -577,7 +577,7 @@ async def test_agent_loop_provider_returns_dict():
     assert ctx.get_global("generated_text") == "dict response"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_provider_returns_dict_generated_text_key():
     """Provider returns dict with 'generated_text' key."""
     ctx = NodeContext()
@@ -592,7 +592,7 @@ async def test_agent_loop_provider_returns_dict_generated_text_key():
     assert ctx.get_global("generated_text") == "from gen_text key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_tool_description_in_prompt():
     """When agent_tools provided, tool descriptions appear in prompt."""
     ctx = NodeContext()
@@ -617,7 +617,7 @@ async def test_agent_loop_tool_description_in_prompt():
     assert "Search for messages" in captured["prompt"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_invalid_json_tool_call():
     """Agent returns malformed JSON in tool call block → loop breaks, text preserved."""
     ctx = NodeContext()
@@ -640,7 +640,7 @@ async def test_agent_loop_invalid_json_tool_call():
     # The text is the raw tool call output which gets discarded
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_messages_with_empty_text_excluded():
     """Messages with empty/None text are excluded from the prompt."""
     ctx = NodeContext()
@@ -666,7 +666,7 @@ async def test_agent_loop_messages_with_empty_text_excluded():
 # ── BaseNodeHandler ──────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_base_handler_execute_is_abstract():
     """BaseNodeHandler cannot be instantiated directly (abstract method)."""
 

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -62,7 +62,7 @@ def _search_engine(messages=None, semantic_available=True):
 # ── SourceHandler ──────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_source_handler_sets_channel_ids():
     ctx = NodeContext()
     await SourceHandler().execute({"channel_ids": [1, 2, 3]}, ctx, {})
@@ -72,7 +72,7 @@ async def test_source_handler_sets_channel_ids():
 # ── RetrieveContextHandler ────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_no_search_engine():
     ctx = NodeContext()
     await RetrieveContextHandler().execute({}, ctx, {})
@@ -81,7 +81,7 @@ async def test_retrieve_context_no_search_engine():
     assert any(e["code"] == "missing_dependency" for e in errors)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_hybrid_with_semantic():
     ctx = NodeContext()
     engine = _search_engine([_msg("hybrid")])
@@ -91,7 +91,7 @@ async def test_retrieve_context_hybrid_with_semantic():
     assert ctx.get_global("context_messages")[0].text == "hybrid"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_semantic_method():
     ctx = NodeContext()
     engine = _search_engine([_msg("semantic")])
@@ -100,7 +100,7 @@ async def test_retrieve_context_semantic_method():
     assert ctx.get_global("context_messages")[0].text == "semantic"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_fallback_to_local():
     ctx = NodeContext()
     engine = _search_engine([_msg("local")], semantic_available=False)
@@ -109,7 +109,7 @@ async def test_retrieve_context_fallback_to_local():
     assert ctx.get_global("context_messages")[0].text == "local"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_search_exception():
     ctx = NodeContext()
     engine = AsyncMock()
@@ -119,7 +119,7 @@ async def test_retrieve_context_search_exception():
     assert ctx.get_global("context_messages") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_single_source_scopes_channel():
     ctx = NodeContext()
     ctx.set_global("source_channel_ids", [42])
@@ -129,7 +129,7 @@ async def test_retrieve_context_single_source_scopes_channel():
     assert kwargs["channel_id"] == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_retrieve_context_uses_preseeded_channel_scope_when_multiple_sources():
     ctx = NodeContext()
     ctx.set_global("source_channel_ids", [1, 2])
@@ -143,14 +143,14 @@ async def test_retrieve_context_uses_preseeded_channel_scope_when_multiple_sourc
 # ── LlmGenerateHandler ────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_no_provider_raises():
     ctx = NodeContext()
     with pytest.raises(RuntimeError, match="no provider_callable"):
         await LlmGenerateHandler().execute({}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_provider_returns_str():
     ctx = NodeContext()
     ctx.set_global("context_messages", [])
@@ -165,7 +165,7 @@ async def test_llm_generate_provider_returns_str():
     assert ctx.get_global("citations") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_provider_returns_dict():
     ctx = NodeContext()
     m = _msg(text="source text", channel_title="Chan", date=datetime(2024, 3, 15, tzinfo=timezone.utc))
@@ -181,7 +181,7 @@ async def test_llm_generate_provider_returns_dict():
     assert ctx.get_global("citations") == ["a"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_generate_source_parts_format():
     ctx = NodeContext()
     m = _msg(text="body", channel_title="Title", date=datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc))
@@ -203,14 +203,14 @@ async def test_llm_generate_source_parts_format():
 # ── LlmRefineHandler ──────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_no_provider_raises():
     ctx = NodeContext()
     with pytest.raises(RuntimeError, match="no provider_callable"):
         await LlmRefineHandler().execute({}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_with_generated_text():
     ctx = NodeContext()
     ctx.set_global("generated_text", "original")
@@ -221,7 +221,7 @@ async def test_llm_refine_with_generated_text():
     provider.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_fallback_to_context_messages():
     ctx = NodeContext()
     msgs = [_msg(text="first"), _msg(text="second"), _msg(text="third"), _msg(text="fourth")]
@@ -241,7 +241,7 @@ async def test_llm_refine_fallback_to_context_messages():
     assert ctx.get_global("generated_text") == "refined from messages"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_llm_refine_provider_returns_empty_no_update():
     ctx = NodeContext()
     ctx.set_global("generated_text", "keep this")
@@ -256,7 +256,7 @@ async def test_llm_refine_provider_returns_empty_no_update():
 # ── ImageGenerateHandler ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_no_service():
     ctx = NodeContext()
     ctx.set_global("generated_text", "a cat")
@@ -266,7 +266,7 @@ async def test_image_generate_no_service():
     assert any(e["code"] == "missing_dependency" for e in errors)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_no_model():
     ctx = NodeContext()
     svc = AsyncMock()
@@ -274,7 +274,7 @@ async def test_image_generate_no_model():
     svc.generate.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_success():
     ctx = NodeContext()
     ctx.set_global("generated_text", "a sunset")
@@ -284,7 +284,7 @@ async def test_image_generate_success():
     assert ctx.get_global("image_url") == "https://img.example/1.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_image_generate_exception_no_crash():
     ctx = NodeContext()
     ctx.set_global("generated_text", "x")
@@ -297,7 +297,7 @@ async def test_image_generate_exception_no_crash():
 # ── PublishHandler ────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_without_reply():
     ctx = NodeContext()
     await PublishHandler().execute(
@@ -308,7 +308,7 @@ async def test_publish_without_reply():
     assert ctx.get_global("publish_reply") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_with_reply_and_messages():
     ctx = NodeContext()
     m = _msg(message_id=42)
@@ -318,7 +318,7 @@ async def test_publish_with_reply_and_messages():
     assert ctx.get_global("reply_to_message_id") == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_with_reply_empty_messages():
     ctx = NodeContext()
     ctx.set_global("context_messages", [])
@@ -329,7 +329,7 @@ async def test_publish_with_reply_empty_messages():
 # ── NotifyHandler ─────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_no_service():
     ctx = NodeContext()
     ctx.set_global("generated_text", "hello")
@@ -338,7 +338,7 @@ async def test_notify_no_service():
     assert any(e["code"] == "missing_dependency" for e in errors)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_success():
     ctx = NodeContext()
     ctx.set_global("generated_text", "news")
@@ -350,7 +350,7 @@ async def test_notify_success():
     svc.send_text.assert_awaited_once_with("[Chan] news")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_send_raises():
     ctx = NodeContext()
     ctx.set_global("generated_text", "x")
@@ -363,7 +363,7 @@ async def test_notify_send_raises():
 # ── FilterHandler ─────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_keywords_match():
     ctx = NodeContext()
     m1 = _msg(text="buy cheap crypto")
@@ -373,7 +373,7 @@ async def test_filter_keywords_match():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_match_links():
     ctx = NodeContext()
     m1 = _msg(text="visit https://example.com now")
@@ -383,7 +383,7 @@ async def test_filter_match_links():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_service_message():
     ctx = NodeContext()
     m1 = _msg(text="user joined the group")
@@ -395,7 +395,7 @@ async def test_filter_service_message():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_anonymous_sender():
     ctx = NodeContext()
     m1 = _msg(sender_id=None, sender_name=None)
@@ -405,7 +405,7 @@ async def test_filter_anonymous_sender():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_regex():
     ctx = NodeContext()
     m1 = _msg(text="price: $100")
@@ -415,7 +415,7 @@ async def test_filter_regex():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_invalid_regex():
     ctx = NodeContext()
     m1 = _msg(text="anything")
@@ -424,7 +424,7 @@ async def test_filter_invalid_regex():
     assert ctx.get_global("context_messages") == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_message_filter_service_join():
     ctx = NodeContext()
     m1 = _msg(text="joined")
@@ -444,7 +444,7 @@ async def test_filter_message_filter_service_join():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_message_filter_sender_kind():
     ctx = NodeContext()
     m1 = _msg(text="anon")
@@ -460,7 +460,7 @@ async def test_filter_message_filter_sender_kind():
     assert ctx.get_global("context_messages") == [m1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_unknown_type_returns_all():
     ctx = NodeContext()
     m1 = _msg(text="a")
@@ -473,7 +473,7 @@ async def test_filter_unknown_type_returns_all():
 # ── DelayHandler ──────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @patch("asyncio.sleep", new_callable=AsyncMock)
 async def test_delay_fixed(mock_sleep):
     ctx = NodeContext()
@@ -481,7 +481,7 @@ async def test_delay_fixed(mock_sleep):
     mock_sleep.assert_awaited_once_with(5.0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @patch("asyncio.sleep", new_callable=AsyncMock)
 async def test_delay_zero(mock_sleep):
     ctx = NodeContext()
@@ -489,7 +489,7 @@ async def test_delay_zero(mock_sleep):
     mock_sleep.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @patch("asyncio.sleep", new_callable=AsyncMock)
 async def test_delay_range(mock_sleep):
     ctx = NodeContext()
@@ -501,7 +501,7 @@ async def test_delay_range(mock_sleep):
 # ── ReactHandler ──────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -509,7 +509,7 @@ async def test_react_no_client_pool():
         await ReactHandler().execute({"emoji": "👍"}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_success():
     ctx = NodeContext()
     m = _msg(channel_id=-100, message_id=7)
@@ -523,7 +523,7 @@ async def test_react_success():
     pool.release_client.assert_awaited_once_with("phone1")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_client_none_breaks_loop():
     ctx = NodeContext()
     m1 = _msg()
@@ -535,7 +535,7 @@ async def test_react_client_none_breaks_loop():
     pool.get_available_client.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_random_emojis():
     ctx = NodeContext()
     m = _msg(channel_id=-100, message_id=1)
@@ -552,7 +552,7 @@ async def test_react_random_emojis():
 # ── Issue #463: ReactHandler records structured node errors ───────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_records_error_when_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -566,7 +566,7 @@ async def test_react_records_error_when_no_client_pool():
     assert errors[0]["node_id"] == "react_1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_records_no_available_client_when_pool_returns_none():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -581,7 +581,7 @@ async def test_react_records_no_available_client_when_pool_returns_none():
     assert errors[0]["node_id"] == "react_1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_records_flood_wait_error():
     from telethon.errors import FloodWaitError
 
@@ -604,7 +604,7 @@ async def test_react_records_flood_wait_error():
     assert errors[0]["node_id"] == "react_1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_records_chat_write_forbidden_error():
     from telethon.errors import ChatWriteForbiddenError
 
@@ -625,7 +625,7 @@ async def test_react_records_chat_write_forbidden_error():
     assert errors[0]["code"] == "chat_write_forbidden"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_records_unexpected_error_for_generic_exception():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=42)])
@@ -646,7 +646,7 @@ async def test_react_records_unexpected_error_for_generic_exception():
 # ── ForwardHandler ────────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -654,7 +654,7 @@ async def test_forward_no_client_pool():
         await ForwardHandler().execute({"targets": []}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_success():
     ctx = NodeContext()
     m = _msg(channel_id=-200, message_id=10)
@@ -668,7 +668,7 @@ async def test_forward_success():
     session.forward_messages.assert_awaited_once_with(-300, 10, -200)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_missing_phone_or_dialog_skips():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -682,7 +682,7 @@ async def test_forward_missing_phone_or_dialog_skips():
     pool.get_client_by_phone.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_get_client_returns_none_skips():
     ctx = NodeContext()
     m = _msg()
@@ -697,7 +697,7 @@ async def test_forward_get_client_returns_none_skips():
 # ── Issue #463: ForwardHandler records structured node errors ────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_records_error_when_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -712,7 +712,7 @@ async def test_forward_records_error_when_no_client_pool():
     assert errors[0]["node_id"] == "fwd_1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_records_no_available_client_when_pool_returns_none():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -727,7 +727,7 @@ async def test_forward_records_no_available_client_when_pool_returns_none():
     assert errors and errors[0]["code"] == "no_available_client"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_records_flood_wait_error():
     from telethon.errors import FloodWaitError
 
@@ -753,7 +753,7 @@ async def test_forward_records_flood_wait_error():
 # ── DeleteMessageHandler ─────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -761,7 +761,7 @@ async def test_delete_no_client_pool():
         await DeleteMessageHandler().execute({}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_success():
     ctx = NodeContext()
     m = _msg(channel_id=-500, message_id=22)
@@ -774,7 +774,7 @@ async def test_delete_success():
     session.delete_messages.assert_awaited_once_with(-500, [22])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_client_none_breaks():
     ctx = NodeContext()
     m1 = _msg()
@@ -789,7 +789,7 @@ async def test_delete_client_none_breaks():
 # ── Issue #463: DeleteMessageHandler records structured node errors ──────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_records_error_when_no_client_pool():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -802,7 +802,7 @@ async def test_delete_records_error_when_no_client_pool():
     assert errors[0]["node_id"] == "del_1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_records_no_available_client_when_pool_returns_none():
     ctx = NodeContext()
     ctx.set_global("context_messages", [_msg()])
@@ -818,7 +818,7 @@ async def test_delete_records_no_available_client_when_pool_returns_none():
 # ── ConditionHandler ──────────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_not_empty_with_value():
     ctx = NodeContext()
     ctx.set_global("generated_text", "exists")
@@ -826,7 +826,7 @@ async def test_condition_not_empty_with_value():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_not_empty_with_empty():
     ctx = NodeContext()
     ctx.set_global("generated_text", "")
@@ -834,7 +834,7 @@ async def test_condition_not_empty_with_empty():
     assert ctx.get_global("condition_result") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_empty():
     ctx = NodeContext()
     ctx.set_global("val", "")
@@ -842,7 +842,7 @@ async def test_condition_empty():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_contains():
     ctx = NodeContext()
     ctx.set_global("text", "Hello World")
@@ -850,7 +850,7 @@ async def test_condition_contains():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_eq():
     ctx = NodeContext()
     ctx.set_global("status", "ok")
@@ -858,7 +858,7 @@ async def test_condition_eq():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_gt():
     ctx = NodeContext()
     ctx.set_global("count", "10")
@@ -866,7 +866,7 @@ async def test_condition_gt():
     assert ctx.get_global("condition_result") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_condition_gt_type_error():
     ctx = NodeContext()
     ctx.set_global("count", "not_a_number")
@@ -877,7 +877,7 @@ async def test_condition_gt_type_error():
 # ── SearchQueryTriggerHandler ─────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_trigger_no_engine():
     ctx = NodeContext()
     await SearchQueryTriggerHandler().execute({"query": "test"}, ctx, {})
@@ -885,7 +885,7 @@ async def test_search_trigger_no_engine():
     assert any(e["code"] == "missing_dependency" for e in errors)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_trigger_empty_query():
     ctx = NodeContext()
     engine = _search_engine()
@@ -893,7 +893,7 @@ async def test_search_trigger_empty_query():
     engine.search_local.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_trigger_messages_found():
     ctx = NodeContext()
     m = _msg(text="matched text", channel_title="Chan")
@@ -904,7 +904,7 @@ async def test_search_trigger_messages_found():
     assert ctx.get_global("trigger_matched") is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_trigger_empty_result():
     ctx = NodeContext()
     engine = _search_engine([])
@@ -912,7 +912,7 @@ async def test_search_trigger_empty_result():
     assert ctx.get_global("trigger_matched") is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_trigger_exception():
     ctx = NodeContext()
     engine = AsyncMock()
@@ -924,7 +924,7 @@ async def test_search_trigger_exception():
 # --- AgentLoopHandler ---
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_generates_text():
     ctx = NodeContext()
     ctx.set_global("context_messages", [
@@ -945,14 +945,14 @@ async def test_agent_loop_generates_text():
     assert call_kwargs.kwargs["max_tokens"] == 500
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_no_provider_raises():
     ctx = NodeContext()
     with pytest.raises(RuntimeError, match="no provider_callable"):
         await AgentLoopHandler().execute({}, ctx, {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_empty_messages():
     ctx = NodeContext()
     ctx.set_global("context_messages", [])
@@ -964,7 +964,7 @@ async def test_agent_loop_empty_messages():
     assert ctx.get_global("generated_text") == "Nothing to analyze"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_multi_step_with_tools():
     """Agent calls a tool, gets result, then gives final answer."""
     ctx = NodeContext()
@@ -998,7 +998,7 @@ async def test_agent_loop_multi_step_with_tools():
     assert "search_messages" in second_prompt
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_max_steps_exhaustion():
     """Agent keeps calling tools until max_steps is reached."""
     ctx = NodeContext()
@@ -1024,7 +1024,7 @@ async def test_agent_loop_max_steps_exhaustion():
     assert ctx.get_global("generated_text") == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_tool_error():
     """Tool raises an exception — agent receives error message and continues."""
     ctx = NodeContext()
@@ -1051,7 +1051,7 @@ async def test_agent_loop_tool_error():
     assert ctx.get_global("generated_text") == "Final answer despite tool error"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_unknown_tool():
     """Agent references a tool name not in agent_tools."""
     ctx = NodeContext()
@@ -1077,7 +1077,7 @@ async def test_agent_loop_unknown_tool():
     assert ctx.get_global("generated_text") == "Final answer after unknown tool"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_messages_respects_limit():
     """FetchMessagesHandler slices context_messages to node_config['limit']."""
     from src.services.pipeline_nodes.handlers import FetchMessagesHandler
@@ -1100,7 +1100,7 @@ async def test_fetch_messages_respects_limit():
     assert len(ctx.get_global("context_messages")) == 10
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_loop_with_tools_in_graph_execution():
     """Integration: AgentLoopHandler receives agent_tools through PipelineExecutor."""
     from src.models import ContentPipeline, PipelineEdge, PipelineGraph, PipelineNode

--- a/tests/test_pipeline_service.py
+++ b/tests/test_pipeline_service.py
@@ -30,7 +30,7 @@ async def svc(db):
     return PipelineService(PipelineBundle.from_database(db))
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_and_list_pipeline(svc):
     pipeline_id = await svc.add(
         name="Digest",
@@ -48,7 +48,7 @@ async def test_add_and_list_pipeline(svc):
     assert items[0]["target_refs"] == ["+100|77"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_invalid_prompt_is_rejected(svc):
     with pytest.raises(PipelineValidationError):
         await svc.add(
@@ -59,7 +59,7 @@ async def test_invalid_prompt_is_rejected(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_missing_dialog_cache_is_rejected(svc):
     with pytest.raises(PipelineValidationError):
         await svc.add(

--- a/tests/test_pipeline_service_edge_cases.py
+++ b/tests/test_pipeline_service_edge_cases.py
@@ -69,32 +69,32 @@ async def pipeline_id(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_returns_all(svc, pipeline_id):
     items = await svc.list()
     assert len(items) == 1
     assert items[0].name == "TestPipeline"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_active_only(svc, pipeline_id):
     items = await svc.list(active_only=True)
     assert len(items) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_existing(svc, pipeline_id):
     p = await svc.get(pipeline_id)
     assert p is not None
     assert p.id == pipeline_id
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_nonexistent(svc):
     assert await svc.get(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_retrieval_scope_single_source(svc):
     pipeline_id = await svc.add(
         name="SingleSource",
@@ -108,7 +108,7 @@ async def test_get_retrieval_scope_single_source(svc):
     assert scope.channel_id == 1001
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_retrieval_scope_multi_source(svc, pipeline_id):
     pipeline = await svc.get(pipeline_id)
     scope = await svc.get_retrieval_scope(pipeline)
@@ -116,7 +116,7 @@ async def test_get_retrieval_scope_multi_source(svc, pipeline_id):
     assert scope.channel_id is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_deactivates(svc, pipeline_id):
     result = await svc.toggle(pipeline_id)
     assert result is True
@@ -124,7 +124,7 @@ async def test_toggle_deactivates(svc, pipeline_id):
     assert p.is_active is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_reactivates(svc, pipeline_id):
     await svc.toggle(pipeline_id)  # deactivate
     result = await svc.toggle(pipeline_id)  # reactivate
@@ -133,13 +133,13 @@ async def test_toggle_reactivates(svc, pipeline_id):
     assert p.is_active is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_nonexistent(svc):
     result = await svc.toggle(99999)
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete(svc, pipeline_id):
     await svc.delete(pipeline_id)
     assert await svc.get(pipeline_id) is None
@@ -150,7 +150,7 @@ async def test_delete(svc, pipeline_id):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_pipeline(svc, pipeline_id):
     ok = await svc.update(
         pipeline_id,
@@ -169,14 +169,14 @@ async def test_update_pipeline(svc, pipeline_id):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sources(svc, pipeline_id):
     sources = await svc.get_sources(pipeline_id)
     assert len(sources) == 2
     assert {s.channel_id for s in sources} == {1001, 1002}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_targets(svc, pipeline_id):
     targets = await svc.get_targets(pipeline_id)
     assert len(targets) == 1
@@ -184,7 +184,7 @@ async def test_get_targets(svc, pipeline_id):
     assert targets[0].dialog_id == 77
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_detail(svc, pipeline_id):
     detail = await svc.get_detail(pipeline_id)
     assert detail is not None
@@ -194,12 +194,12 @@ async def test_get_detail(svc, pipeline_id):
     assert len(detail["source_titles"]) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_detail_nonexistent(svc):
     assert await svc.get_detail(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_with_relations(svc, pipeline_id):
     rows = await svc.get_with_relations()
     assert len(rows) == 1
@@ -207,13 +207,13 @@ async def test_get_with_relations(svc, pipeline_id):
     assert rows[0]["source_ids"] == [1001, 1002]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_with_relations_active_only(svc, pipeline_id):
     rows = await svc.get_with_relations(active_only=True)
     assert len(rows) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_with_relations_source_title_fallback(svc):
     """Source channel not found in channels_by_id falls back to str(channel_id)."""
     # Create a pipeline using channel 1001 which exists
@@ -235,7 +235,7 @@ async def test_get_with_relations_source_title_fallback(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_cached_dialogs_by_phone(svc, db):
     result = await svc.list_cached_dialogs_by_phone()
     assert "+100" in result
@@ -247,7 +247,7 @@ async def test_list_cached_dialogs_by_phone(svc, db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_empty_name(svc):
     with pytest.raises(PipelineValidationError, match="[Нн]азвание"):
         await svc.add(
@@ -258,7 +258,7 @@ async def test_build_pipeline_empty_name(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_empty_template(svc):
     with pytest.raises(PipelineValidationError, match="[Шш]аблон"):
         await svc.add(
@@ -269,7 +269,7 @@ async def test_build_pipeline_empty_template(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_invalid_mode(svc):
     with pytest.raises(PipelineValidationError, match="[Рр]ежим"):
         await svc.add(
@@ -281,7 +281,7 @@ async def test_build_pipeline_invalid_mode(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_invalid_interval(svc):
     with pytest.raises(PipelineValidationError, match="[Ии]нтервал"):
         await svc.add(
@@ -298,7 +298,7 @@ async def test_build_pipeline_invalid_interval(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_sources_empty(svc):
     with pytest.raises(PipelineValidationError, match="[Вв]ыберите.*источник"):
         await svc.add(
@@ -309,7 +309,7 @@ async def test_normalize_sources_empty(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_sources_unknown_channel(svc):
     with pytest.raises(PipelineValidationError, match="[Нн]еизвестные"):
         await svc.add(
@@ -325,7 +325,7 @@ async def test_normalize_sources_unknown_channel(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_targets_empty(svc):
     with pytest.raises(PipelineValidationError, match="[Вв]ыберите.*цель"):
         await svc.add(
@@ -336,7 +336,7 @@ async def test_normalize_targets_empty(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_targets_unknown_phone(svc):
     with pytest.raises(PipelineValidationError, match="[Аа]ккаунт"):
         await svc.add(
@@ -347,7 +347,7 @@ async def test_normalize_targets_unknown_phone(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_targets_bot_rejected(svc, db):
     """Targets pointing at bots should be rejected."""
     await db.repos.dialog_cache.replace_dialogs(
@@ -370,7 +370,7 @@ async def test_normalize_targets_bot_rejected(svc, db):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_targets_dialog_not_cached(svc):
     with pytest.raises(PipelineValidationError, match="кеш"):
         await svc.add(
@@ -381,7 +381,7 @@ async def test_normalize_targets_dialog_not_cached(svc):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_targets_duplicate_ref_deduped(svc, db):
     """Duplicate target refs are deduplicated."""
     pid = await svc.add(
@@ -402,7 +402,7 @@ async def test_normalize_targets_duplicate_ref_deduped(svc, db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_json(svc, pipeline_id):
     data = await svc.export_json(pipeline_id)
     assert data is not None
@@ -412,12 +412,12 @@ async def test_export_json(svc, pipeline_id):
     assert data["publish_mode"] == "moderated"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_json_nonexistent(svc):
     assert await svc.export_json(99999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_export_json_with_pipeline_graph(svc, db):
     """Export pipeline that has a pipeline_json graph."""
     graph = PipelineGraph(
@@ -438,7 +438,7 @@ async def test_export_json_with_pipeline_graph(svc, db):
     assert len(data["pipeline_json"]["nodes"]) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_from_dict(svc, pipeline_id):
     """Import a pipeline from a dict."""
     export = await svc.export_json(pipeline_id)
@@ -452,7 +452,7 @@ async def test_import_json_from_dict(svc, pipeline_id):
     assert imported.is_active is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_from_string(svc, pipeline_id):
     """Import a pipeline from a JSON string."""
     export = await svc.export_json(pipeline_id)
@@ -463,7 +463,7 @@ async def test_import_json_from_string(svc, pipeline_id):
     assert new_id > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_with_pipeline_graph(svc, pipeline_id, db):
     """Import with pipeline_json field."""
     graph = PipelineGraph(
@@ -483,7 +483,7 @@ async def test_import_json_with_pipeline_graph(svc, pipeline_id, db):
     assert len(imported.pipeline_json.nodes) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_with_target_refs(svc, pipeline_id):
     """Import with target_refs in the data."""
     export = await svc.export_json(pipeline_id)
@@ -495,7 +495,7 @@ async def test_import_json_with_target_refs(svc, pipeline_id):
     assert len(targets) >= 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_with_invalid_pipeline_graph(svc, pipeline_id):
     """Import with unparsable pipeline_json field -- should be ignored gracefully."""
     export = await svc.export_json(pipeline_id)
@@ -510,7 +510,7 @@ async def test_import_json_with_invalid_pipeline_graph(svc, pipeline_id):
     assert imported.pipeline_json is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_empty_sources_and_targets(svc):
     """Import with no sources/targets creates inactive pipeline."""
     data = {
@@ -524,7 +524,7 @@ async def test_import_json_empty_sources_and_targets(svc):
     assert new_id > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_injects_source_ids_into_dag_source_node(svc):
     """Regression: source_ids from --source must backfill DAG source node config.
 
@@ -563,7 +563,7 @@ async def test_import_json_injects_source_ids_into_dag_source_node(svc):
     assert src_node.config["channel_ids"] == [1001]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_import_json_preserves_explicit_channel_ids(svc):
     """If the imported SOURCE node already has channel_ids, don't overwrite."""
     data = {
@@ -603,7 +603,7 @@ async def test_import_json_preserves_explicit_channel_ids(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_templates_no_repo(db):
     """When pipeline_templates is None, returns empty list."""
     from src.database.bundles import PipelineBundle
@@ -620,7 +620,7 @@ async def test_list_templates_no_repo(db):
     assert templates == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_templates_with_repo(svc, db):
     """When pipeline_templates repo exists, delegates to list_all."""
     mock_tpl_repo = MagicMock()
@@ -641,7 +641,7 @@ async def test_list_templates_with_repo(svc, db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_no_repo(db):
     """When pipeline_templates is None, raises error."""
     from src.database.bundles import PipelineBundle
@@ -663,7 +663,7 @@ async def test_create_from_template_no_repo(db):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_not_found(svc, db):
     """When template_id not found, raises error."""
     mock_tpl_repo = MagicMock()
@@ -684,7 +684,7 @@ async def test_create_from_template_not_found(svc, db):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_success(svc, db):
     """Create pipeline from a template with llm_generate node."""
     graph = PipelineGraph(
@@ -726,7 +726,7 @@ async def test_create_from_template_success(svc, db):
     assert p.pipeline_json is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_no_prompt_in_graph(svc, db):
     """Template with no prompt_template in graph uses name as prompt."""
     graph = PipelineGraph(
@@ -757,7 +757,7 @@ async def test_create_from_template_no_prompt_in_graph(svc, db):
     assert p.prompt_template == "FallbackName"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_from_template_no_sources_targets(svc, db):
     """Create from template without sources/targets creates inactive pipeline."""
     graph = PipelineGraph(
@@ -800,14 +800,14 @@ async def test_create_from_template_no_sources_targets(svc, db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_pipeline_not_found(svc, db):
     result = await svc.edit_via_llm(99999, "change something", db)
     assert result["ok"] is False
     assert "не найден" in result["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_success(svc, db, pipeline_id):
     """edit_via_llm with a working provider returns updated graph."""
     new_graph_json = json.dumps({
@@ -828,7 +828,7 @@ async def test_edit_via_llm_success(svc, db, pipeline_id):
     assert len(result["pipeline_json"]["nodes"]) == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_with_markdown_fences(svc, db, pipeline_id):
     """edit_via_llm strips markdown code fences from LLM response."""
     new_graph = {"nodes": [], "edges": []}
@@ -846,7 +846,7 @@ async def test_edit_via_llm_with_markdown_fences(svc, db, pipeline_id):
     assert result["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_provider_failure(svc, db, pipeline_id):
     """edit_via_llm returns error when provider raises."""
     mock_provider = AsyncMock(side_effect=RuntimeError("API down"))
@@ -861,7 +861,7 @@ async def test_edit_via_llm_provider_failure(svc, db, pipeline_id):
     assert "API down" in result["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_dict_result(svc, db, pipeline_id):
     """edit_via_llm handles provider returning dict with 'text' key."""
     new_graph = {"nodes": [], "edges": []}
@@ -878,7 +878,7 @@ async def test_edit_via_llm_dict_result(svc, db, pipeline_id):
     assert result["ok"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_via_llm_pipeline_without_graph(svc, db, pipeline_id):
     """edit_via_llm works when pipeline has no existing pipeline_json."""
     p = await svc.get(pipeline_id)
@@ -901,7 +901,7 @@ async def test_edit_via_llm_pipeline_without_graph(svc, db, pipeline_id):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_strips_llm_model(svc):
     """Empty/whitespace llm_model is normalized to None."""
     pid = await svc.add(
@@ -915,7 +915,7 @@ async def test_build_pipeline_strips_llm_model(svc):
     assert p.llm_model is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_keeps_llm_model(svc):
     pid = await svc.add(
         name="KeepModel",
@@ -928,7 +928,7 @@ async def test_build_pipeline_keeps_llm_model(svc):
     assert p.llm_model == "gpt-4"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_pipeline_invalid_template_variable(svc):
     with pytest.raises(PipelineValidationError):
         await svc.add(
@@ -944,7 +944,7 @@ async def test_build_pipeline_invalid_template_variable(svc):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_init_with_database(db):
     """PipelineService accepts Database and wraps it in PipelineBundle."""
     svc = PipelineService(db)
@@ -983,26 +983,26 @@ async def graph_pipeline_id(svc, db):
     return pid
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_graph_returns_graph(svc, graph_pipeline_id):
     graph = await svc.get_graph(graph_pipeline_id)
     assert graph is not None
     assert len(graph.nodes) == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_graph_returns_none_for_legacy(svc, pipeline_id):
     graph = await svc.get_graph(pipeline_id)
     assert graph is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_graph_pipeline_not_found(svc):
     graph = await svc.get_graph(99999)
     assert graph is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_node(svc, graph_pipeline_id):
     new_node = PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="publish", config={"targets": []})
     ok = await svc.add_node(graph_pipeline_id, new_node)
@@ -1012,7 +1012,7 @@ async def test_add_node(svc, graph_pipeline_id):
     assert graph.nodes[3].id == "pub"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_node_auto_position(svc, graph_pipeline_id):
     new_node = PipelineNode(id="delay1", type=PipelineNodeType.DELAY, name="delay", config={})
     await svc.add_node(graph_pipeline_id, new_node)
@@ -1021,14 +1021,14 @@ async def test_add_node_auto_position(svc, graph_pipeline_id):
     assert added.position["x"] > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_node_no_graph(svc, pipeline_id):
     new_node = PipelineNode(id="x", type=PipelineNodeType.DELAY, name="d")
     ok = await svc.add_node(pipeline_id, new_node)
     assert ok is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_node_removes_edges(svc, graph_pipeline_id):
     ok = await svc.remove_node(graph_pipeline_id, "fetch")
     assert ok is True
@@ -1040,13 +1040,13 @@ async def test_remove_node_removes_edges(svc, graph_pipeline_id):
         assert e.from_node != "fetch" and e.to_node != "fetch"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_node_not_found(svc, graph_pipeline_id):
     ok = await svc.remove_node(graph_pipeline_id, "nonexistent")
     assert ok is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replace_node_preserves_edges(svc, graph_pipeline_id):
     new_node = PipelineNode(id="gen", type=PipelineNodeType.AGENT_LOOP, name="agent", config={"max_steps": 5})
     ok = await svc.replace_node(graph_pipeline_id, "gen", new_node)
@@ -1060,7 +1060,7 @@ async def test_replace_node_preserves_edges(svc, graph_pipeline_id):
     assert edge_from_fetch[0].to_node == "gen"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replace_node_with_new_id_updates_edges(svc, graph_pipeline_id):
     new_node = PipelineNode(id="agent_v2", type=PipelineNodeType.AGENT_LOOP, name="agent", config={})
     ok = await svc.replace_node(graph_pipeline_id, "gen", new_node)
@@ -1072,7 +1072,7 @@ async def test_replace_node_with_new_id_updates_edges(svc, graph_pipeline_id):
     assert any(e.to_node == "agent_v2" for e in graph.edges)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replace_first_node_with_new_id_updates_edges(svc, graph_pipeline_id):
     """Regression: replacing the first node (index 0) must still rewrite edges."""
     new_node = PipelineNode(id="src_v2", type=PipelineNodeType.SOURCE, name="source", config={})
@@ -1083,7 +1083,7 @@ async def test_replace_first_node_with_new_id_updates_edges(svc, graph_pipeline_
     assert any(e.from_node == "src_v2" for e in graph.edges)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_edge(svc, graph_pipeline_id):
     ok = await svc.add_edge(graph_pipeline_id, "src", "gen")
     assert ok is True
@@ -1091,7 +1091,7 @@ async def test_add_edge(svc, graph_pipeline_id):
     assert any(e.from_node == "src" and e.to_node == "gen" for e in graph.edges)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_edge_idempotent(svc, graph_pipeline_id):
     await svc.add_edge(graph_pipeline_id, "src", "gen")
     graph1 = await svc.get_graph(graph_pipeline_id)
@@ -1100,13 +1100,13 @@ async def test_add_edge_idempotent(svc, graph_pipeline_id):
     assert len(graph1.edges) == len(graph2.edges)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_edge_no_graph(svc, pipeline_id):
     ok = await svc.add_edge(pipeline_id, "a", "b")
     assert ok is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_edge(svc, graph_pipeline_id):
     ok = await svc.remove_edge(graph_pipeline_id, "src", "fetch")
     assert ok is True
@@ -1114,7 +1114,7 @@ async def test_remove_edge(svc, graph_pipeline_id):
     assert not any(e.from_node == "src" and e.to_node == "fetch" for e in graph.edges)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_edge_not_found(svc, graph_pipeline_id):
     ok = await svc.remove_edge(graph_pipeline_id, "src", "gen")
     assert ok is False

--- a/tests/test_pipeline_templates_builtin.py
+++ b/tests/test_pipeline_templates_builtin.py
@@ -199,7 +199,7 @@ async def _create_from_template(db, template_name, source_ids, target_refs=None)
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_forward_template_source_wiring(_seeded_db):
     db = _seeded_db
     pipeline_id = await _create_from_template(
@@ -218,7 +218,7 @@ async def test_forward_template_source_wiring(_seeded_db):
     assert forward_node.config["targets"][0]["dialog_id"] == 77
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_react_template_source_wiring(_seeded_db):
     db = _seeded_db
     pipeline_id = await _create_from_template(db, "Реакции на сообщения", [1001])
@@ -232,7 +232,7 @@ async def test_react_template_source_wiring(_seeded_db):
     assert react_node is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cleanup_template_source_wiring(_seeded_db):
     db = _seeded_db
     pipeline_id = await _create_from_template(db, "Удаление join/leave сообщений", [1001])
@@ -250,7 +250,7 @@ async def test_cleanup_template_source_wiring(_seeded_db):
     assert delete_node is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_template_without_targets_no_injection(_seeded_db):
     """Templates without source_ids should leave source node config empty."""
     db = _seeded_db

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -61,7 +61,7 @@ _LLM_ENV_VARS = [
 ]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipelines_page_renders(pipeline_client, monkeypatch):
     for var in _LLM_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
@@ -73,7 +73,7 @@ async def test_pipelines_page_renders(pipeline_client, monkeypatch):
     assert "LLM-провайдер не настроен" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_pipeline_route(pipeline_client):
     resp = await pipeline_client.post(
         "/pipelines/add",

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -16,7 +16,7 @@ from src.services.production_limits_service import (
 # === RateLimiter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_allows_under_limits():
     """Requests under all limits succeed."""
     limiter = RateLimiter(RateLimitConfig(requests_per_minute=10, tokens_per_minute=1000))
@@ -27,7 +27,7 @@ async def test_rate_limiter_allows_under_limits():
         assert wait_time == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_blocks_over_rpm():
     """Requests over requests_per_minute limit are blocked."""
     limiter = RateLimiter(RateLimitConfig(requests_per_minute=3, tokens_per_minute=1000))
@@ -40,7 +40,7 @@ async def test_rate_limiter_blocks_over_rpm():
     assert wait_time > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_blocks_over_tpm():
     """Requests over tokens_per_minute limit are blocked."""
     limiter = RateLimiter(RateLimitConfig(requests_per_minute=10, tokens_per_minute=500))
@@ -53,7 +53,7 @@ async def test_rate_limiter_blocks_over_tpm():
     assert wait_time > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_blocks_over_tpd():
     """Requests over tokens_per_day limit are blocked."""
     limiter = RateLimiter(
@@ -68,7 +68,7 @@ async def test_rate_limiter_blocks_over_tpd():
     assert wait_time > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_get_usage():
     """get_usage returns correct structure with accumulated counts."""
     limiter = RateLimiter(
@@ -90,7 +90,7 @@ async def test_rate_limiter_get_usage():
     assert usage["day"]["limit_tokens"] == 10000
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_window_reset():
     """Minute and day windows reset after their respective durations."""
     fake_time = 1000.0
@@ -120,7 +120,7 @@ async def test_rate_limiter_window_reset():
 # === CostTracker tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_estimate_text_cost():
     """Token cost estimation: (tokens / 1000) * cost_per_1k_tokens."""
     tracker = CostTracker(CostConfig(cost_per_1k_tokens=2.0))
@@ -129,7 +129,7 @@ async def test_cost_tracker_estimate_text_cost():
     assert await tracker.estimate_cost(tokens=1500, is_image=False) == 3.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_estimate_image_cost():
     """Image cost estimation returns fixed cost_per_image regardless of tokens."""
     tracker = CostTracker(CostConfig(cost_per_image=0.05))
@@ -138,7 +138,7 @@ async def test_cost_tracker_estimate_image_cost():
     assert await tracker.estimate_cost(tokens=1000, is_image=True) == 0.05
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_cap_not_exceeded():
     """check_cost_cap allows when within budget and does not charge."""
     tracker = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=10.0))
@@ -150,7 +150,7 @@ async def test_cost_tracker_cap_not_exceeded():
     assert tracker.get_daily_cost() == 0.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_cap_exceeded():
     """check_cost_cap blocks when the request would exceed the daily cap."""
     tracker = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=1.0))
@@ -163,7 +163,7 @@ async def test_cost_tracker_cap_exceeded():
     assert estimated > 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_record_cost_accumulates():
     """record_cost adds to the running daily total."""
     tracker = CostTracker(CostConfig(cost_per_1k_tokens=2.0, daily_cost_cap=100.0))
@@ -177,7 +177,7 @@ async def test_cost_tracker_record_cost_accumulates():
     assert tracker.get_daily_cost() == 3.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_remaining_budget():
     """remaining_budget returns cap minus accumulated cost, floored at 0."""
     tracker = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=5.0))
@@ -189,7 +189,7 @@ async def test_cost_tracker_remaining_budget():
     assert tracker.get_remaining_budget() == 3.0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_day_reset():
     """Daily cost resets after 86400 seconds."""
     fake_time = 5000.0
@@ -209,7 +209,7 @@ async def test_cost_tracker_day_reset():
 # === ProductionLimitsService tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_production_limits_acquire_allowed():
     """Acquire succeeds when both rate and cost caps are within limits."""
     service = ProductionLimitsService(
@@ -224,7 +224,7 @@ async def test_production_limits_acquire_allowed():
     assert error is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_production_limits_acquire_blocked_by_cost_cap():
     """Acquire fails with cost-cap message when daily budget is exhausted."""
     service = ProductionLimitsService(
@@ -239,7 +239,7 @@ async def test_production_limits_acquire_blocked_by_cost_cap():
     assert "Daily cost cap exceeded" in error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_production_limits_get_stats():
     """get_stats aggregates rate-limiter usage and cost tracker state."""
     service = ProductionLimitsService(
@@ -261,7 +261,7 @@ async def test_production_limits_get_stats():
 # === RateLimiter wait_and_acquire tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_wait_and_acquire_times_out():
     """wait_and_acquire returns False when max_wait is exceeded."""
     limiter = RateLimiter(RateLimitConfig(requests_per_minute=0))
@@ -270,7 +270,7 @@ async def test_rate_limiter_wait_and_acquire_times_out():
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_rate_limiter_wait_and_acquire_succeeds_after_window():
     """wait_and_acquire returns True once a window opens."""
     limiter = RateLimiter(RateLimitConfig(requests_per_minute=1))
@@ -300,7 +300,7 @@ async def test_rate_limiter_wait_and_acquire_succeeds_after_window():
 # === CostTracker record_cost day reset ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cost_tracker_record_cost_day_reset():
     """record_cost resets daily_cost when 86400s have elapsed."""
     fake_time = 5000.0
@@ -319,7 +319,7 @@ async def test_cost_tracker_record_cost_day_reset():
 # === ProductionLimitsService execute_with_retry ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_retry_success():
     """execute_with_retry returns result on first successful call."""
     service = ProductionLimitsService(
@@ -331,7 +331,7 @@ async def test_execute_with_retry_success():
     assert result == "ok"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_retry_retries_on_failure():
     """execute_with_retry retries and eventually succeeds."""
     service = ProductionLimitsService(
@@ -354,7 +354,7 @@ async def test_execute_with_retry_retries_on_failure():
     assert call_count == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_retry_raises_after_max_retries():
     """execute_with_retry raises when all retries are exhausted."""
     service = ProductionLimitsService(
@@ -373,7 +373,7 @@ async def test_execute_with_retry_raises_after_max_retries():
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_execute_with_retry_rate_limit_raises():
     """execute_with_retry raises RuntimeError when rate limit blocks acquire."""
     service = ProductionLimitsService(

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -65,120 +65,120 @@ def fake_client_session_factory(resp):
 # === _parse_json_for_text tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_none_returns_empty():
     assert await _parse_json_for_text(None) == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_string_returns_as_is():
     assert await _parse_json_for_text("hello world") == "hello world"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_openai_choices_with_message():
     data = {"choices": [{"message": {"content": "OpenAI reply"}}]}
     assert await _parse_json_for_text(data) == "OpenAI reply"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_openai_choices_with_text():
     data = {"choices": [{"text": "OpenAI text"}]}
     assert await _parse_json_for_text(data) == "OpenAI text"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_cohere_generations():
     data = {"generations": [{"text": "Cohere response"}]}
     assert await _parse_json_for_text(data) == "Cohere response"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_huggingface_generated_text():
     data = {"generated_text": "HF output"}
     assert await _parse_json_for_text(data) == "HF output"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_outputs_with_content():
     data = {"outputs": [{"content": "Output content"}]}
     assert await _parse_json_for_text(data) == "Output content"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_outputs_with_text():
     data = {"outputs": [{"text": "Output text"}]}
     assert await _parse_json_for_text(data) == "Output text"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_outputs_string():
     data = {"outputs": ["string output"]}
     assert "string output" in await _parse_json_for_text(data)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_string():
     data = {"result": "Result string"}
     assert await _parse_json_for_text(data) == "Result string"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_dict_with_text():
     data = {"result": {"text": "Result text"}}
     assert await _parse_json_for_text(data) == "Result text"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_dict_with_content():
     data = {"result": {"content": "Result content"}}
     assert await _parse_json_for_text(data) == "Result content"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_dict_with_generated_text():
     data = {"result": {"generated_text": "Generated"}}
     assert await _parse_json_for_text(data) == "Generated"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_dict_fallback():
     data = {"result": {"unknown_key": "value"}}
     assert "unknown_key" in await _parse_json_for_text(data)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_ollama_results_nested():
     data = {"results": [{"content": {"text": "Ollama nested"}}]}
     assert await _parse_json_for_text(data) == "Ollama nested"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_ollama_results_flat():
     data = {"results": [{"text": "Ollama flat"}]}
     assert await _parse_json_for_text(data) == "Ollama flat"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_fallback_first_string():
     data = {"key1": 123, "key2": "first string", "key3": "second"}
     assert await _parse_json_for_text(data) == "first string"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_fallback_str():
     data = {"key1": 123, "key2": [1, 2]}
     result = await _parse_json_for_text(data)
     assert "key1" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_list():
     data = [{"text": "list item"}]
     assert await _parse_json_for_text(data) == "list item"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_unknown_type():
     result = await _parse_json_for_text(42)
     assert result == "42"
@@ -187,7 +187,7 @@ async def test_parse_json_unknown_type():
 # === Cohere adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cohere_adapter_parses_generations(monkeypatch):
     resp = FakeResp(
         status=200, json_data={"generations": [{"text": "Hello from Cohere"}]}, text_data="ok"
@@ -198,7 +198,7 @@ async def test_cohere_adapter_parses_generations(monkeypatch):
     assert "Hello from Cohere" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cohere_adapter_with_model(monkeypatch):
     resp = FakeResp(status=200, json_data={"generations": [{"text": "Model response"}]})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -207,7 +207,7 @@ async def test_cohere_adapter_with_model(monkeypatch):
     assert "Model response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cohere_adapter_error_status(monkeypatch):
     resp = FakeResp(status=500, text_data="Internal error")
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -217,7 +217,7 @@ async def test_cohere_adapter_error_status(monkeypatch):
     assert "500" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cohere_adapter_custom_base_url(monkeypatch):
     resp = FakeResp(status=200, json_data={"generations": [{"text": "OK"}]})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -226,7 +226,7 @@ async def test_cohere_adapter_custom_base_url(monkeypatch):
     assert "OK" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cohere_shim():
     adapter = make_cohere("test_key")
     assert callable(adapter)
@@ -235,7 +235,7 @@ async def test_cohere_shim():
 # === Ollama adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_adapter_parses_results(monkeypatch):
     resp = FakeResp(status=200, json_data={"results": [{"content": {"text": "Ollama says hi"}}]})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -244,7 +244,7 @@ async def test_ollama_adapter_parses_results(monkeypatch):
     assert "Ollama says hi" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_adapter_with_api_key(monkeypatch):
     resp = FakeResp(status=200, json_data={"results": [{"text": "Auth response"}]})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -253,7 +253,7 @@ async def test_ollama_adapter_with_api_key(monkeypatch):
     assert "Auth response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_adapter_error_status(monkeypatch):
     resp = FakeResp(status=400, text_data="Bad request")
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -263,7 +263,7 @@ async def test_ollama_adapter_error_status(monkeypatch):
     assert "400" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ollama_shim():
     adapter = make_ollama("http://localhost:11434")
     assert callable(adapter)
@@ -272,7 +272,7 @@ async def test_ollama_shim():
 # === HuggingFace adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hf_adapter_parses_generated_text(monkeypatch):
     resp = FakeResp(status=200, json_data={"generated_text": "HF reply"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -281,7 +281,7 @@ async def test_hf_adapter_parses_generated_text(monkeypatch):
     assert "HF reply" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hf_adapter_without_model(monkeypatch):
     resp = FakeResp(status=200, json_data={"generated_text": "No model response"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -290,7 +290,7 @@ async def test_hf_adapter_without_model(monkeypatch):
     assert "No model response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_hf_adapter_error_status(monkeypatch):
     resp = FakeResp(status=403, text_data="Forbidden")
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -300,7 +300,7 @@ async def test_hf_adapter_error_status(monkeypatch):
     assert "403" in str(exc_info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_huggingface_shim():
     adapter = make_huggingface("test_token")
     assert callable(adapter)
@@ -309,7 +309,7 @@ async def test_huggingface_shim():
 # === Generic HTTP adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generic_http_adapter_success(monkeypatch):
     resp = FakeResp(status=200, json_data={"text": "Generic response"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -318,7 +318,7 @@ async def test_generic_http_adapter_success(monkeypatch):
     assert "Generic response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generic_http_adapter_with_model(monkeypatch):
     resp = FakeResp(status=200, json_data={"result": "Model output"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -327,7 +327,7 @@ async def test_generic_http_adapter_with_model(monkeypatch):
     assert "Model output" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generic_http_adapter_with_api_key(monkeypatch):
     resp = FakeResp(status=200, json_data={"text": "Authenticated"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -336,7 +336,7 @@ async def test_generic_http_adapter_with_api_key(monkeypatch):
     assert "Authenticated" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generic_http_adapter_custom_header(monkeypatch):
     resp = FakeResp(status=200, json_data={"text": "Custom header"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -349,7 +349,7 @@ async def test_generic_http_adapter_custom_header(monkeypatch):
     assert "Custom header" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_generic_http_adapter_error(monkeypatch):
     resp = FakeResp(status=502, text_data="Bad gateway")
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -362,7 +362,7 @@ async def test_generic_http_adapter_error(monkeypatch):
 # === Context7 adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_context7_adapter_success(monkeypatch):
     resp = FakeResp(status=200, json_data={"text": "Context7 response"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -371,7 +371,7 @@ async def test_context7_adapter_success(monkeypatch):
     assert "Context7 response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_context7_adapter_custom_base_url(monkeypatch):
     resp = FakeResp(status=200, json_data={"text": "Custom base"})
     monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
@@ -383,7 +383,7 @@ async def test_context7_adapter_custom_base_url(monkeypatch):
 # === Anthropic adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_anthropic_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_anthropic_adapter
 
@@ -397,7 +397,7 @@ async def test_anthropic_adapter_success(monkeypatch):
     assert "Claude response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_anthropic_adapter_error_status(monkeypatch):
     from src.services.provider_adapters import make_anthropic_adapter
 
@@ -408,7 +408,7 @@ async def test_anthropic_adapter_error_status(monkeypatch):
         await adapter("hello")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_anthropic_adapter_custom_base_url(monkeypatch):
     from src.services.provider_adapters import make_anthropic_adapter
 
@@ -422,7 +422,7 @@ async def test_anthropic_adapter_custom_base_url(monkeypatch):
     assert "ZAI response" in out
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_anthropic_adapter_malformed_response(monkeypatch):
     """When response JSON lacks expected structure, falls back to str()."""
     from src.services.provider_adapters import make_anthropic_adapter
@@ -438,7 +438,7 @@ async def test_anthropic_adapter_malformed_response(monkeypatch):
 # === _parse_json_for_text edge cases (edge-case lines) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_openai_choices_empty_list():
     """Empty choices list falls through to str(data) fallback."""
     data = {"choices": []}
@@ -446,7 +446,7 @@ async def test_parse_json_openai_choices_empty_list():
     assert "choices" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_cohere_generations_empty():
     """Empty generations list falls through."""
     data = {"generations": []}
@@ -454,7 +454,7 @@ async def test_parse_json_cohere_generations_empty():
     assert "generations" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_outputs_non_dict_item():
     """outputs with non-dict items falls to str(out)."""
     data = {"outputs": [42]}
@@ -462,7 +462,7 @@ async def test_parse_json_outputs_non_dict_item():
     assert "42" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_dict_nested():
     """result dict with unknown keys falls to str(r)."""
     data = {"result": {"random_key": 123}}
@@ -470,7 +470,7 @@ async def test_parse_json_result_dict_nested():
     assert "random_key" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_ollama_results_non_dict():
     """results with non-dict items raises IndexError, falls to str(data)."""
     data = {"results": []}
@@ -478,14 +478,14 @@ async def test_parse_json_ollama_results_non_dict():
     assert "results" in result
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_list_empty():
     """Empty list falls to str(data)."""
     result = await _parse_json_for_text([])
     assert result == "[]"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_parse_json_result_non_dict_non_string():
     """result that is neither str nor dict falls to str(r)."""
     data = {"result": [1, 2, 3]}
@@ -498,7 +498,7 @@ async def test_parse_json_result_non_dict_non_string():
 # === Image adapter tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_together_image_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_together_image_adapter
 
@@ -512,7 +512,7 @@ async def test_together_image_adapter_success(monkeypatch):
     assert result == "https://img.example.com/1.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_together_image_adapter_error_status(monkeypatch):
     from src.services.provider_adapters import make_together_image_adapter
 
@@ -523,7 +523,7 @@ async def test_together_image_adapter_error_status(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_together_image_adapter_empty_data(monkeypatch):
     from src.services.provider_adapters import make_together_image_adapter
 
@@ -534,7 +534,7 @@ async def test_together_image_adapter_empty_data(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_huggingface_image_adapter_warns_no_slash(monkeypatch, caplog):
     import logging
 
@@ -566,7 +566,7 @@ async def test_huggingface_image_adapter_warns_no_slash(monkeypatch, caplog):
         assert result.endswith(".png")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_huggingface_image_adapter_error_status(monkeypatch):
     from src.services.provider_adapters import make_huggingface_image_adapter
 
@@ -581,7 +581,7 @@ async def test_huggingface_image_adapter_error_status(monkeypatch):
             await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_huggingface_image_adapter_non_image_content_type(monkeypatch):
     from src.services.provider_adapters import make_huggingface_image_adapter
 
@@ -599,7 +599,7 @@ async def test_huggingface_image_adapter_non_image_content_type(monkeypatch):
             await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_image_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_openai_image_adapter
 
@@ -613,7 +613,7 @@ async def test_openai_image_adapter_success(monkeypatch):
     assert result == "https://img.example.com/dalle.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_image_adapter_error_status(monkeypatch):
     from src.services.provider_adapters import make_openai_image_adapter
 
@@ -624,7 +624,7 @@ async def test_openai_image_adapter_error_status(monkeypatch):
         await adapter("a sunset")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_image_adapter_empty_data(monkeypatch):
     from src.services.provider_adapters import make_openai_image_adapter
 
@@ -635,7 +635,7 @@ async def test_openai_image_adapter_empty_data(monkeypatch):
         await adapter("a sunset")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 
@@ -668,7 +668,7 @@ async def test_replicate_image_adapter_success(monkeypatch):
     assert result == "https://img.example.com/replicate.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_create_error(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 
@@ -690,7 +690,7 @@ async def test_replicate_image_adapter_create_error(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_missing_poll_url(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 
@@ -712,7 +712,7 @@ async def test_replicate_image_adapter_missing_poll_url(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_prediction_failed(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 
@@ -744,7 +744,7 @@ async def test_replicate_image_adapter_prediction_failed(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_prediction_canceled(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 
@@ -776,7 +776,7 @@ async def test_replicate_image_adapter_prediction_canceled(monkeypatch):
         await adapter("a cat")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_warns_no_slash(monkeypatch, caplog):
     import logging
 
@@ -813,7 +813,7 @@ async def test_replicate_image_adapter_warns_no_slash(monkeypatch, caplog):
     assert result == "https://img.example.com/img.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_list_output(monkeypatch):
     """Replicate adapter returns first item when output is a list."""
     from src.services.provider_adapters import make_replicate_image_adapter
@@ -846,7 +846,7 @@ async def test_replicate_image_adapter_list_output(monkeypatch):
     assert result == "https://img.example.com/1.png"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_replicate_image_adapter_timeout(monkeypatch):
     """Replicate adapter raises RuntimeError when prediction times out."""
 

--- a/tests/test_provider_service.py
+++ b/tests/test_provider_service.py
@@ -110,7 +110,7 @@ def test_openai_provider_not_registered_without_key(clean_env):
     assert "openai" not in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_provider_calls_api(clean_env):
     """OpenAI provider makes correct API call."""
     os.environ["OPENAI_API_KEY"] = "test_key"
@@ -135,7 +135,7 @@ async def test_openai_provider_calls_api(clean_env):
         assert result == "Hello"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_provider_error_status(clean_env):
     """OpenAI provider raises on error status."""
     os.environ["OPENAI_API_KEY"] = "test_key"

--- a/tests/test_provider_service_adapters.py
+++ b/tests/test_provider_service_adapters.py
@@ -96,7 +96,7 @@ def test_http_adapter_registration_exception(clean_env):
 # === get_provider_status_list exception ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_db_exception():
     """Returns empty list when DB load fails."""
     svc = AgentProviderService()
@@ -117,7 +117,7 @@ async def test_get_provider_status_list_db_exception():
 # === get_provider_callable: OpenAI not registered but GPT model requested ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_gpt_fallback_without_openai():
     """When OpenAI not registered but gpt model requested, falls back to default."""
     svc = AgentProviderService()
@@ -129,7 +129,7 @@ async def test_get_provider_gpt_fallback_without_openai():
 # === _make_openai_compat_provider: non-200 status ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_compat_provider_non_200():
     """Provider raises RuntimeError on non-200 status."""
     svc = AgentProviderService()
@@ -158,7 +158,7 @@ async def test_openai_compat_provider_non_200():
 # === _make_openai_compat_provider: malformed response ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_compat_provider_malformed_response():
     """Provider returns stringified response when choices not found."""
     svc = AgentProviderService()
@@ -188,7 +188,7 @@ async def test_openai_compat_provider_malformed_response():
 # === _make_openai_provider: malformed response fallback ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_openai_provider_malformed_response_fallback(clean_env):
     """OpenAI provider returns stringified response when choices not found."""
     os.environ["OPENAI_API_KEY"] = "test-key"
@@ -218,7 +218,7 @@ async def test_openai_provider_malformed_response_fallback(clean_env):
 # === get_provider_status_list: with configs ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_with_configs():
     """Returns status list for configured providers."""
     svc = AgentProviderService()

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -19,7 +19,7 @@ def mock_config():
     return MagicMock()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_no_db_or_config():
     """Returns 0 when db or config is None."""
     svc = AgentProviderService(db=None, config=None)
@@ -32,7 +32,7 @@ async def test_load_db_providers_no_db_or_config():
     assert await svc3.load_db_providers() == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_registers_openai(mock_db, mock_config):
     """OpenAI-style provider from DB is registered as adapter."""
     mock_cfg = MagicMock()
@@ -56,7 +56,7 @@ async def test_load_db_providers_registers_openai(mock_db, mock_config):
     assert "openai" in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_skips_empty_secrets(mock_db, mock_config):
     """Provider with empty secrets (all required) is skipped."""
     mock_cfg = MagicMock()
@@ -79,7 +79,7 @@ async def test_load_db_providers_skips_empty_secrets(mock_db, mock_config):
     assert not svc.has_providers()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_skips_disabled(mock_db, mock_config):
     """Disabled provider is skipped."""
     mock_cfg = MagicMock()
@@ -101,7 +101,7 @@ async def test_load_db_providers_skips_disabled(mock_db, mock_config):
     assert added == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_skips_duplicate(mock_db, mock_config):
     """Provider already in registry (from env) is not duplicated."""
     mock_cfg = MagicMock()
@@ -125,7 +125,7 @@ async def test_load_db_providers_skips_duplicate(mock_db, mock_config):
     assert added == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reload_db_providers_clears_and_reloads(mock_db, mock_config):
     """reload clears db providers and reloads."""
     mock_cfg = MagicMock()
@@ -153,7 +153,7 @@ async def test_reload_db_providers_clears_and_reloads(mock_db, mock_config):
     assert "groq" not in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_provider_service_loads_db_providers(mock_db, mock_config):
     """Async helper should eagerly load DB-backed providers when config is available."""
     with patch("src.services.provider_service.AgentProviderService.load_db_providers", new=AsyncMock()) as mock_load:
@@ -163,7 +163,7 @@ async def test_build_provider_service_loads_db_providers(mock_db, mock_config):
     mock_load.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_cohere_adapter(mock_db, mock_config):
     """Cohere provider gets make_cohere_adapter."""
     mock_cfg = MagicMock()
@@ -186,7 +186,7 @@ async def test_load_db_providers_cohere_adapter(mock_db, mock_config):
     assert "cohere" in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_ollama_adapter_with_key(mock_db, mock_config):
     """Ollama provider with api_key is registered."""
     mock_cfg = MagicMock()
@@ -209,7 +209,7 @@ async def test_load_db_providers_ollama_adapter_with_key(mock_db, mock_config):
     assert "ollama" in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_ollama_without_api_key(mock_db, mock_config):
     """Ollama with no api_key should be valid since api_key is optional."""
     mock_cfg = MagicMock()
@@ -233,7 +233,7 @@ async def test_load_db_providers_ollama_without_api_key(mock_db, mock_config):
     assert "ollama" in svc._registry
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_db_providers_handles_exception(mock_db, mock_config):
     """Exception during load_provider_configs returns 0 gracefully."""
     with patch(
@@ -299,7 +299,7 @@ def test_has_valid_secrets_requires_secrets_for_required_providers():
     assert svc._has_valid_secrets(cfg) is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_disabled(mock_db, mock_config):
     """get_provider_status_list returns disabled status."""
     mock_cfg = MagicMock()
@@ -324,7 +324,7 @@ async def test_get_provider_status_list_disabled(mock_db, mock_config):
     assert statuses[0]["status"] == "disabled"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_invalid_secrets(mock_db, mock_config):
     """get_provider_status_list returns invalid_secrets with reason."""
     mock_cfg = MagicMock()
@@ -349,7 +349,7 @@ async def test_get_provider_status_list_invalid_secrets(mock_db, mock_config):
     assert "SESSION_ENCRYPTION_KEY" in statuses[0]["reason"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_no_adapter(mock_db, mock_config):
     """get_provider_status_list returns no_adapter for unsupported providers."""
     mock_cfg = MagicMock()
@@ -374,7 +374,7 @@ async def test_get_provider_status_list_no_adapter(mock_db, mock_config):
     assert "google_genai" in statuses[0]["reason"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_active(mock_db, mock_config):
     """get_provider_status_list returns active for registered providers."""
     mock_cfg = MagicMock()
@@ -399,7 +399,7 @@ async def test_get_provider_status_list_active(mock_db, mock_config):
     assert statuses[0]["status"] == "active"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_provider_status_list_no_db():
     """Returns empty list when no DB configured."""
     svc = AgentProviderService(db=None, config=None)

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -118,7 +118,7 @@ def make_pipeline(**overrides):
     return ContentPipeline(**defaults)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_no_text():
     db = FakeDB()
     pool = FakeClientPool()
@@ -133,7 +133,7 @@ async def test_publish_service_no_text():
     assert "No generated text" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_blocks_unapproved_run_for_moderated_pipeline():
     db = FakeDB()
     pool = FakeClientPool()
@@ -148,7 +148,7 @@ async def test_publish_service_blocks_unapproved_run_for_moderated_pipeline():
     assert "not approved" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_no_targets():
     db = FakeDB()
     pool = FakeClientPool()
@@ -163,7 +163,7 @@ async def test_publish_service_no_targets():
     assert "No targets" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_success():
     db = FakeDB()
     db.repos.content_pipelines.set_targets(
@@ -188,7 +188,7 @@ async def test_publish_service_success():
     assert pool.released == ["+1234567890"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_allows_auto_pipeline_without_approval():
     db = FakeDB()
     db.repos.content_pipelines.set_targets(
@@ -214,7 +214,7 @@ async def test_publish_service_allows_auto_pipeline_without_approval():
     assert pool.released == ["+1234567890"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_client_unavailable():
     db = FakeDB()
     db.repos.content_pipelines.set_targets(
@@ -236,7 +236,7 @@ async def test_publish_service_client_unavailable():
 # === Additional tests for image, timeout, edge cases ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_with_image_url():
     """Publishes via send_file when run has image_url."""
     db = FakeDB()
@@ -272,7 +272,7 @@ async def test_publish_service_with_image_url():
     assert client.sent_messages == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_whitespace_text():
     """Empty/whitespace generated_text is skipped."""
     db = FakeDB()
@@ -296,7 +296,7 @@ async def test_publish_service_whitespace_text():
     assert "No generated text" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_entity_resolution_fail():
     """Entity resolution failure produces error result."""
     db = FakeDB()
@@ -325,7 +325,7 @@ async def test_publish_service_entity_resolution_fail():
     assert "Could not resolve" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_timeout():
     """asyncio.TimeoutError produces 'Timeout' error."""
     db = FakeDB()
@@ -356,7 +356,7 @@ async def test_publish_service_timeout():
     assert "Timeout" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_missing_run_id():
     """Missing run id returns early error."""
     db = FakeDB()
@@ -371,7 +371,7 @@ async def test_publish_service_missing_run_id():
     assert "Missing" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_missing_pipeline_id():
     """Missing pipeline id returns early error."""
     db = FakeDB()
@@ -386,7 +386,7 @@ async def test_publish_service_missing_pipeline_id():
     assert "Missing" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_with_reply_to():
     """Sends message with reply_to when metadata has publish_reply."""
     db = FakeDB()
@@ -410,7 +410,7 @@ async def test_publish_service_with_reply_to():
     assert results[0].success is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_general_exception():
     """General exception during publishing produces error result."""
     db = FakeDB()
@@ -439,7 +439,7 @@ async def test_publish_service_general_exception():
     assert "unexpected error" in results[0].error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_preview_targets():
     """preview_targets returns target info dicts."""
     db = FakeDB()
@@ -462,7 +462,7 @@ async def test_publish_service_preview_targets():
     assert preview[0]["type"] == "channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_publish_service_resolve_entity_fallback():
     """_resolve_entity falls back to resolve_input_entity when pool has no resolver."""
     db = FakeDB()

--- a/tests/test_quality_scoring_service.py
+++ b/tests/test_quality_scoring_service.py
@@ -130,7 +130,7 @@ def test_passes_threshold_low_value():
 # === score_content tests (integration with default provider) ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_content_uses_default_provider(mock_db):
     """Score content uses default provider which returns DRAFT prefix."""
     service = QualityScoringService(mock_db)
@@ -141,7 +141,7 @@ async def test_score_content_uses_default_provider(mock_db):
     assert score.issues == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_content_with_model_param(mock_db):
     """Score content passes model parameter."""
     service = QualityScoringService(mock_db)
@@ -153,7 +153,7 @@ async def test_score_content_with_model_param(mock_db):
 # === score_and_check tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_and_check_with_default_provider(mock_db):
     """Score and check with default provider."""
     service = QualityScoringService(mock_db)
@@ -163,7 +163,7 @@ async def test_score_and_check_with_default_provider(mock_db):
     assert passes is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_and_check_custom_threshold_lower(mock_db):
     """Custom threshold lower than score passes."""
     service = QualityScoringService(mock_db)
@@ -172,7 +172,7 @@ async def test_score_and_check_custom_threshold_lower(mock_db):
     assert passes is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_and_check_custom_threshold_higher(mock_db):
     """Custom threshold higher than score fails."""
     service = QualityScoringService(mock_db)
@@ -184,7 +184,7 @@ async def test_score_and_check_custom_threshold_higher(mock_db):
 # === Edge case tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_content_empty_string(mock_db):
     """Handles empty content string."""
     service = QualityScoringService(mock_db)
@@ -192,7 +192,7 @@ async def test_score_content_empty_string(mock_db):
     assert score.overall == 0.5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_content_long_string(mock_db):
     """Handles long content string."""
     service = QualityScoringService(mock_db)
@@ -201,7 +201,7 @@ async def test_score_content_long_string(mock_db):
     assert score.overall == 0.5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_score_and_check_with_model(mock_db):
     """Score and check with model parameter."""
     service = QualityScoringService(mock_db)

--- a/tests/test_react_agent_and_s3_store.py
+++ b/tests/test_react_agent_and_s3_store.py
@@ -500,7 +500,7 @@ class TestS3StoreInit:
 class TestS3StoreUploadFile:
     """Tests for S3Store.upload_file method."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_upload_file_import_error(self):
         """upload_file returns None when boto3 is not installed."""
         store = S3Store(
@@ -514,7 +514,7 @@ class TestS3StoreUploadFile:
             result = await store.upload_file("/tmp/test.jpg")
             assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_upload_file_boto3_exception(self):
         """upload_file returns None on boto3 exception."""
         store = S3Store(
@@ -538,7 +538,7 @@ class TestS3StoreUploadFile:
             result = await store.upload_file("/tmp/test.jpg")
             assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_upload_file_success(self):
         """upload_file returns URL on successful upload."""
         store = S3Store(
@@ -566,7 +566,7 @@ class TestS3StoreUploadFile:
             assert result == "https://s3.example.com/my-bucket/test_image.jpg"
             mock_client.upload_file.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_upload_file_uses_basename(self):
         """upload_file uses basename of path as S3 key."""
         store = S3Store(

--- a/tests/test_resolve_entity.py
+++ b/tests/test_resolve_entity.py
@@ -92,7 +92,7 @@ def _user_entity(user_id: int, first_name: str = "First", last_name: str = "Last
 class TestResolveAnyEntityClientPool:
     """Tests for ClientPool.resolve_any_entity()."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_user_by_username(self):
         pool = _make_pool()
         entity = _user_entity(111, "Alex", "Z", "alxz500")
@@ -110,7 +110,7 @@ class TestResolveAnyEntityClientPool:
         assert result["title"] == "Alex Z"
         assert result["username"] == "alxz500"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_bot_by_username(self):
         pool = _make_pool()
         entity = _user_entity(222, "My", "Bot", "mybot", bot=True)
@@ -125,7 +125,7 @@ class TestResolveAnyEntityClientPool:
         assert result is not None
         assert result["channel_type"] == "bot"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_channel_by_username(self):
         pool = _make_pool()
         entity = _channel_entity(333, "News Channel", "newschan", broadcast=True)
@@ -141,7 +141,7 @@ class TestResolveAnyEntityClientPool:
         assert result["channel_type"] == "channel"
         assert result["title"] == "News Channel"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_group_by_username(self):
         pool = _make_pool()
         entity = _channel_entity(444, "My Group", "mygroup", broadcast=False, megagroup=True)
@@ -156,7 +156,7 @@ class TestResolveAnyEntityClientPool:
         assert result is not None
         assert result["channel_type"] == "supergroup"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_by_tme_link(self):
         pool = _make_pool()
         entity = _user_entity(555, "Alex", "", "alxz500")
@@ -171,7 +171,7 @@ class TestResolveAnyEntityClientPool:
         assert result is not None
         assert result["channel_id"] == 555
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_tme_post_link_stripped_to_channel(self):
         """t.me/chan/123 → resolve t.me/chan, not the post number."""
         pool = _make_pool()
@@ -189,7 +189,7 @@ class TestResolveAnyEntityClientPool:
         call_args = mock_session.resolve_entity.call_args[0][0]
         assert "123" not in str(call_args)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_positive_numeric_id_uses_peer_user(self):
         """Positive numeric ID → PeerUser."""
         from telethon.tl.types import PeerUser
@@ -207,7 +207,7 @@ class TestResolveAnyEntityClientPool:
         assert isinstance(peer_arg, PeerUser)
         assert peer_arg.user_id == 12345
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_negative_numeric_id_uses_peer_channel(self):
         """Negative Bot API format ID → PeerChannel with stripped MTProto ID.
 
@@ -228,7 +228,7 @@ class TestResolveAnyEntityClientPool:
         assert isinstance(peer_arg, PeerChannel)
         assert peer_arg.channel_id == 1234567890
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_username_not_found_returns_none(self):
         from telethon.errors import UsernameNotOccupiedError
         pool = _make_pool()
@@ -245,7 +245,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_username_invalid_returns_none(self):
         from telethon.errors import UsernameInvalidError
         pool = _make_pool()
@@ -262,7 +262,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_timeout_returns_none(self):
         pool = _make_pool()
         mock_session = AsyncMock()
@@ -278,7 +278,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_available_client_raises(self):
         pool = _make_pool()
         pool.get_available_client = AsyncMock(return_value=None)
@@ -286,7 +286,7 @@ class TestResolveAnyEntityClientPool:
         with pytest.raises(RuntimeError, match="no_client"):
             await pool.resolve_any_entity("@alxz500")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_forbidden_returns_none(self):
         from telethon.tl.types import ChannelForbidden
         pool = _make_pool()
@@ -302,7 +302,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_preferred_phone_tried_first(self):
         """If phone given, get_client_by_phone is called before get_available_client."""
         pool = _make_pool()
@@ -319,7 +319,7 @@ class TestResolveAnyEntityClientPool:
         pool.get_client_by_phone.assert_called_once_with("+123")
         pool.get_available_client.assert_not_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_preferred_phone_fallback_to_any(self):
         """If preferred phone unavailable, falls back to any available client."""
         pool = _make_pool()
@@ -336,7 +336,7 @@ class TestResolveAnyEntityClientPool:
         assert result is not None
         pool.get_available_client.assert_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_user_with_no_last_name(self):
         """User with only first_name → title is just first_name."""
         pool = _make_pool()
@@ -351,7 +351,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result["title"] == "Alex"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generic_exception_returns_none(self):
         """Unexpected exception → returns None gracefully."""
         pool = _make_pool()
@@ -368,7 +368,7 @@ class TestResolveAnyEntityClientPool:
 
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_random_garbage_input_returns_none(self):
         """Arbitrary garbage text → treated as username string, not found."""
         from telethon.errors import UsernameInvalidError
@@ -395,7 +395,7 @@ class TestResolveAnyEntityClientPool:
 class TestResolveEntityTool:
     """Tests for the resolve_entity MCP tool in dialogs.py."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_user_success(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(return_value={
@@ -415,7 +415,7 @@ class TestResolveEntityTool:
         assert "111" in text
         assert "@alxz500" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_bot_shows_bot_type(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(return_value={
@@ -429,7 +429,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "@mybot"})
         assert "bot" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resolve_channel_shows_channel_type(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(return_value={
@@ -443,7 +443,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "@newschan"})
         assert "channel" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_identifier_returns_error(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
@@ -451,7 +451,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": ""})
         assert "обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_identifier_returns_error(self, mock_db):
         pool = MagicMock()
         handlers = _get_tool_handlers(mock_db, client_pool=pool)
@@ -459,7 +459,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({})
         assert "обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_gate(self, mock_db):
         handlers = _get_tool_handlers(mock_db, client_pool=None)
 
@@ -467,7 +467,7 @@ class TestResolveEntityTool:
         # require_pool returns a message about Telegram client not available
         assert "telegram" in _text(result).lower() or "cli" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_entity_not_found_returns_not_found(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(return_value=None)
@@ -476,7 +476,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "@gibberish_nonexistent"})
         assert "не найдена" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_client_raises_runtime_error(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(side_effect=RuntimeError("no_client"))
@@ -485,7 +485,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "@alxz500"})
         assert "аккаунт" in _text(result).lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generic_exception_returns_error(self, mock_db):
         pool = MagicMock()
         pool.resolve_any_entity = AsyncMock(side_effect=Exception("network error"))
@@ -494,7 +494,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "@alxz500"})
         assert "Ошибка resolve" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_random_garbage_text_attempts_resolve(self, mock_db):
         """Arbitrary text → tool attempts resolve (returns not found)."""
         pool = MagicMock()
@@ -506,7 +506,7 @@ class TestResolveEntityTool:
         assert _text(result)
         pool.resolve_any_entity.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_at_nonexistent_username_attempts_resolve(self, mock_db):
         """@skdjfsdlkjf → tool calls resolve_any_entity with the identifier."""
         pool = MagicMock()
@@ -519,7 +519,7 @@ class TestResolveEntityTool:
         call_identifier = pool.resolve_any_entity.call_args[0][0]
         assert "skdjfsdlkjf" in call_identifier
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_entity_without_username_no_username_line(self, mock_db):
         """Entity with no username → username line not shown."""
         pool = MagicMock()
@@ -534,7 +534,7 @@ class TestResolveEntityTool:
         result = await handlers["resolve_entity"]({"identifier": "999"})
         assert "Username" not in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_phone_param_passed_to_resolve(self, mock_db):
         """phone param is forwarded to resolve_any_entity."""
         pool = MagicMock()

--- a/tests/test_s3_store.py
+++ b/tests/test_s3_store.py
@@ -40,7 +40,7 @@ def test_from_env_partial(monkeypatch):
     assert store is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_upload_file_success():
     mock_s3 = MagicMock()
     mock_client = MagicMock()
@@ -53,7 +53,7 @@ async def test_upload_file_success():
         mock_client.upload_file.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_upload_file_no_boto3():
     with patch.dict("sys.modules", {"boto3": None}):
         store = S3Store("https://s3.test", "bucket", "ak", "sk")
@@ -61,7 +61,7 @@ async def test_upload_file_no_boto3():
         assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_upload_file_failure():
     mock_s3 = MagicMock()
     mock_client = MagicMock()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,7 +9,7 @@ from src.database.bundles import SchedulerBundle
 from src.scheduler.service import SchedulerManager
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_collection_without_enqueuer():
     """Without task_enqueuer, _run_collection returns zero stats."""
     manager = SchedulerManager(SchedulerConfig())
@@ -19,7 +19,7 @@ async def test_run_collection_without_enqueuer():
     assert stats["errors"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_collection_with_enqueuer():
     """Successful collection returns enqueue stats."""
     result = MagicMock()
@@ -39,7 +39,7 @@ async def test_run_collection_with_enqueuer():
     assert stats["errors"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_settings_updates_interval():
     """load_settings() reads interval from DB and updates _current_interval_minutes."""
     bundle_mock = MagicMock(spec=SchedulerBundle)
@@ -53,7 +53,7 @@ async def test_load_settings_updates_interval():
     assert manager.interval_minutes == 15
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_settings_no_bundle():
     """load_settings() is a no-op when no scheduler_bundle is set."""
     manager = SchedulerManager(SchedulerConfig())
@@ -61,7 +61,7 @@ async def test_load_settings_no_bundle():
     assert manager.interval_minutes == 60
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_load_settings_missing_value_keeps_default():
     """load_settings() keeps config default when DB has no saved interval."""
     bundle_mock = MagicMock(spec=SchedulerBundle)
@@ -73,7 +73,7 @@ async def test_load_settings_missing_value_keeps_default():
     assert manager.interval_minutes == 60
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_collection_enqueuer_error():
     """Enqueue error returns error stats without crashing."""
     enqueuer = MagicMock()

--- a/tests/test_scheduler_manager.py
+++ b/tests/test_scheduler_manager.py
@@ -43,7 +43,7 @@ def scheduler_config():
     return SchedulerConfig(collect_interval_minutes=60)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_start_stop(scheduler_config, mock_bundle):
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
     await mgr.start()
@@ -54,7 +54,7 @@ async def test_scheduler_start_stop(scheduler_config, mock_bundle):
     assert not mgr.is_running
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_start_already_running(scheduler_config, mock_bundle):
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
     await mgr.start()
@@ -65,7 +65,7 @@ async def test_scheduler_start_already_running(scheduler_config, mock_bundle):
     await mgr.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_start_cleans_stale_scheduler(scheduler_config, mock_bundle):
     """If a previous scheduler exists but is not running, start() should clean it up."""
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
@@ -83,7 +83,7 @@ async def test_scheduler_start_cleans_stale_scheduler(scheduler_config, mock_bun
     await mgr.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_update_interval(scheduler_config, mock_bundle):
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
     await mgr.start()
@@ -92,7 +92,7 @@ async def test_scheduler_update_interval(scheduler_config, mock_bundle):
     await mgr.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_trigger_now_with_enqueuer(
     scheduler_config,
     mock_bundle,
@@ -108,14 +108,14 @@ async def test_scheduler_trigger_now_with_enqueuer(
     mock_task_enqueuer.enqueue_all_channels.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_trigger_now_without_enqueuer(scheduler_config, mock_bundle):
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
     res = await mgr.trigger_now()
     assert res["enqueued"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_trigger_background(
     scheduler_config,
     mock_bundle,
@@ -131,7 +131,7 @@ async def test_scheduler_trigger_background(
     await mgr._bg_task
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_collection_failure(
     scheduler_config,
     mock_bundle,
@@ -147,7 +147,7 @@ async def test_run_collection_failure(
     assert res["errors"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sync_search_query_jobs(
     scheduler_config,
     mock_bundle,
@@ -182,7 +182,7 @@ async def test_sync_search_query_jobs(
     await mgr.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_search_query_with_enqueuer(
     scheduler_config,
     mock_bundle,
@@ -197,13 +197,13 @@ async def test_run_search_query_with_enqueuer(
     mock_task_enqueuer.enqueue_sq_stats.assert_called_once_with(1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_search_query_no_enqueuer(scheduler_config, mock_bundle):
     mgr = SchedulerManager(scheduler_config, scheduler_bundle=mock_bundle)
     await mgr._run_search_query(1)  # Should return without error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_saved_interval_from_bundle(mock_bundle):
     mock_bundle.get_setting = AsyncMock(return_value="5")
     config = SchedulerConfig(collect_interval_minutes=60)

--- a/tests/test_scheduler_pipeline.py
+++ b/tests/test_scheduler_pipeline.py
@@ -49,7 +49,7 @@ class FakeScheduler:
         self.existing = [j for j in self.existing if j.id != job_id]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sync_pipeline_jobs_adds_and_removes():
     p1 = FakePipeline(1, 10, is_active=True)
     p2 = FakePipeline(2, 20, is_active=True)
@@ -97,7 +97,7 @@ class FakePipelineService:
         return self._pipeline
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_handler_without_env_marks_failed():
     fake_tasks = FakeTasksRepo()
     # collector and channel_bundle can be dummies; handler will fail early due to missing env
@@ -115,7 +115,7 @@ async def test_pipeline_run_handler_without_env_marks_failed():
     assert "Pipeline execution environment not configured" in last["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_handler_uses_content_generation_service(monkeypatch):
     fake_tasks = FakeTasksRepo()
     pipeline = FakePipeline(1, 10, is_active=True)

--- a/tests/test_scheduler_process_agent_paths.py
+++ b/tests/test_scheduler_process_agent_paths.py
@@ -74,7 +74,7 @@ async def _make_mgr(db=None, *, config=None, task_enqueuer=None, sq_bundle=None,
 
 
 class TestSchedulerUpdateInterval:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_update_interval_while_running(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -84,7 +84,7 @@ class TestSchedulerUpdateInterval:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_update_interval_stores_when_job_disabled(self):
         """update_interval stores value when collect_all job is not registered."""
         mock_bundle = _make_mock_bundle("1")  # job disabled
@@ -100,7 +100,7 @@ class TestSchedulerUpdateInterval:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_update_interval_when_not_running(self):
         mgr = await _make_mgr()
         mgr.update_interval(45)
@@ -108,12 +108,12 @@ class TestSchedulerUpdateInterval:
 
 
 class TestSchedulerGetJobNextRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_job_next_run_scheduler_none(self):
         mgr = await _make_mgr()
         assert mgr.get_job_next_run("collect_all") is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_job_next_run_existing_job(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -123,7 +123,7 @@ class TestSchedulerGetJobNextRun:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_job_next_run_nonexistent_job(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -135,13 +135,13 @@ class TestSchedulerGetJobNextRun:
 
 
 class TestSchedulerGetAllJobsNextRun:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_empty_when_scheduler_none(self):
         mgr = await _make_mgr()
         result = mgr.get_all_jobs_next_run()
         assert result == {}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_returns_dict_when_running(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -152,7 +152,7 @@ class TestSchedulerGetAllJobsNextRun:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_ttl_cache_returns_same_object_within_5s(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -164,7 +164,7 @@ class TestSchedulerGetAllJobsNextRun:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_ttl_cache_refreshes_after_expiry(self):
         mgr = await _make_mgr()
         await mgr.start()
@@ -180,7 +180,7 @@ class TestSchedulerGetAllJobsNextRun:
 
 
 class TestSchedulerSyncSearchQueryJobs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_sq_jobs_adds_job_for_active_query(self):
         sq = SearchQuery(id=5, name="test", query="test", track_stats=True, interval_minutes=15)
         sq_bundle = _make_mock_sq_bundle([sq])
@@ -193,7 +193,7 @@ class TestSchedulerSyncSearchQueryJobs:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_sq_jobs_skips_non_track_stats(self):
         sq = SearchQuery(id=6, name="no_track", query="no_track", track_stats=False, interval_minutes=15)
         sq_bundle = _make_mock_sq_bundle([sq])
@@ -206,7 +206,7 @@ class TestSchedulerSyncSearchQueryJobs:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_sq_jobs_removes_stale_job(self):
         sq = SearchQuery(id=7, name="q7", query="q7", track_stats=True, interval_minutes=10)
         sq_bundle = _make_mock_sq_bundle([sq])
@@ -222,7 +222,7 @@ class TestSchedulerSyncSearchQueryJobs:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_sq_jobs_no_bundle(self):
         """sync_search_query_jobs should return immediately when bundle is None."""
         mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=_make_mock_bundle())
@@ -234,7 +234,7 @@ class TestSchedulerSyncSearchQueryJobs:
 
 
 class TestSchedulerSyncPipelineJobs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_pipeline_jobs_adds_jobs(self):
         pipeline = MagicMock()
         pipeline.id = 10
@@ -252,7 +252,7 @@ class TestSchedulerSyncPipelineJobs:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_pipeline_jobs_removes_stale(self):
         pipeline = MagicMock()
         pipeline.id = 11
@@ -271,7 +271,7 @@ class TestSchedulerSyncPipelineJobs:
         finally:
             await mgr.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_sync_pipeline_jobs_no_bundle(self):
         mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=_make_mock_bundle())
         await mgr.start()
@@ -282,13 +282,13 @@ class TestSchedulerSyncPipelineJobs:
 
 
 class TestSchedulerGetPotentialJobs:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_potential_jobs_basic(self):
         mgr = await _make_mgr()
         jobs = await mgr.get_potential_jobs()
         assert any(j["job_id"] == "collect_all" for j in jobs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_potential_jobs_with_task_enqueuer(self):
         enqueuer = _make_task_enqueuer()
         mgr = await _make_mgr(task_enqueuer=enqueuer)
@@ -297,7 +297,7 @@ class TestSchedulerGetPotentialJobs:
         assert "photo_due" in job_ids
         assert "photo_auto" in job_ids
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_potential_jobs_with_sq_bundle(self):
         sq = SearchQuery(id=20, name="sq20", query="sq20", track_stats=True, interval_minutes=10)
         sq_bundle = _make_mock_sq_bundle([sq])
@@ -305,7 +305,7 @@ class TestSchedulerGetPotentialJobs:
         jobs = await mgr.get_potential_jobs()
         assert any(j["job_id"] == "sq_20" for j in jobs)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_potential_jobs_with_pipeline_bundle(self):
         pipeline = MagicMock()
         pipeline.id = 99
@@ -320,20 +320,20 @@ class TestSchedulerGetPotentialJobs:
 
 
 class TestSchedulerLoadSettings:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_settings_reads_interval(self):
         mock_bundle = _make_mock_bundle("25")
         mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=60), scheduler_bundle=mock_bundle)
         await mgr.load_settings()
         assert mgr._current_interval_minutes == 25
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_settings_uses_default_when_no_bundle(self):
         mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=60))
         await mgr.load_settings()
         assert mgr._current_interval_minutes == 60
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_load_settings_invalid_value_uses_default(self):
         mock_bundle = _make_mock_bundle("not_a_number")
         mgr = SchedulerManager(SchedulerConfig(collect_interval_minutes=45), scheduler_bundle=mock_bundle)
@@ -342,24 +342,24 @@ class TestSchedulerLoadSettings:
 
 
 class TestSchedulerIsJobEnabled:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_job_enabled_returns_true_when_no_bundle(self):
         mgr = SchedulerManager(SchedulerConfig())
         assert await mgr.is_job_enabled("collect_all") is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_job_enabled_returns_true_by_default(self):
         mock_bundle = _make_mock_bundle(None)
         mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
         assert await mgr.is_job_enabled("collect_all") is True
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_job_enabled_returns_false_when_disabled(self):
         mock_bundle = _make_mock_bundle("1")
         mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
         assert await mgr.is_job_enabled("collect_all") is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_is_job_enabled_returns_true_when_not_one(self):
         mock_bundle = _make_mock_bundle("0")
         mgr = SchedulerManager(SchedulerConfig(), scheduler_bundle=mock_bundle)
@@ -367,13 +367,13 @@ class TestSchedulerIsJobEnabled:
 
 
 class TestSchedulerRunPhotoDue:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_due_no_enqueuer(self):
         mgr = await _make_mgr()
         result = await mgr._run_photo_due()
         assert result == {"processed": 0}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_due_with_enqueuer(self):
         enqueuer = _make_task_enqueuer()
         mgr = await _make_mgr(task_enqueuer=enqueuer)
@@ -381,13 +381,13 @@ class TestSchedulerRunPhotoDue:
         assert result == {"enqueued": True}
         enqueuer.enqueue_photo_due.assert_called_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_auto_no_enqueuer(self):
         mgr = await _make_mgr()
         result = await mgr._run_photo_auto()
         assert result == {"jobs": 0}
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_photo_auto_with_enqueuer(self):
         enqueuer = _make_task_enqueuer()
         mgr = await _make_mgr(task_enqueuer=enqueuer)
@@ -507,14 +507,14 @@ class TestCLINotification:
 
 
 class TestCLITestReadChecks:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_get_stats_pass(self, db):
         from src.cli.commands.test import Status, _check_get_stats
 
         result = await _check_get_stats(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_account_list_pass(self, db):
         from src.cli.commands.test import Status, _check_account_list
 
@@ -522,56 +522,56 @@ class TestCLITestReadChecks:
         assert result.status == Status.PASS
         assert "accounts" in result.detail
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_channel_list_pass(self, db):
         from src.cli.commands.test import Status, _check_channel_list
 
         result = await _check_channel_list(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_queries_skip_when_empty(self, db):
         from src.cli.commands.test import Status, _check_notification_queries
 
         result = await _check_notification_queries(db)
         assert result.status == Status.SKIP
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_local_search_pass(self, db):
         from src.cli.commands.test import Status, _check_local_search
 
         result = await _check_local_search(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_collection_tasks_pass(self, db):
         from src.cli.commands.test import Status, _check_collection_tasks
 
         result = await _check_collection_tasks(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_recent_searches_skip_when_empty(self, db):
         from src.cli.commands.test import Status, _check_recent_searches
 
         result = await _check_recent_searches(db)
         assert result.status == Status.SKIP
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_pipeline_list_pass(self, db):
         from src.cli.commands.test import Status, _check_pipeline_list
 
         result = await _check_pipeline_list(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_notification_bot_pass(self, db):
         from src.cli.commands.test import Status, _check_notification_bot
 
         result = await _check_notification_bot(db)
         assert result.status == Status.PASS
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_photo_tasks_pass(self, db):
         from src.cli.commands.test import Status, _check_photo_tasks
 
@@ -788,7 +788,7 @@ class TestProcessControl:
 
 
 class TestDBConnection:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_connect_creates_wal_db(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -804,7 +804,7 @@ class TestDBConnection:
         finally:
             await conn.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_close_is_idempotent(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -814,7 +814,7 @@ class TestDBConnection:
         await conn.close()
         await conn.close()  # second close should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_close_when_not_connected(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -822,7 +822,7 @@ class TestDBConnection:
         conn = DBConnection(db_path)
         await conn.close()  # should not raise
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_execute_fetchall(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -835,7 +835,7 @@ class TestDBConnection:
         finally:
             await conn.close()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_creates_parent_directory(self, tmp_path):
         from src.database.connection import DBConnection
 
@@ -917,7 +917,7 @@ class TestAgentManagerInit:
 
 
 class TestAgentManagerRefreshSettingsCache:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_settings_cache_no_preflight(self, db):
         from src.agent.manager import AgentManager
 
@@ -925,7 +925,7 @@ class TestAgentManagerRefreshSettingsCache:
         # Should not raise
         await mgr.refresh_settings_cache(preflight=False)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_refresh_settings_cache_with_preflight_no_config(self, db):
         from src.agent.manager import AgentManager
 
@@ -935,7 +935,7 @@ class TestAgentManagerRefreshSettingsCache:
 
 
 class TestAgentManagerGetRuntimeStatus:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_runtime_status_returns_status(self, db):
         from src.agent.manager import AgentManager, AgentRuntimeStatus
 
@@ -945,7 +945,7 @@ class TestAgentManagerGetRuntimeStatus:
         assert isinstance(status.claude_available, bool)
         assert isinstance(status.deepagents_available, bool)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_runtime_status_no_backends(self, db):
         from src.agent.manager import AgentManager, ClaudeSdkBackend
 
@@ -955,7 +955,7 @@ class TestAgentManagerGetRuntimeStatus:
             status = await mgr.get_runtime_status()
         assert isinstance(status.selected_backend, (str, type(None)))
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_runtime_status_dev_mode_override(self, db):
         from src.agent.manager import AgentManager
 

--- a/tests/test_scheduler_ui.py
+++ b/tests/test_scheduler_ui.py
@@ -19,13 +19,13 @@ class FakeScheduler:
         return self._job if self._job and self._job.id == job_id else None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_job_next_run_returns_none_when_no_scheduler():
     mgr = SchedulerManager()
     assert mgr.get_job_next_run("pipeline_run_1") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_job_next_run_returns_time_when_job_exists():
     dt = datetime(2026, 3, 17, 12, 0)
     job = FakeJob("pipeline_run_1", next_run_time=dt)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -14,7 +14,7 @@ from src.web.routes.search import _extract_length
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_local_empty(db):
     engine = SearchEngine(db)
     result = await engine.search_local("test")
@@ -23,7 +23,7 @@ async def test_search_local_empty(db):
     assert result.query == "test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_local_with_results(db):
     messages = [
         Message(
@@ -47,7 +47,7 @@ async def test_search_local_with_results(db):
     assert "crypto" in (result.messages[0].text or "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_local_pagination(db):
     messages = [
         Message(
@@ -66,7 +66,7 @@ async def test_search_local_pagination(db):
     assert result.total == 20
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_local_maps_channel_title(db):
     from src.models import Channel
 
@@ -88,7 +88,7 @@ async def test_search_local_maps_channel_title(db):
     assert result.messages[0].channel_username == "crypto_news"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_with_results(db, monkeypatch):
     await db.insert_messages_batch(
         [
@@ -204,7 +204,7 @@ async def _connect_search_account(
     await harness.initialize_connected_accounts()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_returns_results(db, real_pool_harness_factory):
     mock_msg = _make_mock_api_message()
     mock_chat = MagicMock()
@@ -235,7 +235,7 @@ async def test_search_telegram_returns_results(db, real_pool_harness_factory):
     assert result.messages[0].channel_title == "Test Channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_ignores_quota_probe_failure_when_search_succeeds(
     db,
     real_pool_harness_factory,
@@ -273,7 +273,7 @@ async def test_search_telegram_ignores_quota_probe_failure_when_search_succeeds(
     assert result.messages[0].message_id == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_caches_to_db(db, real_pool_harness_factory):
     mock_msg = _make_mock_api_message(channel_id=100456, msg_id=7, text="cached search result")
     mock_chat = MagicMock()
@@ -302,7 +302,7 @@ async def test_search_telegram_caches_to_db(db, real_pool_harness_factory):
     assert messages[0].text == "cached search result"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_no_pool(db):
     engine = SearchEngine(db, pool=None)
     result = await engine.search_telegram("anything")
@@ -313,7 +313,7 @@ async def test_search_telegram_no_pool(db):
     assert result.error == "Нет подключённых Telegram-аккаунтов."
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_no_premium(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     engine = SearchEngine(db, pool=harness.pool)
@@ -324,7 +324,7 @@ async def test_search_telegram_no_premium(db, real_pool_harness_factory):
     assert "Premium" in result.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_flood_wait_does_not_mark_generic_account_flood(
     db,
     real_pool_harness_factory,
@@ -359,7 +359,7 @@ async def test_search_telegram_flood_wait_does_not_mark_generic_account_flood(
     assert "Flood Wait" in unavailable_reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_search_quota_flood_wait_returns_none_and_marks_premium_flood(
     db,
     real_pool_harness_factory,
@@ -393,7 +393,7 @@ async def test_check_search_quota_flood_wait_returns_none_and_marks_premium_floo
     assert "Flood Wait" in unavailable_reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_runtime_error_returns_search_result(
     db,
     real_pool_harness_factory,
@@ -420,7 +420,7 @@ async def test_search_my_chats_runtime_error_returns_search_result(
     assert "telegram api failure" in result.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_returns_results(db, real_pool_harness_factory):
     mock_msg = _make_resolved_message()
     harness = real_pool_harness_factory()
@@ -443,7 +443,7 @@ async def test_search_my_chats_returns_results(db, real_pool_harness_factory):
     assert result.messages[0].channel_title == "My Chat"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_skips_warm_dialog_cache_when_already_fetched(
     db,
     real_pool_harness_factory,
@@ -470,7 +470,7 @@ async def test_search_my_chats_skips_warm_dialog_cache_when_already_fetched(
     client.get_dialogs.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_reports_flood_wait_and_marks_account(
     db,
     real_pool_harness_factory,
@@ -505,7 +505,7 @@ async def test_search_my_chats_reports_flood_wait_and_marks_account(
     assert flooded.flood_wait_until is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_no_pool(db):
     engine = SearchEngine(db, pool=None)
     result = await engine.search_my_chats("anything")
@@ -514,7 +514,7 @@ async def test_search_my_chats_no_pool(db):
     assert result.error == "Нет подключённых Telegram-аккаунтов."
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_no_clients(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     engine = SearchEngine(db, pool=harness.pool)
@@ -524,7 +524,7 @@ async def test_search_my_chats_no_clients(db, real_pool_harness_factory):
     assert result.error == "Нет доступных Telegram-аккаунтов. Проверьте подключение."
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_in_channel_returns_results(db, real_pool_harness_factory):
     mock_msg = _make_resolved_message(chat_id=200456, chat_title="Target Channel")
     harness = real_pool_harness_factory()
@@ -547,7 +547,7 @@ async def test_search_in_channel_returns_results(db, real_pool_harness_factory):
     assert result.messages[0].channel_title == "Target Channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_in_channel_all_channels(db, real_pool_harness_factory):
     mock_msg = _make_resolved_message(chat_id=300789, chat_title="All Chats Result")
     harness = real_pool_harness_factory()
@@ -569,7 +569,7 @@ async def test_search_in_channel_all_channels(db, real_pool_harness_factory):
     assert result.messages[0].channel_title == "All Chats Result"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_in_channel_entity_not_found(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await _connect_search_account(
@@ -589,7 +589,7 @@ async def test_search_in_channel_entity_not_found(db, real_pool_harness_factory)
     assert "Не удалось найти канал" in result.error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_in_channel_runtime_error_returns_search_result(
     db,
     real_pool_harness_factory,

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -35,7 +35,7 @@ async def _insert_messages(db, texts, channel_id=100, base_date=None):
         await db.repos.messages.insert_message(msg)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_and_list(svc):
     sq_id = await svc.add("аренда квартир", 30)
     assert sq_id > 0
@@ -46,7 +46,7 @@ async def test_add_and_list(svc):
     assert items[0].interval_minutes == 30
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle(svc):
     sq_id = await svc.add("query", 60)
     items = await svc.list()
@@ -57,7 +57,7 @@ async def test_toggle(svc):
     assert items[0].is_active is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete(svc):
     sq_id = await svc.add("query", 60)
     await svc.delete(sq_id)
@@ -65,7 +65,7 @@ async def test_delete(svc):
     assert len(items) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_record_stat_and_daily_stats(bundle, svc):
     sq_id = await svc.add("query", 60)
     await bundle.record_stat(sq_id, 42)
@@ -74,7 +74,7 @@ async def test_record_stat_and_daily_stats(bundle, svc):
     assert stats[0].count == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_record_stat_deduplication(bundle, svc):
     sq_id = await svc.add("query", 60)
     await bundle.record_stat(sq_id, 10)
@@ -84,7 +84,7 @@ async def test_record_stat_deduplication(bundle, svc):
     assert stats[0].count == 20  # overwritten, not accumulated
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_with_stats_from_fts(svc, bundle, db):
     await _insert_messages(db, ["hello world", "hello again", "goodbye"])
 
@@ -104,7 +104,7 @@ async def test_get_with_stats_from_fts(svc, bundle, db):
     assert goodbye_item["daily_stats"] == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_last_recorded_at_all(bundle):
     repo = bundle.search_queries
     sq = SearchQuery(query="test")
@@ -116,7 +116,7 @@ async def test_get_last_recorded_at_all(bundle):
     assert result[sq_id] is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fts_daily_stats_groups_by_day(bundle, db):
     now = datetime.now()
     yesterday = now - timedelta(days=1)
@@ -142,7 +142,7 @@ async def test_fts_daily_stats_groups_by_day(bundle, db):
     assert total == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_once_counts_today_only(svc, db):
     now = datetime.now()
     old = now - timedelta(days=5)
@@ -158,7 +158,7 @@ async def test_run_once_counts_today_only(svc, db):
     assert count == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_query(svc):
     sq_id = await svc.add("original", 60)
     result = await svc.update(
@@ -179,13 +179,13 @@ async def test_update_query(svc):
     assert sq.track_stats is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_nonexistent(svc):
     result = await svc.update(999, "q", 60)
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fts_boolean_query(bundle, db):
     """FTS5 boolean query with OR/AND should match correctly."""
     await _insert_messages(
@@ -205,7 +205,7 @@ async def test_fts_boolean_query(bundle, db):
     assert count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_exclude_patterns(bundle, db):
     """Exclude patterns should filter out matching messages."""
     await _insert_messages(
@@ -224,7 +224,7 @@ async def test_exclude_patterns(bundle, db):
     assert count == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_max_length_filter(bundle, db):
     """max_length should filter out messages with text >= max_length."""
     await _insert_messages(
@@ -242,7 +242,7 @@ async def test_max_length_filter(bundle, db):
     assert total == 1  # only "short" passes length filter
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fts_collector_matching():
     """Test the _fts_query_matches function."""
     from src.services.notification_matcher import _fts_query_matches
@@ -259,7 +259,7 @@ async def test_fts_collector_matching():
     assert not _fts_query_matches("аренда квартир", "продажа домов")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fts_query_matches_wildcards():
     """Test _fts_query_matches handles FTS5 trailing wildcards."""
     from src.services.notification_matcher import _fts_query_matches
@@ -285,7 +285,7 @@ async def test_fts_query_matches_wildcards():
     assert not _fts_query_matches("* AND байк*", "аренда квартиры")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_exclude_patterns_list_property():
     sq = SearchQuery(query="test", exclude_patterns="foo\nbar\n  baz  \n\n")
     assert sq.exclude_patterns_list == ["foo", "bar", "baz"]
@@ -294,7 +294,7 @@ async def test_exclude_patterns_list_property():
     assert sq2.exclude_patterns_list == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_interval_minutes_validation():
     with pytest.raises(ValueError):
         SearchQuery(query="q", interval_minutes=0)

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -86,7 +86,7 @@ def service(bundle):
 # === add/list/get tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_creates_search_query(service, bundle):
     """Add delegates to bundle.add() with correct fields."""
     sq_id = await service.add(
@@ -111,7 +111,7 @@ async def test_add_creates_search_query(service, bundle):
     assert stored.max_length == 500
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_returns_all_queries(service, bundle):
     """List delegates to bundle.get_all()."""
     await service.add("query1")
@@ -122,7 +122,7 @@ async def test_list_returns_all_queries(service, bundle):
     assert len(result) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_list_active_only(service, bundle):
     """List with active_only filters inactive queries."""
     id1 = await service.add("active query")
@@ -135,7 +135,7 @@ async def test_list_active_only(service, bundle):
     assert result[0].id == id1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_returns_query_by_id(service, bundle):
     """Get delegates to bundle.get_by_id()."""
     sq_id = await service.add("test")
@@ -146,7 +146,7 @@ async def test_get_returns_query_by_id(service, bundle):
     assert result.query == "test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_nonexistent_returns_none(service):
     """Get returns None for nonexistent query."""
     result = await service.get(999)
@@ -157,7 +157,7 @@ async def test_get_nonexistent_returns_none(service):
 # === toggle tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_switches_active_state(service, bundle):
     """Toggle switches is_active on existing query."""
     sq_id = await service.add("test", is_regex=False)
@@ -169,7 +169,7 @@ async def test_toggle_switches_active_state(service, bundle):
     assert stored.is_active is False  # Started as True, toggled to False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_toggle_nonexistent_does_nothing(service):
     """Toggle is a no-op when query not found."""
     # Should not raise
@@ -179,7 +179,7 @@ async def test_toggle_nonexistent_does_nothing(service):
 # === update tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_modifies_query(service, bundle):
     """Update delegates to bundle.update() preserving is_active."""
     sq_id = await service.add("old query")
@@ -205,7 +205,7 @@ async def test_update_modifies_query(service, bundle):
     assert stored.is_active is False  # Preserved
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_nonexistent_returns_false(service):
     """Update returns False when query not found."""
     result = await service.update(
@@ -220,7 +220,7 @@ async def test_update_nonexistent_returns_false(service):
 # === run_once tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_once_regex_query_returns_zero(service, bundle):
     """Regex queries return 0 (not FTS-countable)."""
     sq_id = await service.add("test", is_regex=True)
@@ -230,7 +230,7 @@ async def test_run_once_regex_query_returns_zero(service, bundle):
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_once_fts_query_with_stats(service, bundle):
     """FTS query records stats when track_stats=True."""
     sq_id = await service.add("test", is_fts=True, track_stats=True)
@@ -288,7 +288,7 @@ def test_fill_missing_days_none_stats():
 # === get_with_stats tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_with_stats_excludes_regex_from_fts(service, bundle):
     """Regex queries are excluded from FTS stats batch."""
     await service.add("regex.*", is_regex=True, track_stats=True)

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -14,7 +14,7 @@ def _make_search_result(query="test"):
     return SearchResult(messages=[], total=0, query=query)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_ai_mode():
     """Test search with AI mode."""
     engine = MagicMock()
@@ -28,7 +28,7 @@ async def test_search_ai_mode():
     assert result.total == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_ai_mode_without_ai_search():
     """Test search with AI mode but no AI search engine."""
     engine = MagicMock()
@@ -41,7 +41,7 @@ async def test_search_ai_mode_without_ai_search():
     engine.search_local.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_telegram_mode():
     """Test search with telegram mode."""
     engine = MagicMock()
@@ -53,7 +53,7 @@ async def test_search_telegram_mode():
     engine.search_telegram.assert_called_once_with("test", limit=10)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_my_chats_mode():
     """Test search with my_chats mode."""
     engine = MagicMock()
@@ -65,7 +65,7 @@ async def test_search_my_chats_mode():
     engine.search_my_chats.assert_called_once_with("test", limit=10)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_channel_mode():
     """Test search with channel mode."""
     engine = MagicMock()
@@ -77,7 +77,7 @@ async def test_search_channel_mode():
     engine.search_in_channel.assert_called_once_with(100, "test", limit=10)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_semantic_mode():
     """Test search with semantic mode."""
     engine = MagicMock()
@@ -99,7 +99,7 @@ async def test_search_semantic_mode():
     engine.search_semantic.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_hybrid_mode():
     """Test search with hybrid mode."""
     engine = MagicMock()
@@ -122,7 +122,7 @@ async def test_search_hybrid_mode():
     engine.search_hybrid.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_local_mode_default():
     """Test search falls back to local for unknown mode."""
     engine = MagicMock()
@@ -134,7 +134,7 @@ async def test_search_local_mode_default():
     engine.search_local.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_check_quota():
     """Test check_quota delegates to engine."""
     engine = MagicMock()

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -8,7 +8,6 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.collection_queue import CollectionQueue
@@ -58,7 +57,7 @@ def _make_pipeline_db(tmp_path, db_name="pipeline7.db"):
 # ---------------------------------------------------------------------------
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def base_app(tmp_path):
     """Minimal app fixture for web route tests."""
     config = AppConfig()
@@ -119,7 +118,7 @@ async def base_app(tmp_path):
     await db.close()
 
 
-@pytest_asyncio.fixture(loop_scope="function")
+@pytest.fixture
 async def route_client(base_app):
     """AsyncClient with Basic auth for web route tests."""
     app, db, pool_mock = base_app
@@ -145,43 +144,43 @@ async def route_client(base_app):
 class TestWebSchedulerRoutes:
     """Tests for src/web/routes/scheduler.py"""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_scheduler_page_renders(self, route_client):
         """GET /scheduler/ returns 200."""
         resp = await route_client.get("/scheduler/")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_scheduler_page_status_filter(self, route_client):
         """GET /scheduler/?status=active filters tasks."""
         resp = await route_client.get("/scheduler/?status=active")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_scheduler_page_completed_status(self, route_client):
         """GET /scheduler/?status=completed returns 200."""
         resp = await route_client.get("/scheduler/?status=completed")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_scheduler_page_invalid_status(self, route_client):
         """GET /scheduler/?status=invalid defaults to all."""
         resp = await route_client.get("/scheduler/?status=invalid")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_start_scheduler(self, route_client):
         """POST /scheduler/start redirects to scheduler page."""
         resp = await route_client.post("/scheduler/start")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_stop_scheduler(self, route_client):
         """POST /scheduler/stop redirects to scheduler page."""
         resp = await route_client.post("/scheduler/stop")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_trigger_collection(self, route_client):
         """POST /scheduler/trigger enqueues all channels."""
         from src.services.collection_service import BulkEnqueueResult
@@ -197,13 +196,13 @@ class TestWebSchedulerRoutes:
             resp = await route_client.post("/scheduler/trigger")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_job_valid(self, route_client):
         """POST /scheduler/jobs/collect_all/toggle toggles the job."""
         resp = await route_client.post("/scheduler/jobs/collect_all/toggle")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_job_invalid_id(self, route_client):
         """POST /scheduler/jobs/invalid_job/toggle returns redirect with error."""
         resp = await route_client.post("/scheduler/jobs/invalid_job_xyz!/toggle")
@@ -213,13 +212,13 @@ class TestWebSchedulerRoutes:
             query = query.decode()
         assert "invalid_job" in query or resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_toggle_job_sq_pattern(self, route_client):
         """POST /scheduler/jobs/sq_1/toggle is valid job id pattern."""
         resp = await route_client.post("/scheduler/jobs/sq_1/toggle")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_set_interval_collect_all(self, route_client):
         """POST /scheduler/jobs/collect_all/set-interval updates interval."""
         resp = await route_client.post(
@@ -228,7 +227,7 @@ class TestWebSchedulerRoutes:
         )
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_set_interval_invalid_value(self, route_client):
         """POST /scheduler/jobs/collect_all/set-interval with invalid value redirects."""
         resp = await route_client.post(
@@ -237,13 +236,13 @@ class TestWebSchedulerRoutes:
         )
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_task(self, route_client):
         """POST /scheduler/tasks/999/cancel cancels non-existent task."""
         resp = await route_client.post("/scheduler/tasks/999/cancel")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_clear_pending_collect(self, route_client):
         """POST /scheduler/tasks/clear-pending-collect clears pending tasks."""
         resp = await route_client.post("/scheduler/tasks/clear-pending-collect")
@@ -258,13 +257,13 @@ class TestWebSchedulerRoutes:
 class TestWebSettingsRoutes:
     """Tests for web/routes/settings.py — provider/image/notification settings."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_page_renders(self, route_client):
         """GET /settings/ returns 200."""
         resp = await route_client.get("/settings/")
         assert resp.status_code == 200
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_agent_providers_page(self, route_client):
         """GET /settings/agent-providers returns 200 or redirect."""
         with patch("src.web.routes.settings._agent_provider_service") as mock_fn:
@@ -274,7 +273,7 @@ class TestWebSettingsRoutes:
             resp = await route_client.get("/settings/agent-providers")
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_image_providers_get(self, route_client):
         """GET /settings/image-providers returns 200."""
         with patch("src.web.routes.settings._image_provider_service") as mock_fn:
@@ -284,7 +283,7 @@ class TestWebSettingsRoutes:
             resp = await route_client.get("/settings/image-providers")
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_notification_status(self, route_client):
         """GET /settings/notifications/status returns 200 or redirect.
 
@@ -294,7 +293,7 @@ class TestWebSettingsRoutes:
         resp = await route_client.get("/settings/notifications/status")
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_provider_bulk_test_status(self, route_client):
         """GET /settings/agent-providers/bulk-test/status returns JSON."""
         resp = await route_client.get(
@@ -303,19 +302,19 @@ class TestWebSettingsRoutes:
         )
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_page_agent_tab(self, route_client):
         """GET /settings/?tab=agent returns 200."""
         resp = await route_client.get("/settings/?tab=agent")
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_semantic_search_settings_page(self, route_client):
         """GET /settings/semantic-search returns 200."""
         resp = await route_client.get("/settings/semantic-search")
         assert resp.status_code in (200, 302, 303, 404)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_settings_save_agent_prompt_template(self, base_app, route_client):
         """POST /settings/agent-prompt-template saves template."""
         resp = await route_client.post(
@@ -834,14 +833,14 @@ def _text(result: dict) -> str:
 
 
 class TestListChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_returns_not_found(self, mock_db):
         mock_db.get_channels = AsyncMock(return_value=[])
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["list_channels"]({})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_active_only_filter(self, mock_db):
         ch = _make_channel_mock(is_active=True)
         mock_db.get_channels = AsyncMock(return_value=[ch])
@@ -850,7 +849,7 @@ class TestListChannelsTool:
         mock_db.get_channels.assert_awaited_once_with(active_only=True, include_filtered=True)
         assert "TestChan" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_include_filtered_false(self, mock_db):
         ch = _make_channel_mock(is_filtered=False)
         mock_db.get_channels = AsyncMock(return_value=[ch])
@@ -858,7 +857,7 @@ class TestListChannelsTool:
         await handlers["list_channels"]({"include_filtered": False})
         mock_db.get_channels.assert_awaited_once_with(active_only=False, include_filtered=False)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_filtered_channel_shown_with_flag(self, mock_db):
         ch = _make_channel_mock(is_filtered=True)
         mock_db.get_channels = AsyncMock(return_value=[ch])
@@ -867,7 +866,7 @@ class TestListChannelsTool:
         text = _text(result)
         assert "отфильтрован" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inactive_channel_shown(self, mock_db):
         ch = _make_channel_mock(is_active=False)
         mock_db.get_channels = AsyncMock(return_value=[ch])
@@ -876,7 +875,7 @@ class TestListChannelsTool:
         text = _text(result)
         assert "неактивен" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
         mock_db.get_channels = AsyncMock(side_effect=Exception("db error"))
         handlers = _get_channel_tool_handlers(mock_db)
@@ -886,7 +885,7 @@ class TestListChannelsTool:
 
 
 class TestGetChannelStatsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_stats_returns_empty_message(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
@@ -894,7 +893,7 @@ class TestGetChannelStatsTool:
         result = await handlers["get_channel_stats"]({})
         assert "не собрана" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_stats_shows_data(self, mock_db):
         stat = MagicMock()
         stat.subscriber_count = 5000
@@ -907,7 +906,7 @@ class TestGetChannelStatsTool:
         assert "5000" in text
         assert "200" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(side_effect=Exception("stats fail"))
@@ -917,19 +916,19 @@ class TestGetChannelStatsTool:
 
 
 class TestImportChannelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_text_returns_error(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["import_channels"]({})
         assert "text обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_identifiers_extracted(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["import_channels"]({"text": "no valid identifiers here"})
         assert "Не удалось распознать" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["import_channels"]({"text": "@testchannel, @another"})
@@ -937,7 +936,7 @@ class TestImportChannelsTool:
         # Should ask for confirmation
         assert "confirm" in text.lower() or "подтвердит" in text.lower() or "импортирует" in text.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_confirmed_import(self, mock_db):
         mock_db.repos = MagicMock()
         with patch("src.services.channel_service.ChannelService.add_by_identifier", new=AsyncMock(return_value=True)):
@@ -948,7 +947,7 @@ class TestImportChannelsTool:
 
 
 class TestRefreshChannelTypesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_pool_returns_error(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db, client_pool=None)
         result = await handlers["refresh_channel_types"]({})
@@ -956,7 +955,7 @@ class TestRefreshChannelTypesTool:
         # should warn about no pool
         assert "pool" in text.lower() or "Telegram" in text or "подключён" in text.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_requires_confirmation(self, mock_db):
         mock_pool = MagicMock()
         mock_pool.clients = {"+1": MagicMock()}
@@ -972,13 +971,13 @@ class TestRefreshChannelTypesTool:
 
 
 class TestGenerateImageTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_prompt_returns_error(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["generate_image"]({})
         assert "prompt обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_service_returns_not_configured(self, mock_db):
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
         with patch(f"{_svc_path}.is_available", new=AsyncMock(return_value=False)):
@@ -987,7 +986,7 @@ class TestGenerateImageTool:
         text = _text(result)
         assert "не настроена" in text or "Ошибка" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_returns_non_url(self, mock_db):
         """When result is a local path (not URL), prints it directly."""
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
@@ -1000,7 +999,7 @@ class TestGenerateImageTool:
         text = _text(result)
         assert "/local/path/img.png" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_returns_none(self, mock_db):
         """When result is None, prints 'не вернула результат'."""
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
@@ -1013,7 +1012,7 @@ class TestGenerateImageTool:
         text = _text(result)
         assert "не вернула" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generate_exception(self, mock_db):
         """Exception in generate returns error text."""
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
@@ -1028,13 +1027,13 @@ class TestGenerateImageTool:
 
 
 class TestListImageModelsTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_missing_provider_returns_error(self, mock_db):
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["list_image_models"]({})
         assert "provider обязателен" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_models_found(self, mock_db):
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
         with patch(f"{_svc_path}.search_models", new=AsyncMock(return_value=[])):
@@ -1042,7 +1041,7 @@ class TestListImageModelsTool:
             result = await handlers["list_image_models"]({"provider": "replicate"})
         assert "не найдены" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_models_with_run_count_and_rank(self, mock_db):
         models = [
             {"id": "model1", "run_count": 10000, "rank": 1},
@@ -1057,7 +1056,7 @@ class TestListImageModelsTool:
         assert "10,000" in text
         assert "rank 1" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_models_all_shown_beyond_30(self, mock_db):
         models = [{"id": f"m{i}"} for i in range(35)]
         _svc_path = "src.services.image_generation_service.ImageGenerationService"
@@ -1070,7 +1069,7 @@ class TestListImageModelsTool:
 
 
 class TestListGeneratedImagesTool:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_images_returns_empty_message(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generated_images.list_recent = AsyncMock(return_value=[])
@@ -1078,7 +1077,7 @@ class TestListGeneratedImagesTool:
         result = await handlers["list_generated_images"]({})
         assert "Нет сгенерированных" in _text(result)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_with_images_shows_list(self, mock_db):
         img = MagicMock()
         img.id = 1
@@ -1094,7 +1093,7 @@ class TestListGeneratedImagesTool:
         assert "A beautiful sunset" in text
         assert "replicate:flux" in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_long_prompt_truncated(self, mock_db):
         img = MagicMock()
         img.id = 2
@@ -1109,7 +1108,7 @@ class TestListGeneratedImagesTool:
         text = _text(result)
         assert "..." in text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
         mock_db.repos = MagicMock()
         mock_db.repos.generated_images.list_recent = AsyncMock(side_effect=Exception("db fail"))
@@ -1192,7 +1191,7 @@ class TestPhotoTaskServiceNormalizeMode:
 
 
 class TestPhotoTaskServiceSendNow:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_now_success(self, tmp_path):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1225,7 +1224,7 @@ class TestPhotoTaskServiceSendNow:
         assert item.status == PhotoBatchStatus.COMPLETED
         bundle.update_item.assert_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_now_failure_marks_failed(self, tmp_path):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1257,7 +1256,7 @@ class TestPhotoTaskServiceSendNow:
 
 
 class TestPhotoTaskServiceScheduleSend:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_schedule_send_success(self, tmp_path):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1290,7 +1289,7 @@ class TestPhotoTaskServiceScheduleSend:
         )
         assert item is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_schedule_send_failure_marks_failed(self, tmp_path):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1319,7 +1318,7 @@ class TestPhotoTaskServiceScheduleSend:
 
 
 class TestPhotoTaskServiceCancelItem:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_delegates_to_bundle(self):
         from src.services.photo_task_service import PhotoTaskService
 
@@ -1330,7 +1329,7 @@ class TestPhotoTaskServiceCancelItem:
         assert result is True
         bundle.cancel_item.assert_awaited_once_with(99)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_cancel_returns_false_if_not_found(self):
         from src.services.photo_task_service import PhotoTaskService
 
@@ -1342,7 +1341,7 @@ class TestPhotoTaskServiceCancelItem:
 
 
 class TestPhotoTaskServiceRunDue:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_due_no_items(self):
         from src.services.photo_task_service import PhotoTaskService
 
@@ -1352,7 +1351,7 @@ class TestPhotoTaskServiceRunDue:
         processed = await svc.run_due()
         assert processed == 0
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_due_processes_one_item(self, tmp_path):
         from src.services.photo_task_service import PhotoTaskService
 
@@ -1386,7 +1385,7 @@ class TestPhotoTaskServiceRunDue:
         processed = await svc.run_due()
         assert processed == 1
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_run_due_handles_item_failure(self, tmp_path):
         from src.services.photo_task_service import PhotoTaskService
 
@@ -1425,7 +1424,7 @@ class TestPhotoTaskServiceRunDue:
 
 
 class TestPhotoTaskServiceCreateBatch:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_batch_empty_entries(self):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1434,7 +1433,7 @@ class TestPhotoTaskServiceCreateBatch:
         with pytest.raises(ValueError, match="Batch manifest is empty"):
             await svc.create_batch(phone="+1", target=target, entries=[])
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_create_batch_success(self, tmp_path):
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
@@ -1481,7 +1480,7 @@ class TestPhotoTaskServiceCreateBatch:
 class TestTelegramSearchNoPool:
     """Tests for TelegramSearch when pool is None."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_telegram_no_pool(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1492,7 +1491,7 @@ class TestTelegramSearchNoPool:
         assert result.error is not None
         assert "аккаунт" in result.error.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_my_chats_no_pool(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1502,7 +1501,7 @@ class TestTelegramSearchNoPool:
         result = await ts.search_my_chats("hello")
         assert result.error is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_in_channel_no_pool(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1512,7 +1511,7 @@ class TestTelegramSearchNoPool:
         result = await ts.search_in_channel(channel_id=100, query="hello")
         assert result.error is not None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_search_quota_no_pool(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1526,7 +1525,7 @@ class TestTelegramSearchNoPool:
 class TestTelegramSearchNoPremiumClient:
     """Tests for TelegramSearch when no premium client is available."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_telegram_no_premium_client(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1540,7 +1539,7 @@ class TestTelegramSearchNoPremiumClient:
         assert result.error is not None
         assert "No premium accounts" in result.error
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_check_search_quota_no_premium_client(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1552,7 +1551,7 @@ class TestTelegramSearchNoPremiumClient:
         result = await ts.check_search_quota("test")
         assert result is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_my_chats_no_available_client(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1565,7 +1564,7 @@ class TestTelegramSearchNoPremiumClient:
         assert result.error is not None
         assert "доступн" in result.error.lower() or "аккаунт" in result.error.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_search_in_channel_no_available_client(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1581,7 +1580,7 @@ class TestTelegramSearchNoPremiumClient:
 class TestTelegramSearchPremiumUnavailabilityReason:
     """Tests for _get_premium_unavailability_reason."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_no_reason_getter(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1592,7 +1591,7 @@ class TestTelegramSearchPremiumUnavailabilityReason:
         reason = await ts._get_premium_unavailability_reason()
         assert "Premium" in reason
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reason_getter_returns_string(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch
@@ -1604,7 +1603,7 @@ class TestTelegramSearchPremiumUnavailabilityReason:
         reason = await ts._get_premium_unavailability_reason()
         assert "Flood waited" in reason
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_reason_getter_raises(self):
         from src.search.persistence import SearchPersistence
         from src.search.telegram_search import TelegramSearch

--- a/tests/test_task_enqueuer.py
+++ b/tests/test_task_enqueuer.py
@@ -18,7 +18,7 @@ from src.services.task_enqueuer import TaskEnqueuer
 # === enqueue_content_generate tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_content_generate_creates_task(task_enqueuer, mock_db):
     """Creates CONTENT_GENERATE task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -41,7 +41,7 @@ async def test_enqueue_content_generate_creates_task(task_enqueuer, mock_db):
     assert result == 101
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_content_generate_skips_if_active(task_enqueuer, mock_db):
     """Skips creation if active task for same pipeline exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)
@@ -55,7 +55,7 @@ async def test_enqueue_content_generate_skips_if_active(task_enqueuer, mock_db):
 # === enqueue_content_publish tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_content_publish_creates_task(task_enqueuer, mock_db):
     """Creates CONTENT_PUBLISH task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -75,7 +75,7 @@ async def test_enqueue_content_publish_creates_task(task_enqueuer, mock_db):
     assert result == 202
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_content_publish_with_pipeline_id(task_enqueuer, mock_db):
     """Creates CONTENT_PUBLISH task with pipeline_id in payload."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -116,7 +116,7 @@ def task_enqueuer(mock_db, mock_collection_service):
 # === enqueue_all_channels tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_delegates(task_enqueuer, mock_collection_service):
     """Delegates to collection service."""
     mock_result = MagicMock(queued_count=3)
@@ -131,7 +131,7 @@ async def test_enqueue_all_channels_delegates(task_enqueuer, mock_collection_ser
 # === enqueue_sq_stats tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_sq_stats_creates_task(task_enqueuer, mock_db):
     """Creates SQ_STATS task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -154,7 +154,7 @@ async def test_enqueue_sq_stats_creates_task(task_enqueuer, mock_db):
     assert result == 42
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_sq_stats_skips_if_active(task_enqueuer, mock_db):
     """Skips creation if active task already exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)
@@ -168,7 +168,7 @@ async def test_enqueue_sq_stats_skips_if_active(task_enqueuer, mock_db):
 # === enqueue_photo_due tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_photo_due_creates_task(task_enqueuer, mock_db):
     """Creates PHOTO_DUE task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -184,7 +184,7 @@ async def test_enqueue_photo_due_creates_task(task_enqueuer, mock_db):
     assert result == 15
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_photo_due_skips_if_active(task_enqueuer, mock_db):
     """Skips creation if active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)
@@ -198,7 +198,7 @@ async def test_enqueue_photo_due_skips_if_active(task_enqueuer, mock_db):
 # === enqueue_photo_auto tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_photo_auto_creates_task(task_enqueuer, mock_db):
     """Creates PHOTO_AUTO task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -214,7 +214,7 @@ async def test_enqueue_photo_auto_creates_task(task_enqueuer, mock_db):
     assert result == 16
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_photo_auto_skips_if_active(task_enqueuer, mock_db):
     """Skips creation if active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)
@@ -228,7 +228,7 @@ async def test_enqueue_photo_auto_skips_if_active(task_enqueuer, mock_db):
 # === enqueue_pipeline_run tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_pipeline_run_creates_task(task_enqueuer, mock_db):
     """Creates PIPELINE_RUN task when no active task exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=False)
@@ -251,7 +251,7 @@ async def test_enqueue_pipeline_run_creates_task(task_enqueuer, mock_db):
     assert result == 99
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_pipeline_run_skips_if_active(task_enqueuer, mock_db):
     """Skips creation if active task for same pipeline exists."""
     mock_db.repos.tasks.has_active_task = AsyncMock(return_value=True)

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -90,36 +90,36 @@ def pool(mock_auth, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_connected_phones_returns_set(pool):
     pool.clients = {"+7001": MagicMock()}
     assert pool.connected_phones() == {"+7001"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_phone_for_channel_returns_none_when_unknown(pool):
     assert pool.get_phone_for_channel(999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_register_and_get_phone_for_channel(pool):
     pool.register_channel_phone(42, "+7001")
     assert pool.get_phone_for_channel(42) == "+7001"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_clear_channel_phone(pool):
     pool.register_channel_phone(42, "+7001")
     pool.clear_channel_phone(42)
     assert pool.get_phone_for_channel(42) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_warming_false_initially(pool):
     assert pool.is_warming() is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_warming_true_when_task_running(pool):
     async def _long_task():
         await asyncio.sleep(10)
@@ -135,19 +135,19 @@ async def test_is_warming_true_when_task_running(pool):
             pass
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_for_warm_no_task(pool):
     await pool.wait_for_warm()  # Should not raise
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_for_warm_completed_task(pool):
     pool._warming_task = asyncio.create_task(asyncio.sleep(0))
     await asyncio.sleep(0.05)
     await pool.wait_for_warm(timeout=1.0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_for_warm_timeout(pool):
     async def _long():
         await asyncio.sleep(999)
@@ -163,7 +163,7 @@ async def test_wait_for_warm_timeout(pool):
             pass
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_warm_all_dialogs_registers_channel_phones(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
 
@@ -185,7 +185,7 @@ async def test_warm_all_dialogs_registers_channel_phones(mock_auth, mock_db):
     mock_db.repos.channels.update_channel_preferred_phone.assert_called_once_with(12345, "+7001")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_warm_all_dialogs_skips_non_channel_entities(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
 
@@ -205,7 +205,7 @@ async def test_warm_all_dialogs_skips_non_channel_entities(mock_auth, mock_db):
     assert pool.get_phone_for_channel(999) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_warm_all_dialogs_handles_failure(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
 
@@ -220,7 +220,7 @@ async def test_warm_all_dialogs_handles_failure(mock_auth, mock_db):
         await pool.warm_all_dialogs()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_warm_all_dialogs_skips_get_client_by_phone_none(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
     pool.clients["+7001"] = MagicMock()
@@ -235,7 +235,7 @@ async def test_warm_all_dialogs_skips_get_client_by_phone_none(mock_auth, mock_d
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_invalidate_dialogs_cache_specific_phone(pool):
     pool._store_cached_dialogs("+7001", "full", [{"channel_id": 1}])
     pool._store_cached_dialogs("+7002", "full", [{"channel_id": 2}])
@@ -245,14 +245,14 @@ async def test_invalidate_dialogs_cache_specific_phone(pool):
     assert pool._get_cached_dialogs("+7002", "full") is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_invalidate_dialogs_cache_all(pool):
     pool._store_cached_dialogs("+7001", "full", [{"channel_id": 1}])
     pool.invalidate_dialogs_cache()
     assert pool._get_cached_dialogs("+7001", "full") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cached_dialogs_expired(pool):
     pool._dialogs_cache_ttl_sec = 0.0
     pool._store_cached_dialogs("+7001", "full", [{"channel_id": 1}])
@@ -260,7 +260,7 @@ async def test_cached_dialogs_expired(pool):
     assert pool._get_cached_dialogs("+7001", "full") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cached_dialogs_channels_only_falls_back_to_full(pool):
     full_data = [{"channel_id": 1, "channel_type": "channel"}, {"channel_id": 2, "channel_type": "dm"}]
     pool._store_cached_dialogs("+7001", "full", full_data)
@@ -270,12 +270,12 @@ async def test_cached_dialogs_channels_only_falls_back_to_full(pool):
     assert len(result) == 1  # Only non-dm/bot/saved
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cached_dialogs_channels_only_no_full_cache(pool):
     assert pool._get_cached_dialogs("+7001", "channels_only") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_db_cached_dialogs_stale(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
     pool._dialogs_db_cache_ttl_sec = 0.0
@@ -287,7 +287,7 @@ async def test_get_db_cached_dialogs_stale(mock_auth, mock_db):
     assert result is None  # stale, should return None to trigger fresh fetch
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_db_cached_dialogs_returns_full(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
 
@@ -305,7 +305,7 @@ async def test_get_db_cached_dialogs_returns_full(mock_auth, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_channel(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -324,7 +324,7 @@ async def test_resolve_any_entity_channel(mock_auth, mock_db):
     assert result["channel_type"] == "channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_user(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -344,7 +344,7 @@ async def test_resolve_any_entity_user(mock_auth, mock_db):
     assert result["title"] == "Ivan Petrov"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_bot(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -362,7 +362,7 @@ async def test_resolve_any_entity_bot(mock_auth, mock_db):
     assert result["channel_type"] == "bot"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_negative_id_as_channel(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -381,7 +381,7 @@ async def test_resolve_any_entity_negative_id_as_channel(mock_auth, mock_db):
     assert result is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_positive_id_as_user(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -399,7 +399,7 @@ async def test_resolve_any_entity_positive_id_as_user(mock_auth, mock_db):
     assert result["channel_type"] == "dm"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_no_client_raises(mock_auth, mock_db):
     pool = ClientPool(mock_auth, mock_db)
 
@@ -407,7 +407,7 @@ async def test_resolve_any_entity_no_client_raises(mock_auth, mock_db):
         await pool.resolve_any_entity("@test")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_timeout(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -423,7 +423,7 @@ async def test_resolve_any_entity_timeout(mock_auth, mock_db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_username_not_found(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -439,7 +439,7 @@ async def test_resolve_any_entity_username_not_found(mock_auth, mock_db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_flood_raises_after_exhaustion(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -457,7 +457,7 @@ async def test_resolve_any_entity_flood_raises_after_exhaustion(mock_auth, mock_
         await pool.resolve_any_entity("@test")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_channel_forbidden(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -474,7 +474,7 @@ async def test_resolve_any_entity_channel_forbidden(mock_auth, mock_db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_generic_error(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -490,7 +490,7 @@ async def test_resolve_any_entity_generic_error(mock_auth, mock_db):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_any_entity_with_preferred_phone(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -514,19 +514,19 @@ async def test_resolve_any_entity_with_preferred_phone(mock_auth, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_channel_meta_group_returns_none(pool):
     result = await pool.fetch_channel_meta(1, "group")
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_channel_meta_no_client(pool):
     result = await pool.fetch_channel_meta(1, "channel")
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_channel_meta_success(pool):
     client = AsyncMock()
     entity = SimpleNamespace()
@@ -555,7 +555,7 @@ async def test_fetch_channel_meta_success(pool):
     assert result["has_comments"] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_channel_meta_timeout(pool):
     client = AsyncMock()
     client.get_entity = AsyncMock(side_effect=asyncio.TimeoutError())
@@ -569,7 +569,7 @@ async def test_fetch_channel_meta_timeout(pool):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fetch_channel_meta_generic_error(pool):
     client = AsyncMock()
     entity = SimpleNamespace()
@@ -590,7 +590,7 @@ async def test_fetch_channel_meta_generic_error(pool):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_scam():
     entity = SimpleNamespace(scam=True, fake=False, restricted=False, monoforum=False,
                              forum=False, gigagroup=False, megagroup=False, broadcast=False)
@@ -599,7 +599,7 @@ async def test_classify_entity_scam():
     assert deactivate is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_fake():
     entity = SimpleNamespace(scam=False, fake=True, restricted=False, monoforum=False,
                              forum=False, gigagroup=False, megagroup=False, broadcast=False)
@@ -608,7 +608,7 @@ async def test_classify_entity_fake():
     assert deactivate is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_restricted():
     entity = SimpleNamespace(scam=False, fake=False, restricted=True, monoforum=False,
                              forum=False, gigagroup=False, megagroup=False, broadcast=False)
@@ -617,7 +617,7 @@ async def test_classify_entity_restricted():
     assert deactivate is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_monoforum():
     entity = SimpleNamespace(scam=False, fake=False, restricted=False, monoforum=True,
                              forum=False, gigagroup=False, megagroup=False, broadcast=False)
@@ -626,7 +626,7 @@ async def test_classify_entity_monoforum():
     assert deactivate is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_forum():
     entity = SimpleNamespace(scam=False, fake=False, restricted=False, monoforum=False,
                              forum=True, gigagroup=False, megagroup=False, broadcast=False)
@@ -635,7 +635,7 @@ async def test_classify_entity_forum():
     assert deactivate is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_gigagroup():
     entity = SimpleNamespace(scam=False, fake=False, restricted=False, monoforum=False,
                              forum=False, gigagroup=True, megagroup=False, broadcast=False)
@@ -644,7 +644,7 @@ async def test_classify_entity_gigagroup():
     assert deactivate is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_classify_entity_plain_group():
     entity = SimpleNamespace(scam=False, fake=False, restricted=False, monoforum=False,
                              forum=False, gigagroup=False, megagroup=False, broadcast=False)
@@ -659,7 +659,7 @@ async def test_classify_entity_plain_group():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_channel_forbidden(pool):
     client = AsyncMock()
     cf = ChannelForbidden(id=1, access_hash=1, title="Forbidden", broadcast=False)
@@ -674,7 +674,7 @@ async def test_resolve_channel_channel_forbidden(pool):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_numeric_id(pool):
     client = AsyncMock()
     entity = SimpleNamespace(id=123, title="Ch", broadcast=True, megagroup=False, gigagroup=False,
@@ -691,7 +691,7 @@ async def test_resolve_channel_numeric_id(pool):
     assert result["channel_id"] == 123
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_generic_error(pool):
     client = AsyncMock()
     client.get_entity = AsyncMock(side_effect=RuntimeError("unknown"))
@@ -705,7 +705,7 @@ async def test_resolve_channel_generic_error(pool):
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_username_invalid(pool):
     client = AsyncMock()
     client.get_entity = AsyncMock(side_effect=UsernameInvalidError("inv"))
@@ -725,7 +725,7 @@ async def test_resolve_channel_username_invalid(pool):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_dialogs_no_non_flooded_accounts(pool, mock_db):
     future = datetime.now(timezone.utc) + timedelta(minutes=10)
     mock_db.get_accounts.return_value = [
@@ -743,7 +743,7 @@ async def test_get_dialogs_no_non_flooded_accounts(pool, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_client_cleans_up_all_state(pool, mock_auth, mock_db):
     client = AsyncMock()
     pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
@@ -761,7 +761,7 @@ async def test_remove_client_cleans_up_all_state(pool, mock_auth, mock_db):
     assert "+7001" not in pool._premium_flood_wait_until
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_remove_client_with_active_leases(pool, mock_auth, mock_db):
     client = AsyncMock()
     pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
@@ -786,13 +786,13 @@ async def test_remove_client_with_active_leases(pool, mock_auth, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_phone_not_connected(pool):
     result = await pool.reconnect_phone("+7001")
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_phone_already_connected(pool):
     client = AsyncMock()
     client.is_connected = MagicMock(return_value=True)
@@ -802,7 +802,7 @@ async def test_reconnect_phone_already_connected(pool):
     assert result is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_phone_reconnect_succeeds(pool):
     client = AsyncMock()
     client.is_connected = MagicMock(side_effect=[False, True])
@@ -814,7 +814,7 @@ async def test_reconnect_phone_reconnect_succeeds(pool):
     client.connect.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reconnect_phone_reconnect_fails(pool):
     client = AsyncMock()
     client.is_connected = MagicMock(return_value=False)
@@ -831,7 +831,7 @@ async def test_reconnect_phone_reconnect_fails(pool):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_disconnect_all_timeout_forces_cleanup(pool):
     client = AsyncMock()
     client.disconnect = AsyncMock(side_effect=asyncio.TimeoutError())
@@ -846,7 +846,7 @@ async def test_disconnect_all_timeout_forces_cleanup(pool):
     assert "+7001" not in pool.clients
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_disconnect_all_general_error(pool):
     async def _error_remove(phone):
         raise RuntimeError("unexpected")
@@ -863,7 +863,7 @@ async def test_disconnect_all_general_error(pool):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_users_info_no_direct_session(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, is_primary=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -890,7 +890,7 @@ async def test_get_users_info_no_direct_session(mock_auth, mock_db):
     pool._backend_router.release.assert_called_once_with(lease)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_users_info_error_skips_account(pool, mock_db):
     acc = Account(phone="+7001", is_active=True, is_primary=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -903,7 +903,7 @@ async def test_get_users_info_error_skips_account(pool, mock_db):
     assert len(info) == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_users_info_no_account_for_phone(pool, mock_db):
     acc = Account(phone="+7001", is_active=True, is_primary=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -926,21 +926,21 @@ async def test_get_users_info_no_account_for_phone(pool, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_runtime_config_none():
     config = ClientPool._normalize_runtime_config(None)
     assert config.backend_mode == "auto"
     assert config.cli_transport == "hybrid"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_runtime_config_invalid_backend():
     rc = TelegramRuntimeConfig(backend_mode="invalid_mode", cli_transport="in_process")
     config = ClientPool._normalize_runtime_config(rc)
     assert config.backend_mode == "auto"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_runtime_config_invalid_transport():
     rc = TelegramRuntimeConfig(backend_mode="auto", cli_transport="invalid_transport")
     config = ClientPool._normalize_runtime_config(rc)
@@ -953,7 +953,7 @@ async def test_normalize_runtime_config_invalid_transport():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_premium_unavailability_not_connected(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, is_premium=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -964,7 +964,7 @@ async def test_premium_unavailability_not_connected(mock_auth, mock_db):
     assert "не подключён" in reason
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_premium_unavailability_some_blocked(mock_auth, mock_db):
     acc = Account(phone="+7001", is_active=True, is_premium=True, session_string="s1")
     mock_db.get_accounts.return_value = [acc]
@@ -982,13 +982,13 @@ async def test_premium_unavailability_some_blocked(mock_auth, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_no_client(pool):
     result = await pool.leave_channels("+7001", [(123, "channel")])
     assert result == {123: False}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_dm_type(pool):
     client = AsyncMock()
     entity = SimpleNamespace()
@@ -1005,7 +1005,7 @@ async def test_leave_channels_dm_type(pool):
     assert result[123] is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_leave_channels_generic_error(pool):
     client = AsyncMock()
     entity = SimpleNamespace()
@@ -1028,13 +1028,13 @@ async def test_leave_channels_generic_error(pool):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_no_client(pool):
     result = await pool.get_forum_topics(1)
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_dialogs_fetched_but_still_fails(pool, mock_db):
     client = AsyncMock()
     client.get_entity = AsyncMock(side_effect=ValueError("not found"))
@@ -1052,7 +1052,7 @@ async def test_get_forum_topics_dialogs_fetched_but_still_fails(pool, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_forum_topics_resolves_by_username(pool, mock_db):
     client = AsyncMock()
     entity = SimpleNamespace()
@@ -1090,14 +1090,14 @@ async def test_get_forum_topics_resolves_by_username(pool, mock_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_document_no_attributes():
     media = MessageMediaDocument(document=None)
     msg = SimpleNamespace(media=media)
     assert Collector._get_media_type(msg) == "document"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_video_note():
     attr = DocumentAttributeVideo(duration=10, w=100, h=100, round_message=True)
     doc = SimpleNamespace(attributes=[attr])
@@ -1106,7 +1106,7 @@ async def test_get_media_type_video_note():
     assert Collector._get_media_type(msg) == "video_note"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_audio():
     attr = DocumentAttributeAudio(duration=10, voice=False)
     doc = SimpleNamespace(attributes=[attr])
@@ -1115,7 +1115,7 @@ async def test_get_media_type_audio():
     assert Collector._get_media_type(msg) == "audio"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_gif():
     attr = DocumentAttributeAnimated()
     doc = SimpleNamespace(attributes=[attr])
@@ -1124,25 +1124,25 @@ async def test_get_media_type_gif():
     assert Collector._get_media_type(msg) == "gif"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_web_page():
     msg = SimpleNamespace(media=MessageMediaWebPage(webpage=SimpleNamespace()))
     assert Collector._get_media_type(msg) == "web_page"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_location():
     msg = SimpleNamespace(media=MessageMediaGeo(geo=SimpleNamespace()))
     assert Collector._get_media_type(msg) == "location"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_geo_live():
     msg = SimpleNamespace(media=MessageMediaGeoLive(geo=SimpleNamespace(), period=60))
     assert Collector._get_media_type(msg) == "geo_live"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_contact():
     msg = SimpleNamespace(media=MessageMediaContact(
         phone_number="", first_name="", last_name="", vcard="", user_id=0
@@ -1150,20 +1150,20 @@ async def test_get_media_type_contact():
     assert Collector._get_media_type(msg) == "contact"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_dice():
     msg = SimpleNamespace(media=MessageMediaDice(emoticon="🎲", value=6))
     assert Collector._get_media_type(msg) == "dice"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_game():
     game = SimpleNamespace(id=0, access_hash=0, short_name="", title="", description="")
     msg = SimpleNamespace(media=MessageMediaGame(game=game))
     assert Collector._get_media_type(msg) == "game"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_media_type_unknown():
     msg = SimpleNamespace(media=SimpleNamespace())
     assert Collector._get_media_type(msg) == "unknown"
@@ -1175,7 +1175,7 @@ async def test_get_media_type_unknown():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_no_emoticon_no_document_id():
     """Reaction with no emoticon and no document_id should be skipped."""
     reaction_obj = SimpleNamespace(emoticon=None, document_id=None)
@@ -1184,7 +1184,7 @@ async def test_extract_reactions_no_emoticon_no_document_id():
     assert Collector._extract_reactions(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_no_reaction_attr():
     """Reaction item with reaction=None should be skipped."""
     result_item = SimpleNamespace(reaction=None, count=1)
@@ -1192,7 +1192,7 @@ async def test_extract_reactions_no_reaction_attr():
     assert Collector._extract_reactions(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_extract_reactions_mixed_valid_and_invalid():
     """Only valid reactions should be included."""
     valid_reaction = SimpleNamespace(emoticon="👍")
@@ -1216,34 +1216,34 @@ async def test_extract_reactions_mixed_valid_and_invalid():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sender_name_no_sender():
     msg = SimpleNamespace(sender=None)
     assert Collector._get_sender_name(msg) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sender_name_with_title():
     sender = SimpleNamespace(title="My Channel")
     msg = SimpleNamespace(sender=sender)
     assert Collector._get_sender_name(msg) == "My Channel"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sender_name_with_first_and_last():
     sender = SimpleNamespace(first_name="Ivan", last_name="Petrov")
     msg = SimpleNamespace(sender=sender)
     assert Collector._get_sender_name(msg) == "Ivan Petrov"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sender_name_with_first_only():
     sender = SimpleNamespace(first_name="Ivan", last_name="")
     msg = SimpleNamespace(sender=sender)
     assert Collector._get_sender_name(msg) == "Ivan"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_sender_name_empty_names():
     sender = SimpleNamespace(first_name="", last_name="")
     msg = SimpleNamespace(sender=sender)
@@ -1256,7 +1256,7 @@ async def test_get_sender_name_empty_names():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_precheck_sample_breaks_on_cancel():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1282,7 +1282,7 @@ async def test_precheck_sample_breaks_on_cancel():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_channels_cancellation():
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
     db = MagicMock()
@@ -1308,7 +1308,7 @@ async def test_collect_all_channels_cancellation():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fallback_availability_with_clients():
     pool = make_mock_pool(clients={"+7001": object()})
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1318,7 +1318,7 @@ async def test_fallback_availability_with_clients():
     assert result.state == "available"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fallback_availability_no_clients():
     pool = make_mock_pool(clients={})
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1332,7 +1332,7 @@ async def test_fallback_availability_no_clients():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_is_running_initially_false():
     pool = make_mock_pool()
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1340,7 +1340,7 @@ async def test_is_running_initially_false():
     assert collector.is_stats_running is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delay_between_channels_sec():
     pool = make_mock_pool()
     config = SchedulerConfig(delay_between_channels_sec=5)
@@ -1354,7 +1354,7 @@ async def test_delay_between_channels_sec():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_log_unavailability_deduplication():
     pool = make_mock_pool()
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1373,7 +1373,7 @@ async def test_log_unavailability_deduplication():
     assert collector._last_unavailability_log[0] == "no_connected_active"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reset_unavailability_log():
     pool = make_mock_pool()
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1388,7 +1388,7 @@ async def test_reset_unavailability_log():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_maybe_auto_delete_disabled():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1399,7 +1399,7 @@ async def test_maybe_auto_delete_disabled():
     assert result is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_maybe_auto_delete_enabled():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1412,7 +1412,7 @@ async def test_maybe_auto_delete_enabled():
     db.delete_messages_for_channel.assert_called_once_with(123)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_maybe_auto_delete_error():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1430,7 +1430,7 @@ async def test_maybe_auto_delete_error():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sample_channel_no_client():
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1438,7 +1438,7 @@ async def test_sample_channel_no_client():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sample_channel_resolve_entity_fails():
     client = AsyncMock()
     client.get_entity = AsyncMock(side_effect=ValueError("not found"))
@@ -1449,7 +1449,7 @@ async def test_sample_channel_resolve_entity_fails():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sample_channel_flood_wait():
     client = AsyncMock()
     flood_err = FloodWaitError(request=None, capture=0)
@@ -1462,7 +1462,7 @@ async def test_sample_channel_flood_wait():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sample_channel_with_messages():
     entity = SimpleNamespace()
     client = AsyncMock()
@@ -1482,7 +1482,7 @@ async def test_sample_channel_with_messages():
     assert result[0]["message_id"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sample_channel_cancelled_mid_stream():
     entity = SimpleNamespace()
     client = AsyncMock()
@@ -1510,7 +1510,7 @@ async def test_sample_channel_cancelled_mid_stream():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_username_fallback_fails():
     channel = Channel(channel_id=123, username="gone")
     client = AsyncMock()
@@ -1533,7 +1533,7 @@ async def test_collect_stats_username_fallback_fails():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_no_username_resolves_numeric():
     channel = Channel(channel_id=123)
     entity = SimpleNamespace(id=123, date=None)
@@ -1564,7 +1564,7 @@ async def test_collect_stats_no_username_resolves_numeric():
     assert result.subscriber_count == 100
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_timeout_during_messages():
     channel = Channel(channel_id=123, username="test")
     entity = SimpleNamespace(id=123, date=None)
@@ -1595,7 +1595,7 @@ async def test_collect_stats_timeout_during_messages():
     assert result.subscriber_count == 50
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_updates_channel_type():
     channel = Channel(channel_id=123, username="test", channel_type=None)
     entity = SimpleNamespace(id=123, date=None, broadcast=True, megagroup=False,
@@ -1634,7 +1634,7 @@ async def test_collect_stats_updates_channel_type():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_waits_on_flood():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1660,7 +1660,7 @@ async def test_collect_all_stats_waits_on_flood():
     assert stats["errors"] == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_stats_generic_error():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1680,7 +1680,7 @@ async def test_collect_all_stats_generic_error():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_discover_phone_for_channel_success():
     pool = make_mock_pool()
 
@@ -1699,7 +1699,7 @@ async def test_discover_phone_for_channel_success():
     assert result == "+7002"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_discover_phone_for_channel_flood():
     pool = make_mock_pool()
 
@@ -1725,7 +1725,7 @@ async def test_discover_phone_for_channel_flood():
     pool.report_flood.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_discover_phone_for_channel_no_access():
     pool = make_mock_pool()
 
@@ -1743,7 +1743,7 @@ async def test_discover_phone_for_channel_no_access():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_discover_phone_for_channel_client_none():
     pool = make_mock_pool()
     pool.get_client_by_phone = AsyncMock(return_value=None)
@@ -1759,7 +1759,7 @@ async def test_discover_phone_for_channel_client_none():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_still_exists_true():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1769,7 +1769,7 @@ async def test_channel_still_exists_true():
     assert await collector._channel_still_exists(1) is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_still_exists_false():
     pool = make_mock_pool()
     db = MagicMock()
@@ -1784,7 +1784,7 @@ async def test_channel_still_exists_false():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cancel_and_is_cancelled():
     pool = make_mock_pool()
     collector = Collector(pool, MagicMock(), SchedulerConfig())
@@ -1799,7 +1799,7 @@ async def test_cancel_and_is_cancelled():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_raise_collection_unavailability_all_flooded():
     pool = make_mock_pool()
     next_at = datetime.now(timezone.utc) + timedelta(seconds=120)
@@ -1817,7 +1817,7 @@ async def test_raise_collection_unavailability_all_flooded():
     assert exc.value.retry_after_sec == 120
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_raise_collection_unavailability_no_active():
     pool = make_mock_pool()
     pool.get_collection_availability = AsyncMock(
@@ -1838,7 +1838,7 @@ async def test_raise_collection_unavailability_no_active():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_numeric_timeout():
     """Timeout resolving numeric PeerChannel -> returns 0."""
     channel = Channel(channel_id=123, title="Test")
@@ -1852,7 +1852,7 @@ async def test_collect_channel_numeric_timeout():
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_numeric_flood_wait():
     """FloodWaitError on numeric resolve -> HandledFloodWaitError -> flood_wait_sec set."""
     channel = Channel(channel_id=123, title="Test")
@@ -1870,7 +1870,7 @@ async def test_collect_channel_numeric_flood_wait():
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_private_group_invalidates_bad_phone():
     """When private group's phone can't resolve entity, clear and discover."""
     channel = Channel(channel_id=123, title="Test", preferred_phone="+7001")
@@ -1903,7 +1903,7 @@ async def test_collect_channel_private_group_invalidates_bad_phone():
     db.repos.channels.update_channel_preferred_phone.assert_called_once_with(123, None)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_cancelled_during_batch():
     """Cancel event set during message streaming breaks the loop."""
     ch = Channel(channel_id=-100999, title="Test", username="test", last_collected_id=0)
@@ -1942,7 +1942,7 @@ async def test_collect_channel_cancelled_during_batch():
     assert count == 0  # all messages dropped because channel deleted
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_username_not_occupied_deactivates():
     """UsernameNotOccupiedError from run_with_flood_wait(_collect_messages()) deactivates channel."""
     ch = Channel(id=5, channel_id=123, title="Test", username="gone")
@@ -1980,7 +1980,7 @@ async def test_collect_channel_username_not_occupied_deactivates():
     db.set_channel_active.assert_called_once_with(5, False)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_flush_error_in_finally():
     """Error flushing batch in finally block sets stop_due_to_persistence_error."""
     ch = Channel(channel_id=123, title="Test", username="test")
@@ -2008,7 +2008,7 @@ async def test_collect_channel_flush_error_in_finally():
     assert result == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_channel_update_last_id_error():
     """Error updating last_collected_id in finally is caught."""
     ch = Channel(channel_id=123, title="Test", username="test")
@@ -2048,7 +2048,7 @@ async def test_collect_channel_update_last_id_error():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auto_delete_caching():
     pool = make_mock_pool()
     db = MagicMock()
@@ -2073,7 +2073,7 @@ async def test_auto_delete_caching():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_no_availability_fn():
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
     del pool.get_stats_availability  # No availability function
@@ -2085,7 +2085,7 @@ async def test_collect_stats_no_availability_fn():
         await collector._collect_channel_stats(channel)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_availability_not_async():
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=None))
     pool.get_stats_availability = MagicMock(return_value="not_async")  # not awaitable
@@ -2103,7 +2103,7 @@ async def test_collect_stats_availability_not_async():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_flood_wait_retries():
     channel = Channel(channel_id=123, username="test")
 
@@ -2138,7 +2138,7 @@ async def test_collect_stats_flood_wait_retries():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_stats_availability_delegates():
     pool = make_mock_pool()
     pool.get_stats_availability = AsyncMock(

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -35,7 +35,7 @@ class _FakeClient:
         return self._download_return
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_creates_output_dir(tmp_path, monkeypatch):
     """output_dir must be created (mkdir) and returned path must be inside it."""
     db = Database(str(tmp_path / "test.db"))
@@ -70,7 +70,7 @@ async def test_download_media_creates_output_dir(tmp_path, monkeypatch):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_download_media_rejects_path_escape(tmp_path, monkeypatch):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()
@@ -100,7 +100,7 @@ async def test_download_media_rejects_path_escape(tmp_path, monkeypatch):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_accounts_connect_reads_session_from_db(tmp_path):
     """accounts.connect handler must NOT accept session_string from payload;
     it reads it from the accounts table."""
@@ -124,7 +124,7 @@ async def test_accounts_connect_reads_session_from_db(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_accounts_connect_raises_for_unknown_phone(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()
@@ -139,7 +139,7 @@ async def test_accounts_connect_raises_for_unknown_phone(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_service_uses_config_prefixes(tmp_path):
     """dispatcher._notification_service must propagate bot prefixes from AppConfig."""
     from src.config import AppConfig
@@ -160,7 +160,7 @@ async def test_notification_service_uses_config_prefixes(tmp_path):
         await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_service_without_config_uses_defaults(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -9,13 +9,13 @@ import pytest
 from src.telegram.utils import normalize_utc
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_utc_none_returns_none():
     """None input returns None."""
     assert normalize_utc(None) is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_utc_naive_treated_as_utc():
     """Naive datetime gets UTC tzinfo."""
     naive = datetime(2024, 3, 15, 10, 30, 45)
@@ -31,7 +31,7 @@ async def test_normalize_utc_naive_treated_as_utc():
     assert result.second == 45
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_utc_aware_converted():
     """Non-UTC timezone converted to UTC."""
     # Create datetime in UTC+5
@@ -46,7 +46,7 @@ async def test_normalize_utc_aware_converted():
     assert result.minute == 30
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_utc_already_utc():
     """Already-UTC datetime returned as-is."""
     utc_dt = datetime(2024, 3, 15, 10, 30, 45, tzinfo=timezone.utc)
@@ -55,7 +55,7 @@ async def test_normalize_utc_already_utc():
     assert result == utc_dt
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_normalize_utc_preserves_values():
     """Time components unchanged after conversion from naive."""
     naive = datetime(2024, 12, 31, 23, 59, 59, 999999)

--- a/tests/test_translation_service.py
+++ b/tests/test_translation_service.py
@@ -36,14 +36,14 @@ def test_detect_language_none_for_short():
 
 # ── translate_message ────────────────────────────────────────────────
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_skips_same_language():
     svc = TranslationService(db=AsyncMock())
     result = await svc.translate_message("Привет", "ru", "ru")
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_calls_provider():
     mock_provider = AsyncMock(return_value="Hello, how are you?")
     mock_provider_service = MagicMock()
@@ -55,7 +55,7 @@ async def test_translate_message_calls_provider():
     mock_provider.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_no_provider():
     svc = TranslationService(db=AsyncMock(), provider_service=None)
     result = await svc.translate_message("你好", "zh", "en")
@@ -64,7 +64,7 @@ async def test_translate_message_no_provider():
 
 # ── translate_batch ──────────────────────────────────────────────────
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch():
     mock_provider = AsyncMock(return_value="1: Hello\n2: Good morning")
     mock_provider_service = MagicMock()
@@ -84,7 +84,7 @@ async def test_translate_batch():
     assert results[1] == (2, "Good morning")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_skips_same_lang():
     mock_provider_service = MagicMock()
     svc = TranslationService(db=AsyncMock(), provider_service=mock_provider_service)
@@ -133,7 +133,7 @@ def test_get_source_filter():
 
 # ── DB repository methods ───────────────────────────────────────────
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_language_stats(db):
     # Insert messages with detected_lang
     await db.repos.messages._db.execute(
@@ -156,7 +156,7 @@ async def test_language_stats(db):
     assert lang_map["ru"] == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_translation(db):
     await db.repos.messages._db.execute(
         "INSERT INTO messages (channel_id, message_id, text, date, detected_lang) VALUES (?, ?, ?, ?, ?)",
@@ -183,7 +183,7 @@ async def test_update_translation(db):
     assert msg.translation_custom == "Hallo"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_untranslated_messages(db):
     # Insert channels first for JOIN
     await db.repos.messages._db.execute(
@@ -206,7 +206,7 @@ async def test_get_untranslated_messages(db):
     assert msgs[0].detected_lang == "zh-cn"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_untranslated_with_source_filter(db):
     await db.repos.messages._db.execute(
         "INSERT OR IGNORE INTO channels (channel_id, title, username) VALUES (?, ?, ?)",
@@ -228,7 +228,7 @@ async def test_get_untranslated_with_source_filter(db):
     assert msgs[0].detected_lang == "zh-cn"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_backfill_language_detection(db):
     await db.repos.messages._db.execute(
         "INSERT INTO messages (channel_id, message_id, text, date) VALUES (?, ?, ?, ?)",
@@ -263,7 +263,7 @@ def test_detect_language_with_none_text():
 # ── translate_message with stub default provider ────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_skips_stub_default_provider():
     """When get_provider_callable returns the stub default, translate skips."""
     svc = TranslationService(db=AsyncMock())
@@ -278,7 +278,7 @@ async def test_translate_message_skips_stub_default_provider():
     assert result is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_message_exception_returns_none():
     """When provider raises, translate_message returns None."""
     mock_provider = AsyncMock(side_effect=RuntimeError("API down"))
@@ -295,14 +295,14 @@ async def test_translate_message_exception_returns_none():
 # ── translate_batch edge cases ──────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_empty_messages():
     svc = TranslationService(db=AsyncMock(), provider_service=MagicMock())
     result = await svc.translate_batch([], "en")
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_no_provider():
     svc = TranslationService(db=AsyncMock(), provider_service=None)
     msgs = [Message(id=1, channel_id=100, message_id=1, text="hi", detected_lang="ru", date=datetime.now(timezone.utc))]
@@ -310,7 +310,7 @@ async def test_translate_batch_no_provider():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_skips_stub_default_provider():
     """Batch translation should skip when only stub default provider available."""
     mock_default = AsyncMock(return_value="stub")
@@ -326,7 +326,7 @@ async def test_translate_batch_skips_stub_default_provider():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_provider_exception():
     """Batch translation returns [] when provider raises."""
     mock_provider = AsyncMock(side_effect=RuntimeError("API error"))
@@ -342,7 +342,7 @@ async def test_translate_batch_provider_exception():
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_provider_returns_none():
     """Batch translation returns [] when provider returns None."""
     mock_provider = AsyncMock(return_value=None)
@@ -361,7 +361,7 @@ async def test_translate_batch_provider_returns_none():
 # ── get_settings ────────────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_settings():
     mock_db = AsyncMock()
     mock_db.get_setting = AsyncMock(side_effect=lambda k: f"value_for_{k}")

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -33,7 +33,7 @@ def service(mock_db):
 # === get_trending_topics tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_empty_db(service, mock_db):
     """get_trending_topics returns empty list when no messages."""
     mock_db.execute_fetchall = AsyncMock(return_value=[])
@@ -43,7 +43,7 @@ async def test_get_trending_topics_empty_db(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_filters_high_frequency(service, mock_db):
     """get_trending_topics filters out words appearing in >85% of messages via max_df."""
     # "hello" appears in all 10 messages → 100% > max_df 85% → filtered
@@ -59,7 +59,7 @@ async def test_get_trending_topics_filters_high_frequency(service, mock_db):
     assert "topic" in keywords  # 30% documents → kept
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_respects_limit(service, mock_db):
     """get_trending_topics respects the limit parameter."""
     keywords = [
@@ -86,7 +86,7 @@ async def test_get_trending_topics_respects_limit(service, mock_db):
     assert {topic.keyword for topic in result}.issubset(set(keywords))
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_short_words_filtered(service, mock_db):
     """get_trending_topics filters words shorter than 4 characters."""
     mock_db.execute_fetchall = AsyncMock(
@@ -104,7 +104,7 @@ async def test_get_trending_topics_short_words_filtered(service, mock_db):
     assert "verify" in words
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_with_data(service, mock_db):
     """get_trending_topics processes and returns topics correctly."""
     mock_db.execute_fetchall = AsyncMock(
@@ -125,7 +125,7 @@ async def test_get_trending_topics_with_data(service, mock_db):
     assert important.count == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_non_alpha_only(service, mock_db):
     """get_trending_topics only includes alphabetic words (4+ chars, RU/EN)."""
     mock_db.execute_fetchall = AsyncMock(
@@ -145,7 +145,7 @@ async def test_get_trending_topics_non_alpha_only(service, mock_db):
     assert "keepword" in words
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_respects_days(service, mock_db):
     """get_trending_topics respects days parameter."""
     mock_db.execute_fetchall = AsyncMock(
@@ -164,7 +164,7 @@ async def test_get_trending_topics_respects_days(service, mock_db):
 # === get_trending_channels tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_channels_empty_db(service, mock_db):
     """get_trending_channels returns empty list when no data."""
     mock_db.execute_fetchall = AsyncMock(return_value=[])
@@ -174,7 +174,7 @@ async def test_get_trending_channels_empty_db(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_channels_with_min_messages(service, mock_db):
     """get_trending_channels only includes channels with >= 3 messages."""
     # SQL HAVING COUNT >= 3 filters, so mock only returns qualifying rows
@@ -198,7 +198,7 @@ async def test_get_trending_channels_with_min_messages(service, mock_db):
     assert result[0].message_count == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_channels_respects_limit(service, mock_db):
     """get_trending_channels respects the limit parameter."""
     # Mock returns 5 items (as SQL LIMIT would do)
@@ -223,7 +223,7 @@ async def test_get_trending_channels_respects_limit(service, mock_db):
 # === get_trending_emojis tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_emojis_empty_db(service, mock_db):
     """get_trending_emojis returns empty list when no reactions."""
     mock_db.execute_fetchall = AsyncMock(return_value=[])
@@ -233,7 +233,7 @@ async def test_get_trending_emojis_empty_db(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_emojis_from_reactions(service, mock_db):
     """get_trending_emojis aggregates reactions correctly."""
     mock_db.execute_fetchall = AsyncMock(
@@ -252,7 +252,7 @@ async def test_get_trending_emojis_from_reactions(service, mock_db):
     assert result[1].count == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_emojis_respects_limit(service, mock_db):
     """get_trending_emojis respects the limit parameter."""
     mock_db.execute_fetchall = AsyncMock(
@@ -267,7 +267,7 @@ async def test_get_trending_emojis_respects_limit(service, mock_db):
 # === get_message_velocity tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_message_velocity_empty(service, mock_db):
     """get_message_velocity returns empty list when no messages."""
     mock_db.execute_fetchall = AsyncMock(return_value=[])
@@ -277,7 +277,7 @@ async def test_get_message_velocity_empty(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_message_velocity_by_channel(service, mock_db):
     """get_message_velocity returns daily counts for a channel."""
     mock_db.execute_fetchall = AsyncMock(
@@ -299,7 +299,7 @@ async def test_get_message_velocity_by_channel(service, mock_db):
 # === get_peak_hours tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_peak_hours_empty(service, mock_db):
     """get_peak_hours returns empty list when no messages."""
     mock_db.execute_fetchall = AsyncMock(return_value=[])
@@ -309,7 +309,7 @@ async def test_get_peak_hours_empty(service, mock_db):
     assert result == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_peak_hours_distribution(service, mock_db):
     """get_peak_hours returns hourly distribution correctly."""
     mock_db.execute_fetchall = AsyncMock(
@@ -383,7 +383,7 @@ def test_peak_hour_dataclass():
 # === Regression tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_trending_topics_tfidf_suppresses_noise(service, mock_db):
     """Regression #329: words in every message should not appear in trends."""
     # "hello" appears in all 10 messages → max_df filters it out

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -124,7 +124,7 @@ def test_handled_types_contains_expected():
 # === start/stop tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_creates_task(dispatcher):
     """start() creates background task."""
     await dispatcher.start()
@@ -133,7 +133,7 @@ async def test_start_creates_task(dispatcher):
     await dispatcher.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_idempotent(dispatcher):
     """start() is idempotent - second call does nothing."""
     await dispatcher.start()
@@ -143,7 +143,7 @@ async def test_start_idempotent(dispatcher):
     await dispatcher.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_cancels_task(dispatcher):
     """stop() cancels background task."""
     await dispatcher.start()
@@ -151,13 +151,13 @@ async def test_stop_cancels_task(dispatcher):
     assert dispatcher._task is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stop_without_start(dispatcher):
     """stop() without start() does nothing."""
     await dispatcher.stop()  # Should not raise
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_requeues_interrupted_tasks(mock_collector, mock_channel_bundle, mock_tasks_repo):
     """start() requeues interrupted tasks on startup."""
     mock_tasks_repo.requeue_running_generic_tasks_on_startup.return_value = 3
@@ -175,7 +175,7 @@ async def test_start_requeues_interrupted_tasks(mock_collector, mock_channel_bun
     mock_tasks_repo.requeue_running_generic_tasks_on_startup.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_stops_after_cancelled_result(
     mock_collector,
     mock_channel_bundle,
@@ -213,7 +213,7 @@ async def test_handle_stats_all_stops_after_cancelled_result(
 # === _run_loop tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_loop_processes_task(mock_collector, mock_channel_bundle, mock_tasks_repo):
     """_run_loop processes available tasks."""
     task = CollectionTask(
@@ -241,7 +241,7 @@ async def test_run_loop_processes_task(mock_collector, mock_channel_bundle, mock
 # === _handle_stats_all tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_empty_channels(dispatcher, mock_tasks_repo):
     """_handle_stats_all completes immediately if next_index >= len(channel_ids)."""
     task = CollectionTask(
@@ -262,7 +262,7 @@ async def test_handle_stats_all_empty_channels(dispatcher, mock_tasks_repo):
     assert args[1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_no_task_id(dispatcher, mock_tasks_repo):
     """_handle_stats_all returns early if task.id is None."""
     task = CollectionTask(
@@ -277,7 +277,7 @@ async def test_handle_stats_all_no_task_id(dispatcher, mock_tasks_repo):
     mock_tasks_repo.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_invalid_payload(dispatcher, mock_tasks_repo):
     """_handle_stats_all fails if payload is wrong type."""
     task = CollectionTask(
@@ -294,7 +294,7 @@ async def test_handle_stats_all_invalid_payload(dispatcher, mock_tasks_repo):
     assert args[1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_processes_batch(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -322,7 +322,7 @@ async def test_handle_stats_all_processes_batch(
     assert mock_collector.collect_channel_stats.call_count == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_channel_not_found(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -352,7 +352,7 @@ async def test_handle_stats_all_channel_not_found(
     mock_collector.collect_channel_stats.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_timeout(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -385,7 +385,7 @@ async def test_handle_stats_all_timeout(
     assert kwargs.get("messages_collected") == 1  # channel processed despite error
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_stats_unavailable(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -420,7 +420,7 @@ async def test_handle_stats_all_stats_unavailable(
     assert args[1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_flood_wait_reschedules_same_task(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -463,7 +463,7 @@ async def test_handle_stats_all_flood_wait_reschedules_same_task(
 # === _handle_sq_stats tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_sq_stats_success(dispatcher, mock_tasks_repo, mock_sq_bundle):
     """_handle_sq_stats records stats successfully."""
     dispatcher._sq_bundle = mock_sq_bundle
@@ -483,7 +483,7 @@ async def test_handle_sq_stats_success(dispatcher, mock_tasks_repo, mock_sq_bund
     assert args[1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_sq_stats_no_bundle(dispatcher, mock_tasks_repo):
     """_handle_sq_stats completes with note when no bundle configured."""
     dispatcher._sq_bundle = None
@@ -503,7 +503,7 @@ async def test_handle_sq_stats_no_bundle(dispatcher, mock_tasks_repo):
     assert "note" in kwargs
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_sq_stats_invalid_payload(dispatcher, mock_tasks_repo):
     """_handle_sq_stats fails with invalid payload."""
     dispatcher._sq_bundle = MagicMock()
@@ -522,7 +522,7 @@ async def test_handle_sq_stats_invalid_payload(dispatcher, mock_tasks_repo):
     assert args[1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_sq_stats_query_not_found(dispatcher, mock_tasks_repo, mock_sq_bundle):
     """_handle_sq_stats completes when query not found."""
     dispatcher._sq_bundle = mock_sq_bundle
@@ -542,7 +542,7 @@ async def test_handle_sq_stats_query_not_found(dispatcher, mock_tasks_repo, mock
     assert args[1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_sq_stats_exception(dispatcher, mock_tasks_repo, mock_sq_bundle):
     """_handle_sq_stats handles exceptions."""
     dispatcher._sq_bundle = mock_sq_bundle
@@ -565,7 +565,7 @@ async def test_handle_sq_stats_exception(dispatcher, mock_tasks_repo, mock_sq_bu
 # === _handle_photo_due tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_photo_due_success(dispatcher, mock_tasks_repo, mock_photo_task_service):
     """_handle_photo_due processes due photos."""
     dispatcher._photo_task_service = mock_photo_task_service
@@ -586,7 +586,7 @@ async def test_handle_photo_due_success(dispatcher, mock_tasks_repo, mock_photo_
     assert kwargs.get("messages_collected") == 5
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_photo_due_no_service(dispatcher, mock_tasks_repo):
     """_handle_photo_due fails when no service configured (was COMPLETED silently)."""
     dispatcher._photo_task_service = None
@@ -605,7 +605,7 @@ async def test_handle_photo_due_no_service(dispatcher, mock_tasks_repo):
     assert args[1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_photo_due_exception(dispatcher, mock_tasks_repo, mock_photo_task_service):
     """_handle_photo_due handles exceptions."""
     dispatcher._photo_task_service = mock_photo_task_service
@@ -628,7 +628,7 @@ async def test_handle_photo_due_exception(dispatcher, mock_tasks_repo, mock_phot
 # === _handle_photo_auto tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_photo_auto_success(dispatcher, mock_tasks_repo, mock_photo_auto_upload_service):
     """_handle_photo_auto processes auto jobs."""
     dispatcher._photo_auto_upload_service = mock_photo_auto_upload_service
@@ -649,7 +649,7 @@ async def test_handle_photo_auto_success(dispatcher, mock_tasks_repo, mock_photo
     assert kwargs.get("messages_collected") == 3
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_photo_auto_no_service(dispatcher, mock_tasks_repo):
     """_handle_photo_auto fails when no service configured (was COMPLETED silently)."""
     dispatcher._photo_auto_upload_service = None
@@ -671,7 +671,7 @@ async def test_handle_photo_auto_no_service(dispatcher, mock_tasks_repo):
 # === _handle_pipeline_run tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_pipeline_run_invalid_payload(dispatcher, mock_tasks_repo):
     """_handle_pipeline_run fails with invalid payload."""
     dispatcher._pipeline_bundle = MagicMock()
@@ -693,7 +693,7 @@ async def test_handle_pipeline_run_invalid_payload(dispatcher, mock_tasks_repo):
     assert "Invalid PIPELINE_RUN payload" in kwargs.get("error", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_pipeline_run_missing_deps(dispatcher, mock_tasks_repo):
     """_handle_pipeline_run fails when dependencies not configured."""
     dispatcher._pipeline_bundle = None
@@ -718,7 +718,7 @@ async def test_handle_pipeline_run_missing_deps(dispatcher, mock_tasks_repo):
 # === _dispatch tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatch_unknown_type(dispatcher, mock_tasks_repo):
     """_dispatch fails for unknown task type."""
     task = CollectionTask(
@@ -739,7 +739,7 @@ async def test_dispatch_unknown_type(dispatcher, mock_tasks_repo):
 # === Error recovery tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_loop_handles_exception(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -782,7 +782,7 @@ async def test_run_loop_handles_exception(
 # === _handle_pipeline_run extended tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_pipeline_run_success_with_mocked_services(
     dispatcher, mock_tasks_repo
 ):
@@ -829,7 +829,7 @@ async def test_handle_pipeline_run_success_with_mocked_services(
     assert args[1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_pipeline_run_pipeline_not_found(dispatcher, mock_tasks_repo):
     """_handle_pipeline_run completes when pipeline not found."""
     mock_pipeline_bundle = MagicMock()
@@ -854,7 +854,7 @@ async def test_handle_pipeline_run_pipeline_not_found(dispatcher, mock_tasks_rep
     assert "not found" in kwargs.get("note", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_repo):
     """_handle_pipeline_run handles generation errors."""
     from unittest.mock import patch
@@ -898,7 +898,7 @@ async def test_handle_pipeline_run_generation_exception(dispatcher, mock_tasks_r
 # === _handle_content_generate tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_repo):
     """_handle_content_generate publishes automatically when mode is AUTO."""
     from unittest.mock import patch
@@ -954,7 +954,7 @@ async def test_handle_content_generate_with_auto_publish(dispatcher, mock_tasks_
     assert args[1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_generate_without_auto_publish(
     dispatcher, mock_tasks_repo
 ):
@@ -1003,7 +1003,7 @@ async def test_handle_content_generate_without_auto_publish(
     assert kwargs.get("messages_collected") == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_generate_pipeline_not_found(
     dispatcher, mock_tasks_repo
 ):
@@ -1030,7 +1030,7 @@ async def test_handle_content_generate_pipeline_not_found(
     assert "not found" in kwargs.get("note", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_generate_exception(dispatcher, mock_tasks_repo):
     """_handle_content_generate handles exceptions."""
     from unittest.mock import patch
@@ -1067,7 +1067,7 @@ async def test_handle_content_generate_exception(dispatcher, mock_tasks_repo):
 # === _handle_content_publish tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_publish_no_approved_runs(dispatcher, mock_tasks_repo):
     """_handle_content_publish completes when no approved runs."""
     mock_db = MagicMock()
@@ -1098,7 +1098,7 @@ async def test_handle_content_publish_no_approved_runs(dispatcher, mock_tasks_re
     assert "No approved runs" in kwargs.get("note", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
     """_handle_content_publish publishes approved runs."""
     from unittest.mock import patch
@@ -1170,7 +1170,7 @@ async def test_handle_content_publish_success(dispatcher, mock_tasks_repo):
 # === _handle_stats_all extended edge cases ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_timeout_waiting_for_collector(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -1203,7 +1203,7 @@ async def test_handle_stats_all_timeout_waiting_for_collector(
     assert "Timed out" in kwargs.get("error", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handle_stats_all_exception_during_stats(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -1241,7 +1241,7 @@ async def test_handle_stats_all_exception_during_stats(
 # === _run_loop extended exception recovery tests ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_loop_marks_task_failed_on_unexpected_exception(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):
@@ -1290,7 +1290,7 @@ async def test_run_loop_marks_task_failed_on_unexpected_exception(
 # === _build_image_service ===
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_image_service_no_config(mock_collector, mock_channel_bundle, mock_tasks_repo):
     """Without config, falls back to env-based registration."""
     dispatcher = UnifiedDispatcher(
@@ -1302,7 +1302,7 @@ async def test_build_image_service_no_config(mock_collector, mock_channel_bundle
     assert svc is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_image_service_with_db_config(
     mock_collector, mock_channel_bundle, mock_tasks_repo, db, monkeypatch,
 ):
@@ -1332,7 +1332,7 @@ async def test_build_image_service_with_db_config(
     assert "together" in svc.adapter_names
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_image_service_disabled_blocks_env(
     mock_collector, mock_channel_bundle, mock_tasks_repo, db, monkeypatch,
 ):

--- a/tests/test_unified_dispatcher_pipeline_runs.py
+++ b/tests/test_unified_dispatcher_pipeline_runs.py
@@ -69,7 +69,7 @@ def _task(task_type, task_id=1, payload=None, status=CollectionTaskStatus.RUNNIN
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_full_flow_with_chaining():
     """Translate batch processes messages and chains follow-up task when more remain."""
     mock_db = MagicMock()
@@ -120,7 +120,7 @@ async def test_translate_batch_full_flow_with_chaining():
     d._tasks.create_generic_task.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_no_remaining_no_chain():
     """Translate batch does not chain when no more messages remain."""
     mock_db = MagicMock()
@@ -155,7 +155,7 @@ async def test_translate_batch_no_remaining_no_chain():
     d._tasks.create_generic_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_no_messages():
     """Translate batch completes immediately when no messages to translate."""
     mock_db = MagicMock()
@@ -182,7 +182,7 @@ async def test_translate_batch_no_messages():
     assert "No more messages" in call[1].get("note", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_only_stub_provider():
     """Translate batch fails when only the stub default provider is available."""
     mock_db = MagicMock()
@@ -206,7 +206,7 @@ async def test_translate_batch_only_stub_provider():
     assert "stub" in call[1].get("error", "").lower()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_exception():
     """Translate batch handles exceptions during processing."""
     mock_db = MagicMock()
@@ -229,7 +229,7 @@ async def test_translate_batch_exception():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_auto_publish_failure():
     """Auto-publish failure marks task as FAILED with descriptive error."""
     d = _make_dispatcher()
@@ -278,7 +278,7 @@ async def test_content_generate_auto_publish_failure():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_with_approved_runs():
     """Publish approved runs successfully."""
     d = _make_dispatcher()
@@ -349,7 +349,7 @@ async def test_content_publish_with_approved_runs():
     assert call[1].get("messages_collected") == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_run_without_pipeline_id():
     """Runs with pipeline_id=None are skipped during publish."""
     d = _make_dispatcher()
@@ -404,7 +404,7 @@ async def test_content_publish_run_without_pipeline_id():
     assert call[1].get("messages_collected") == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_pipeline_not_found():
     """Runs whose pipeline is not found are skipped."""
     d = _make_dispatcher()
@@ -462,7 +462,7 @@ async def test_content_publish_pipeline_not_found():
     assert call[1].get("messages_collected") == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_exception():
     """Exception during publish marks task as FAILED."""
     d = _make_dispatcher()
@@ -491,7 +491,7 @@ async def test_content_publish_exception():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_outer_exception_during_setup():
     """Exception during service setup is caught by outer try/except."""
     d = _make_dispatcher()
@@ -522,7 +522,7 @@ async def test_pipeline_run_outer_exception_during_setup():
     assert call[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_generation_fails_with_run_id():
     """Generation failure with run_id set marks both run and task as failed."""
     d = _make_dispatcher()
@@ -561,7 +561,7 @@ async def test_pipeline_run_generation_fails_with_run_id():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_run_loop_marks_running_task_failed_on_exception():
     """When dispatch raises unexpectedly, running task should be marked failed."""
     d = _make_dispatcher(poll_interval_sec=0.01)
@@ -621,7 +621,7 @@ async def test_run_loop_marks_running_task_failed_on_exception():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_stop_event_interrupts_batch():
     """When stop_event is set during batch processing, handler exits early."""
     d = _make_dispatcher(poll_interval_sec=0.01)
@@ -640,7 +640,7 @@ async def test_stats_all_stop_event_interrupts_batch():
     d._collector.collect_channel_stats.assert_not_awaited()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_successful_completion():
     """Full batch processes all channels and completes."""
     d = _make_dispatcher(poll_interval_sec=0.01)
@@ -663,7 +663,7 @@ async def test_stats_all_successful_completion():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_exception_during_stat_recording():
     """Exception during stat recording marks task as failed."""
     d = _make_dispatcher()
@@ -688,7 +688,7 @@ async def test_sq_stats_exception_during_stat_recording():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_moderated_mode_no_publish():
     """Content generate with moderated mode does not auto-publish."""
     d = _make_dispatcher()
@@ -739,7 +739,7 @@ def test_handled_types_includes_translate_batch():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_handler_map_cached():
     """_handler_map returns the same dict on subsequent calls."""
     d = _make_dispatcher()
@@ -753,7 +753,7 @@ async def test_handler_map_cached():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_recovered_tasks_logged():
     """start() recovers interrupted tasks and logs the count."""
     d = _make_dispatcher()
@@ -771,7 +771,7 @@ async def test_start_recovered_tasks_logged():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_pipeline_not_found():
     """When pipeline not found, task is marked COMPLETED with note."""
     d = _make_dispatcher()
@@ -799,7 +799,7 @@ async def test_content_generate_pipeline_not_found():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_pipeline_not_found_with_deps():
     """Pipeline not found returns COMPLETED with note even with all deps set."""
     d = _make_dispatcher()

--- a/tests/test_unified_dispatcher_tasks.py
+++ b/tests/test_unified_dispatcher_tasks.py
@@ -49,7 +49,7 @@ def _dispatcher(**kw):
     return UnifiedDispatcher(**defaults)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dispatch_unknown_type():
     d = _dispatcher()
     # CHANNEL_COLLECT is not in the handler map, so it triggers "Unknown" path
@@ -60,21 +60,21 @@ async def test_dispatch_unknown_type():
     assert "Unknown" in call[1]["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_no_id():
     d = _dispatcher()
     await d._handle_stats_all(_task(CollectionTaskType.STATS_ALL, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_wrong_payload():
     d = _dispatcher()
     await d._handle_stats_all(_task(CollectionTaskType.STATS_ALL, payload={"bad": True}))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_empty_ids_completes():
     d = _dispatcher()
     p = StatsAllTaskPayload(channel_ids=[])
@@ -82,7 +82,7 @@ async def test_stats_all_empty_ids_completes():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_collects_and_completes():
     d = _dispatcher()
     ch = MagicMock(channel_id=42)
@@ -92,7 +92,7 @@ async def test_stats_all_collects_and_completes():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_channel_not_found():
     d = _dispatcher()
     d._channel_bundle.get_by_channel_id = AsyncMock(return_value=None)
@@ -101,7 +101,7 @@ async def test_stats_all_channel_not_found():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_reschedules_on_flood_wait():
     """_handle_stats_all reschedules same task when all clients flooded."""
     d = _dispatcher()
@@ -121,21 +121,21 @@ async def test_stats_all_reschedules_on_flood_wait():
     assert call_args[1]["payload"].next_index == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_no_id():
     d = _dispatcher()
     await d._handle_sq_stats(_task(CollectionTaskType.SQ_STATS, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_no_bundle():
     d = _dispatcher(sq_bundle=None)
     await d._handle_sq_stats(_task(CollectionTaskType.SQ_STATS))
     d._tasks.update_collection_task.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_wrong_payload():
     sq_bundle = MagicMock()
     d = _dispatcher(sq_bundle=sq_bundle)
@@ -143,7 +143,7 @@ async def test_sq_stats_wrong_payload():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_query_not_found():
     sq_bundle = MagicMock()
     sq_bundle.get_by_id = AsyncMock(return_value=None)
@@ -153,7 +153,7 @@ async def test_sq_stats_query_not_found():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_sq_stats_records_stat():
     sq = MagicMock(query="test query")
     sq_bundle = MagicMock()
@@ -166,21 +166,21 @@ async def test_sq_stats_records_stat():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_due_no_id():
     d = _dispatcher()
     await d._handle_photo_due(_task(CollectionTaskType.PHOTO_DUE, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_due_no_service():
     d = _dispatcher(photo_task_service=None)
     await d._handle_photo_due(_task(CollectionTaskType.PHOTO_DUE))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_due_success():
     pts = AsyncMock()
     pts.run_due = AsyncMock(return_value=5)
@@ -189,7 +189,7 @@ async def test_photo_due_success():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_due_error():
     pts = AsyncMock()
     pts.run_due = AsyncMock(side_effect=RuntimeError("boom"))
@@ -198,21 +198,21 @@ async def test_photo_due_error():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_no_id():
     d = _dispatcher()
     await d._handle_photo_auto(_task(CollectionTaskType.PHOTO_AUTO, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_no_service():
     d = _dispatcher(photo_auto_upload_service=None)
     await d._handle_photo_auto(_task(CollectionTaskType.PHOTO_AUTO))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_success():
     paus = AsyncMock()
     paus.run_due = AsyncMock(return_value=3)
@@ -221,7 +221,7 @@ async def test_photo_auto_success():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.COMPLETED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_photo_auto_error():
     paus = AsyncMock()
     paus.run_due = AsyncMock(side_effect=RuntimeError("boom"))
@@ -230,21 +230,21 @@ async def test_photo_auto_error():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_no_id():
     d = _dispatcher()
     await d._handle_pipeline_run(_task(CollectionTaskType.PIPELINE_RUN, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_wrong_payload():
     d = _dispatcher()
     await d._handle_pipeline_run(_task(CollectionTaskType.PIPELINE_RUN, payload={"bad": True}))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pipeline_run_no_deps():
     d = _dispatcher(pipeline_bundle=None, search_engine=None, db=None)
     p = PipelineRunTaskPayload(pipeline_id=1)
@@ -252,21 +252,21 @@ async def test_pipeline_run_no_deps():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_no_id():
     d = _dispatcher()
     await d._handle_content_generate(_task(CollectionTaskType.CONTENT_GENERATE, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_wrong_payload():
     d = _dispatcher()
     await d._handle_content_generate(_task(CollectionTaskType.CONTENT_GENERATE, payload={"bad": True}))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_generate_no_deps():
     d = _dispatcher(pipeline_bundle=None, search_engine=None, db=None)
     p = ContentGenerateTaskPayload(pipeline_id=1)
@@ -274,21 +274,21 @@ async def test_content_generate_no_deps():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_no_id():
     d = _dispatcher()
     await d._handle_content_publish(_task(CollectionTaskType.CONTENT_PUBLISH, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_wrong_payload():
     d = _dispatcher()
     await d._handle_content_publish(_task(CollectionTaskType.CONTENT_PUBLISH, payload={"bad": True}))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_content_publish_no_deps():
     d = _dispatcher(pipeline_bundle=None, db=None)
     p = ContentPublishTaskPayload(pipeline_id=1)
@@ -296,21 +296,21 @@ async def test_content_publish_no_deps():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_no_id():
     d = _dispatcher()
     await d._handle_translate_batch(_task(CollectionTaskType.TRANSLATE_BATCH, task_id=None))
     d._tasks.update_collection_task.assert_not_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_wrong_payload():
     d = _dispatcher()
     await d._handle_translate_batch(_task(CollectionTaskType.TRANSLATE_BATCH, payload={"bad": True}))
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_translate_batch_no_db():
     d = _dispatcher(db=None)
     p = TranslateBatchTaskPayload()
@@ -318,7 +318,7 @@ async def test_translate_batch_no_db():
     assert d._tasks.update_collection_task.call_args[0][1] == CollectionTaskStatus.FAILED
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_stop():
     d = _dispatcher()
     await d.start()
@@ -327,7 +327,7 @@ async def test_start_stop():
     assert d._task is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_idempotent():
     d = _dispatcher()
     await d.start()
@@ -337,14 +337,14 @@ async def test_start_idempotent():
     await d.stop()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_image_service_no_db():
     d = _dispatcher(db=None, config=None)
     svc = await d._build_image_service()
     assert svc is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_build_image_service_db_exception():
     mock_db = MagicMock()
     mock_config = MagicMock()
@@ -390,7 +390,7 @@ class TestPipelineRunHappyPathSemantics:
     GenerationRun.result_count exactly — for all three run shapes.
     """
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_generation_run_maps_citation_count_to_messages_collected(self, monkeypatch):
         from tests.factories.pipeline_runs import make_generation_run
 
@@ -430,7 +430,7 @@ class TestPipelineRunHappyPathSemantics:
         assert call.kwargs["messages_collected"] == 3
         assert "id=42" in call.kwargs["note"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_action_only_run_propagates_action_count(self, monkeypatch):
         from tests.factories.pipeline_runs import make_action_only_run
 
@@ -465,7 +465,7 @@ class TestPipelineRunHappyPathSemantics:
         assert call.kwargs["messages_collected"] == 5
         assert call.args[1] == CollectionTaskStatus.COMPLETED
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_mixed_run_uses_generation_count(self, monkeypatch):
         """Mixed run: dispatcher stores generation count (not action count),
         consistent with summarize_result() precedence.
@@ -502,7 +502,7 @@ class TestPipelineRunHappyPathSemantics:
         call = d._tasks.update_collection_task.call_args
         assert call.kwargs["messages_collected"] == 2  # generation wins
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_empty_text_positive_count_regression(self, monkeypatch):
         """Issue #463 regression: run with empty text but positive result_count
         must NOT be stored as messages_collected=0.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -102,7 +102,7 @@ async def client(tmp_path, real_pool_harness_factory):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_health_endpoint(client):
     resp = await client.get("/health")
     assert resp.status_code == 200
@@ -112,7 +112,7 @@ async def test_health_endpoint(client):
     assert "accounts_connected" in data
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_health_endpoint_logs_db_probe_failure(client, monkeypatch, caplog):
     async def _broken_execute(query):
         raise RuntimeError("db unavailable")
@@ -127,7 +127,7 @@ async def test_health_endpoint_logs_db_probe_failure(client, monkeypatch, caplog
     assert "Health check DB probe failed" in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dashboard(client):
     resp = await client.get("/dashboard/")
     assert resp.status_code == 200
@@ -172,7 +172,7 @@ def test_agent_available_ignores_invalid_fallback_model(monkeypatch):
     assert _agent_available_for_request(request) is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_footer_renders_actual_version(client):
     expected_version = tomllib.loads(
         PYPROJECT_PATH.read_text(encoding="utf-8"),
@@ -184,14 +184,14 @@ async def test_footer_renders_actual_version(client):
     assert f"TG Agent v{expected_version}" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_login_page(client):
     resp = await client.get("/auth/login")
     assert resp.status_code == 200
     assert "/settings" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_page_without_auth(unauth_client):
     resp = await unauth_client.get("/login", follow_redirects=False)
     assert resp.status_code == 200
@@ -199,7 +199,7 @@ async def test_web_login_page_without_auth(unauth_client):
     assert 'action="/login"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_rejects_unsafe_next_without_auth(unauth_client):
     resp = await unauth_client.get(
         "/login?next=https://evil.example",
@@ -209,7 +209,7 @@ async def test_web_login_rejects_unsafe_next_without_auth(unauth_client):
     assert 'name="next" value="/"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page(client):
     resp = await client.get("/settings/")
     assert resp.status_code == 200
@@ -222,7 +222,7 @@ async def test_settings_page(client):
     assert "activateTabFromHash" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_static_js_handles_pane_hashes(client):
     resp = await client.get("/static/settings.js")
     assert resp.status_code == 200
@@ -231,7 +231,7 @@ async def test_settings_static_js_handles_pane_hashes(client):
     assert "hashchange" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_image_providers_tab(client):
     resp = await client.get("/settings/")
     assert resp.status_code == 200
@@ -239,7 +239,7 @@ async def test_settings_page_image_providers_tab(client):
     assert "Изображения" in resp.text  # tab label
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_image_provider(client):
     resp = await client.post(
         "/settings/image-providers/add",
@@ -251,7 +251,7 @@ async def test_add_image_provider(client):
     assert "Together AI" in resp2.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_image_provider_invalid(client):
     resp = await client.post(
         "/settings/image-providers/add",
@@ -261,7 +261,7 @@ async def test_add_image_provider_invalid(client):
     assert "error=image_provider_invalid" in str(resp.url)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_image_providers(client):
     # First add a provider
     await client.post("/settings/image-providers/add", data={"provider": "openai"})
@@ -277,14 +277,14 @@ async def test_save_image_providers(client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_image_provider(client):
     await client.post("/settings/image-providers/add", data={"provider": "replicate"})
     resp = await client.post("/settings/image-providers/replicate/delete")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_images_page_shows_db_configured_provider(client):
     """Provider added via Settings should appear on /images page."""
     # Add provider with API key via settings
@@ -303,7 +303,7 @@ async def test_images_page_shows_db_configured_provider(client):
     assert "replicate" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_startup_continues_after_pool_initialize_timeout(tmp_path, db, caplog, monkeypatch):
     """start_container proceeds when pool.initialize() hangs past the timeout."""
     import asyncio
@@ -350,7 +350,7 @@ async def test_startup_continues_after_pool_initialize_timeout(tmp_path, db, cap
     assert "telegram pool timed out" in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_hides_credentials_form_when_env_credentials_configured(
     client, monkeypatch
 ):
@@ -371,7 +371,7 @@ async def test_settings_page_hides_credentials_form_when_env_credentials_configu
     assert template_text.index("_accounts.html") < template_text.index("_scheduler.html")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_keeps_credentials_form_for_invalid_env_api_id(client, monkeypatch):
     monkeypatch.setenv("TG_API_ID", "not-a-number")
     monkeypatch.setenv("TG_API_HASH", "env-hash")
@@ -383,7 +383,7 @@ async def test_settings_page_keeps_credentials_form_for_invalid_env_api_id(clien
     assert 'action="/settings/save-credentials"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
     db = client._transport.app.state.db
     await db.set_setting("min_subscribers_filter", "broken")
@@ -398,7 +398,7 @@ async def test_settings_page_ignores_invalid_persisted_numeric_settings(client):
     assert 'value="60"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_semantic_persists_values_and_resets_index(client):
     db = client._transport.app.state.db
     await db.insert_messages_batch(
@@ -437,7 +437,7 @@ async def test_settings_save_semantic_persists_values_and_resets_index(client):
     assert await db.get_setting("semantic_last_embedded_id") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_semantic_index_runs_embedding_service(client, monkeypatch):
     monkeypatch.setattr(
         EmbeddingService,
@@ -452,7 +452,7 @@ async def test_settings_semantic_index_runs_embedding_service(client, monkeypatc
     assert "indexed=7" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_persists_dev_mode_and_override(client):
     db = client._transport.app.state.db
     # Need a valid provider config for deepagents override to be accepted
@@ -483,7 +483,7 @@ async def test_settings_save_agent_persists_dev_mode_and_override(client):
     assert await db.get_setting("agent_backend_override") == "deepagents"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_shows_ai_agent_block_only_in_dev_mode(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -505,7 +505,7 @@ async def test_settings_page_shows_ai_agent_block_only_in_dev_mode(client):
     assert 'name="agent_form_scope" value="prompt_template"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_preserves_override_when_toggling_dev_mode_only(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_backend_override", "deepagents")
@@ -535,7 +535,7 @@ async def test_settings_save_agent_preserves_override_when_toggling_dev_mode_onl
     assert await db.get_setting("agent_backend_override") == "deepagents"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_requires_disclaimer_to_enable_dev_mode(client):
     db = client._transport.app.state.db
 
@@ -549,7 +549,7 @@ async def test_settings_save_agent_requires_disclaimer_to_enable_dev_mode(client
     assert await db.get_setting("agent_dev_mode_enabled") == "0"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_backend_override_keeps_dev_mode_enabled(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -580,7 +580,7 @@ async def test_settings_save_agent_backend_override_keeps_dev_mode_enabled(clien
     assert await db.get_setting("agent_backend_override") == "deepagents"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_can_disable_dev_mode_without_disclaimer(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -598,7 +598,7 @@ async def test_settings_save_agent_can_disable_dev_mode_without_disclaimer(clien
     assert await db.get_setting("agent_backend_override") == "auto"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_persists_prompt_template(client):
     db = client._transport.app.state.db
     template = "Канал: {channel_title}\nТема: {topic}\nДата: {date}\n{source_messages}"
@@ -616,7 +616,7 @@ async def test_settings_save_agent_persists_prompt_template(client):
     assert await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) == template
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_rejects_invalid_prompt_template(client):
     db = client._transport.app.state.db
     await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, "Канал: {channel_title}")
@@ -635,7 +635,7 @@ async def test_settings_save_agent_rejects_invalid_prompt_template(client):
     assert await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) == "Канал: {channel_title}"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_blank_prompt_template_resets_to_default(client):
     db = client._transport.app.state.db
     await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, "Канал: {channel_title}")
@@ -653,7 +653,7 @@ async def test_settings_save_agent_blank_prompt_template_resets_to_default(clien
     assert await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) == DEFAULT_AGENT_PROMPT_TEMPLATE
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_backend_override_submit_keeps_ai_agent_block_visible(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -675,7 +675,7 @@ async def test_settings_backend_override_submit_keeps_ai_agent_block_visible(cli
     assert "Backend override" in page.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_add_agent_provider_requires_dev_mode(client):
     db = client._transport.app.state.db
 
@@ -690,7 +690,7 @@ async def test_settings_add_agent_provider_requires_dev_mode(client):
     assert await db.get_setting("agent_deepagents_providers_v1") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_add_agent_provider_persists_provider_in_db(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -707,7 +707,7 @@ async def test_settings_add_agent_provider_persists_provider_in_db(client):
     assert "openai" in raw
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_providers_preserves_priority_order(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -750,7 +750,7 @@ async def test_settings_save_agent_providers_preserves_priority_order(client, mo
     assert raw.index('"provider": "anthropic"') < raw.index('"provider": "openai"')
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_providers_skips_probe_for_disabled_provider(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -786,7 +786,7 @@ async def test_settings_save_agent_providers_skips_probe_for_disabled_provider(c
     assert configs[0].last_validation_error == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_refresh_agent_provider_models_returns_json(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -812,7 +812,7 @@ async def test_settings_refresh_agent_provider_models_returns_json(client, monke
     assert "compatibility" in payload
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_refresh_agent_provider_models_uses_unsaved_form_values(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -850,7 +850,7 @@ async def test_settings_refresh_agent_provider_models_uses_unsaved_form_values(c
     assert seen_cfg.secret_fields["api_key"] == "unsaved-openai-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_refresh_provider_posts_unsaved_form_data(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -866,7 +866,7 @@ async def test_settings_page_refresh_provider_posts_unsaved_form_data(client):
     assert 'data-provider-refresh-btn="openai"' in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_refresh_agent_provider_models_preserves_saved_values_when_form_empty(
     client, monkeypatch
 ):
@@ -909,7 +909,7 @@ async def test_settings_refresh_agent_provider_models_preserves_saved_values_whe
     assert seen_cfg.secret_fields["api_key"] == "saved-openai-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_refresh_all_agent_provider_models_requires_dev_mode(client):
     resp = await client.post("/settings/agent-providers/refresh-all")
 
@@ -918,7 +918,7 @@ async def test_settings_refresh_all_agent_provider_models_requires_dev_mode(clie
     assert resp.json()["error"] == "Developer mode is required."
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_refresh_all_agent_provider_models_uses_unsaved_form_values(
     client, monkeypatch
 ):
@@ -971,7 +971,7 @@ async def test_settings_refresh_all_agent_provider_models_uses_unsaved_form_valu
     assert seen_cfg.secret_fields["api_key"] == "unsaved-openai-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_renders_selected_model_compatibility(client):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1011,7 +1011,7 @@ async def test_settings_page_renders_selected_model_compatibility(client):
     assert "gpt-4.1-mini [supported]" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_probe_agent_provider_model_returns_cached_json(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1055,7 +1055,7 @@ async def test_settings_probe_agent_provider_model_returns_cached_json(client, m
     assert any(record.status == "supported" for record in cache["openai"].compatibility.values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_save_agent_providers_keeps_unsupported_probe_in_cache_only(
     client, monkeypatch
 ):
@@ -1103,7 +1103,7 @@ async def test_settings_save_agent_providers_keeps_unsupported_probe_in_cache_on
     assert any(record.status == "unsupported" for record in cache["openai"].compatibility.values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_bulk_test_requires_dev_mode(client):
     resp = await client.post("/settings/agent-providers/test-all")
 
@@ -1111,7 +1111,7 @@ async def test_settings_bulk_test_requires_dev_mode(client):
     assert resp.json()["ok"] is False
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_bulk_test_uses_unsaved_form_values(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1160,7 +1160,7 @@ async def test_settings_bulk_test_uses_unsaved_form_values(client, monkeypatch):
     assert captured_configs[0].secret_fields["api_key"] == "unsaved-openai-key"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_bulk_test_clears_running_status_when_startup_raises(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1180,7 +1180,7 @@ async def test_settings_bulk_test_clears_running_status_when_startup_raises(clie
     assert status["error"] == "log sink unavailable"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_bulk_test_refreshes_each_provider_once(client, monkeypatch, tmp_path):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1249,7 +1249,7 @@ async def test_settings_bulk_test_refreshes_each_provider_once(client, monkeypat
     probe_mock.assert_awaited_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
@@ -1329,7 +1329,7 @@ async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path)
     assert export_path.exists()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_blocks_agent_provider_writes_without_encryption_secret(tmp_path):
     config = AppConfig()
     config.database.path = str(tmp_path / "test_no_secret.db")
@@ -1387,26 +1387,26 @@ async def test_settings_page_blocks_agent_provider_writes_without_encryption_sec
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_page(client):
     resp = await client.get("/channels/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_page(client):
     resp = await client.get("/search")
     assert resp.status_code == 200
     assert "Поиск" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page(client):
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_filter_active(client):
     db = client._transport.app.state.db
     await db.create_collection_task(-100901, "Active Task")
@@ -1424,13 +1424,13 @@ async def test_scheduler_filter_active(client):
     assert "Active Task" not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_filter_invalid_status(client):
     resp = await client.get("/scheduler/?status=bogus")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_pagination_out_of_range(client):
     db = client._transport.app.state.db
     await db.create_collection_task(-100950, "Some Task")
@@ -1440,7 +1440,7 @@ async def test_scheduler_pagination_out_of_range(client):
     assert "Some Task" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_limit_preserved_in_links(client):
     db = client._transport.app.state.db
     for i in range(15):
@@ -1451,21 +1451,21 @@ async def test_scheduler_limit_preserved_in_links(client):
     assert "limit=10" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_query(client):
     resp = await client.get("/search?q=test&mode=local")
     assert resp.status_code == 200
     assert "test" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_invalid_channel_id_returns_error(client):
     resp = await client.get("/search?q=test&mode=channel&channel_id=abc")
     assert resp.status_code == 200
     assert "Некорректный ID канала: abc" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_with_semantic_mode(client, monkeypatch):
     from src.models import Message
     from src.services.embedding_service import EmbeddingService
@@ -1504,7 +1504,7 @@ async def test_search_with_semantic_mode(client, monkeypatch):
     assert "Семантический" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_runtime_error_is_rendered(client, monkeypatch):
     from src.web import deps
 
@@ -1531,7 +1531,7 @@ async def unauth_client(client):
         yield c
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_no_auth_browser_redirects_to_web_login(unauth_client):
     resp = await unauth_client.get(
         "/",
@@ -1542,7 +1542,7 @@ async def test_no_auth_browser_redirects_to_web_login(unauth_client):
     assert resp.headers["location"] == "/login?next=%2F"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_no_auth_htmx_returns_hx_redirect(unauth_client):
     resp = await unauth_client.get(
         "/",
@@ -1553,7 +1553,7 @@ async def test_no_auth_htmx_returns_hx_redirect(unauth_client):
     assert resp.headers["HX-Redirect"] == "/login?next=%2F"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_no_auth_api_returns_401(unauth_client):
     resp = await unauth_client.get(
         "/",
@@ -1564,20 +1564,20 @@ async def test_no_auth_api_returns_401(unauth_client):
     assert "WWW-Authenticate" in resp.headers
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_health_no_auth(unauth_client):
     resp = await unauth_client.get("/health")
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_basic_auth_sets_cookie(client):
     resp = await client.get("/dashboard/", follow_redirects=False)
     assert resp.status_code == 200
     assert COOKIE_NAME in resp.cookies
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cookie_auth_without_basic(client):
     token = create_session_token("admin", "test_secret_key")
     transport = client._transport
@@ -1590,7 +1590,7 @@ async def test_cookie_auth_without_basic(client):
         assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_root_redirects_to_search_when_agent_unavailable(client):
     """Without LLM keys the root page should redirect to /search, not /agent."""
     resp = await client.get("/", follow_redirects=False)
@@ -1598,7 +1598,7 @@ async def test_root_redirects_to_search_when_agent_unavailable(client):
     assert resp.headers["location"] == "/search"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_sets_cookie_and_redirects_to_next(unauth_client):
     resp = await unauth_client.post(
         "/login",
@@ -1613,7 +1613,7 @@ async def test_web_login_post_sets_cookie_and_redirects_to_next(unauth_client):
     assert page.status_code == 200
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_rejects_invalid_password(unauth_client):
     resp = await unauth_client.post(
         "/login",
@@ -1625,7 +1625,7 @@ async def test_web_login_post_rejects_invalid_password(unauth_client):
     assert COOKIE_NAME not in resp.headers.get("set-cookie", "")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_blocks_open_redirect(unauth_client):
     resp = await unauth_client.post(
         "/login",
@@ -1636,7 +1636,7 @@ async def test_web_login_post_blocks_open_redirect(unauth_client):
     assert resp.headers["location"] == "/"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_blocks_backslash_redirect(unauth_client):
     resp = await unauth_client.post(
         "/login",
@@ -1647,7 +1647,7 @@ async def test_web_login_post_blocks_backslash_redirect(unauth_client):
     assert resp.headers["location"] == "/"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_blocks_percent_encoded_backslash_redirect(unauth_client):
     resp = await unauth_client.post(
         "/login",
@@ -1658,25 +1658,28 @@ async def test_web_login_post_blocks_percent_encoded_backslash_redirect(unauth_c
     assert resp.headers["location"] == "/"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_post_non_ascii_password_accepted(tmp_path, real_pool_harness_factory):
     """Non-ASCII passwords (e.g. Cyrillic) must not raise TypeError in secrets.compare_digest."""
     non_ascii_pw = "пароль123"
     config = make_test_config(tmp_path, password=non_ascii_pw)
     harness = real_pool_harness_factory()
-    app, _ = await build_web_app(config, harness)
+    app, db = await build_web_app(config, harness)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
+            resp = await c.post("/login", data={"password": non_ascii_pw, "next": "/"})
+        assert resp.status_code == 303
 
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
-        resp = await c.post("/login", data={"password": non_ascii_pw, "next": "/"})
-    assert resp.status_code == 303
-
-    async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
-        resp = await c.post("/login", data={"password": "wrong", "next": "/"})
-    assert resp.status_code == 401
+        async with AsyncClient(transport=transport, base_url="http://test", follow_redirects=False) as c:
+            resp = await c.post("/login", data={"password": "wrong", "next": "/"})
+        assert resp.status_code == 401
+    finally:
+        await app.state.collection_queue.shutdown()
+        await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_web_login_redirects_authenticated_user_to_next(client):
     token = create_session_token("admin", "test_secret_key")
     transport = client._transport
@@ -1690,7 +1693,7 @@ async def test_web_login_redirects_authenticated_user_to_next(client):
         assert resp.headers["location"] == "/channels/"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_logout_clears_cookie_and_redirects_to_login(client):
     resp = await client.get("/logout", follow_redirects=False)
     assert resp.status_code == 303
@@ -1700,14 +1703,14 @@ async def test_logout_clears_cookie_and_redirects_to_login(client):
     assert "Max-Age=0" in cookie_header or "max-age=0" in cookie_header
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cookie_not_secure_on_http(client):
     resp = await client.get("/dashboard/", follow_redirects=False)
     cookie_header = resp.headers.get("set-cookie", "")
     assert "Secure" not in cookie_header
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cookie_secure_on_https(client):
     transport = client._transport
     auth_header = base64.b64encode(b":testpass").decode()
@@ -1722,7 +1725,7 @@ async def test_cookie_secure_on_https(client):
         assert "Secure" in cookie_header
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_invalid_cookie_falls_back(unauth_client):
     unauth_client.cookies.set(COOKIE_NAME, "fake.token")
     resp = await unauth_client.get(
@@ -1734,14 +1737,14 @@ async def test_invalid_cookie_falls_back(unauth_client):
     assert resp.headers["location"] == "/login?next=%2F"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_logout_no_auth_required(unauth_client):
     resp = await unauth_client.get("/logout", follow_redirects=False)
     assert resp.status_code == 303
     assert resp.headers["location"] == "/login"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_shows_accounts(tmp_path):
     """Settings page displays accounts from DB."""
     config = AppConfig()
@@ -1786,7 +1789,7 @@ async def test_settings_shows_accounts(tmp_path):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_no_accounts(client):
     """Settings page shows 'no accounts' message when DB has no accounts."""
     db = client._transport.app.state.db
@@ -1798,7 +1801,7 @@ async def test_settings_no_accounts(client):
     assert "/auth/login" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_rejects_invalid_api_id(client):
     db = client._transport.app.state.db
 
@@ -1812,7 +1815,7 @@ async def test_settings_rejects_invalid_api_id(client):
     assert await db.get_setting("tg_api_id") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_success(client):
     """Adding a channel via identifier queues a worker command."""
     db = client._transport.app.state.db
@@ -1822,7 +1825,7 @@ async def test_resolve_channel_success(client):
     assert commands[0].command_type == "channels.add_identifier"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_add_logs_unexpected_error(client, monkeypatch, caplog):
     db = client._transport.app.state.db
     with caplog.at_level(logging.ERROR, logger="src.web.routes.channels"):
@@ -1839,7 +1842,7 @@ async def test_channels_add_logs_unexpected_error(client, monkeypatch, caplog):
     assert "Channel add runtime failure" not in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_send_code_logs_exception(client, monkeypatch, caplog):
     db = client._transport.app.state.db
     monkeypatch.setattr(
@@ -1859,7 +1862,7 @@ async def test_auth_send_code_logs_exception(client, monkeypatch, caplog):
     assert "Failed to send auth code for phone=+7000" not in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_logs_exception(client, monkeypatch, caplog):
     with caplog.at_level(logging.ERROR, logger="src.web.routes.settings"):
         resp = await client.post("/settings/notifications/setup", follow_redirects=False)
@@ -1869,7 +1872,7 @@ async def test_notification_setup_logs_exception(client, monkeypatch, caplog):
     assert "Notification setup failed" not in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_error_redirects_are_logged_globally(client, caplog):
     with caplog.at_level(logging.WARNING, logger="src.web.app"):
         resp = await client.post(
@@ -1884,7 +1887,7 @@ async def test_error_redirects_are_logged_globally(client, caplog):
     assert "error=invalid_value" in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_blocks_cross_origin_post(client):
     resp = await client.post(
         "/channels/add",
@@ -1896,7 +1899,7 @@ async def test_csrf_blocks_cross_origin_post(client):
     assert "CSRF validation failed" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_blocks_null_origin(client):
     resp = await client.post(
         "/channels/add",
@@ -1908,7 +1911,7 @@ async def test_csrf_blocks_null_origin(client):
     assert "CSRF validation failed" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_blocks_post_without_origin_or_referer(client):
     """POST without Origin/Referer headers remains allowed for Basic-auth clients."""
     transport = client._transport
@@ -1926,7 +1929,7 @@ async def test_csrf_blocks_post_without_origin_or_referer(client):
         assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_blocks_cookie_auth_post_without_origin_or_referer(client):
     token = create_session_token("admin", "test_secret_key")
     transport = client._transport
@@ -1944,7 +1947,7 @@ async def test_csrf_blocks_cookie_auth_post_without_origin_or_referer(client):
         assert "CSRF" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_allows_same_origin_post(client):
     resp = await client.post(
         "/channels/add",
@@ -1955,7 +1958,7 @@ async def test_csrf_allows_same_origin_post(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_csrf_allows_same_origin_post_behind_proxy(client):
     resp = await client.post(
         "/channels/add",
@@ -1970,7 +1973,7 @@ async def test_csrf_allows_same_origin_post_behind_proxy(client):
     assert resp.status_code == 303
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_channel_fail(tmp_path):
     """Failed resolve redirects with error query param."""
     config = AppConfig()
@@ -2029,7 +2032,7 @@ async def test_resolve_channel_fail(tmp_path):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dialogs_endpoint(client):
     """GET /channels/dialogs returns JSON list of channels."""
     db = client._transport.app.state.db
@@ -2049,7 +2052,7 @@ async def test_dialogs_endpoint(client):
     assert "already_added" in data[0]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_bulk(client):
     """POST /channels/add-bulk adds selected channels from dialogs."""
     db = client._transport.app.state.db
@@ -2071,7 +2074,7 @@ async def test_add_bulk(client):
     assert "Dialog Chan 2" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_channel_redirect_has_msg(client):
     """Adding a channel redirects with queued command id."""
     resp = await client.post(
@@ -2081,7 +2084,7 @@ async def test_add_channel_redirect_has_msg(client):
     assert "command_id=" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_notification_account_round_trip(client):
     from src.models import Account
 
@@ -2101,7 +2104,7 @@ async def test_save_notification_account_round_trip(client):
     assert "+79990000001" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_page_shows_stale_notification_account_warning(client):
     db = client._transport.app.state.db
     await db.set_setting("notification_account_phone", "+79990000009")
@@ -2111,7 +2114,7 @@ async def test_settings_page_shows_stale_notification_account_warning(client):
     assert "Выбранный аккаунт уведомлений удалён." in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_status_returns_error_for_unavailable_selected_account(client):
     from src.models import Account
 
@@ -2144,7 +2147,7 @@ async def test_notification_status_returns_error_for_unavailable_selected_accoun
     assert "не подключён" in data["error"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channel_type_displayed(client):
     """Channel type column is shown on channels page after adding a channel."""
     from src.models import Channel
@@ -2158,7 +2161,7 @@ async def test_channel_type_displayed(client):
     assert "Тип" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_add_scam_channel_is_inactive(tmp_path):
     """Adding a scam channel via /channels/add queues a worker command."""
     config = AppConfig()
@@ -2229,7 +2232,7 @@ async def test_add_scam_channel_is_inactive(tmp_path):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_bulk_add_scam_dialog_is_inactive(tmp_path):
     """Adding a scam dialog via /channels/add-bulk creates it with is_active=False."""
     config = AppConfig()
@@ -2311,7 +2314,7 @@ async def test_bulk_add_scam_dialog_is_inactive(tmp_path):
     await db.close()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_analyze_applies_filters(client):
     from datetime import datetime, timezone
 
@@ -2342,7 +2345,7 @@ async def test_filter_analyze_applies_filters(client):
     assert channel.is_filtered is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
     from src.models import Channel
 
@@ -2373,7 +2376,7 @@ async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
     assert row["filter_flags"] == "low_uniqueness"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_apply_without_snapshot_returns_error(client, monkeypatch):
     from src.models import Channel
 
@@ -2400,14 +2403,14 @@ async def test_filter_apply_without_snapshot_returns_error(client, monkeypatch):
     assert row["filter_flags"] == ""
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_toggle_missing_channel_returns_not_found_msg(client):
     resp = await client.post("/channels/999999/filter-toggle", follow_redirects=False)
     assert resp.status_code == 303
     assert "msg=channel_not_found" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_filter_toggle_sets_manual_flag(client):
     from src.models import Channel
 
@@ -2430,7 +2433,7 @@ async def test_filter_toggle_sets_manual_flag(client):
     assert row["filter_flags"] == "manual"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_filtered_channel_is_allowed(client):
     """Manual collect (web UI) must proceed even when channel is filtered."""
     from src.models import Channel
@@ -2457,7 +2460,7 @@ async def test_collect_filtered_channel_is_allowed(client):
     await client._transport.app.state.collection_queue.shutdown()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_delete_channel_cancels_pending_collection_tasks(client):
     from src.models import Channel
 
@@ -2478,7 +2481,7 @@ async def test_delete_channel_cancels_pending_collection_tasks(client):
     assert task.note == "Канал удалён пользователем."
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_creates_pending_task(client):
     db = client._transport.app.state.db
 
@@ -2495,7 +2498,7 @@ async def test_stats_all_creates_pending_task(client):
     assert tasks[0].payload.task_kind == CollectionTaskType.STATS_ALL.value
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_queued_when_collector_running(client):
     app = client._transport.app.state
     db = app.db
@@ -2513,7 +2516,7 @@ async def test_stats_all_queued_when_collector_running(client):
     assert tasks[0].status == CollectionTaskStatus.PENDING
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_blocks_duplicate_active_task(client):
     db = client._transport.app.state.db
     await db.create_stats_task(StatsAllTaskPayload(channel_ids=[]))
@@ -2523,7 +2526,7 @@ async def test_stats_all_blocks_duplicate_active_task(client):
     assert "error=stats_running" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_stats_all_prioritizes_channels_without_stats(client):
     from src.models import Channel, ChannelStats
 
@@ -2546,7 +2549,7 @@ async def test_stats_all_prioritizes_channels_without_stats(client):
     assert channel_ids.index(-100901) > channel_ids.index(-100903)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_results_have_tg_links(client):
     """Search results contain links to original Telegram messages."""
     from datetime import datetime, timezone
@@ -2570,7 +2573,7 @@ async def test_search_results_have_tg_links(client):
     assert "bi-link-45deg" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_search_results_private_channel_link(client):
     """Private channel messages get t.me/c/ links."""
     from datetime import datetime, timezone
@@ -2593,7 +2596,7 @@ async def test_search_results_private_channel_link(client):
     assert "t.me/c/-100999/7" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_htmx_returns_scheduler_link_and_creates_tasks(client, monkeypatch):
     """POST /channels/collect-all with HTMX header returns explicit status and queues tasks."""
     from src.models import Channel
@@ -2623,7 +2626,7 @@ async def test_collect_all_htmx_returns_scheduler_link_and_creates_tasks(client,
     assert all(task.status == "pending" for task in tasks)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_htmx_noop_when_tasks_already_exist(client):
     from src.models import Channel
 
@@ -2657,7 +2660,7 @@ async def test_collect_all_htmx_noop_when_tasks_already_exist(client):
     assert {task.channel_id for task in tasks} == {-100703, -100704}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_non_htmx_redirects_with_new_message_and_creates_tasks(
     client, monkeypatch
 ):
@@ -2687,7 +2690,7 @@ async def test_collect_all_non_htmx_redirects_with_new_message_and_creates_tasks
     assert tasks[0].status == "pending"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_all_non_htmx_redirects_with_empty_message_when_no_channels(client):
     resp = await client.post("/channels/collect-all", follow_redirects=False)
     assert resp.status_code == 303
@@ -2703,7 +2706,7 @@ async def test_collect_all_non_htmx_redirects_with_empty_message_when_no_channel
     assert 'href="/scheduler"' not in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_enqueue_all_channels_skips_inactive_filtered_and_duplicate_tasks(
     client, monkeypatch
 ):
@@ -2746,7 +2749,7 @@ async def test_enqueue_all_channels_skips_inactive_filtered_and_duplicate_tasks(
     assert {task.channel_id for task in tasks} == {-100708, -100709}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_get_channel_ids_with_active_tasks_returns_distinct_non_stats_ids(client):
     db = client._transport.app.state.db
     await db.create_collection_task(-100801, "One")
@@ -2760,7 +2763,7 @@ async def test_get_channel_ids_with_active_tasks_returns_distinct_non_stats_ids(
     assert active_ids == {-100801, -100802}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_channels_page_collect_all_button_matches_htmx_fragment(client):
     template_path = Path("src/web/templates/channels.html")
     template_text = template_path.read_text(encoding="utf-8")
@@ -2783,7 +2786,7 @@ async def test_channels_page_collect_all_button_matches_htmx_fragment(client):
     assert _COLLECT_ALL_BTN == f'<span id="collect-all-btn">{_COLLECT_ALL_FORM}</span>'
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_valid(client):
     """POST /settings/save-scheduler with valid interval persists and redirects."""
     resp = await client.post(
@@ -2797,7 +2800,7 @@ async def test_save_scheduler_valid(client):
     assert await db.get_setting("collect_interval_minutes") == "30"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_invalid_value(client):
     """POST /settings/save-scheduler with non-numeric value redirects to error."""
     resp = await client.post(
@@ -2809,7 +2812,7 @@ async def test_save_scheduler_invalid_value(client):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_clamps_to_min(client):
     """POST /settings/save-scheduler clamps value below 1 to 1."""
     resp = await client.post(
@@ -2823,7 +2826,7 @@ async def test_save_scheduler_clamps_to_min(client):
     assert await db.get_setting("collect_interval_minutes") == "1"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_scheduler_clamps_to_max(client):
     """POST /settings/save-scheduler clamps value above 1440 to 1440."""
     resp = await client.post(
@@ -2837,7 +2840,7 @@ async def test_save_scheduler_clamps_to_max(client):
     assert await db.get_setting("collect_interval_minutes") == "1440"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters_valid(client):
     from src.models import Channel, ChannelStats
 
@@ -2859,7 +2862,7 @@ async def test_save_filters_valid(client):
     assert channel.is_filtered is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_filters_invalid_value(client):
     resp = await client.post(
         "/settings/save-filters",
@@ -2870,7 +2873,7 @@ async def test_save_filters_invalid_value(client):
     assert "error=invalid_value" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_credentials_valid_and_masked_path(client):
     db = client._transport.app.state.db
     auth = client._transport.app.state.auth
@@ -2900,7 +2903,7 @@ async def test_save_credentials_valid_and_masked_path(client):
     assert auth._api_hash == "hash-2"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_and_delete_json(client, monkeypatch):
 
     from src.models import Account
@@ -2945,7 +2948,7 @@ async def test_notification_setup_and_delete_json(client, monkeypatch):
     assert delete_resp.json()["status"] == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notification_setup_returns_conflict_when_account_unavailable(client):
     from src.models import Account
 
@@ -2961,7 +2964,7 @@ async def test_notification_setup_returns_conflict_when_account_unavailable(clie
     assert resp.json()["status"] == "queued"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_route_enqueues_command(client):
     """Web route only enqueues a telegram command; worker executes the collection."""
     from src.models import Channel
@@ -2986,7 +2989,7 @@ async def test_collect_stats_route_enqueues_command(client):
     assert commands[0].payload == {"channel_pk": channel.id}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_collect_stats_route_missing_channel(client):
     """If the channel does not exist, the route redirects to /channels without enqueueing."""
     db = client._transport.app.state.db
@@ -2998,7 +3001,7 @@ async def test_collect_stats_route_missing_channel(client):
     assert not any(c.command_type == "channels.collect_stats" for c in commands)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_edit_search_query_route(client):
     # Add a search query first
     resp = await client.post(
@@ -3036,7 +3039,7 @@ async def test_edit_search_query_route(client):
 
 
 class TestWebAgent:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_agent_page_auto_creates_thread(self, client):
         client._transport.app.state.agent_manager = AsyncMock()
         client._transport.app.state.agent_manager.get_runtime_status = AsyncMock(
@@ -3058,7 +3061,7 @@ class TestWebAgent:
         assert resp.url.path == "/agent"
         assert "thread_id=" in str(resp.url.query)
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_agent_page_redirects_to_first_thread(self, client):
         db = client._transport.app.state.db
         client._transport.app.state.agent_manager = AsyncMock()
@@ -3082,7 +3085,7 @@ class TestWebAgent:
         assert resp.status_code == 200
         assert str(resp.url).endswith("?thread_id=1")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_agent_page_shows_deepagents_status_and_hides_claude_model_select(self, client):
         db = client._transport.app.state.db
         await db.create_agent_thread("First")
@@ -3109,7 +3112,7 @@ class TestWebAgent:
         assert "openai:gpt-4.1-mini" in resp.text
         assert 'id="model-select"' not in resp.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_agent_thread_creation_and_deletion(self, client):
         # Create
         resp_create = await client.post("/agent/threads", follow_redirects=False)
@@ -3133,7 +3136,7 @@ class TestWebAgent:
         thread_after = await db.get_agent_thread(int(thread_id))
         assert thread_after is None
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_get_channels_and_topics(self, client):
         from src.models import Channel
 
@@ -3151,7 +3154,7 @@ class TestWebAgent:
         assert resp_topics.status_code == 202
         assert resp_topics.json()["status"] == "queued"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_inject_context_success(self, client):
         from datetime import datetime
 
@@ -3168,7 +3171,7 @@ class TestWebAgent:
         assert resp.status_code == 200
         assert "Context Channel" in resp.json()["content"]
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_chat_stream_and_stop(self, client):
         db = client._transport.app.state.db
         thread_id = await db.create_agent_thread("Новый тред")
@@ -3215,7 +3218,7 @@ class TestWebAgent:
         agent_manager.cancel_stream.assert_called_once_with(thread_id)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_no_bot(client):
     """Route now queues worker-side notification test command."""
     db = client._transport.app.state.db
@@ -3226,7 +3229,7 @@ async def test_test_notification_no_bot(client):
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_no_queries(client, monkeypatch):
     """Notification route queues command even without matching queries."""
     db = client._transport.app.state.db
@@ -3237,7 +3240,7 @@ async def test_test_notification_no_queries(client, monkeypatch):
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_no_messages(client, monkeypatch):
     """Active query exists but web still only queues notification command."""
     from src.models import SearchQuery
@@ -3254,7 +3257,7 @@ async def test_test_notification_no_messages(client, monkeypatch):
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_with_public_channel_message(client, monkeypatch):
     """Message preview generation moved to worker; web only queues command."""
     from datetime import datetime, timezone
@@ -3282,7 +3285,7 @@ async def test_test_notification_with_public_channel_message(client, monkeypatch
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_with_private_channel_message(client, monkeypatch):
     """Private channel preview generation moved to worker; web only queues command."""
     from datetime import datetime, timezone
@@ -3310,7 +3313,7 @@ async def test_test_notification_with_private_channel_message(client, monkeypatc
     assert commands[0].command_type == "notifications.test"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_test_notification_notify_fails(client, monkeypatch):
     """Route now queues command and leaves success/failure to worker result."""
     db = client._transport.app.state.db
@@ -3343,7 +3346,7 @@ async def error_client(client):
         yield c
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unhandled_exception_returns_error_page(error_client):
     """Unhandled exception in a route returns 500 with error template."""
     resp = await error_client.get("/test-500")
@@ -3353,7 +3356,7 @@ async def test_unhandled_exception_returns_error_page(error_client):
     assert "/debug/" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unhandled_exception_htmx_returns_fragment(error_client):
     """HTMX request to a broken route returns an alert fragment, not full page."""
     resp = await error_client.get("/test-500", headers={"HX-Request": "true"})
@@ -3362,7 +3365,7 @@ async def test_unhandled_exception_htmx_returns_fragment(error_client):
     assert "/debug/" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_unhandled_exception_logged_to_logbuffer(error_client):
     """Exception traceback is captured by logger (and thus by LogBuffer)."""
     app = error_client._transport.app
@@ -3375,7 +3378,7 @@ async def test_unhandled_exception_logged_to_logbuffer(error_client):
     assert any("kaboom" in r["message"] for r in new_records)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_job_toggle_invalid_id(client):
     """POST /scheduler/jobs/{job_id}/toggle with invalid job_id redirects to error."""
     resp = await client.post("/scheduler/jobs/bogus_job/toggle", follow_redirects=False)
@@ -3383,7 +3386,7 @@ async def test_scheduler_job_toggle_invalid_id(client):
     assert "error=invalid_job" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_job_toggle_enables_and_disables(client):
     """Toggling collect_all job persists disabled flag to settings."""
     db = client._transport.app.state.db
@@ -3399,7 +3402,7 @@ async def test_scheduler_job_toggle_enables_and_disables(client):
     assert await db.repos.settings.get_setting("scheduler_job_disabled:collect_all") == "0"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_job_set_interval_invalid_id(client):
     """POST /scheduler/jobs/{job_id}/set-interval with invalid job_id redirects to error."""
     resp = await client.post(
@@ -3411,7 +3414,7 @@ async def test_scheduler_job_set_interval_invalid_id(client):
     assert "error=invalid_job" in resp.headers["location"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_job_set_interval_collect_all(client):
     """Setting interval for collect_all persists to settings."""
     db = client._transport.app.state.db
@@ -3425,7 +3428,7 @@ async def test_scheduler_job_set_interval_collect_all(client):
     assert await db.repos.settings.get_setting("collect_interval_minutes") == "45"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_job_set_interval_clamps_values(client):
     """Interval is clamped to 1–1440 range."""
     db = client._transport.app.state.db
@@ -3444,7 +3447,7 @@ async def test_scheduler_job_set_interval_clamps_values(client):
     assert await db.repos.settings.get_setting("collect_interval_minutes") == "1440"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scheduler_page_shows_disabled_job(client):
     """Disabled job shows unchecked checkbox on scheduler page."""
     db = client._transport.app.state.db
@@ -3456,7 +3459,7 @@ async def test_scheduler_page_shows_disabled_job(client):
     assert "collect_all" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_empty(client):
     """Analytics page renders without error when no messages exist."""
     resp = await client.get("/analytics")
@@ -3464,7 +3467,7 @@ async def test_analytics_page_empty(client):
     assert "Аналитика" in resp.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_analytics_page_with_date_filter(client):
     """Analytics page accepts date_from/date_to query params."""
     resp = await client.get("/analytics?date_from=2025-01-01&date_to=2025-12-31&limit=20")
@@ -3477,7 +3480,7 @@ async def test_analytics_page_with_date_filter(client):
 # ── Backend override validation tests ──────────────────────────────────────────────
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_rejects_deepagents_override_without_providers(client):
     """Deepagents override is rejected when no valid providers are configured."""
     db = client._transport.app.state.db
@@ -3498,7 +3501,7 @@ async def test_save_agent_rejects_deepagents_override_without_providers(client):
     assert await db.get_setting("agent_backend_override") != "deepagents"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_rejects_claude_override_without_api_key(client, monkeypatch):
     """Claude override is rejected when no API key is available."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -3521,7 +3524,7 @@ async def test_save_agent_rejects_claude_override_without_api_key(client, monkey
     assert await db.get_setting("agent_backend_override") != "claude"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_save_agent_accepts_auto_override_always(client):
     """Auto override is always accepted regardless of provider/key state."""
     db = client._transport.app.state.db
@@ -3542,7 +3545,7 @@ async def test_save_agent_accepts_auto_override_always(client):
     assert await db.get_setting("agent_backend_override") == "auto"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_flood_status_returns_ok_for_expired(tmp_path, real_pool_harness_factory):
     """GET /settings/flood-status returns ok/0 when flood_wait_until is in the past."""
     from datetime import timedelta
@@ -3550,22 +3553,25 @@ async def test_flood_status_returns_ok_for_expired(tmp_path, real_pool_harness_f
     config = make_test_config(tmp_path)
     harness = real_pool_harness_factory()
     app, db = await build_web_app(config, harness)
+    try:
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        await db.add_account(Account(phone="+70010", session_string="s10", is_active=True))
+        await db.update_account_flood("+70010", past)
 
-    past = datetime.now(timezone.utc) - timedelta(hours=1)
-    await db.add_account(Account(phone="+70010", session_string="s10", is_active=True))
-    await db.update_account_flood("+70010", past)
+        async with make_auth_client(app) as c:
+            resp = await c.get("/settings/flood-status")
 
-    async with make_auth_client(app) as c:
-        resp = await c.get("/settings/flood-status")
+        assert resp.status_code == 200
+        data = resp.json()
+        entry = next(d for d in data if d["phone"] == "+70010")
+        assert entry["flood_wait_until"] == "ok"
+        assert entry["remaining_seconds"] == 0
+    finally:
+        await app.state.collection_queue.shutdown()
+        await db.close()
 
-    assert resp.status_code == 200
-    data = resp.json()
-    entry = next(d for d in data if d["phone"] == "+70010")
-    assert entry["flood_wait_until"] == "ok"
-    assert entry["remaining_seconds"] == 0
 
-
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_settings_clears_stale_flood_on_load(tmp_path, real_pool_harness_factory, monkeypatch):
     """GET /settings clears flood_wait_until from DB when the timestamp is expired."""
     from datetime import timedelta
@@ -3575,23 +3581,26 @@ async def test_settings_clears_stale_flood_on_load(tmp_path, real_pool_harness_f
     config = make_test_config(tmp_path)
     harness = real_pool_harness_factory()
     app, db = await build_web_app(config, harness)
+    try:
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        await db.add_account(Account(phone="+70011", session_string="s11", is_active=True))
+        await db.update_account_flood("+70011", past)
 
-    past = datetime.now(timezone.utc) - timedelta(hours=1)
-    await db.add_account(Account(phone="+70011", session_string="s11", is_active=True))
-    await db.update_account_flood("+70011", past)
+        probe_mock = AsyncMock(return_value=("ok", None))
+        monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
+        fake_manager = SimpleNamespace(available=False)
+        monkeypatch.setattr(
+            settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+        )
 
-    probe_mock = AsyncMock(return_value=("ok", None))
-    monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
-    fake_manager = SimpleNamespace(available=False)
-    monkeypatch.setattr(
-        settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
-    )
+        async with make_auth_client(app) as c:
+            resp = await c.get("/settings")
 
-    async with make_auth_client(app) as c:
-        resp = await c.get("/settings")
+        assert resp.status_code == 200
 
-    assert resp.status_code == 200
-
-    accounts = await db.get_accounts()
-    acc = next(a for a in accounts if a.phone == "+70011")
-    assert acc.flood_wait_until is None
+        accounts = await db.get_accounts()
+        acc = next(a for a in accounts if a.phone == "+70011")
+        assert acc.flood_wait_until is None
+    finally:
+        await app.state.collection_queue.shutdown()
+        await db.close()

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -19,7 +19,7 @@ from tests.helpers import build_web_app, make_auth_client
 class TestLoginPage:
     """Tests for GET /auth/login (Telegram account login page)."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_login_page_api_configured(self, db, real_pool_harness_factory):
         """Test login page when API credentials are configured."""
         config = AppConfig()
@@ -40,7 +40,7 @@ class TestLoginPage:
         # When API is configured, step should be "phone"
         assert "phone" in response.text.lower() or "телефон" in response.text.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_login_page_api_not_configured(self, db, real_pool_harness_factory):
         """Test login page when API credentials are not configured."""
         config = AppConfig()
@@ -65,7 +65,7 @@ class TestLoginPage:
 class TestSaveCredentials:
     """Tests for POST /auth/save-credentials."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_save_credentials_success(self, db, real_pool_harness_factory):
         """Test successful credential save."""
         config = AppConfig()
@@ -102,7 +102,7 @@ class TestSaveCredentials:
 class TestSendCode:
     """Tests for POST /auth/send-code."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_code_api_not_configured(self, db, real_pool_harness_factory):
         """Test send-code returns error when API credentials are not configured."""
         config = AppConfig()
@@ -125,7 +125,7 @@ class TestSendCode:
         # Should show credentials step with error
         assert "API credentials" in response.text or "api_id" in response.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_code_success(self, db, real_pool_harness_factory):
         """Test send-code enqueues command instead of direct RPC."""
         config = AppConfig()
@@ -151,7 +151,7 @@ class TestSendCode:
         commands = await db.repos.telegram_commands.list_commands(limit=1)
         assert commands[0].command_type == "auth.send_code"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_code_exception(self, db, real_pool_harness_factory):
         """Test send-code route does not execute auth inline."""
         config = AppConfig()
@@ -184,7 +184,7 @@ class TestSendCode:
 class TestResendCode:
     """Tests for POST /auth/resend-code."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resend_code_success(self, db, real_pool_harness_factory):
         """Test resend-code enqueues command instead of direct RPC."""
         config = AppConfig()
@@ -210,7 +210,7 @@ class TestResendCode:
         commands = await db.repos.telegram_commands.list_commands(limit=1)
         assert commands[0].command_type == "auth.resend_code"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_resend_code_exception(self, db, real_pool_harness_factory):
         """Test resend-code route does not execute auth inline."""
         config = AppConfig()
@@ -243,7 +243,7 @@ class TestResendCode:
 class TestVerifyCode:
     """Tests for POST /auth/verify-code."""
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_success(self, db, real_pool_harness_factory):
         """Test verify-code enqueues command instead of direct RPC."""
         config = AppConfig()
@@ -282,7 +282,7 @@ class TestVerifyCode:
         commands = await db.repos.telegram_commands.list_commands(limit=1)
         assert commands[0].command_type == "auth.verify_code"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_2fa_required(self, db, real_pool_harness_factory):
         """Test login page shows 2FA state from failed queued command."""
         config = AppConfig()
@@ -309,7 +309,7 @@ class TestVerifyCode:
         assert response.status_code == 200
         assert "2fa" in response.text.lower() or "password" in response.text.lower()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_invalid_code(self, db, real_pool_harness_factory):
         """Test login page surfaces invalid-code error from failed queued command."""
         config = AppConfig()
@@ -346,7 +346,7 @@ class TestVerifyCode:
         assert response.status_code == 200
         assert "Invalid code" in response.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_exception(self, db, real_pool_harness_factory):
         """Test login page surfaces generic queued verify error."""
         config = AppConfig()
@@ -380,7 +380,7 @@ class TestVerifyCode:
         assert response.status_code == 200
         assert "Flood wait" in response.text
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_with_2fa_password(self, db, real_pool_harness_factory):
         """Test verify-code enqueues 2FA password for worker processing."""
         config = AppConfig()
@@ -412,7 +412,7 @@ class TestVerifyCode:
         commands = await db.repos.telegram_commands.list_commands(limit=1)
         assert commands[0].payload["password_2fa"] == "my2fapassword"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_verify_code_existing_account_not_primary(self, db, real_pool_harness_factory):
         """Test queued verify-code carries non-primary context for later accounts."""
         config = AppConfig()


### PR DESCRIPTION
## Summary
- set pytest filterwarnings to the strict ["error"] mode
- add a CI guard that fails if filterwarnings is changed away from exactly ["error"]

Closes #479

## Validation
- python CI guard snippet
- ruff check src/ tests/ conftest.py

Note: the full pytest suite now surfaces existing warning/resource cleanup failures under strict mode, which is expected for this issue and should be fixed instead of suppressed.