### PR TITLE
refactor(tasks): split UnifiedDispatcher task handlers

### DIFF
--- a/src/services/task_handlers/__init__.py
+++ b/src/services/task_handlers/__init__.py
@@ -1,0 +1,16 @@
+from src.services.task_handlers.base import TaskHandler, TaskHandlerContext
+from src.services.task_handlers.content import ContentTaskHandler
+from src.services.task_handlers.photo import PhotoTaskHandler
+from src.services.task_handlers.pipeline import PipelineTaskHandler
+from src.services.task_handlers.stats import StatsTaskHandler
+from src.services.task_handlers.translation import TranslationTaskHandler
+
+__all__ = [
+    "ContentTaskHandler",
+    "PhotoTaskHandler",
+    "PipelineTaskHandler",
+    "StatsTaskHandler",
+    "TaskHandler",
+    "TaskHandlerContext",
+    "TranslationTaskHandler",
+]

--- a/src/services/task_handlers/base.py
+++ b/src/services/task_handlers/base.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from src.database.bundles import ChannelBundle, PipelineBundle, SearchQueryBundle
+from src.database.repositories.collection_tasks import CollectionTasksRepository
+from src.models import CollectionTask, CollectionTaskType
+from src.telegram.collector import Collector
+
+if TYPE_CHECKING:
+    from src.database import Database
+    from src.search.engine import SearchEngine
+    from src.services.image_generation_service import ImageGenerationService
+    from src.services.photo_auto_upload_service import PhotoAutoUploadService
+    from src.services.photo_task_service import PhotoTaskService
+    from src.telegram.notifier import Notifier
+
+logger = logging.getLogger(__name__)
+
+
+class TaskHandler(Protocol):
+    task_types: tuple[CollectionTaskType, ...]
+
+    async def handle(self, task: CollectionTask) -> None: ...
+
+
+@dataclass(slots=True)
+class TaskHandlerContext:
+    collector: Collector
+    channel_bundle: ChannelBundle
+    tasks: CollectionTasksRepository
+    stop_event: asyncio.Event
+    sq_bundle: SearchQueryBundle | None = None
+    photo_task_service: PhotoTaskService | None = None
+    photo_auto_upload_service: PhotoAutoUploadService | None = None
+    poll_interval_sec: float = 5.0
+    channel_timeout_sec: float = 120.0
+    search_engine: "SearchEngine | None" = None
+    pipeline_bundle: PipelineBundle | None = None
+    db: "Database | None" = None
+    client_pool: object | None = None
+    notifier: "Notifier | None" = None
+    config: object | None = None
+    llm_provider_service: object | None = None
+
+
+async def build_image_service(context: TaskHandlerContext) -> "ImageGenerationService":
+    from src.services.image_generation_service import ImageGenerationService
+
+    adapters = None
+    if context.db and context.config:
+        try:
+            from src.services.image_provider_service import ImageProviderService
+
+            svc = ImageProviderService(context.db, context.config)
+            configs = await svc.load_provider_configs()
+            built = svc.build_adapters(configs)
+            if configs:
+                adapters = built
+            elif built:
+                adapters = built
+        except Exception:
+            logger.warning("Failed to load image provider configs from DB", exc_info=True)
+            adapters = {}
+    return ImageGenerationService(adapters=adapters)
+
+
+async def resolve_llm_provider_service(context: TaskHandlerContext) -> object:
+    if context.llm_provider_service is not None:
+        return context.llm_provider_service
+    from src.services.provider_service import build_provider_service
+
+    return await build_provider_service(context.db, context.config)

--- a/src/services/task_handlers/content.py
+++ b/src/services/task_handlers/content.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    ContentGenerateTaskPayload,
+    ContentPublishTaskPayload,
+)
+from src.services.task_handlers.base import TaskHandlerContext, build_image_service, resolve_llm_provider_service
+
+logger = logging.getLogger(__name__)
+
+
+class ContentTaskHandler:
+    task_types = (CollectionTaskType.CONTENT_GENERATE, CollectionTaskType.CONTENT_PUBLISH)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        if task.task_type == CollectionTaskType.CONTENT_GENERATE:
+            await self.handle_content_generate(task)
+            return
+        if task.task_type == CollectionTaskType.CONTENT_PUBLISH:
+            await self.handle_content_publish(task)
+            return
+        raise ValueError(f"Unsupported content task type: {task.task_type}")
+
+    async def handle_content_generate(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, ContentGenerateTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Invalid CONTENT_GENERATE payload"
+            )
+            return
+
+        if not ctx.db or not ctx.search_engine or not ctx.pipeline_bundle:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Pipeline execution environment not configured",
+            )
+            return
+
+        pipeline_id = payload.pipeline_id
+        try:
+            from src.models import PipelinePublishMode
+            from src.services.content_generation_service import ContentGenerationService
+            from src.services.draft_notification_service import DraftNotificationService
+            from src.services.pipeline_service import PipelineService
+            from src.services.publish_service import PublishService
+            from src.services.quality_scoring_service import QualityScoringService
+
+            svc = PipelineService(ctx.pipeline_bundle)
+            pipeline = await svc.get(pipeline_id)
+            if pipeline is None:
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.COMPLETED,
+                    note=f"Pipeline id={pipeline_id} not found",
+                )
+                return
+
+            db = ctx.db
+            notification_service = DraftNotificationService(db, ctx.notifier)
+            image_service = await build_image_service(ctx)
+            provider_service = await resolve_llm_provider_service(ctx)
+            quality_service = QualityScoringService(db, provider_service=provider_service)
+            gen = ContentGenerationService(
+                db,
+                ctx.search_engine,
+                config=ctx.config,
+                image_service=image_service,
+                notification_service=notification_service,
+                quality_service=quality_service,
+                client_pool=ctx.client_pool,
+                provider_service=provider_service,
+            )
+            run = await gen.generate(pipeline=pipeline, model=pipeline.llm_model)
+
+            effective_mode = (
+                (run.metadata or {}).get("effective_publish_mode", pipeline.publish_mode.value)
+                if run is not None
+                else pipeline.publish_mode.value
+            )
+            if effective_mode == PipelinePublishMode.AUTO.value and run is not None:
+                publish_svc = PublishService(db, ctx.client_pool)
+                try:
+                    await publish_svc.publish_run(run, pipeline)
+                except Exception as pub_exc:
+                    logger.exception(
+                        "Auto-publish failed for run id=%s (pipeline_id=%d); generation already saved",
+                        run.id,
+                        pipeline_id,
+                    )
+                    await ctx.tasks.update_collection_task(
+                        task.id,
+                        CollectionTaskStatus.FAILED,
+                        error=f"Generation ok but publish failed: {pub_exc!s:.400}",
+                    )
+                    return
+
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=1 if run is not None else 0,
+                note=f"Generated run id={run.id}" if run is not None else "Generation returned no result",
+            )
+        except Exception as exc:
+            logger.exception("Content generate handler failed for pipeline_id=%d", pipeline_id)
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )
+
+    async def handle_content_publish(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, ContentPublishTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Invalid CONTENT_PUBLISH payload"
+            )
+            return
+
+        if not ctx.db or not ctx.pipeline_bundle:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Pipeline execution environment not configured",
+            )
+            return
+
+        if ctx.client_pool is None:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="client_pool not configured",
+            )
+            return
+
+        pipeline_id = payload.pipeline_id
+        try:
+            from src.database.repositories.generation_runs import GenerationRunsRepository
+            from src.services.pipeline_service import PipelineService
+            from src.services.publish_service import PublishService
+
+            db = ctx.db
+            publish_svc = PublishService(db, ctx.client_pool)
+
+            filter_sql = "AND pipeline_id = ?" if pipeline_id is not None else ""
+            params: tuple = (pipeline_id,) if pipeline_id is not None else ()
+            cur = await db.execute(
+                f"SELECT * FROM generation_runs WHERE moderation_status = 'approved' {filter_sql} ORDER BY id ASC",
+                params,
+            )
+            rows = await cur.fetchall()
+            if not rows:
+                await ctx.tasks.update_collection_task(
+                    task.id, CollectionTaskStatus.COMPLETED, note="No approved runs to publish"
+                )
+                return
+
+            runs = [GenerationRunsRepository._to_generation_run(row) for row in rows]
+
+            pipeline_svc = PipelineService(ctx.pipeline_bundle)
+            published = 0
+            for run in runs:
+                if run.pipeline_id is None:
+                    continue
+                pipeline = await pipeline_svc.get(run.pipeline_id)
+                if pipeline is None:
+                    continue
+                results = await publish_svc.publish_run(run, pipeline)
+                if any(r.success for r in results):
+                    published += 1
+
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=published,
+                note=f"Published {published}/{len(runs)} runs",
+            )
+        except Exception as exc:
+            logger.exception("Content publish handler failed")
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )

--- a/src/services/task_handlers/photo.py
+++ b/src/services/task_handlers/photo.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType
+from src.services.task_handlers.base import TaskHandlerContext
+
+
+class PhotoTaskHandler:
+    task_types = (CollectionTaskType.PHOTO_DUE, CollectionTaskType.PHOTO_AUTO)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        if task.task_type == CollectionTaskType.PHOTO_DUE:
+            await self.handle_photo_due(task)
+            return
+        if task.task_type == CollectionTaskType.PHOTO_AUTO:
+            await self.handle_photo_auto(task)
+            return
+        raise ValueError(f"Unsupported photo task type: {task.task_type}")
+
+    async def handle_photo_due(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        if not ctx.photo_task_service:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="PhotoTaskService not configured",
+            )
+            return
+        try:
+            processed = await ctx.photo_task_service.run_due()
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=processed,
+            )
+        except Exception as exc:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )
+
+    async def handle_photo_auto(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        if not ctx.photo_auto_upload_service:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="PhotoAutoUploadService not configured",
+            )
+            return
+        try:
+            jobs = await ctx.photo_auto_upload_service.run_due()
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=jobs,
+            )
+        except Exception as exc:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )

--- a/src/services/task_handlers/pipeline.py
+++ b/src/services/task_handlers/pipeline.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType, PipelineRunTaskPayload
+from src.services.task_handlers.base import TaskHandlerContext, build_image_service, resolve_llm_provider_service
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineTaskHandler:
+    task_types = (CollectionTaskType.PIPELINE_RUN,)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        await self.handle_pipeline_run(task)
+
+    async def handle_pipeline_run(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, PipelineRunTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Invalid PIPELINE_RUN payload",
+            )
+            return
+
+        if not ctx.pipeline_bundle or not ctx.search_engine or not ctx.db:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Pipeline execution environment not configured",
+            )
+            return
+
+        pipeline_id = payload.pipeline_id
+        run_id: int | None = None
+        try:
+            from src.services.content_generation_service import ContentGenerationService
+            from src.services.draft_notification_service import DraftNotificationService
+            from src.services.pipeline_service import PipelineService
+            from src.services.quality_scoring_service import QualityScoringService
+
+            svc = PipelineService(ctx.pipeline_bundle)
+            pipeline = await svc.get(pipeline_id)
+            if pipeline is None:
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.COMPLETED,
+                    note=f"Pipeline id={pipeline_id} not found",
+                )
+                return
+
+            db = ctx.db
+            notification_service = DraftNotificationService(db, ctx.notifier)
+            image_service = await build_image_service(ctx)
+            provider_service = await resolve_llm_provider_service(ctx)
+            quality_service = QualityScoringService(db, provider_service=provider_service)
+            gen = ContentGenerationService(
+                db,
+                ctx.search_engine,
+                config=ctx.config,
+                image_service=image_service,
+                notification_service=notification_service,
+                quality_service=quality_service,
+                client_pool=ctx.client_pool,
+                provider_service=provider_service,
+            )
+            try:
+                run = await gen.generate(
+                    pipeline=pipeline,
+                    model=pipeline.llm_model,
+                    dry_run=payload.dry_run,
+                    since_hours=payload.since_hours,
+                )
+                run_id = run.id
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.COMPLETED,
+                    messages_collected=run.result_count,
+                    note=f"Pipeline run id={run_id}",
+                )
+            except Exception as exc:
+                logger.exception("Pipeline run failed for pipeline_id=%d run_id=%s", pipeline_id, run_id)
+                if run_id is not None:
+                    await db.repos.generation_runs.set_status(run_id, "failed")
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.FAILED,
+                    error=str(exc)[:500],
+                )
+        except Exception as exc:
+            logger.exception("Pipeline run handler failed for pipeline_id=%d", pipeline_id)
+            if run_id is not None:
+                await ctx.db.repos.generation_runs.set_status(run_id, "failed")
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime, timezone
+
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    SqStatsTaskPayload,
+    StatsAllTaskPayload,
+)
+from src.services.task_handlers.base import TaskHandlerContext
+
+logger = logging.getLogger(__name__)
+
+
+class StatsTaskHandler:
+    task_types = (CollectionTaskType.STATS_ALL, CollectionTaskType.SQ_STATS)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        if task.task_type == CollectionTaskType.STATS_ALL:
+            await self.handle_stats_all(task)
+            return
+        if task.task_type == CollectionTaskType.SQ_STATS:
+            await self.handle_sq_stats(task)
+            return
+        raise ValueError(f"Unsupported stats task type: {task.task_type}")
+
+    async def handle_stats_all(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, StatsAllTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Unsupported stats task payload"
+            )
+            return
+
+        channel_ids = payload.channel_ids
+        next_index = payload.next_index
+        channels_ok = payload.channels_ok or 0
+        channels_err = payload.channels_err or 0
+
+        logger.info(
+            "Running stats task #%s: next_index=%d total=%d",
+            task.id,
+            next_index,
+            len(channel_ids),
+        )
+
+        if next_index >= len(channel_ids):
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=len(channel_ids),
+            )
+            return
+
+        cursor = next_index
+        collector_wait_sec = 0.0
+        while cursor < len(channel_ids):
+            if ctx.stop_event.is_set():
+                break
+
+            fresh = await ctx.tasks.get_collection_task(task.id)
+            if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
+                return
+
+            if ctx.collector.is_running:
+                await asyncio.sleep(ctx.poll_interval_sec)
+                collector_wait_sec += ctx.poll_interval_sec
+                if collector_wait_sec >= ctx.channel_timeout_sec:
+                    await ctx.tasks.update_collection_task(
+                        task.id,
+                        CollectionTaskStatus.FAILED,
+                        messages_collected=channels_ok + channels_err,
+                        error="Timed out waiting for collector to finish",
+                    )
+                    return
+                continue
+            collector_wait_sec = 0.0
+
+            channel_id = channel_ids[cursor]
+            channel = await ctx.channel_bundle.get_by_channel_id(channel_id)
+            if channel is None:
+                channels_err += 1
+                cursor += 1
+                progress_payload = StatsAllTaskPayload(
+                    channel_ids=channel_ids,
+                    next_index=cursor,
+                    channels_ok=channels_ok,
+                    channels_err=channels_err,
+                )
+                await ctx.tasks.persist_stats_progress(
+                    task.id,
+                    payload=progress_payload,
+                    messages_collected=channels_ok + channels_err,
+                )
+                continue
+
+            try:
+                result = await asyncio.wait_for(
+                    ctx.collector.collect_channel_stats(channel),
+                    timeout=ctx.channel_timeout_sec,
+                )
+            except asyncio.TimeoutError:
+                channels_err += 1
+                cursor += 1
+            except Exception as exc:
+                logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
+                channels_err += 1
+                cursor += 1
+            else:
+                fresh = await ctx.tasks.get_collection_task(task.id)
+                if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
+                    return
+                if result is None:
+                    availability = await ctx.collector.get_stats_availability()
+                    if (
+                        availability.state == "all_flooded"
+                        and availability.next_available_at_utc is not None
+                    ):
+                        reschedule_payload = StatsAllTaskPayload(
+                            channel_ids=channel_ids,
+                            next_index=cursor,
+                            channels_ok=channels_ok,
+                            channels_err=channels_err,
+                        )
+                        await ctx.tasks.reschedule_stats_task(
+                            task.id,
+                            payload=reschedule_payload,
+                            run_after=availability.next_available_at_utc,
+                            messages_collected=channels_ok + channels_err,
+                        )
+                        return
+
+                    await ctx.tasks.update_collection_task(
+                        task.id,
+                        CollectionTaskStatus.FAILED,
+                        messages_collected=channels_ok + channels_err,
+                        error="No active connected Telegram accounts",
+                    )
+                    return
+
+                channels_ok += 1
+                cursor += 1
+
+            progress_payload = StatsAllTaskPayload(
+                channel_ids=channel_ids,
+                next_index=cursor,
+                channels_ok=channels_ok,
+                channels_err=channels_err,
+            )
+            await ctx.tasks.persist_stats_progress(
+                task.id,
+                payload=progress_payload,
+                messages_collected=channels_ok + channels_err,
+            )
+
+            if cursor < len(channel_ids):
+                await asyncio.sleep(ctx.collector.delay_between_channels_sec)
+
+        if cursor < len(channel_ids):
+            reschedule_payload = StatsAllTaskPayload(
+                channel_ids=channel_ids,
+                next_index=cursor,
+                channels_ok=channels_ok,
+                channels_err=channels_err,
+            )
+            await ctx.tasks.reschedule_stats_task(
+                task.id,
+                payload=reschedule_payload,
+                run_after=datetime.now(timezone.utc),
+                messages_collected=channels_ok + channels_err,
+            )
+            return
+
+        await ctx.tasks.update_collection_task(
+            task.id,
+            CollectionTaskStatus.COMPLETED,
+            messages_collected=channels_ok + channels_err,
+        )
+
+    async def handle_sq_stats(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        if not ctx.sq_bundle:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                note="No search query bundle configured",
+            )
+            return
+
+        payload = task.payload
+        if not isinstance(payload, SqStatsTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error="Invalid SQ_STATS payload",
+            )
+            return
+
+        sq = await ctx.sq_bundle.get_by_id(payload.sq_id)
+        if not sq:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                note=f"Search query id={payload.sq_id} not found",
+            )
+            return
+
+        try:
+            today = date.today().isoformat()
+            daily = await ctx.sq_bundle.get_fts_daily_stats_for_query(sq, days=1)
+            today_count = 0
+            for d in daily:
+                if d.day == today:
+                    today_count = d.count
+                    break
+            await ctx.sq_bundle.record_stat(payload.sq_id, today_count)
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=today_count,
+                note=f"sq={sq.query}",
+            )
+        except Exception as exc:
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )

--- a/src/services/task_handlers/translation.py
+++ b/src/services/task_handlers/translation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType, TranslateBatchTaskPayload
+from src.services.task_handlers.base import TaskHandlerContext
+
+logger = logging.getLogger(__name__)
+
+
+class TranslationTaskHandler:
+    task_types = (CollectionTaskType.TRANSLATE_BATCH,)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        await self.handle_translate_batch(task)
+
+    async def handle_translate_batch(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+
+        payload = task.payload
+        if not isinstance(payload, TranslateBatchTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Invalid TRANSLATE_BATCH payload"
+            )
+            return
+
+        if not ctx.db:
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Database not configured"
+            )
+            return
+
+        try:
+            from src.services.provider_service import build_provider_service
+            from src.services.translation_service import TranslationService
+
+            provider_name = await ctx.db.get_setting("translation_provider")
+            model = await ctx.db.get_setting("translation_model")
+
+            provider_service = await build_provider_service(ctx.db, ctx.config)
+
+            resolved = provider_service.get_provider_callable(provider_name)
+            if resolved is provider_service._registry.get("default"):
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.FAILED,
+                    error="No translation provider configured (only stub default available)",
+                )
+                return
+
+            svc = TranslationService(ctx.db, provider_service=provider_service)
+
+            target_lang = payload.target_lang
+            source_filter = payload.source_filter or []
+            batch_size = payload.batch_size or 20
+            last_id = payload.last_processed_id or 0
+
+            msgs = await ctx.db.repos.messages.get_untranslated_messages(
+                target=target_lang,
+                source_langs=source_filter or None,
+                limit=batch_size,
+                after_id=last_id,
+            )
+
+            if not msgs:
+                await ctx.tasks.update_collection_task(
+                    task.id,
+                    CollectionTaskStatus.COMPLETED,
+                    note="No more messages to translate",
+                )
+                return
+
+            results = await svc.translate_batch(msgs, target_lang, provider_name=provider_name, model=model)
+
+            for msg_id, translated in results:
+                await ctx.db.repos.messages.update_translation(msg_id, target_lang, translated)
+
+            new_last_id = max(m.id for m in msgs if m.id is not None) if msgs else last_id
+
+            remaining = await ctx.db.repos.messages.get_untranslated_messages(
+                target=target_lang,
+                source_langs=source_filter or None,
+                limit=1,
+                after_id=new_last_id,
+            )
+
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.COMPLETED,
+                messages_collected=len(results),
+                note=f"Translated {len(results)}/{len(msgs)} messages",
+            )
+
+            if remaining:
+                follow_up = TranslateBatchTaskPayload(
+                    target_lang=target_lang,
+                    source_filter=source_filter,
+                    batch_size=batch_size,
+                    last_processed_id=new_last_id,
+                )
+                await ctx.tasks.create_generic_task(
+                    CollectionTaskType.TRANSLATE_BATCH,
+                    title=f"Translation batch ({target_lang}) cont.",
+                    payload=follow_up,
+                )
+
+        except Exception as exc:
+            logger.exception("Translate batch handler failed")
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                error=str(exc)[:500],
+            )

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Awaitable, Callable, TypeVar
 
 from src.database.bundles import ChannelBundle, PipelineBundle, SearchQueryBundle
 from src.database.repositories.collection_tasks import CollectionTasksRepository
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
+TTaskHandler = TypeVar("TTaskHandler", bound=TaskHandler)
 
 _HANDLER_CLASSES = (
     StatsTaskHandler,
@@ -38,7 +39,11 @@ _HANDLER_CLASSES = (
     TranslationTaskHandler,
 )
 
-HANDLED_TYPES = [task_type.value for handler_cls in _HANDLER_CLASSES for task_type in handler_cls.task_types]
+HANDLED_TYPES = [
+    task_type.value
+    for handler_cls in _HANDLER_CLASSES
+    for task_type in handler_cls.task_types
+]
 
 
 class UnifiedDispatcher:
@@ -101,11 +106,7 @@ class UnifiedDispatcher:
             llm_provider_service=self._llm_provider_service,
         )
 
-    def _build_handlers(self) -> dict[type[TaskHandler], TaskHandler]:
-        context = self._handler_context()
-        return {handler_cls: handler_cls(context) for handler_cls in _HANDLER_CLASSES}
-
-    def _handler(self, handler_cls: type[TaskHandler]) -> TaskHandler:
+    def _handler(self, handler_cls: type[TTaskHandler]) -> TTaskHandler:
         return handler_cls(self._handler_context())
 
     async def _build_image_service(self) -> "ImageGenerationService":
@@ -167,7 +168,7 @@ class UnifiedDispatcher:
                         logger.exception("Failed to mark broken task as failed")
                 await asyncio.sleep(current_interval)
 
-    def _handler_map(self) -> dict[CollectionTaskType, object]:
+    def _handler_map(self) -> dict[CollectionTaskType, Callable[[CollectionTask], Awaitable[None]]]:
         try:
             return self.__handler_map
         except AttributeError:

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -2,22 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from src.database.bundles import ChannelBundle, PipelineBundle, SearchQueryBundle
 from src.database.repositories.collection_tasks import CollectionTasksRepository
-from src.models import (
-    CollectionTask,
-    CollectionTaskStatus,
-    CollectionTaskType,
-    ContentGenerateTaskPayload,
-    ContentPublishTaskPayload,
-    PipelineRunTaskPayload,
-    SqStatsTaskPayload,
-    StatsAllTaskPayload,
-    TranslateBatchTaskPayload,
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType
+from src.services.task_handlers import (
+    ContentTaskHandler,
+    PhotoTaskHandler,
+    PipelineTaskHandler,
+    StatsTaskHandler,
+    TaskHandler,
+    TaskHandlerContext,
+    TranslationTaskHandler,
 )
+from src.services.task_handlers.base import build_image_service
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
@@ -30,20 +30,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-HANDLED_TYPES = [
-    CollectionTaskType.STATS_ALL.value,
-    CollectionTaskType.SQ_STATS.value,
-    CollectionTaskType.PHOTO_DUE.value,
-    CollectionTaskType.PHOTO_AUTO.value,
-    CollectionTaskType.PIPELINE_RUN.value,
-    CollectionTaskType.CONTENT_GENERATE.value,
-    CollectionTaskType.CONTENT_PUBLISH.value,
-    CollectionTaskType.TRANSLATE_BATCH.value,
-]
+_HANDLER_CLASSES = (
+    StatsTaskHandler,
+    PhotoTaskHandler,
+    PipelineTaskHandler,
+    ContentTaskHandler,
+    TranslationTaskHandler,
+)
+
+HANDLED_TYPES = [task_type.value for handler_cls in _HANDLER_CLASSES for task_type in handler_cls.task_types]
 
 
 class UnifiedDispatcher:
-    """Polls DB for non-CHANNEL_COLLECT tasks and dispatches them to handlers."""
+    """Polls DB for non-CHANNEL_COLLECT tasks and dispatches them to task handlers."""
 
     def __init__(
         self,
@@ -64,7 +63,6 @@ class UnifiedDispatcher:
         config: object | None = None,
         llm_provider_service: object | None = None,
     ):
-
         self._collector = collector
         self._channel_bundle = channel_bundle
         self._tasks = tasks_repo
@@ -83,27 +81,35 @@ class UnifiedDispatcher:
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
 
+    def _handler_context(self) -> TaskHandlerContext:
+        return TaskHandlerContext(
+            collector=self._collector,
+            channel_bundle=self._channel_bundle,
+            tasks=self._tasks,
+            stop_event=self._stop_event,
+            sq_bundle=self._sq_bundle,
+            photo_task_service=self._photo_task_service,
+            photo_auto_upload_service=self._photo_auto_upload_service,
+            poll_interval_sec=self._poll_interval_sec,
+            channel_timeout_sec=self._channel_timeout_sec,
+            search_engine=self._search_engine,
+            pipeline_bundle=self._pipeline_bundle,
+            db=self._db,
+            client_pool=self._client_pool,
+            notifier=self._notifier,
+            config=self._config,
+            llm_provider_service=self._llm_provider_service,
+        )
+
+    def _build_handlers(self) -> dict[type[TaskHandler], TaskHandler]:
+        context = self._handler_context()
+        return {handler_cls: handler_cls(context) for handler_cls in _HANDLER_CLASSES}
+
+    def _handler(self, handler_cls: type[TaskHandler]) -> TaskHandler:
+        return handler_cls(self._handler_context())
+
     async def _build_image_service(self) -> "ImageGenerationService":
-        from src.services.image_generation_service import ImageGenerationService
-
-        adapters = None
-        if self._db and self._config:
-            try:
-                from src.services.image_provider_service import ImageProviderService
-
-                svc = ImageProviderService(self._db, self._config)
-                configs = await svc.load_provider_configs()
-                built = svc.build_adapters(configs)
-                if configs:
-                    # DB has entries — honour them, even if all disabled → {}
-                    adapters = built
-                elif built:
-                    # No DB entries but env-only adapters found by build_adapters
-                    adapters = built
-            except Exception:
-                logger.warning("Failed to load image provider configs from DB", exc_info=True)
-                adapters = {}  # don't fall back to env-only; honour user's saved state
-        return ImageGenerationService(adapters=adapters)
+        return await build_image_service(self._handler_context())
 
     async def start(self) -> None:
         if self._task and not self._task.done():
@@ -161,7 +167,7 @@ class UnifiedDispatcher:
                         logger.exception("Failed to mark broken task as failed")
                 await asyncio.sleep(current_interval)
 
-    def _handler_map(self) -> dict:
+    def _handler_map(self) -> dict[CollectionTaskType, object]:
         try:
             return self.__handler_map
         except AttributeError:
@@ -188,656 +194,26 @@ class UnifiedDispatcher:
             return
         await handler(task)
 
-    # ── STATS_ALL ──
-
     async def _handle_stats_all(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        payload = task.payload
-        if not isinstance(payload, StatsAllTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Unsupported stats task payload"
-            )
-            return
-
-        channel_ids = payload.channel_ids
-        next_index = payload.next_index
-        channels_ok = payload.channels_ok or 0
-        channels_err = payload.channels_err or 0
-
-        logger.info(
-            "Running stats task #%s: next_index=%d total=%d",
-            task.id,
-            next_index,
-            len(channel_ids),
-        )
-
-        if next_index >= len(channel_ids):
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=len(channel_ids),
-            )
-            return
-
-        cursor = next_index
-
-        collector_wait_sec = 0.0
-        while cursor < len(channel_ids):
-            if self._stop_event.is_set():
-                break
-
-            # Check if task was cancelled from UI
-            fresh = await self._tasks.get_collection_task(task.id)
-            if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
-                return
-
-            if self._collector.is_running:
-                await asyncio.sleep(self._poll_interval_sec)
-                collector_wait_sec += self._poll_interval_sec
-                if collector_wait_sec >= self._channel_timeout_sec:
-                    await self._tasks.update_collection_task(
-                        task.id,
-                        CollectionTaskStatus.FAILED,
-                        messages_collected=channels_ok + channels_err,
-                        error="Timed out waiting for collector to finish",
-                    )
-                    return
-                continue
-            collector_wait_sec = 0.0
-
-            channel_id = channel_ids[cursor]
-            channel = await self._channel_bundle.get_by_channel_id(channel_id)
-            if channel is None:
-                channels_err += 1
-                cursor += 1
-                progress_payload = StatsAllTaskPayload(
-                    channel_ids=channel_ids,
-                    next_index=cursor,
-                    channels_ok=channels_ok,
-                    channels_err=channels_err,
-                )
-                await self._tasks.persist_stats_progress(
-                    task.id,
-                    payload=progress_payload,
-                    messages_collected=channels_ok + channels_err,
-                )
-                continue
-
-            try:
-                result = await asyncio.wait_for(
-                    self._collector.collect_channel_stats(channel),
-                    timeout=self._channel_timeout_sec,
-                )
-            except asyncio.TimeoutError:
-                channels_err += 1
-                cursor += 1
-            except Exception as exc:
-                logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
-                channels_err += 1
-                cursor += 1
-            else:
-                fresh = await self._tasks.get_collection_task(task.id)
-                if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
-                    return
-                if result is None:
-                    availability = await self._collector.get_stats_availability()
-                    if (
-                        availability.state == "all_flooded"
-                        and availability.next_available_at_utc is not None
-                    ):
-                        reschedule_payload = StatsAllTaskPayload(
-                            channel_ids=channel_ids,
-                            next_index=cursor,
-                            channels_ok=channels_ok,
-                            channels_err=channels_err,
-                        )
-                        await self._tasks.reschedule_stats_task(
-                            task.id,
-                            payload=reschedule_payload,
-                            run_after=availability.next_available_at_utc,
-                            messages_collected=channels_ok + channels_err,
-                        )
-                        return
-
-                    await self._tasks.update_collection_task(
-                        task.id,
-                        CollectionTaskStatus.FAILED,
-                        messages_collected=channels_ok + channels_err,
-                        error="No active connected Telegram accounts",
-                    )
-                    return
-
-                channels_ok += 1
-                cursor += 1
-
-            progress_payload = StatsAllTaskPayload(
-                channel_ids=channel_ids,
-                next_index=cursor,
-                channels_ok=channels_ok,
-                channels_err=channels_err,
-            )
-            await self._tasks.persist_stats_progress(
-                task.id,
-                payload=progress_payload,
-                messages_collected=channels_ok + channels_err,
-            )
-
-            if cursor < len(channel_ids):
-                await asyncio.sleep(self._collector.delay_between_channels_sec)
-
-        # Final update — check if interrupted by stop event
-        if cursor < len(channel_ids):
-            # Graceful shutdown: reschedule so the remaining channels are processed on next run
-            reschedule_payload = StatsAllTaskPayload(
-                channel_ids=channel_ids,
-                next_index=cursor,
-                channels_ok=channels_ok,
-                channels_err=channels_err,
-            )
-            await self._tasks.reschedule_stats_task(
-                task.id,
-                payload=reschedule_payload,
-                run_after=datetime.now(timezone.utc),
-                messages_collected=channels_ok + channels_err,
-            )
-            return
-
-        await self._tasks.update_collection_task(
-            task.id,
-            CollectionTaskStatus.COMPLETED,
-            messages_collected=channels_ok + channels_err,
-        )
-
-    # ── SQ_STATS ──
+        await self._handler(StatsTaskHandler).handle_stats_all(task)
 
     async def _handle_sq_stats(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        if not self._sq_bundle:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                note="No search query bundle configured",
-            )
-            return
-
-        payload = task.payload
-        if not isinstance(payload, SqStatsTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="Invalid SQ_STATS payload",
-            )
-            return
-
-        sq = await self._sq_bundle.get_by_id(payload.sq_id)
-        if not sq:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                note=f"Search query id={payload.sq_id} not found",
-            )
-            return
-
-        try:
-            today = date.today().isoformat()
-            daily = await self._sq_bundle.get_fts_daily_stats_for_query(sq, days=1)
-            today_count = 0
-            for d in daily:
-                if d.day == today:
-                    today_count = d.count
-                    break
-            await self._sq_bundle.record_stat(payload.sq_id, today_count)
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=today_count,
-                note=f"sq={sq.query}",
-            )
-        except Exception as exc:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
-
-    # ── PHOTO_DUE ──
+        await self._handler(StatsTaskHandler).handle_sq_stats(task)
 
     async def _handle_photo_due(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        if not self._photo_task_service:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="PhotoTaskService not configured",
-            )
-            return
-        try:
-            processed = await self._photo_task_service.run_due()
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=processed,
-            )
-        except Exception as exc:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
-
-    # ── PHOTO_AUTO ──
+        await self._handler(PhotoTaskHandler).handle_photo_due(task)
 
     async def _handle_photo_auto(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        if not self._photo_auto_upload_service:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="PhotoAutoUploadService not configured",
-            )
-            return
-        try:
-            jobs = await self._photo_auto_upload_service.run_due()
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=jobs,
-            )
-        except Exception as exc:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
+        await self._handler(PhotoTaskHandler).handle_photo_auto(task)
 
     async def _handle_pipeline_run(self, task: CollectionTask) -> None:
-        """Handle a PIPELINE_RUN generic task by executing the pipeline generation.
-
-        This will create a generation_run record and run the pipeline generation
-        using the configured SearchEngine and provider. The task is marked as
-        completed on success or failed otherwise.
-        """
-        if task.id is None:
-            return
-
-        payload = task.payload
-        if not isinstance(payload, PipelineRunTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="Invalid PIPELINE_RUN payload",
-            )
-            return
-
-        if not self._pipeline_bundle or not self._search_engine or not self._db:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="Pipeline execution environment not configured",
-            )
-            return
-
-        pipeline_id = payload.pipeline_id
-        run_id: int | None = None
-        try:
-            # Import lazily to avoid circular imports during module load
-            from src.services.content_generation_service import ContentGenerationService
-            from src.services.draft_notification_service import DraftNotificationService
-            from src.services.pipeline_service import PipelineService
-            from src.services.quality_scoring_service import QualityScoringService
-
-            svc = PipelineService(self._pipeline_bundle)
-            pipeline = await svc.get(pipeline_id)
-            if pipeline is None:
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.COMPLETED,
-                    note=f"Pipeline id={pipeline_id} not found",
-                )
-                return
-
-            db = self._db
-            notification_service = DraftNotificationService(db, self._notifier)
-            image_service = await self._build_image_service()
-            provider_service = self._llm_provider_service
-            if provider_service is None:
-                from src.services.provider_service import build_provider_service
-
-                provider_service = await build_provider_service(db, self._config)
-            quality_service = QualityScoringService(db, provider_service=provider_service)
-            gen = ContentGenerationService(
-                db,
-                self._search_engine,
-                config=self._config,
-                image_service=image_service,
-                notification_service=notification_service,
-                quality_service=quality_service,
-                client_pool=self._client_pool,
-                provider_service=provider_service,
-            )
-            try:
-                run = await gen.generate(
-                    pipeline=pipeline,
-                    model=pipeline.llm_model,
-                    dry_run=payload.dry_run,
-                    since_hours=payload.since_hours,
-                )
-                run_id = run.id
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.COMPLETED,
-                    messages_collected=run.result_count,
-                    note=f"Pipeline run id={run_id}",
-                )
-            except Exception as exc:
-                logger.exception("Pipeline run failed for pipeline_id=%d run_id=%s", pipeline_id, run_id)
-                if run_id is not None:
-                    await db.repos.generation_runs.set_status(run_id, "failed")
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.FAILED,
-                    error=str(exc)[:500],
-                )
-        except Exception as exc:
-            logger.exception("Pipeline run handler failed for pipeline_id=%d", pipeline_id)
-            if run_id is not None:
-                await self._db.repos.generation_runs.set_status(run_id, "failed")
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
-
-    # ── CONTENT_GENERATE ──
+        await self._handler(PipelineTaskHandler).handle_pipeline_run(task)
 
     async def _handle_content_generate(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        payload = task.payload
-        if not isinstance(payload, ContentGenerateTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Invalid CONTENT_GENERATE payload"
-            )
-            return
-
-        if not self._db or not self._search_engine or not self._pipeline_bundle:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="Pipeline execution environment not configured",
-            )
-            return
-
-        pipeline_id = payload.pipeline_id
-        try:
-            from src.models import PipelinePublishMode
-            from src.services.content_generation_service import ContentGenerationService
-            from src.services.draft_notification_service import DraftNotificationService
-            from src.services.pipeline_service import PipelineService
-            from src.services.quality_scoring_service import QualityScoringService
-
-            svc = PipelineService(self._pipeline_bundle)
-            pipeline = await svc.get(pipeline_id)
-            if pipeline is None:
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.COMPLETED,
-                    note=f"Pipeline id={pipeline_id} not found",
-                )
-                return
-
-            db = self._db
-            notification_service = DraftNotificationService(db, self._notifier)
-            image_service = await self._build_image_service()
-            provider_service = self._llm_provider_service
-            if provider_service is None:
-                from src.services.provider_service import build_provider_service
-
-                provider_service = await build_provider_service(db, self._config)
-            quality_service = QualityScoringService(db, provider_service=provider_service)
-            gen = ContentGenerationService(
-                db,
-                self._search_engine,
-                config=self._config,
-                image_service=image_service,
-                notification_service=notification_service,
-                quality_service=quality_service,
-                client_pool=self._client_pool,
-                provider_service=provider_service,
-            )
-            run = await gen.generate(pipeline=pipeline, model=pipeline.llm_model)
-
-            effective_mode = (
-                (run.metadata or {}).get("effective_publish_mode", pipeline.publish_mode.value)
-                if run is not None else pipeline.publish_mode.value
-            )
-            if effective_mode == PipelinePublishMode.AUTO.value and run is not None:
-                from src.services.publish_service import PublishService
-
-                publish_svc = PublishService(db, self._client_pool)
-                try:
-                    await publish_svc.publish_run(run, pipeline)
-                except Exception as pub_exc:
-                    logger.exception(
-                        "Auto-publish failed for run id=%s (pipeline_id=%d); generation already saved",
-                        run.id,
-                        pipeline_id,
-                    )
-                    await self._tasks.update_collection_task(
-                        task.id,
-                        CollectionTaskStatus.FAILED,
-                        error=f"Generation ok but publish failed: {pub_exc!s:.400}",
-                    )
-                    return
-
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=1 if run is not None else 0,
-                note=f"Generated run id={run.id}" if run is not None else "Generation returned no result",
-            )
-        except Exception as exc:
-            logger.exception("Content generate handler failed for pipeline_id=%d", pipeline_id)
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
-
-    # ── CONTENT_PUBLISH ──
+        await self._handler(ContentTaskHandler).handle_content_generate(task)
 
     async def _handle_content_publish(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        payload = task.payload
-        if not isinstance(payload, ContentPublishTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Invalid CONTENT_PUBLISH payload"
-            )
-            return
-
-        if not self._db or not self._pipeline_bundle:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="Pipeline execution environment not configured",
-            )
-            return
-
-        if self._client_pool is None:
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error="client_pool not configured",
-            )
-            return
-
-        pipeline_id = payload.pipeline_id
-        try:
-            from src.services.pipeline_service import PipelineService
-            from src.services.publish_service import PublishService
-
-            db = self._db
-            pool = self._client_pool
-            publish_svc = PublishService(db, pool)
-
-            filter_sql = "AND pipeline_id = ?" if pipeline_id is not None else ""
-            params: tuple = (pipeline_id,) if pipeline_id is not None else ()
-            cur = await db.execute(
-                f"SELECT * FROM generation_runs WHERE moderation_status = 'approved' {filter_sql} ORDER BY id ASC",
-                params,
-            )
-            rows = await cur.fetchall()
-            if not rows:
-                await self._tasks.update_collection_task(
-                    task.id, CollectionTaskStatus.COMPLETED, note="No approved runs to publish"
-                )
-                return
-
-            from src.database.repositories.generation_runs import GenerationRunsRepository
-
-            runs = [GenerationRunsRepository._to_generation_run(row) for row in rows]
-
-            pipeline_svc = PipelineService(self._pipeline_bundle)
-            published = 0
-            for run in runs:
-                if run.pipeline_id is None:
-                    continue
-                pipeline = await pipeline_svc.get(run.pipeline_id)
-                if pipeline is None:
-                    continue
-                results = await publish_svc.publish_run(run, pipeline)
-                if any(r.success for r in results):
-                    published += 1
-
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=published,
-                note=f"Published {published}/{len(runs)} runs",
-            )
-        except Exception as exc:
-            logger.exception("Content publish handler failed")
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
-
-    # ── TRANSLATE_BATCH ──
+        await self._handler(ContentTaskHandler).handle_content_publish(task)
 
     async def _handle_translate_batch(self, task: CollectionTask) -> None:
-        if task.id is None:
-            return
-
-        payload = task.payload
-        if not isinstance(payload, TranslateBatchTaskPayload):
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Invalid TRANSLATE_BATCH payload"
-            )
-            return
-
-        if not self._db:
-            await self._tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Database not configured"
-            )
-            return
-
-        try:
-            from src.services.provider_service import build_provider_service
-            from src.services.translation_service import TranslationService
-
-            # Load translation settings
-            provider_name = await self._db.get_setting("translation_provider")
-            model = await self._db.get_setting("translation_model")
-
-            provider_service = await build_provider_service(self._db, self._config)
-
-            # Fail fast if no real provider is configured (only stub default available)
-            resolved = provider_service.get_provider_callable(provider_name)
-            if resolved is provider_service._registry.get("default"):
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.FAILED,
-                    error="No translation provider configured (only stub default available)",
-                )
-                return
-
-            svc = TranslationService(self._db, provider_service=provider_service)
-
-            target_lang = payload.target_lang
-            source_filter = payload.source_filter or []
-            batch_size = payload.batch_size or 20
-            last_id = payload.last_processed_id or 0
-
-            # Exclude messages where source == target
-            msgs = await self._db.repos.messages.get_untranslated_messages(
-                target=target_lang,
-                source_langs=source_filter or None,
-                limit=batch_size,
-                after_id=last_id,
-            )
-
-            if not msgs:
-                await self._tasks.update_collection_task(
-                    task.id,
-                    CollectionTaskStatus.COMPLETED,
-                    note="No more messages to translate",
-                )
-                return
-
-            results = await svc.translate_batch(
-                msgs, target_lang, provider_name=provider_name, model=model
-            )
-
-            for msg_id, translated in results:
-                await self._db.repos.messages.update_translation(msg_id, target_lang, translated)
-
-            new_last_id = max(m.id for m in msgs if m.id is not None) if msgs else last_id
-
-            # Check if more messages remain
-            remaining = await self._db.repos.messages.get_untranslated_messages(
-                target=target_lang,
-                source_langs=source_filter or None,
-                limit=1,
-                after_id=new_last_id,
-            )
-
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.COMPLETED,
-                messages_collected=len(results),
-                note=f"Translated {len(results)}/{len(msgs)} messages",
-            )
-
-            # Self-chain: create follow-up task if more remain
-            if remaining:
-                follow_up = TranslateBatchTaskPayload(
-                    target_lang=target_lang,
-                    source_filter=source_filter,
-                    batch_size=batch_size,
-                    last_processed_id=new_last_id,
-                )
-                await self._tasks.create_generic_task(
-                    CollectionTaskType.TRANSLATE_BATCH,
-                    title=f"Translation batch ({target_lang}) cont.",
-                    payload=follow_up,
-                )
-
-        except Exception as exc:
-            logger.exception("Translate batch handler failed")
-            await self._tasks.update_collection_task(
-                task.id,
-                CollectionTaskStatus.FAILED,
-                error=str(exc)[:500],
-            )
+        await self._handler(TranslationTaskHandler).handle_translate_batch(task)

--- a/tests/test_task_handlers_registry.py
+++ b/tests/test_task_handlers_registry.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType
+from src.services.task_handlers import (
+    ContentTaskHandler,
+    PhotoTaskHandler,
+    PipelineTaskHandler,
+    StatsTaskHandler,
+    TaskHandlerContext,
+    TranslationTaskHandler,
+)
+from src.services.unified_dispatcher import HANDLED_TYPES, UnifiedDispatcher
+
+
+def _context() -> TaskHandlerContext:
+    collector = MagicMock()
+    collector.is_running = False
+    collector.delay_between_channels_sec = 0.0
+    channel_bundle = MagicMock()
+    tasks = MagicMock()
+    tasks.update_collection_task = AsyncMock()
+    return TaskHandlerContext(
+        collector=collector,
+        channel_bundle=channel_bundle,
+        tasks=tasks,
+        stop_event=MagicMock(),
+    )
+
+
+def test_handled_types_are_derived_from_task_handlers():
+    expected = [
+        task_type.value
+        for handler_cls in (
+            StatsTaskHandler,
+            PhotoTaskHandler,
+            PipelineTaskHandler,
+            ContentTaskHandler,
+            TranslationTaskHandler,
+        )
+        for task_type in handler_cls.task_types
+    ]
+
+    assert HANDLED_TYPES == expected
+
+
+@pytest.mark.anyio
+async def test_dispatcher_routes_each_handled_type_to_compatibility_shim():
+    tasks = MagicMock()
+    tasks.update_collection_task = AsyncMock()
+    dispatcher = UnifiedDispatcher(
+        collector=MagicMock(),
+        channel_bundle=MagicMock(),
+        tasks_repo=tasks,
+    )
+
+    called = []
+    for task_type, handler_name in (
+        (CollectionTaskType.STATS_ALL, "_handle_stats_all"),
+        (CollectionTaskType.SQ_STATS, "_handle_sq_stats"),
+        (CollectionTaskType.PHOTO_DUE, "_handle_photo_due"),
+        (CollectionTaskType.PHOTO_AUTO, "_handle_photo_auto"),
+        (CollectionTaskType.PIPELINE_RUN, "_handle_pipeline_run"),
+        (CollectionTaskType.CONTENT_GENERATE, "_handle_content_generate"),
+        (CollectionTaskType.CONTENT_PUBLISH, "_handle_content_publish"),
+        (CollectionTaskType.TRANSLATE_BATCH, "_handle_translate_batch"),
+    ):
+        async def shim(task, task_type=task_type):
+            called.append(task_type)
+
+        setattr(dispatcher, handler_name, shim)
+
+    for task_type in CollectionTaskType:
+        if task_type.value not in HANDLED_TYPES:
+            continue
+        await dispatcher._dispatch(
+            CollectionTask(id=1, task_type=task_type, status=CollectionTaskStatus.RUNNING)
+        )
+
+    assert called == [CollectionTaskType(value) for value in HANDLED_TYPES]
+
+
+def test_task_handler_metadata_covers_only_supported_task_types():
+    context = _context()
+    handlers = [
+        StatsTaskHandler(context),
+        PhotoTaskHandler(context),
+        PipelineTaskHandler(context),
+        ContentTaskHandler(context),
+        TranslationTaskHandler(context),
+    ]
+
+    handled = [task_type for handler in handlers for task_type in handler.task_types]
+
+    assert handled == [CollectionTaskType(value) for value in HANDLED_TYPES]
+    assert CollectionTaskType.CHANNEL_COLLECT not in handled


### PR DESCRIPTION
## Summary
- split UnifiedDispatcher task execution into dedicated task handler classes
- keep UnifiedDispatcher focused on polling, recovery, handler lookup, and compatibility shims
- derive HANDLED_TYPES from handler metadata and add registry/dispatch coverage

Closes #511

## Tests
- ruff check src/ tests/ conftest.py
- python3 -m pytest tests/test_unified_dispatcher.py tests/test_unified_dispatcher_tasks.py tests/test_unified_dispatcher_pipeline_runs.py tests/test_scheduler_pipeline.py tests/test_task_handlers_registry.py -v
- python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto
- python3 -m pytest tests/ -v -m aiosqlite_serial