### PR TITLE
fix(agent): route zai through openai compatible endpoint

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -39,7 +39,7 @@ from src.agent.prompt_template import (
     build_prompt_template_context,
     render_prompt_template,
 )
-from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
+from src.agent.provider_registry import ProviderRuntimeConfig, normalize_zai_base_url
 from src.config import AppConfig
 from src.database import Database
 from src.services.agent_provider_service import (
@@ -1207,10 +1207,8 @@ class DeepagentsBackend:
             extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
 
         if provider == "zai":
-            model_provider = "anthropic"
-            base_url = cfg.plain_fields.get("base_url", "").strip() or ZAI_DEFAULT_BASE_URL
-            extra.pop("base_url", None)
-            extra["anthropic_api_url"] = base_url
+            model_provider = "openai"
+            extra["base_url"] = normalize_zai_base_url(cfg.plain_fields.get("base_url", ""))
         self._init_attempted_model = cfg.model_name
 
         # ReAct fallback for Ollama models without native function calling

--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -4,7 +4,18 @@ from dataclasses import dataclass, field
 
 from src.agent.models import CLAUDE_MODELS
 
-ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/anthropic/v1"
+ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
+ZAI_LEGACY_ANTHROPIC_BASE_URLS = {
+    "https://api.z.ai/api/anthropic",
+    "https://api.z.ai/api/anthropic/v1",
+}
+
+
+def normalize_zai_base_url(base_url: str = "") -> str:
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized or normalized in ZAI_LEGACY_ANTHROPIC_BASE_URLS:
+        return ZAI_DEFAULT_BASE_URL
+    return normalized
 
 
 @dataclass(frozen=True, slots=True)
@@ -262,7 +273,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
     "zai": ProviderSpec(
         name="zai",
         display_name="Z.AI",
-        package_name="langchain-anthropic",
+        package_name="langchain-openai",
         static_models=("glm-5", "glm-5-turbo", "glm-4.7"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
         plain_fields=(_field("base_url", "Base URL", placeholder=ZAI_DEFAULT_BASE_URL),),

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -20,6 +20,7 @@ from src.agent.provider_registry import (
     ZAI_DEFAULT_BASE_URL,
     ProviderRuntimeConfig,
     ProviderSpec,
+    normalize_zai_base_url,
     provider_spec,
 )
 from src.config import AppConfig, resolve_session_encryption_secret
@@ -666,7 +667,7 @@ class AgentProviderService:
             return None
         if provider == "zai":
             base_url = cfg.plain_fields.get("base_url", "").strip()
-            normalized = self._normalize_urlish(base_url or ZAI_DEFAULT_BASE_URL)
+            normalized = self._normalize_urlish(normalize_zai_base_url(base_url))
             if normalized == ZAI_DEFAULT_BASE_URL:
                 return normalized
             return None
@@ -892,10 +893,7 @@ class AgentProviderService:
                 )
                 continue
             if key == "base_url" and provider_name == "zai":
-                v = value or ZAI_DEFAULT_BASE_URL
-                if v.rstrip("/") == "https://api.z.ai/api/anthropic":
-                    v = ZAI_DEFAULT_BASE_URL
-                normalized[key] = self._normalize_urlish(v)
+                normalized[key] = self._normalize_urlish(normalize_zai_base_url(value))
                 continue
             if key == "base_url" and provider_name in _OPENAI_STYLE_DEFAULT_BASE_URLS:
                 normalized[key] = self._normalize_urlish(

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -74,9 +74,8 @@ class AgentProviderService:
         if zai_key and "zai" not in self._registry:
             try:
                 from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL
-                from src.services.provider_adapters import make_anthropic_adapter
 
-                self.register_provider("zai", make_anthropic_adapter(zai_key, base_url=ZAI_DEFAULT_BASE_URL))
+                self.register_provider("zai", self._make_openai_compat_provider(ZAI_DEFAULT_BASE_URL, zai_key))
             except Exception:
                 logger.debug("Failed to register zai adapter", exc_info=True)
 
@@ -266,10 +265,10 @@ class AgentProviderService:
             return make_anthropic_adapter(api_key, base_url=base_url or None)
 
         if provider == "zai":
-            from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL
+            from src.agent.provider_registry import normalize_zai_base_url
 
-            base_url = (cfg.plain_fields.get("base_url", "") or "").strip() or ZAI_DEFAULT_BASE_URL
-            return make_anthropic_adapter(api_key, base_url=base_url)
+            base_url = normalize_zai_base_url(cfg.plain_fields.get("base_url", ""))
+            return self._make_openai_compat_provider(base_url, api_key)
 
         if provider == "google_genai":
             # Google GenAI also needs a different request schema.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1660,8 +1660,8 @@ def test_build_agent_langchain_import_error_blames_correct_provider(db, monkeypa
     assert "ollama" in mgr._deepagents_backend._init_error
 
 
-def test_build_agent_zai_uses_anthropic_init_chat_model(db):
-    """Z.AI should reuse the Anthropic integration with a custom API URL."""
+def test_build_agent_zai_uses_openai_compatible_init_chat_model(db):
+    """Z.AI should use its OpenAI-compatible GLM endpoint."""
     config = AppConfig()
     config.agent.fallback_model = "openai:gpt-4.1-mini"
     mgr = AgentManager(db, config)
@@ -1696,9 +1696,43 @@ def test_build_agent_zai_uses_anthropic_init_chat_model(db):
 
     assert agent is not None
     assert captured["model"] == "glm-5"
-    assert captured["provider"] == "anthropic"
+    assert captured["provider"] == "openai"
     assert captured["kwargs"]["api_key"] == "zai-key"
-    assert captured["kwargs"]["anthropic_api_url"] == ZAI_DEFAULT_BASE_URL
+    assert captured["kwargs"]["base_url"] == ZAI_DEFAULT_BASE_URL
+
+
+def test_build_agent_zai_normalizes_legacy_anthropic_url(db):
+    """Saved legacy Z.AI Anthropic URLs should not be sent to the OpenAI-compatible client."""
+    config = AppConfig()
+    mgr = AgentManager(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5-turbo",
+        plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+        secret_fields={"api_key": "zai-key"},
+    )
+
+    captured: dict[str, object] = {}
+    fake_model = SimpleNamespace(name="zai-model")
+
+    def fake_init_chat_model(*, model, model_provider, **kwargs):
+        captured["model"] = model
+        captured["provider"] = model_provider
+        captured["kwargs"] = kwargs
+        return fake_model
+
+    with (
+        patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
+        patch("deepagents.create_deep_agent", return_value=MagicMock(run=MagicMock(return_value="ok"))),
+    ):
+        mgr._deepagents_backend._build_agent(cfg, record_last_used=False)
+
+    assert captured["model"] == "glm-5-turbo"
+    assert captured["provider"] == "openai"
+    assert captured["kwargs"]["base_url"] == ZAI_DEFAULT_BASE_URL
 
 
 def test_build_agent_tools_import_error_shows_details(db, monkeypatch):

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -1189,6 +1189,43 @@ def test_canonical_endpoint_fingerprint_for_ollama_cloud(db):
     assert fingerprint == "ollama://cloud"
 
 
+def test_canonical_endpoint_fingerprint_for_zai_legacy_url(db):
+    """Legacy Z.AI Anthropic URLs are canonicalized to the OpenAI-compatible default."""
+    service = AgentProviderService(db, AppConfig())
+
+    cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5-turbo",
+        plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+    )
+
+    fingerprint = service.canonical_endpoint_fingerprint(cfg)
+
+    assert fingerprint == "https://api.z.ai/api/paas/v4"
+
+
+def test_normalize_plain_fields_for_zai_legacy_url(db):
+    """Saving provider settings rewrites the old Z.AI Anthropic URL."""
+    service = AgentProviderService(db, AppConfig())
+
+    normalized = service._normalize_plain_fields(
+        "zai",
+        {"base_url": "https://api.z.ai/api/anthropic"},
+        {"api_key": "zai-key"},
+    )
+
+    assert normalized["base_url"] == "https://api.z.ai/api/paas/v4"
+
+
+def test_zai_provider_spec_uses_openai_package_hint():
+    spec = provider_spec("zai")
+
+    assert spec is not None
+    assert spec.package_name == "langchain-openai"
+
+
 # === Z.AI edge case tests ===
 
 

--- a/tests/test_provider_service_adapters.py
+++ b/tests/test_provider_service_adapters.py
@@ -38,7 +38,11 @@ def test_zai_registration_failure_path(clean_env):
     """Z.AI adapter registration failure is caught gracefully."""
     os.environ["ZAI_API_KEY"] = "zai-test-key"
     with patch("src.agent.provider_registry.ZAI_DEFAULT_BASE_URL", "http://zai.test", create=True):
-        with patch("src.services.provider_adapters.make_anthropic_adapter", side_effect=ImportError("no anthropic")):
+        with patch.object(
+            AgentProviderService,
+            "_make_openai_compat_provider",
+            side_effect=RuntimeError("no openai"),
+        ):
             svc = AgentProviderService()
     assert "zai" not in svc._registry
 


### PR DESCRIPTION
## Summary
- switch Z.AI deepagents runtime from Anthropic-compatible routing to the official OpenAI-compatible GLM endpoint
- normalize saved legacy Z.AI Anthropic base URLs to the current OpenAI-compatible base URL
- update provider registration and regression tests for the Z.AI endpoint path

## Tests
- ruff check src/ tests/ conftest.py
- pytest tests/test_agent.py -v -k "zai or deepagents"
- pytest tests/test_agent_provider_service.py -v -k "zai or canonical_endpoint_fingerprint or normalize_plain_fields"
- pytest tests/test_provider_service_adapters.py -v -k zai
- pytest tests/test_agent.py tests/test_agent_provider_service.py tests/test_provider_service.py tests/test_provider_service_adapters.py tests/test_provider_adapters.py -v

Closes #516