### PR TITLE
refactor(agent): add shared tool context helpers

### DIFF
--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -13,7 +13,7 @@ import functools
 from claude_agent_sdk import SdkMcpTool, create_sdk_mcp_server
 
 from src.agent.runtime_context import AgentRuntimeContext
-from src.agent.tools._registry import _text_response  # noqa: F401
+from src.agent.tools._registry import AgentToolContext, _text_response  # noqa: F401
 
 
 def _wrap_with_session_gate(tool: SdkMcpTool) -> SdkMcpTool:
@@ -90,7 +90,20 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None):
         client_pool=client_pool,
         scheduler_manager=scheduler_manager,
     )
-    extras = {"scheduler_manager": scheduler_manager, "config": config, "runtime_context": runtime_context}
+    tool_context = AgentToolContext.build(
+        db=db,
+        config=config,
+        client_pool=client_pool,
+        scheduler_manager=scheduler_manager,
+        embedding_service=embedding_service,
+        runtime_context=runtime_context,
+    )
+    extras = {
+        "scheduler_manager": scheduler_manager,
+        "config": config,
+        "runtime_context": runtime_context,
+        "tool_context": tool_context,
+    }
 
     all_tools = []
     for module in [
@@ -232,10 +245,19 @@ def build_agent_tools_dict(
         client_pool=client_pool,
         scheduler_manager=scheduler_manager,
     )
+    tool_context = AgentToolContext.build(
+        db=db,
+        config=config,
+        client_pool=client_pool,
+        scheduler_manager=scheduler_manager,
+        embedding_service=embedding_service,
+        runtime_context=runtime_context,
+    )
     extras: dict = {
         "scheduler_manager": scheduler_manager,
         "config": config,
         "runtime_context": runtime_context,
+        "tool_context": tool_context,
     }
     tools_dict: dict[str, object] = {}
 

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import json as _json
 import logging
 import re as _re
+from dataclasses import dataclass
+from typing import Any
+
+from src.agent.runtime_context import AgentRuntimeContext
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +16,157 @@ logger = logging.getLogger(__name__)
 def _text_response(text: str) -> dict:
     """Wrap text into MCP tool response format."""
     return {"content": [{"type": "text", "text": text}]}
+
+
+class ToolInputError(ValueError):
+    """User-facing tool argument validation error."""
+
+    def to_response(self) -> dict:
+        return _text_response(f"Ошибка: {self}")
+
+
+@dataclass(slots=True)
+class AgentToolContext:
+    """Shared dependencies and guards for agent tool handlers."""
+
+    db: object
+    config: object | None = None
+    client_pool: object | None = None
+    scheduler_manager: object | None = None
+    embedding_service: object | None = None
+    runtime_context: AgentRuntimeContext | None = None
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        db: object,
+        config: object | None = None,
+        client_pool: object | None = None,
+        scheduler_manager: object | None = None,
+        embedding_service: object | None = None,
+        runtime_context: AgentRuntimeContext | None = None,
+    ) -> "AgentToolContext":
+        runtime_context = runtime_context or AgentRuntimeContext.build(
+            db=db,
+            config=config,
+            client_pool=client_pool,
+            scheduler_manager=scheduler_manager,
+        )
+        return cls(
+            db=db,
+            config=config,
+            client_pool=client_pool,
+            scheduler_manager=scheduler_manager,
+            embedding_service=embedding_service,
+            runtime_context=runtime_context,
+        )
+
+    def require_pool(self, action: str = "Эта операция") -> dict | None:
+        return require_pool(self.client_pool, action)
+
+    async def resolve_phone(self, raw_phone: str) -> tuple[str, dict | None]:
+        return await resolve_phone(self.db, raw_phone)
+
+    async def require_phone_permission(self, phone: str, tool_name: str) -> dict | None:
+        return await require_phone_permission(self.db, phone, tool_name)
+
+    def channel_service(self):
+        from src.services.channel_service import ChannelService
+
+        return ChannelService(self.db, self.client_pool, None)
+
+    def pipeline_service(self):
+        from src.services.pipeline_service import PipelineService
+
+        return PipelineService(self.db)
+
+
+def get_tool_context(
+    kwargs: dict,
+    *,
+    db: object,
+    client_pool: object | None = None,
+    embedding_service: object | None = None,
+) -> AgentToolContext:
+    """Return the shared tool context passed by the registry, or build one for direct tests."""
+    ctx = kwargs.get("tool_context")
+    if isinstance(ctx, AgentToolContext):
+        return ctx
+    return AgentToolContext.build(
+        db=db,
+        config=kwargs.get("config"),
+        client_pool=client_pool,
+        scheduler_manager=kwargs.get("scheduler_manager"),
+        embedding_service=embedding_service,
+        runtime_context=kwargs.get("runtime_context"),
+    )
+
+
+def arg_bool(args: dict[str, Any], name: str, default: bool = False) -> bool:
+    return bool(args.get(name, default))
+
+
+def arg_str(args: dict[str, Any], name: str, default: str = "", *, required: bool = False) -> str:
+    value = args.get(name, default)
+    if value is None:
+        value = ""
+    value = str(value).strip()
+    if required and not value:
+        raise ToolInputError(f"{name} обязателен.")
+    return value
+
+
+def arg_int(args: dict[str, Any], name: str, default: int | None = None, *, required: bool = False) -> int | None:
+    value = args.get(name, default)
+    if value is None or value == "":
+        if required:
+            raise ToolInputError(f"{name} обязателен.")
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ToolInputError(f"{name} должен быть целым числом.") from exc
+
+
+def arg_csv_ints(
+    args: dict[str, Any],
+    name: str,
+    *,
+    required: bool = False,
+    allow_empty: bool = False,
+) -> list[int]:
+    value = args.get(name, "")
+    if value is None:
+        value = ""
+    if isinstance(value, (list, tuple)):
+        parts = [str(v).strip() for v in value]
+    else:
+        parts = [part.strip() for part in str(value).split(",")]
+    parts = [part for part in parts if part]
+    if not parts:
+        if required and not allow_empty:
+            raise ToolInputError(f"{name} обязателен.")
+        return []
+    result: list[int] = []
+    invalid: list[str] = []
+    for part in parts:
+        try:
+            result.append(int(part))
+        except ValueError:
+            invalid.append(part)
+    if invalid:
+        raise ToolInputError(f"{name} должен содержать целые числа через запятую: {', '.join(invalid)}")
+    return result
+
+
+def require_args(args: dict[str, Any], *names: str) -> dict[str, str]:
+    values = {name: arg_str(args, name) for name in names}
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        joined = ", ".join(missing)
+        raise ToolInputError(f"{joined} обязательны.")
+    return values
 
 
 def normalize_phone(phone: str) -> str:

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -5,11 +5,20 @@ from typing import Annotated
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, require_confirmation, require_pool
+from src.agent.tools._registry import (
+    ToolInputError,
+    _text_response,
+    arg_bool,
+    arg_int,
+    arg_str,
+    get_tool_context,
+    require_confirmation,
+)
 
 
 def register(db, client_pool, embedding_service, **kwargs):
     """Register channel-related agent tools."""
+    ctx = get_tool_context(kwargs, db=db, client_pool=client_pool, embedding_service=embedding_service)
     tools = []
 
     # ------------------------------------------------------------------
@@ -27,8 +36,8 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def list_channels(args):
-        active_only = bool(args.get("active_only", False))
-        include_filtered = bool(args.get("include_filtered", True))
+        active_only = arg_bool(args, "active_only", False)
+        include_filtered = arg_bool(args, "include_filtered", True)
         try:
             channels = await db.get_channels(active_only=active_only, include_filtered=include_filtered)
             if not channels:
@@ -91,16 +100,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def add_channel(args):
-        identifier = args.get("identifier")
-        if not identifier:
-            return _text_response("Ошибка: identifier обязателен.")
+        try:
+            identifier = arg_str(args, "identifier", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
         gate = require_confirmation(f"добавит канал по идентификатору '{identifier}'", args)
         if gate:
             return gate
         try:
-            from src.services.channel_service import ChannelService
-
-            svc = ChannelService(db, client_pool, None)
+            svc = ctx.channel_service()
             added = await svc.add_by_identifier(identifier)
             if added:
                 return _text_response(f"Канал '{identifier}' успешно добавлен.")
@@ -125,19 +133,18 @@ def register(db, client_pool, embedding_service, **kwargs):
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_channel(args):
-        pk = args.get("pk")
-        if pk is None:
-            return _text_response("Ошибка: pk обязателен.")
-        ch = await db.get_channel_by_pk(int(pk))
+        try:
+            pk = arg_int(args, "pk", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        ch = await db.get_channel_by_pk(pk)
         name = ch.title if ch else f"id={pk}"
         gate = require_confirmation(f"удалит канал '{name}' и все его сообщения", args)
         if gate:
             return gate
         try:
-            from src.services.channel_service import ChannelService
-
-            svc = ChannelService(db, client_pool, None)
-            await svc.delete(int(pk))
+            svc = ctx.channel_service()
+            await svc.delete(pk)
             return _text_response(f"Канал '{name}' удалён.")
         except Exception as e:
             return _text_response(f"Ошибка удаления канала: {e}")
@@ -154,15 +161,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"]},
     )
     async def toggle_channel(args):
-        pk = args.get("pk")
-        if pk is None:
-            return _text_response("Ошибка: pk обязателен.")
         try:
-            from src.services.channel_service import ChannelService
-
-            svc = ChannelService(db, client_pool, None)
-            await svc.toggle(int(pk))
-            ch = await db.get_channel_by_pk(int(pk))
+            pk = arg_int(args, "pk", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            svc = ctx.channel_service()
+            await svc.toggle(pk)
+            ch = await db.get_channel_by_pk(pk)
             if ch:
                 status = "активен" if ch.is_active else "неактивен"
                 return _text_response(f"Канал '{ch.title}' теперь {status}.")
@@ -186,9 +192,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def import_channels(args):
-        text = args.get("text")
-        if not text:
-            return _text_response("Ошибка: text обязателен.")
+        try:
+            text = arg_str(args, "text", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
         from src.parsers import extract_identifiers
 
         identifiers = extract_identifiers(text)
@@ -198,9 +205,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            from src.services.channel_service import ChannelService
-
-            svc = ChannelService(db, client_pool, None)
+            svc = ctx.channel_service()
             added = 0
             errors = []
             for ident in identifiers:
@@ -232,7 +237,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"confirm": Annotated[bool, "Установите true для подтверждения действия"]},
     )
     async def refresh_channel_types(args):
-        pool_gate = require_pool(client_pool, "Обновление типов каналов")
+        pool_gate = ctx.require_pool("Обновление типов каналов")
         if pool_gate:
             return pool_gate
         gate = require_confirmation("обновит типы всех активных каналов через Telegram API", args)
@@ -284,7 +289,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def refresh_channel_meta(args):
-        pool_gate = require_pool(client_pool, "Обновление метаданных каналов")
+        pool_gate = ctx.require_pool("Обновление метаданных каналов")
         if pool_gate:
             return pool_gate
         identifier = args.get("identifier")
@@ -380,9 +385,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def create_tag(args):
-        name = (args.get("name") or "").strip()
-        if not name:
-            return _text_response("Ошибка: name обязателен.")
+        try:
+            name = arg_str(args, "name", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
         gate = require_confirmation(f"создаст тег '{name}'", args)
         if gate:
             return gate
@@ -404,9 +410,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_tag(args):
-        name = (args.get("name") or "").strip()
-        if not name:
-            return _text_response("Ошибка: name обязателен.")
+        try:
+            name = arg_str(args, "name", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
         gate = require_confirmation(f"удалит тег '{name}' у всех каналов", args)
         if gate:
             return gate
@@ -428,16 +435,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def set_channel_tags(args):
-        pk = args.get("pk")
-        if pk is None:
-            return _text_response("Ошибка: pk обязателен.")
+        try:
+            pk = arg_int(args, "pk", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
         raw = args.get("tags", "")
         tag_names = [t.strip() for t in str(raw).split(",") if t.strip()]
         try:
-            ch = await db.get_channel_by_pk(int(pk))
+            ch = await db.get_channel_by_pk(pk)
             if ch is None:
                 return _text_response(f"Канал pk={pk} не найден.")
-            await db.repos.channels.set_channel_tags(int(pk), tag_names)
+            await db.repos.channels.set_channel_tags(pk, tag_names)
             if tag_names:
                 return _text_response(f"Теги канала '{ch.title}' обновлены: {', '.join(tag_names)}")
             return _text_response(f"Теги канала '{ch.title}' очищены.")

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -144,7 +144,7 @@ def build_deepagents_tools(
             from src.services.channel_service import ChannelService
 
             svc = ChannelService(db, client_pool, None)
-            result = _run_sync("add_channel", lambda: svc.add_by_identifier(identifier))
+            result = runtime_context.run_sync("add_channel", lambda: svc.add_by_identifier(identifier))
             return f"Канал добавлен: {result}" if result else f"Не удалось добавить канал: {identifier}"
         except Exception as exc:
             return f"Ошибка добавления канала: {exc}"
@@ -157,7 +157,7 @@ def build_deepagents_tools(
             from src.services.channel_service import ChannelService
 
             svc = ChannelService(db, client_pool, None)
-            _run_sync("delete_channel", lambda: svc.delete(pk))
+            runtime_context.run_sync("delete_channel", lambda: svc.delete(pk))
             return f"Канал pk={pk} удалён."
         except Exception as exc:
             return f"Ошибка удаления канала: {exc}"
@@ -170,7 +170,7 @@ def build_deepagents_tools(
             from src.services.channel_service import ChannelService
 
             svc = ChannelService(db, client_pool, None)
-            _run_sync("toggle_channel", lambda: svc.toggle(pk))
+            runtime_context.run_sync("toggle_channel", lambda: svc.toggle(pk))
             return f"Канал pk={pk} переключён."
         except Exception as exc:
             return f"Ошибка переключения канала: {exc}"
@@ -233,7 +233,7 @@ def build_deepagents_tools(
             from src.services.pipeline_service import PipelineService
 
             svc = PipelineService(db)
-            _run_sync("delete_pipeline", lambda: svc.delete(pipeline_id))
+            runtime_context.run_sync("delete_pipeline", lambda: svc.delete(pipeline_id))
             return f"Пайплайн id={pipeline_id} удалён."
         except Exception as exc:
             return f"Ошибка удаления пайплайна: {exc}"

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -8,7 +8,11 @@ from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
 from src.agent.tools._registry import (
+    ToolInputError,
     _text_response,
+    arg_csv_ints,
+    arg_str,
+    get_tool_context,
     require_confirmation,
     require_phone_permission,
     require_pool,
@@ -19,7 +23,20 @@ from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 
 
 def register(db, client_pool, embedding_service, **kwargs):
+    ctx = get_tool_context(kwargs, db=db, client_pool=client_pool, embedding_service=embedding_service)
     tools = []
+
+    async def _prepare_telegram_tool(args, *, tool_name: str, action: str) -> tuple[str, dict | None]:
+        pool_gate = ctx.require_pool(action)
+        if pool_gate:
+            return "", pool_gate
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
+        if err:
+            return "", err
+        perm_gate = await ctx.require_phone_permission(phone, tool_name)
+        if perm_gate:
+            return "", perm_gate
+        return phone, None
 
     @tool(
         "send_message",
@@ -33,18 +50,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def send_message(args):
-        pool_gate = require_pool(client_pool, "Отправка сообщения")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(args, tool_name="send_message", action="Отправка сообщения")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "send_message")
-        if perm_gate:
-            return perm_gate
-        recipient = args.get("recipient", "")
-        text = args.get("text", "")
-        if not recipient or not text:
+        try:
+            recipient = arg_str(args, "recipient", required=True)
+            text = arg_str(args, "text", required=True)
+        except ToolInputError:
             return _text_response("Ошибка: recipient и text обязательны.")
         preview = text[:120] + ("..." if len(text) > 120 else "")
         gate = require_confirmation(
@@ -121,21 +133,17 @@ def register(db, client_pool, embedding_service, **kwargs):
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_message(args):
-        pool_gate = require_pool(client_pool, "Удаление сообщений")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(args, tool_name="delete_message", action="Удаление сообщений")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "delete_message")
-        if perm_gate:
-            return perm_gate
-        chat_id = args.get("chat_id", "")
-        message_ids_str = args.get("message_ids", "")
-        if not chat_id or not message_ids_str:
+        try:
+            chat_id = arg_str(args, "chat_id", required=True)
+            arg_str(args, "message_ids", required=True)
+        except ToolInputError:
             return _text_response("Ошибка: chat_id и message_ids обязательны.")
-        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
-        if not ids:
+        try:
+            ids = arg_csv_ints(args, "message_ids", required=True)
+        except ToolInputError:
             return _text_response("Ошибка: не указаны валидные message_ids.")
         gate = require_confirmation(
             f"удалит {len(ids)} сообщений из чата {chat_id}: {ids}", args
@@ -166,22 +174,18 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def forward_messages(args):
-        pool_gate = require_pool(client_pool, "Пересылка сообщений")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(args, tool_name="forward_messages", action="Пересылка сообщений")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "forward_messages")
-        if perm_gate:
-            return perm_gate
-        from_chat = args.get("from_chat", "")
-        to_chat = args.get("to_chat", "")
-        message_ids_str = args.get("message_ids", "")
-        if not from_chat or not to_chat or not message_ids_str:
+        try:
+            from_chat = arg_str(args, "from_chat", required=True)
+            to_chat = arg_str(args, "to_chat", required=True)
+            arg_str(args, "message_ids", required=True)
+        except ToolInputError:
             return _text_response("Ошибка: from_chat, to_chat и message_ids обязательны.")
-        ids = [int(x.strip()) for x in message_ids_str.split(",") if x.strip().isdigit()]
-        if not ids:
+        try:
+            ids = arg_csv_ints(args, "message_ids", required=True)
+        except ToolInputError:
             return _text_response("Ошибка: не указаны валидные message_ids.")
         gate = require_confirmation(
             f"перешлёт {len(ids)} сообщений из {from_chat} в {to_chat}: {ids}", args
@@ -415,17 +419,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def edit_admin(args):
-        pool_gate = require_pool(client_pool, "Изменение прав администратора")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(
+            args,
+            tool_name="edit_admin",
+            action="Изменение прав администратора",
+        )
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "edit_admin")
-        if perm_gate:
-            return perm_gate
-        chat_id = args.get("chat_id", "")
-        user_id = args.get("user_id", "")
+        chat_id = arg_str(args, "chat_id")
+        user_id = arg_str(args, "user_id")
         is_admin = args.get("is_admin", True)
         title = args.get("title") or None
         if not chat_id or not user_id:
@@ -469,17 +471,15 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def edit_permissions(args):
         from datetime import datetime
 
-        pool_gate = require_pool(client_pool, "Изменение ограничений пользователя")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(
+            args,
+            tool_name="edit_permissions",
+            action="Изменение ограничений пользователя",
+        )
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "edit_permissions")
-        if perm_gate:
-            return perm_gate
-        chat_id = args.get("chat_id", "")
-        user_id = args.get("user_id", "")
+        chat_id = arg_str(args, "chat_id")
+        user_id = arg_str(args, "user_id")
         until_date_str = args.get("until_date") or None
         send_messages = args.get("send_messages")
         send_media = args.get("send_media")
@@ -526,17 +526,11 @@ def register(db, client_pool, embedding_service, **kwargs):
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def kick_participant(args):
-        pool_gate = require_pool(client_pool, "Исключение участника")
-        if pool_gate:
-            return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await _prepare_telegram_tool(args, tool_name="kick_participant", action="Исключение участника")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "kick_participant")
-        if perm_gate:
-            return perm_gate
-        chat_id = args.get("chat_id", "")
-        user_id = args.get("user_id", "")
+        chat_id = arg_str(args, "chat_id")
+        user_id = arg_str(args, "user_id")
         if not chat_id or not user_id:
             return _text_response("Ошибка: chat_id и user_id обязательны.")
         gate = require_confirmation(f"исключит {user_id} из чата {chat_id}", args)

--- a/src/agent/tools/pipelines.py
+++ b/src/agent/tools/pipelines.py
@@ -8,14 +8,41 @@ from typing import Annotated
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, require_confirmation, require_pool
+from src.agent.tools._registry import (
+    ToolInputError,
+    _text_response,
+    arg_bool,
+    arg_csv_ints,
+    arg_int,
+    arg_str,
+    get_tool_context,
+    require_confirmation,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def register(db, client_pool, embedding_service, **kwargs):
     config = kwargs.get("config")
+    ctx = get_tool_context(kwargs, db=db, client_pool=client_pool, embedding_service=embedding_service)
     tools = []
+
+    def _parse_target_refs(raw: str):
+        from src.services.pipeline_service import PipelineTargetRef
+
+        target_refs = []
+        for part in raw.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if "|" not in part:
+                raise ToolInputError(f"Неверный формат target_ref: '{part}'. Ожидается 'phone|dialog_id'.")
+            phone, dialog_id = part.split("|", 1)
+            try:
+                target_refs.append(PipelineTargetRef(phone=phone.strip(), dialog_id=int(dialog_id.strip())))
+            except ValueError as exc:
+                raise ToolInputError(f"dialog_id в target_ref '{part}' должен быть целым числом.") from exc
+        return target_refs
 
     async def _build_image_service():
         """Build ImageGenerationService with DB providers + env fallback."""
@@ -46,10 +73,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     )
     async def list_pipelines(args):
         try:
-            from src.services.pipeline_service import PipelineService
-
-            svc = PipelineService(db)
-            active_only = bool(args.get("active_only", False))
+            svc = ctx.pipeline_service()
+            active_only = arg_bool(args, "active_only", False)
             pipelines = await svc.list(active_only=active_only)
             if not pipelines:
                 return _text_response("Пайплайны не найдены.")
@@ -76,14 +101,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def get_pipeline_detail(args):
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
         try:
-            from src.services.pipeline_service import PipelineService
-
-            svc = PipelineService(db)
-            detail = await svc.get_detail(int(pipeline_id))
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            svc = ctx.pipeline_service()
+            detail = await svc.get_detail(pipeline_id)
             if detail is None:
                 return _text_response(f"Пайплайн id={pipeline_id} не найден.")
             p = detail["pipeline"]
@@ -116,7 +140,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     )
     async def get_pipeline_queue(args):
         try:
-            limit = int(args.get("limit", 20))
+            limit = arg_int(args, "limit", 20) or 20
             runs = await db.repos.generation_runs.list_by_status(["pending", "running"], limit=limit)
             if not runs:
                 return _text_response("Очередь генерации пуста.")
@@ -139,11 +163,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def get_refinement_steps(args):
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
         try:
-            pipeline = await db.repos.content_pipelines.get_by_id(int(pipeline_id))
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
             if pipeline is None:
                 return _text_response(f"Пайплайн id={pipeline_id} не найден.")
             steps = pipeline.refinement_steps or []
@@ -183,26 +208,18 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            from src.services.pipeline_service import PipelineService, PipelineTargetRef
-
-            name = args.get("name", "").strip()
-            prompt_template = args.get("prompt_template", "").strip()
-            source_str = args.get("source_channel_ids", "")
-            target_str = args.get("target_refs", "")
+            name = arg_str(args, "name")
+            prompt_template = arg_str(args, "prompt_template")
+            source_str = arg_str(args, "source_channel_ids")
+            target_str = arg_str(args, "target_refs")
             if not name or not prompt_template or not source_str or not target_str:
                 return _text_response(
                     "Ошибка: name, prompt_template, source_channel_ids и target_refs обязательны."
                 )
-            source_ids = [int(x.strip()) for x in source_str.split(",") if x.strip()]
-            target_refs = []
-            for part in target_str.split(","):
-                part = part.strip()
-                if "|" not in part:
-                    return _text_response(f"Неверный формат target_ref: '{part}'. Ожидается 'phone|dialog_id'.")
-                phone, dialog_id = part.split("|", 1)
-                target_refs.append(PipelineTargetRef(phone=phone.strip(), dialog_id=int(dialog_id.strip())))
+            source_ids = arg_csv_ints(args, "source_channel_ids", required=True)
+            target_refs = _parse_target_refs(target_str)
 
-            svc = PipelineService(db)
+            svc = ctx.pipeline_service()
             llm_model = args.get("llm_model")
             publish_mode = args.get("publish_mode", "moderated")
             pipeline_id = await svc.add(
@@ -214,6 +231,8 @@ def register(db, client_pool, embedding_service, **kwargs):
                 publish_mode=publish_mode,
             )
             return _text_response(f"Пайплайн '{name}' создан (id={pipeline_id}).")
+        except ToolInputError as e:
+            return e.to_response()
         except Exception as e:
             return _text_response(f"Ошибка создания пайплайна: {e}")
 
@@ -238,14 +257,15 @@ def register(db, client_pool, embedding_service, **kwargs):
         gate = require_confirmation("изменит настройки пайплайна", args)
         if gate:
             return gate
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
         try:
-            from src.services.pipeline_service import PipelineService, PipelineTargetRef
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            from src.services.pipeline_service import PipelineTargetRef
 
-            svc = PipelineService(db)
-            existing = await svc.get_detail(int(pipeline_id))
+            svc = ctx.pipeline_service()
+            existing = await svc.get_detail(pipeline_id)
             if existing is None:
                 return _text_response(f"Пайплайн id={pipeline_id} не найден.")
             p = existing["pipeline"]
@@ -257,28 +277,20 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             source_str = args.get("source_channel_ids")
             if source_str:
-                source_ids = [int(x.strip()) for x in source_str.split(",") if x.strip()]
+                source_ids = arg_csv_ints(args, "source_channel_ids", required=True)
             else:
                 source_ids = existing["source_ids"]
 
             target_str = args.get("target_refs")
             if target_str:
-                target_refs = []
-                for part in target_str.split(","):
-                    part = part.strip()
-                    if "|" not in part:
-                        return _text_response(
-                            f"Неверный формат target_ref: '{part}'. Ожидается 'phone|dialog_id'."
-                        )
-                    phone, dialog_id = part.split("|", 1)
-                    target_refs.append(PipelineTargetRef(phone=phone.strip(), dialog_id=int(dialog_id.strip())))
+                target_refs = _parse_target_refs(target_str)
             else:
                 target_refs = [
                     PipelineTargetRef(phone=t.phone, dialog_id=t.dialog_id) for t in existing["targets"]
                 ]
 
             ok = await svc.update(
-                int(pipeline_id),
+                pipeline_id,
                 name=name,
                 prompt_template=prompt_template,
                 source_channel_ids=source_ids,
@@ -289,6 +301,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             if ok:
                 return _text_response(f"Пайплайн '{name}' (id={pipeline_id}) обновлён.")
             return _text_response(f"Не удалось обновить пайплайн id={pipeline_id}.")
+        except ToolInputError as e:
+            return e.to_response()
         except Exception as e:
             return _text_response(f"Ошибка редактирования пайплайна: {e}")
 
@@ -300,17 +314,16 @@ def register(db, client_pool, embedding_service, **kwargs):
         {"pipeline_id": Annotated[int, "ID пайплайна из list_pipelines"]},
     )
     async def toggle_pipeline(args):
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
         try:
-            from src.services.pipeline_service import PipelineService
-
-            svc = PipelineService(db)
-            ok = await svc.toggle(int(pipeline_id))
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            svc = ctx.pipeline_service()
+            ok = await svc.toggle(pipeline_id)
             if not ok:
                 return _text_response(f"Пайплайн id={pipeline_id} не найден.")
-            pipeline = await svc.get(int(pipeline_id))
+            pipeline = await svc.get(pipeline_id)
             status = "активирован" if pipeline and pipeline.is_active else "деактивирован"
             name = pipeline.name if pipeline else f"id={pipeline_id}"
             return _text_response(f"Пайплайн '{name}' {status}.")
@@ -329,19 +342,18 @@ def register(db, client_pool, embedding_service, **kwargs):
         annotations=ToolAnnotations(destructiveHint=True),
     )
     async def delete_pipeline(args):
-        pipeline_id = args.get("pipeline_id")
-        if pipeline_id is None:
-            return _text_response("Ошибка: pipeline_id обязателен.")
         try:
-            from src.services.pipeline_service import PipelineService
-
-            svc = PipelineService(db)
-            pipeline = await svc.get(int(pipeline_id))
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            svc = ctx.pipeline_service()
+            pipeline = await svc.get(pipeline_id)
             name = pipeline.name if pipeline else f"id={pipeline_id}"
             gate = require_confirmation(f"безвозвратно удалит пайплайн '{name}'", args)
             if gate:
                 return gate
-            await svc.delete(int(pipeline_id))
+            await svc.delete(pipeline_id)
             return _text_response(f"Пайплайн '{name}' удалён.")
         except Exception as e:
             return _text_response(f"Ошибка удаления пайплайна: {e}")
@@ -553,7 +565,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def publish_pipeline_run(args):
-        gate = require_pool(client_pool, "Публикация контента")
+        gate = ctx.require_pool("Публикация контента")
         if gate:
             return gate
         gate = require_confirmation("опубликует генерацию в целевые каналы", args)

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.agent.tools._registry import (
+    AgentToolContext,
+    ToolInputError,
     _text_response,
+    arg_bool,
+    arg_csv_ints,
+    arg_int,
+    arg_str,
     normalize_phone,
     require_confirmation,
     require_phone_permission,
@@ -74,6 +80,41 @@ class TestRequireConfirmation:
         result = require_confirmation("удалит канал", {"confirm": False})
         assert result is not None
         assert "confirm=true" in result["content"][0]["text"]
+
+
+# ── argument helpers / tool context ───────────────────────────────────────────
+
+
+class TestArgumentHelpers:
+    def test_arg_str_strips_and_requires(self):
+        assert arg_str({"name": "  test  "}, "name", required=True) == "test"
+        with pytest.raises(ToolInputError, match="name обязателен"):
+            arg_str({"name": " "}, "name", required=True)
+
+    def test_arg_int_parses_and_reports_invalid(self):
+        assert arg_int({"pk": "42"}, "pk", required=True) == 42
+        with pytest.raises(ToolInputError, match="pk должен быть целым числом"):
+            arg_int({"pk": "x"}, "pk", required=True)
+
+    def test_arg_csv_ints_parses_list_and_reports_invalid(self):
+        assert arg_csv_ints({"ids": "1, 2,3"}, "ids", required=True) == [1, 2, 3]
+        with pytest.raises(ToolInputError, match="ids должен содержать целые числа"):
+            arg_csv_ints({"ids": "1,a"}, "ids", required=True)
+
+    def test_arg_bool_preserves_existing_truthy_semantics(self):
+        assert arg_bool({"confirm": 1}, "confirm") is True
+        assert arg_bool({"confirm": False}, "confirm") is False
+
+
+class TestAgentToolContext:
+    def test_build_preserves_dependencies(self):
+        db = MagicMock()
+        pool = MagicMock()
+        ctx = AgentToolContext.build(db=db, client_pool=pool)
+        assert ctx.db is db
+        assert ctx.client_pool is pool
+        assert ctx.runtime_context is not None
+        assert ctx.runtime_context.db is db
 
 
 # ── require_pool ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add shared AgentToolContext and typed-ish argument helpers for agent tools
- pass the shared context through MCP and pipeline tool construction
- migrate representative channel, pipeline, messaging, and sync tool paths without changing public tool contracts

Closes #509

## Tests
- ruff check src/ tests/ conftest.py
- python3 -m pytest tests/ -v -k agent
- python3 -m pytest tests/test_agent_tools_registry.py tests/test_agent_tools_channels.py tests/test_agent_tools_pipelines.py tests/test_agent_tools_messaging_errors.py -v