### PR TITLE
fix(agent): use zai coding endpoint

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, field
 
 from src.agent.models import CLAUDE_MODELS
 
-ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/paas/v4"
+ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+ZAI_GENERAL_BASE_URL = "https://api.z.ai/api/paas/v4"
 ZAI_LEGACY_ANTHROPIC_BASE_URLS = {
     "https://api.z.ai/api/anthropic",
     "https://api.z.ai/api/anthropic/v1",

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -805,7 +805,7 @@ class AgentProviderService:
         # Use the native Z.AI API endpoint with Bearer auth instead.
         headers = {"Authorization": f"Bearer {api_key}"}
         payload = await self._fetch_json(
-            "https://api.z.ai/api/paas/v4/models", headers=headers
+            f"{ZAI_DEFAULT_BASE_URL}/models", headers=headers
         )
         return [
             str(item.get("id", "")).strip()

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -910,7 +910,7 @@ async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
     models = await service._fetch_live_models(spec, cfg)
 
     assert models == ["glm-5"]
-    assert captured["url"] == "https://api.z.ai/api/paas/v4/models"
+    assert captured["url"] == "https://api.z.ai/api/coding/paas/v4/models"
     assert captured["headers"] == {"Authorization": "Bearer zai-key"}
 
 
@@ -1203,7 +1203,7 @@ def test_canonical_endpoint_fingerprint_for_zai_legacy_url(db):
 
     fingerprint = service.canonical_endpoint_fingerprint(cfg)
 
-    assert fingerprint == "https://api.z.ai/api/paas/v4"
+    assert fingerprint == "https://api.z.ai/api/coding/paas/v4"
 
 
 def test_normalize_plain_fields_for_zai_legacy_url(db):
@@ -1216,7 +1216,7 @@ def test_normalize_plain_fields_for_zai_legacy_url(db):
         {"api_key": "zai-key"},
     )
 
-    assert normalized["base_url"] == "https://api.z.ai/api/paas/v4"
+    assert normalized["base_url"] == "https://api.z.ai/api/coding/paas/v4"
 
 
 def test_zai_provider_spec_uses_openai_package_hint():


### PR DESCRIPTION
## Summary
- switch Z.AI default runtime base URL to the Coding Plan OpenAI-compatible endpoint
- keep general Z.AI endpoint as an explicit constant for future/custom use
- fetch Z.AI model catalog from the same coding endpoint used by runtime
- update legacy URL normalization expectations

## Verification
- Official Z.AI docs checked: General API uses https://api.z.ai/api/paas/v4, Coding Plan tools use https://api.z.ai/api/coding/paas/v4
- Live smoke with local ZAI_API_KEY:
  - https://api.z.ai/api/paas/v4/chat/completions -> 429 insufficient balance/resource package
  - https://api.z.ai/api/coding/paas/v4/chat/completions -> 200 with glm-5-turbo
  - updated provider adapter returned ok with glm-5-turbo and glm-4.7

## Tests
- ruff check src/ tests/ conftest.py
- pytest tests/test_agent.py -v -k "zai or deepagents"
- pytest tests/test_agent_provider_service.py -v -k "zai or canonical_endpoint_fingerprint or normalize_plain_fields"
- pytest tests/test_provider_service_adapters.py -v -k zai

Closes #516