### PR TITLE
refactor(web): add shared response helpers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,19 @@ db.repos.settings.get("key")
 - `src/web/container.py` — `AppContainer` агрегирует все сервисы
 - `src/web/deps.py` — хелперы `deps.get_db()`, `deps.get_pool()` и др.
 
+## Web Route Layering
+
+Для новых и постепенно рефакторимых web routes используем тонкие входные точки:
+
+- `forms`: парсят и валидируют данные FastAPI form/query/path без бизнес-логики.
+- `handlers`: оркестрируют сервисы и возвращают доменный результат.
+- `responses`: мапят результат в `RedirectResponse`, `JSONResponse` или template response.
+
+Общие redirect/JSON helpers живут в `src/web/responses.py`. Flash-redirects должны использовать
+query-string convention `?msg=...` / `?error=...` и статус `303`; route modules не должны заново
+кодировать этот boilerplate, если хватает общего helper-а. Не создавайте пустые `forms` или
+`handlers` модули заранее — выделяйте их при реальном разрезании конкретного route domain.
+
 ## Ключевые паттерны
 
 | Паттерн | Описание |

--- a/src/web/responses.py
+++ b/src/web/responses.py
@@ -1,0 +1,60 @@
+"""Shared response helpers for web route modules."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from fastapi.responses import JSONResponse, RedirectResponse
+
+
+def see_other(url: str) -> RedirectResponse:
+    """Return a POST/redirect/GET response."""
+    return RedirectResponse(url=url, status_code=303)
+
+
+def flash_redirect(
+    path: str,
+    *,
+    msg: str | None = None,
+    error: str | None = None,
+    extra: Mapping[str, object | None] | None = None,
+    fragment: str | None = None,
+) -> RedirectResponse:
+    """Redirect with the app's query-string flash convention."""
+    if msg is not None and error is not None:
+        raise ValueError("flash_redirect accepts either msg or error, not both")
+
+    parts = urlsplit(path)
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    if msg is not None:
+        query["msg"] = msg
+    if error is not None:
+        query["error"] = error
+    if extra:
+        for key, value in extra.items():
+            if value is not None:
+                query[key] = str(value)
+
+    target = urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            parts.path,
+            urlencode(query),
+            fragment if fragment is not None else parts.fragment,
+        )
+    )
+    return see_other(target)
+
+
+def json_response(content: Any, *, status_code: int = 200) -> JSONResponse:
+    return JSONResponse(content=content, status_code=status_code)
+
+
+def json_ok(**payload: Any) -> JSONResponse:
+    return json_response({"ok": True, **payload})
+
+
+def json_error(error: str, *, status_code: int = 400, **payload: Any) -> JSONResponse:
+    return json_response({"ok": False, "error": error, **payload}, status_code=status_code)

--- a/src/web/responses.py
+++ b/src/web/responses.py
@@ -26,6 +26,8 @@ def flash_redirect(
         raise ValueError("flash_redirect accepts either msg or error, not both")
 
     parts = urlsplit(path)
+    if parts.scheme or parts.netloc:
+        raise ValueError(f"flash_redirect requires a relative path, got: {path!r}")
     query = dict(parse_qsl(parts.query, keep_blank_values=True))
     if msg is not None:
         query["msg"] = msg
@@ -52,9 +54,18 @@ def json_response(content: Any, *, status_code: int = 200) -> JSONResponse:
     return JSONResponse(content=content, status_code=status_code)
 
 
+def _reject_payload_keys(payload: Mapping[str, object], reserved: set[str]) -> None:
+    collisions = sorted(reserved.intersection(payload))
+    if collisions:
+        keys = ", ".join(collisions)
+        raise ValueError(f"response payload cannot override reserved key(s): {keys}")
+
+
 def json_ok(**payload: Any) -> JSONResponse:
+    _reject_payload_keys(payload, {"ok"})
     return json_response({"ok": True, **payload})
 
 
 def json_error(error: str, *, status_code: int = 400, **payload: Any) -> JSONResponse:
+    _reject_payload_keys(payload, {"ok", "error"})
     return json_response({"ok": False, "error": error, **payload}, status_code=status_code)

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 from pydantic import ValidationError
 
 from src.web import deps
+from src.web.responses import flash_redirect
 
 router = APIRouter()
 
@@ -29,7 +30,7 @@ async def add_search_query(
     max_length: int | None = Form(None),
 ):
     if not query.strip():
-        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
+        return flash_redirect("/search-queries", error="invalid_value")
     svc = deps.search_query_service(request)
     try:
         await svc.add(
@@ -43,11 +44,11 @@ async def add_search_query(
             max_length=max_length,
         )
     except ValidationError:
-        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
+        return flash_redirect("/search-queries", error="invalid_value")
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return RedirectResponse(url="/search-queries?msg=sq_added", status_code=303)
+    return flash_redirect("/search-queries", msg="sq_added")
 
 
 @router.post("/{sq_id}/toggle")
@@ -57,7 +58,7 @@ async def toggle_search_query(request: Request, sq_id: int):
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return RedirectResponse(url="/search-queries?msg=sq_toggled", status_code=303)
+    return flash_redirect("/search-queries", msg="sq_toggled")
 
 
 @router.post("/{sq_id}/edit")
@@ -74,7 +75,7 @@ async def edit_search_query(
     max_length: int | None = Form(None),
 ):
     if not query.strip():
-        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
+        return flash_redirect("/search-queries", error="invalid_value")
     svc = deps.search_query_service(request)
     try:
         await svc.update(
@@ -89,11 +90,11 @@ async def edit_search_query(
             max_length=max_length,
         )
     except ValidationError:
-        return RedirectResponse(url="/search-queries?error=invalid_value", status_code=303)
+        return flash_redirect("/search-queries", error="invalid_value")
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return RedirectResponse(url="/search-queries?msg=sq_edited", status_code=303)
+    return flash_redirect("/search-queries", msg="sq_edited")
 
 
 @router.post("/{sq_id}/delete")
@@ -103,11 +104,11 @@ async def delete_search_query(request: Request, sq_id: int):
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return RedirectResponse(url="/search-queries?msg=sq_deleted", status_code=303)
+    return flash_redirect("/search-queries", msg="sq_deleted")
 
 
 @router.post("/{sq_id}/run")
 async def run_search_query(request: Request, sq_id: int):
     svc = deps.search_query_service(request)
     await svc.run_once(sq_id)
-    return RedirectResponse(url="/search-queries?msg=sq_run", status_code=303)
+    return flash_redirect("/search-queries", msg="sq_run")

--- a/tests/test_web_route_helpers.py
+++ b/tests/test_web_route_helpers.py
@@ -134,6 +134,14 @@ def test_flash_redirect_rejects_message_and_error_together():
         flash_redirect("/settings", msg="saved", error="invalid")
 
 
+@pytest.mark.parametrize("target", ["https://evil.example/path", "//evil.example/path"])
+def test_flash_redirect_rejects_absolute_targets(target):
+    from src.web.responses import flash_redirect
+
+    with pytest.raises(ValueError, match="relative path"):
+        flash_redirect(target, msg="saved")
+
+
 def test_json_response_helpers():
     from src.web.responses import json_error, json_ok, json_response
 
@@ -147,3 +155,13 @@ def test_json_response_helpers():
     assert json.loads(ok.body) == {"ok": True, "started": True}
     assert error.status_code == 422
     assert json.loads(error.body) == {"ok": False, "error": "invalid", "field": "name"}
+
+
+def test_json_helpers_reject_reserved_payload_keys():
+    from src.web.responses import json_error, json_ok
+
+    with pytest.raises(ValueError, match="reserved key"):
+        json_ok(**{"ok": False})
+
+    with pytest.raises(ValueError, match="reserved key"):
+        json_error("invalid", **{"ok": True})

--- a/tests/test_web_route_helpers.py
+++ b/tests/test_web_route_helpers.py
@@ -1,7 +1,10 @@
 """Tests for web route helpers and small module behaviors."""
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
+
+import pytest
 
 from src.web.routes import dialogs as dialogs_mod
 
@@ -88,3 +91,59 @@ def test_redirect_target_post_no_referer():
     request.headers = {}
     result = redirect_target_from_request(request)
     assert result == "/"
+
+
+# --- shared web responses ---
+
+
+def test_see_other_returns_303_redirect():
+    from src.web.responses import see_other
+
+    response = see_other("/settings")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings"
+
+
+def test_flash_redirect_adds_message_code():
+    from src.web.responses import flash_redirect
+
+    response = flash_redirect("/search-queries", msg="sq_added")
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/search-queries?msg=sq_added"
+
+
+def test_flash_redirect_encodes_values_and_skips_none_extras():
+    from src.web.responses import flash_redirect
+
+    response = flash_redirect(
+        "/pipelines?phone=%2B123",
+        error="bad value",
+        extra={"command_id": 42, "skip": None},
+        fragment="details",
+    )
+
+    assert response.headers["location"] == "/pipelines?phone=%2B123&error=bad+value&command_id=42#details"
+
+
+def test_flash_redirect_rejects_message_and_error_together():
+    from src.web.responses import flash_redirect
+
+    with pytest.raises(ValueError, match="either msg or error"):
+        flash_redirect("/settings", msg="saved", error="invalid")
+
+
+def test_json_response_helpers():
+    from src.web.responses import json_error, json_ok, json_response
+
+    plain = json_response({"items": []}, status_code=202)
+    ok = json_ok(started=True)
+    error = json_error("invalid", status_code=422, field="name")
+
+    assert plain.status_code == 202
+    assert json.loads(plain.body) == {"items": []}
+    assert ok.status_code == 200
+    assert json.loads(ok.body) == {"ok": True, "started": True}
+    assert error.status_code == 422
+    assert json.loads(error.body) == {"ok": False, "error": "invalid", "field": "name"}


### PR DESCRIPTION
## Summary
- add shared web response helpers for 303 redirects, flash query redirects, and JSON helpers
- migrate the small search queries route path to use the new flash redirect helper
- document the web route layering convention for forms, handlers, and responses

## Tests
- pytest tests/test_web_route_helpers.py -v
- pytest tests/routes/test_search_queries_routes.py -v
- ruff check src/ tests/ conftest.py
- git diff --check

Closes #504