### PR TITLE
fix(db): auto-migrate legacy Z.AI Anthropic base_url

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -815,7 +815,73 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
         )
         await db.commit()
 
+    # Rewrite legacy Anthropic-compatible Z.AI base_url to the OpenAI-compatible
+    # default. Older versions stored https://api.z.ai/api/anthropic[/v1] which
+    # the deepagents runtime now rejects (see #518/#519/#526).
+    cur = await db.execute(
+        "SELECT value FROM settings WHERE key = '_migration_zai_base_url_v1' LIMIT 1"
+    )
+    if not await cur.fetchone():
+        await _migrate_zai_legacy_base_url(db)
+        await db.execute(
+            "INSERT OR IGNORE INTO settings (key, value) VALUES ('_migration_zai_base_url_v1', '1')"
+        )
+        await db.commit()
+
     return fts_available
+
+
+async def _migrate_zai_legacy_base_url(db: aiosqlite.Connection) -> None:
+    """Rewrite legacy Z.AI Anthropic-compatible base_url to the OpenAI-compatible default.
+
+    The deepagents runtime calls Z.AI through ``init_chat_model("openai", base_url=...)``
+    which only works against the ``/api/paas/v4`` family. Existing installs may still
+    have ``https://api.z.ai/api/anthropic`` saved from earlier versions; this rewrites
+    them in-place and clears the stale ``last_validation_error`` so the UI stops
+    showing the old message.
+    """
+    import json
+
+    from src.agent.provider_registry import (
+        ZAI_GENERAL_BASE_URL,
+        is_zai_legacy_anthropic_base_url,
+    )
+
+    cur = await db.execute(
+        "SELECT value FROM settings WHERE key = 'agent_deepagents_providers_v1' LIMIT 1"
+    )
+    row = await cur.fetchone()
+    if not row or not row["value"]:
+        return
+    try:
+        data = json.loads(row["value"])
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(data, list):
+        return
+
+    changed = False
+    for item in data:
+        if not isinstance(item, dict) or item.get("provider") != "zai":
+            continue
+        plain = item.get("plain_fields")
+        if not isinstance(plain, dict):
+            continue
+        current = str(plain.get("base_url", "") or "")
+        if is_zai_legacy_anthropic_base_url(current):
+            plain["base_url"] = ZAI_GENERAL_BASE_URL
+            item["last_validation_error"] = ""
+            changed = True
+
+    if not changed:
+        return
+
+    await db.execute(
+        "UPDATE settings SET value = ? WHERE key = 'agent_deepagents_providers_v1'",
+        (json.dumps(data, ensure_ascii=False),),
+    )
+    await db.commit()
+    logger.info("Migrated legacy Z.AI Anthropic-compatible base_url to %s", ZAI_GENERAL_BASE_URL)
 
 
 async def _migrate_tool_permission_key(db: aiosqlite.Connection, old_key: str, new_key: str) -> None:

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -6,7 +6,7 @@ import struct
 import aiosqlite
 import pytest
 
-from src.database.migrations import _migrate_vec_to_portable
+from src.database.migrations import _migrate_vec_to_portable, _migrate_zai_legacy_base_url
 
 
 @pytest.mark.anyio
@@ -123,5 +123,185 @@ async def test_migrate_vec_skips_empty_vec_table(tmp_path):
         cur = await conn.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
         row = await cur.fetchone()
         assert row["cnt"] == 0
+    finally:
+        await conn.close()
+
+
+_ZAI_PROVIDERS_KEY = "agent_deepagents_providers_v1"
+
+
+def _zai_payload(base_url: str, *, last_validation_error: str = "") -> str:
+    return json.dumps(
+        [
+            {
+                "provider": "zai",
+                "enabled": True,
+                "priority": 0,
+                "selected_model": "glm-5-turbo",
+                "plain_fields": {"base_url": base_url},
+                "secret_fields_enc": {},
+                "last_validation_error": last_validation_error,
+            }
+        ]
+    )
+
+
+async def _open_zai_db(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "zai.db"))
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    await conn.commit()
+    return conn
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+@pytest.mark.parametrize(
+    "legacy_url",
+    ["https://api.z.ai/api/anthropic", "https://api.z.ai/api/anthropic/v1"],
+)
+async def test_migrate_zai_legacy_base_url_rewrites_legacy(tmp_path, legacy_url):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (
+                _ZAI_PROVIDERS_KEY,
+                _zai_payload(
+                    legacy_url,
+                    last_validation_error="Anthropic-compatible proxy ...",
+                ),
+            ),
+        )
+        await conn.commit()
+
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        row = await cur.fetchone()
+        data = json.loads(row["value"])
+        assert data[0]["plain_fields"]["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert data[0]["last_validation_error"] == ""
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_zai_legacy_base_url_leaves_valid_unchanged(tmp_path):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        valid_payload = _zai_payload("https://api.z.ai/api/paas/v4")
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (_ZAI_PROVIDERS_KEY, valid_payload),
+        )
+        await conn.commit()
+
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        row = await cur.fetchone()
+        assert json.loads(row["value"]) == json.loads(valid_payload)
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_zai_legacy_base_url_idempotent(tmp_path):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (_ZAI_PROVIDERS_KEY, _zai_payload("https://api.z.ai/api/anthropic")),
+        )
+        await conn.commit()
+
+        await _migrate_zai_legacy_base_url(conn)
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        row = await cur.fetchone()
+        data = json.loads(row["value"])
+        assert data[0]["plain_fields"]["base_url"] == "https://api.z.ai/api/paas/v4"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_zai_legacy_base_url_handles_missing_setting(tmp_path):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        assert await cur.fetchone() is None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_zai_legacy_base_url_handles_malformed_json(tmp_path):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (_ZAI_PROVIDERS_KEY, "not-json{"),
+        )
+        await conn.commit()
+
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        row = await cur.fetchone()
+        assert row["value"] == "not-json{"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_migrate_zai_legacy_base_url_skips_other_providers(tmp_path):
+    conn = await _open_zai_db(tmp_path)
+    try:
+        payload = json.dumps(
+            [
+                {
+                    "provider": "openai",
+                    "enabled": True,
+                    "priority": 0,
+                    "selected_model": "gpt-4o-mini",
+                    "plain_fields": {"base_url": "https://api.z.ai/api/anthropic"},
+                    "secret_fields_enc": {},
+                    "last_validation_error": "",
+                }
+            ]
+        )
+        await conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (_ZAI_PROVIDERS_KEY, payload),
+        )
+        await conn.commit()
+
+        await _migrate_zai_legacy_base_url(conn)
+
+        cur = await conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (_ZAI_PROVIDERS_KEY,)
+        )
+        row = await cur.fetchone()
+        assert json.loads(row["value"]) == json.loads(payload)
     finally:
         await conn.close()


### PR DESCRIPTION
## Summary
- Adds one-shot data migration `_migrate_zai_legacy_base_url` (gated by `_migration_zai_base_url_v1` marker) that rewrites legacy `https://api.z.ai/api/anthropic[/v1]` to `ZAI_GENERAL_BASE_URL` in the `agent_deepagents_providers_v1` settings JSON and clears the stale `last_validation_error`.
- Restores the agent chat for users upgrading past #518/#519/#526 without requiring them to manually edit the Z.AI Base URL in Settings.

## Test plan
- [x] `pytest tests/test_migrations.py -v` (11 passed)
- [x] `pytest tests/test_provider_runtime_integration.py tests/test_agent_provider_service.py` (56 passed, 1 skipped)
- [x] `ruff check src/database/migrations.py tests/test_migrations.py`
- [ ] Manual: install with legacy URL in DB, run `python -m src.main serve`, verify base_url is rewritten and Agent chat answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)