### PR TITLE
[codex] Add graceful collection shutdown

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -6,20 +6,17 @@ from src.agent.models import CLAUDE_MODELS
 
 ZAI_GENERAL_BASE_URL = "https://api.z.ai/api/paas/v4"
 ZAI_CODING_BASE_URL = "https://api.z.ai/api/coding/paas/v4"
-# Backwards-compatible alias. Used to substitute a default for an empty
-# base_url; that auto-defaulting was removed because the Coding Plan and the
-# pay-per-token PaaS endpoints are not interchangeable. Kept as an alias to
-# avoid breaking external references; equal to ZAI_CODING_BASE_URL because
-# that is what new installs default to.
+# Default to the subscription/Coding Plan endpoint when a user only provides
+# ZAI_API_KEY. The pay-per-token endpoint can still be selected explicitly.
 ZAI_DEFAULT_BASE_URL = ZAI_CODING_BASE_URL
 ZAI_LEGACY_ANTHROPIC_BASE_URLS = {
     "https://api.z.ai/api/anthropic",
     "https://api.z.ai/api/anthropic/v1",
 }
 ZAI_BASE_URL_REQUIRED_HINT = (
-    "Z.AI Base URL is required. Use https://api.z.ai/api/coding/paas/v4 for "
-    "the GLM Coding Plan, or https://api.z.ai/api/paas/v4 for pay-per-token "
-    "PaaS access."
+    "Z.AI Base URL is optional. Empty value defaults to "
+    "https://api.z.ai/api/coding/paas/v4 for the GLM Coding Plan; use "
+    "https://api.z.ai/api/paas/v4 only for pay-per-token PaaS access."
 )
 
 
@@ -31,10 +28,9 @@ def is_zai_legacy_anthropic_base_url(base_url: str = "") -> bool:
 def normalize_zai_base_url(base_url: str = "") -> str:
     """Strip whitespace and trailing slash from a Z.AI base URL.
 
-    Unlike earlier versions this no longer substitutes a default value when the
-    input is empty: callers that need a populated URL must validate first.
+    Empty value means the subscription/Coding Plan endpoint.
     """
-    return (base_url or "").strip().rstrip("/")
+    return (base_url or "").strip().rstrip("/") or ZAI_DEFAULT_BASE_URL
 
 
 @dataclass(frozen=True, slots=True)
@@ -299,7 +295,6 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field(
                 "base_url",
                 "Base URL",
-                required=True,
                 placeholder=(
                     "https://api.z.ai/api/coding/paas/v4 (Coding Plan) or "
                     "https://api.z.ai/api/paas/v4 (pay-per-token PaaS)"

--- a/src/cli/commands/serve.py
+++ b/src/cli/commands/serve.py
@@ -36,7 +36,7 @@ def run(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     try:
-        uvicorn.run(app, host=config.web.host, port=config.web.port)
+        uvicorn.run(app, host=config.web.host, port=config.web.port, timeout_graceful_shutdown=150)
     except KeyboardInterrupt:
         pass
     finally:

--- a/src/cli/commands/server_control.py
+++ b/src/cli/commands/server_control.py
@@ -11,6 +11,10 @@ from src.config import load_config
 def run_stop(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     try:
+        print(
+            "Останавливаю сервер gracefully. Если сейчас идёт сбор канала, "
+            "подожду завершения активной задачи; остальные останутся pending в БД."
+        )
         outcome = stop_server(pid_file_path(config))
     except ProcessControlError as exc:
         print(str(exc))
@@ -23,6 +27,10 @@ def run_stop(args: argparse.Namespace) -> None:
 def run_restart(args: argparse.Namespace) -> None:
     config = load_config(args.config)
     try:
+        print(
+            "Перезапускаю сервер gracefully. Если сейчас идёт сбор канала, "
+            "подожду завершения активной задачи; остальные останутся pending в БД."
+        )
         outcome = stop_server(pid_file_path(config))
     except ProcessControlError as exc:
         print(str(exc))

--- a/src/cli/process_control.py
+++ b/src/cli/process_control.py
@@ -139,8 +139,8 @@ def unregister_current_process(path: Path) -> None:
 
 def stop_server(
     path: Path,
-    timeout_sec: float = 10.0,
-    kill_timeout_sec: float = 1.0,
+    timeout_sec: float = 150.0,
+    kill_timeout_sec: float = 5.0,
 ) -> StopOutcome:
     pid = read_pid(path)
     if pid is None:

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -21,6 +21,9 @@ class CollectionQueue:
     # How often the worker re-checks the DB for new PENDING channel-collect tasks
     # written by the web container in split / embedded-worker setups (#491 follow-up).
     DB_PULL_INTERVAL_SEC = 3.0
+    GRACEFUL_SHUTDOWN_TIMEOUT_SEC = 120.0
+    FORCE_CANCEL_TIMEOUT_SEC = 10.0
+    SHUTDOWN_REQUEUE_NOTE = "Остановка сервиса во время сбора; задача будет продолжена после запуска."
 
     def __init__(self, collector: Collector, channels: ChannelBundle | Database):
         self._collector = collector
@@ -38,6 +41,7 @@ class CollectionQueue:
         self._known_task_ids: set[int] = set()
         self._pull_task: asyncio.Task | None = None
         self._pull_stop = asyncio.Event()
+        self._shutdown_requested = False
 
     async def enqueue(self, channel: Channel, force: bool = False, full: bool = True) -> int | None:
         """Enqueue a channel for collection, atomically skipping duplicates.
@@ -57,6 +61,12 @@ class CollectionQueue:
         )
         if task_id is None:
             return None
+        if self._shutdown_requested:
+            logger.info(
+                "Service is shutting down; collection task %d stays PENDING in DB",
+                task_id,
+            )
+            return task_id
         try:
             self._queue.put_nowait((task_id, channel, force, full))
             self._known_task_ids.add(task_id)
@@ -119,6 +129,9 @@ class CollectionQueue:
             remaining = max(0.0, run_after.timestamp() - time.time())
             if remaining > 0:
                 await asyncio.sleep(remaining)
+            if self._shutdown_requested:
+                self._known_task_ids.discard(task_id)
+                return
             try:
                 self._queue.put_nowait((task_id, channel, force, full))
                 self._known_task_ids.add(task_id)
@@ -141,6 +154,8 @@ class CollectionQueue:
 
     async def _run_worker(self) -> None:
         while True:
+            if self._shutdown_requested:
+                break
             try:
                 task_id, channel, force, full = await asyncio.wait_for(
                     self._queue.get(), timeout=1.0
@@ -205,6 +220,11 @@ class CollectionQueue:
                 self._queue.task_done()
                 continue
 
+            if self._shutdown_requested:
+                self._known_task_ids.discard(task_id)
+                self._queue.task_done()
+                continue
+
             try:
                 self._current_task_id = task_id
                 await self._channels.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
@@ -216,11 +236,15 @@ class CollectionQueue:
                     channel, full=full, progress_callback=_progress, force=force
                 )
                 if self._collector.is_cancelled:
-                    await self._channels.cancel_collection_task(
-                        task_id,
-                        note="Задача отменена во время сбора.",
-                    )
-                    logger.info("Task %d cancelled during collection", task_id)
+                    if self._shutdown_requested:
+                        await self._reset_task_to_pending_after_shutdown(task_id)
+                        logger.info("Task %d requeued after service shutdown interrupted collection", task_id)
+                    else:
+                        await self._channels.cancel_collection_task(
+                            task_id,
+                            note="Задача отменена во время сбора.",
+                        )
+                        logger.info("Task %d cancelled during collection", task_id)
                 else:
                     note = None
                     if count == 0 and not force and channel.id is not None:
@@ -300,6 +324,17 @@ class CollectionQueue:
                 self._known_task_ids.discard(task_id)
                 self._queue.task_done()
 
+    async def _reset_task_to_pending_after_shutdown(self, task_id: int) -> None:
+        reset = getattr(self._channels, "reset_collection_task_to_pending", None)
+        if callable(reset):
+            await reset(task_id, note=self.SHUTDOWN_REQUEUE_NOTE)
+            return
+        await self._channels.update_collection_task(
+            task_id,
+            CollectionTaskStatus.PENDING,
+            note=self.SHUTDOWN_REQUEUE_NOTE,
+        )
+
     async def _try_reconnect_and_requeue(
         self, task_id: int, channel: Channel, full: bool, force: bool, exc: Exception
     ) -> bool:
@@ -343,6 +378,8 @@ class CollectionQueue:
         pending = await self._channels.get_pending_channel_tasks()
         count = 0
         for task in pending:
+            if self._shutdown_requested:
+                break
             if task.id is None or task.id in self._known_task_ids:
                 continue
             if task.channel_id is None:
@@ -439,17 +476,18 @@ class CollectionQueue:
             except asyncio.TimeoutError:
                 continue
 
-    async def shutdown(self) -> None:
-        await self.stop_db_pull()
-        if self._worker and not self._worker.done():
-            self._worker.cancel()
+    def _drain_memory_queue(self) -> int:
+        drained = 0
+        while True:
             try:
-                await self._worker
-            except asyncio.CancelledError:
-                pass
-        # Snapshot tasks before cancelling — the done_callback (discard)
-        # removes them from the set as soon as each resolves, so iterating
-        # the live set in a second loop would see an empty collection.
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            self._queue.task_done()
+            drained += 1
+        return drained
+
+    async def _cancel_delayed_requeues(self) -> None:
         pending = list(self._delayed_requeues)
         for task in pending:
             task.cancel()
@@ -459,4 +497,63 @@ class CollectionQueue:
             except asyncio.CancelledError:
                 pass
         self._delayed_requeues.clear()
+
+    async def shutdown(self, *, grace_timeout: float | None = None) -> None:
+        self._shutdown_requested = True
+        await self.stop_db_pull()
+        await self._cancel_delayed_requeues()
+
+        if self._worker and not self._worker.done():
+            timeout = self.GRACEFUL_SHUTDOWN_TIMEOUT_SEC if grace_timeout is None else grace_timeout
+            active_task_id = self._current_task_id
+            if active_task_id is not None:
+                logger.warning(
+                    "Останавливаем сервис: ждём завершения активной задачи сбора #%d "
+                    "(до %.0f сек). Новые задачи останутся pending в БД.",
+                    active_task_id,
+                    timeout,
+                )
+            try:
+                await asyncio.wait_for(asyncio.shield(self._worker), timeout=timeout)
+            except asyncio.TimeoutError:
+                active_task_id = self._current_task_id or active_task_id
+                if active_task_id is not None:
+                    logger.warning(
+                        "Активная задача сбора #%d не завершилась за %.0f сек; "
+                        "останавливаем сбор и возвращаем задачу в pending.",
+                        active_task_id,
+                        timeout,
+                    )
+                await self._collector.cancel()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._worker),
+                        timeout=self.FORCE_CANCEL_TIMEOUT_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    if active_task_id is not None:
+                        await self._reset_task_to_pending_after_shutdown(active_task_id)
+                    self._worker.cancel()
+                    try:
+                        await self._worker
+                    except asyncio.CancelledError:
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Collection queue worker failed during shutdown")
+
+        drained = self._drain_memory_queue()
+        if drained:
+            logger.info(
+                "Left %d queued collection task(s) pending in DB for the next worker start",
+                drained,
+            )
+        if self._current_task_id is not None:
+            try:
+                await self._reset_task_to_pending_after_shutdown(self._current_task_id)
+            except Exception:
+                logger.exception("Failed to reset active collection task during shutdown")
+            self._current_task_id = None
         self._retried_tasks.clear()
+        self._known_task_ids.clear()

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -262,6 +262,14 @@ class ChannelBundle:
             messages_collected=messages_collected,
         )
 
+    async def reset_collection_task_to_pending(
+        self,
+        task_id: int,
+        *,
+        note: str | None = None,
+    ) -> None:
+        await self.tasks.reset_collection_task_to_pending(task_id, note=note)
+
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
         await self.tasks.update_collection_task_progress(task_id, messages_collected)
 

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -668,6 +668,15 @@ class Database:
             messages_collected=messages_collected,
         )
 
+    async def reset_collection_task_to_pending(
+        self,
+        task_id: int,
+        *,
+        note: str | None = None,
+    ) -> None:
+        self._require()
+        await self._tasks.reset_collection_task_to_pending(task_id, note=note)
+
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
         self._require()
         return await self._tasks.get_collection_task(task_id)
@@ -742,6 +751,10 @@ class Database:
     async def fail_running_collection_tasks_on_startup(self) -> int:
         self._require()
         return await self._tasks.fail_running_collection_tasks_on_startup()
+
+    async def reset_orphaned_running_tasks(self) -> int:
+        self._require()
+        return await self._tasks.reset_orphaned_running_tasks()
 
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
         self._require()

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -306,6 +306,29 @@ class CollectionTasksRepository:
         )
         await self._db.commit()
 
+    async def reset_collection_task_to_pending(
+        self,
+        task_id: int,
+        *,
+        note: str | None = None,
+    ) -> None:
+        sets = [
+            "status = ?",
+            "started_at = NULL",
+            "completed_at = NULL",
+            "error = NULL",
+        ]
+        params: list[Any] = [CollectionTaskStatus.PENDING.value]
+        if note is not None:
+            sets.append("note = ?")
+            params.append(note)
+        params.append(task_id)
+        await self._db.execute(
+            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
+            tuple(params),
+        )
+        await self._db.commit()
+
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
         cur = await self._db.execute("SELECT * FROM collection_tasks WHERE id = ?", (task_id,))
         row = await cur.fetchone()
@@ -485,7 +508,7 @@ class CollectionTasksRepository:
         """
         cur = await self._db.execute(
             "UPDATE collection_tasks "
-            "SET status = ?, started_at = NULL "
+            "SET status = ?, started_at = NULL, completed_at = NULL, error = NULL "
             "WHERE task_type = ? AND status = ?",
             (
                 CollectionTaskStatus.PENDING.value,

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -17,7 +17,6 @@ import aiohttp
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
     PROVIDER_SPECS,
-    ZAI_BASE_URL_REQUIRED_HINT,
     ZAI_CODING_BASE_URL,
     ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
@@ -435,8 +434,6 @@ class AgentProviderService:
             return f"Unknown provider: {cfg.provider}"
         if cfg.provider == "zai":
             base_url = cfg.plain_fields.get("base_url", "").strip()
-            if not base_url:
-                return ZAI_BASE_URL_REQUIRED_HINT
             if is_zai_legacy_anthropic_base_url(base_url):
                 return (
                     "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
@@ -822,8 +819,6 @@ class AgentProviderService:
                 f"/models. Use {ZAI_GENERAL_BASE_URL} or {ZAI_CODING_BASE_URL}."
             )
         resolved_base_url = normalize_zai_base_url(base_url)
-        if not resolved_base_url:
-            raise RuntimeError(ZAI_BASE_URL_REQUIRED_HINT)
         headers = {"Authorization": f"Bearer {api_key}"}
         payload = await self._fetch_json(
             f"{resolved_base_url.rstrip('/')}/models", headers=headers

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -6,6 +6,8 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import aiohttp
 
+from src.agent.provider_registry import normalize_zai_base_url
+
 logger = logging.getLogger(__name__)
 
 # Base URLs for OpenAI-compatible providers (shared with agent_provider_service.py).
@@ -69,26 +71,17 @@ class AgentProviderService:
         if openai_key:
             self.register_provider("openai", self._make_openai_provider(openai_key))
 
-        # optional Z.AI provider — needs an explicit ZAI_BASE_URL because the
-        # subscription (Coding Plan, https://api.z.ai/api/coding/paas/v4) and
-        # pay-per-token PaaS (https://api.z.ai/api/paas/v4) live on different
-        # endpoints and we cannot guess which one the user has.
+        # optional Z.AI provider. ZAI_BASE_URL is optional; empty value means
+        # the subscription/Coding Plan endpoint.
         zai_key = os.environ.get("ZAI_API_KEY")
-        zai_base = (os.environ.get("ZAI_BASE_URL") or "").strip().rstrip("/")
-        if zai_key and zai_base and "zai" not in self._registry:
+        zai_base = normalize_zai_base_url(os.environ.get("ZAI_BASE_URL") or "")
+        if zai_key and "zai" not in self._registry:
             try:
                 self.register_provider(
                     "zai", self._make_openai_compat_provider(zai_base, zai_key)
                 )
             except Exception:
                 logger.debug("Failed to register zai adapter", exc_info=True)
-        elif zai_key and not zai_base:
-            logger.info(
-                "ZAI_API_KEY set but ZAI_BASE_URL is empty — skipping env-based "
-                "registration. Configure the Z.AI provider via Settings or set "
-                "ZAI_BASE_URL to https://api.z.ai/api/coding/paas/v4 (Coding "
-                "Plan) or https://api.z.ai/api/paas/v4 (pay-per-token PaaS)."
-            )
 
         # optional Context7 provider (user may supply CONTEXT7_API_KEY)
         context7_key = os.environ.get("CONTEXT7_API_KEY") or os.environ.get("CTX7_API_KEY")
@@ -286,9 +279,6 @@ class AgentProviderService:
                 logger.debug("Skipping db provider %s: Anthropic-compatible URL is not OpenAI-compatible", provider)
                 return None
             base_url = normalize_zai_base_url(raw_base_url)
-            if not base_url:
-                logger.debug("Skipping db provider %s: base_url is empty", provider)
-                return None
             return self._make_openai_compat_provider(base_url, api_key)
 
         if provider == "google_genai":

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -694,7 +694,15 @@ class Collector:
                             )
                             # finally releases current phone; next iter picks up found
                             continue
-                        raise  # no phone has access — show error in UI
+                        logger.warning(
+                            "Channel %d (%s): no connected account can resolve entity; "
+                            "deactivating and skipping collection",
+                            channel_id,
+                            channel.title or channel.username or "no title",
+                        )
+                        if channel.id:
+                            await self._db.set_channel_active(channel.id, False)
+                        return total_collected
 
                 # Превентивная фильтрация по subscriber_ratio до загрузки
                 # сообщений.

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -49,6 +49,8 @@ from src.web.timing import TimingBuffer
 logger = logging.getLogger(__name__)
 _is_dev = os.environ.get("ENV", "PROD").upper() == "DEV"
 _POOL_INIT_TIMEOUT = 20
+_SHUTDOWN_DEFAULT_TIMEOUT = 15.0
+_SHUTDOWN_COLLECTION_QUEUE_TIMEOUT = 140.0
 
 
 async def load_telegram_credentials(db: Database, config: AppConfig) -> tuple[int, str]:
@@ -291,9 +293,6 @@ async def start_container(container: AppContainer) -> None:
     if _is_dev:
         t1 = time.monotonic()
 
-    recovered = await container.channel_bundle.fail_running_collection_tasks_on_startup()
-    if recovered:
-        logger.warning("Marked %d interrupted collection tasks as failed on startup", recovered)
     photo_recovered = await container.photo_task_service.recover_running()
     if photo_recovered:
         logger.warning("Requeued %d interrupted photo tasks on startup", photo_recovered)
@@ -386,29 +385,33 @@ async def _cancel_bg_tasks(tasks: set[asyncio.Task]) -> None:
 
 async def stop_container(container: AppContainer) -> None:
     container.shutting_down = True
-    shutdown_coroutines = []
-    if container.unified_dispatcher is not None:
-        shutdown_coroutines.append(("unified_dispatcher", container.unified_dispatcher.stop()))
-    if container.telegram_command_dispatcher is not None:
-        shutdown_coroutines.append(("telegram_command_dispatcher", container.telegram_command_dispatcher.stop()))
-    if container.collection_queue is not None:
-        shutdown_coroutines.append(("collection_queue", container.collection_queue.shutdown()))
-    if container.agent_manager is not None:
-        shutdown_coroutines.append(("agent_manager", container.agent_manager.close_all()))
-    shutdown_coroutines.extend(
-        [
-            ("scheduler", container.scheduler.stop()),
-            ("collector", container.collector.cancel()),
-            ("bg_tasks", _cancel_bg_tasks(container.bg_tasks)),
-            ("pool", container.pool.disconnect_all()),
-            ("auth", container.auth.cleanup()),
-            ("db", container.db.close()),
-        ]
-    )
-    for name, coro in shutdown_coroutines:
+
+    async def _stop_step(name: str, coro, *, timeout: float = _SHUTDOWN_DEFAULT_TIMEOUT) -> None:
         try:
-            await asyncio.wait_for(coro, timeout=5.0)
+            await asyncio.wait_for(coro, timeout=timeout)
         except asyncio.TimeoutError:
-            logger.warning("Shutdown of %s timed out", name)
+            logger.warning("Shutdown of %s timed out after %.0fs", name, timeout)
         except Exception:
             logger.warning("Error shutting down %s", name, exc_info=True)
+
+    # Stop producers first so no new collection work is created while the
+    # queue is draining the active channel collection.
+    await _stop_step("scheduler", container.scheduler.stop())
+    if container.unified_dispatcher is not None:
+        await _stop_step("unified_dispatcher", container.unified_dispatcher.stop())
+    if container.telegram_command_dispatcher is not None:
+        await _stop_step("telegram_command_dispatcher", container.telegram_command_dispatcher.stop())
+    if container.collection_queue is not None:
+        await _stop_step(
+            "collection_queue",
+            container.collection_queue.shutdown(),
+            timeout=_SHUTDOWN_COLLECTION_QUEUE_TIMEOUT,
+        )
+    if container.agent_manager is not None:
+        await _stop_step("agent_manager", container.agent_manager.close_all())
+
+    await _stop_step("collector", container.collector.cancel())
+    await _stop_step("bg_tasks", _cancel_bg_tasks(container.bg_tasks))
+    await _stop_step("pool", container.pool.disconnect_all())
+    await _stop_step("auth", container.auth.cleanup())
+    await _stop_step("db", container.db.close())

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TypeVar
 
 from fastapi import Request
@@ -49,6 +50,17 @@ from src.web.timing import TimingBuffer
 
 T = TypeVar("T")
 _MISSING = object()
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRuntimeState:
+    state: str
+    manager: AgentManager | None = None
+    error: str | None = None
+
+    @property
+    def live(self) -> bool:
+        return self.state == "live" and self.manager is not None
 
 
 def _request_cached(request: Request, key: str, factory: Callable[[], T]) -> T:
@@ -261,19 +273,39 @@ def is_shutting_down(request: Request) -> bool:
     return get_container(request).shutting_down
 
 
-def get_agent_manager(request: Request) -> AgentManager | None:
+def get_agent_runtime_state(request: Request) -> AgentRuntimeState:
     manager = getattr(request.app.state, "agent_manager", None)
     if manager is not None:
-        return manager
+        return AgentRuntimeState("live", manager=manager)
+
     embedded_worker = getattr(request.app.state, "embedded_worker", None)
     embedded_container = getattr(embedded_worker, "container", None)
     if embedded_container is not None:
-        ready_event = getattr(embedded_worker, "_ready_event", None)
-        if ready_event is not None and ready_event.is_set():
+        agent_ready = getattr(embedded_worker, "agent_ready", None)
+        if agent_ready is None:
+            ready_event = getattr(embedded_worker, "_ready_event", None)
+            agent_ready = bool(ready_event is not None and ready_event.is_set())
+        if bool(agent_ready):
             manager = getattr(embedded_container, "agent_manager", None)
             if manager is not None:
-                return manager
-    return None
+                return AgentRuntimeState("live", manager=manager)
+
+    startup_failed = bool(getattr(embedded_worker, "startup_failed", False))
+    if startup_failed:
+        return AgentRuntimeState(
+            "failed",
+            error=getattr(embedded_worker, "startup_error", None)
+            or "Embedded worker failed to start. Check server logs for details.",
+        )
+
+    if embedded_worker is not None or getattr(request.app.state, "embed_worker", False):
+        return AgentRuntimeState("starting")
+
+    return AgentRuntimeState("split_web")
+
+
+def get_agent_manager(request: Request) -> AgentManager | None:
+    return get_agent_runtime_state(request).manager
 
 
 def get_llm_provider_service(request: Request) -> AgentProviderService:

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -59,10 +59,24 @@ class EmbeddedWorker:
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
         self._ready_event = asyncio.Event()
+        self._agent_ready_event = asyncio.Event()
+        self._startup_error: str | None = None
 
     @property
     def container(self) -> AppContainer | None:
         return self._container
+
+    @property
+    def agent_ready(self) -> bool:
+        return self._agent_ready_event.is_set()
+
+    @property
+    def startup_failed(self) -> bool:
+        return self._startup_error is not None
+
+    @property
+    def startup_error(self) -> str | None:
+        return self._startup_error
 
     async def wait_ready(self, timeout: float | None = None) -> bool:
         """Wait until the worker has published its first heartbeat.
@@ -81,7 +95,7 @@ class EmbeddedWorker:
             raise RuntimeError("EmbeddedWorker already started")
         self._task = asyncio.create_task(self._run(), name="embedded-worker")
 
-    async def stop(self, timeout: float = 10.0) -> None:
+    async def stop(self, timeout: float = 150.0) -> None:
         if self._task is None:
             return
         self._stop_event.set()
@@ -103,7 +117,9 @@ class EmbeddedWorker:
                 self._config, log_buffer=LogBuffer(maxlen=500)
             )
             await start_container(self._container)
+            self._agent_ready_event.set()
         except Exception:
+            self._startup_error = "Embedded worker failed to start. Check server logs for details."
             logger.exception(
                 "[embedded-worker] failed to start; UI will show worker_down banner"
             )
@@ -137,4 +153,5 @@ class EmbeddedWorker:
             except Exception:
                 logger.exception("[embedded-worker] stop_container raised")
             self._container = None
+            self._agent_ready_event.clear()
             logger.info("[embedded-worker] stopped")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -20,12 +20,45 @@ class ChatRequest(BaseModel):
     model: str | None = None
 
 
+def _agent_unavailable_copy(runtime_state: deps.AgentRuntimeState) -> tuple[str, str]:
+    if runtime_state.state == "starting":
+        return (
+            "Агент запускается.",
+            "Embedded worker поднимает live runtime. Обновите страницу через несколько секунд.",
+        )
+    if runtime_state.state == "failed":
+        return (
+            "Агент не запустился.",
+            runtime_state.error or "Embedded worker failed to start. Check server logs for details.",
+        )
+    return (
+        "Чат недоступен в web-процессе.",
+        "Agent chat is only available in the worker process. "
+        "Run `python -m src.main worker` alongside the web server to enable it.",
+    )
+
+
+def _agent_unavailable_response(runtime_state: deps.AgentRuntimeState) -> JSONResponse:
+    _, detail = _agent_unavailable_copy(runtime_state)
+    headers = {"Retry-After": "3"} if runtime_state.state == "starting" else None
+    return JSONResponse(
+        {
+            "detail": detail,
+            "runtime_state": runtime_state.state,
+        },
+        status_code=503,
+        headers=headers,
+    )
+
+
 @router.get("", response_class=HTMLResponse)
 async def agent_page(request: Request, thread_id: int | None = None):
     db = deps.get_db(request)
-    agent_manager = deps.get_agent_manager(request)
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
     threads = await db.get_agent_threads()
     agent_status = None
+    agent_disabled_title = None
     agent_disabled_reason = None
     if agent_manager is not None:
         runtime_status = await agent_manager.get_runtime_status()
@@ -41,10 +74,7 @@ async def agent_page(request: Request, thread_id: int | None = None):
             "error": runtime_status.error,
         }
     else:
-        agent_disabled_reason = (
-            "Agent chat is only available in the worker process. "
-            "Run `python -m src.main worker` alongside the web server to enable it."
-        )
+        agent_disabled_title, agent_disabled_reason = _agent_unavailable_copy(agent_runtime_state)
 
     messages = []
     active_thread = None
@@ -72,6 +102,8 @@ async def agent_page(request: Request, thread_id: int | None = None):
             "active_thread": active_thread,
             "messages": messages,
             "agent_status": agent_status,
+            "agent_runtime_state": agent_runtime_state.state,
+            "agent_disabled_title": agent_disabled_title,
             "agent_disabled_reason": agent_disabled_reason,
             "model_options": CLAUDE_MODELS,
         },
@@ -198,15 +230,10 @@ async def resolve_permission(request: Request, thread_id: int, request_id: str):
     choice = body.get("choice", "deny")
     if choice not in ("once", "session", "deny"):
         raise HTTPException(status_code=400, detail="Invalid choice")
-    agent_manager = deps.get_agent_manager(request)
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
     if agent_manager is None:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Agent chat is only available in the worker process. "
-                "Run `python -m src.main worker` alongside the web server."
-            ),
-        )
+        return _agent_unavailable_response(agent_runtime_state)
     ok = agent_manager.permission_gate.resolve(request_id, choice)
     return JSONResponse({"ok": ok})
 
@@ -233,15 +260,10 @@ async def chat(request: Request, thread_id: int):
     model = raw_model if raw_model in CLAUDE_MODEL_IDS else None
 
     db = deps.get_db(request)
-    agent_manager = deps.get_agent_manager(request)
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
     if agent_manager is None:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Agent chat is only available in the worker process. "
-                "Run `python -m src.main worker` alongside the web server."
-            ),
-        )
+        return _agent_unavailable_response(agent_runtime_state)
     runtime_status = await agent_manager.get_runtime_status()
     if runtime_status.selected_backend is None:
         raise HTTPException(

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -517,7 +517,7 @@
 
 {% if agent_disabled_reason %}
 <div class="alert alert-warning" role="alert">
-    <strong>Чат недоступен в web-процессе.</strong> {{ agent_disabled_reason }}
+    <strong>{{ agent_disabled_title }}</strong> {{ agent_disabled_reason }}
 </div>
 {% endif %}
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -460,6 +460,26 @@ async def test_get_pending_channel_tasks(collection_tasks_repo):
     assert tasks[0].id == id2
 
 
+async def test_reset_collection_task_to_pending(collection_tasks_repo):
+    task_id = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.update_collection_task(
+        task_id,
+        CollectionTaskStatus.FAILED,
+        error="interrupted",
+        note="old note",
+    )
+
+    await collection_tasks_repo.reset_collection_task_to_pending(task_id, note="shutdown")
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.status == CollectionTaskStatus.PENDING
+    assert task.started_at is None
+    assert task.completed_at is None
+    assert task.error is None
+    assert task.note == "shutdown"
+
+
 # fail_running_collection_tasks_on_startup tests
 
 

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -174,6 +174,72 @@ async def test_agent_chat_in_embedded_worker_mode_uses_worker_agent_manager(web_
 
 
 @pytest.mark.anyio
+async def test_agent_page_with_old_thread_during_embedded_worker_startup_is_retryable(tmp_path):
+    async with _web_mode_client(tmp_path) as (client, container):
+        thread_id = await container.db.create_agent_thread("Old chat")
+        await container.db.save_agent_message(thread_id, "user", "previous message")
+        client._transport.app.state.embedded_worker = SimpleNamespace(
+            agent_ready=False,
+            startup_failed=False,
+            container=SimpleNamespace(agent_manager=MagicMock()),
+        )
+
+        resp = await client.get(f"/agent?thread_id={thread_id}", follow_redirects=True)
+
+        assert resp.status_code == 200
+        assert "Old chat" in resp.text
+        assert "previous message" in resp.text
+        assert "Агент запускается." in resp.text
+        assert "Чат недоступен в web-процессе" not in resp.text
+        assert "Agent chat is only available in the worker process" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_agent_chat_during_embedded_worker_startup_returns_retryable_503(tmp_path):
+    async with _web_mode_client(tmp_path) as (client, container):
+        thread_id = await container.db.create_agent_thread("Old chat")
+        client._transport.app.state.embedded_worker = SimpleNamespace(
+            agent_ready=False,
+            startup_failed=False,
+            container=SimpleNamespace(agent_manager=MagicMock()),
+        )
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            json={"message": "hi"},
+        )
+
+        assert resp.status_code == 503
+        assert resp.headers["retry-after"] == "3"
+        body = resp.json()
+        assert body["runtime_state"] == "starting"
+        assert "worker process" not in body["detail"]
+        assert await container.db.get_agent_messages(thread_id) == []
+
+
+@pytest.mark.anyio
+async def test_agent_permission_during_embedded_worker_startup_returns_retryable_503(tmp_path):
+    async with _web_mode_client(tmp_path) as (client, container):
+        thread_id = await container.db.create_agent_thread("Old chat")
+        client._transport.app.state.embedded_worker = SimpleNamespace(
+            agent_ready=False,
+            startup_failed=False,
+            container=SimpleNamespace(agent_manager=MagicMock()),
+        )
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/permission/abc-123",
+            json={"choice": "once"},
+        )
+
+        assert resp.status_code == 503
+        assert resp.headers["retry-after"] == "3"
+        body = resp.json()
+        assert body["runtime_state"] == "starting"
+        assert "worker process" not in body["detail"]
+
+
+@pytest.mark.anyio
 async def test_agent_permission_in_web_mode_returns_worker_only_error(tmp_path):
     """POST /agent/threads/{id}/permission/{req_id} in web returns the same 503 contract."""
     async with _web_mode_client(tmp_path) as (client, container):

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -921,8 +921,8 @@ async def test_fetch_live_models_zai_uses_bearer_auth(db, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_fetch_live_models_zai_requires_explicit_base_url(db):
-    """Empty base_url is rejected before hitting the network."""
+async def test_fetch_live_models_zai_defaults_empty_base_url(db, monkeypatch):
+    """Empty base_url uses the subscription/Coding Plan endpoint."""
     config = AppConfig()
     config.security.session_encryption_key = "provider-secret"
     service = AgentProviderService(db, config)
@@ -937,8 +937,20 @@ async def test_fetch_live_models_zai_requires_explicit_base_url(db):
 
     spec = provider_spec("zai")
     assert spec is not None
-    with pytest.raises(RuntimeError, match="Base URL is required"):
-        await service._fetch_live_models(spec, cfg)
+    captured: dict[str, object] = {}
+
+    async def _fake_fetch_json(url, headers=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        return {"data": [{"id": "glm-5-turbo"}]}
+
+    monkeypatch.setattr(service, "_fetch_json", _fake_fetch_json)
+
+    models = await service._fetch_live_models(spec, cfg)
+
+    assert models == ["glm-5-turbo"]
+    assert captured["url"] == f"{ZAI_CODING_BASE_URL}/models"
+    assert captured["headers"] == {"Authorization": "Bearer zai-key"}
 
 
 @pytest.mark.anyio
@@ -1276,9 +1288,8 @@ def test_canonical_endpoint_fingerprint_for_zai_default_and_coding_urls(db):
         plain_fields={"base_url": ZAI_CODING_BASE_URL},
     )
 
-    # Empty base_url no longer auto-fills a default; the canonical fingerprint
-    # treats it as unknown/custom (None).
-    assert service.canonical_endpoint_fingerprint(empty_cfg) is None
+    # Empty base_url means the subscription/Coding Plan endpoint.
+    assert service.canonical_endpoint_fingerprint(empty_cfg) == ZAI_CODING_BASE_URL
     assert service.canonical_endpoint_fingerprint(general_cfg) == ZAI_GENERAL_BASE_URL
     assert service.canonical_endpoint_fingerprint(coding_cfg) == ZAI_CODING_BASE_URL
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -108,6 +108,23 @@ async def test_start_container_calls_load_settings(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_start_container_does_not_fail_running_channel_tasks(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    container = _make_container(db)
+    scheduler_mock = AsyncMock()
+    scheduler_mock.load_settings = AsyncMock()
+    container.scheduler = scheduler_mock
+
+    try:
+        await start_container(container)
+        container.channel_bundle.fail_running_collection_tasks_on_startup.assert_not_called()
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
 async def test_start_container_web_mode_skips_telegram_runtime(tmp_path):
     """Web runtime should not initialize Telegram pool or worker dispatchers."""
     db = Database(str(tmp_path / "test.db"))

--- a/tests/test_cli_serve_commands.py
+++ b/tests/test_cli_serve_commands.py
@@ -100,7 +100,9 @@ def test_stop_success(capsys):
          patch("src.cli.commands.server_control.stop_server", return_value=outcome), \
          patch("src.cli.commands.server_control.pid_file_path", return_value="/tmp/test.pid"):
         run_stop(_args())
-    assert "stopped" in capsys.readouterr().out.lower()
+    out = capsys.readouterr().out
+    assert "подожду завершения активной задачи" in out
+    assert "stopped" in out.lower()
 
 
 def test_stop_process_control_error():
@@ -142,4 +144,6 @@ def test_restart_success(capsys):
          patch("src.cli.commands.server_control.pid_file_path", return_value="/tmp/test.pid"), \
          patch("src.cli.commands.serve.run") as mock_serve:
         run_restart(_args())
+    out = capsys.readouterr().out
+    assert "подожду завершения активной задачи" in out
     mock_serve.assert_called_once()

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -8,6 +8,7 @@ ignored until the next worker restart.
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 
 import pytest
@@ -28,6 +29,24 @@ class _FakeCollector:
 
     async def cancel(self):
         return None
+
+
+class _BlockingCollector:
+    def __init__(self):
+        self.calls: list[int] = []
+        self.started = asyncio.Event()
+        self.finish = asyncio.Event()
+        self.is_cancelled = False
+
+    async def collect_single_channel(self, channel, *, full=False, progress_callback=None, force=False):
+        self.calls.append(channel.channel_id)
+        self.started.set()
+        await self.finish.wait()
+        return 7
+
+    async def cancel(self):
+        self.is_cancelled = True
+        self.finish.set()
 
 
 async def _seed_channel(db: Database, channel_id: int = -1001) -> None:
@@ -212,6 +231,69 @@ async def test_clear_pending_tasks_clears_known_task_ids(tmp_path):
 
         assert deleted == 1
         assert queue._known_task_ids == set()
+    finally:
+        await queue.shutdown()
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_shutdown_waits_for_active_collection_and_leaves_queued_pending(tmp_path, caplog):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db, -1001)
+        await _seed_channel(db, -1002)
+        channels = await db.get_channels(active_only=True)
+        by_id = {channel.channel_id: channel for channel in channels}
+
+        collector = _BlockingCollector()
+        queue = CollectionQueue(collector, db)
+        first_id = await queue.enqueue(by_id[-1001])
+        second_id = await queue.enqueue(by_id[-1002])
+        await asyncio.wait_for(collector.started.wait(), timeout=1.0)
+
+        caplog.set_level(logging.WARNING, logger="src.collection_queue")
+        shutdown_task = asyncio.create_task(queue.shutdown(grace_timeout=2.0))
+        await asyncio.sleep(0.05)
+        assert not shutdown_task.done()
+
+        collector.finish.set()
+        await asyncio.wait_for(shutdown_task, timeout=2.0)
+
+        first = await db.get_collection_task(first_id)
+        second = await db.get_collection_task(second_id)
+        assert first.status == "completed"
+        assert first.messages_collected == 7
+        assert second.status == "pending"
+        assert collector.calls == [-1001]
+        assert "ждём завершения активной задачи сбора" in caplog.text
+        assert "Новые задачи останутся pending в БД" in caplog.text
+    finally:
+        await queue.shutdown()
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_shutdown_timeout_requeues_active_collection_task(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db, -1001)
+        channel = (await db.get_channels(active_only=True))[0]
+
+        collector = _BlockingCollector()
+        queue = CollectionQueue(collector, db)
+        task_id = await queue.enqueue(channel)
+        await asyncio.wait_for(collector.started.wait(), timeout=1.0)
+
+        await queue.shutdown(grace_timeout=0.01)
+
+        task = await db.get_collection_task(task_id)
+        assert task.status == "pending"
+        assert task.started_at is None
+        assert task.error is None
+        assert "Остановка сервиса" in (task.note or "")
+        assert collector.is_cancelled is True
     finally:
         await queue.shutdown()
         await db.close()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -480,6 +480,29 @@ async def test_collect_private_group_discovers_access_phone(db):
 
 
 @pytest.mark.anyio
+async def test_collect_private_group_without_resolvable_entity_deactivates_without_error(db):
+    ch = Channel(channel_id=1877929309, title="Private Group")
+    await db.add_channel(ch)
+
+    mock_client = AsyncMock()
+    mock_client.get_dialogs = AsyncMock(return_value=[])
+    mock_client.get_entity = AsyncMock(side_effect=ValueError("Could not find the input entity"))
+
+    pool = make_mock_pool(
+        clients={"+7000": object()},
+        get_available_client=AsyncMock(return_value=(mock_client, "+7000")),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig())
+    stats = await collector.collect_all_channels()
+
+    assert stats["errors"] == 0
+    channel = await db.get_channel_by_channel_id(1877929309)
+    assert channel is not None
+    assert channel.is_active is False
+
+
+@pytest.mark.anyio
 async def test_collect_all_dialogs_timeout(db):
     """Hanging get_dialogs() must not block collection (30s timeout)."""
     ch = Channel(channel_id=123, title="Test", username="test")

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -908,15 +908,15 @@ def test_build_adapter_for_config_zai():
     assert adapter is not None
 
 
-def test_build_adapter_for_config_zai_skips_when_base_url_empty():
-    """Without base_url the zai adapter is skipped — required field, no auto-default."""
+def test_build_adapter_for_config_zai_defaults_when_base_url_empty():
+    """Without base_url the zai adapter uses the subscription endpoint."""
     svc = AgentProviderService()
     cfg = MagicMock()
     cfg.provider = "zai"
     cfg.secret_fields = {"api_key": "zai-test"}
     cfg.plain_fields = {}
     adapter = svc._build_adapter_for_config(cfg)
-    assert adapter is None
+    assert adapter is not None
 
 
 def test_build_adapter_for_config_google_genai_returns_none():

--- a/tests/test_provider_runtime_integration.py
+++ b/tests/test_provider_runtime_integration.py
@@ -131,16 +131,26 @@ async def test_zai_db_config_builds_runtime_adapter_and_calls_general_chat_endpo
 
 
 @pytest.mark.anyio
-async def test_zai_db_config_with_empty_base_url_is_not_registered(db, monkeypatch):
+async def test_zai_db_config_with_empty_base_url_defaults_to_coding_endpoint(db, monkeypatch):
     config = await _save_zai_config(db, "")
+    FakeAiohttpClientSession.requests = []
     monkeypatch.setattr(
         "src.services.provider_service.aiohttp.ClientSession",
         FakeAiohttpClientSession,
     )
 
     service = RuntimeProviderService(db, config)
-    assert await service.load_db_providers() == 0
-    assert not service.has_providers()
+    assert await service.load_db_providers() == 1
+
+    result = await service.get_provider_callable("zai")(
+        prompt="hello",
+        model="glm-5-turbo",
+        max_tokens=16,
+        temperature=0.2,
+    )
+
+    assert result == "runtime-ok"
+    assert FakeAiohttpClientSession.requests[-1].url == f"{ZAI_CODING_BASE_URL}/chat/completions"
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_service_adapters.py
+++ b/tests/test_provider_service_adapters.py
@@ -47,11 +47,11 @@ def test_zai_registration_failure_path(clean_env):
     assert "zai" not in svc._registry
 
 
-def test_zai_env_registration_skipped_without_base_url(clean_env):
-    """ZAI_API_KEY without ZAI_BASE_URL no longer registers a provider."""
+def test_zai_env_registration_defaults_without_base_url(clean_env):
+    """ZAI_API_KEY without ZAI_BASE_URL uses the subscription endpoint."""
     os.environ["ZAI_API_KEY"] = "zai-test-key"
     svc = AgentProviderService()
-    assert "zai" not in svc._registry
+    assert "zai" in svc._registry
 
 
 # === Context7 registration failure ===


### PR DESCRIPTION
## Summary

- Add a shared live runtime path for `/agent` so web startup with embedded worker reports retryable startup state instead of stale worker-only errors.
- Make channel collection shutdown graceful: stop producers, wait for the active collection task, and leave queued or interrupted work pending in the DB for the next worker start.
- Add explicit stop/restart messaging so users see that the service is waiting for active channel collection to finish.

## Root Cause

The collection queue cancelled its worker immediately during shutdown. That could interrupt `collect_single_channel`, mark active work incorrectly, and leave restart behavior dependent on startup recovery that converted running channel tasks to failed.

## Validation

- `ruff check src/collection_queue.py src/web/bootstrap.py src/web/embedded_worker.py src/cli/process_control.py src/cli/commands/server_control.py src/cli/commands/serve.py src/database/repositories/collection_tasks.py src/database/bundles.py src/database/facade.py tests/test_collection_queue_db_pull.py tests/repositories/test_collection_tasks_repository.py tests/test_bootstrap.py tests/test_cli_serve_commands.py`
- `python3 -m pytest tests/test_collection_queue_db_pull.py tests/repositories/test_collection_tasks_repository.py::test_reset_collection_task_to_pending tests/test_bootstrap.py::test_start_container_does_not_fail_running_channel_tasks tests/test_cli_serve_commands.py::test_stop_success tests/test_cli_serve_commands.py::test_restart_success -v`
- `python3 -m pytest tests/test_bootstrap.py tests/test_cli_serve_commands.py tests/repositories/test_collection_tasks_repository.py -v`
- `python3 -m pytest tests/test_cli.py::TestCLIServerControl -v`
- `python3 -m pytest tests/routes/test_accounts_agent_web_mode.py -v`