### PR TITLE
fix(agent): default Z.AI to general endpoint

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,7 @@ Supported env vars (examples)
 - FIREWORKS_BASE, FIREWORKS_API_KEY — Fireworks inference endpoint
 - DEEPSEEK_BASE, DEEPSEEK_API_KEY — DeepSeek endpoint
 - TOGETHER_BASE, TOGETHER_API_KEY — Together API base
+- ZAI_API_KEY — Z.AI API key (OpenAI-compatible chat completions)
 
 Env-based registration
 
@@ -22,6 +23,13 @@ Settings UI
 - Use the Settings → Developer → Providers form to add, edit or remove provider configurations. Secret fields are encrypted before storage using SESSION_ENCRYPTION_KEY; when this key is not set the UI is read-only for provider secrets.
 - The provider registry uses canonical provider names (e.g. "openai", "cohere", "ollama", "huggingface", "context7").
 - For local Ollama testing, set OLLAMA_BASE to your server URL and optionally OLLAMA_DEFAULT_MODEL.
+
+Z.AI endpoints
+
+- The `zai` provider uses the OpenAI-compatible Z.AI API. Empty Base URL defaults to the general endpoint: `https://api.z.ai/api/paas/v4`.
+- GLM Coding Plan users can opt in by setting Base URL to `https://api.z.ai/api/coding/paas/v4`; model refresh and chat runtime both use the configured endpoint.
+- Do not use `https://api.z.ai/api/anthropic` or `/anthropic/v1` with the `zai` provider. That URL is the Anthropic-compatible proxy for tools such as Claude Code; configure the `anthropic` provider for that endpoint instead.
+- References: https://docs.z.ai/api-reference/introduction and https://docs.z.ai/devpack/tool/claude
 
 Context7 & operator caution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "langchain==1.2.12",
     "langchain-core==1.2.19",
     "langchain-ollama==1.0.1",
+    "langchain-openai==1.1.11",
     "pytest==9.0.2",
     "pytest-timeout==2.4.0",
     "pytest-xdist==3.8.0",

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -39,7 +39,13 @@ from src.agent.prompt_template import (
     build_prompt_template_context,
     render_prompt_template,
 )
-from src.agent.provider_registry import ProviderRuntimeConfig, normalize_zai_base_url
+from src.agent.provider_registry import (
+    ZAI_CODING_BASE_URL,
+    ZAI_DEFAULT_BASE_URL,
+    ProviderRuntimeConfig,
+    is_zai_legacy_anthropic_base_url,
+    normalize_zai_base_url,
+)
 from src.config import AppConfig
 from src.database import Database
 from src.services.agent_provider_service import (
@@ -1207,8 +1213,17 @@ class DeepagentsBackend:
             extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
 
         if provider == "zai":
+            raw_base_url = cfg.plain_fields.get("base_url", "")
+            if is_zai_legacy_anthropic_base_url(raw_base_url):
+                self._init_error = (
+                    "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
+                    "anthropic provider with this URL instead, or use the OpenAI-compatible "
+                    f"endpoint {ZAI_DEFAULT_BASE_URL}. Coding Plan users can explicitly set "
+                    f"{ZAI_CODING_BASE_URL}."
+                )
+                raise RuntimeError(self._init_error)
             model_provider = "openai"
-            extra["base_url"] = normalize_zai_base_url(cfg.plain_fields.get("base_url", ""))
+            extra["base_url"] = normalize_zai_base_url(raw_base_url)
         self._init_attempted_model = cfg.model_name
 
         # ReAct fallback for Ollama models without native function calling

--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -4,17 +4,23 @@ from dataclasses import dataclass, field
 
 from src.agent.models import CLAUDE_MODELS
 
-ZAI_DEFAULT_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
 ZAI_GENERAL_BASE_URL = "https://api.z.ai/api/paas/v4"
+ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
+ZAI_DEFAULT_BASE_URL = ZAI_GENERAL_BASE_URL
 ZAI_LEGACY_ANTHROPIC_BASE_URLS = {
     "https://api.z.ai/api/anthropic",
     "https://api.z.ai/api/anthropic/v1",
 }
 
 
+def is_zai_legacy_anthropic_base_url(base_url: str = "") -> bool:
+    normalized = (base_url or "").strip().rstrip("/")
+    return normalized in ZAI_LEGACY_ANTHROPIC_BASE_URLS
+
+
 def normalize_zai_base_url(base_url: str = "") -> str:
     normalized = (base_url or "").strip().rstrip("/")
-    if not normalized or normalized in ZAI_LEGACY_ANTHROPIC_BASE_URLS:
+    if not normalized:
         return ZAI_DEFAULT_BASE_URL
     return normalized
 

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -17,9 +17,11 @@ import aiohttp
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
     PROVIDER_SPECS,
+    ZAI_CODING_BASE_URL,
     ZAI_DEFAULT_BASE_URL,
     ProviderRuntimeConfig,
     ProviderSpec,
+    is_zai_legacy_anthropic_base_url,
     normalize_zai_base_url,
     provider_spec,
 )
@@ -430,6 +432,15 @@ class AgentProviderService:
         spec = provider_spec(cfg.provider)
         if spec is None:
             return f"Unknown provider: {cfg.provider}"
+        if cfg.provider == "zai" and is_zai_legacy_anthropic_base_url(
+            cfg.plain_fields.get("base_url", "")
+        ):
+            return (
+                "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
+                "anthropic provider with this URL instead, or use the OpenAI-compatible "
+                f"endpoint {ZAI_DEFAULT_BASE_URL}. Coding Plan users can explicitly set "
+                f"{ZAI_CODING_BASE_URL}."
+            )
         for spec_field in spec.plain_fields:
             if spec_field.required and not cfg.plain_fields.get(spec_field.name, "").strip():
                 return f"Missing required field: {spec_field.label}"
@@ -668,7 +679,7 @@ class AgentProviderService:
         if provider == "zai":
             base_url = cfg.plain_fields.get("base_url", "").strip()
             normalized = self._normalize_urlish(normalize_zai_base_url(base_url))
-            if normalized == ZAI_DEFAULT_BASE_URL:
+            if normalized in {ZAI_DEFAULT_BASE_URL, ZAI_CODING_BASE_URL}:
                 return normalized
             return None
         if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
@@ -703,6 +714,7 @@ class AgentProviderService:
         if provider == "zai":
             assert cfg is not None
             return await self._fetch_zai_models(
+                cfg.plain_fields.get("base_url", ""),
                 cfg.secret_fields.get("api_key", ""),
             )
         if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
@@ -800,12 +812,16 @@ class AgentProviderService:
         )
         return [str(item.get("id", "")).strip() for item in payload if item.get("id")]
 
-    async def _fetch_zai_models(self, api_key: str) -> list[str]:
-        # The Anthropic-compatible proxy endpoint doesn't expose /models.
-        # Use the native Z.AI API endpoint with Bearer auth instead.
+    async def _fetch_zai_models(self, base_url: str, api_key: str) -> list[str]:
+        if is_zai_legacy_anthropic_base_url(base_url):
+            raise RuntimeError(
+                "The Z.AI Anthropic-compatible proxy does not expose OpenAI-compatible "
+                f"/models. Use {ZAI_DEFAULT_BASE_URL} or {ZAI_CODING_BASE_URL}."
+            )
+        resolved_base_url = normalize_zai_base_url(base_url)
         headers = {"Authorization": f"Bearer {api_key}"}
         payload = await self._fetch_json(
-            f"{ZAI_DEFAULT_BASE_URL}/models", headers=headers
+            f"{resolved_base_url.rstrip('/')}/models", headers=headers
         )
         return [
             str(item.get("id", "")).strip()

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -265,9 +265,16 @@ class AgentProviderService:
             return make_anthropic_adapter(api_key, base_url=base_url or None)
 
         if provider == "zai":
-            from src.agent.provider_registry import normalize_zai_base_url
+            from src.agent.provider_registry import (
+                is_zai_legacy_anthropic_base_url,
+                normalize_zai_base_url,
+            )
 
-            base_url = normalize_zai_base_url(cfg.plain_fields.get("base_url", ""))
+            raw_base_url = cfg.plain_fields.get("base_url", "")
+            if is_zai_legacy_anthropic_base_url(raw_base_url):
+                logger.debug("Skipping db provider %s: Anthropic-compatible URL is not OpenAI-compatible", provider)
+                return None
+            base_url = normalize_zai_base_url(raw_base_url)
             return self._make_openai_compat_provider(base_url, api_key)
 
         if provider == "google_genai":

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1701,8 +1701,8 @@ def test_build_agent_zai_uses_openai_compatible_init_chat_model(db):
     assert captured["kwargs"]["base_url"] == ZAI_DEFAULT_BASE_URL
 
 
-def test_build_agent_zai_normalizes_legacy_anthropic_url(db):
-    """Saved legacy Z.AI Anthropic URLs should not be sent to the OpenAI-compatible client."""
+def test_build_agent_zai_rejects_legacy_anthropic_url(db):
+    """Saved legacy Z.AI Anthropic URLs should not reach the OpenAI-compatible client."""
     config = AppConfig()
     mgr = AgentManager(db, config)
 
@@ -1715,24 +1715,17 @@ def test_build_agent_zai_normalizes_legacy_anthropic_url(db):
         secret_fields={"api_key": "zai-key"},
     )
 
-    captured: dict[str, object] = {}
-    fake_model = SimpleNamespace(name="zai-model")
-
     def fake_init_chat_model(*, model, model_provider, **kwargs):
-        captured["model"] = model
-        captured["provider"] = model_provider
-        captured["kwargs"] = kwargs
-        return fake_model
+        raise AssertionError(f"legacy URL should fail validation before model init: {model} {model_provider} {kwargs}")
 
     with (
         patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
         patch("deepagents.create_deep_agent", return_value=MagicMock(run=MagicMock(return_value="ok"))),
     ):
-        mgr._deepagents_backend._build_agent(cfg, record_last_used=False)
+        with pytest.raises(RuntimeError, match="Anthropic-compatible proxy"):
+            mgr._deepagents_backend._build_agent(cfg, record_last_used=False)
 
-    assert captured["model"] == "glm-5-turbo"
-    assert captured["provider"] == "openai"
-    assert captured["kwargs"]["base_url"] == ZAI_DEFAULT_BASE_URL
+    assert "anthropic provider" in (mgr._deepagents_backend.init_error or "")
 
 
 def test_build_agent_tools_import_error_shows_details(db, monkeypatch):

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agent.manager import AgentManager
-from src.agent.provider_registry import ProviderRuntimeConfig, provider_spec
+from src.agent.provider_registry import (
+    ZAI_CODING_BASE_URL,
+    ZAI_GENERAL_BASE_URL,
+    ProviderRuntimeConfig,
+    provider_spec,
+)
 from src.config import AppConfig
 from src.services.agent_provider_service import (
     MODEL_CACHE_SETTINGS_KEY,
@@ -883,7 +888,7 @@ async def test_fetch_live_models_success_updates_cache(db, monkeypatch):
 
 @pytest.mark.anyio
 async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
-    """Z.AI live model fetch uses native API endpoint with Bearer auth."""
+    """Z.AI live model fetch uses general API endpoint with Bearer auth by default."""
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
     service = AgentProviderService(db, config)
@@ -910,7 +915,41 @@ async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
     models = await service._fetch_live_models(spec, cfg)
 
     assert models == ["glm-5"]
-    assert captured["url"] == "https://api.z.ai/api/coding/paas/v4/models"
+    assert captured["url"] == f"{ZAI_GENERAL_BASE_URL}/models"
+    assert captured["headers"] == {"Authorization": "Bearer zai-key"}
+
+
+@pytest.mark.anyio
+async def test_fetch_live_models_zai_honors_configured_coding_base_url(db, monkeypatch):
+    """Z.AI live model fetch follows the configured base_url."""
+    config = AppConfig()
+    config.security.session_encryption_key = "provider-secret"
+    service = AgentProviderService(db, config)
+
+    cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5",
+        plain_fields={"base_url": ZAI_CODING_BASE_URL},
+        secret_fields={"api_key": "zai-key"},
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _fake_fetch_json(url, headers=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return {"data": [{"id": "glm-5"}]}
+
+    monkeypatch.setattr(service, "_fetch_json", _fake_fetch_json)
+
+    spec = provider_spec("zai")
+    assert spec is not None
+    models = await service._fetch_live_models(spec, cfg)
+
+    assert models == ["glm-5"]
+    assert captured["url"] == f"{ZAI_CODING_BASE_URL}/models"
     assert captured["headers"] == {"Authorization": "Bearer zai-key"}
 
 
@@ -1189,34 +1228,51 @@ def test_canonical_endpoint_fingerprint_for_ollama_cloud(db):
     assert fingerprint == "ollama://cloud"
 
 
-def test_canonical_endpoint_fingerprint_for_zai_legacy_url(db):
-    """Legacy Z.AI Anthropic URLs are canonicalized to the OpenAI-compatible default."""
+def test_canonical_endpoint_fingerprint_for_zai_default_and_coding_urls(db):
+    """Known Z.AI OpenAI-compatible endpoints are canonicalized distinctly."""
     service = AgentProviderService(db, AppConfig())
 
+    default_cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5-turbo",
+        plain_fields={"base_url": ""},
+    )
+    coding_cfg = ProviderRuntimeConfig(
+        provider="zai",
+        enabled=True,
+        priority=0,
+        selected_model="glm-5-turbo",
+        plain_fields={"base_url": ZAI_CODING_BASE_URL},
+    )
+
+    assert service.canonical_endpoint_fingerprint(default_cfg) == ZAI_GENERAL_BASE_URL
+    assert service.canonical_endpoint_fingerprint(coding_cfg) == ZAI_CODING_BASE_URL
+
+
+def test_zai_legacy_anthropic_url_is_validation_error_not_rewritten(db):
+    """Z.AI Anthropic proxy URL is invalid for the OpenAI-compatible Z.AI provider."""
+    service = AgentProviderService(db, AppConfig())
+    legacy_url = "https://api.z.ai/api/anthropic"
     cfg = ProviderRuntimeConfig(
         provider="zai",
         enabled=True,
         priority=0,
         selected_model="glm-5-turbo",
-        plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+        plain_fields={"base_url": legacy_url},
+        secret_fields={"api_key": "zai-key"},
     )
-
-    fingerprint = service.canonical_endpoint_fingerprint(cfg)
-
-    assert fingerprint == "https://api.z.ai/api/coding/paas/v4"
-
-
-def test_normalize_plain_fields_for_zai_legacy_url(db):
-    """Saving provider settings rewrites the old Z.AI Anthropic URL."""
-    service = AgentProviderService(db, AppConfig())
 
     normalized = service._normalize_plain_fields(
         "zai",
-        {"base_url": "https://api.z.ai/api/anthropic"},
+        {"base_url": legacy_url},
         {"api_key": "zai-key"},
     )
 
-    assert normalized["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+    assert service.canonical_endpoint_fingerprint(cfg) is None
+    assert normalized["base_url"] == legacy_url
+    assert "Anthropic-compatible proxy" in service.validate_provider_config(cfg)
 
 
 def test_zai_provider_spec_uses_openai_package_hint():

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -718,7 +718,7 @@ def test_run_chat_prompt_real_manager_uses_db_deepagents_provider(cli_db, capsys
                     enabled=True,
                     priority=0,
                     selected_model="glm-5-turbo",
-                    plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+                    plain_fields={"base_url": ""},
                     secret_fields={"api_key": "zai-key"},
                 )
             ]

--- a/tests/test_cli_provider.py
+++ b/tests/test_cli_provider.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src.agent.provider_registry import ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_CODING_BASE_URL, ZAI_DEFAULT_BASE_URL, ProviderRuntimeConfig
 from src.config import AppConfig
 from src.database import Database
 from src.services.agent_provider_service import AgentProviderService, ProviderModelCacheEntry
@@ -335,7 +335,7 @@ def test_probe_zai_real_service_reads_db_and_refreshes_models(cli_db, capsys, mo
             enabled=True,
             priority=0,
             selected_model="glm-5-turbo",
-            plain_fields={"base_url": "https://api.z.ai/api/anthropic/v1"},
+            plain_fields={"base_url": ZAI_CODING_BASE_URL},
             secret_fields={"api_key": "zai-key"},
         ),
     )
@@ -360,7 +360,7 @@ def test_probe_zai_real_service_reads_db_and_refreshes_models(cli_db, capsys, mo
     assert "Probing zai" in out
     assert "OK: 2 models available" in out
     assert "glm-5-turbo" in out
-    assert fetched == [(f"{ZAI_DEFAULT_BASE_URL}/models", {"Authorization": "Bearer zai-key"})]
+    assert fetched == [(f"{ZAI_CODING_BASE_URL}/models", {"Authorization": "Bearer zai-key"})]
 
 
 def test_test_all_real_service_reads_db_and_refreshes_zai_models(cli_db, capsys, monkeypatch):

--- a/tests/test_provider_runtime_integration.py
+++ b/tests/test_provider_runtime_integration.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 from dataclasses import dataclass
 from typing import Any
 
+import httpx
 import pytest
 
 from src.agent.provider_registry import (
-    ZAI_DEFAULT_BASE_URL,
+    ZAI_CODING_BASE_URL,
     ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
 )
@@ -65,8 +68,6 @@ class FakeAiohttpClientSession:
     ) -> FakeAiohttpResponse:
         del kwargs
         self.requests.append(RecordedRequest("POST", url, headers, json))
-        if url.startswith(ZAI_GENERAL_BASE_URL.rstrip("/") + "/chat/completions"):
-            return FakeAiohttpResponse(429, {"error": "rate limited on general endpoint"})
         return FakeAiohttpResponse(
             200,
             {"choices": [{"message": {"content": "runtime-ok"}}]},
@@ -92,11 +93,11 @@ async def _save_zai_config(db, base_url: str = "") -> AppConfig:
 
 
 @pytest.mark.anyio
-async def test_zai_db_config_builds_runtime_adapter_and_calls_coding_chat_endpoint(
+async def test_zai_db_config_builds_runtime_adapter_and_calls_default_general_chat_endpoint(
     db,
     monkeypatch,
 ):
-    config = await _save_zai_config(db, ZAI_DEFAULT_BASE_URL)
+    config = await _save_zai_config(db, "")
     FakeAiohttpClientSession.requests = []
     monkeypatch.setattr(
         "src.services.provider_service.aiohttp.ClientSession",
@@ -116,7 +117,7 @@ async def test_zai_db_config_builds_runtime_adapter_and_calls_coding_chat_endpoi
     assert result == "runtime-ok"
     request = FakeAiohttpClientSession.requests[-1]
     assert request.method == "POST"
-    assert request.url == f"{ZAI_DEFAULT_BASE_URL}/chat/completions"
+    assert request.url == f"{ZAI_GENERAL_BASE_URL}/chat/completions"
     assert request.headers == {
         "Content-Type": "application/json",
         "Authorization": "Bearer zai-test-key",
@@ -130,19 +131,8 @@ async def test_zai_db_config_builds_runtime_adapter_and_calls_coding_chat_endpoi
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    "legacy_base_url",
-    [
-        "https://api.z.ai/api/anthropic",
-        "https://api.z.ai/api/anthropic/v1",
-    ],
-)
-async def test_zai_legacy_anthropic_base_url_is_normalized_before_runtime_call(
-    db,
-    monkeypatch,
-    legacy_base_url,
-):
-    config = await _save_zai_config(db, legacy_base_url)
+async def test_zai_explicit_coding_endpoint_is_honored_by_runtime_adapter(db, monkeypatch):
+    config = await _save_zai_config(db, ZAI_CODING_BASE_URL)
     FakeAiohttpClientSession.requests = []
     monkeypatch.setattr(
         "src.services.provider_service.aiohttp.ClientSession",
@@ -150,16 +140,56 @@ async def test_zai_legacy_anthropic_base_url_is_normalized_before_runtime_call(
     )
 
     service = RuntimeProviderService(db, config)
-    await service.load_db_providers()
+    assert await service.load_db_providers() == 1
+
     result = await service.get_provider_callable("zai")(prompt="hello", model="glm-5-turbo")
 
     assert result == "runtime-ok"
-    assert FakeAiohttpClientSession.requests[-1].url == f"{ZAI_DEFAULT_BASE_URL}/chat/completions"
+    assert FakeAiohttpClientSession.requests[-1].url == f"{ZAI_CODING_BASE_URL}/chat/completions"
 
 
 @pytest.mark.anyio
-async def test_zai_models_success_does_not_mask_wrong_general_chat_endpoint(db, monkeypatch):
-    config = await _save_zai_config(db, ZAI_GENERAL_BASE_URL)
+@pytest.mark.parametrize(
+    "legacy_base_url",
+    [
+        "https://api.z.ai/api/anthropic",
+        "https://api.z.ai/api/anthropic/v1",
+    ],
+)
+async def test_zai_legacy_anthropic_base_url_is_rejected_before_runtime_registration(
+    db,
+    legacy_base_url,
+):
+    config = await _save_zai_config(db, legacy_base_url)
+    db_service = DbAgentProviderService(db, config)
+    loaded = await db_service.load_provider_configs()
+
+    validation_error = db_service.validate_provider_config(loaded[0])
+    assert "Anthropic-compatible proxy" in validation_error
+    assert "anthropic provider" in validation_error
+    assert ZAI_GENERAL_BASE_URL in validation_error
+
+    service = RuntimeProviderService(db, config)
+    assert await service.load_db_providers() == 0
+    assert not service.has_providers()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "configured_base_url,expected_models_url",
+    [
+        ("", f"{ZAI_GENERAL_BASE_URL}/models"),
+        (ZAI_GENERAL_BASE_URL, f"{ZAI_GENERAL_BASE_URL}/models"),
+        (ZAI_CODING_BASE_URL, f"{ZAI_CODING_BASE_URL}/models"),
+    ],
+)
+async def test_zai_model_refresh_uses_configured_base_url(
+    db,
+    monkeypatch,
+    configured_base_url,
+    expected_models_url,
+):
+    config = await _save_zai_config(db, configured_base_url)
     db_service = DbAgentProviderService(db, config)
 
     fetches: list[tuple[str, dict[str, str] | None]] = []
@@ -169,26 +199,169 @@ async def test_zai_models_success_does_not_mask_wrong_general_chat_endpoint(db, 
         return {"data": [{"id": "glm-5-turbo"}]}
 
     monkeypatch.setattr(db_service, "_fetch_json", fake_fetch_json)
-    entry = await db_service.refresh_models_for_provider("zai", _zai_cfg(ZAI_GENERAL_BASE_URL))
+    entry = await db_service.refresh_models_for_provider("zai", _zai_cfg(configured_base_url))
 
     assert entry.error == ""
     assert entry.models == ["glm-5-turbo"]
-    assert fetches == [(f"{ZAI_DEFAULT_BASE_URL}/models", {"Authorization": "Bearer zai-test-key"})]
+    assert fetches == [(expected_models_url, {"Authorization": "Bearer zai-test-key"})]
 
-    FakeAiohttpClientSession.requests = []
-    monkeypatch.setattr(
-        "src.services.provider_service.aiohttp.ClientSession",
-        FakeAiohttpClientSession,
+
+@pytest.mark.anyio
+async def test_zai_model_refresh_rejects_legacy_anthropic_models_endpoint(db, monkeypatch):
+    config = await _save_zai_config(db, "https://api.z.ai/api/anthropic/v1")
+    db_service = DbAgentProviderService(db, config)
+
+    async def fake_fetch_json(url: str, headers: dict[str, str] | None = None) -> dict[str, Any]:
+        raise AssertionError(f"legacy URL must be rejected before HTTP fetch: {url} {headers}")
+
+    monkeypatch.setattr(db_service, "_fetch_json", fake_fetch_json)
+    entry = await db_service.refresh_models_for_provider(
+        "zai",
+        _zai_cfg("https://api.z.ai/api/anthropic/v1"),
     )
-    runtime_service = RuntimeProviderService(db, config)
-    await runtime_service.load_db_providers()
 
-    with pytest.raises(RuntimeError, match="Provider error 429"):
-        await runtime_service.get_provider_callable("zai")(prompt="hello", model="glm-5-turbo")
+    assert entry.error
+    assert "Anthropic-compatible proxy" in entry.error
 
-    assert FakeAiohttpClientSession.requests[-1].url == (
-        f"{ZAI_GENERAL_BASE_URL}/chat/completions"
+
+@pytest.mark.parametrize(
+    "provider,base_url,model,expected_url",
+    [
+        # Expected URLs are hardcoded so the test catches changes to the
+        # configured endpoint flowing through LangChain.
+        (
+            "zai",
+            "",
+            "glm-5-turbo",
+            "https://api.z.ai/api/paas/v4/chat/completions",
+        ),
+        (
+            "zai",
+            "https://api.z.ai/api/coding/paas/v4",
+            "glm-5-turbo",
+            "https://api.z.ai/api/coding/paas/v4/chat/completions",
+        ),
+        (
+            "openai",
+            "https://api.openai.com/v1",
+            "gpt-4o-mini",
+            "https://api.openai.com/v1/chat/completions",
+        ),
+    ],
+)
+@pytest.mark.anyio
+async def test_deepagents_chat_runs_real_init_chat_model_and_create_deep_agent(
+    db,
+    monkeypatch,
+    provider,
+    base_url,
+    model,
+    expected_url,
+):
+    """Build a real langchain model + real deepagents agent and verify the
+    actual outbound HTTP call hits the correct OpenAI-compat endpoint.
+
+    Catches regressions on the AgentManager → langchain → openai → httpx path
+    that mocking init_chat_model / create_deep_agent would silently miss
+    (e.g. the Z.AI Coding endpoint regression from #516).
+    """
+    config = AppConfig()
+    config.security.session_encryption_key = "deepagents-runtime-secret"
+    cfg = ProviderRuntimeConfig(
+        provider=provider,
+        enabled=True,
+        priority=0,
+        selected_model=model,
+        plain_fields={"base_url": base_url},
+        secret_fields={"api_key": f"{provider}-test-key"},
     )
+    await DbAgentProviderService(db, config).save_provider_configs([cfg])
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    captured_requests: list[dict[str, Any]] = []
+
+    def _build_response(request: httpx.Request) -> httpx.Response:
+        body = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "deepagents-runtime-ok",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+        return httpx.Response(
+            status_code=200,
+            headers={"Content-Type": "application/json"},
+            content=json.dumps(body).encode("utf-8"),
+            request=request,
+        )
+
+    def _capture(request: httpx.Request) -> None:
+        try:
+            payload = json.loads(request.content) if request.content else None
+        except json.JSONDecodeError:
+            payload = None
+        captured_requests.append(
+            {
+                "method": request.method,
+                "url": str(request.url),
+                "headers": {k.lower(): v for k, v in request.headers.items()},
+                "payload": payload,
+            }
+        )
+
+    def fake_sync_send(self, request, **kwargs):
+        del self, kwargs
+        _capture(request)
+        return _build_response(request)
+
+    async def fake_async_send(self, request, **kwargs):
+        del self, kwargs
+        _capture(request)
+        return _build_response(request)
+
+    monkeypatch.setattr(httpx.Client, "send", fake_sync_send)
+    monkeypatch.setattr(httpx.AsyncClient, "send", fake_async_send)
+
+    # Build the real DeepagentsBackend → real init_chat_model → real
+    # create_deep_agent. The backend's _build_agent reads cfg, normalizes
+    # the Z.AI base URL and selects model_provider="openai" — exactly the
+    # production path that the #516 regression broke.
+    from src.agent.manager import DeepagentsBackend
+
+    backend = DeepagentsBackend(db, config)
+    await backend.refresh_settings_cache()
+    agent = backend._build_agent(cfg, tools=[])
+
+    result = await asyncio.to_thread(
+        agent.invoke,
+        {"messages": [{"role": "user", "content": "hello"}]},
+    )
+
+    assert captured_requests, "Expected at least one HTTP request from deepagents agent"
+    first = captured_requests[0]
+    assert first["method"] == "POST"
+    assert first["url"] == expected_url
+    assert first["headers"].get("authorization") == f"Bearer {provider}-test-key"
+    assert first["payload"] is not None
+    assert first["payload"]["model"] == model
+    user_messages = [m for m in first["payload"]["messages"] if m.get("role") == "user"]
+    assert any("hello" in (m.get("content") or "") for m in user_messages)
+
+    text = backend._extract_result_text(result)
+    assert "deepagents-runtime-ok" in text
 
 
 @pytest.mark.real_provider_smoke


### PR DESCRIPTION
Closes #523. Reopened from #524 after the stack base merged via squash (which auto-closed the original PR).

## Summary
- default Z.AI OpenAI-compatible base URL to the general endpoint
- keep Coding Plan endpoint as explicit opt-in
- reject Z.AI Anthropic-compatible proxy URLs for the `zai` provider with a clear validation error
- make Z.AI `/models` refresh use the configured base URL
- document Z.AI endpoint selection in provider docs

## Validation
- `ruff check src/ tests/ conftest.py`
- `pytest tests/test_provider_runtime_integration.py -v`
- `pytest tests/test_agent_provider_service.py -v -k zai`
- `pytest tests/test_agent.py -v -k zai`
- `pytest tests/test_cli_provider.py -v`
- `pytest tests/test_cli_agent_commands.py -v`
- `pytest tests/test_provider_service.py tests/test_provider_service_adapters.py tests/test_agent_provider_service.py -v`