### PR TITLE
fix(web): use embedded worker agent manager

### DIFF
--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -262,6 +262,13 @@ def is_shutting_down(request: Request) -> bool:
 
 
 def get_agent_manager(request: Request) -> AgentManager | None:
+    manager = getattr(request.app.state, "agent_manager", None)
+    if manager is not None:
+        return manager
+    embedded_worker = getattr(request.app.state, "embedded_worker", None)
+    embedded_container = getattr(embedded_worker, "container", None)
+    if embedded_container is not None:
+        return getattr(embedded_container, "agent_manager", None)
     return get_container(request).agent_manager
 
 

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -268,8 +268,13 @@ def get_agent_manager(request: Request) -> AgentManager | None:
     embedded_worker = getattr(request.app.state, "embedded_worker", None)
     embedded_container = getattr(embedded_worker, "container", None)
     if embedded_container is not None:
-        return getattr(embedded_container, "agent_manager", None)
-    return get_container(request).agent_manager
+        manager = getattr(embedded_container, "agent_manager", None)
+        if manager is not None:
+            return manager
+    container = getattr(request.app.state, "container", None)
+    if container is not None:
+        return getattr(container, "agent_manager", None)
+    return None
 
 
 def get_llm_provider_service(request: Request) -> AgentProviderService:

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -268,12 +268,11 @@ def get_agent_manager(request: Request) -> AgentManager | None:
     embedded_worker = getattr(request.app.state, "embedded_worker", None)
     embedded_container = getattr(embedded_worker, "container", None)
     if embedded_container is not None:
-        manager = getattr(embedded_container, "agent_manager", None)
-        if manager is not None:
-            return manager
-    container = getattr(request.app.state, "container", None)
-    if container is not None:
-        return getattr(container, "agent_manager", None)
+        ready_event = getattr(embedded_worker, "_ready_event", None)
+        if ready_event is not None and ready_event.is_set():
+            manager = getattr(embedded_container, "agent_manager", None)
+            if manager is not None:
+                return manager
     return None
 
 

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -194,19 +194,9 @@ def _agent_available(config: AppConfig | None = None) -> bool:
 
 
 def _request_agent_manager(request: Request):
-    manager = getattr(request.app.state, "agent_manager", None)
-    if manager is not None:
-        return manager
-    embedded_worker = getattr(request.app.state, "embedded_worker", None)
-    embedded_container = getattr(embedded_worker, "container", None)
-    if embedded_container is not None:
-        manager = getattr(embedded_container, "agent_manager", None)
-        if manager is not None:
-            return manager
-    container = getattr(request.app.state, "container", None)
-    if container is None:
-        return None
-    return getattr(container, "agent_manager", None)
+    from src.web import deps
+
+    return deps.get_agent_manager(request)
 
 
 def _agent_available_for_request(request: Request) -> bool:

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -197,6 +197,12 @@ def _request_agent_manager(request: Request):
     manager = getattr(request.app.state, "agent_manager", None)
     if manager is not None:
         return manager
+    embedded_worker = getattr(request.app.state, "embedded_worker", None)
+    embedded_container = getattr(embedded_worker, "container", None)
+    if embedded_container is not None:
+        manager = getattr(embedded_container, "agent_manager", None)
+        if manager is not None:
+            return manager
     container = getattr(request.app.state, "container", None)
     if container is None:
         return None

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -158,7 +158,10 @@ async def test_agent_chat_in_embedded_worker_mode_uses_worker_agent_manager(web_
         yield 'data: {"done": true, "full_text": "ok"}\n\n'
 
     manager.chat_stream = _fake_stream
-    app.state.embedded_worker = SimpleNamespace(container=SimpleNamespace(agent_manager=manager))
+    app.state.embedded_worker = SimpleNamespace(
+        _ready_event=SimpleNamespace(is_set=lambda: True),
+        container=SimpleNamespace(agent_manager=manager),
+    )
 
     resp = await web_mode_client.post(
         f"/agent/threads/{thread_id}/chat",

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import base64
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -133,6 +135,39 @@ async def test_agent_chat_in_web_mode_returns_worker_only_error(tmp_path):
         assert resp.status_code == 503
         detail = resp.json().get("detail", "")
         assert "worker" in detail.lower()
+
+
+@pytest.mark.anyio
+async def test_agent_chat_in_embedded_worker_mode_uses_worker_agent_manager(web_mode_app, web_mode_client):
+    """Normal `serve` mode has a web container plus an embedded worker container.
+    Agent chat should use the worker AgentManager instead of returning the split-mode 503."""
+    app, container = web_mode_app
+    thread_id = await container.db.create_agent_thread("Test thread")
+
+    runtime = MagicMock()
+    runtime.selected_backend = "deepagents"
+    runtime.using_override = False
+    runtime.error = None
+
+    manager = MagicMock()
+    manager.get_runtime_status = AsyncMock(return_value=runtime)
+    manager.estimate_prompt_tokens = AsyncMock(return_value=100)
+
+    async def _fake_stream(*args, **kwargs):
+        yield 'data: {"delta": "ok"}\n\n'
+        yield 'data: {"done": true, "full_text": "ok"}\n\n'
+
+    manager.chat_stream = _fake_stream
+    app.state.embedded_worker = SimpleNamespace(container=SimpleNamespace(agent_manager=manager))
+
+    resp = await web_mode_client.post(
+        f"/agent/threads/{thread_id}/chat",
+        json={"message": "hi"},
+    )
+
+    assert resp.status_code == 200
+    assert "Agent chat is only available in the worker process" not in resp.text
+    assert '"full_text": "ok"' in resp.text
 
 
 @pytest.mark.anyio

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -162,6 +162,25 @@ def test_agent_available_uses_container_manager(monkeypatch):
     assert _agent_available_for_request(request) is True
 
 
+def test_agent_available_uses_embedded_worker_manager(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_FALLBACK_MODEL", raising=False)
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                config=AppConfig(),
+                embedded_worker=SimpleNamespace(
+                    container=SimpleNamespace(agent_manager=SimpleNamespace(available=True))
+                ),
+            )
+        )
+    )
+
+    assert _agent_available_for_request(request) is True
+
+
 def test_agent_available_ignores_invalid_fallback_model(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -145,23 +145,6 @@ def test_templates_have_actual_app_version():
     assert get_app_version() == expected_version
 
 
-def test_agent_available_uses_container_manager(monkeypatch):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-    monkeypatch.delenv("AGENT_FALLBACK_MODEL", raising=False)
-
-    request = SimpleNamespace(
-        app=SimpleNamespace(
-            state=SimpleNamespace(
-                config=AppConfig(),
-                container=SimpleNamespace(agent_manager=SimpleNamespace(available=True)),
-            )
-        )
-    )
-
-    assert _agent_available_for_request(request) is True
-
-
 def test_agent_available_uses_embedded_worker_manager(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -172,13 +155,34 @@ def test_agent_available_uses_embedded_worker_manager(monkeypatch):
             state=SimpleNamespace(
                 config=AppConfig(),
                 embedded_worker=SimpleNamespace(
-                    container=SimpleNamespace(agent_manager=SimpleNamespace(available=True))
+                    _ready_event=SimpleNamespace(is_set=lambda: True),
+                    container=SimpleNamespace(agent_manager=SimpleNamespace(available=True)),
                 ),
             )
         )
     )
 
     assert _agent_available_for_request(request) is True
+
+
+def test_agent_available_ignores_embedded_worker_before_ready(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_FALLBACK_MODEL", raising=False)
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                config=AppConfig(),
+                embedded_worker=SimpleNamespace(
+                    _ready_event=SimpleNamespace(is_set=lambda: False),
+                    container=SimpleNamespace(agent_manager=SimpleNamespace(available=True)),
+                ),
+            )
+        )
+    )
+
+    assert _agent_available_for_request(request) is False
 
 
 def test_agent_available_ignores_invalid_fallback_model(monkeypatch):


### PR DESCRIPTION
Closes #516.

## Summary
- Let web agent dependencies resolve `AgentManager` from the embedded worker container when `python -m src.main serve` owns the worker.
- Keep pure web/split mode behavior unchanged: without an embedded worker or direct manager, `/agent` chat still returns the worker-only 503.
- Update template agent availability detection so the Chat nav can reflect embedded-worker availability.

## Validation
- `ruff check src/ tests/ conftest.py`
- `pytest tests/routes/test_accounts_agent_web_mode.py -v`
- `pytest tests/test_web.py -v -k "agent_available or agent_chat or agent_page"`
- `pytest tests/routes/test_agent_routes_threads.py tests/routes/test_agent_routes_streaming.py tests/test_agent.py tests/test_agent_manager_runtime_paths.py -v`
- `pytest tests/test_web.py -v`