### PR TITLE
refactor(web): atomize settings routes

### DIFF
--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -1,1269 +1,224 @@
-import asyncio
-import logging
-import os
-from datetime import UTC, datetime
-from types import SimpleNamespace
+from __future__ import annotations
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 
-from src.agent.manager import AgentManager
-from src.agent.prompt_template import (
-    AGENT_PROMPT_TEMPLATE_SETTING,
-    ALLOWED_TEMPLATE_VARIABLES,
-    DEFAULT_AGENT_PROMPT_TEMPLATE,
-    PromptTemplateError,
-    validate_prompt_template,
-)
-from src.agent.provider_registry import PROVIDER_ORDER, ProviderRuntimeConfig
-from src.agent.provider_registry import provider_spec as deepagents_provider_spec
-from src.services.agent_provider_service import (
-    AgentProviderService,
-    ProviderModelCacheEntry,
-    ProviderModelCompatibilityRecord,
-)
-from src.services.embedding_service import (
-    DEFAULT_EMBEDDINGS_BATCH_SIZE,
-    DEFAULT_EMBEDDINGS_MODEL,
-    DEFAULT_EMBEDDINGS_PROVIDER,
-    EMBEDDINGS_API_KEY_SETTING,
-    EMBEDDINGS_BASE_URL_SETTING,
-    EMBEDDINGS_BATCH_SIZE_SETTING,
-    EMBEDDINGS_MODEL_SETTING,
-    EMBEDDINGS_PROVIDER_SETTING,
-    LAST_EMBEDDED_ID_SETTING,
-    EmbeddingService,
-)
-from src.services.image_provider_service import (
-    IMAGE_PROVIDER_ORDER,
-    IMAGE_PROVIDER_SPECS,
-    ImageProviderService,
-    image_provider_spec,
-)
-from src.services.notification_service import NotificationService  # noqa: F401
-from src.settings_utils import parse_int_setting
 from src.web import deps
+from src.web.settings.forms import (
+    SettingsFormError,
+    parse_agent_form,
+    parse_credentials_form,
+    parse_filters_form,
+    parse_image_provider_save_form,
+    parse_notification_account_form,
+    parse_provider_add_form,
+    parse_provider_config_form,
+    parse_scheduler_form,
+    parse_semantic_index_form,
+    parse_semantic_search_form,
+    parse_translation_form,
+    parse_translation_run_form,
+)
+from src.web.settings.handlers import (
+    handle_add_agent_provider,
+    handle_add_image_provider,
+    handle_delete_agent_provider,
+    handle_delete_image_provider,
+    handle_delete_notification_bot,
+    handle_notification_bot_status,
+    handle_probe_agent_provider_model,
+    handle_refresh_agent_provider_models,
+    handle_refresh_all_agent_provider_models,
+    handle_run_semantic_index,
+    handle_save_agent_providers,
+    handle_save_agent_settings,
+    handle_save_credentials,
+    handle_save_filters,
+    handle_save_image_providers,
+    handle_save_notification_account,
+    handle_save_scheduler_settings,
+    handle_save_semantic_search_settings,
+    handle_save_translation_settings,
+    handle_settings_page,
+    handle_setup_notification_bot,
+    handle_test_all_agent_provider_models,
+    handle_test_all_agent_provider_models_status,
+    handle_test_notification,
+    handle_translation_backfill_lang,
+    handle_translation_run_batch,
+)
+from src.web.settings.responses import (
+    SettingsFlash,
+    settings_flash_response,
+    settings_json_response,
+    settings_result_response,
+)
 
 router = APIRouter()
-logger = logging.getLogger(__name__)
-
-CREDENTIALS_MASK = "••••••••"
-
-def _image_provider_service(request: Request) -> ImageProviderService:
-    return ImageProviderService(deps.get_db(request), request.app.state.config)
 
 
-def _wants_json(request: Request) -> bool:
-    return "application/json" in request.headers.get("accept", "")
-
-
-def _agent_provider_service(request: Request) -> AgentProviderService:
-    return AgentProviderService(deps.get_db(request), request.app.state.config)
-
-
-async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
-    snapshot = await deps.get_db(request).repos.runtime_snapshots.get_snapshot("notification_target_status")
-    payload = snapshot.payload if snapshot is not None else {}
-    return payload if isinstance(payload, dict) else {}
-
-
-async def _notification_snapshot_bot(request: Request):
-    payload = await _notification_snapshot_payload(request)
-    raw_bot = payload.get("bot")
-    if not isinstance(raw_bot, dict) or not raw_bot.get("configured"):
-        return None
-    return SimpleNamespace(
-        bot_username=raw_bot.get("bot_username"),
-        bot_id=raw_bot.get("bot_id"),
-        created_at=(
-            datetime.fromisoformat(raw_bot["created_at"])
-            if isinstance(raw_bot.get("created_at"), str)
-            else None
-        ),
-    )
-
-
-async def _enqueue_notification_command(
-    request: Request,
-    command_type: str,
-    *,
-    requested_by: str,
-    redirect_code: str,
-    payload: dict[str, object] | None = None,
-):
-    command_id = await deps.telegram_command_service(request).enqueue(
-        command_type,
-        payload=payload or {},
-        requested_by=requested_by,
-    )
-    if _wants_json(request):
-        return JSONResponse({"status": "queued", "command_id": command_id}, status_code=202)
-    return RedirectResponse(
-        url=f"/settings?msg={redirect_code}&command_id={command_id}",
-        status_code=303,
-    )
-
-
-async def _reload_llm_providers(request: Request) -> None:
-    """Reload the shared LLM provider service from DB after settings change."""
-    svc = getattr(request.app.state, "llm_provider_service", None)
-    if svc is not None:
-        try:
-            await svc.reload_db_providers()
-        except Exception:
-            logger.warning("Failed to reload LLM providers from DB", exc_info=True)
-
-
-async def _semantic_settings_context(request: Request) -> dict[str, object]:
-    db = deps.get_db(request)
-    last_embedded_id = parse_int_setting(
-        await db.get_setting(LAST_EMBEDDED_ID_SETTING),
-        setting_name=LAST_EMBEDDED_ID_SETTING,
-        default=0,
-        logger=logger,
-    )
-    batch_size = parse_int_setting(
-        await db.get_setting(EMBEDDINGS_BATCH_SIZE_SETTING),
-        setting_name=EMBEDDINGS_BATCH_SIZE_SETTING,
-        default=DEFAULT_EMBEDDINGS_BATCH_SIZE,
-        logger=logger,
-    )
-    embedding_dimensions = await db.repos.messages.get_embedding_dimensions()
-    embeddings_count = await db.repos.messages.count_embeddings()
-    return {
-        "semantic_embeddings_provider": (
-            await db.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
-        ),
-        "semantic_embeddings_model": (
-            await db.get_setting(EMBEDDINGS_MODEL_SETTING) or DEFAULT_EMBEDDINGS_MODEL
-        ),
-        "semantic_embeddings_api_key": (
-            CREDENTIALS_MASK if await db.get_setting(EMBEDDINGS_API_KEY_SETTING) else ""
-        ),
-        "semantic_embeddings_base_url": await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
-        "semantic_embeddings_batch_size": batch_size,
-        "semantic_last_embedded_id": last_embedded_id,
-        "semantic_embedding_dimensions": embedding_dimensions,
-        "semantic_embeddings_count": embeddings_count,
-    }
-
-
-def _settings_agent_manager(request: Request) -> tuple[AgentManager, bool]:
-    manager = deps.get_agent_manager(request)
-    if manager is not None:
-        return manager, True
-    pool = getattr(request.app.state, "pool", None)
-    return AgentManager(deps.get_db(request), request.app.state.config, client_pool=pool), False
-
-
-async def _dev_mode_enabled(request: Request) -> bool:
-    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
-
-
-async def _require_agent_dev_mode(
-    request: Request,
-    *,
-    json_mode: bool = False,
-):
-    if await _dev_mode_enabled(request):
-        return None
-    if json_mode:
-        return JSONResponse({"ok": False, "error": "Developer mode is required."}, status_code=403)
-    return RedirectResponse(url="/settings?error=agent_dev_mode_required", status_code=303)
-
-
-def _bulk_test_lock(request: Request) -> asyncio.Lock:
-    lock = getattr(request.app.state, "agent_provider_bulk_test_lock", None)
-    if lock is None:
-        lock = asyncio.Lock()
-        request.app.state.agent_provider_bulk_test_lock = lock
-    return lock
-
-
-def _bulk_test_status_payload(request: Request) -> dict[str, object]:
-    status = getattr(request.app.state, "agent_provider_bulk_test_status", None)
-    if status is None:
-        status = {
-            "running": False,
-            "started_at": "",
-            "finished_at": "",
-            "current_provider": "",
-            "current_model": "",
-            "completed_probes": 0,
-            "total_probes": 0,
-            "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
-            "providers": {},
-            "catalog_path": "",
-            "error": "",
-            "recent_events": [],
-        }
-        request.app.state.agent_provider_bulk_test_status = status
-    return status
-
-
-def _replace_bulk_test_status(request: Request, status: dict[str, object]) -> None:
-    request.app.state.agent_provider_bulk_test_status = status
-
-
-def _bulk_test_recent_event(status: dict[str, object], message: str) -> None:
-    events = list(status.get("recent_events", []))
-    events.append(f"{datetime.now(UTC).astimezone().strftime('%H:%M:%S')} {message}")
-    status["recent_events"] = events[-12:]
-
-
-async def _provider_configs_from_bulk_form(
-    request: Request,
-    service: AgentProviderService,
-) -> list[ProviderRuntimeConfig]:
-    form = await request.form()
-    existing = await service.load_provider_configs()
-    if any(str(key).startswith("provider_present__") for key in form.keys()):
-        return service.parse_provider_form(form, existing)
-    return existing
-
-
-async def _run_bulk_test_job(
-    request: Request,
-    configs: list[ProviderRuntimeConfig] | None = None,
-) -> None:
-    service = _agent_provider_service(request)
-    manager, is_persistent_manager = _settings_agent_manager(request)
-    if configs is None:
-        configs = await service.load_provider_configs()
-    status = {
-        "running": True,
-        "started_at": datetime.now(UTC).isoformat(),
-        "finished_at": "",
-        "current_provider": "",
-        "current_model": "",
-        "completed_probes": 0,
-        "total_probes": 0,
-        "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
-        "providers": {},
-        "catalog_path": "",
-        "error": "",
-        "recent_events": [],
-    }
-    try:
-        _replace_bulk_test_status(request, status)
-        logger.info("Bulk compatibility test started: providers=%d", len(configs))
-        total_probes = 0
-        entries_by_provider: dict[str, ProviderModelCacheEntry] = {}
-        for cfg in configs:
-            entry = await service.refresh_models_for_provider(cfg.provider, cfg)
-            entries_by_provider[cfg.provider] = entry
-            total_probes += len(entry.models)
-        status["total_probes"] = total_probes
-        _bulk_test_recent_event(status, f"Запущено тестирование {total_probes} моделей.")
-
-        for cfg in configs:
-            status["current_provider"] = cfg.provider
-            entry = entries_by_provider[cfg.provider]
-            logger.info(
-                "Bulk compatibility refresh: provider=%s selected_model=%s",
-                cfg.provider,
-                cfg.selected_model or "<empty>",
-            )
-            logger.info(
-                "Bulk compatibility models loaded: provider=%s source=%s count=%d error=%s",
-                cfg.provider,
-                entry.source,
-                len(entry.models),
-                entry.error or "",
-            )
-            provider_results: list[dict[str, str]] = []
-            provider_summary = {"supported": 0, "unsupported": 0, "unknown": 0}
-            status["providers"][cfg.provider] = {
-                "models": provider_results,
-                "source": entry.source,
-                "summary": provider_summary,
-            }
-            for model in entry.models:
-                status["current_model"] = model
-                _bulk_test_recent_event(status, f"Тестируется {cfg.provider} / {model}")
-                model_cfg = ProviderRuntimeConfig(
-                    provider=cfg.provider,
-                    enabled=cfg.enabled,
-                    priority=cfg.priority,
-                    selected_model=model,
-                    plain_fields=dict(cfg.plain_fields),
-                    secret_fields=dict(cfg.secret_fields),
-                )
-                validation_error = service.validate_provider_config(model_cfg)
-                if validation_error:
-                    logger.info(
-                        (
-                            "Bulk compatibility probe blocked: provider=%s "
-                            "model=%s status=unsupported reason=%s"
-                        ),
-                        cfg.provider,
-                        model,
-                        validation_error,
-                    )
-                    record = ProviderModelCompatibilityRecord(
-                        model=model,
-                        status="unsupported",
-                        reason=validation_error,
-                        config_fingerprint=service.config_fingerprint(model_cfg),
-                        probe_kind="dev-bulk",
-                    )
-                else:
-                    logger.info(
-                        "Bulk compatibility probe started: provider=%s model=%s",
-                        cfg.provider,
-                        model,
-                    )
-                    record = await _probe_provider_config(
-                        service,
-                        manager,
-                        model_cfg,
-                        probe_kind="dev-bulk",
-                        force=True,
-                    )
-                    logger.info(
-                        (
-                            "Bulk compatibility probe finished: provider=%s "
-                            "model=%s status=%s reason=%s"
-                        ),
-                        cfg.provider,
-                        record.model or model,
-                        record.status,
-                        record.reason or "",
-                    )
-                status["summary"][record.status] = status["summary"].get(record.status, 0) + 1
-                provider_summary[record.status] = provider_summary.get(record.status, 0) + 1
-                status["completed_probes"] = int(status["completed_probes"]) + 1
-                provider_results.append(
-                    {
-                        "model": record.model,
-                        "status": record.status,
-                        "reason": record.reason,
-                        "tested_at": record.tested_at,
-                    }
-                )
-            logger.info(
-                (
-                    "Bulk compatibility provider summary: provider=%s "
-                    "supported=%d unsupported=%d unknown=%d"
-                ),
-                cfg.provider,
-                provider_summary["supported"],
-                provider_summary["unsupported"],
-                provider_summary["unknown"],
-            )
-            _bulk_test_recent_event(
-                status,
-                (
-                    f"Провайдер {cfg.provider} завершён: "
-                    f"supported={provider_summary['supported']}, "
-                    f"unsupported={provider_summary['unsupported']}, "
-                    f"unknown={provider_summary['unknown']}"
-                ),
-            )
-
-        cache = await service.load_model_cache()
-        catalog_path = await service.export_compatibility_catalog(configs, cache)
-        status["catalog_path"] = str(catalog_path)
-        if is_persistent_manager:
-            await manager.refresh_settings_cache(preflight=True)
-        logger.info(
-            "Bulk compatibility test finished: supported=%d unsupported=%d unknown=%d catalog=%s",
-            status["summary"]["supported"],
-            status["summary"]["unsupported"],
-            status["summary"]["unknown"],
-            catalog_path,
-        )
-        _bulk_test_recent_event(
-            status,
-            (
-                f"Тестирование завершено. supported={status['summary']['supported']}, "
-                f"unsupported={status['summary']['unsupported']}, "
-                f"unknown={status['summary']['unknown']}"
-            ),
-        )
-    except Exception as exc:
-        status["error"] = str(exc)
-        logger.exception("Bulk compatibility test failed")
-        _bulk_test_recent_event(status, f"Ошибка: {exc}")
-    finally:
-        status["running"] = False
-        status["finished_at"] = datetime.now(UTC).isoformat()
-        status["current_provider"] = ""
-        status["current_model"] = ""
-
-
-async def _probe_provider_config(
-    service: AgentProviderService,
-    manager: AgentManager,
-    cfg: ProviderRuntimeConfig,
-    *,
-    probe_kind: str,
-    force: bool = False,
-) -> ProviderModelCompatibilityRecord:
-    return await service.ensure_model_compatibility(
-        cfg,
-        probe_runner=lambda current_cfg, current_probe_kind: manager.probe_provider_config(
-            current_cfg,
-            probe_kind=current_probe_kind,
-        ),
-        probe_kind=probe_kind,
-        force=force,
-    )
+def _settings_form_error_response(exc: SettingsFormError):
+    return settings_flash_response(SettingsFlash(error=exc.code))
 
 
 @router.get("/", response_class=HTMLResponse)
 async def settings_page(request: Request):
-    auth = deps.get_auth(request)
-    db = deps.get_db(request)
-    pool = deps.get_pool(request)
-    api_id_raw = await db.get_setting("tg_api_id") or ""
-    api_hash_raw = await db.get_setting("tg_api_hash") or ""
-    min_subscribers_filter = parse_int_setting(
-        await db.get_setting("min_subscribers_filter"),
-        setting_name="min_subscribers_filter",
-        default=0,
-        logger=logger,
-    )
-    auto_delete_filtered = (await db.get_setting("auto_delete_filtered") or "0") == "1"
-    auto_delete_on_collect = (await db.get_setting("auto_delete_on_collect") or "0") == "1"
-    saved_interval = await db.get_setting("collect_interval_minutes")
-    agent_dev_mode_enabled = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
-    agent_backend_override = await db.get_setting("agent_backend_override") or "auto"
-    agent_prompt_template = (
-        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
-    )
-    if agent_backend_override not in {"auto", "claude", "deepagents"}:
-        agent_backend_override = "auto"
-    config = request.app.state.config
-    provider_service = _agent_provider_service(request)
-    telegram_credentials_from_env = bool(
-        os.environ.get("TG_API_ID", "").strip().isdigit()
-        and os.environ.get("TG_API_HASH", "").strip()
-    )
-    collect_interval_minutes = parse_int_setting(
-        saved_interval,
-        setting_name="collect_interval_minutes",
-        default=config.scheduler.collect_interval_minutes,
-        logger=logger,
-    )
-    accounts = await db.get_accounts()
-    _now = datetime.now(UTC)
-    for _acc in accounts:
-        if _acc.flood_wait_until is not None:
-            _flood_until = _acc.flood_wait_until
-            if _flood_until.tzinfo is None:
-                _flood_until = _flood_until.replace(tzinfo=UTC)
-            if _flood_until <= _now:
-                await db.update_account_flood(_acc.phone, None)
-                _acc.flood_wait_until = None
-    connected_phones = set(pool.clients.keys())
-    account_status: dict[str, dict[str, object]] = {}
-    flooded_connected = []
-    for _acc in accounts:
-        connected = _acc.phone in connected_phones
-        if not _acc.is_active:
-            state = "inactive"
-            remaining_seconds = 0
-        elif not connected:
-            state = "disconnected"
-            remaining_seconds = 0
-        elif _acc.flood_wait_until is not None:
-            _flood_until = _acc.flood_wait_until
-            if _flood_until.tzinfo is None:
-                _flood_until = _flood_until.replace(tzinfo=UTC)
-            remaining_seconds = max(0, int((_flood_until - _now).total_seconds()))
-            if remaining_seconds > 0:
-                state = "flood"
-                flooded_connected.append(_flood_until)
-            else:
-                state = "available"
-        else:
-            state = "available"
-            remaining_seconds = 0
-        account_status[_acc.phone] = {
-            "state": state,
-            "remaining_seconds": remaining_seconds,
-            "remaining_minutes": max(1, remaining_seconds // 60) if remaining_seconds else 0,
-        }
-    all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
-        [acc for acc in accounts if acc.is_active and acc.phone in connected_phones]
-    )
-    next_available_at = min(flooded_connected) if flooded_connected else None
-    notification_target = await deps.get_notification_target_service(request).describe_target()
-    notification_bot = await _notification_snapshot_bot(request)
-    notification_bot_error = ""
-    provider_configs = await provider_service.load_provider_configs()
-    provider_cache = await provider_service.load_model_cache()
-    provider_views = provider_service.build_provider_views(provider_configs, provider_cache)
-    configured_names = {cfg.provider for cfg in provider_configs}
-    available_provider_options = [
-        provider_service.provider_specs[name]
-        for name in PROVIDER_ORDER
-        if name not in configured_names
-    ]
-    img_provider_service = _image_provider_service(request)
-    img_provider_configs = await img_provider_service.load_provider_configs()
-    img_provider_views = img_provider_service.build_provider_views(img_provider_configs)
-    configured_img_names = {cfg.provider for cfg in img_provider_configs}
-    available_img_options = [
-        IMAGE_PROVIDER_SPECS[name] for name in IMAGE_PROVIDER_ORDER if name not in configured_img_names
-    ]
-    semantic_context = await _semantic_settings_context(request)
-
-    # Translation settings
-    translation_provider = await db.get_setting("translation_provider") or ""
-    translation_model = await db.get_setting("translation_model") or ""
-    translation_target_lang = await db.get_setting("translation_target_lang") or ""
-    translation_source_filter = await db.get_setting("translation_source_filter") or ""
-    translation_auto_on_collect = await db.get_setting("translation_auto_on_collect") or "0"
-    language_stats = await db.repos.messages.get_language_stats()
-
-    from src.agent.tools.permissions import (
-        build_template_context,
-        load_tool_permissions_all_phones,
-    )
-
-    phone_permissions = await load_tool_permissions_all_phones(db, accounts)
-    # Build per-phone template contexts
-    phone_perm_contexts = {
-        phone: build_template_context(perms)
-        for phone, perms in phone_permissions.items()
-    }
-
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "settings.html",
-        {
-            "is_configured": auth.is_configured,
-            "telegram_credentials_from_env": telegram_credentials_from_env,
-            "api_id": CREDENTIALS_MASK if api_id_raw else "",
-            "api_hash": CREDENTIALS_MASK if api_hash_raw else "",
-            "min_subscribers_filter": min_subscribers_filter,
-            "auto_delete_filtered": auto_delete_filtered,
-            "auto_delete_on_collect": auto_delete_on_collect,
-            "accounts": accounts,
-            "account_status": account_status,
-            "account_phones": [acc.phone for acc in accounts],
-            "connected_phones": connected_phones,
-            "all_accounts_flooded": all_accounts_flooded,
-            "next_available_at": next_available_at,
-            "notification_target": notification_target,
-            "notification_selected_phone": notification_target.configured_phone or "",
-            "notification_bot": notification_bot,
-            "notification_bot_error": notification_bot_error,
-            "collect_interval_minutes": collect_interval_minutes,
-            "agent_dev_mode_enabled": agent_dev_mode_enabled,
-            "agent_backend_override": agent_backend_override,
-            "agent_prompt_template": agent_prompt_template,
-            "agent_fallback_model": config.agent.fallback_model
-            or os.environ.get("AGENT_FALLBACK_MODEL", "").strip(),
-            "agent_prompt_template_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
-            "agent_provider_writes_enabled": provider_service.writes_enabled,
-            "agent_provider_views": provider_views,
-            "agent_provider_options": available_provider_options,
-            "img_provider_writes_enabled": img_provider_service.writes_enabled,
-            "img_provider_views": img_provider_views,
-            "img_provider_options": available_img_options,
-            "default_image_model": await db.get_setting("default_image_model") or "",
-            **semantic_context,
-            "phone_perm_contexts": phone_perm_contexts,
-            "translation_provider": translation_provider,
-            "translation_model": translation_model,
-            "translation_target_lang": translation_target_lang,
-            "translation_source_filter": translation_source_filter,
-            "translation_auto_on_collect": translation_auto_on_collect,
-            "language_stats": language_stats,
-        },
-    )
+    context = await handle_settings_page(request)
+    return deps.get_templates(request).TemplateResponse(request, "settings.html", context)
 
 
 @router.post("/save-scheduler")
 async def save_scheduler_settings(request: Request):
-    form = await request.form()
     try:
-        interval = int(form.get("collect_interval_minutes", 60))
-    except (TypeError, ValueError):
-        return RedirectResponse(url="/settings?error=invalid_value", status_code=303)
-    interval = max(1, min(1440, interval))
-    db = deps.get_db(request)
-    await db.set_setting("collect_interval_minutes", str(interval))
-    scheduler = getattr(request.app.state, "scheduler", None)
-    if scheduler:
-        scheduler.update_interval(interval)
-    return RedirectResponse(url="/settings?msg=scheduler_saved", status_code=303)
+        form = parse_scheduler_form(await request.form())
+    except SettingsFormError as exc:
+        return _settings_form_error_response(exc)
+    return settings_flash_response(await handle_save_scheduler_settings(request, form))
 
 
 @router.post("/save-semantic-search")
 async def save_semantic_search_settings(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-
-    provider = str(form.get("semantic_embeddings_provider", DEFAULT_EMBEDDINGS_PROVIDER)).strip()
-    model = str(form.get("semantic_embeddings_model", DEFAULT_EMBEDDINGS_MODEL)).strip()
-    base_url = str(form.get("semantic_embeddings_base_url", "")).strip()
-    api_key_raw = form.get("semantic_embeddings_api_key")
-    batch_size_raw = str(form.get("semantic_embeddings_batch_size", DEFAULT_EMBEDDINGS_BATCH_SIZE))
-    reset_index = str(form.get("semantic_reset_index", "")).strip() == "1"
-
-    if not provider or not model:
-        return RedirectResponse(url="/settings?error=semantic_invalid_value", status_code=303)
     try:
-        batch_size = int(batch_size_raw)
-    except (TypeError, ValueError):
-        return RedirectResponse(url="/settings?error=semantic_invalid_value", status_code=303)
-    batch_size = max(1, min(1000, batch_size))
-
-    current_values = {
-        EMBEDDINGS_PROVIDER_SETTING: await db.get_setting(EMBEDDINGS_PROVIDER_SETTING)
-        or DEFAULT_EMBEDDINGS_PROVIDER,
-        EMBEDDINGS_MODEL_SETTING: await db.get_setting(EMBEDDINGS_MODEL_SETTING)
-        or DEFAULT_EMBEDDINGS_MODEL,
-        EMBEDDINGS_BASE_URL_SETTING: await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
-        EMBEDDINGS_API_KEY_SETTING: await db.get_setting(EMBEDDINGS_API_KEY_SETTING) or "",
-    }
-    changed = (
-        current_values[EMBEDDINGS_PROVIDER_SETTING] != provider
-        or current_values[EMBEDDINGS_MODEL_SETTING] != model
-        or current_values[EMBEDDINGS_BASE_URL_SETTING] != base_url
-    )
-    await db.set_setting(EMBEDDINGS_PROVIDER_SETTING, provider)
-    await db.set_setting(EMBEDDINGS_MODEL_SETTING, model)
-    await db.set_setting(EMBEDDINGS_BASE_URL_SETTING, base_url)
-    await db.set_setting(EMBEDDINGS_BATCH_SIZE_SETTING, str(batch_size))
-    if api_key_raw is not None:
-        api_key = str(api_key_raw).strip()
-        if api_key != CREDENTIALS_MASK:
-            await db.set_setting(EMBEDDINGS_API_KEY_SETTING, api_key)
-    if changed or reset_index:
-        await db.repos.messages.reset_embeddings_index()
-        deps.get_search_engine(request).invalidate_numpy_index()
-    return RedirectResponse(url="/settings?msg=semantic_saved", status_code=303)
+        form = parse_semantic_search_form(await request.form())
+    except SettingsFormError as exc:
+        return _settings_form_error_response(exc)
+    return settings_flash_response(await handle_save_semantic_search_settings(request, form))
 
 
 @router.post("/semantic-index")
 async def run_semantic_index(request: Request):
-    db = deps.get_db(request)
-    if not deps.get_search_engine(request).semantic_available:
-        return RedirectResponse(url="/settings?error=semantic_unavailable", status_code=303)
-    form = await request.form()
-    reset_index = str(form.get("semantic_reset_index", "")).strip() == "1"
-    if reset_index:
-        await db.repos.messages.reset_embeddings_index()
-    indexed = await EmbeddingService(db, request.app.state.config).index_pending_messages()
-    if indexed > 0 or reset_index:
-        deps.get_search_engine(request).invalidate_numpy_index()
-    return RedirectResponse(
-        url=f"/settings?msg=semantic_indexed&indexed={indexed}",
-        status_code=303,
-    )
+    form = parse_semantic_index_form(await request.form())
+    return settings_flash_response(await handle_run_semantic_index(request, form))
 
 
 @router.post("/save-agent")
 async def save_agent_settings(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-
-    form_scope = str(form.get("agent_form_scope", "dev_mode")).strip()
-
-    if form_scope == "tool_permissions":
-        from src.agent.tools.permissions import TOOL_CATEGORIES, save_tool_permissions
-
-        phone = str(form.get("phone", "")).strip() or None
-        permissions = {}
-        for tool_name in TOOL_CATEGORIES:
-            permissions[tool_name] = form.get(f"tool_perm__{tool_name}") == "1"
-        await save_tool_permissions(db, permissions, phone=phone)
-        return RedirectResponse(url="/settings?msg=tool_permissions_saved#pane-tool-permissions", status_code=303)
-
-    current_dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
-    current_backend_override = await db.get_setting("agent_backend_override") or "auto"
-    current_prompt_template = (
-        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
-    )
-
-    wants_dev_mode = str(form.get("agent_dev_mode_enabled", "")).strip() == "1"
-    disclaimer_accepted = str(form.get("agent_dev_mode_disclaimer", "")).strip() == "1"
-    backend_override_raw = form.get("agent_backend_override")
-    if backend_override_raw is None:
-        backend_override = current_backend_override
-    else:
-        backend_override = str(backend_override_raw).strip()
-    if backend_override not in {"auto", "claude", "deepagents"}:
-        backend_override = "auto"
-
-    if form_scope == "backend_override":
-        dev_mode_enabled = current_dev_mode
-    else:
-        if not wants_dev_mode:
-            dev_mode_enabled = False
-        elif disclaimer_accepted:
-            dev_mode_enabled = True
-        else:
-            dev_mode_enabled = current_dev_mode
-
-    if form_scope == "prompt_template":
-        prompt_template = str(form.get("agent_prompt_template") or "")
-        if not prompt_template.strip():
-            prompt_template = DEFAULT_AGENT_PROMPT_TEMPLATE
-        try:
-            validate_prompt_template(prompt_template)
-        except PromptTemplateError as exc:
-            logger.warning("Rejected invalid agent prompt template: %s", exc)
-            return RedirectResponse(
-                url="/settings?error=agent_prompt_template_invalid",
-                status_code=303,
-            )
-    else:
-        prompt_template = current_prompt_template
-
-    # Reset override when dev mode is off to prevent stale override from activating later
-    if not dev_mode_enabled:
-        backend_override = "auto"
-
-    if backend_override != "auto" and dev_mode_enabled:
-        if backend_override == "deepagents":
-            service = _agent_provider_service(request)
-            configs = await service.load_provider_configs()
-            has_valid = any(
-                cfg.enabled and not service.validate_provider_config(cfg) for cfg in configs
-            )
-            if not has_valid:
-                logger.warning(
-                    "Rejected deepagents override in dev mode: no valid provider configs are available"
-                )
-                return RedirectResponse(
-                    url="/settings?error=agent_backend_no_valid_providers", status_code=303
-                )
-        elif backend_override == "claude":
-            if not (
-                os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
-            ):
-                logger.warning(
-                    "Rejected claude override in dev mode: no API credentials are available"
-                )
-                return RedirectResponse(
-                    url="/settings?error=agent_backend_claude_unavailable", status_code=303
-                )
-
-    await db.set_setting("agent_dev_mode_enabled", "1" if dev_mode_enabled else "0")
-    await db.set_setting("agent_backend_override", backend_override)
-    await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
-    agent_manager = deps.get_agent_manager(request)
-    if agent_manager is not None:
-        await agent_manager.refresh_settings_cache(preflight=True)
-    return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
-
+    try:
+        form = parse_agent_form(await request.form())
+    except SettingsFormError as exc:
+        return _settings_form_error_response(exc)
+    return settings_flash_response(await handle_save_agent_settings(request, form))
 
 
 @router.post("/agent-providers/add")
 async def add_agent_provider(request: Request):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(
-            url="/settings?error=agent_provider_secret_required", status_code=303
-        )
-    dev_mode_required = await _require_agent_dev_mode(request)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    form = await request.form()
-    provider_name = str(form.get("provider", "")).strip()
-    if deepagents_provider_spec(provider_name) is None:
-        return RedirectResponse(url="/settings?error=agent_provider_invalid", status_code=303)
-    configs = await service.load_provider_configs()
-    if any(cfg.provider == provider_name for cfg in configs):
-        return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
-    priority = max((cfg.priority for cfg in configs), default=-1) + 1
-    configs.append(service.create_empty_config(provider_name, priority))
-    await service.save_provider_configs(configs)
-    agent_manager = deps.get_agent_manager(request)
-    if agent_manager is not None:
-        await agent_manager.refresh_settings_cache(preflight=True)
-    await _reload_llm_providers(request)
-    return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
+    form = parse_provider_add_form(await request.form())
+    return settings_flash_response(await handle_add_agent_provider(request, form))
 
 
 @router.post("/agent-providers/save")
 async def save_agent_providers(request: Request):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(
-            url="/settings?error=agent_provider_secret_required", status_code=303
-        )
-    dev_mode_required = await _require_agent_dev_mode(request)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    form = await request.form()
-    existing = await service.load_provider_configs()
-    configs = service.parse_provider_form(form, existing)
-    manager, is_persistent_manager = _settings_agent_manager(request)
-    validated: list[ProviderRuntimeConfig] = []
-    for cfg in configs:
-        validation_error = ""
-        if cfg.enabled:
-            validation_error = service.validate_provider_config(cfg)
-        if cfg.enabled and not validation_error:
-            await _probe_provider_config(
-                service,
-                manager,
-                cfg,
-                probe_kind="save-time",
-            )
-        validated.append(
-            ProviderRuntimeConfig(
-                provider=cfg.provider,
-                enabled=cfg.enabled,
-                priority=cfg.priority,
-                selected_model=cfg.selected_model,
-                plain_fields=cfg.plain_fields,
-                secret_fields=cfg.secret_fields,
-                last_validation_error=validation_error,
-            )
-        )
-    await service.save_provider_configs(validated)
-    if is_persistent_manager:
-        await manager.refresh_settings_cache(preflight=True)
-    await _reload_llm_providers(request)
-    return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
+    form = parse_provider_config_form(await request.form())
+    return settings_flash_response(await handle_save_agent_providers(request, form))
 
 
 @router.post("/agent-providers/{provider_name}/delete")
 async def delete_agent_provider(request: Request, provider_name: str):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(
-            url="/settings?error=agent_provider_secret_required", status_code=303
-        )
-    dev_mode_required = await _require_agent_dev_mode(request)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    configs = await service.load_provider_configs()
-    configs = [cfg for cfg in configs if cfg.provider != provider_name]
-    for index, cfg in enumerate(configs):
-        cfg.priority = index
-    await service.save_provider_configs(configs)
-    agent_manager = deps.get_agent_manager(request)
-    if agent_manager is not None:
-        await agent_manager.refresh_settings_cache(preflight=True)
-    await _reload_llm_providers(request)
-    return RedirectResponse(url="/settings?msg=agent_saved", status_code=303)
+    return settings_flash_response(await handle_delete_agent_provider(request, provider_name))
 
 
 @router.post("/agent-providers/{provider_name}/refresh")
 async def refresh_agent_provider_models(request: Request, provider_name: str):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return JSONResponse(
-            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."}, status_code=409
-        )
-    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    if deepagents_provider_spec(provider_name) is None:
-        return JSONResponse({"ok": False, "error": "Unknown provider."}, status_code=404)
-    form = await request.form()
-    configs = await service.load_provider_configs()
-    cfg = service.parse_single_provider_form(form, configs, provider_name)
-    entry = await service.refresh_models_for_provider(provider_name, cfg)
-    return JSONResponse(
-        {
-            "ok": True,
-            "provider": provider_name,
-            "models": entry.models,
-            "source": entry.source,
-            "error": entry.error,
-            "fetched_at": entry.fetched_at,
-            "compatibility": (
-                service.build_compatibility_payload(cfg, entry) if cfg is not None else {}
-            ),
-        }
-    )
+    form = parse_provider_config_form(await request.form())
+    return settings_json_response(await handle_refresh_agent_provider_models(request, provider_name, form))
 
 
 @router.post("/agent-providers/refresh-all")
 async def refresh_all_agent_provider_models(request: Request):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return JSONResponse(
-            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."}, status_code=409
-        )
-    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    configs = await _provider_configs_from_bulk_form(request, service)
-    config_map = {cfg.provider: cfg for cfg in configs}
-    results = await service.refresh_all_models(configs)
-    return JSONResponse(
-        {
-            "ok": True,
-            "providers": {
-                provider: {
-                    "models": entry.models,
-                    "source": entry.source,
-                    "error": entry.error,
-                    "fetched_at": entry.fetched_at,
-                    "compatibility": (
-                        service.build_compatibility_payload(config_map[provider], entry)
-                        if provider in config_map
-                        else {}
-                    ),
-                }
-                for provider, entry in results.items()
-            },
-        }
-    )
+    form = parse_provider_config_form(await request.form())
+    return settings_json_response(await handle_refresh_all_agent_provider_models(request, form))
 
 
 @router.post("/agent-providers/{provider_name}/probe")
 async def probe_agent_provider_model(request: Request, provider_name: str):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return JSONResponse(
-            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."}, status_code=409
-        )
-    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
-    if dev_mode_required is not None:
-        return dev_mode_required
-    if deepagents_provider_spec(provider_name) is None:
-        return JSONResponse({"ok": False, "error": "Unknown provider."}, status_code=404)
-
-    form = await request.form()
-    existing = await service.load_provider_configs()
-    cfg = service.parse_single_provider_form(form, existing, provider_name)
-    validation_error = service.validate_provider_config(cfg)
-    if validation_error:
-        logger.info(
-            "Compatibility probe skipped: provider=%s model=%s status=unsupported reason=%s",
-            provider_name,
-            cfg.selected_model or "<empty>",
-            validation_error,
-        )
-        return JSONResponse(
-            {
-                "ok": True,
-                "provider": provider_name,
-                "model": cfg.selected_model,
-                "status": "unsupported",
-                "reason": validation_error,
-                "tested_at": "",
-                "config_fingerprint": service.config_fingerprint(cfg),
-            }
-        )
-
-    manager, _ = _settings_agent_manager(request)
-    logger.info(
-        "Compatibility probe requested: provider=%s model=%s kind=auto-select",
-        provider_name,
-        cfg.selected_model or "<empty>",
-    )
-    record = await _probe_provider_config(
-        service,
-        manager,
-        cfg,
-        probe_kind="auto-select",
-    )
-    logger.info(
-        "Compatibility probe finished: provider=%s model=%s status=%s kind=%s reason=%s",
-        provider_name,
-        record.model or "<empty>",
-        record.status,
-        record.probe_kind,
-        record.reason or "",
-    )
-    return JSONResponse(
-        {
-            "ok": True,
-            "provider": provider_name,
-            "model": record.model,
-            "status": record.status,
-            "reason": record.reason,
-            "tested_at": record.tested_at,
-            "config_fingerprint": record.config_fingerprint,
-            "probe_kind": record.probe_kind,
-        }
-    )
+    form = parse_provider_config_form(await request.form())
+    return settings_json_response(await handle_probe_agent_provider_model(request, provider_name, form))
 
 
 @router.post("/agent-providers/test-all")
 async def test_all_agent_provider_models(request: Request):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return JSONResponse(
-            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."}, status_code=409
-        )
-    if not await _dev_mode_enabled(request):
-        return JSONResponse({"ok": False, "error": "Developer mode is required."}, status_code=403)
-    configs = await _provider_configs_from_bulk_form(request, service)
-    async with _bulk_test_lock(request):
-        status = _bulk_test_status_payload(request)
-        if status.get("running"):
-            return JSONResponse(
-                {
-                    "ok": False,
-                    "error": "Bulk compatibility test is already running.",
-                    **status,
-                },
-                status_code=409,
-            )
-        initial_status = {
-            "running": True,
-            "started_at": datetime.now(UTC).isoformat(),
-            "finished_at": "",
-            "current_provider": "",
-            "current_model": "",
-            "completed_probes": 0,
-            "total_probes": 0,
-            "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
-            "providers": {},
-            "catalog_path": "",
-            "error": "",
-            "recent_events": ["Запуск массового тестирования..."],
-        }
-        _replace_bulk_test_status(request, initial_status)
-        request.app.state.agent_provider_bulk_test_task = asyncio.create_task(
-            _run_bulk_test_job(request, configs=configs)
-        )
-    return JSONResponse({"ok": True, "started": True, **_bulk_test_status_payload(request)})
+    form = parse_provider_config_form(await request.form())
+    return settings_json_response(await handle_test_all_agent_provider_models(request, form))
 
 
 @router.get("/agent-providers/test-all/status")
 async def test_all_agent_provider_models_status(request: Request):
-    service = _agent_provider_service(request)
-    if not service.writes_enabled:
-        return JSONResponse(
-            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."}, status_code=409
-        )
-    if not await _dev_mode_enabled(request):
-        return JSONResponse({"ok": False, "error": "Developer mode is required."}, status_code=403)
-    return JSONResponse({"ok": True, **_bulk_test_status_payload(request)})
+    return settings_json_response(await handle_test_all_agent_provider_models_status(request))
 
 
 @router.post("/save-filters")
 async def save_filters(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-    min_subs = str(form.get("min_subscribers_filter", "0")).strip()
-    if not min_subs.isdigit():
-        return RedirectResponse(url="/settings?error=invalid_value", status_code=303)
-    await db.set_setting("min_subscribers_filter", min_subs)
-    await db.set_setting(
-        "auto_delete_filtered",
-        "1" if form.get("auto_delete_filtered") else "0",
-    )
-    await db.set_setting(
-        "auto_delete_on_collect",
-        "1" if form.get("auto_delete_on_collect") else "0",
-    )
-    if int(min_subs) > 0:
-        all_stats = await db.get_latest_stats_for_all()
-        to_filter = [
-            (channel_id, "low_subscriber_manual")
-            for channel_id, stats in all_stats.items()
-            if stats.subscriber_count is not None and stats.subscriber_count < int(min_subs)
-        ]
-        if to_filter:
-            await db.set_channels_filtered_bulk(to_filter)
-    return RedirectResponse(url="/settings?msg=filters_saved", status_code=303)
+    try:
+        form = parse_filters_form(await request.form())
+    except SettingsFormError as exc:
+        return _settings_form_error_response(exc)
+    return settings_flash_response(await handle_save_filters(request, form))
 
 
 @router.post("/save-notification-account")
 async def save_notification_account(request: Request):
-    form = await request.form()
-    selected_phone = str(form.get("notification_account_phone", "")).strip()
-    db = deps.get_db(request)
-    valid_phones = {acc.phone for acc in await db.get_accounts()}
-    if selected_phone and selected_phone not in valid_phones:
-        return RedirectResponse(url="/settings?error=notification_account_invalid", status_code=303)
-
-    await deps.get_notification_target_service(request).set_configured_phone(selected_phone or None)
-    # Invalidate cached me.id so the next notify() re-resolves it for the new account.
-    notifier = deps.get_notifier(request)
-    if notifier:
-        notifier.invalidate_me_cache()
-    return RedirectResponse(url="/settings?msg=notification_account_saved", status_code=303)
+    form = parse_notification_account_form(await request.form())
+    return settings_flash_response(await handle_save_notification_account(request, form))
 
 
 @router.post("/save-credentials")
 async def save_credentials(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-    auth = deps.get_auth(request)
-
-    api_id = str(form.get("api_id", "")).strip()
-    api_hash = str(form.get("api_hash", "")).strip()
-
-    id_changed = api_id and api_id != CREDENTIALS_MASK
-    hash_changed = api_hash and api_hash != CREDENTIALS_MASK
-
-    if id_changed and not api_id.isdigit():
-        return RedirectResponse(url="/settings?error=invalid_api_id", status_code=303)
-
-    if id_changed:
-        await db.set_setting("tg_api_id", api_id)
-    if hash_changed:
-        await db.set_setting("tg_api_hash", api_hash)
-
-    if id_changed or hash_changed:
-        actual_id = api_id if id_changed else (await db.get_setting("tg_api_id") or "")
-        actual_hash = api_hash if hash_changed else (await db.get_setting("tg_api_hash") or "")
-        if actual_id and actual_hash:
-            if not actual_id.isdigit():
-                return RedirectResponse(url="/settings?error=invalid_api_id", status_code=303)
-            auth.update_credentials(int(actual_id), actual_hash)
-
-    return RedirectResponse(url="/settings?msg=credentials_saved", status_code=303)
+    form = parse_credentials_form(await request.form())
+    return settings_flash_response(await handle_save_credentials(request, form))
 
 
 @router.post("/notifications/setup")
 async def setup_notification_bot(request: Request):
-    return await _enqueue_notification_command(
-        request,
-        "notifications.setup_bot",
-        requested_by="web:settings.notifications.setup",
-        redirect_code="notification_setup_queued",
-    )
+    return settings_result_response(await handle_setup_notification_bot(request))
 
 
 @router.get("/notifications/status")
 async def notification_bot_status(request: Request):
-    payload = await _notification_snapshot_payload(request)
-    raw_target = payload.get("target")
-    if isinstance(raw_target, dict) and raw_target.get("state") not in {None, "available"}:
-        return JSONResponse(
-            {"configured": False, "error": raw_target.get("message", "")},
-            status_code=409,
-        )
-    bot = await _notification_snapshot_bot(request)
-    if bot is None:
-        return JSONResponse({"configured": False})
-    return JSONResponse(
-        {
-            "configured": True,
-            "bot_username": bot.bot_username,
-            "bot_id": bot.bot_id,
-            "created_at": bot.created_at.isoformat() if bot.created_at else None,
-        }
-    )
+    return settings_json_response(await handle_notification_bot_status(request))
 
 
 @router.post("/notifications/delete")
 async def delete_notification_bot(request: Request):
-    return await _enqueue_notification_command(
-        request,
-        "notifications.delete_bot",
-        requested_by="web:settings.notifications.delete",
-        redirect_code="notification_delete_queued",
-    )
+    return settings_result_response(await handle_delete_notification_bot(request))
 
 
 @router.post("/notifications/test")
 async def test_notification(request: Request):
-    return await _enqueue_notification_command(
-        request,
-        "notifications.test",
-        requested_by="web:settings.notifications.test",
-        redirect_code="notification_test_queued",
-    )
-
-
-# ── Image Providers ──
+    return settings_result_response(await handle_test_notification(request))
 
 
 @router.post("/image-providers/add")
 async def add_image_provider(request: Request):
-    service = _image_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
-    form = await request.form()
-    provider_name = str(form.get("provider", "")).strip()
-    if image_provider_spec(provider_name) is None:
-        return RedirectResponse(url="/settings?error=image_provider_invalid", status_code=303)
-    configs = await service.load_provider_configs()
-    if any(cfg.provider == provider_name for cfg in configs):
-        return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
-    configs.append(service.create_empty_config(provider_name))
-    await service.save_provider_configs(configs)
-    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+    form = parse_provider_add_form(await request.form())
+    return settings_flash_response(await handle_add_image_provider(request, form))
 
 
 @router.post("/image-providers/save")
 async def save_image_providers(request: Request):
-    service = _image_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
-    form = await request.form()
-    existing = await service.load_provider_configs()
-    configs = service.parse_provider_form(form, existing)
-    # Validate enabled configs have an API key or env var fallback
-    for cfg in configs:
-        if not cfg.enabled:
-            continue
-        spec = image_provider_spec(cfg.provider)
-        if spec is None:
-            continue
-        has_key = bool(cfg.api_key.strip())
-        has_env = any(os.environ.get(v) for v in spec.env_vars)
-        if not has_key and not has_env:
-            return RedirectResponse(
-                url="/settings?error=image_provider_missing_key", status_code=303
-            )
-    await service.save_provider_configs(configs)
-    default_model = str(form.get("default_image_model", "")).strip()
-    await deps.get_db(request).set_setting("default_image_model", default_model)
-    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+    form = parse_image_provider_save_form(await request.form())
+    return settings_flash_response(await handle_save_image_providers(request, form))
 
 
 @router.post("/image-providers/{provider_name}/delete")
 async def delete_image_provider(request: Request, provider_name: str):
-    service = _image_provider_service(request)
-    if not service.writes_enabled:
-        return RedirectResponse(url="/settings?error=image_provider_secret_required", status_code=303)
-    configs = await service.load_provider_configs()
-    configs = [cfg for cfg in configs if cfg.provider != provider_name]
-    await service.save_provider_configs(configs)
-    return RedirectResponse(url="/settings?msg=image_saved", status_code=303)
+    return settings_flash_response(await handle_delete_image_provider(request, provider_name))
 
 
 @router.post("/save-translation")
 async def save_translation_settings(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-    await db.set_setting("translation_provider", str(form.get("translation_provider", "")).strip())
-    await db.set_setting("translation_model", str(form.get("translation_model", "")).strip())
-    await db.set_setting("translation_target_lang", str(form.get("translation_target_lang", "")).strip().lower())
-    await db.set_setting("translation_source_filter", str(form.get("translation_source_filter", "")).strip().lower())
-    await db.set_setting("translation_auto_on_collect", "1" if form.get("translation_auto_on_collect") else "0")
-    return RedirectResponse(url="/settings?msg=translation_saved#pane-translation", status_code=303)
+    form = parse_translation_form(await request.form())
+    return settings_flash_response(await handle_save_translation_settings(request, form))
 
 
 @router.post("/translation-backfill")
 async def translation_backfill_lang(request: Request):
-    db = deps.get_db(request)
-    updated = await db.repos.messages.backfill_language_detection(batch_size=5000)
-    return RedirectResponse(
-        url=f"/settings?msg=translation_backfill_done&count={updated}#pane-translation", status_code=303
-    )
+    return settings_flash_response(await handle_translation_backfill_lang(request))
 
 
 @router.post("/translation-run")
 async def translation_run_batch(request: Request):
-    form = await request.form()
-    db = deps.get_db(request)
-    target_lang = str(form.get("target_lang", "en")).strip().lower() or "en"
-    source_filter_raw = await db.get_setting("translation_source_filter") or ""
-    source_filter = [s.strip() for s in source_filter_raw.split(",") if s.strip()]
-
-    from src.models import CollectionTaskType, TranslateBatchTaskPayload
-
-    payload = TranslateBatchTaskPayload(
-        target_lang=target_lang,
-        source_filter=source_filter,
-    )
-    await db.repos.tasks.create_generic_task(
-        CollectionTaskType.TRANSLATE_BATCH,
-        title=f"Translation batch ({target_lang})",
-        payload=payload,
-    )
-    return RedirectResponse(url="/settings?msg=translation_run_started#pane-translation", status_code=303)
+    form = parse_translation_run_form(await request.form())
+    return settings_flash_response(await handle_translation_run_batch(request, form))
 
 
-    # Account toggle/delete endpoints moved to src/web/routes/accounts.py
+# Account toggle/delete endpoints live in src/web/routes/accounts.py.

--- a/src/web/settings/__init__.py
+++ b/src/web/settings/__init__.py
@@ -1,0 +1,2 @@
+"""Internal settings route helpers."""
+

--- a/src/web/settings/forms.py
+++ b/src/web/settings/forms.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from src.services.embedding_service import (
+    DEFAULT_EMBEDDINGS_BATCH_SIZE,
+    DEFAULT_EMBEDDINGS_MODEL,
+    DEFAULT_EMBEDDINGS_PROVIDER,
+)
+
+CREDENTIALS_MASK = "••••••••"
+
+
+class SettingsFormError(ValueError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+FormMapping = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SchedulerSettingsForm:
+    interval_minutes: int
+
+
+@dataclass(frozen=True)
+class SemanticSearchSettingsForm:
+    provider: str
+    model: str
+    base_url: str
+    api_key: str | None
+    batch_size: int
+    reset_index: bool
+
+
+@dataclass(frozen=True)
+class SemanticIndexForm:
+    reset_index: bool
+
+
+@dataclass(frozen=True)
+class AgentToolPermissionsForm:
+    phone: str | None
+    permissions: dict[str, bool]
+
+
+@dataclass(frozen=True)
+class AgentSettingsForm:
+    form_scope: str
+    wants_dev_mode: bool
+    disclaimer_accepted: bool
+    backend_override: str | None
+    prompt_template: str | None
+    tool_permissions: AgentToolPermissionsForm | None
+
+
+@dataclass(frozen=True)
+class ProviderAddForm:
+    provider: str
+
+
+@dataclass(frozen=True)
+class ProviderConfigForm:
+    raw: FormMapping
+
+
+@dataclass(frozen=True)
+class FiltersForm:
+    min_subscribers: str
+    auto_delete_filtered: bool
+    auto_delete_on_collect: bool
+
+
+@dataclass(frozen=True)
+class NotificationAccountForm:
+    selected_phone: str
+
+
+@dataclass(frozen=True)
+class CredentialsForm:
+    api_id: str
+    api_hash: str
+
+
+@dataclass(frozen=True)
+class ImageProviderSaveForm:
+    raw: FormMapping
+    default_model: str
+
+
+@dataclass(frozen=True)
+class TranslationSettingsForm:
+    provider: str
+    model: str
+    target_lang: str
+    source_filter: str
+    auto_on_collect: bool
+
+
+@dataclass(frozen=True)
+class TranslationRunForm:
+    target_lang: str
+
+
+def _text(form: FormMapping, key: str, default: object = "") -> str:
+    return str(form.get(key, default)).strip()
+
+
+def _checked(form: FormMapping, key: str) -> bool:
+    return bool(form.get(key))
+
+
+def parse_scheduler_form(form: FormMapping) -> SchedulerSettingsForm:
+    try:
+        interval = int(form.get("collect_interval_minutes", 60))
+    except (TypeError, ValueError) as exc:
+        raise SettingsFormError("invalid_value") from exc
+    return SchedulerSettingsForm(interval_minutes=max(1, min(1440, interval)))
+
+
+def parse_semantic_search_form(form: FormMapping) -> SemanticSearchSettingsForm:
+    provider = _text(form, "semantic_embeddings_provider", DEFAULT_EMBEDDINGS_PROVIDER)
+    model = _text(form, "semantic_embeddings_model", DEFAULT_EMBEDDINGS_MODEL)
+    base_url = _text(form, "semantic_embeddings_base_url")
+    api_key = _text(form, "semantic_embeddings_api_key") if "semantic_embeddings_api_key" in form else None
+    reset_index = _text(form, "semantic_reset_index") == "1"
+    if not provider or not model:
+        raise SettingsFormError("semantic_invalid_value")
+    try:
+        batch_size = int(str(form.get("semantic_embeddings_batch_size", DEFAULT_EMBEDDINGS_BATCH_SIZE)))
+    except (TypeError, ValueError) as exc:
+        raise SettingsFormError("semantic_invalid_value") from exc
+    return SemanticSearchSettingsForm(
+        provider=provider,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        batch_size=max(1, min(1000, batch_size)),
+        reset_index=reset_index,
+    )
+
+
+def parse_semantic_index_form(form: FormMapping) -> SemanticIndexForm:
+    return SemanticIndexForm(reset_index=_text(form, "semantic_reset_index") == "1")
+
+
+def parse_agent_form(form: FormMapping) -> AgentSettingsForm:
+    form_scope = _text(form, "agent_form_scope", "dev_mode")
+    backend_override = _text(form, "agent_backend_override") if "agent_backend_override" in form else None
+    tool_permissions = None
+    if form_scope == "tool_permissions":
+        from src.agent.tools.permissions import TOOL_CATEGORIES
+
+        permissions = {
+            tool_name: form.get(f"tool_perm__{tool_name}") == "1"
+            for tool_name in TOOL_CATEGORIES
+        }
+        phone = _text(form, "phone") or None
+        tool_permissions = AgentToolPermissionsForm(phone=phone, permissions=permissions)
+
+    return AgentSettingsForm(
+        form_scope=form_scope,
+        wants_dev_mode=_text(form, "agent_dev_mode_enabled") == "1",
+        disclaimer_accepted=_text(form, "agent_dev_mode_disclaimer") == "1",
+        backend_override=backend_override,
+        prompt_template=str(form.get("agent_prompt_template") or "") if form_scope == "prompt_template" else None,
+        tool_permissions=tool_permissions,
+    )
+
+
+def parse_provider_add_form(form: FormMapping) -> ProviderAddForm:
+    return ProviderAddForm(provider=_text(form, "provider"))
+
+
+def parse_provider_config_form(form: FormMapping) -> ProviderConfigForm:
+    return ProviderConfigForm(raw=form)
+
+
+def parse_filters_form(form: FormMapping) -> FiltersForm:
+    min_subscribers = _text(form, "min_subscribers_filter", "0")
+    if not min_subscribers.isdigit():
+        raise SettingsFormError("invalid_value")
+    return FiltersForm(
+        min_subscribers=min_subscribers,
+        auto_delete_filtered=_checked(form, "auto_delete_filtered"),
+        auto_delete_on_collect=_checked(form, "auto_delete_on_collect"),
+    )
+
+
+def parse_notification_account_form(form: FormMapping) -> NotificationAccountForm:
+    return NotificationAccountForm(selected_phone=_text(form, "notification_account_phone"))
+
+
+def parse_credentials_form(form: FormMapping) -> CredentialsForm:
+    return CredentialsForm(
+        api_id=_text(form, "api_id"),
+        api_hash=_text(form, "api_hash"),
+    )
+
+
+def parse_image_provider_save_form(form: FormMapping) -> ImageProviderSaveForm:
+    return ImageProviderSaveForm(raw=form, default_model=_text(form, "default_image_model"))
+
+
+def parse_translation_form(form: FormMapping) -> TranslationSettingsForm:
+    return TranslationSettingsForm(
+        provider=_text(form, "translation_provider"),
+        model=_text(form, "translation_model"),
+        target_lang=_text(form, "translation_target_lang").lower(),
+        source_filter=_text(form, "translation_source_filter").lower(),
+        auto_on_collect=_checked(form, "translation_auto_on_collect"),
+    )
+
+
+def parse_translation_run_form(form: FormMapping) -> TranslationRunForm:
+    return TranslationRunForm(target_lang=_text(form, "target_lang", "en").lower() or "en")
+

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -1,0 +1,1206 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from fastapi import Request
+
+from src.agent.manager import AgentManager
+from src.agent.prompt_template import (
+    AGENT_PROMPT_TEMPLATE_SETTING,
+    ALLOWED_TEMPLATE_VARIABLES,
+    DEFAULT_AGENT_PROMPT_TEMPLATE,
+    PromptTemplateError,
+    validate_prompt_template,
+)
+from src.agent.provider_registry import PROVIDER_ORDER, ProviderRuntimeConfig
+from src.agent.provider_registry import provider_spec as deepagents_provider_spec
+from src.services.agent_provider_service import (
+    AgentProviderService,
+    ProviderModelCacheEntry,
+    ProviderModelCompatibilityRecord,
+)
+from src.services.embedding_service import (
+    DEFAULT_EMBEDDINGS_BATCH_SIZE,
+    DEFAULT_EMBEDDINGS_MODEL,
+    DEFAULT_EMBEDDINGS_PROVIDER,
+    EMBEDDINGS_API_KEY_SETTING,
+    EMBEDDINGS_BASE_URL_SETTING,
+    EMBEDDINGS_BATCH_SIZE_SETTING,
+    EMBEDDINGS_MODEL_SETTING,
+    EMBEDDINGS_PROVIDER_SETTING,
+    LAST_EMBEDDED_ID_SETTING,
+    EmbeddingService,
+)
+from src.services.image_provider_service import (
+    IMAGE_PROVIDER_ORDER,
+    IMAGE_PROVIDER_SPECS,
+    ImageProviderService,
+    image_provider_spec,
+)
+from src.settings_utils import parse_int_setting
+from src.web import deps
+from src.web.settings.forms import (
+    CREDENTIALS_MASK,
+    AgentSettingsForm,
+    CredentialsForm,
+    FiltersForm,
+    ImageProviderSaveForm,
+    NotificationAccountForm,
+    ProviderAddForm,
+    ProviderConfigForm,
+    SchedulerSettingsForm,
+    SemanticIndexForm,
+    SemanticSearchSettingsForm,
+    TranslationRunForm,
+    TranslationSettingsForm,
+)
+from src.web.settings.responses import SettingsFlash, SettingsJson
+
+logger = logging.getLogger("src.web.routes.settings")
+
+
+def _image_provider_service(request: Request) -> ImageProviderService:
+    return ImageProviderService(deps.get_db(request), request.app.state.config)
+
+
+def _wants_json(request: Request) -> bool:
+    return "application/json" in request.headers.get("accept", "")
+
+
+def _agent_provider_service(request: Request) -> AgentProviderService:
+    return AgentProviderService(deps.get_db(request), request.app.state.config)
+
+
+async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
+    snapshot = await deps.get_db(request).repos.runtime_snapshots.get_snapshot("notification_target_status")
+    payload = snapshot.payload if snapshot is not None else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _notification_snapshot_bot(request: Request):
+    payload = await _notification_snapshot_payload(request)
+    raw_bot = payload.get("bot")
+    if not isinstance(raw_bot, dict) or not raw_bot.get("configured"):
+        return None
+    return SimpleNamespace(
+        bot_username=raw_bot.get("bot_username"),
+        bot_id=raw_bot.get("bot_id"),
+        created_at=(
+            datetime.fromisoformat(raw_bot["created_at"])
+            if isinstance(raw_bot.get("created_at"), str)
+            else None
+        ),
+    )
+
+
+async def _enqueue_notification_command(
+    request: Request,
+    command_type: str,
+    *,
+    requested_by: str,
+    redirect_code: str,
+    payload: dict[str, object] | None = None,
+) -> SettingsFlash | SettingsJson:
+    command_id = await deps.telegram_command_service(request).enqueue(
+        command_type,
+        payload=payload or {},
+        requested_by=requested_by,
+    )
+    if _wants_json(request):
+        return SettingsJson({"status": "queued", "command_id": command_id}, status_code=202)
+    return SettingsFlash(msg=redirect_code, extra={"command_id": command_id})
+
+
+async def _reload_llm_providers(request: Request) -> None:
+    """Reload the shared LLM provider service from DB after settings change."""
+    svc = getattr(request.app.state, "llm_provider_service", None)
+    if svc is not None:
+        try:
+            await svc.reload_db_providers()
+        except Exception:
+            logger.warning("Failed to reload LLM providers from DB", exc_info=True)
+
+
+async def _semantic_settings_context(request: Request) -> dict[str, object]:
+    db = deps.get_db(request)
+    last_embedded_id = parse_int_setting(
+        await db.get_setting(LAST_EMBEDDED_ID_SETTING),
+        setting_name=LAST_EMBEDDED_ID_SETTING,
+        default=0,
+        logger=logger,
+    )
+    batch_size = parse_int_setting(
+        await db.get_setting(EMBEDDINGS_BATCH_SIZE_SETTING),
+        setting_name=EMBEDDINGS_BATCH_SIZE_SETTING,
+        default=DEFAULT_EMBEDDINGS_BATCH_SIZE,
+        logger=logger,
+    )
+    embedding_dimensions = await db.repos.messages.get_embedding_dimensions()
+    embeddings_count = await db.repos.messages.count_embeddings()
+    return {
+        "semantic_embeddings_provider": (
+            await db.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
+        ),
+        "semantic_embeddings_model": (
+            await db.get_setting(EMBEDDINGS_MODEL_SETTING) or DEFAULT_EMBEDDINGS_MODEL
+        ),
+        "semantic_embeddings_api_key": (
+            CREDENTIALS_MASK if await db.get_setting(EMBEDDINGS_API_KEY_SETTING) else ""
+        ),
+        "semantic_embeddings_base_url": await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
+        "semantic_embeddings_batch_size": batch_size,
+        "semantic_last_embedded_id": last_embedded_id,
+        "semantic_embedding_dimensions": embedding_dimensions,
+        "semantic_embeddings_count": embeddings_count,
+    }
+
+
+def _settings_agent_manager(request: Request) -> tuple[AgentManager, bool]:
+    manager = deps.get_agent_manager(request)
+    if manager is not None:
+        return manager, True
+    pool = getattr(request.app.state, "pool", None)
+    return AgentManager(deps.get_db(request), request.app.state.config, client_pool=pool), False
+
+
+async def _dev_mode_enabled(request: Request) -> bool:
+    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
+
+
+async def _require_agent_dev_mode(
+    request: Request,
+    *,
+    json_mode: bool = False,
+) -> SettingsFlash | SettingsJson | None:
+    if await _dev_mode_enabled(request):
+        return None
+    if json_mode:
+        return SettingsJson({"ok": False, "error": "Developer mode is required."}, status_code=403)
+    return SettingsFlash(error="agent_dev_mode_required")
+
+
+def _bulk_test_lock(request: Request) -> asyncio.Lock:
+    lock = getattr(request.app.state, "agent_provider_bulk_test_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        request.app.state.agent_provider_bulk_test_lock = lock
+    return lock
+
+
+def _bulk_test_status_payload(request: Request) -> dict[str, object]:
+    status = getattr(request.app.state, "agent_provider_bulk_test_status", None)
+    if status is None:
+        status = {
+            "running": False,
+            "started_at": "",
+            "finished_at": "",
+            "current_provider": "",
+            "current_model": "",
+            "completed_probes": 0,
+            "total_probes": 0,
+            "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
+            "providers": {},
+            "catalog_path": "",
+            "error": "",
+            "recent_events": [],
+        }
+        request.app.state.agent_provider_bulk_test_status = status
+    return status
+
+
+def _replace_bulk_test_status(request: Request, status: dict[str, object]) -> None:
+    request.app.state.agent_provider_bulk_test_status = status
+
+
+def _bulk_test_recent_event(status: dict[str, object], message: str) -> None:
+    events = list(status.get("recent_events", []))
+    events.append(f"{datetime.now(UTC).astimezone().strftime('%H:%M:%S')} {message}")
+    status["recent_events"] = events[-12:]
+
+
+async def _provider_configs_from_bulk_form(
+    form: ProviderConfigForm,
+    service: AgentProviderService,
+) -> list[ProviderRuntimeConfig]:
+    existing = await service.load_provider_configs()
+    if any(str(key).startswith("provider_present__") for key in form.raw.keys()):
+        return service.parse_provider_form(form.raw, existing)
+    return existing
+
+
+async def _probe_provider_config(
+    service: AgentProviderService,
+    manager: AgentManager,
+    cfg: ProviderRuntimeConfig,
+    *,
+    probe_kind: str,
+    force: bool = False,
+) -> ProviderModelCompatibilityRecord:
+    return await service.ensure_model_compatibility(
+        cfg,
+        probe_runner=lambda current_cfg, current_probe_kind: manager.probe_provider_config(
+            current_cfg,
+            probe_kind=current_probe_kind,
+        ),
+        probe_kind=probe_kind,
+        force=force,
+    )
+
+
+async def _run_bulk_test_job(
+    request: Request,
+    configs: list[ProviderRuntimeConfig] | None = None,
+) -> None:
+    service = _agent_provider_service(request)
+    manager, is_persistent_manager = _settings_agent_manager(request)
+    if configs is None:
+        configs = await service.load_provider_configs()
+    status = {
+        "running": True,
+        "started_at": datetime.now(UTC).isoformat(),
+        "finished_at": "",
+        "current_provider": "",
+        "current_model": "",
+        "completed_probes": 0,
+        "total_probes": 0,
+        "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
+        "providers": {},
+        "catalog_path": "",
+        "error": "",
+        "recent_events": [],
+    }
+    try:
+        _replace_bulk_test_status(request, status)
+        logger.info("Bulk compatibility test started: providers=%d", len(configs))
+        total_probes = 0
+        entries_by_provider: dict[str, ProviderModelCacheEntry] = {}
+        for cfg in configs:
+            entry = await service.refresh_models_for_provider(cfg.provider, cfg)
+            entries_by_provider[cfg.provider] = entry
+            total_probes += len(entry.models)
+        status["total_probes"] = total_probes
+        _bulk_test_recent_event(status, f"Запущено тестирование {total_probes} моделей.")
+
+        for cfg in configs:
+            status["current_provider"] = cfg.provider
+            entry = entries_by_provider[cfg.provider]
+            logger.info(
+                "Bulk compatibility refresh: provider=%s selected_model=%s",
+                cfg.provider,
+                cfg.selected_model or "<empty>",
+            )
+            logger.info(
+                "Bulk compatibility models loaded: provider=%s source=%s count=%d error=%s",
+                cfg.provider,
+                entry.source,
+                len(entry.models),
+                entry.error or "",
+            )
+            provider_results: list[dict[str, str]] = []
+            provider_summary = {"supported": 0, "unsupported": 0, "unknown": 0}
+            status["providers"][cfg.provider] = {
+                "models": provider_results,
+                "source": entry.source,
+                "summary": provider_summary,
+            }
+            for model in entry.models:
+                status["current_model"] = model
+                _bulk_test_recent_event(status, f"Тестируется {cfg.provider} / {model}")
+                model_cfg = ProviderRuntimeConfig(
+                    provider=cfg.provider,
+                    enabled=cfg.enabled,
+                    priority=cfg.priority,
+                    selected_model=model,
+                    plain_fields=dict(cfg.plain_fields),
+                    secret_fields=dict(cfg.secret_fields),
+                )
+                validation_error = service.validate_provider_config(model_cfg)
+                if validation_error:
+                    logger.info(
+                        (
+                            "Bulk compatibility probe blocked: provider=%s "
+                            "model=%s status=unsupported reason=%s"
+                        ),
+                        cfg.provider,
+                        model,
+                        validation_error,
+                    )
+                    record = ProviderModelCompatibilityRecord(
+                        model=model,
+                        status="unsupported",
+                        reason=validation_error,
+                        config_fingerprint=service.config_fingerprint(model_cfg),
+                        probe_kind="dev-bulk",
+                    )
+                else:
+                    logger.info(
+                        "Bulk compatibility probe started: provider=%s model=%s",
+                        cfg.provider,
+                        model,
+                    )
+                    record = await _probe_provider_config(
+                        service,
+                        manager,
+                        model_cfg,
+                        probe_kind="dev-bulk",
+                        force=True,
+                    )
+                    logger.info(
+                        (
+                            "Bulk compatibility probe finished: provider=%s "
+                            "model=%s status=%s reason=%s"
+                        ),
+                        cfg.provider,
+                        record.model or model,
+                        record.status,
+                        record.reason or "",
+                    )
+                status["summary"][record.status] = status["summary"].get(record.status, 0) + 1
+                provider_summary[record.status] = provider_summary.get(record.status, 0) + 1
+                status["completed_probes"] = int(status["completed_probes"]) + 1
+                provider_results.append(
+                    {
+                        "model": record.model,
+                        "status": record.status,
+                        "reason": record.reason,
+                        "tested_at": record.tested_at,
+                    }
+                )
+            logger.info(
+                (
+                    "Bulk compatibility provider summary: provider=%s "
+                    "supported=%d unsupported=%d unknown=%d"
+                ),
+                cfg.provider,
+                provider_summary["supported"],
+                provider_summary["unsupported"],
+                provider_summary["unknown"],
+            )
+            _bulk_test_recent_event(
+                status,
+                (
+                    f"Провайдер {cfg.provider} завершён: "
+                    f"supported={provider_summary['supported']}, "
+                    f"unsupported={provider_summary['unsupported']}, "
+                    f"unknown={provider_summary['unknown']}"
+                ),
+            )
+
+        cache = await service.load_model_cache()
+        catalog_path = await service.export_compatibility_catalog(configs, cache)
+        status["catalog_path"] = str(catalog_path)
+        if is_persistent_manager:
+            await manager.refresh_settings_cache(preflight=True)
+        logger.info(
+            "Bulk compatibility test finished: supported=%d unsupported=%d unknown=%d catalog=%s",
+            status["summary"]["supported"],
+            status["summary"]["unsupported"],
+            status["summary"]["unknown"],
+            catalog_path,
+        )
+        _bulk_test_recent_event(
+            status,
+            (
+                f"Тестирование завершено. supported={status['summary']['supported']}, "
+                f"unsupported={status['summary']['unsupported']}, "
+                f"unknown={status['summary']['unknown']}"
+            ),
+        )
+    except Exception as exc:
+        status["error"] = str(exc)
+        logger.exception("Bulk compatibility test failed")
+        _bulk_test_recent_event(status, f"Ошибка: {exc}")
+    finally:
+        status["running"] = False
+        status["finished_at"] = datetime.now(UTC).isoformat()
+        status["current_provider"] = ""
+        status["current_model"] = ""
+
+
+async def handle_settings_page(request: Request) -> dict[str, object]:
+    auth = deps.get_auth(request)
+    db = deps.get_db(request)
+    pool = deps.get_pool(request)
+    api_id_raw = await db.get_setting("tg_api_id") or ""
+    api_hash_raw = await db.get_setting("tg_api_hash") or ""
+    min_subscribers_filter = parse_int_setting(
+        await db.get_setting("min_subscribers_filter"),
+        setting_name="min_subscribers_filter",
+        default=0,
+        logger=logger,
+    )
+    auto_delete_filtered = (await db.get_setting("auto_delete_filtered") or "0") == "1"
+    auto_delete_on_collect = (await db.get_setting("auto_delete_on_collect") or "0") == "1"
+    saved_interval = await db.get_setting("collect_interval_minutes")
+    agent_dev_mode_enabled = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
+    agent_backend_override = await db.get_setting("agent_backend_override") or "auto"
+    agent_prompt_template = (
+        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
+    )
+    if agent_backend_override not in {"auto", "claude", "deepagents"}:
+        agent_backend_override = "auto"
+    config = request.app.state.config
+    provider_service = _agent_provider_service(request)
+    telegram_credentials_from_env = bool(
+        os.environ.get("TG_API_ID", "").strip().isdigit()
+        and os.environ.get("TG_API_HASH", "").strip()
+    )
+    collect_interval_minutes = parse_int_setting(
+        saved_interval,
+        setting_name="collect_interval_minutes",
+        default=config.scheduler.collect_interval_minutes,
+        logger=logger,
+    )
+    accounts = await db.get_accounts()
+    now = datetime.now(UTC)
+    for account in accounts:
+        if account.flood_wait_until is not None:
+            flood_until = account.flood_wait_until
+            if flood_until.tzinfo is None:
+                flood_until = flood_until.replace(tzinfo=UTC)
+            if flood_until <= now:
+                await db.update_account_flood(account.phone, None)
+                account.flood_wait_until = None
+    connected_phones = set(pool.clients.keys())
+    account_status: dict[str, dict[str, object]] = {}
+    flooded_connected = []
+    for account in accounts:
+        connected = account.phone in connected_phones
+        if not account.is_active:
+            state = "inactive"
+            remaining_seconds = 0
+        elif not connected:
+            state = "disconnected"
+            remaining_seconds = 0
+        elif account.flood_wait_until is not None:
+            flood_until = account.flood_wait_until
+            if flood_until.tzinfo is None:
+                flood_until = flood_until.replace(tzinfo=UTC)
+            remaining_seconds = max(0, int((flood_until - now).total_seconds()))
+            if remaining_seconds > 0:
+                state = "flood"
+                flooded_connected.append(flood_until)
+            else:
+                state = "available"
+        else:
+            state = "available"
+            remaining_seconds = 0
+        account_status[account.phone] = {
+            "state": state,
+            "remaining_seconds": remaining_seconds,
+            "remaining_minutes": max(1, remaining_seconds // 60) if remaining_seconds else 0,
+        }
+    all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
+        [acc for acc in accounts if acc.is_active and acc.phone in connected_phones]
+    )
+    next_available_at = min(flooded_connected) if flooded_connected else None
+    notification_target = await deps.get_notification_target_service(request).describe_target()
+    notification_bot = await _notification_snapshot_bot(request)
+    notification_bot_error = ""
+    provider_configs = await provider_service.load_provider_configs()
+    provider_cache = await provider_service.load_model_cache()
+    provider_views = provider_service.build_provider_views(provider_configs, provider_cache)
+    configured_names = {cfg.provider for cfg in provider_configs}
+    available_provider_options = [
+        provider_service.provider_specs[name]
+        for name in PROVIDER_ORDER
+        if name not in configured_names
+    ]
+    img_provider_service = _image_provider_service(request)
+    img_provider_configs = await img_provider_service.load_provider_configs()
+    img_provider_views = img_provider_service.build_provider_views(img_provider_configs)
+    configured_img_names = {cfg.provider for cfg in img_provider_configs}
+    available_img_options = [
+        IMAGE_PROVIDER_SPECS[name] for name in IMAGE_PROVIDER_ORDER if name not in configured_img_names
+    ]
+    semantic_context = await _semantic_settings_context(request)
+
+    translation_provider = await db.get_setting("translation_provider") or ""
+    translation_model = await db.get_setting("translation_model") or ""
+    translation_target_lang = await db.get_setting("translation_target_lang") or ""
+    translation_source_filter = await db.get_setting("translation_source_filter") or ""
+    translation_auto_on_collect = await db.get_setting("translation_auto_on_collect") or "0"
+    language_stats = await db.repos.messages.get_language_stats()
+
+    from src.agent.tools.permissions import (
+        build_template_context,
+        load_tool_permissions_all_phones,
+    )
+
+    phone_permissions = await load_tool_permissions_all_phones(db, accounts)
+    phone_perm_contexts = {
+        phone: build_template_context(perms)
+        for phone, perms in phone_permissions.items()
+    }
+
+    return {
+        "is_configured": auth.is_configured,
+        "telegram_credentials_from_env": telegram_credentials_from_env,
+        "api_id": CREDENTIALS_MASK if api_id_raw else "",
+        "api_hash": CREDENTIALS_MASK if api_hash_raw else "",
+        "min_subscribers_filter": min_subscribers_filter,
+        "auto_delete_filtered": auto_delete_filtered,
+        "auto_delete_on_collect": auto_delete_on_collect,
+        "accounts": accounts,
+        "account_status": account_status,
+        "account_phones": [acc.phone for acc in accounts],
+        "connected_phones": connected_phones,
+        "all_accounts_flooded": all_accounts_flooded,
+        "next_available_at": next_available_at,
+        "notification_target": notification_target,
+        "notification_selected_phone": notification_target.configured_phone or "",
+        "notification_bot": notification_bot,
+        "notification_bot_error": notification_bot_error,
+        "collect_interval_minutes": collect_interval_minutes,
+        "agent_dev_mode_enabled": agent_dev_mode_enabled,
+        "agent_backend_override": agent_backend_override,
+        "agent_prompt_template": agent_prompt_template,
+        "agent_fallback_model": config.agent.fallback_model or os.environ.get("AGENT_FALLBACK_MODEL", "").strip(),
+        "agent_prompt_template_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
+        "agent_provider_writes_enabled": provider_service.writes_enabled,
+        "agent_provider_views": provider_views,
+        "agent_provider_options": available_provider_options,
+        "img_provider_writes_enabled": img_provider_service.writes_enabled,
+        "img_provider_views": img_provider_views,
+        "img_provider_options": available_img_options,
+        "default_image_model": await db.get_setting("default_image_model") or "",
+        **semantic_context,
+        "phone_perm_contexts": phone_perm_contexts,
+        "translation_provider": translation_provider,
+        "translation_model": translation_model,
+        "translation_target_lang": translation_target_lang,
+        "translation_source_filter": translation_source_filter,
+        "translation_auto_on_collect": translation_auto_on_collect,
+        "language_stats": language_stats,
+    }
+
+
+async def handle_save_scheduler_settings(
+    request: Request,
+    form: SchedulerSettingsForm,
+) -> SettingsFlash:
+    db = deps.get_db(request)
+    await db.set_setting("collect_interval_minutes", str(form.interval_minutes))
+    scheduler = getattr(request.app.state, "scheduler", None)
+    if scheduler:
+        scheduler.update_interval(form.interval_minutes)
+    return SettingsFlash(msg="scheduler_saved")
+
+
+async def handle_save_semantic_search_settings(
+    request: Request,
+    form: SemanticSearchSettingsForm,
+) -> SettingsFlash:
+    db = deps.get_db(request)
+    current_values = {
+        EMBEDDINGS_PROVIDER_SETTING: await db.get_setting(EMBEDDINGS_PROVIDER_SETTING)
+        or DEFAULT_EMBEDDINGS_PROVIDER,
+        EMBEDDINGS_MODEL_SETTING: await db.get_setting(EMBEDDINGS_MODEL_SETTING)
+        or DEFAULT_EMBEDDINGS_MODEL,
+        EMBEDDINGS_BASE_URL_SETTING: await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
+        EMBEDDINGS_API_KEY_SETTING: await db.get_setting(EMBEDDINGS_API_KEY_SETTING) or "",
+    }
+    changed = (
+        current_values[EMBEDDINGS_PROVIDER_SETTING] != form.provider
+        or current_values[EMBEDDINGS_MODEL_SETTING] != form.model
+        or current_values[EMBEDDINGS_BASE_URL_SETTING] != form.base_url
+    )
+    await db.set_setting(EMBEDDINGS_PROVIDER_SETTING, form.provider)
+    await db.set_setting(EMBEDDINGS_MODEL_SETTING, form.model)
+    await db.set_setting(EMBEDDINGS_BASE_URL_SETTING, form.base_url)
+    await db.set_setting(EMBEDDINGS_BATCH_SIZE_SETTING, str(form.batch_size))
+    if form.api_key is not None and form.api_key != CREDENTIALS_MASK:
+        await db.set_setting(EMBEDDINGS_API_KEY_SETTING, form.api_key)
+    if changed or form.reset_index:
+        await db.repos.messages.reset_embeddings_index()
+        deps.get_search_engine(request).invalidate_numpy_index()
+    return SettingsFlash(msg="semantic_saved")
+
+
+async def handle_run_semantic_index(request: Request, form: SemanticIndexForm) -> SettingsFlash:
+    db = deps.get_db(request)
+    if not deps.get_search_engine(request).semantic_available:
+        return SettingsFlash(error="semantic_unavailable")
+    if form.reset_index:
+        await db.repos.messages.reset_embeddings_index()
+    indexed = await EmbeddingService(db, request.app.state.config).index_pending_messages()
+    if indexed > 0 or form.reset_index:
+        deps.get_search_engine(request).invalidate_numpy_index()
+    return SettingsFlash(msg="semantic_indexed", extra={"indexed": indexed})
+
+
+async def handle_save_agent_settings(request: Request, form: AgentSettingsForm) -> SettingsFlash:
+    db = deps.get_db(request)
+
+    if form.form_scope == "tool_permissions":
+        from src.agent.tools.permissions import save_tool_permissions
+
+        if form.tool_permissions is None:
+            return SettingsFlash(error="invalid_value")
+        await save_tool_permissions(
+            db,
+            form.tool_permissions.permissions,
+            phone=form.tool_permissions.phone,
+        )
+        return SettingsFlash(msg="tool_permissions_saved", fragment="pane-tool-permissions")
+
+    current_dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
+    current_backend_override = await db.get_setting("agent_backend_override") or "auto"
+    current_prompt_template = (
+        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
+    )
+
+    if form.backend_override is None:
+        backend_override = current_backend_override
+    else:
+        backend_override = form.backend_override
+    if backend_override not in {"auto", "claude", "deepagents"}:
+        backend_override = "auto"
+
+    if form.form_scope == "backend_override":
+        dev_mode_enabled = current_dev_mode
+    else:
+        if not form.wants_dev_mode:
+            dev_mode_enabled = False
+        elif form.disclaimer_accepted:
+            dev_mode_enabled = True
+        else:
+            dev_mode_enabled = current_dev_mode
+
+    if form.form_scope == "prompt_template":
+        prompt_template = form.prompt_template or ""
+        if not prompt_template.strip():
+            prompt_template = DEFAULT_AGENT_PROMPT_TEMPLATE
+        try:
+            validate_prompt_template(prompt_template)
+        except PromptTemplateError as exc:
+            logger.warning("Rejected invalid agent prompt template: %s", exc)
+            return SettingsFlash(error="agent_prompt_template_invalid")
+    else:
+        prompt_template = current_prompt_template
+
+    if not dev_mode_enabled:
+        backend_override = "auto"
+
+    if backend_override != "auto" and dev_mode_enabled:
+        if backend_override == "deepagents":
+            service = _agent_provider_service(request)
+            configs = await service.load_provider_configs()
+            has_valid = any(
+                cfg.enabled and not service.validate_provider_config(cfg) for cfg in configs
+            )
+            if not has_valid:
+                logger.warning(
+                    "Rejected deepagents override in dev mode: no valid provider configs are available"
+                )
+                return SettingsFlash(error="agent_backend_no_valid_providers")
+        elif backend_override == "claude":
+            if not (
+                os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+            ):
+                logger.warning(
+                    "Rejected claude override in dev mode: no API credentials are available"
+                )
+                return SettingsFlash(error="agent_backend_claude_unavailable")
+
+    await db.set_setting("agent_dev_mode_enabled", "1" if dev_mode_enabled else "0")
+    await db.set_setting("agent_backend_override", backend_override)
+    await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is not None:
+        await agent_manager.refresh_settings_cache(preflight=True)
+    return SettingsFlash(msg="agent_saved")
+
+
+async def handle_add_agent_provider(request: Request, form: ProviderAddForm) -> SettingsFlash:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="agent_provider_secret_required")
+    dev_mode_required = await _require_agent_dev_mode(request)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    provider_name = form.provider
+    if deepagents_provider_spec(provider_name) is None:
+        return SettingsFlash(error="agent_provider_invalid")
+    configs = await service.load_provider_configs()
+    if any(cfg.provider == provider_name for cfg in configs):
+        return SettingsFlash(msg="agent_saved")
+    priority = max((cfg.priority for cfg in configs), default=-1) + 1
+    configs.append(service.create_empty_config(provider_name, priority))
+    await service.save_provider_configs(configs)
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is not None:
+        await agent_manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
+    return SettingsFlash(msg="agent_saved")
+
+
+async def handle_save_agent_providers(request: Request, form: ProviderConfigForm) -> SettingsFlash:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="agent_provider_secret_required")
+    dev_mode_required = await _require_agent_dev_mode(request)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    existing = await service.load_provider_configs()
+    configs = service.parse_provider_form(form.raw, existing)
+    manager, is_persistent_manager = _settings_agent_manager(request)
+    validated: list[ProviderRuntimeConfig] = []
+    for cfg in configs:
+        validation_error = ""
+        if cfg.enabled:
+            validation_error = service.validate_provider_config(cfg)
+        if cfg.enabled and not validation_error:
+            await _probe_provider_config(
+                service,
+                manager,
+                cfg,
+                probe_kind="save-time",
+            )
+        validated.append(
+            ProviderRuntimeConfig(
+                provider=cfg.provider,
+                enabled=cfg.enabled,
+                priority=cfg.priority,
+                selected_model=cfg.selected_model,
+                plain_fields=cfg.plain_fields,
+                secret_fields=cfg.secret_fields,
+                last_validation_error=validation_error,
+            )
+        )
+    await service.save_provider_configs(validated)
+    if is_persistent_manager:
+        await manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
+    return SettingsFlash(msg="agent_saved")
+
+
+async def handle_delete_agent_provider(request: Request, provider_name: str) -> SettingsFlash:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="agent_provider_secret_required")
+    dev_mode_required = await _require_agent_dev_mode(request)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    configs = await service.load_provider_configs()
+    configs = [cfg for cfg in configs if cfg.provider != provider_name]
+    for index, cfg in enumerate(configs):
+        cfg.priority = index
+    await service.save_provider_configs(configs)
+    agent_manager = deps.get_agent_manager(request)
+    if agent_manager is not None:
+        await agent_manager.refresh_settings_cache(preflight=True)
+    await _reload_llm_providers(request)
+    return SettingsFlash(msg="agent_saved")
+
+
+async def handle_refresh_agent_provider_models(
+    request: Request,
+    provider_name: str,
+    form: ProviderConfigForm,
+) -> SettingsJson:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsJson(
+            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."},
+            status_code=409,
+        )
+    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    if deepagents_provider_spec(provider_name) is None:
+        return SettingsJson({"ok": False, "error": "Unknown provider."}, status_code=404)
+    configs = await service.load_provider_configs()
+    cfg = service.parse_single_provider_form(form.raw, configs, provider_name)
+    entry = await service.refresh_models_for_provider(provider_name, cfg)
+    return SettingsJson(
+        {
+            "ok": True,
+            "provider": provider_name,
+            "models": entry.models,
+            "source": entry.source,
+            "error": entry.error,
+            "fetched_at": entry.fetched_at,
+            "compatibility": (
+                service.build_compatibility_payload(cfg, entry) if cfg is not None else {}
+            ),
+        }
+    )
+
+
+async def handle_refresh_all_agent_provider_models(
+    request: Request,
+    form: ProviderConfigForm,
+) -> SettingsJson:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsJson(
+            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."},
+            status_code=409,
+        )
+    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    configs = await _provider_configs_from_bulk_form(form, service)
+    config_map = {cfg.provider: cfg for cfg in configs}
+    results = await service.refresh_all_models(configs)
+    return SettingsJson(
+        {
+            "ok": True,
+            "providers": {
+                provider: {
+                    "models": entry.models,
+                    "source": entry.source,
+                    "error": entry.error,
+                    "fetched_at": entry.fetched_at,
+                    "compatibility": (
+                        service.build_compatibility_payload(config_map[provider], entry)
+                        if provider in config_map
+                        else {}
+                    ),
+                }
+                for provider, entry in results.items()
+            },
+        }
+    )
+
+
+async def handle_probe_agent_provider_model(
+    request: Request,
+    provider_name: str,
+    form: ProviderConfigForm,
+) -> SettingsJson:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsJson(
+            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."},
+            status_code=409,
+        )
+    dev_mode_required = await _require_agent_dev_mode(request, json_mode=True)
+    if dev_mode_required is not None:
+        return dev_mode_required
+    if deepagents_provider_spec(provider_name) is None:
+        return SettingsJson({"ok": False, "error": "Unknown provider."}, status_code=404)
+
+    existing = await service.load_provider_configs()
+    cfg = service.parse_single_provider_form(form.raw, existing, provider_name)
+    validation_error = service.validate_provider_config(cfg)
+    if validation_error:
+        logger.info(
+            "Compatibility probe skipped: provider=%s model=%s status=unsupported reason=%s",
+            provider_name,
+            cfg.selected_model or "<empty>",
+            validation_error,
+        )
+        return SettingsJson(
+            {
+                "ok": True,
+                "provider": provider_name,
+                "model": cfg.selected_model,
+                "status": "unsupported",
+                "reason": validation_error,
+                "tested_at": "",
+                "config_fingerprint": service.config_fingerprint(cfg),
+            }
+        )
+
+    manager, _ = _settings_agent_manager(request)
+    logger.info(
+        "Compatibility probe requested: provider=%s model=%s kind=auto-select",
+        provider_name,
+        cfg.selected_model or "<empty>",
+    )
+    record = await _probe_provider_config(
+        service,
+        manager,
+        cfg,
+        probe_kind="auto-select",
+    )
+    logger.info(
+        "Compatibility probe finished: provider=%s model=%s status=%s kind=%s reason=%s",
+        provider_name,
+        record.model or "<empty>",
+        record.status,
+        record.probe_kind,
+        record.reason or "",
+    )
+    return SettingsJson(
+        {
+            "ok": True,
+            "provider": provider_name,
+            "model": record.model,
+            "status": record.status,
+            "reason": record.reason,
+            "tested_at": record.tested_at,
+            "config_fingerprint": record.config_fingerprint,
+            "probe_kind": record.probe_kind,
+        }
+    )
+
+
+async def handle_test_all_agent_provider_models(
+    request: Request,
+    form: ProviderConfigForm,
+) -> SettingsJson:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsJson(
+            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."},
+            status_code=409,
+        )
+    if not await _dev_mode_enabled(request):
+        return SettingsJson({"ok": False, "error": "Developer mode is required."}, status_code=403)
+    configs = await _provider_configs_from_bulk_form(form, service)
+    async with _bulk_test_lock(request):
+        status = _bulk_test_status_payload(request)
+        if status.get("running"):
+            return SettingsJson(
+                {
+                    "ok": False,
+                    "error": "Bulk compatibility test is already running.",
+                    **status,
+                },
+                status_code=409,
+            )
+        initial_status = {
+            "running": True,
+            "started_at": datetime.now(UTC).isoformat(),
+            "finished_at": "",
+            "current_provider": "",
+            "current_model": "",
+            "completed_probes": 0,
+            "total_probes": 0,
+            "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
+            "providers": {},
+            "catalog_path": "",
+            "error": "",
+            "recent_events": ["Запуск массового тестирования..."],
+        }
+        _replace_bulk_test_status(request, initial_status)
+        request.app.state.agent_provider_bulk_test_task = asyncio.create_task(
+            _run_bulk_test_job(request, configs=configs)
+        )
+    return SettingsJson({"ok": True, "started": True, **_bulk_test_status_payload(request)})
+
+
+async def handle_test_all_agent_provider_models_status(request: Request) -> SettingsJson:
+    service = _agent_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsJson(
+            {"ok": False, "error": "SESSION_ENCRYPTION_KEY is required."},
+            status_code=409,
+        )
+    if not await _dev_mode_enabled(request):
+        return SettingsJson({"ok": False, "error": "Developer mode is required."}, status_code=403)
+    return SettingsJson({"ok": True, **_bulk_test_status_payload(request)})
+
+
+async def handle_save_filters(request: Request, form: FiltersForm) -> SettingsFlash:
+    db = deps.get_db(request)
+    await db.set_setting("min_subscribers_filter", form.min_subscribers)
+    await db.set_setting(
+        "auto_delete_filtered",
+        "1" if form.auto_delete_filtered else "0",
+    )
+    await db.set_setting(
+        "auto_delete_on_collect",
+        "1" if form.auto_delete_on_collect else "0",
+    )
+    if int(form.min_subscribers) > 0:
+        all_stats = await db.get_latest_stats_for_all()
+        to_filter = [
+            (channel_id, "low_subscriber_manual")
+            for channel_id, stats in all_stats.items()
+            if stats.subscriber_count is not None and stats.subscriber_count < int(form.min_subscribers)
+        ]
+        if to_filter:
+            await db.set_channels_filtered_bulk(to_filter)
+    return SettingsFlash(msg="filters_saved")
+
+
+async def handle_save_notification_account(
+    request: Request,
+    form: NotificationAccountForm,
+) -> SettingsFlash:
+    db = deps.get_db(request)
+    valid_phones = {acc.phone for acc in await db.get_accounts()}
+    if form.selected_phone and form.selected_phone not in valid_phones:
+        return SettingsFlash(error="notification_account_invalid")
+
+    await deps.get_notification_target_service(request).set_configured_phone(form.selected_phone or None)
+    notifier = deps.get_notifier(request)
+    if notifier:
+        notifier.invalidate_me_cache()
+    return SettingsFlash(msg="notification_account_saved")
+
+
+async def handle_save_credentials(request: Request, form: CredentialsForm) -> SettingsFlash:
+    db = deps.get_db(request)
+    auth = deps.get_auth(request)
+
+    id_changed = form.api_id and form.api_id != CREDENTIALS_MASK
+    hash_changed = form.api_hash and form.api_hash != CREDENTIALS_MASK
+
+    if id_changed and not form.api_id.isdigit():
+        return SettingsFlash(error="invalid_api_id")
+
+    if id_changed:
+        await db.set_setting("tg_api_id", form.api_id)
+    if hash_changed:
+        await db.set_setting("tg_api_hash", form.api_hash)
+
+    if id_changed or hash_changed:
+        actual_id = form.api_id if id_changed else (await db.get_setting("tg_api_id") or "")
+        actual_hash = form.api_hash if hash_changed else (await db.get_setting("tg_api_hash") or "")
+        if actual_id and actual_hash:
+            if not actual_id.isdigit():
+                return SettingsFlash(error="invalid_api_id")
+            auth.update_credentials(int(actual_id), actual_hash)
+
+    return SettingsFlash(msg="credentials_saved")
+
+
+async def handle_setup_notification_bot(request: Request) -> SettingsFlash | SettingsJson:
+    return await _enqueue_notification_command(
+        request,
+        "notifications.setup_bot",
+        requested_by="web:settings.notifications.setup",
+        redirect_code="notification_setup_queued",
+    )
+
+
+async def handle_notification_bot_status(request: Request) -> SettingsJson:
+    payload = await _notification_snapshot_payload(request)
+    raw_target = payload.get("target")
+    if isinstance(raw_target, dict) and raw_target.get("state") not in {None, "available"}:
+        return SettingsJson(
+            {"configured": False, "error": raw_target.get("message", "")},
+            status_code=409,
+        )
+    bot = await _notification_snapshot_bot(request)
+    if bot is None:
+        return SettingsJson({"configured": False})
+    return SettingsJson(
+        {
+            "configured": True,
+            "bot_username": bot.bot_username,
+            "bot_id": bot.bot_id,
+            "created_at": bot.created_at.isoformat() if bot.created_at else None,
+        }
+    )
+
+
+async def handle_delete_notification_bot(request: Request) -> SettingsFlash | SettingsJson:
+    return await _enqueue_notification_command(
+        request,
+        "notifications.delete_bot",
+        requested_by="web:settings.notifications.delete",
+        redirect_code="notification_delete_queued",
+    )
+
+
+async def handle_test_notification(request: Request) -> SettingsFlash | SettingsJson:
+    return await _enqueue_notification_command(
+        request,
+        "notifications.test",
+        requested_by="web:settings.notifications.test",
+        redirect_code="notification_test_queued",
+    )
+
+
+async def handle_add_image_provider(request: Request, form: ProviderAddForm) -> SettingsFlash:
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="image_provider_secret_required")
+    provider_name = form.provider
+    if image_provider_spec(provider_name) is None:
+        return SettingsFlash(error="image_provider_invalid")
+    configs = await service.load_provider_configs()
+    if any(cfg.provider == provider_name for cfg in configs):
+        return SettingsFlash(msg="image_saved")
+    configs.append(service.create_empty_config(provider_name))
+    await service.save_provider_configs(configs)
+    return SettingsFlash(msg="image_saved")
+
+
+async def handle_save_image_providers(
+    request: Request,
+    form: ImageProviderSaveForm,
+) -> SettingsFlash:
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="image_provider_secret_required")
+    existing = await service.load_provider_configs()
+    configs = service.parse_provider_form(form.raw, existing)
+    for cfg in configs:
+        if not cfg.enabled:
+            continue
+        spec = image_provider_spec(cfg.provider)
+        if spec is None:
+            continue
+        has_key = bool(cfg.api_key.strip())
+        has_env = any(os.environ.get(var) for var in spec.env_vars)
+        if not has_key and not has_env:
+            return SettingsFlash(error="image_provider_missing_key")
+    await service.save_provider_configs(configs)
+    await deps.get_db(request).set_setting("default_image_model", form.default_model)
+    return SettingsFlash(msg="image_saved")
+
+
+async def handle_delete_image_provider(request: Request, provider_name: str) -> SettingsFlash:
+    service = _image_provider_service(request)
+    if not service.writes_enabled:
+        return SettingsFlash(error="image_provider_secret_required")
+    configs = await service.load_provider_configs()
+    configs = [cfg for cfg in configs if cfg.provider != provider_name]
+    await service.save_provider_configs(configs)
+    return SettingsFlash(msg="image_saved")
+
+
+async def handle_save_translation_settings(
+    request: Request,
+    form: TranslationSettingsForm,
+) -> SettingsFlash:
+    db = deps.get_db(request)
+    await db.set_setting("translation_provider", form.provider)
+    await db.set_setting("translation_model", form.model)
+    await db.set_setting("translation_target_lang", form.target_lang)
+    await db.set_setting("translation_source_filter", form.source_filter)
+    await db.set_setting("translation_auto_on_collect", "1" if form.auto_on_collect else "0")
+    return SettingsFlash(msg="translation_saved", fragment="pane-translation")
+
+
+async def handle_translation_backfill_lang(request: Request) -> SettingsFlash:
+    db = deps.get_db(request)
+    updated = await db.repos.messages.backfill_language_detection(batch_size=5000)
+    return SettingsFlash(
+        msg="translation_backfill_done",
+        extra={"count": updated},
+        fragment="pane-translation",
+    )
+
+
+async def handle_translation_run_batch(
+    request: Request,
+    form: TranslationRunForm,
+) -> SettingsFlash:
+    db = deps.get_db(request)
+    source_filter_raw = await db.get_setting("translation_source_filter") or ""
+    source_filter = [source.strip() for source in source_filter_raw.split(",") if source.strip()]
+
+    from src.models import CollectionTaskType, TranslateBatchTaskPayload
+
+    payload = TranslateBatchTaskPayload(
+        target_lang=form.target_lang,
+        source_filter=source_filter,
+    )
+    await db.repos.tasks.create_generic_task(
+        CollectionTaskType.TRANSLATE_BATCH,
+        title=f"Translation batch ({form.target_lang})",
+        payload=payload,
+    )
+    return SettingsFlash(msg="translation_run_started", fragment="pane-translation")

--- a/src/web/settings/responses.py
+++ b/src/web/settings/responses.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from src.web.responses import flash_redirect, json_response
+
+
+@dataclass(frozen=True)
+class SettingsFlash:
+    msg: str | None = None
+    error: str | None = None
+    extra: dict[str, object | None] = field(default_factory=dict)
+    fragment: str | None = None
+
+
+@dataclass(frozen=True)
+class SettingsJson:
+    payload: dict[str, Any]
+    status_code: int = 200
+
+
+def settings_flash_response(result: SettingsFlash) -> RedirectResponse:
+    return flash_redirect(
+        "/settings",
+        msg=result.msg,
+        error=result.error,
+        extra=result.extra,
+        fragment=result.fragment,
+    )
+
+
+def settings_json_response(result: SettingsJson) -> JSONResponse:
+    return json_response(result.payload, status_code=result.status_code)
+
+
+def settings_result_response(result: SettingsFlash | SettingsJson) -> RedirectResponse | JSONResponse:
+    if isinstance(result, SettingsJson):
+        return settings_json_response(result)
+    return settings_flash_response(result)
+

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -22,10 +22,10 @@ async def db(base_app):
 async def test_settings_page_renders(route_client):
     """Test settings page renders."""
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -36,10 +36,10 @@ async def test_settings_page_renders(route_client):
 async def test_settings_shows_accounts(route_client):
     """Test settings page shows accounts."""
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -55,10 +55,10 @@ async def test_settings_shows_flood_banner_and_account_availability(route_client
         await db.update_account_flood(acc.phone, future)
 
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -72,10 +72,10 @@ async def test_settings_shows_flood_banner_and_account_availability(route_client
 async def test_settings_msg_param(route_client):
     """Test settings page with message param."""
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/?msg=credentials_saved")
@@ -324,7 +324,7 @@ async def test_save_semantic_search_reset_index(route_client, db):
 async def test_run_semantic_index(route_client, db):
     """Test running semantic index."""
     with patch(
-        "src.web.routes.settings.EmbeddingService.index_pending_messages",
+        "src.web.settings.handlers.EmbeddingService.index_pending_messages",
         AsyncMock(return_value=5),
     ):
         resp = await route_client.post(
@@ -341,7 +341,7 @@ async def test_run_semantic_index(route_client, db):
 async def test_run_semantic_index_with_reset(route_client, db):
     """Test running semantic index with reset."""
     with patch(
-        "src.web.routes.settings.EmbeddingService.index_pending_messages",
+        "src.web.settings.handlers.EmbeddingService.index_pending_messages",
         AsyncMock(return_value=3),
     ):
         resp = await route_client.post(
@@ -460,7 +460,7 @@ async def test_add_agent_provider_writes_disabled(route_client, db):
     """Test add agent provider when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = False
         mock_service.load_provider_configs = AsyncMock(return_value=[])
@@ -480,7 +480,7 @@ async def test_add_agent_provider_dev_mode_required(route_client, db):
     """Test add agent provider requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True  # Set writes_enabled first
         mock_service.load_provider_configs = AsyncMock(return_value=[])
@@ -501,7 +501,7 @@ async def test_save_agent_providers_writes_disabled(route_client, db):
     """Test save agent providers when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = False
         mock_service.load_provider_configs = AsyncMock(return_value=[])
@@ -521,7 +521,7 @@ async def test_delete_agent_provider_writes_disabled(route_client, db):
     """Test delete agent provider when writes are disabled."""
     await db.set_setting("agent_dev_mode_enabled", "1")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = False
         mock_service.load_provider_configs = AsyncMock(return_value=[])
@@ -592,7 +592,7 @@ async def test_test_all_agent_provider_models_dev_mode_required(route_client, db
     """Test test all requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True  # Must be True to reach dev_mode check
         mock_service_cls.return_value = mock_service
@@ -618,7 +618,7 @@ async def test_test_all_status_dev_mode_required(route_client, db):
     """Test test all status requires dev mode."""
     await db.set_setting("agent_dev_mode_enabled", "0")
 
-    with patch("src.web.routes.settings.AgentProviderService") as mock_service_cls:
+    with patch("src.web.settings.handlers.AgentProviderService") as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True  # Must be True to reach dev_mode check
         mock_service_cls.return_value = mock_service

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -29,10 +29,10 @@ async def test_settings_page_flood_wait_naive_tz(route_client, db):
         await db.update_account_flood(acc.phone, future_naive)
 
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -48,10 +48,10 @@ async def test_settings_page_expired_flood_cleared(route_client, db):
         await db.update_account_flood(acc.phone, past)
 
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -75,10 +75,10 @@ async def test_settings_page_inactive_account(route_client, db):
     await db.add_account(Account(phone="+15555555555", session_string="test2"))
 
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ):
         resp = await route_client.get("/settings/")
@@ -89,10 +89,10 @@ async def test_settings_page_inactive_account(route_client, db):
 async def test_settings_page_notification_bot_error(route_client, db):
     """Test settings page renders without inline notification bot fetch."""
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ), patch(
         "src.web.routes.settings.deps.get_notification_target_service"
@@ -218,7 +218,7 @@ async def test_run_semantic_index_unavailable(route_client, db):
 async def test_run_semantic_index_with_reset_flag(route_client, db):
     """Test semantic index with reset flag (line 628)."""
     with patch(
-        "src.web.routes.settings.EmbeddingService.index_pending_messages",
+        "src.web.settings.handlers.EmbeddingService.index_pending_messages",
         AsyncMock(return_value=0),
     ), patch(
         "src.web.routes.settings.deps.get_search_engine"
@@ -398,9 +398,9 @@ async def test_add_agent_provider_invalid_name(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "1")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -422,9 +422,9 @@ async def test_add_agent_provider_already_exists(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "1")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -453,9 +453,9 @@ async def test_add_agent_provider_refreshes_manager(route_client, db):
     route_client._transport_app.state.agent_manager = mock_manager
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -483,7 +483,7 @@ async def test_save_agent_providers_dev_mode_required(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "0")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -508,11 +508,11 @@ async def test_save_agent_providers_probes_enabled(route_client, db):
     cfg.provider = "openai"
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
         "src.web.routes.settings.deps.get_agent_manager"
     ) as mock_get_mgr, patch(
-        "src.web.routes.settings._probe_provider_config",
+        "src.web.settings.handlers._probe_provider_config",
         AsyncMock(return_value=MagicMock()),
     ):
         mock_service = MagicMock()
@@ -545,7 +545,7 @@ async def test_delete_agent_provider_dev_mode_required(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "0")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -571,7 +571,7 @@ async def test_delete_agent_provider_refreshes_manager(route_client, db):
     route_client._transport_app.state.agent_manager = mock_manager
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -599,7 +599,7 @@ async def test_refresh_agent_provider_dev_mode_required_json(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "0")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -618,9 +618,9 @@ async def test_refresh_agent_provider_unknown(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "1")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -643,9 +643,9 @@ async def test_probe_agent_provider_unknown(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "1")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -665,9 +665,9 @@ async def test_probe_agent_provider_validation_blocked(route_client, db):
     await db.set_setting("agent_dev_mode_enabled", "1")
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -706,11 +706,11 @@ async def test_probe_agent_provider_success(route_client, db):
     )
 
     with patch(
-        "src.web.routes.settings.AgentProviderService"
+        "src.web.settings.handlers.AgentProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deepagents_provider_spec"
+        "src.web.settings.handlers.deepagents_provider_spec"
     ) as mock_spec, patch(
-        "src.web.routes.settings._probe_provider_config",
+        "src.web.settings.handlers._probe_provider_config",
         AsyncMock(return_value=record),
     ):
         mock_service = MagicMock()
@@ -972,9 +972,9 @@ async def test_test_notification_notify_fails(route_client, db):
 async def test_add_image_provider_invalid(route_client, db):
     """Test add image provider with invalid name (lines 1204-1207)."""
     with patch(
-        "src.web.routes.settings.ImageProviderService"
+        "src.web.settings.handlers.ImageProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.image_provider_spec"
+        "src.web.settings.handlers.image_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -994,9 +994,9 @@ async def test_add_image_provider_invalid(route_client, db):
 async def test_add_image_provider_already_exists(route_client, db):
     """Test add image provider when it already exists (lines 1208-1209)."""
     with patch(
-        "src.web.routes.settings.ImageProviderService"
+        "src.web.settings.handlers.ImageProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.image_provider_spec"
+        "src.web.settings.handlers.image_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -1019,9 +1019,9 @@ async def test_add_image_provider_already_exists(route_client, db):
 async def test_save_image_providers_missing_key(route_client, db):
     """Test save image providers with missing API key (lines 1226-1233)."""
     with patch(
-        "src.web.routes.settings.ImageProviderService"
+        "src.web.settings.handlers.ImageProviderService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.image_provider_spec"
+        "src.web.settings.handlers.image_provider_spec"
     ) as mock_spec:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -1052,7 +1052,7 @@ async def test_save_image_providers_missing_key(route_client, db):
 async def test_save_image_providers_success(route_client, db):
     """Test save image providers success (lines 1236-1239)."""
     with patch(
-        "src.web.routes.settings.ImageProviderService"
+        "src.web.settings.handlers.ImageProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -1076,7 +1076,7 @@ async def test_save_image_providers_success(route_client, db):
 async def test_delete_image_provider(route_client, db):
     """Test delete image provider (lines 1246-1250)."""
     with patch(
-        "src.web.routes.settings.ImageProviderService"
+        "src.web.settings.handlers.ImageProviderService"
     ) as mock_service_cls:
         mock_service = MagicMock()
         mock_service.writes_enabled = True
@@ -1159,10 +1159,10 @@ async def test_settings_page_reload_llm_providers_failure(route_client, db, capl
     route_client._transport_app.state.llm_provider_service = mock_llm_svc
 
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ), caplog.at_level(
         logging.WARNING, logger="src.web.routes.settings"

--- a/tests/test_cli_channel_pipeline_route_paths.py
+++ b/tests/test_cli_channel_pipeline_route_paths.py
@@ -1050,13 +1050,13 @@ async def test_channels_refresh_meta_success(_route_client_b3):
 def _settings_patch():
     """Patch AgentProviderService methods to avoid needing config."""
     with patch(
-        "src.web.routes.settings.AgentProviderService.load_provider_configs",
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ), patch(
-        "src.web.routes.settings.AgentProviderService.load_model_cache",
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
         AsyncMock(return_value={}),
     ), patch(
-        "src.web.routes.settings.ImageProviderService.load_provider_configs",
+        "src.web.settings.handlers.ImageProviderService.load_provider_configs",
         AsyncMock(return_value=[]),
     ):
         yield

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -1295,20 +1295,20 @@ class TestUnifiedDispatcherHandlers:
 
 class TestSettingsRouteHelpers:
     async def test_require_agent_dev_mode_disabled(self, db):
-        from src.web.routes.settings import _require_agent_dev_mode
+        from src.web.settings.handlers import _require_agent_dev_mode
 
         request = MagicMock()
         # Patch deps.get_db to return our real db
-        with patch("src.web.routes.settings.deps.get_db", return_value=db):
+        with patch("src.web.settings.handlers.deps.get_db", return_value=db):
             await db.set_setting("agent_dev_mode_enabled", "0")
             result = await _require_agent_dev_mode(request)
             assert result is not None  # returns redirect
 
     async def test_require_agent_dev_mode_enabled(self, db):
-        from src.web.routes.settings import _require_agent_dev_mode
+        from src.web.settings.handlers import _require_agent_dev_mode
 
         request = MagicMock()
-        with patch("src.web.routes.settings.deps.get_db", return_value=db):
+        with patch("src.web.settings.handlers.deps.get_db", return_value=db):
             await db.set_setting("agent_dev_mode_enabled", "1")
             result = await _require_agent_dev_mode(request)
             assert result is None

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -266,7 +266,7 @@ class TestWebSettingsRoutes:
     @pytest.mark.anyio
     async def test_settings_agent_providers_page(self, route_client):
         """GET /settings/agent-providers returns 200 or redirect."""
-        with patch("src.web.routes.settings._agent_provider_service") as mock_fn:
+        with patch("src.web.settings.handlers._agent_provider_service") as mock_fn:
             svc = MagicMock()
             svc.load_provider_configs = AsyncMock(return_value=[])
             mock_fn.return_value = svc
@@ -276,7 +276,7 @@ class TestWebSettingsRoutes:
     @pytest.mark.anyio
     async def test_settings_image_providers_get(self, route_client):
         """GET /settings/image-providers returns 200."""
-        with patch("src.web.routes.settings._image_provider_service") as mock_fn:
+        with patch("src.web.settings.handlers._image_provider_service") as mock_fn:
             svc = MagicMock()
             svc.load_provider_configs = AsyncMock(return_value=[])
             mock_fn.return_value = svc

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -711,13 +711,13 @@ async def test_settings_add_agent_provider_persists_provider_in_db(client):
 async def test_settings_save_agent_providers_preserves_priority_order(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     probe_mock = AsyncMock()
     fake_manager = SimpleNamespace(refresh_settings_cache=AsyncMock())
-    monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
+    monkeypatch.setattr(settings_handlers, "_probe_provider_config", probe_mock)
     monkeypatch.setattr(
-        settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+        settings_handlers, "_settings_agent_manager", lambda request: (fake_manager, False)
     )
 
     await client.post(
@@ -757,13 +757,13 @@ async def test_settings_save_agent_providers_skips_probe_for_disabled_provider(c
     await client.post(
         "/settings/agent-providers/add", data={"provider": "openai"}, follow_redirects=False
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     probe_mock = AsyncMock()
     fake_manager = SimpleNamespace(refresh_settings_cache=AsyncMock())
-    monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
+    monkeypatch.setattr(settings_handlers, "_probe_provider_config", probe_mock)
     monkeypatch.setattr(
-        settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+        settings_handlers, "_settings_agent_manager", lambda request: (fake_manager, False)
     )
 
     resp = await client.post(
@@ -1018,7 +1018,7 @@ async def test_settings_probe_agent_provider_model_returns_cached_json(client, m
     await client.post(
         "/settings/agent-providers/add", data={"provider": "openai"}, follow_redirects=False
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     fake_manager = SimpleNamespace(
         probe_provider_config=AsyncMock(
@@ -1032,7 +1032,7 @@ async def test_settings_probe_agent_provider_model_returns_cached_json(client, m
         )
     )
     monkeypatch.setattr(
-        settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+        settings_handlers, "_settings_agent_manager", lambda request: (fake_manager, False)
     )
 
     resp = await client.post(
@@ -1064,7 +1064,7 @@ async def test_settings_save_agent_providers_keeps_unsupported_probe_in_cache_on
     await client.post(
         "/settings/agent-providers/add", data={"provider": "openai"}, follow_redirects=False
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     fake_manager = SimpleNamespace(
         probe_provider_config=AsyncMock(
@@ -1080,7 +1080,7 @@ async def test_settings_save_agent_providers_keeps_unsupported_probe_in_cache_on
         refresh_settings_cache=AsyncMock(),
     )
     monkeypatch.setattr(
-        settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+        settings_handlers, "_settings_agent_manager", lambda request: (fake_manager, False)
     )
 
     resp = await client.post(
@@ -1128,7 +1128,7 @@ async def test_settings_bulk_test_uses_unsaved_form_values(client, monkeypatch):
             )
         ]
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     captured_configs: list[ProviderRuntimeConfig] = []
     started = asyncio.Event()
@@ -1139,7 +1139,7 @@ async def test_settings_bulk_test_uses_unsaved_form_values(client, monkeypatch):
             captured_configs.extend(configs)
         started.set()
 
-    monkeypatch.setattr(settings_routes, "_run_bulk_test_job", _fake_run_bulk_test_job)
+    monkeypatch.setattr(settings_handlers, "_run_bulk_test_job", _fake_run_bulk_test_job)
 
     resp = await client.post(
         "/settings/agent-providers/test-all",
@@ -1164,18 +1164,18 @@ async def test_settings_bulk_test_uses_unsaved_form_values(client, monkeypatch):
 async def test_settings_bulk_test_clears_running_status_when_startup_raises(client, monkeypatch):
     db = client._transport.app.state.db
     await db.set_setting("agent_dev_mode_enabled", "1")
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     request = SimpleNamespace(app=client._transport.app, state=SimpleNamespace())
 
     def _broken_logger_info(*args, **kwargs):
         raise RuntimeError("log sink unavailable")
 
-    monkeypatch.setattr(settings_routes.logger, "info", _broken_logger_info)
+    monkeypatch.setattr(settings_handlers.logger, "info", _broken_logger_info)
 
-    await settings_routes._run_bulk_test_job(request, configs=[])
+    await settings_handlers._run_bulk_test_job(request, configs=[])
 
-    status = settings_routes._bulk_test_status_payload(request)
+    status = settings_handlers._bulk_test_status_payload(request)
     assert status["running"] is False
     assert status["error"] == "log sink unavailable"
 
@@ -1196,7 +1196,7 @@ async def test_settings_bulk_test_refreshes_each_provider_once(client, monkeypat
             )
         ]
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     refresh_calls: list[str] = []
     request = SimpleNamespace(app=client._transport.app, state=SimpleNamespace())
@@ -1231,19 +1231,19 @@ async def test_settings_bulk_test_refreshes_each_provider_once(client, monkeypat
         "refresh_models_for_provider",
         _fake_refresh_models_for_provider,
     )
-    monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
+    monkeypatch.setattr(settings_handlers, "_probe_provider_config", probe_mock)
     monkeypatch.setattr(
         AgentProviderService,
         "export_compatibility_catalog",
         _fake_export_catalog,
     )
     monkeypatch.setattr(
-        settings_routes,
+        settings_handlers,
         "_settings_agent_manager",
         lambda request: (SimpleNamespace(refresh_settings_cache=AsyncMock()), False),
     )
 
-    await settings_routes._run_bulk_test_job(request)
+    await settings_handlers._run_bulk_test_job(request)
 
     assert refresh_calls == ["openai"]
     probe_mock.assert_awaited_once()
@@ -1265,13 +1265,13 @@ async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path)
             )
         ]
     )
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     export_path = tmp_path / "compat_catalog.json"
 
     async def _fake_run_bulk_test_job(request, configs=None):
         del configs
-        status = settings_routes._bulk_test_status_payload(request)
+        status = settings_handlers._bulk_test_status_payload(request)
         status.update(
             {
                 "running": False,
@@ -1309,7 +1309,7 @@ async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path)
         )
         export_path.write_text('{"providers": []}', encoding="utf-8")
 
-    monkeypatch.setattr(settings_routes, "_run_bulk_test_job", _fake_run_bulk_test_job)
+    monkeypatch.setattr(settings_handlers, "_run_bulk_test_job", _fake_run_bulk_test_job)
 
     resp = await client.post("/settings/agent-providers/test-all")
 
@@ -3576,7 +3576,7 @@ async def test_settings_clears_stale_flood_on_load(tmp_path, real_pool_harness_f
     """GET /settings clears flood_wait_until from DB when the timestamp is expired."""
     from datetime import timedelta
 
-    from src.web.routes import settings as settings_routes
+    from src.web.settings import handlers as settings_handlers
 
     config = make_test_config(tmp_path)
     harness = real_pool_harness_factory()
@@ -3587,10 +3587,10 @@ async def test_settings_clears_stale_flood_on_load(tmp_path, real_pool_harness_f
         await db.update_account_flood("+70011", past)
 
         probe_mock = AsyncMock(return_value=("ok", None))
-        monkeypatch.setattr(settings_routes, "_probe_provider_config", probe_mock)
+        monkeypatch.setattr(settings_handlers, "_probe_provider_config", probe_mock)
         fake_manager = SimpleNamespace(available=False)
         monkeypatch.setattr(
-            settings_routes, "_settings_agent_manager", lambda request: (fake_manager, False)
+            settings_handlers, "_settings_agent_manager", lambda request: (fake_manager, False)
         )
 
         async with make_auth_client(app) as c:


### PR DESCRIPTION
## Summary
- Split settings internals into `src/web/settings/forms.py`, `handlers.py`, and `responses.py`.
- Keep `src/web/routes/settings.py` as thin route entrypoints for the existing `/settings` contract.
- Update tests that patched moved private helpers to target `src.web.settings.handlers`.

## Validation
- `ruff check src/ tests/ conftest.py`
- `pytest tests/routes/test_settings_routes.py tests/routes/test_settings_routes_provider_notifications.py -v`
- `pytest tests/routes/ -v -k settings`
- `pytest tests/test_web.py -v -k "settings or notification"`
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` (`6747 passed, 1 skipped`)
- `pytest tests/ -v -m aiosqlite_serial` (`828 passed`)

Closes #505