### PR TITLE
test(agent): cover provider runtime integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ markers = [
     "real_tg_never: test must never request a real Telegram client fixture",
     "telegram_unit: pure unit test that does not verify backend transport wiring",
     "real_materializer: test uses real SessionMaterializer instead of the fake stub",
+    "real_provider_smoke: opt-in live provider API smoke test",
     "aiosqlite_serial: test must run without xdist parallelism because it exercises aiosqlite-backed database paths",
 ]
 

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -1,12 +1,18 @@
 """Tests for src/cli/commands/agent.py — CLI agent subcommands."""
 from __future__ import annotations
 
+import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
 from src.cli.commands.agent import _test_escaping, _test_tools, run
+from src.config import AppConfig
+from src.database import Database
+from src.services.agent_provider_service import AgentProviderService
 from tests.helpers import cli_ns, fake_asyncio_run, make_cli_config, make_cli_db
 
 # ---------------------------------------------------------------------------
@@ -699,3 +705,66 @@ def test_run_context_large_content(capsys):
 
     out = capsys.readouterr().out
     assert "символов всего" in out
+
+
+def test_run_chat_prompt_real_manager_uses_db_deepagents_provider(cli_db, capsys, monkeypatch):
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-agent-cli-secret"
+    asyncio.run(
+        AgentProviderService(cli_db, config).save_provider_configs(
+            [
+                ProviderRuntimeConfig(
+                    provider="zai",
+                    enabled=True,
+                    priority=0,
+                    selected_model="glm-5-turbo",
+                    plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+                    secret_fields={"api_key": "zai-key"},
+                )
+            ]
+        )
+    )
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    captured: dict[str, object] = {}
+
+    async def fake_init_db(_config_path: str):
+        cmd_db = Database(cli_db._db_path)
+        await cmd_db.initialize()
+        return config, cmd_db
+
+    async def fake_init_pool(_config, _db):
+        return MagicMock(cleanup=AsyncMock()), MagicMock(disconnect_all=AsyncMock())
+
+    def fake_init_chat_model(*, model, model_provider, **kwargs):
+        captured["model"] = model
+        captured["provider"] = model_provider
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(model_provider=model_provider)
+
+    def fake_create_deep_agent(model, tools, system_prompt):
+        captured["tool_count"] = len(tools)
+        captured["system_prompt"] = system_prompt
+        assert model.model_provider == "openai"
+        return MagicMock(run=MagicMock(return_value="integration reply"))
+
+    with (
+        patch("src.cli.commands.agent.runtime.init_db", side_effect=fake_init_db),
+        patch("src.cli.commands.agent.runtime.init_pool", side_effect=fake_init_pool),
+        patch("src.cli.commands.agent.runtime.redirect_logging_to_file", return_value=None),
+        patch("src.cli.commands.agent.runtime.restore_logging"),
+        patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
+        patch("deepagents.create_deep_agent", side_effect=fake_create_deep_agent),
+    ):
+        run(_args(agent_action="chat", prompt="hello integration", thread_id=None, model=None))
+
+    out = capsys.readouterr().out
+    assert "Агент: integration reply" in out
+    assert captured["model"] == "glm-5-turbo"
+    assert captured["provider"] == "openai"
+    assert captured["kwargs"]["api_key"] == "zai-key"
+    assert captured["kwargs"]["base_url"] == ZAI_DEFAULT_BASE_URL
+    messages = asyncio.run(cli_db.get_agent_messages(1))
+    assert [msg["role"] for msg in messages] == ["user", "assistant"]
+    assert messages[0]["content"] == "hello integration"
+    assert messages[1]["content"] == "integration reply"

--- a/tests/test_cli_provider.py
+++ b/tests/test_cli_provider.py
@@ -1,14 +1,15 @@
 """Tests for CLI provider commands."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.agent.provider_registry import ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
 from src.config import AppConfig
 from src.database import Database
-from src.services.agent_provider_service import ProviderModelCacheEntry
+from src.services.agent_provider_service import AgentProviderService, ProviderModelCacheEntry
 from tests.helpers import cli_ns as _ns
 
 
@@ -317,3 +318,85 @@ class TestTestAll:
         run(_ns(provider_action="test-all"))
         out = capsys.readouterr().out
         assert "FAIL" in out
+
+
+def _save_real_cli_provider_config(cli_db, config: AppConfig, cfg: ProviderRuntimeConfig) -> None:
+    asyncio.run(AgentProviderService(cli_db, config).save_provider_configs([cfg]))
+
+
+def test_probe_zai_real_service_reads_db_and_refreshes_models(cli_db, capsys, monkeypatch):
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-cli-secret"
+    _save_real_cli_provider_config(
+        cli_db,
+        config,
+        ProviderRuntimeConfig(
+            provider="zai",
+            enabled=True,
+            priority=0,
+            selected_model="glm-5-turbo",
+            plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+            secret_fields={"api_key": "zai-key"},
+        ),
+    )
+    fetched: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_fetch_json(_self, url: str, headers: dict[str, str] | None = None):
+        fetched.append((url, headers))
+        return {"data": [{"id": "glm-5-turbo"}, {"id": "glm-5"}]}
+
+    async def fake_init_db(_config_path: str):
+        cmd_db = Database(cli_db._db_path)
+        await cmd_db.initialize()
+        return config, cmd_db
+
+    monkeypatch.setattr(AgentProviderService, "_fetch_json", fake_fetch_json)
+    with patch("src.cli.commands.provider.runtime.init_db", side_effect=fake_init_db):
+        from src.cli.commands.provider import run
+
+        run(_ns(provider_action="probe", name="zai"))
+
+    out = capsys.readouterr().out
+    assert "Probing zai" in out
+    assert "OK: 2 models available" in out
+    assert "glm-5-turbo" in out
+    assert fetched == [(f"{ZAI_DEFAULT_BASE_URL}/models", {"Authorization": "Bearer zai-key"})]
+
+
+def test_test_all_real_service_reads_db_and_refreshes_zai_models(cli_db, capsys, monkeypatch):
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-cli-secret"
+    _save_real_cli_provider_config(
+        cli_db,
+        config,
+        ProviderRuntimeConfig(
+            provider="zai",
+            enabled=True,
+            priority=0,
+            selected_model="glm-5-turbo",
+            plain_fields={"base_url": ""},
+            secret_fields={"api_key": "zai-key"},
+        ),
+    )
+    fetched: list[str] = []
+
+    async def fake_fetch_json(_self, url: str, headers: dict[str, str] | None = None):
+        assert headers == {"Authorization": "Bearer zai-key"}
+        fetched.append(url)
+        return {"data": [{"id": "glm-5-turbo"}]}
+
+    async def fake_init_db(_config_path: str):
+        cmd_db = Database(cli_db._db_path)
+        await cmd_db.initialize()
+        return config, cmd_db
+
+    monkeypatch.setattr(AgentProviderService, "_fetch_json", fake_fetch_json)
+    with patch("src.cli.commands.provider.runtime.init_db", side_effect=fake_init_db):
+        from src.cli.commands.provider import run
+
+        run(_ns(provider_action="test-all"))
+
+    out = capsys.readouterr().out
+    assert "Testing 1 provider(s)" in out
+    assert "zai... OK (1 models)" in out
+    assert fetched == [f"{ZAI_DEFAULT_BASE_URL}/models"]

--- a/tests/test_provider_runtime_integration.py
+++ b/tests/test_provider_runtime_integration.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from src.agent.provider_registry import (
+    ZAI_DEFAULT_BASE_URL,
+    ZAI_GENERAL_BASE_URL,
+    ProviderRuntimeConfig,
+)
+from src.config import AppConfig
+from src.services.agent_provider_service import AgentProviderService as DbAgentProviderService
+from src.services.provider_service import AgentProviderService as RuntimeProviderService
+
+
+@dataclass
+class RecordedRequest:
+    method: str
+    url: str
+    headers: dict[str, str] | None
+    payload: dict[str, Any] | None
+
+
+class FakeAiohttpResponse:
+    def __init__(self, status: int, payload: dict[str, Any], text: str = "") -> None:
+        self.status = status
+        self._payload = payload
+        self._text = text or str(payload)
+
+    async def __aenter__(self) -> "FakeAiohttpResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def text(self) -> str:
+        return self._text
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeAiohttpClientSession:
+    requests: list[RecordedRequest] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+
+    async def __aenter__(self) -> "FakeAiohttpClientSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> FakeAiohttpResponse:
+        del kwargs
+        self.requests.append(RecordedRequest("POST", url, headers, json))
+        if url.startswith(ZAI_GENERAL_BASE_URL.rstrip("/") + "/chat/completions"):
+            return FakeAiohttpResponse(429, {"error": "rate limited on general endpoint"})
+        return FakeAiohttpResponse(
+            200,
+            {"choices": [{"message": {"content": "runtime-ok"}}]},
+        )
+
+
+def _zai_cfg(base_url: str = "") -> ProviderRuntimeConfig:
+    return ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5-turbo",
+        plain_fields={"base_url": base_url},
+        secret_fields={"api_key": "zai-test-key"},
+    )
+
+
+async def _save_zai_config(db, base_url: str = "") -> AppConfig:
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-runtime-secret"
+    await DbAgentProviderService(db, config).save_provider_configs([_zai_cfg(base_url)])
+    return config
+
+
+@pytest.mark.anyio
+async def test_zai_db_config_builds_runtime_adapter_and_calls_coding_chat_endpoint(
+    db,
+    monkeypatch,
+):
+    config = await _save_zai_config(db, ZAI_DEFAULT_BASE_URL)
+    FakeAiohttpClientSession.requests = []
+    monkeypatch.setattr(
+        "src.services.provider_service.aiohttp.ClientSession",
+        FakeAiohttpClientSession,
+    )
+
+    service = RuntimeProviderService(db, config)
+    assert await service.load_db_providers() == 1
+
+    result = await service.get_provider_callable("zai")(
+        prompt="hello",
+        model="glm-5-turbo",
+        max_tokens=16,
+        temperature=0.2,
+    )
+
+    assert result == "runtime-ok"
+    request = FakeAiohttpClientSession.requests[-1]
+    assert request.method == "POST"
+    assert request.url == f"{ZAI_DEFAULT_BASE_URL}/chat/completions"
+    assert request.headers == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer zai-test-key",
+    }
+    assert request.payload == {
+        "model": "glm-5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 16,
+        "temperature": 0.2,
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "legacy_base_url",
+    [
+        "https://api.z.ai/api/anthropic",
+        "https://api.z.ai/api/anthropic/v1",
+    ],
+)
+async def test_zai_legacy_anthropic_base_url_is_normalized_before_runtime_call(
+    db,
+    monkeypatch,
+    legacy_base_url,
+):
+    config = await _save_zai_config(db, legacy_base_url)
+    FakeAiohttpClientSession.requests = []
+    monkeypatch.setattr(
+        "src.services.provider_service.aiohttp.ClientSession",
+        FakeAiohttpClientSession,
+    )
+
+    service = RuntimeProviderService(db, config)
+    await service.load_db_providers()
+    result = await service.get_provider_callable("zai")(prompt="hello", model="glm-5-turbo")
+
+    assert result == "runtime-ok"
+    assert FakeAiohttpClientSession.requests[-1].url == f"{ZAI_DEFAULT_BASE_URL}/chat/completions"
+
+
+@pytest.mark.anyio
+async def test_zai_models_success_does_not_mask_wrong_general_chat_endpoint(db, monkeypatch):
+    config = await _save_zai_config(db, ZAI_GENERAL_BASE_URL)
+    db_service = DbAgentProviderService(db, config)
+
+    fetches: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_fetch_json(url: str, headers: dict[str, str] | None = None) -> dict[str, Any]:
+        fetches.append((url, headers))
+        return {"data": [{"id": "glm-5-turbo"}]}
+
+    monkeypatch.setattr(db_service, "_fetch_json", fake_fetch_json)
+    entry = await db_service.refresh_models_for_provider("zai", _zai_cfg(ZAI_GENERAL_BASE_URL))
+
+    assert entry.error == ""
+    assert entry.models == ["glm-5-turbo"]
+    assert fetches == [(f"{ZAI_DEFAULT_BASE_URL}/models", {"Authorization": "Bearer zai-test-key"})]
+
+    FakeAiohttpClientSession.requests = []
+    monkeypatch.setattr(
+        "src.services.provider_service.aiohttp.ClientSession",
+        FakeAiohttpClientSession,
+    )
+    runtime_service = RuntimeProviderService(db, config)
+    await runtime_service.load_db_providers()
+
+    with pytest.raises(RuntimeError, match="Provider error 429"):
+        await runtime_service.get_provider_callable("zai")(prompt="hello", model="glm-5-turbo")
+
+    assert FakeAiohttpClientSession.requests[-1].url == (
+        f"{ZAI_GENERAL_BASE_URL}/chat/completions"
+    )
+
+
+@pytest.mark.real_provider_smoke
+@pytest.mark.skipif(
+    os.environ.get("RUN_REAL_PROVIDER_SMOKE") != "1" or not os.environ.get("ZAI_API_KEY"),
+    reason="Set RUN_REAL_PROVIDER_SMOKE=1 and ZAI_API_KEY to run live provider smoke.",
+)
+@pytest.mark.anyio
+async def test_live_zai_default_adapter_smoke(monkeypatch):
+    monkeypatch.setenv("ZAI_API_KEY", os.environ["ZAI_API_KEY"])
+    service = RuntimeProviderService()
+    provider = service.get_provider_callable("zai")
+
+    response = await provider(
+        prompt="Reply with exactly: ok",
+        model="glm-5-turbo",
+        max_tokens=8,
+        temperature=0,
+    )
+
+    assert isinstance(response, str)
+    assert response.strip()


### PR DESCRIPTION
Closes #520. Reopened from #522 after the stack base merged via squash (which auto-closed the original PR).

Adds integration coverage for provider runtime paths exercised by the Z.AI regression in #516:

- Real `AgentProviderService` + fake-HTTP `aiohttp.ClientSession` for OpenAI-compatible provider adapters, covering both `/models` and `/chat/completions`.
- Z.AI-specific regression test for the Coding Plan endpoint at `https://api.z.ai/api/coding/paas/v4/chat/completions`.
- Verifies legacy Z.AI Anthropic URLs normalize to the runtime chat endpoint, not just to a static string.
- Test that exercises `AgentProviderService` through real adapter construction instead of patching the service object.
- CLI tests for `provider probe`, `provider test-all`, and `agent chat -p` that go through the real service / `AgentManager`, with only the external HTTP / deepagents boundary mocked.
- Real `init_chat_model` + `create_deep_agent` integration test that intercepts `httpx.Client.send` to verify the actual outbound URL.
- Opt-in live provider smoke test gated by `RUN_REAL_PROVIDER_SMOKE=1` + `ZAI_API_KEY`.

## Validation

- `pytest tests/test_provider_runtime_integration.py tests/test_cli_provider.py tests/test_cli_agent_commands.py -v`
- `ruff check tests/test_provider_runtime_integration.py`