### PR TITLE
refactor(agent): canonicalize provider metadata

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -40,12 +40,7 @@ from src.agent.prompt_template import (
     render_prompt_template,
 )
 from src.agent.provider_registry import (
-    ZAI_BASE_URL_REQUIRED_HINT,
-    ZAI_CODING_BASE_URL,
-    ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
-    is_zai_legacy_anthropic_base_url,
-    normalize_zai_base_url,
 )
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.zai_errors import format_provider_error
@@ -1218,38 +1213,11 @@ class DeepagentsBackend:
                 "иначе deepagents переиспользует Claude SDK credentials."
             )
             raise RuntimeError(self._init_error)
-        model_provider = provider
-        extra: dict[str, object] = {
-            key: value for key, value in cfg.plain_fields.items() if value.strip()
-        }
-        if provider == "ollama":
-            api_key = cfg.secret_fields.get("api_key", "").strip()
-            normalized_base_url = self._provider_service.normalize_ollama_base_url(
-                str(extra.get("base_url", "")),
-                api_key,
-            )
-            extra["base_url"] = normalized_base_url
-            if api_key:
-                extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
-        else:
-            extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
-
-        if provider == "zai":
-            raw_base_url = cfg.plain_fields.get("base_url", "")
-            if is_zai_legacy_anthropic_base_url(raw_base_url):
-                self._init_error = (
-                    "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
-                    "anthropic provider with this URL instead, or use the OpenAI-compatible "
-                    f"endpoint {ZAI_GENERAL_BASE_URL}. Coding Plan users can explicitly set "
-                    f"{ZAI_CODING_BASE_URL}."
-                )
-                raise RuntimeError(self._init_error)
-            normalized_base_url = normalize_zai_base_url(raw_base_url)
-            if not normalized_base_url:
-                self._init_error = ZAI_BASE_URL_REQUIRED_HINT
-                raise RuntimeError(self._init_error)
-            model_provider = "openai"
-            extra["base_url"] = normalized_base_url
+        try:
+            model_provider, extra = self._provider_service.deepagents_runtime_options(cfg)
+        except RuntimeError as exc:
+            self._init_error = str(exc)
+            raise
         self._init_attempted_model = cfg.model_name
 
         # ReAct fallback for Ollama models without native function calling

--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from urllib.parse import urlsplit, urlunsplit
 
 from src.agent.models import CLAUDE_MODELS
 
@@ -51,10 +52,19 @@ class ProviderSpec:
     static_models: tuple[str, ...]
     plain_fields: tuple[ProviderFieldSpec, ...] = ()
     secret_fields: tuple[ProviderFieldSpec, ...] = ()
+    default_base_url: str = ""
+    runtime_provider: str = ""
+    openai_compatible: bool = False
+    supports_lightweight_adapter: bool = False
+    canonical_export_mode: str = "provider_default"
 
     @property
     def all_fields(self) -> tuple[ProviderFieldSpec, ...]:
         return self.plain_fields + self.secret_fields
+
+    @property
+    def resolved_runtime_provider(self) -> str:
+        return self.runtime_provider or self.name
 
 
 def _field(
@@ -84,6 +94,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         static_models=("gpt-4.1", "gpt-4.1-mini", "gpt-4o-mini", "gpt-5-nano"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
         plain_fields=(_field("base_url", "Base URL", placeholder="https://api.openai.com/v1"),),
+        default_base_url="https://api.openai.com/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "anthropic": ProviderSpec(
         name="anthropic",
@@ -91,6 +105,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-anthropic",
         static_models=tuple(m[0] for m in CLAUDE_MODELS),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        supports_lightweight_adapter=True,
     ),
     "azure_openai": ProviderSpec(
         name="azure_openai",
@@ -103,6 +118,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("azure_deployment", "Deployment", required=True),
             _field("api_version", "API version", placeholder="2024-10-21"),
         ),
+        canonical_export_mode="none",
     ),
     "azure_ai": ProviderSpec(
         name="azure_ai",
@@ -114,6 +130,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("endpoint", "Endpoint", required=True),
             _field("project_name", "Project name"),
         ),
+        canonical_export_mode="none",
     ),
     "google_vertexai": ProviderSpec(
         name="google_vertexai",
@@ -124,6 +141,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("project", "Project", required=True),
             _field("location", "Location", required=True, placeholder="us-central1"),
         ),
+        canonical_export_mode="none",
     ),
     "google_genai": ProviderSpec(
         name="google_genai",
@@ -143,6 +161,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("aws_session_token", "AWS session token", secret=True),
         ),
         plain_fields=(_field("region_name", "Region", required=True, placeholder="us-east-1"),),
+        canonical_export_mode="none",
     ),
     "bedrock_converse": ProviderSpec(
         name="bedrock_converse",
@@ -155,6 +174,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("aws_session_token", "AWS session token", secret=True),
         ),
         plain_fields=(_field("region_name", "Region", required=True, placeholder="us-east-1"),),
+        canonical_export_mode="none",
     ),
     "cohere": ProviderSpec(
         name="cohere",
@@ -162,6 +182,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-cohere",
         static_models=("command-r-plus", "command-r", "command-a-03-2025"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        supports_lightweight_adapter=True,
     ),
     "fireworks": ProviderSpec(
         name="fireworks",
@@ -175,6 +196,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         plain_fields=(
             _field("base_url", "Base URL", placeholder="https://api.fireworks.ai/inference/v1"),
         ),
+        default_base_url="https://api.fireworks.ai/inference/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "together": ProviderSpec(
         name="together",
@@ -185,6 +210,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             "Qwen/Qwen2.5-72B-Instruct-Turbo",
         ),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.together.xyz/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "mistralai": ProviderSpec(
         name="mistralai",
@@ -192,6 +221,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-mistralai",
         static_models=("mistral-large-latest", "mistral-medium-latest", "ministral-8b-latest"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.mistral.ai/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "huggingface": ProviderSpec(
         name="huggingface",
@@ -199,6 +232,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-huggingface",
         static_models=("microsoft/Phi-3-mini-4k-instruct", "meta-llama/Llama-3.1-8B-Instruct"),
         secret_fields=(_field("api_key", "API token", secret=True),),
+        supports_lightweight_adapter=True,
     ),
     "groq": ProviderSpec(
         name="groq",
@@ -206,6 +240,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-groq",
         static_models=("llama-3.3-70b-versatile", "llama-3.1-8b-instant", "mixtral-8x7b-32768"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.groq.com/openai/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "ollama": ProviderSpec(
         name="ollama",
@@ -235,6 +273,8 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
                 help_text="Optional for local Ollama. Required for direct Ollama Cloud API access.",
             ),
         ),
+        supports_lightweight_adapter=True,
+        canonical_export_mode="ollama_cloud",
     ),
     "google_anthropic_vertex": ProviderSpec(
         name="google_anthropic_vertex",
@@ -245,6 +285,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("project", "Project", required=True),
             _field("location", "Location", required=True, placeholder="us-east5"),
         ),
+        canonical_export_mode="none",
     ),
     "deepseek": ProviderSpec(
         name="deepseek",
@@ -252,6 +293,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-deepseek",
         static_models=("deepseek-chat", "deepseek-reasoner"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.deepseek.com/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "ibm": ProviderSpec(
         name="ibm",
@@ -263,6 +308,7 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
             _field("url", "API URL", required=True),
             _field("project_id", "Project ID"),
         ),
+        canonical_export_mode="none",
     ),
     "nvidia": ProviderSpec(
         name="nvidia",
@@ -277,6 +323,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-xai",
         static_models=("grok-2-1212", "grok-3-mini", "grok-3"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.x.ai/v1",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "perplexity": ProviderSpec(
         name="perplexity",
@@ -284,6 +334,10 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
         package_name="langchain-perplexity",
         static_models=("sonar", "sonar-pro", "sonar-reasoning"),
         secret_fields=(_field("api_key", "API key", required=True, secret=True),),
+        default_base_url="https://api.perplexity.ai",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="default_base_url",
     ),
     "zai": ProviderSpec(
         name="zai",
@@ -306,6 +360,11 @@ PROVIDER_SPECS: dict[str, ProviderSpec] = {
                 ),
             ),
         ),
+        default_base_url=ZAI_DEFAULT_BASE_URL,
+        runtime_provider="openai",
+        openai_compatible=True,
+        supports_lightweight_adapter=True,
+        canonical_export_mode="zai_base_url",
     ),
 }
 
@@ -314,6 +373,101 @@ PROVIDER_ORDER = tuple(PROVIDER_SPECS.keys())
 
 def provider_spec(name: str) -> ProviderSpec | None:
     return PROVIDER_SPECS.get(name)
+
+
+def default_base_url_for(provider_name: str) -> str:
+    spec = provider_spec(provider_name)
+    return spec.default_base_url if spec is not None else ""
+
+
+def normalize_urlish(raw: str) -> str:
+    value = raw.strip()
+    if not value:
+        return ""
+    parsed = urlsplit(value)
+    if not parsed.scheme or not parsed.netloc:
+        return value.rstrip("/")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "")).rstrip("/")
+
+
+def normalize_ollama_base_url(base_url: str, api_key: str = "") -> str:
+    raw = base_url.strip()
+    if not raw:
+        return "https://ollama.com" if api_key.strip() else "http://localhost:11434"
+
+    parsed = urlsplit(raw)
+    if not parsed.scheme or not parsed.netloc:
+        return raw.rstrip("/")
+
+    normalized_path = parsed.path.rstrip("/")
+    if normalized_path == "/api":
+        normalized_path = ""
+    return urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", "")).rstrip("/")
+
+
+def normalize_provider_plain_fields(
+    provider_name: str,
+    plain_fields: dict[str, str],
+    secret_fields: dict[str, str] | None = None,
+) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    spec = provider_spec(provider_name)
+    if spec is None:
+        return normalized
+    secret_fields = secret_fields or {}
+    for spec_field in spec.plain_fields:
+        key = spec_field.name
+        value = plain_fields.get(key, "").strip()
+        if key == "base_url" and provider_name == "ollama":
+            normalized[key] = normalize_ollama_base_url(value, secret_fields.get("api_key", ""))
+            continue
+        if key == "base_url" and provider_name == "zai":
+            if is_zai_legacy_anthropic_base_url(value):
+                normalized[key] = normalize_urlish(value)
+            else:
+                normalized[key] = normalize_urlish(normalize_zai_base_url(value))
+            continue
+        if key == "base_url" and spec.default_base_url:
+            normalized[key] = normalize_urlish(value or spec.default_base_url)
+            continue
+        if key in {"base_url", "endpoint", "azure_endpoint", "url"}:
+            normalized_value = normalize_urlish(value)
+            if normalized_value:
+                normalized[key] = normalized_value
+            continue
+        if value:
+            normalized[key] = value
+    return normalized
+
+
+def canonical_endpoint_fingerprint_for_config(cfg: ProviderRuntimeConfig) -> str | None:
+    spec = provider_spec(cfg.provider)
+    if spec is None:
+        return None
+    mode = spec.canonical_export_mode
+    if mode == "none":
+        return None
+    if mode == "ollama_cloud":
+        api_key = cfg.secret_fields.get("api_key", "").strip()
+        base_url = normalize_ollama_base_url(cfg.plain_fields.get("base_url", ""), api_key)
+        if api_key and base_url == "https://ollama.com":
+            return "ollama://cloud"
+        return None
+    if mode == "zai_base_url":
+        raw_base_url = cfg.plain_fields.get("base_url", "").strip()
+        if is_zai_legacy_anthropic_base_url(raw_base_url):
+            return None
+        normalized = normalize_urlish(normalize_zai_base_url(raw_base_url))
+        if normalized in {ZAI_GENERAL_BASE_URL, ZAI_CODING_BASE_URL}:
+            return normalized
+        return None
+    if mode == "default_base_url":
+        default_base_url = spec.default_base_url
+        normalized = normalize_urlish(cfg.plain_fields.get("base_url", "").strip() or default_base_url)
+        if normalized == normalize_urlish(default_base_url):
+            return normalized
+        return None
+    return f"{cfg.provider}://default"
 
 
 @dataclass(slots=True)

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -16,7 +16,6 @@ import aiohttp
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
     PROVIDER_SPECS,
-    ZAI_BASE_URL_REQUIRED_HINT,
     ZAI_CODING_BASE_URL,
     ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
@@ -468,8 +467,6 @@ class AgentProviderService:
                     f"{ZAI_CODING_BASE_URL}."
                 )
             normalized_base_url = normalize_zai_base_url(raw_base_url)
-            if not normalized_base_url:
-                raise RuntimeError(ZAI_BASE_URL_REQUIRED_HINT)
             extra["base_url"] = normalized_base_url
         return model_provider, extra
 

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -10,18 +10,23 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
     PROVIDER_SPECS,
+    ZAI_BASE_URL_REQUIRED_HINT,
     ZAI_CODING_BASE_URL,
     ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
     ProviderSpec,
+    canonical_endpoint_fingerprint_for_config,
+    default_base_url_for,
     is_zai_legacy_anthropic_base_url,
+    normalize_ollama_base_url,
+    normalize_provider_plain_fields,
+    normalize_urlish,
     normalize_zai_base_url,
     provider_spec,
 )
@@ -41,27 +46,6 @@ _PYPROJECT_PATH = _PROJECT_ROOT / "pyproject.toml"
 COMMUNITY_COMPATIBILITY_CATALOG_PATH = (
     _PROJECT_ROOT / "data" / "deepagents_model_compatibility_catalog.json"
 )
-
-_OPENAI_STYLE_DEFAULT_BASE_URLS = {
-    "openai": "https://api.openai.com/v1",
-    "groq": "https://api.groq.com/openai/v1",
-    "deepseek": "https://api.deepseek.com/v1",
-    "xai": "https://api.x.ai/v1",
-    "perplexity": "https://api.perplexity.ai",
-    "together": "https://api.together.xyz/v1",
-    "fireworks": "https://api.fireworks.ai/inference/v1",
-    "mistralai": "https://api.mistral.ai/v1",
-}
-_NON_CANONICAL_EXPORT_PROVIDERS = {
-    "azure_openai",
-    "azure_ai",
-    "google_vertexai",
-    "google_anthropic_vertex",
-    "bedrock",
-    "bedrock_converse",
-    "ibm",
-}
-
 
 @dataclass(slots=True)
 class ProviderModelCompatibilityRecord:
@@ -451,6 +435,44 @@ class AgentProviderService:
             return "Model is required."
         return ""
 
+    def deepagents_runtime_options(
+        self,
+        cfg: ProviderRuntimeConfig,
+    ) -> tuple[str, dict[str, object]]:
+        spec = provider_spec(cfg.provider)
+        if spec is None:
+            raise RuntimeError(f"Unknown provider: {cfg.provider}")
+
+        model_provider = spec.resolved_runtime_provider
+        extra: dict[str, object] = {
+            key: value for key, value in cfg.plain_fields.items() if value.strip()
+        }
+        if cfg.provider == "ollama":
+            api_key = cfg.secret_fields.get("api_key", "").strip()
+            extra["base_url"] = self.normalize_ollama_base_url(
+                str(extra.get("base_url", "")),
+                api_key,
+            )
+            if api_key:
+                extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
+            return model_provider, extra
+
+        extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
+        if cfg.provider == "zai":
+            raw_base_url = cfg.plain_fields.get("base_url", "")
+            if is_zai_legacy_anthropic_base_url(raw_base_url):
+                raise RuntimeError(
+                    "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
+                    "anthropic provider with this URL instead, or use the OpenAI-compatible "
+                    f"endpoint {ZAI_GENERAL_BASE_URL}. Coding Plan users can explicitly set "
+                    f"{ZAI_CODING_BASE_URL}."
+                )
+            normalized_base_url = normalize_zai_base_url(raw_base_url)
+            if not normalized_base_url:
+                raise RuntimeError(ZAI_BASE_URL_REQUIRED_HINT)
+            extra["base_url"] = normalized_base_url
+        return model_provider, extra
+
     def config_fingerprint(
         self,
         cfg: ProviderRuntimeConfig,
@@ -461,9 +483,7 @@ class AgentProviderService:
         spec = provider_spec(cfg.provider)
         if spec is None:
             raise RuntimeError(f"Unknown provider: {cfg.provider}")
-        normalized_plain = self._normalize_plain_fields(
-            cfg.provider, cfg.plain_fields, cfg.secret_fields
-        )
+        normalized_plain = self.normalize_provider_plain_fields(cfg)
         secret_payload = {
             field.name: cfg.secret_fields.get(field.name, "").strip()
             for field in spec.secret_fields
@@ -667,43 +687,13 @@ class AgentProviderService:
         return export_path
 
     def canonical_endpoint_fingerprint(self, cfg: ProviderRuntimeConfig) -> str | None:
-        provider = cfg.provider
-        if provider in _NON_CANONICAL_EXPORT_PROVIDERS:
-            return None
-        if provider == "ollama":
-            api_key = cfg.secret_fields.get("api_key", "").strip()
-            base_url = self.normalize_ollama_base_url(cfg.plain_fields.get("base_url", ""), api_key)
-            if api_key and base_url == "https://ollama.com":
-                return "ollama://cloud"
-            return None
-        if provider == "zai":
-            base_url = cfg.plain_fields.get("base_url", "").strip()
-            normalized = self._normalize_urlish(normalize_zai_base_url(base_url))
-            if normalized in {ZAI_GENERAL_BASE_URL, ZAI_CODING_BASE_URL}:
-                return normalized
-            return None
-        if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
-            base_url = cfg.plain_fields.get("base_url", "").strip()
-            default_base_url = _OPENAI_STYLE_DEFAULT_BASE_URLS[provider]
-            normalized = self._normalize_urlish(base_url or default_base_url)
-            if normalized == default_base_url:
-                return normalized
-            return None
-        return f"{provider}://default"
+        return canonical_endpoint_fingerprint_for_config(cfg)
+
+    def default_base_url_for(self, provider_name: str) -> str:
+        return default_base_url_for(provider_name)
 
     def normalize_ollama_base_url(self, base_url: str, api_key: str = "") -> str:
-        raw = base_url.strip()
-        if not raw:
-            return "https://ollama.com" if api_key.strip() else "http://localhost:11434"
-
-        parsed = urlsplit(raw)
-        if not parsed.scheme or not parsed.netloc:
-            return raw.rstrip("/")
-
-        normalized_path = parsed.path.rstrip("/")
-        if normalized_path == "/api":
-            normalized_path = ""
-        return urlunsplit((parsed.scheme, parsed.netloc, normalized_path, "", "")).rstrip("/")
+        return normalize_ollama_base_url(base_url, api_key)
 
     async def _fetch_live_models(
         self,
@@ -717,12 +707,9 @@ class AgentProviderService:
                 cfg.plain_fields.get("base_url", ""),
                 cfg.secret_fields.get("api_key", ""),
             )
-        if provider in _OPENAI_STYLE_DEFAULT_BASE_URLS:
+        if spec.openai_compatible and spec.default_base_url:
             assert cfg is not None
-            base_url = (
-                cfg.plain_fields.get("base_url", "").strip()
-                or _OPENAI_STYLE_DEFAULT_BASE_URLS[provider]
-            )
+            base_url = cfg.plain_fields.get("base_url", "").strip() or spec.default_base_url
             return await self._fetch_openai_models(base_url, cfg.secret_fields.get("api_key", ""))
         if provider == "anthropic":
             assert cfg is not None
@@ -895,46 +882,13 @@ class AgentProviderService:
         plain_fields: dict[str, str],
         secret_fields: dict[str, str],
     ) -> dict[str, str]:
-        normalized: dict[str, str] = {}
-        spec = provider_spec(provider_name)
-        if spec is None:
-            return normalized
-        for spec_field in spec.plain_fields:
-            key = spec_field.name
-            value = plain_fields.get(key, "").strip()
-            if key == "base_url" and provider_name == "ollama":
-                normalized[key] = self.normalize_ollama_base_url(
-                    value,
-                    secret_fields.get("api_key", ""),
-                )
-                continue
-            if key == "base_url" and provider_name == "zai":
-                normalized[key] = self._normalize_urlish(normalize_zai_base_url(value))
-                continue
-            if key == "base_url" and provider_name in _OPENAI_STYLE_DEFAULT_BASE_URLS:
-                normalized[key] = self._normalize_urlish(
-                    value or _OPENAI_STYLE_DEFAULT_BASE_URLS[provider_name]
-                )
-                continue
-            if key in {"base_url", "endpoint", "azure_endpoint", "url"}:
-                normalized_value = self._normalize_urlish(value)
-                if normalized_value:
-                    normalized[key] = normalized_value
-                continue
-            if value:
-                normalized[key] = value
-        return normalized
+        return normalize_provider_plain_fields(provider_name, plain_fields, secret_fields)
+
+    def normalize_provider_plain_fields(self, cfg: ProviderRuntimeConfig) -> dict[str, str]:
+        return normalize_provider_plain_fields(cfg.provider, cfg.plain_fields, cfg.secret_fields)
 
     def _normalize_urlish(self, raw: str) -> str:
-        value = raw.strip()
-        if not value:
-            return ""
-        parsed = urlsplit(value)
-        if not parsed.scheme or not parsed.netloc:
-            return value.rstrip("/")
-        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "")).rstrip(
-            "/"
-        )
+        return normalize_urlish(raw)
 
     def _parse_provider_form_item(
         self,

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -6,22 +6,14 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 
 import aiohttp
 
-from src.agent.provider_registry import normalize_zai_base_url
+from src.agent.provider_registry import (
+    is_zai_legacy_anthropic_base_url,
+    normalize_ollama_base_url,
+    normalize_zai_base_url,
+    provider_spec,
+)
 
 logger = logging.getLogger(__name__)
-
-# Base URLs for OpenAI-compatible providers (shared with agent_provider_service.py).
-_OPENAI_STYLE_BASE_URLS: Dict[str, str] = {
-    "openai": "https://api.openai.com/v1",
-    "groq": "https://api.groq.com/openai/v1",
-    "deepseek": "https://api.deepseek.com/v1",
-    "xai": "https://api.x.ai/v1",
-    "perplexity": "https://api.perplexity.ai",
-    "together": "https://api.together.xyz/v1",
-    "fireworks": "https://api.fireworks.ai/inference/v1",
-    "mistralai": "https://api.mistral.ai/v1",
-}
-
 
 async def build_provider_service(
     db: object | None = None,
@@ -115,9 +107,13 @@ class AgentProviderService:
 
             ollama_base = os.environ.get("OLLAMA_BASE") or os.environ.get("OLLAMA_URL")
             if ollama_base and "ollama" not in self._registry:
+                normalized_ollama_base = normalize_ollama_base_url(
+                    ollama_base,
+                    os.environ.get("OLLAMA_API_KEY", ""),
+                )
                 _http_adapters.append(
                     ("ollama", lambda: make_ollama_adapter(
-                        ollama_base, os.environ.get("OLLAMA_API_KEY")
+                        normalized_ollama_base, os.environ.get("OLLAMA_API_KEY")
                     ))
                 )
 
@@ -245,11 +241,26 @@ class AgentProviderService:
         provider = cfg.provider
         api_key = (cfg.secret_fields.get("api_key", "") or "").strip()
 
+        spec = provider_spec(provider)
+        if spec is None:
+            return None
+
+        if provider == "zai":
+            raw_base_url = cfg.plain_fields.get("base_url", "")
+            if is_zai_legacy_anthropic_base_url(raw_base_url):
+                logger.debug(
+                    "Skipping db provider %s: Anthropic-compatible URL is not OpenAI-compatible",
+                    provider,
+                )
+                return None
+            base_url = normalize_zai_base_url(raw_base_url)
+            return self._make_openai_compat_provider(base_url, api_key)
+
         # OpenAI-compatible providers
-        if provider in _OPENAI_STYLE_BASE_URLS:
+        if spec.openai_compatible and spec.default_base_url:
             base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
             if not base_url:
-                base_url = _OPENAI_STYLE_BASE_URLS[provider]
+                base_url = spec.default_base_url
             return self._make_openai_compat_provider(base_url, api_key)
 
         if provider == "cohere":
@@ -258,6 +269,7 @@ class AgentProviderService:
 
         if provider == "ollama":
             base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
+            base_url = normalize_ollama_base_url(base_url, api_key)
             return make_ollama_adapter(base_url=base_url or None, api_key=api_key or None)
 
         if provider == "huggingface":
@@ -267,19 +279,6 @@ class AgentProviderService:
         if provider == "anthropic":
             base_url = (cfg.plain_fields.get("base_url", "") or "").strip()
             return make_anthropic_adapter(api_key, base_url=base_url or None)
-
-        if provider == "zai":
-            from src.agent.provider_registry import (
-                is_zai_legacy_anthropic_base_url,
-                normalize_zai_base_url,
-            )
-
-            raw_base_url = cfg.plain_fields.get("base_url", "")
-            if is_zai_legacy_anthropic_base_url(raw_base_url):
-                logger.debug("Skipping db provider %s: Anthropic-compatible URL is not OpenAI-compatible", provider)
-                return None
-            base_url = normalize_zai_base_url(raw_base_url)
-            return self._make_openai_compat_provider(base_url, api_key)
 
         if provider == "google_genai":
             # Google GenAI also needs a different request schema.

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -19,7 +19,7 @@ from src.agent.manager import (
     _SettingsCache,
     _ToolTracker,
 )
-from src.agent.provider_registry import ProviderRuntimeConfig
+from src.agent.provider_registry import ZAI_CODING_BASE_URL, ProviderRuntimeConfig
 from src.config import AppConfig
 from src.database import Database
 
@@ -1244,6 +1244,39 @@ class TestDeepagentsBackendBuildAgent:
         ):
             backend._build_agent(cfg)
             assert captured["model"] == "gpt-4"
+
+    def test_build_agent_zai_empty_base_url_uses_registry_runtime_options(self, mock_db):
+        """Z.AI defaults and LangChain provider mapping come from provider service helpers."""
+        config = AppConfig()
+        backend = DeepagentsBackend(mock_db, config)
+
+        cfg = ProviderRuntimeConfig(
+            provider="zai",
+            enabled=True,
+            priority=0,
+            selected_model="glm-5-turbo",
+            plain_fields={"base_url": ""},
+            secret_fields={"api_key": "zai-key"},
+        )
+
+        captured = {}
+
+        def fake_init_chat_model(*, model, model_provider, **kwargs):
+            captured["model"] = model
+            captured["model_provider"] = model_provider
+            captured.update(kwargs)
+            return MagicMock()
+
+        with (
+            patch("langchain.chat_models.init_chat_model", side_effect=fake_init_chat_model),
+            patch("deepagents.create_deep_agent", return_value=MagicMock()),
+        ):
+            backend._build_agent(cfg)
+
+        assert captured["model"] == "glm-5-turbo"
+        assert captured["model_provider"] == "openai"
+        assert captured["base_url"] == ZAI_CODING_BASE_URL
+        assert captured["api_key"] == "zai-key"
 
     def test_build_agent_record_last_used(self, mock_db):
         """_build_agent records last used provider/model when flag is True."""

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -12,6 +12,9 @@ from src.agent.provider_registry import (
     ZAI_CODING_BASE_URL,
     ZAI_GENERAL_BASE_URL,
     ProviderRuntimeConfig,
+    default_base_url_for,
+    normalize_ollama_base_url,
+    normalize_provider_plain_fields,
     provider_spec,
 )
 from src.config import AppConfig
@@ -1323,6 +1326,36 @@ def test_zai_provider_spec_uses_openai_package_hint():
 
     assert spec is not None
     assert spec.package_name == "langchain-openai"
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("openai", "https://api.openai.com/v1"),
+        ("groq", "https://api.groq.com/openai/v1"),
+        ("deepseek", "https://api.deepseek.com/v1"),
+        ("xai", "https://api.x.ai/v1"),
+        ("perplexity", "https://api.perplexity.ai"),
+        ("together", "https://api.together.xyz/v1"),
+        ("fireworks", "https://api.fireworks.ai/inference/v1"),
+        ("mistralai", "https://api.mistral.ai/v1"),
+    ],
+)
+def test_openai_compatible_provider_specs_expose_default_base_urls(provider, base_url):
+    spec = provider_spec(provider)
+
+    assert spec is not None
+    assert spec.openai_compatible is True
+    assert spec.supports_lightweight_adapter is True
+    assert spec.default_base_url == base_url
+    assert default_base_url_for(provider) == base_url
+
+
+def test_registry_normalization_helpers_keep_zai_and_ollama_policy():
+    zai_fields = normalize_provider_plain_fields("zai", {"base_url": ""}, {"api_key": "zai-key"})
+
+    assert zai_fields["base_url"] == ZAI_CODING_BASE_URL
+    assert normalize_ollama_base_url("https://ollama.com/api", "ollama-key") == "https://ollama.com"
 
 
 # === Z.AI edge case tests ===

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -299,6 +299,29 @@ def test_has_valid_secrets_requires_secrets_for_required_providers():
     assert svc._has_valid_secrets(cfg) is False
 
 
+@pytest.mark.parametrize(
+    ("provider", "default_base_url"),
+    [
+        ("openai", "https://api.openai.com/v1"),
+        ("groq", "https://api.groq.com/openai/v1"),
+        ("deepseek", "https://api.deepseek.com/v1"),
+    ],
+)
+def test_build_adapter_for_config_uses_registry_default_base_url(provider, default_base_url):
+    svc = AgentProviderService()
+    cfg = MagicMock()
+    cfg.provider = provider
+    cfg.plain_fields = {"base_url": ""}
+    cfg.secret_fields = {"api_key": f"{provider}-key"}
+    sentinel = AsyncMock()
+
+    with patch.object(svc, "_make_openai_compat_provider", return_value=sentinel) as make_adapter:
+        adapter = svc._build_adapter_for_config(cfg)
+
+    assert adapter is sentinel
+    make_adapter.assert_called_once_with(default_base_url, f"{provider}-key")
+
+
 @pytest.mark.anyio
 async def test_get_provider_status_list_disabled(mock_db, mock_config):
     """get_provider_status_list returns disabled status."""


### PR DESCRIPTION
## Summary
- make provider_registry the canonical source for provider default base URLs, runtime provider hints, lightweight adapter support, and canonical export modes
- replace duplicate OpenAI-compatible base URL tables in provider services with registry-derived helpers
- route Deepagents runtime option construction through AgentProviderService while preserving Z.AI and Ollama behavior

## Tests
- ruff check src/ tests/ conftest.py
- python3 -m pytest tests/test_agent_provider_service.py tests/test_provider_service.py tests/test_provider_service_db_load.py tests/test_provider_runtime_integration.py -v
- python3 -m pytest tests/routes/test_settings_routes_provider_notifications.py tests/test_cli_provider.py tests/test_agent_manager_runtime_paths.py -v

Closes #510