### PR TITLE
refactor(web): atomize pipeline routes

### DIFF
--- a/src/web/pipelines/forms.py
+++ b/src/web/pipelines/forms.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import UploadFile
+
+from src.services.pipeline_filters import normalize_filter_config
+from src.services.pipeline_service import PipelineTargetRef, PipelineValidationError
+
+
+@dataclass(frozen=True)
+class CreateWizardForm:
+    name: str
+    pipeline_json: str
+    source_channel_ids: list[int]
+    target_refs: list[str]
+    generate_interval_minutes: int
+    is_active: str
+    run_after: str
+    since_value: int
+    since_unit: str
+    account_phone: str
+
+
+@dataclass(frozen=True)
+class PipelineCreateForm:
+    name: str
+    prompt_template: str
+    source_channel_ids: list[int]
+    target_refs: list[str]
+    llm_model: str
+    image_model: str
+    publish_mode: str
+    generation_backend: str
+    generate_interval_minutes: int
+    is_active: bool
+
+
+@dataclass(frozen=True)
+class PipelineEditForm:
+    name: str
+    prompt_template: str
+    source_channel_ids: list[int]
+    target_refs: list[str]
+    llm_model: str
+    image_model: str
+    publish_mode: str
+    generation_backend: str
+    generate_interval_minutes: int
+    is_active: bool
+    react_emoji: str
+    filter_present: str
+    filter_message_kinds: list[str]
+    filter_service_actions: list[str]
+    filter_media_types: list[str]
+    filter_sender_kinds: list[str]
+    filter_keywords: str
+    filter_regex: str
+    filter_has_text: str
+    dag_source_channel_ids: list[int]
+    account_phone: str
+
+
+@dataclass(frozen=True)
+class PipelineRunForm:
+    since_value: int
+    since_unit: str
+
+
+@dataclass(frozen=True)
+class PipelineGenerateForm:
+    model: str
+    max_tokens: int
+    temperature: float
+
+
+@dataclass(frozen=True)
+class PipelineTemplateCreateForm:
+    template_id: int | None
+    name: str
+    source_channel_ids: list[int]
+    target_refs: list[str]
+    llm_model: str
+    image_model: str
+    generate_interval_minutes: int
+
+
+@dataclass(frozen=True)
+class PipelineImportForm:
+    json_file: UploadFile | None
+    json_text: str
+    name_override: str
+
+
+def parse_target_refs(values: list[str]) -> list[PipelineTargetRef]:
+    refs: list[PipelineTargetRef] = []
+    for value in values:
+        phone, separator, raw_dialog_id = value.partition("|")
+        if not separator:
+            raise PipelineValidationError("Некорректный формат цели pipeline.")
+        try:
+            dialog_id = int(raw_dialog_id)
+        except ValueError as exc:
+            raise PipelineValidationError("Некорректный dialog id для pipeline target.") from exc
+        refs.append(PipelineTargetRef(phone=phone, dialog_id=dialog_id))
+    return refs
+
+
+def get_filter_config(pipeline) -> dict | None:
+    graph = getattr(pipeline, "pipeline_json", None)
+    if graph is None:
+        return None
+    node = next((item for item in graph.nodes if item.type.value == "filter"), None)
+    if node is None:
+        return None
+    return normalize_filter_config(node.config)
+
+
+def build_filter_config_from_form(
+    *,
+    filter_present: str,
+    filter_message_kinds: list[str],
+    filter_service_actions: list[str],
+    filter_media_types: list[str],
+    filter_sender_kinds: list[str],
+    filter_keywords: str,
+    filter_regex: str,
+    filter_has_text: str,
+) -> dict | None:
+    if not filter_present:
+        return None
+    keywords = [item.strip() for item in filter_keywords.splitlines() if item.strip()]
+    return normalize_filter_config(
+        {
+            "type": "message_filter",
+            "message_kinds": filter_message_kinds,
+            "service_actions": filter_service_actions,
+            "media_types": filter_media_types,
+            "sender_kinds": filter_sender_kinds,
+            "keywords": keywords,
+            "regex": filter_regex.strip(),
+            "has_text": True if filter_has_text else None,
+        }
+    )

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -1,0 +1,848 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import File, Form, Request, UploadFile
+from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
+
+from src.agent.prompt_template import ALLOWED_TEMPLATE_VARIABLES
+from src.models import PipelineGenerationBackend, PipelinePublishMode
+from src.services.pipeline_filters import filter_messages
+from src.services.pipeline_llm_requirements import (
+    get_dag_source_channel_ids,
+    get_react_emoji_config,
+    pipeline_is_dag,
+    pipeline_needs_llm,
+    pipeline_needs_publish_mode,
+)
+from src.services.pipeline_service import (
+    PipelineService,
+    PipelineValidationError,
+)
+from src.services.pipeline_service import (
+    to_since_hours as _to_since_hours,
+)
+from src.utils.json import safe_json_dumps
+from src.web import deps
+from src.web.pipelines.forms import (
+    build_filter_config_from_form,
+    get_filter_config,
+    parse_target_refs,
+)
+from src.web.pipelines.responses import PipelineRedirect
+
+logger = logging.getLogger("src.web.routes.pipelines")
+
+
+def _pipeline_redirect(
+    code: str,
+    *,
+    error: bool = False,
+    phone: str | None = None,
+) -> PipelineRedirect:
+    return PipelineRedirect(code=code, error=error, phone=phone)
+
+
+def _target_refs(values):
+    return parse_target_refs(values)
+
+
+def _get_filter_config(pipeline) -> dict | None:
+    return get_filter_config(pipeline)
+
+
+def _build_filter_config_from_form(
+    *,
+    filter_present: str,
+    filter_message_kinds: list[str],
+    filter_service_actions: list[str],
+    filter_media_types: list[str],
+    filter_sender_kinds: list[str],
+    filter_keywords: str,
+    filter_regex: str,
+    filter_has_text: str,
+) -> dict | None:
+    return build_filter_config_from_form(
+        filter_present=filter_present,
+        filter_message_kinds=filter_message_kinds,
+        filter_service_actions=filter_service_actions,
+        filter_media_types=filter_media_types,
+        filter_sender_kinds=filter_sender_kinds,
+        filter_keywords=filter_keywords,
+        filter_regex=filter_regex,
+        filter_has_text=filter_has_text,
+    )
+
+
+async def api_channels_search(request: Request, q: str = ""):
+    """AJAX endpoint for searchable picker — returns up to 50 channels matching *q*."""
+    db = deps.get_db(request)
+    query = q.strip()
+    if len(query) < 2:
+        cur = await db.execute(
+            "SELECT channel_id, title, username FROM channels ORDER BY id DESC LIMIT 50",
+        )
+        rows = await cur.fetchall()
+        return [
+            {
+                "value": row["channel_id"],
+                "title": row["title"] or str(row["channel_id"]),
+                "username": row["username"] or "",
+                "group": "channel",
+            }
+            for row in rows
+        ]
+    cur = await db.execute(
+        """SELECT channel_id, title, username FROM channels
+           WHERE (LOWER(title) LIKE ? OR LOWER(username) LIKE ? OR CAST(channel_id AS TEXT) LIKE ?)
+           ORDER BY channel_id LIMIT 50""",
+        (f"%{query.lower()}%", f"%{query.lower()}%", f"%{query}%"),
+    )
+    rows = await cur.fetchall()
+    return [
+        {
+            "value": row["channel_id"],
+            "title": row["title"] or str(row["channel_id"]),
+            "username": row["username"] or "",
+            "group": "channel",
+        }
+        for row in rows
+    ]
+
+
+async def _page_context(request: Request) -> dict:
+    svc = deps.pipeline_service(request)
+    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
+    accounts = await deps.get_account_bundle(request).list_accounts()
+    selected_phone = request.query_params.get("phone") or (accounts[0].phone if accounts else "")
+    if selected_phone:
+        refresh = request.query_params.get("refresh") == "1"
+        try:
+            await deps.channel_service(request).get_my_dialogs(selected_phone, refresh=refresh)
+        except Exception:
+            logger.warning("Failed to refresh dialog cache for %s", selected_phone, exc_info=True)
+    cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    items = await svc.get_with_relations()
+    # Annotate each item with whether the pipeline actually needs an LLM provider.
+    # Used by the template to disable Generate/Run buttons per-pipeline instead of
+    # globally — non-LLM pipelines (SOURCE→PUBLISH DAGs) remain runnable.
+    needs_llm_map: dict[int, bool] = {}
+    for item in items:
+        pipeline = item.get("pipeline") if isinstance(item, dict) else None
+        if pipeline is None or pipeline.id is None:
+            continue
+        try:
+            needs_llm_map[pipeline.id] = pipeline_needs_llm(pipeline)
+        except Exception:
+            # Fail safe: assume LLM is needed on unexpected shapes.
+            logger.warning("pipeline_needs_llm failed for pipeline_id=%s", pipeline.id, exc_info=True)
+            needs_llm_map[pipeline.id] = True
+    # gather next_run times for pipelines (batch query)
+    next_runs = {}
+    try:
+        scheduler = deps.get_scheduler(request)
+        all_jobs = scheduler.get_all_jobs_next_run()
+        for item in items:
+            pipeline = item.get("pipeline") if isinstance(item, dict) else None
+            if pipeline is None or pipeline.id is None:
+                continue
+            job_id = f"pipeline_run_{pipeline.id}"
+            nr = all_jobs.get(job_id)
+            next_runs[pipeline.id] = nr.isoformat() if nr else None
+    except Exception:
+        next_runs = {}
+    ctx = {
+        "items": items,
+        "channels": channels,
+        "accounts": accounts,
+        "cached_dialogs": cached_dialogs,
+        "selected_phone": selected_phone,
+        "prompt_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
+        "publish_modes": list(PipelinePublishMode),
+        "generation_backends": list(PipelineGenerationBackend),
+        "next_runs": next_runs,
+        "llm_configured": deps.get_llm_provider_service(request).has_providers(),
+        "needs_llm_map": needs_llm_map,
+    }
+    # Only query DB for provider statuses when the banner is visible
+    if not ctx["llm_configured"]:
+        ctx["llm_provider_statuses"] = await deps.get_llm_provider_service(request).get_provider_status_list()
+    return ctx
+
+
+async def pipelines_page(request: Request):
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines.html",
+        await _page_context(request),
+    )
+
+
+async def create_wizard_page(request: Request):
+    svc = deps.pipeline_service(request)
+    accounts = await deps.get_account_bundle(request).list_accounts()
+    cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    llm_provider_svc = deps.get_llm_provider_service(request)
+    llm_configured = llm_provider_svc.has_providers()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/create.html",
+        {
+            "accounts": accounts,
+            "cached_dialogs": cached_dialogs,
+            "llm_configured": llm_configured,
+        },
+    )
+
+
+async def create_wizard_submit(
+    request: Request,
+    name: str = Form(""),
+    pipeline_json: str = Form(""),
+    source_channel_ids: list[int] = Form(default=[]),
+    target_refs: list[str] = Form(default=[]),
+    generate_interval_minutes: int = Form(60),
+    is_active: str = Form(""),
+    run_after: str = Form(""),
+    since_value: int = Form(24),
+    since_unit: str = Form("h"),
+    account_phone: str = Form(""),
+):
+    if not name or not pipeline_json:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    import json as _json
+
+    svc = deps.pipeline_service(request)
+    try:
+        graph_data = _json.loads(pipeline_json)
+        # Extract llm_model from first LLM node config for pipeline-level setting
+        llm_model = ""
+        for node in graph_data.get("nodes", []):
+            if node.get("type") in ("llm_generate", "llm_refine", "agent_loop"):
+                llm_model = node.get("config", {}).get("model", "") or ""
+                break
+        data = {
+            "name": name,
+            "prompt_template": ".",
+            "llm_model": llm_model or None,
+            "source_ids": source_channel_ids,
+            "target_refs": target_refs,
+            "generate_interval_minutes": generate_interval_minutes,
+            "pipeline_json": graph_data,
+            "account_phone": account_phone or None,
+        }
+        pipeline_id = await svc.import_json(data)
+    except PipelineValidationError as exc:
+        return _pipeline_redirect(str(exc), error=True)
+    except Exception as exc:
+        logger.warning("create-wizard failed: %s", exc, exc_info=True)
+        return _pipeline_redirect(f"Ошибка: {exc}", error=True)
+    if is_active:
+        await svc.toggle(pipeline_id)
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    if run_after:
+        _since = _to_since_hours(since_value, since_unit)
+        enqueuer = deps.get_task_enqueuer(request)
+        await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=_since)
+        return _pipeline_redirect("pipeline_run_with_since")
+    return _pipeline_redirect("pipeline_added")
+
+
+async def add_pipeline(
+    request: Request,
+    name: str = Form(""),
+    prompt_template: str = Form(""),
+    source_channel_ids: list[int] = Form(default=[]),
+    target_refs: list[str] = Form(default=[]),
+    llm_model: str = Form(""),
+    image_model: str = Form(""),
+    publish_mode: str = Form(PipelinePublishMode.MODERATED.value),
+    generation_backend: str = Form(PipelineGenerationBackend.CHAIN.value),
+    generate_interval_minutes: int = Form(60),
+    is_active: bool = Form(False),
+):
+    if not name or not prompt_template:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    svc: PipelineService = deps.pipeline_service(request)
+    try:
+        new_pipeline_id = await svc.add(
+            name=name,
+            prompt_template=prompt_template,
+            source_channel_ids=source_channel_ids,
+            target_refs=_target_refs(target_refs),
+            llm_model=llm_model,
+            image_model=image_model,
+            publish_mode=publish_mode,
+            generation_backend=generation_backend,
+            generate_interval_minutes=generate_interval_minutes,
+            is_active=is_active,
+        )
+    except PipelineValidationError:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    # sync scheduler jobs
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    # Warn if pipeline needs LLM but no provider is configured — still create it.
+    try:
+        created = await svc.get(new_pipeline_id)
+        if created is not None and pipeline_needs_llm(created):
+            if not deps.get_llm_provider_service(request).has_providers():
+                return _pipeline_redirect("pipeline_added_no_llm")
+    except Exception:
+        logger.debug("pipeline_needs_llm check failed after add", exc_info=True)
+    return _pipeline_redirect("pipeline_added")
+
+
+async def edit_pipeline(
+    request: Request,
+    pipeline_id: int,
+    name: str = Form(""),
+    prompt_template: str = Form(""),
+    source_channel_ids: list[int] = Form(default=[]),
+    target_refs: list[str] = Form(default=[]),
+    llm_model: str = Form(""),
+    image_model: str = Form(""),
+    publish_mode: str = Form(PipelinePublishMode.MODERATED.value),
+    generation_backend: str = Form(PipelineGenerationBackend.CHAIN.value),
+    generate_interval_minutes: int = Form(60),
+    is_active: bool = Form(False),
+    react_emoji: str = Form(""),
+    filter_present: str = Form(""),
+    filter_message_kinds: list[str] = Form(default=[]),
+    filter_service_actions: list[str] = Form(default=[]),
+    filter_media_types: list[str] = Form(default=[]),
+    filter_sender_kinds: list[str] = Form(default=[]),
+    filter_keywords: str = Form(""),
+    filter_regex: str = Form(""),
+    filter_has_text: str = Form(""),
+    dag_source_channel_ids: list[int] = Form(default=[]),
+    account_phone: str = Form(""),
+):
+    if not name:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    svc: PipelineService = deps.pipeline_service(request)
+    phone = request.query_params.get("phone")
+    existing = await svc.get(pipeline_id)
+    if existing is None:
+        return _pipeline_redirect("pipeline_invalid", error=True, phone=phone)
+    # For DAG pipelines, hidden form fields send defaults — preserve existing values
+    if pipeline_is_dag(existing):
+        if not prompt_template:
+            prompt_template = existing.prompt_template or ""
+        if generation_backend == PipelineGenerationBackend.CHAIN.value and existing.generation_backend:
+            generation_backend = existing.generation_backend.value
+    try:
+        ok = await svc.update(
+            pipeline_id,
+            name=name,
+            prompt_template=prompt_template,
+            source_channel_ids=source_channel_ids,
+            target_refs=_target_refs(target_refs),
+            llm_model=llm_model,
+            image_model=image_model,
+            publish_mode=publish_mode,
+            generation_backend=generation_backend,
+            generate_interval_minutes=generate_interval_minutes,
+            is_active=is_active,
+            react_emoji=react_emoji,
+            filter_config=_build_filter_config_from_form(
+                filter_present=filter_present,
+                filter_message_kinds=filter_message_kinds,
+                filter_service_actions=filter_service_actions,
+                filter_media_types=filter_media_types,
+                filter_sender_kinds=filter_sender_kinds,
+                filter_keywords=filter_keywords,
+                filter_regex=filter_regex,
+                filter_has_text=filter_has_text,
+            ),
+            dag_source_channel_ids=dag_source_channel_ids,
+            account_phone=account_phone,
+        )
+    except PipelineValidationError as exc:
+        return _pipeline_redirect(str(exc), error=True, phone=phone)
+    if not ok:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    # sync scheduler jobs
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return _pipeline_redirect("pipeline_edited")
+
+
+async def toggle_pipeline(request: Request, pipeline_id: int):
+    ok = await deps.pipeline_service(request).toggle(pipeline_id)
+    if not ok:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return _pipeline_redirect("pipeline_toggled")
+
+
+async def delete_pipeline(request: Request, pipeline_id: int):
+    await deps.pipeline_service(request).delete(pipeline_id)
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return _pipeline_redirect("pipeline_deleted")
+
+
+async def run_pipeline(request: Request, pipeline_id: int,
+                       since_value: int = Form(24), since_unit: str = Form("h")):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    # Per-pipeline LLM requirement: pure forward/publish DAGs run fine without a provider.
+    if pipeline_needs_llm(pipeline) and not deps.get_llm_provider_service(request).has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
+    try:
+        since_hours = _to_since_hours(since_value, since_unit)
+        enqueuer = deps.get_task_enqueuer(request)
+        await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_hours)
+    except Exception:
+        logger.warning("Failed to enqueue pipeline run for pipeline_id=%d", pipeline_id, exc_info=True)
+        return _pipeline_redirect("pipeline_run_failed", error=True)
+    return _pipeline_redirect("pipeline_run_enqueued")
+
+
+async def dry_run_pipeline(request: Request, pipeline_id: int):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    if pipeline_needs_llm(pipeline) and not deps.get_llm_provider_service(request).has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
+    try:
+        enqueuer = deps.get_task_enqueuer(request)
+        await enqueuer.enqueue_pipeline_run(pipeline_id, dry_run=True)
+    except Exception:
+        logger.warning("Failed to enqueue dry-run for pipeline_id=%d", pipeline_id, exc_info=True)
+        return _pipeline_redirect("pipeline_run_failed", error=True)
+    return _pipeline_redirect("pipeline_dry_run_enqueued")
+
+
+async def edit_page(request: Request, pipeline_id: int):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
+    accounts = await deps.get_account_bundle(request).list_accounts()
+    selected_phone = request.query_params.get("phone") or (accounts[0].phone if accounts else "")
+    if selected_phone and request.query_params.get("refresh") == "1":
+        try:
+            await deps.channel_service(request).get_my_dialogs(selected_phone, refresh=True)
+        except Exception:
+            logger.warning("Failed to refresh dialog cache for %s", selected_phone, exc_info=True)
+    cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    sources = await db.repos.content_pipelines.list_sources(pipeline_id)
+    targets = await db.repos.content_pipelines.list_targets(pipeline_id)
+    source_ids = [s.channel_id for s in sources]
+    target_refs = [f"{t.phone}|{t.dialog_id}" for t in targets]
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/edit.html",
+        {
+            "pipeline": pipeline,
+            "channels": channels,
+            "accounts": accounts,
+            "cached_dialogs": cached_dialogs,
+            "source_ids": source_ids,
+            "target_refs": target_refs,
+            "prompt_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
+            "generation_backends": list(PipelineGenerationBackend),
+            "publish_modes": list(PipelinePublishMode),
+            "needs_llm": pipeline_needs_llm(pipeline),
+            "needs_publish_mode": pipeline_needs_publish_mode(pipeline),
+            "is_dag": pipeline_is_dag(pipeline),
+            "react_emoji": get_react_emoji_config(pipeline),
+            "filter_config": _get_filter_config(pipeline),
+            "dag_source_channel_ids": get_dag_source_channel_ids(pipeline),
+        },
+    )
+
+
+async def generate_page(request: Request, pipeline_id: int):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/generate.html",
+        {"pipeline": pipeline, "runs": runs, "request": request},
+    )
+
+
+async def generate_stream(
+    request: Request,
+    pipeline_id: int,
+    model: str = "",
+    max_tokens: int = 256,
+    temperature: float = 0.0,
+):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    engine = deps.get_search_engine(request)
+
+    provider_service = deps.get_llm_provider_service(request)
+    if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
+    if not pipeline_needs_llm(pipeline):
+        return _pipeline_redirect("pipeline_no_llm_nodes", error=True)
+    provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
+
+    from src.services.generation_service import GenerationService
+
+    gen = GenerationService(engine, provider_callable=provider_callable)
+    scope = await svc.get_retrieval_scope(pipeline)
+
+    # persist run
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
+    try:
+        await db.repos.generation_runs.set_status(run_id, "running")
+    except Exception:
+        await db.repos.generation_runs.set_status(run_id, "failed")
+        raise
+    async def event_gen():
+        last = None
+        try:
+            async for update in gen.generate_stream(
+                query=scope.query,
+                prompt_template=pipeline.prompt_template,
+                model=(model or pipeline.llm_model),
+                max_tokens=max_tokens,
+                temperature=temperature,
+                channel_id=scope.channel_id,
+            ):
+                last = update
+                data = {
+                    "delta": update.get("delta"),
+                    "text": update.get("generated_text"),
+                    "citations": update.get("citations"),
+                }
+                yield f"data: {safe_json_dumps(data)}\n\n"
+
+            # finished successfully
+            final_text = last.get("generated_text") if last else ""
+            metadata = {"citations": last.get("citations", []) if last else []}
+            await db.repos.generation_runs.save_result(run_id, final_text, metadata)
+            await db.repos.generation_runs.set_status(run_id, "completed")
+            yield f"event: done\ndata: {safe_json_dumps({'run_id': run_id})}\n\n"
+        except Exception:
+            logger.exception("Generation stream failed for pipeline_id=%d run_id=%d", pipeline_id, run_id)
+            await db.repos.generation_runs.set_status(run_id, "failed")
+            yield f"event: error\ndata: {safe_json_dumps({'error': 'Generation failed'})}\n\n"
+        except BaseException:
+            await db.repos.generation_runs.set_status(run_id, "failed")
+            raise
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")
+
+
+async def generate_pipeline(
+    request: Request,
+    pipeline_id: int,
+    model: str = Form(""),
+    max_tokens: int = Form(256),
+    temperature: float = Form(0.0),
+):
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    engine = deps.get_search_engine(request)
+
+    provider_service = deps.get_llm_provider_service(request)
+    if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
+        return _pipeline_redirect("llm_not_configured", error=True)
+
+    from src.services.content_generation_service import ContentGenerationService
+    from src.services.quality_scoring_service import QualityScoringService
+
+    gen = ContentGenerationService(
+        db,
+        engine,
+        config=request.app.state.config,
+        quality_service=QualityScoringService(db, provider_service=provider_service),
+        provider_service=provider_service,
+    )
+    try:
+        run = await gen.generate(
+            pipeline=pipeline,
+            model=(model or pipeline.llm_model),
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    except Exception:
+        logger.exception("Generation failed for pipeline_id=%d", pipeline_id)
+        runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+        return deps.get_templates(request).TemplateResponse(
+            request,
+            "pipelines/generate.html",
+            {"pipeline": pipeline, "runs": runs, "error": "Generation failed", "request": request},
+        )
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/generate.html",
+        {"pipeline": pipeline, "run": run, "request": request},
+    )
+
+
+async def publish_pipeline(request: Request, pipeline_id: int, run_id: int | None = Form(None)):
+    if run_id is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None or run.pipeline_id != pipeline_id:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    # Mark as published (no external publishing performed here)
+    metadata = run.metadata or {}
+    from datetime import datetime, timezone
+
+    metadata["published"] = True
+    metadata["published_at"] = datetime.now(timezone.utc).isoformat()
+    await db.repos.generation_runs.save_result(run_id, run.generated_text or "", metadata)
+    await db.repos.generation_runs.set_status(run_id, "published")
+    return _pipeline_redirect("pipeline_published")
+
+
+async def get_refinement_steps(request: Request, pipeline_id: int):
+    db = deps.get_db(request)
+    pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_not_found", error=True)
+    return JSONResponse(content={"steps": pipeline.refinement_steps})
+
+
+# ------------------------------------------------------------------
+# Dry-run count endpoints
+# ------------------------------------------------------------------
+
+
+def _apply_pipeline_filter(pipeline, messages: list) -> int:
+    """Count messages that would pass the filter node, if any."""
+    if pipeline.pipeline_json is None:
+        return len(messages)
+    graph = pipeline.pipeline_json
+    filter_node = next(
+        (n for n in graph.nodes if n.type.value == "filter"),
+        None,
+    )
+    if filter_node is None:
+        return len(messages)
+    return len(filter_messages(messages, filter_node.config))
+
+
+async def dry_run_count_new(request: Request, source_ids: str = "",
+                             since_value: int = 6, since_unit: str = "h"):
+    since_hours = _to_since_hours(since_value, since_unit)
+    ids = [int(x) for x in source_ids.split(",") if x.strip().isdigit()]
+    db = deps.get_db(request)
+    messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
+    return {"total": len(messages), "after_filter": len(messages)}
+
+
+async def dry_run_count(request: Request, pipeline_id: int,
+                        since_value: int = 6, since_unit: str = "h"):
+    since_hours = _to_since_hours(since_value, since_unit)
+    svc = deps.pipeline_service(request)
+    pipeline = await svc.get(pipeline_id)
+    if pipeline is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    db = deps.get_db(request)
+    if pipeline.pipeline_json:
+        ids = get_dag_source_channel_ids(pipeline) or []
+    else:
+        sources = await db.repos.content_pipelines.list_sources(pipeline_id)
+        ids = [s.channel_id for s in sources]
+    messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
+    after_filter = _apply_pipeline_filter(pipeline, messages)
+    return {"total": len(messages), "after_filter": after_filter}
+
+
+# ------------------------------------------------------------------
+# Templates
+# ------------------------------------------------------------------
+
+
+async def templates_page(request: Request):
+    svc: PipelineService = deps.pipeline_service(request)
+    templates = await svc.list_templates()
+    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
+    accounts = await deps.get_account_bundle(request).list_accounts()
+    cached_dialogs = await svc.list_cached_dialogs_by_phone()
+    llm_configured = deps.get_llm_provider_service(request).has_providers()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "pipelines/templates.html",
+        {
+            "templates": templates,
+            "channels": channels,
+            "accounts": accounts,
+            "cached_dialogs": cached_dialogs,
+            "llm_configured": llm_configured,
+        },
+    )
+
+
+async def templates_json(request: Request):
+    svc: PipelineService = deps.pipeline_service(request)
+    templates = await svc.list_templates()
+    result = []
+    import json as _json
+    for tpl in templates:
+        result.append({
+            "id": tpl.id,
+            "name": tpl.name,
+            "description": tpl.description,
+            "category": tpl.category,
+            "template_json": _json.loads(tpl.template_json.to_json()),
+        })
+    return JSONResponse(content=result)
+
+
+async def create_from_template(
+    request: Request,
+    template_id: int | None = Form(None),
+    name: str = Form(""),
+    source_channel_ids: list[int] = Form(default=[]),
+    target_refs: list[str] = Form(default=[]),
+    llm_model: str = Form(""),
+    image_model: str = Form(""),
+    generate_interval_minutes: int = Form(60),
+):
+    if template_id is None or not name:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    svc: PipelineService = deps.pipeline_service(request)
+    try:
+        pipeline_id = await svc.create_from_template(
+            template_id,
+            name=name,
+            source_ids=source_channel_ids,
+            target_refs=_target_refs(target_refs),
+            overrides={
+                "llm_model": llm_model or None,
+                "image_model": image_model or None,
+                "generate_interval_minutes": generate_interval_minutes,
+            },
+        )
+    except PipelineValidationError as exc:
+        return _pipeline_redirect(str(exc), error=True)
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return RedirectResponse(url=f"/pipelines/{pipeline_id}/edit", status_code=303)
+
+
+# ------------------------------------------------------------------
+# JSON import / export
+# ------------------------------------------------------------------
+
+
+async def export_pipeline(request: Request, pipeline_id: int):
+    svc: PipelineService = deps.pipeline_service(request)
+    data = await svc.export_json(pipeline_id)
+    if data is None:
+        return _pipeline_redirect("pipeline_invalid", error=True)
+    filename = f"pipeline_{pipeline_id}.json"
+    content = safe_json_dumps(data, ensure_ascii=False, indent=2)
+    return Response(
+        content=content,
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+async def import_pipeline(
+    request: Request,
+    json_file: UploadFile | None = File(None),
+    json_text: str = Form(""),
+    name_override: str = Form(""),
+):
+    svc: PipelineService = deps.pipeline_service(request)
+    import json as _json
+
+    try:
+        if json_file and json_file.filename:
+            raw = await json_file.read()
+            data = _json.loads(raw)
+        elif json_text.strip():
+            data = _json.loads(json_text.strip())
+        else:
+            return _pipeline_redirect("Не передан JSON файл или текст.", error=True)
+
+        pipeline_id = await svc.import_json(data, name_override=name_override or None)
+    except PipelineValidationError as exc:
+        return _pipeline_redirect(str(exc), error=True)
+    except Exception as exc:
+        return _pipeline_redirect(f"Ошибка импорта: {exc}", error=True)
+
+    try:
+        scheduler = deps.get_scheduler(request)
+        await scheduler.sync_pipeline_jobs()
+    except Exception:
+        logger.warning("Scheduler sync failed", exc_info=True)
+    return RedirectResponse(url=f"/pipelines/{pipeline_id}/generate", status_code=303)
+
+
+async def ai_edit_pipeline(request: Request, pipeline_id: int):
+    """Accept JSON body: {"instruction": "..."}. Returns updated pipeline_json."""
+    if not deps.get_llm_provider_service(request).has_providers():
+        return JSONResponse(content={"ok": False, "error": "LLM not configured"}, status_code=400)
+    svc: PipelineService = deps.pipeline_service(request)
+    db = deps.get_db(request)
+    try:
+        body = await request.json()
+        instruction = body.get("instruction", "").strip()
+        if not instruction:
+            return JSONResponse(content={"ok": False, "error": "instruction is required"}, status_code=400)
+        result = await svc.edit_via_llm(pipeline_id, instruction, db, config=request.app.state.config)
+        return JSONResponse(content=result)
+    except Exception as exc:
+        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=500)
+
+
+async def set_refinement_steps(request: Request, pipeline_id: int):
+    """Accept JSON body: {"steps": [{"name": "...", "prompt": "...{text}..."}]}."""
+    db = deps.get_db(request)
+    pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
+    if pipeline is None:
+        return _pipeline_redirect("pipeline_not_found", error=True)
+    try:
+        body = await request.json()
+        steps = body.get("steps", [])
+        if not isinstance(steps, list):
+            raise ValueError("steps must be a list")
+        validated = [
+            {"name": str(s.get("name", "")).strip(), "prompt": str(s.get("prompt", "")).strip()}
+            for s in steps
+            if isinstance(s, dict) and s.get("prompt", "").strip()
+        ]
+    except Exception as exc:
+        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=400)
+    await db.repos.content_pipelines.set_refinement_steps(pipeline_id, validated)
+    return JSONResponse(content={"ok": True, "steps": validated})

--- a/src/web/pipelines/responses.py
+++ b/src/web/pipelines/responses.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import Request
+from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
+
+from src.utils.json import safe_json_dumps
+from src.web import deps
+
+
+@dataclass(frozen=True)
+class PipelineRedirect:
+    code: str
+    error: bool = False
+    phone: str | None = None
+
+
+@dataclass(frozen=True)
+class PipelineTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class PipelineJson:
+    content: Any
+    status_code: int = 200
+
+
+@dataclass(frozen=True)
+class PipelineStream:
+    iterator: Any
+    media_type: str = "text/event-stream"
+
+
+@dataclass(frozen=True)
+class PipelineFile:
+    content: Any
+    filename: str
+    media_type: str = "application/json"
+
+
+PipelineResult = PipelineRedirect | PipelineTemplate | PipelineJson | PipelineStream | PipelineFile | Response | Any
+
+
+def pipeline_redirect_response(result: PipelineRedirect) -> RedirectResponse:
+    key = "error" if result.error else "msg"
+    suffix = f"&phone={quote(result.phone, safe='')}" if result.phone else ""
+    return RedirectResponse(url=f"/pipelines?{key}={quote(result.code, safe='')}{suffix}", status_code=303)
+
+
+def pipeline_response(request: Request, result: PipelineResult):
+    if isinstance(result, PipelineRedirect):
+        return pipeline_redirect_response(result)
+    if isinstance(result, PipelineTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    if isinstance(result, PipelineJson):
+        return JSONResponse(content=result.content, status_code=result.status_code)
+    if isinstance(result, PipelineStream):
+        return StreamingResponse(result.iterator, media_type=result.media_type)
+    if isinstance(result, PipelineFile):
+        return Response(
+            content=safe_json_dumps(result.content, ensure_ascii=False, indent=2),
+            media_type=result.media_type,
+            headers={"Content-Disposition": f'attachment; filename="{result.filename}"'},
+        )
+    return result

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -1,221 +1,37 @@
 from __future__ import annotations
 
-import logging
-from urllib.parse import quote
-
 from fastapi import APIRouter, File, Form, Request, UploadFile
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
-from src.agent.prompt_template import ALLOWED_TEMPLATE_VARIABLES
 from src.models import PipelineGenerationBackend, PipelinePublishMode
-from src.services.pipeline_filters import filter_messages, normalize_filter_config
-from src.services.pipeline_llm_requirements import (
-    get_dag_source_channel_ids,
-    get_react_emoji_config,
-    pipeline_is_dag,
-    pipeline_needs_llm,
-    pipeline_needs_publish_mode,
+from src.web.pipelines import handlers
+from src.web.pipelines.forms import (
+    CreateWizardForm,
+    PipelineCreateForm,
+    PipelineEditForm,
+    PipelineGenerateForm,
+    PipelineImportForm,
+    PipelineRunForm,
+    PipelineTemplateCreateForm,
 )
-from src.services.pipeline_service import (
-    PipelineService,
-    PipelineTargetRef,
-    PipelineValidationError,
-)
-from src.services.pipeline_service import (
-    to_since_hours as _to_since_hours,
-)
-from src.utils.json import safe_json_dumps
-from src.web import deps
+from src.web.pipelines.responses import pipeline_response
 
-logger = logging.getLogger(__name__)
 router = APIRouter()
-
-
-def _pipeline_redirect(
-    code: str,
-    *,
-    error: bool = False,
-    phone: str | None = None,
-) -> RedirectResponse:
-    key = "error" if error else "msg"
-    suffix = f"&phone={quote(phone, safe='')}" if phone else ""
-    return RedirectResponse(url=f"/pipelines?{key}={quote(code, safe='')}{suffix}", status_code=303)
-
-
-def _target_refs(values: list[str]) -> list[PipelineTargetRef]:
-    refs: list[PipelineTargetRef] = []
-    for value in values:
-        phone, separator, raw_dialog_id = value.partition("|")
-        if not separator:
-            raise PipelineValidationError("Некорректный формат цели pipeline.")
-        try:
-            dialog_id = int(raw_dialog_id)
-        except ValueError as exc:
-            raise PipelineValidationError("Некорректный dialog id для pipeline target.") from exc
-        refs.append(PipelineTargetRef(phone=phone, dialog_id=dialog_id))
-    return refs
-
-
-def _get_filter_config(pipeline) -> dict | None:
-    graph = getattr(pipeline, "pipeline_json", None)
-    if graph is None:
-        return None
-    node = next((item for item in graph.nodes if item.type.value == "filter"), None)
-    if node is None:
-        return None
-    return normalize_filter_config(node.config)
-
-
-def _build_filter_config_from_form(
-    *,
-    filter_present: str,
-    filter_message_kinds: list[str],
-    filter_service_actions: list[str],
-    filter_media_types: list[str],
-    filter_sender_kinds: list[str],
-    filter_keywords: str,
-    filter_regex: str,
-    filter_has_text: str,
-) -> dict | None:
-    if not filter_present:
-        return None
-    keywords = [item.strip() for item in filter_keywords.splitlines() if item.strip()]
-    return normalize_filter_config(
-        {
-            "type": "message_filter",
-            "message_kinds": filter_message_kinds,
-            "service_actions": filter_service_actions,
-            "media_types": filter_media_types,
-            "sender_kinds": filter_sender_kinds,
-            "keywords": keywords,
-            "regex": filter_regex.strip(),
-            "has_text": True if filter_has_text else None,
-        }
-    )
 
 
 @router.get("/api/channels/search", response_class=JSONResponse)
 async def api_channels_search(request: Request, q: str = ""):
-    """AJAX endpoint for searchable picker — returns up to 50 channels matching *q*."""
-    db = deps.get_db(request)
-    query = q.strip()
-    if len(query) < 2:
-        cur = await db.execute(
-            "SELECT channel_id, title, username FROM channels ORDER BY id DESC LIMIT 50",
-        )
-        rows = await cur.fetchall()
-        return [
-            {
-                "value": row["channel_id"],
-                "title": row["title"] or str(row["channel_id"]),
-                "username": row["username"] or "",
-                "group": "channel",
-            }
-            for row in rows
-        ]
-    cur = await db.execute(
-        """SELECT channel_id, title, username FROM channels
-           WHERE (LOWER(title) LIKE ? OR LOWER(username) LIKE ? OR CAST(channel_id AS TEXT) LIKE ?)
-           ORDER BY channel_id LIMIT 50""",
-        (f"%{query.lower()}%", f"%{query.lower()}%", f"%{query}%"),
-    )
-    rows = await cur.fetchall()
-    return [
-        {
-            "value": row["channel_id"],
-            "title": row["title"] or str(row["channel_id"]),
-            "username": row["username"] or "",
-            "group": "channel",
-        }
-        for row in rows
-    ]
-
-
-async def _page_context(request: Request) -> dict:
-    svc = deps.pipeline_service(request)
-    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
-    accounts = await deps.get_account_bundle(request).list_accounts()
-    selected_phone = request.query_params.get("phone") or (accounts[0].phone if accounts else "")
-    if selected_phone:
-        refresh = request.query_params.get("refresh") == "1"
-        try:
-            await deps.channel_service(request).get_my_dialogs(selected_phone, refresh=refresh)
-        except Exception:
-            logger.warning("Failed to refresh dialog cache for %s", selected_phone, exc_info=True)
-    cached_dialogs = await svc.list_cached_dialogs_by_phone()
-    items = await svc.get_with_relations()
-    # Annotate each item with whether the pipeline actually needs an LLM provider.
-    # Used by the template to disable Generate/Run buttons per-pipeline instead of
-    # globally — non-LLM pipelines (SOURCE→PUBLISH DAGs) remain runnable.
-    needs_llm_map: dict[int, bool] = {}
-    for item in items:
-        pipeline = item.get("pipeline") if isinstance(item, dict) else None
-        if pipeline is None or pipeline.id is None:
-            continue
-        try:
-            needs_llm_map[pipeline.id] = pipeline_needs_llm(pipeline)
-        except Exception:
-            # Fail safe: assume LLM is needed on unexpected shapes.
-            logger.warning("pipeline_needs_llm failed for pipeline_id=%s", pipeline.id, exc_info=True)
-            needs_llm_map[pipeline.id] = True
-    # gather next_run times for pipelines (batch query)
-    next_runs = {}
-    try:
-        scheduler = deps.get_scheduler(request)
-        all_jobs = scheduler.get_all_jobs_next_run()
-        for item in items:
-            pipeline = item.get("pipeline") if isinstance(item, dict) else None
-            if pipeline is None or pipeline.id is None:
-                continue
-            job_id = f"pipeline_run_{pipeline.id}"
-            nr = all_jobs.get(job_id)
-            next_runs[pipeline.id] = nr.isoformat() if nr else None
-    except Exception:
-        next_runs = {}
-    ctx = {
-        "items": items,
-        "channels": channels,
-        "accounts": accounts,
-        "cached_dialogs": cached_dialogs,
-        "selected_phone": selected_phone,
-        "prompt_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
-        "publish_modes": list(PipelinePublishMode),
-        "generation_backends": list(PipelineGenerationBackend),
-        "next_runs": next_runs,
-        "llm_configured": deps.get_llm_provider_service(request).has_providers(),
-        "needs_llm_map": needs_llm_map,
-    }
-    # Only query DB for provider statuses when the banner is visible
-    if not ctx["llm_configured"]:
-        ctx["llm_provider_statuses"] = await deps.get_llm_provider_service(request).get_provider_status_list()
-    return ctx
+    return pipeline_response(request, await handlers.api_channels_search(request, q=q))
 
 
 @router.get("/", response_class=HTMLResponse)
 async def pipelines_page(request: Request):
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines.html",
-        await _page_context(request),
-    )
+    return pipeline_response(request, await handlers.pipelines_page(request))
 
 
 @router.get("/create", response_class=HTMLResponse)
 async def create_wizard_page(request: Request):
-    svc = deps.pipeline_service(request)
-    accounts = await deps.get_account_bundle(request).list_accounts()
-    cached_dialogs = await svc.list_cached_dialogs_by_phone()
-    llm_provider_svc = deps.get_llm_provider_service(request)
-    llm_configured = llm_provider_svc.has_providers()
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines/create.html",
-        {
-            "accounts": accounts,
-            "cached_dialogs": cached_dialogs,
-            "llm_configured": llm_configured,
-        },
-    )
+    return pipeline_response(request, await handlers.create_wizard_page(request))
 
 
 @router.post("/create-wizard")
@@ -232,48 +48,32 @@ async def create_wizard_submit(
     since_unit: str = Form("h"),
     account_phone: str = Form(""),
 ):
-    if not name or not pipeline_json:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    import json as _json
-
-    svc = deps.pipeline_service(request)
-    try:
-        graph_data = _json.loads(pipeline_json)
-        # Extract llm_model from first LLM node config for pipeline-level setting
-        llm_model = ""
-        for node in graph_data.get("nodes", []):
-            if node.get("type") in ("llm_generate", "llm_refine", "agent_loop"):
-                llm_model = node.get("config", {}).get("model", "") or ""
-                break
-        data = {
-            "name": name,
-            "prompt_template": ".",
-            "llm_model": llm_model or None,
-            "source_ids": source_channel_ids,
-            "target_refs": target_refs,
-            "generate_interval_minutes": generate_interval_minutes,
-            "pipeline_json": graph_data,
-            "account_phone": account_phone or None,
-        }
-        pipeline_id = await svc.import_json(data)
-    except PipelineValidationError as exc:
-        return _pipeline_redirect(str(exc), error=True)
-    except Exception as exc:
-        logger.warning("create-wizard failed: %s", exc, exc_info=True)
-        return _pipeline_redirect(f"Ошибка: {exc}", error=True)
-    if is_active:
-        await svc.toggle(pipeline_id)
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    if run_after:
-        _since = _to_since_hours(since_value, since_unit)
-        enqueuer = deps.get_task_enqueuer(request)
-        await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=_since)
-        return _pipeline_redirect("pipeline_run_with_since")
-    return _pipeline_redirect("pipeline_added")
+    form = CreateWizardForm(
+        name=name,
+        pipeline_json=pipeline_json,
+        source_channel_ids=source_channel_ids,
+        target_refs=target_refs,
+        generate_interval_minutes=generate_interval_minutes,
+        is_active=is_active,
+        run_after=run_after,
+        since_value=since_value,
+        since_unit=since_unit,
+        account_phone=account_phone,
+    )
+    result = await handlers.create_wizard_submit(
+        request,
+        name=form.name,
+        pipeline_json=form.pipeline_json,
+        source_channel_ids=form.source_channel_ids,
+        target_refs=form.target_refs,
+        generate_interval_minutes=form.generate_interval_minutes,
+        is_active=form.is_active,
+        run_after=form.run_after,
+        since_value=form.since_value,
+        since_unit=form.since_unit,
+        account_phone=form.account_phone,
+    )
+    return pipeline_response(request, result)
 
 
 @router.post("/add")
@@ -290,39 +90,32 @@ async def add_pipeline(
     generate_interval_minutes: int = Form(60),
     is_active: bool = Form(False),
 ):
-    if not name or not prompt_template:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    svc: PipelineService = deps.pipeline_service(request)
-    try:
-        new_pipeline_id = await svc.add(
-            name=name,
-            prompt_template=prompt_template,
-            source_channel_ids=source_channel_ids,
-            target_refs=_target_refs(target_refs),
-            llm_model=llm_model,
-            image_model=image_model,
-            publish_mode=publish_mode,
-            generation_backend=generation_backend,
-            generate_interval_minutes=generate_interval_minutes,
-            is_active=is_active,
-        )
-    except PipelineValidationError:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    # sync scheduler jobs
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    # Warn if pipeline needs LLM but no provider is configured — still create it.
-    try:
-        created = await svc.get(new_pipeline_id)
-        if created is not None and pipeline_needs_llm(created):
-            if not deps.get_llm_provider_service(request).has_providers():
-                return _pipeline_redirect("pipeline_added_no_llm")
-    except Exception:
-        logger.debug("pipeline_needs_llm check failed after add", exc_info=True)
-    return _pipeline_redirect("pipeline_added")
+    form = PipelineCreateForm(
+        name=name,
+        prompt_template=prompt_template,
+        source_channel_ids=source_channel_ids,
+        target_refs=target_refs,
+        llm_model=llm_model,
+        image_model=image_model,
+        publish_mode=publish_mode,
+        generation_backend=generation_backend,
+        generate_interval_minutes=generate_interval_minutes,
+        is_active=is_active,
+    )
+    result = await handlers.add_pipeline(
+        request,
+        name=form.name,
+        prompt_template=form.prompt_template,
+        source_channel_ids=form.source_channel_ids,
+        target_refs=form.target_refs,
+        llm_model=form.llm_model,
+        image_model=form.image_model,
+        publish_mode=form.publish_mode,
+        generation_backend=form.generation_backend,
+        generate_interval_minutes=form.generate_interval_minutes,
+        is_active=form.is_active,
+    )
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/edit")
@@ -351,176 +144,69 @@ async def edit_pipeline(
     dag_source_channel_ids: list[int] = Form(default=[]),
     account_phone: str = Form(""),
 ):
-    if not name:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    svc: PipelineService = deps.pipeline_service(request)
-    phone = request.query_params.get("phone")
-    existing = await svc.get(pipeline_id)
-    if existing is None:
-        return _pipeline_redirect("pipeline_invalid", error=True, phone=phone)
-    # For DAG pipelines, hidden form fields send defaults — preserve existing values
-    if pipeline_is_dag(existing):
-        if not prompt_template:
-            prompt_template = existing.prompt_template or ""
-        if generation_backend == PipelineGenerationBackend.CHAIN.value and existing.generation_backend:
-            generation_backend = existing.generation_backend.value
-    try:
-        ok = await svc.update(
-            pipeline_id,
-            name=name,
-            prompt_template=prompt_template,
-            source_channel_ids=source_channel_ids,
-            target_refs=_target_refs(target_refs),
-            llm_model=llm_model,
-            image_model=image_model,
-            publish_mode=publish_mode,
-            generation_backend=generation_backend,
-            generate_interval_minutes=generate_interval_minutes,
-            is_active=is_active,
-            react_emoji=react_emoji,
-            filter_config=_build_filter_config_from_form(
-                filter_present=filter_present,
-                filter_message_kinds=filter_message_kinds,
-                filter_service_actions=filter_service_actions,
-                filter_media_types=filter_media_types,
-                filter_sender_kinds=filter_sender_kinds,
-                filter_keywords=filter_keywords,
-                filter_regex=filter_regex,
-                filter_has_text=filter_has_text,
-            ),
-            dag_source_channel_ids=dag_source_channel_ids,
-            account_phone=account_phone,
-        )
-    except PipelineValidationError as exc:
-        return _pipeline_redirect(str(exc), error=True, phone=phone)
-    if not ok:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    # sync scheduler jobs
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    return _pipeline_redirect("pipeline_edited")
+    form = PipelineEditForm(
+        name=name,
+        prompt_template=prompt_template,
+        source_channel_ids=source_channel_ids,
+        target_refs=target_refs,
+        llm_model=llm_model,
+        image_model=image_model,
+        publish_mode=publish_mode,
+        generation_backend=generation_backend,
+        generate_interval_minutes=generate_interval_minutes,
+        is_active=is_active,
+        react_emoji=react_emoji,
+        filter_present=filter_present,
+        filter_message_kinds=filter_message_kinds,
+        filter_service_actions=filter_service_actions,
+        filter_media_types=filter_media_types,
+        filter_sender_kinds=filter_sender_kinds,
+        filter_keywords=filter_keywords,
+        filter_regex=filter_regex,
+        filter_has_text=filter_has_text,
+        dag_source_channel_ids=dag_source_channel_ids,
+        account_phone=account_phone,
+    )
+    result = await handlers.edit_pipeline(request, pipeline_id, **form.__dict__)
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/toggle")
 async def toggle_pipeline(request: Request, pipeline_id: int):
-    ok = await deps.pipeline_service(request).toggle(pipeline_id)
-    if not ok:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    return _pipeline_redirect("pipeline_toggled")
+    return pipeline_response(request, await handlers.toggle_pipeline(request, pipeline_id))
 
 
 @router.post("/{pipeline_id}/delete")
 async def delete_pipeline(request: Request, pipeline_id: int):
-    await deps.pipeline_service(request).delete(pipeline_id)
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    return _pipeline_redirect("pipeline_deleted")
+    return pipeline_response(request, await handlers.delete_pipeline(request, pipeline_id))
 
 
 @router.post("/{pipeline_id}/run")
 async def run_pipeline(request: Request, pipeline_id: int,
                        since_value: int = Form(24), since_unit: str = Form("h")):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    # Per-pipeline LLM requirement: pure forward/publish DAGs run fine without a provider.
-    if pipeline_needs_llm(pipeline) and not deps.get_llm_provider_service(request).has_providers():
-        return _pipeline_redirect("llm_not_configured", error=True)
-    try:
-        since_hours = _to_since_hours(since_value, since_unit)
-        enqueuer = deps.get_task_enqueuer(request)
-        await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_hours)
-    except Exception:
-        logger.warning("Failed to enqueue pipeline run for pipeline_id=%d", pipeline_id, exc_info=True)
-        return _pipeline_redirect("pipeline_run_failed", error=True)
-    return _pipeline_redirect("pipeline_run_enqueued")
+    form = PipelineRunForm(since_value=since_value, since_unit=since_unit)
+    result = await handlers.run_pipeline(
+        request,
+        pipeline_id,
+        since_value=form.since_value,
+        since_unit=form.since_unit,
+    )
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/dry-run")
 async def dry_run_pipeline(request: Request, pipeline_id: int):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    if pipeline_needs_llm(pipeline) and not deps.get_llm_provider_service(request).has_providers():
-        return _pipeline_redirect("llm_not_configured", error=True)
-    try:
-        enqueuer = deps.get_task_enqueuer(request)
-        await enqueuer.enqueue_pipeline_run(pipeline_id, dry_run=True)
-    except Exception:
-        logger.warning("Failed to enqueue dry-run for pipeline_id=%d", pipeline_id, exc_info=True)
-        return _pipeline_redirect("pipeline_run_failed", error=True)
-    return _pipeline_redirect("pipeline_dry_run_enqueued")
+    return pipeline_response(request, await handlers.dry_run_pipeline(request, pipeline_id))
 
 
 @router.get("/{pipeline_id}/edit", response_class=HTMLResponse)
 async def edit_page(request: Request, pipeline_id: int):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    db = deps.get_db(request)
-    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
-    accounts = await deps.get_account_bundle(request).list_accounts()
-    selected_phone = request.query_params.get("phone") or (accounts[0].phone if accounts else "")
-    if selected_phone and request.query_params.get("refresh") == "1":
-        try:
-            await deps.channel_service(request).get_my_dialogs(selected_phone, refresh=True)
-        except Exception:
-            logger.warning("Failed to refresh dialog cache for %s", selected_phone, exc_info=True)
-    cached_dialogs = await svc.list_cached_dialogs_by_phone()
-    sources = await db.repos.content_pipelines.list_sources(pipeline_id)
-    targets = await db.repos.content_pipelines.list_targets(pipeline_id)
-    source_ids = [s.channel_id for s in sources]
-    target_refs = [f"{t.phone}|{t.dialog_id}" for t in targets]
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines/edit.html",
-        {
-            "pipeline": pipeline,
-            "channels": channels,
-            "accounts": accounts,
-            "cached_dialogs": cached_dialogs,
-            "source_ids": source_ids,
-            "target_refs": target_refs,
-            "prompt_variables": sorted(ALLOWED_TEMPLATE_VARIABLES),
-            "generation_backends": list(PipelineGenerationBackend),
-            "publish_modes": list(PipelinePublishMode),
-            "needs_llm": pipeline_needs_llm(pipeline),
-            "needs_publish_mode": pipeline_needs_publish_mode(pipeline),
-            "is_dag": pipeline_is_dag(pipeline),
-            "react_emoji": get_react_emoji_config(pipeline),
-            "filter_config": _get_filter_config(pipeline),
-            "dag_source_channel_ids": get_dag_source_channel_ids(pipeline),
-        },
-    )
+    return pipeline_response(request, await handlers.edit_page(request, pipeline_id))
 
 
 @router.get("/{pipeline_id}/generate", response_class=HTMLResponse)
 async def generate_page(request: Request, pipeline_id: int):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    db = deps.get_db(request)
-    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines/generate.html",
-        {"pipeline": pipeline, "runs": runs, "request": request},
-    )
+    return pipeline_response(request, await handlers.generate_page(request, pipeline_id))
 
 
 @router.get("/{pipeline_id}/generate-stream")
@@ -531,66 +217,14 @@ async def generate_stream(
     max_tokens: int = 256,
     temperature: float = 0.0,
 ):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    db = deps.get_db(request)
-    engine = deps.get_search_engine(request)
-
-    provider_service = deps.get_llm_provider_service(request)
-    if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
-        return _pipeline_redirect("llm_not_configured", error=True)
-    if not pipeline_needs_llm(pipeline):
-        return _pipeline_redirect("pipeline_no_llm_nodes", error=True)
-    provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
-
-    from src.services.generation_service import GenerationService
-
-    gen = GenerationService(engine, provider_callable=provider_callable)
-    scope = await svc.get_retrieval_scope(pipeline)
-
-    # persist run
-    run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)
-    try:
-        await db.repos.generation_runs.set_status(run_id, "running")
-    except Exception:
-        await db.repos.generation_runs.set_status(run_id, "failed")
-        raise
-    async def event_gen():
-        last = None
-        try:
-            async for update in gen.generate_stream(
-                query=scope.query,
-                prompt_template=pipeline.prompt_template,
-                model=(model or pipeline.llm_model),
-                max_tokens=max_tokens,
-                temperature=temperature,
-                channel_id=scope.channel_id,
-            ):
-                last = update
-                data = {
-                    "delta": update.get("delta"),
-                    "text": update.get("generated_text"),
-                    "citations": update.get("citations"),
-                }
-                yield f"data: {safe_json_dumps(data)}\n\n"
-
-            # finished successfully
-            final_text = last.get("generated_text") if last else ""
-            metadata = {"citations": last.get("citations", []) if last else []}
-            await db.repos.generation_runs.save_result(run_id, final_text, metadata)
-            await db.repos.generation_runs.set_status(run_id, "completed")
-            yield f"event: done\ndata: {safe_json_dumps({'run_id': run_id})}\n\n"
-        except Exception:
-            logger.exception("Generation stream failed for pipeline_id=%d run_id=%d", pipeline_id, run_id)
-            await db.repos.generation_runs.set_status(run_id, "failed")
-            yield f"event: error\ndata: {safe_json_dumps({'error': 'Generation failed'})}\n\n"
-        except BaseException:
-            await db.repos.generation_runs.set_status(run_id, "failed")
-            raise
-
-    return StreamingResponse(event_gen(), media_type="text/event-stream")
+    result = await handlers.generate_stream(
+        request,
+        pipeline_id,
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+    )
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/generate")
@@ -601,166 +235,59 @@ async def generate_pipeline(
     max_tokens: int = Form(256),
     temperature: float = Form(0.0),
 ):
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    db = deps.get_db(request)
-    engine = deps.get_search_engine(request)
-
-    provider_service = deps.get_llm_provider_service(request)
-    if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
-        return _pipeline_redirect("llm_not_configured", error=True)
-
-    from src.services.content_generation_service import ContentGenerationService
-    from src.services.quality_scoring_service import QualityScoringService
-
-    gen = ContentGenerationService(
-        db,
-        engine,
-        config=request.app.state.config,
-        quality_service=QualityScoringService(db, provider_service=provider_service),
-        provider_service=provider_service,
-    )
-    try:
-        run = await gen.generate(
-            pipeline=pipeline,
-            model=(model or pipeline.llm_model),
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-    except Exception:
-        logger.exception("Generation failed for pipeline_id=%d", pipeline_id)
-        runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
-        return deps.get_templates(request).TemplateResponse(
-            request,
-            "pipelines/generate.html",
-            {"pipeline": pipeline, "runs": runs, "error": "Generation failed", "request": request},
-        )
-    return deps.get_templates(request).TemplateResponse(
+    form = PipelineGenerateForm(model=model, max_tokens=max_tokens, temperature=temperature)
+    result = await handlers.generate_pipeline(
         request,
-        "pipelines/generate.html",
-        {"pipeline": pipeline, "run": run, "request": request},
+        pipeline_id,
+        model=form.model,
+        max_tokens=form.max_tokens,
+        temperature=form.temperature,
     )
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/publish")
 async def publish_pipeline(request: Request, pipeline_id: int, run_id: int | None = Form(None)):
-    if run_id is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    db = deps.get_db(request)
-    run = await db.repos.generation_runs.get(run_id)
-    if run is None or run.pipeline_id != pipeline_id:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    # Mark as published (no external publishing performed here)
-    metadata = run.metadata or {}
-    from datetime import datetime, timezone
-
-    metadata["published"] = True
-    metadata["published_at"] = datetime.now(timezone.utc).isoformat()
-    await db.repos.generation_runs.save_result(run_id, run.generated_text or "", metadata)
-    await db.repos.generation_runs.set_status(run_id, "published")
-    return _pipeline_redirect("pipeline_published")
+    return pipeline_response(request, await handlers.publish_pipeline(request, pipeline_id, run_id=run_id))
 
 
 @router.get("/{pipeline_id}/refinement-steps")
 async def get_refinement_steps(request: Request, pipeline_id: int):
-    db = deps.get_db(request)
-    pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_not_found", error=True)
-    return JSONResponse(content={"steps": pipeline.refinement_steps})
-
-
-# ------------------------------------------------------------------
-# Dry-run count endpoints
-# ------------------------------------------------------------------
-
-
-def _apply_pipeline_filter(pipeline, messages: list) -> int:
-    """Count messages that would pass the filter node, if any."""
-    if pipeline.pipeline_json is None:
-        return len(messages)
-    graph = pipeline.pipeline_json
-    filter_node = next(
-        (n for n in graph.nodes if n.type.value == "filter"),
-        None,
-    )
-    if filter_node is None:
-        return len(messages)
-    return len(filter_messages(messages, filter_node.config))
+    return pipeline_response(request, await handlers.get_refinement_steps(request, pipeline_id))
 
 
 @router.get("/dry-run-count", response_class=JSONResponse)
 async def dry_run_count_new(request: Request, source_ids: str = "",
                              since_value: int = 6, since_unit: str = "h"):
-    since_hours = _to_since_hours(since_value, since_unit)
-    ids = [int(x) for x in source_ids.split(",") if x.strip().isdigit()]
-    db = deps.get_db(request)
-    messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
-    return {"total": len(messages), "after_filter": len(messages)}
+    result = await handlers.dry_run_count_new(
+        request,
+        source_ids=source_ids,
+        since_value=since_value,
+        since_unit=since_unit,
+    )
+    return pipeline_response(request, result)
 
 
 @router.get("/{pipeline_id}/dry-run-count", response_class=JSONResponse)
 async def dry_run_count(request: Request, pipeline_id: int,
                         since_value: int = 6, since_unit: str = "h"):
-    since_hours = _to_since_hours(since_value, since_unit)
-    svc = deps.pipeline_service(request)
-    pipeline = await svc.get(pipeline_id)
-    if pipeline is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    db = deps.get_db(request)
-    if pipeline.pipeline_json:
-        ids = get_dag_source_channel_ids(pipeline) or []
-    else:
-        sources = await db.repos.content_pipelines.list_sources(pipeline_id)
-        ids = [s.channel_id for s in sources]
-    messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
-    after_filter = _apply_pipeline_filter(pipeline, messages)
-    return {"total": len(messages), "after_filter": after_filter}
-
-
-# ------------------------------------------------------------------
-# Templates
-# ------------------------------------------------------------------
+    result = await handlers.dry_run_count(
+        request,
+        pipeline_id,
+        since_value=since_value,
+        since_unit=since_unit,
+    )
+    return pipeline_response(request, result)
 
 
 @router.get("/templates", response_class=HTMLResponse)
 async def templates_page(request: Request):
-    svc: PipelineService = deps.pipeline_service(request)
-    templates = await svc.list_templates()
-    channels = await deps.get_channel_bundle(request).list_channels(include_filtered=True)
-    accounts = await deps.get_account_bundle(request).list_accounts()
-    cached_dialogs = await svc.list_cached_dialogs_by_phone()
-    llm_configured = deps.get_llm_provider_service(request).has_providers()
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines/templates.html",
-        {
-            "templates": templates,
-            "channels": channels,
-            "accounts": accounts,
-            "cached_dialogs": cached_dialogs,
-            "llm_configured": llm_configured,
-        },
-    )
+    return pipeline_response(request, await handlers.templates_page(request))
 
 
 @router.get("/templates/json", response_class=JSONResponse)
 async def templates_json(request: Request):
-    svc: PipelineService = deps.pipeline_service(request)
-    templates = await svc.list_templates()
-    result = []
-    import json as _json
-    for tpl in templates:
-        result.append({
-            "id": tpl.id,
-            "name": tpl.name,
-            "description": tpl.description,
-            "category": tpl.category,
-            "template_json": _json.loads(tpl.template_json.to_json()),
-        })
-    return JSONResponse(content=result)
+    return pipeline_response(request, await handlers.templates_json(request))
 
 
 @router.post("/from-template")
@@ -774,49 +301,22 @@ async def create_from_template(
     image_model: str = Form(""),
     generate_interval_minutes: int = Form(60),
 ):
-    if template_id is None or not name:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    svc: PipelineService = deps.pipeline_service(request)
-    try:
-        pipeline_id = await svc.create_from_template(
-            template_id,
-            name=name,
-            source_ids=source_channel_ids,
-            target_refs=_target_refs(target_refs),
-            overrides={
-                "llm_model": llm_model or None,
-                "image_model": image_model or None,
-                "generate_interval_minutes": generate_interval_minutes,
-            },
-        )
-    except PipelineValidationError as exc:
-        return _pipeline_redirect(str(exc), error=True)
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    return RedirectResponse(url=f"/pipelines/{pipeline_id}/edit", status_code=303)
-
-
-# ------------------------------------------------------------------
-# JSON import / export
-# ------------------------------------------------------------------
+    form = PipelineTemplateCreateForm(
+        template_id=template_id,
+        name=name,
+        source_channel_ids=source_channel_ids,
+        target_refs=target_refs,
+        llm_model=llm_model,
+        image_model=image_model,
+        generate_interval_minutes=generate_interval_minutes,
+    )
+    result = await handlers.create_from_template(request, **form.__dict__)
+    return pipeline_response(request, result)
 
 
 @router.get("/{pipeline_id}/export")
 async def export_pipeline(request: Request, pipeline_id: int):
-    svc: PipelineService = deps.pipeline_service(request)
-    data = await svc.export_json(pipeline_id)
-    if data is None:
-        return _pipeline_redirect("pipeline_invalid", error=True)
-    filename = f"pipeline_{pipeline_id}.json"
-    content = safe_json_dumps(data, ensure_ascii=False, indent=2)
-    return Response(
-        content=content,
-        media_type="application/json",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
+    return pipeline_response(request, await handlers.export_pipeline(request, pipeline_id))
 
 
 @router.post("/import")
@@ -826,68 +326,21 @@ async def import_pipeline(
     json_text: str = Form(""),
     name_override: str = Form(""),
 ):
-    svc: PipelineService = deps.pipeline_service(request)
-    import json as _json
-
-    try:
-        if json_file and json_file.filename:
-            raw = await json_file.read()
-            data = _json.loads(raw)
-        elif json_text.strip():
-            data = _json.loads(json_text.strip())
-        else:
-            return _pipeline_redirect("Не передан JSON файл или текст.", error=True)
-
-        pipeline_id = await svc.import_json(data, name_override=name_override or None)
-    except PipelineValidationError as exc:
-        return _pipeline_redirect(str(exc), error=True)
-    except Exception as exc:
-        return _pipeline_redirect(f"Ошибка импорта: {exc}", error=True)
-
-    try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
-    except Exception:
-        logger.warning("Scheduler sync failed", exc_info=True)
-    return RedirectResponse(url=f"/pipelines/{pipeline_id}/generate", status_code=303)
+    form = PipelineImportForm(json_file=json_file, json_text=json_text, name_override=name_override)
+    result = await handlers.import_pipeline(
+        request,
+        json_file=form.json_file,
+        json_text=form.json_text,
+        name_override=form.name_override,
+    )
+    return pipeline_response(request, result)
 
 
 @router.post("/{pipeline_id}/ai-edit")
 async def ai_edit_pipeline(request: Request, pipeline_id: int):
-    """Accept JSON body: {"instruction": "..."}. Returns updated pipeline_json."""
-    if not deps.get_llm_provider_service(request).has_providers():
-        return JSONResponse(content={"ok": False, "error": "LLM not configured"}, status_code=400)
-    svc: PipelineService = deps.pipeline_service(request)
-    db = deps.get_db(request)
-    try:
-        body = await request.json()
-        instruction = body.get("instruction", "").strip()
-        if not instruction:
-            return JSONResponse(content={"ok": False, "error": "instruction is required"}, status_code=400)
-        result = await svc.edit_via_llm(pipeline_id, instruction, db, config=request.app.state.config)
-        return JSONResponse(content=result)
-    except Exception as exc:
-        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=500)
+    return pipeline_response(request, await handlers.ai_edit_pipeline(request, pipeline_id))
 
 
 @router.post("/{pipeline_id}/refinement-steps")
 async def set_refinement_steps(request: Request, pipeline_id: int):
-    """Accept JSON body: {"steps": [{"name": "...", "prompt": "...{text}..."}]}."""
-    db = deps.get_db(request)
-    pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
-    if pipeline is None:
-        return _pipeline_redirect("pipeline_not_found", error=True)
-    try:
-        body = await request.json()
-        steps = body.get("steps", [])
-        if not isinstance(steps, list):
-            raise ValueError("steps must be a list")
-        validated = [
-            {"name": str(s.get("name", "")).strip(), "prompt": str(s.get("prompt", "")).strip()}
-            for s in steps
-            if isinstance(s, dict) and s.get("prompt", "").strip()
-        ]
-    except Exception as exc:
-        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=400)
-    await db.repos.content_pipelines.set_refinement_steps(pipeline_id, validated)
-    return JSONResponse(content={"ok": True, "steps": validated})
+    return pipeline_response(request, await handlers.set_refinement_steps(request, pipeline_id))

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -169,11 +169,11 @@ async def test_run_pipeline_enqueues(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
 
     with patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True):
-        with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+        with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
             mock_svc.return_value.get = AsyncMock(
                 return_value=MagicMock(id=1, is_active=True)
             )
-            with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+            with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
                 mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
                 resp = await client.post("/pipelines/1/run", follow_redirects=False)
                 assert resp.status_code == 303
@@ -221,9 +221,9 @@ async def test_run_pipeline_allowed_for_non_llm_dag_without_provider(client):
 
     non_llm_pipeline.generation_backend = PipelineGenerationBackend.CHAIN
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=non_llm_pipeline)
-        with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+        with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
             mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
             resp = await client.post("/pipelines/1/run", follow_redirects=False)
             assert resp.status_code == 303
@@ -239,11 +239,11 @@ async def test_run_pipeline_failure(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
 
     with patch("src.services.provider_service.AgentProviderService.has_providers", return_value=True):
-        with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+        with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
             mock_svc.return_value.get = AsyncMock(
                 return_value=MagicMock(id=1, is_active=True)
             )
-            with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+            with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
                 mock_enq.return_value.enqueue_pipeline_run = AsyncMock(
                     side_effect=Exception("Queue error")
                 )
@@ -460,7 +460,7 @@ async def test_toggle_pipeline_not_found(client):
 def test_target_refs_missing_separator():
     """Test _target_refs with missing separator."""
     from src.services.pipeline_service import PipelineValidationError
-    from src.web.routes.pipelines import _target_refs
+    from src.web.pipelines.forms import parse_target_refs as _target_refs
 
     try:
         _target_refs(["invalid_format"])
@@ -472,7 +472,7 @@ def test_target_refs_missing_separator():
 def test_target_refs_invalid_dialog_id():
     """Test _target_refs with invalid dialog_id."""
     from src.services.pipeline_service import PipelineValidationError
-    from src.web.routes.pipelines import _target_refs
+    from src.web.pipelines.forms import parse_target_refs as _target_refs
 
     try:
         _target_refs(["+1234567890|not_a_number"])
@@ -483,7 +483,7 @@ def test_target_refs_invalid_dialog_id():
 
 def test_target_refs_success():
     """Test _target_refs with valid input."""
-    from src.web.routes.pipelines import _target_refs
+    from src.web.pipelines.forms import parse_target_refs as _target_refs
 
     refs = _target_refs(["+1234567890|100", "+0987654321|200"])
     assert len(refs) == 2

--- a/tests/routes/test_pipelines_routes_dag_and_templates.py
+++ b/tests/routes/test_pipelines_routes_dag_and_templates.py
@@ -214,7 +214,7 @@ async def test_create_wizard_submit_with_run_after(client_with_dialog, base_app)
         "edges": [],
     }
 
-    with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+    with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
         mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
         resp = await client_with_dialog.post(
             "/pipelines/create-wizard",
@@ -317,7 +317,7 @@ async def test_add_pipeline_validation_error(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.add = AsyncMock(side_effect=PipelineValidationError("Bad"))
         resp = await route_client.post(
             "/pipelines/add",
@@ -371,7 +371,7 @@ async def test_edit_pipeline_dag_preserves_backend(client_with_dialog, base_app)
         edges=[PipelineEdge(from_node="src", to_node="pub")],
     )
     pipeline = _make_pipeline(1, dag=dag, backend=PipelineGenerationBackend.AGENT)
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         mock_svc.return_value.update = AsyncMock(return_value=True)
         resp = await client_with_dialog.post(
@@ -406,7 +406,7 @@ async def test_edit_pipeline_dag_preserves_prompt(client_with_dialog, base_app):
     pipeline = _make_pipeline(1, dag=dag)
     pipeline.prompt_template = "original prompt"
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         mock_svc.return_value.update = AsyncMock(return_value=True)
         resp = await client_with_dialog.post(
@@ -463,7 +463,7 @@ async def test_edit_pipeline_validation_error(route_client, base_app):
     app.state.llm_provider_service = _make_provider_svc(has=True)
     pipeline = _make_pipeline(1)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         mock_svc.return_value.update = AsyncMock(side_effect=PipelineValidationError("Bad data"))
         resp = await route_client.post(
@@ -493,7 +493,7 @@ async def test_edit_pipeline_update_returns_false(route_client, base_app):
     app.state.llm_provider_service = _make_provider_svc(has=True)
     pipeline = _make_pipeline(1)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         mock_svc.return_value.update = AsyncMock(return_value=False)
         resp = await route_client.post(
@@ -522,7 +522,7 @@ async def test_edit_pipeline_with_phone_query_param(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=None)
         resp = await route_client.post(
             "/pipelines/1/edit?phone=%2B1234567890",
@@ -561,7 +561,7 @@ async def test_generate_stream_no_llm_nodes(route_client, base_app):
         edges=[PipelineEdge(from_node="src", to_node="pub")],
     )
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=_make_pipeline(1, dag=dag))
         resp = await route_client.get("/pipelines/1/generate-stream", follow_redirects=False)
     assert resp.status_code == 303
@@ -615,7 +615,7 @@ async def test_generate_pipeline_no_llm_nodes_runs_graph(route_client, base_app)
         }
 
     with (
-        patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc,
+        patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc,
         patch(
             "src.services.content_generation_service.ContentGenerationService._run_generation",
             fake_run_generation,
@@ -660,9 +660,9 @@ async def test_dry_run_pipeline_success(client_with_dialog, base_app):
     app.state.llm_provider_service = _make_provider_svc(has=True)
     await client_with_dialog.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=_make_pipeline(1))
-        with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+        with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
             mock_enq.return_value.enqueue_pipeline_run = AsyncMock()
             resp = await client_with_dialog.post("/pipelines/1/dry-run", follow_redirects=False)
     assert resp.status_code == 303
@@ -675,7 +675,7 @@ async def test_dry_run_pipeline_not_found(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=None)
         resp = await route_client.post("/pipelines/999/dry-run", follow_redirects=False)
     assert resp.status_code == 303
@@ -702,9 +702,9 @@ async def test_dry_run_pipeline_enqueue_failure(client_with_dialog, base_app):
     app.state.llm_provider_service = _make_provider_svc(has=True)
     await client_with_dialog.post("/pipelines/add", data=_ADD_DATA)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=_make_pipeline(1))
-        with patch("src.web.routes.pipelines.deps.get_task_enqueuer") as mock_enq:
+        with patch("src.web.pipelines.handlers.deps.get_task_enqueuer") as mock_enq:
             mock_enq.return_value.enqueue_pipeline_run = AsyncMock(side_effect=Exception("fail"))
             resp = await client_with_dialog.post("/pipelines/1/dry-run", follow_redirects=False)
     assert resp.status_code == 303
@@ -720,7 +720,7 @@ async def test_dry_run_count_not_found(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc()
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=None)
         resp = await route_client.get("/pipelines/999/dry-run-count")
     assert resp.status_code == 404
@@ -733,7 +733,7 @@ async def test_dry_run_count_legacy_pipeline(route_client, base_app):
     app.state.llm_provider_service = _make_provider_svc()
     pipeline = _make_pipeline(1)  # legacy — no pipeline_json
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         resp = await route_client.get("/pipelines/1/dry-run-count")
     assert resp.status_code == 200
@@ -760,7 +760,7 @@ async def test_dry_run_count_dag_pipeline(route_client, base_app):
     )
     pipeline = _make_pipeline(1, dag=dag)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.get = AsyncMock(return_value=pipeline)
         resp = await route_client.get("/pipelines/1/dry-run-count")
     assert resp.status_code == 200
@@ -839,7 +839,7 @@ async def test_dry_run_count_new_empty_ids(route_client, base_app):
 
 def test_apply_pipeline_filter_no_pipeline_json():
     """Filter returns all messages when no pipeline_json."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = None
@@ -849,7 +849,7 @@ def test_apply_pipeline_filter_no_pipeline_json():
 
 def test_apply_pipeline_filter_no_filter_node():
     """Filter returns all messages when no filter node in graph."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -862,7 +862,7 @@ def test_apply_pipeline_filter_no_filter_node():
 
 def test_apply_pipeline_filter_keywords():
     """Filter node with keywords filters correctly."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -884,7 +884,7 @@ def test_apply_pipeline_filter_keywords():
 
 def test_apply_pipeline_filter_regex():
     """Filter node with regex pattern filters correctly."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -905,7 +905,7 @@ def test_apply_pipeline_filter_regex():
 
 def test_apply_pipeline_filter_regex_invalid():
     """Invalid regex pattern is treated as non-matching."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -923,7 +923,7 @@ def test_apply_pipeline_filter_regex_invalid():
 
 def test_apply_pipeline_filter_anonymous_sender():
     """Filter node with anonymous_sender checks sender_id."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -944,7 +944,7 @@ def test_apply_pipeline_filter_anonymous_sender():
 
 def test_apply_pipeline_filter_unknown_type():
     """Unknown filter type counts all messages."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -985,7 +985,7 @@ async def test_export_pipeline_not_found(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc()
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.export_json = AsyncMock(return_value=None)
         resp = await route_client.get("/pipelines/999/export", follow_redirects=False)
     assert resp.status_code == 303
@@ -1065,7 +1065,7 @@ async def test_import_pipeline_validation_error(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc()
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.import_json = AsyncMock(side_effect=PipelineValidationError("Bad"))
         resp = await route_client.post(
             "/pipelines/import",
@@ -1082,7 +1082,7 @@ async def test_import_pipeline_general_exception(route_client, base_app):
     app, _, _ = base_app
     app.state.llm_provider_service = _make_provider_svc()
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.import_json = AsyncMock(side_effect=Exception("Unexpected"))
         resp = await route_client.post(
             "/pipelines/import",
@@ -1102,7 +1102,7 @@ async def test_create_from_template_success(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.create_from_template = AsyncMock(return_value=42)
         resp = await route_client.post(
             "/pipelines/from-template",
@@ -1127,7 +1127,7 @@ async def test_create_from_template_validation_error(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.create_from_template = AsyncMock(
             side_effect=PipelineValidationError("Template not found")
         )
@@ -1168,7 +1168,7 @@ async def test_templates_json(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc()
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         tpl = MagicMock()
         tpl.id = 1
         tpl.name = "Test Template"
@@ -1197,9 +1197,9 @@ async def test_templates_page_renders(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc, \
-         patch("src.web.routes.pipelines.deps.get_channel_bundle") as mock_ch, \
-         patch("src.web.routes.pipelines.deps.get_account_bundle") as mock_acct:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc, \
+         patch("src.web.pipelines.handlers.deps.get_channel_bundle") as mock_ch, \
+         patch("src.web.pipelines.handlers.deps.get_account_bundle") as mock_acct:
         mock_svc.return_value.list_templates = AsyncMock(return_value=[])
         mock_svc.return_value.list_cached_dialogs_by_phone = AsyncMock(return_value={})
         mock_ch.return_value.list_channels = AsyncMock(return_value=[])
@@ -1245,7 +1245,7 @@ async def test_ai_edit_pipeline_success(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.edit_via_llm = AsyncMock(
             return_value={"ok": True, "pipeline_json": {"nodes": [], "edges": []}}
         )
@@ -1264,7 +1264,7 @@ async def test_ai_edit_pipeline_exception(route_client, base_app):
     app, db, _ = base_app
     app.state.llm_provider_service = _make_provider_svc(has=True)
 
-    with patch("src.web.routes.pipelines.deps.pipeline_service") as mock_svc:
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
         mock_svc.return_value.edit_via_llm = AsyncMock(side_effect=Exception("LLM error"))
         resp = await route_client.post(
             "/pipelines/1/ai-edit",
@@ -1361,7 +1361,7 @@ async def test_set_refinement_steps_empty_prompt_filtered(client_with_dialog, ba
     await client_with_dialog.post("/pipelines/add", data=_ADD_DATA)
 
     # Mock pipeline exists in DB
-    with patch("src.web.routes.pipelines.deps.get_db") as mock_get_db:
+    with patch("src.web.pipelines.handlers.deps.get_db") as mock_get_db:
         mock_pipeline = MagicMock()
         mock_pipeline.id = 1
         mock_pipeline.refinement_steps = []
@@ -1457,7 +1457,7 @@ async def test_delete_pipeline_handles_scheduler(client_with_dialog, base_app):
 
 def test_apply_pipeline_filter_service_message():
     """Filter node with service_message type checks service types."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(
@@ -1479,7 +1479,7 @@ def test_apply_pipeline_filter_service_message():
 
 def test_apply_pipeline_filter_message_filter_semantic_service():
     """Structured message_filter should use semantic service fields, not text."""
-    from src.web.routes.pipelines import _apply_pipeline_filter
+    from src.web.pipelines.handlers import _apply_pipeline_filter
 
     pipeline = MagicMock()
     pipeline.pipeline_json = PipelineGraph(

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -5137,16 +5137,16 @@ class TestWebPipelinesRoutesCoverage:
 
     def test_pipeline_redirect_with_error(self):
         """Test the redirect helper."""
-        from src.web.routes.pipelines import _pipeline_redirect
+        from src.web.pipelines.responses import PipelineRedirect, pipeline_redirect_response
 
-        resp = _pipeline_redirect("test_msg")
+        resp = pipeline_redirect_response(PipelineRedirect("test_msg"))
         assert resp.status_code == 303
         assert "msg=test_msg" in str(resp.headers.get("location", ""))
 
     def test_pipeline_redirect_with_error_flag(self):
-        from src.web.routes.pipelines import _pipeline_redirect
+        from src.web.pipelines.responses import PipelineRedirect, pipeline_redirect_response
 
-        resp = _pipeline_redirect("err", error=True)
+        resp = pipeline_redirect_response(PipelineRedirect("err", error=True))
         assert "error=err" in str(resp.headers.get("location", ""))
 
 
@@ -6449,7 +6449,7 @@ class TestWebRoutesExtraBatch3:
 
     def test_pipeline_target_refs_parsing(self):
         """Cover _target_refs helper."""
-        from src.web.routes.pipelines import _target_refs
+        from src.web.pipelines.forms import parse_target_refs as _target_refs
 
         refs = _target_refs(["+1|123", "+2|456"])
         assert len(refs) == 2


### PR DESCRIPTION
Closes #506.

## Summary
- Split pipeline route orchestration into `src/web/pipelines/` forms, handlers, and responses modules.
- Kept `/pipelines` FastAPI entrypoints as thin wrappers with existing form defaults and response mapping.
- Updated pipeline route tests to patch/import the new internal module targets.

## Validation
- `ruff check src/ tests/ conftest.py`
- `pytest tests/routes/test_pipelines_routes.py -v`
- `pytest tests/routes/test_pipelines_routes_dag_and_templates.py -v`
- `pytest tests/routes/ -v -k pipeline`
- `pytest tests/test_cross_domain_regression_paths.py -v -k "pipeline_redirect or pipeline_target_refs"`
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto`
- `pytest tests/ -v -m aiosqlite_serial`