### PR TITLE
Fix account runtime diagnostics and CLI parity

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -75,6 +75,7 @@ python -m src.main filter hard-delete [--pks PK1,PK2] [--yes]
 
 ```bash
 python -m src.main search-query list
+python -m src.main search-query get ID
 python -m src.main search-query add "query" [--interval MINUTES] [--regex] [--fts] [--notify]
 python -m src.main search-query edit ID [--query TEXT] [--interval MINUTES]
 python -m src.main search-query delete ID
@@ -97,6 +98,8 @@ python -m src.main pipeline generate ID [--model MODEL] [--preview]
 python -m src.main pipeline runs ID [--limit N] [--status STATUS]
 python -m src.main pipeline run-show RUN_ID
 python -m src.main pipeline queue ID [--limit N]
+python -m src.main pipeline moderation-list [--pipeline-id ID] [--limit N]
+python -m src.main pipeline moderation-view RUN_ID
 python -m src.main pipeline publish RUN_ID
 python -m src.main pipeline approve RUN_ID
 python -m src.main pipeline reject RUN_ID
@@ -114,6 +117,7 @@ python -m src.main pipeline filter clear ID
 python -m src.main image generate "prompt" [--model provider:model_id]
 python -m src.main image models --provider PROVIDER [--query TEXT]
 python -m src.main image providers
+python -m src.main image generated [--limit N]
 ```
 
 ## account
@@ -124,6 +128,7 @@ python -m src.main account info [--phone PHONE]
 python -m src.main account toggle ID
 python -m src.main account delete ID
 python -m src.main account add --phone PHONE [--api-id ID] [--api-hash HASH]
+python -m src.main account add --phone PHONE --code CODE [--password PASSWORD]
 python -m src.main account flood-status
 python -m src.main account flood-clear --phone PHONE
 ```
@@ -146,6 +151,7 @@ python -m src.main scheduler clear-pending
 ```bash
 python -m src.main dialogs list [--phone PHONE]
 python -m src.main dialogs refresh [--phone PHONE]
+python -m src.main dialogs resolve IDENTIFIER [--phone PHONE]
 python -m src.main dialogs leave DIALOG_ID [DIALOG_ID ...] [--phone PHONE] [--yes]
 python -m src.main dialogs topics --channel-id ID [--phone PHONE]
 python -m src.main dialogs cache-status
@@ -204,6 +210,7 @@ python -m src.main photo-loader send --phone PHONE --target DIALOG_ID --files FI
 python -m src.main photo-loader schedule-send --phone PHONE --target DIALOG_ID --files FILE [FILE ...] --at ISO_DATETIME [--mode album|separate] [--caption TEXT]
 python -m src.main photo-loader batch-create --phone PHONE --target DIALOG_ID --manifest FILE [--caption TEXT]
 python -m src.main photo-loader batch-list
+python -m src.main photo-loader items [--batch-id ID] [--limit N]
 python -m src.main photo-loader batch-cancel ID
 python -m src.main photo-loader auto-create --phone PHONE --target DIALOG_ID --folder PATH --interval MINUTES [--mode album|separate] [--caption TEXT]
 python -m src.main photo-loader auto-list

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -10,16 +10,16 @@
 | Добавить канал | `channel add` | `POST /channels/add` | `add_channel` |
 | Удалить канал | `channel delete` | `POST /channels/{pk}/delete` | `delete_channel` |
 | Вкл/выкл канал | `channel toggle` | `POST /channels/{pk}/toggle` | `toggle_channel` |
-| Статистика канала | `channel stats` | `POST /channels/{pk}/stats` | `collect_channel_stats` |
+| Статистика канала | `channel stats` | `POST /channels/{pk}/stats` | `collect_channel_stats`, `get_channel_stats` |
 | Импорт каналов | `channel import` | `POST /channels/import` | `import_channels` |
 | Обновить типы | `channel refresh-types` | `POST /channels/refresh-types` | `refresh_channel_types` |
 | Обновить метаданные | `channel refresh-meta` | — | `refresh_channel_meta` |
 | Массовое добавление из диалогов | `channel add-bulk` | `POST /channels/add-bulk` | — |
-| Список тегов | `channel tag list` | `GET /channels/tags` | — |
-| Создать тег | `channel tag add` | `POST /channels/tags` | — |
-| Удалить тег | `channel tag delete` | `DELETE /channels/tags/{name}` | — |
+| Список тегов | `channel tag list` | `GET /channels/tags` | `list_tags` |
+| Создать тег | `channel tag add` | `POST /channels/tags` | `create_tag` |
+| Удалить тег | `channel tag delete` | `DELETE /channels/tags/{name}` | `delete_tag` |
 | Получить теги канала | `channel tag get` | `GET /channels/{pk}/tags` | — |
-| Обновить теги канала | `channel tag set` | `POST /channels/{pk}/tags` | — |
+| Обновить теги канала | `channel tag set` | `POST /channels/{pk}/tags` | `set_channel_tags` |
 | Список диалогов для импорта | — | `GET /channels/dialogs` | — |
 
 ## Сбор сообщений
@@ -28,7 +28,7 @@
 |----------|-----|-------------|------------|
 | Собрать все каналы | `collect` | `POST /channels/collect-all` | `collect_all_channels` |
 | Собрать один канал | `channel collect` | `POST /channels/{pk}/collect` | `collect_channel` |
-| Статистика всех | — | `POST /channels/stats/all` | `collect_all_stats` |
+| Статистика всех | `channel stats --all` | `POST /channels/stats/all` | `collect_all_stats` |
 | Превью без сохранения | `collect sample` | — | — |
 | Отменить задачу | `scheduler task-cancel` | `POST /scheduler/tasks/{id}/cancel` | `cancel_scheduler_task` |
 | Очистить очередь | `scheduler clear-pending` | `POST /scheduler/tasks/clear-pending-collect` | `clear_pending_tasks` |
@@ -43,13 +43,13 @@
 | Telegram-поиск | `search --mode telegram` | `GET /search?mode=telegram` | `search_telegram` |
 | Поиск по чатам | `search --mode my_chats` | `GET /search?mode=my_chats` | `search_my_chats` |
 | Поиск в канале | `search --mode channel` | `GET /search?mode=channel` | `search_in_channel` |
-| Индексация | — | `POST /settings/semantic-index` | `index_messages` |
+| Индексация | `search --index-now` | `POST /settings/semantic-index` | `index_messages` |
 
 ## Сообщения
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
-| Чтение сообщений | `messages read` | — | — |
+| Чтение сообщений | `messages read` | — | `read_messages` |
 | Перевод одного сообщения | `translate message` | `POST /search/translate/{message_db_id}` | — |
 | Экспорт сообщений | `export json|csv|rss` | — | — |
 
@@ -63,7 +63,7 @@
 | Удалить | `search-query delete` | `POST /search-queries/{id}/delete` | `delete_search_query` |
 | Вкл/выкл | `search-query toggle` | `POST /search-queries/{id}/toggle` | `toggle_search_query` |
 | Запустить вручную | `search-query run` | `POST /search-queries/{id}/run` | `run_search_query` |
-| Получить | — | — | `get_search_query` |
+| Получить | `search-query get` | — | `get_search_query` |
 | Статистика | `search-query stats` | — | `get_search_query_stats` |
 
 ## Фильтры
@@ -100,9 +100,14 @@
 | Отклонить | `pipeline reject` | `POST /moderation/{id}/reject` | `reject_run` |
 | Одобрить (bulk) | `pipeline bulk-approve` | `POST /moderation/bulk-approve` | `bulk_approve_runs` |
 | Отклонить (bulk) | `pipeline bulk-reject` | `POST /moderation/bulk-reject` | `bulk_reject_runs` |
-| Шаги refinement | `pipeline refinement-steps` | `GET/POST /pipelines/{id}/refinement-steps` | — |
-| Страница модерации | — | `GET /moderation/` | `list_pending_moderation` |
-| Просмотр модерации | — | `GET /moderation/{id}/view` | `view_moderation_run` |
+| Шаги refinement | `pipeline refinement-steps` | `GET/POST /pipelines/{id}/refinement-steps` | `get_refinement_steps`, `set_refinement_steps` |
+| Экспорт JSON | `pipeline export` | — | `export_pipeline_json` |
+| Импорт JSON | `pipeline import` | — | `import_pipeline_json` |
+| Список шаблонов | `pipeline templates` | — | `list_pipeline_templates` |
+| Создать из шаблона | `pipeline from-template` | — | `create_pipeline_from_template` |
+| AI edit | `pipeline ai-edit` | — | `ai_edit_pipeline` |
+| Страница модерации | `pipeline moderation-list` | `GET /moderation/` | `list_pending_moderation` |
+| Просмотр модерации | `pipeline moderation-view` | `GET /moderation/{id}/view` | `view_moderation_run` |
 | Стрим генерации | — | `GET /pipelines/{id}/generate-stream` | — |
 
 ## Планировщик
@@ -115,6 +120,7 @@
 | Триггер | `scheduler trigger` | `POST /scheduler/trigger` | `trigger_collection` |
 | Вкл/выкл job | `scheduler job-toggle` | `POST /scheduler/jobs/{id}/toggle` | `toggle_scheduler_job` |
 | Изменить интервал | `scheduler set-interval` | `POST /scheduler/jobs/{id}/set-interval` | `set_scheduler_interval` |
+| Сохранить настройки | `settings set` | `POST /settings/save-scheduler` | `save_scheduler_settings` |
 
 ## Уведомления
 
@@ -164,11 +170,13 @@
 | Список диалогов | `dialogs list` | `GET /dialogs/` | `search_dialogs` |
 | Обновить кеш | `dialogs refresh` | `POST /dialogs/refresh` | `refresh_dialogs` |
 | Покинуть диалоги | `dialogs leave` | `POST /dialogs/leave` | `leave_dialogs` |
+| Resolve entity | `dialogs resolve` | — | `resolve_entity` |
 | Статус кеша | `dialogs cache-status` | `GET /dialogs/cache-status` | `get_cache_status` |
 | Очистить кеш | `dialogs cache-clear` | `POST /dialogs/cache-clear` | `clear_dialog_cache` |
 | Топики форума | `dialogs topics` | `GET /agent/forum-topics` | `get_forum_topics` |
 | Создать канал | `dialogs create-channel` | `POST /dialogs/create-channel` | `create_telegram_channel` |
 | Отправить сообщение | `dialogs send` | `POST /dialogs/send` | `send_message` |
+| Переслать сообщение | `dialogs forward` | `POST /dialogs/forward` | `forward_messages` |
 | Редактировать | `dialogs edit-message` | `POST /dialogs/edit-message` | `edit_message` |
 | Удалить | `dialogs delete-message` | `POST /dialogs/delete-message` | `delete_message` |
 | Закрепить | `dialogs pin-message` | `POST /dialogs/pin-message` | `pin_message` |
@@ -200,7 +208,7 @@
 | Вкл/выкл авто | `photo-loader auto-toggle` | `POST /dialogs/photos/auto/{id}/toggle` | `toggle_auto_upload` |
 | Удалить авто | `photo-loader auto-delete` | `POST /dialogs/photos/auto/{id}/delete` | `delete_auto_upload` |
 | Запустить due | `photo-loader run-due` | `POST /dialogs/photos/run-due` | `run_photo_due` |
-| Список items | — | — | `list_photo_items` |
+| Список items | `photo-loader items` | — | `list_photo_items` |
 
 ## Изображения
 
@@ -209,6 +217,7 @@
 | Генерация | `image generate` | `POST /images/generate` | `generate_image` |
 | Поиск моделей | `image models` | `GET /images/models/search` | `list_image_models` |
 | Список провайдеров | `image providers` | — | `list_image_providers` |
+| Список генераций | `image generated` | — | `list_generated_images` |
 
 ## LLM-провайдеры
 

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -29,20 +29,76 @@ def _matches_phone(phone: str, phone_filter: str) -> bool:
     return phone == phone_filter
 
 
-async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: str = "") -> str:
-    """Return account info grounded only in the live ClientPool."""
-    if not runtime.has_live_telegram:
-        return _NO_LIVE_RUNTIME
+def _connected_phones(client_pool: object | None) -> set[str]:
+    if client_pool is None:
+        return set()
 
+    connected_phones = None
+    instance_attrs = getattr(client_pool, "__dict__", {})
+    if isinstance(instance_attrs, dict) and "connected_phones" in instance_attrs:
+        connected_phones = instance_attrs["connected_phones"]
+    elif callable(getattr(type(client_pool), "connected_phones", None)):
+        connected_phones = getattr(client_pool, "connected_phones")
+
+    if callable(connected_phones):
+        try:
+            phones = connected_phones()
+        except Exception:
+            phones = set()
+        if isinstance(phones, (set, list, tuple)):
+            return {str(phone) for phone in phones}
+
+    try:
+        clients = getattr(client_pool, "clients")
+    except Exception:
+        clients = {}
+    if isinstance(clients, dict):
+        return {str(phone) for phone in clients}
+    return set()
+
+
+def _format_phones(phones: set[str]) -> str:
+    return ", ".join(sorted(phones)) if phones else "-"
+
+
+async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: str = "") -> str:
+    """Return account info with DB/runtime/profile-fetch states kept separate."""
     phone_filter = normalize_phone(phone.strip()) if phone.strip() else ""
+    connected = _connected_phones(runtime.client_pool)
+    if phone_filter:
+        connected = {p for p in connected if _matches_phone(p, phone_filter)}
+
+    if not runtime.has_live_telegram:
+        details = [_NO_LIVE_RUNTIME]
+        if runtime.runtime_kind == "snapshot":
+            details.append(
+                "Web snapshot runtime can show worker-connected phones, but live Telegram API "
+                "is only available in the worker or embedded-worker process."
+            )
+        else:
+            details.append("No live Telegram client pool is attached to this agent backend.")
+        if connected:
+            details.append(f"Runtime connected phones snapshot: {_format_phones(connected)}.")
+        return "\n".join(details)
+
     users = await runtime.client_pool.get_users_info(include_avatar=False)
     if phone_filter:
         users = [u for u in users if _matches_phone(str(u.phone), phone_filter)]
-    if not users:
-        return "Live Telegram accounts not found for this request: не найдены."
 
     db_accounts = await runtime.db.get_accounts()
     db_by_phone = {a.phone: a for a in db_accounts}
+    active_count = sum(1 for a in db_accounts if getattr(a, "is_active", False))
+    if not users:
+        if connected:
+            lines = [
+                "Live Telegram account profiles unavailable for this request.",
+                f"DB active accounts: {active_count}.",
+                f"Runtime connected phones: {_format_phones(connected)}.",
+                "Telegram profile fetch returned no profiles; do not treat this as disconnected.",
+            ]
+            return "\n".join(lines)
+        return "Live Telegram accounts not found for this request: не найдены."
+
     lines = [f"Live Telegram accounts ({len(users)}):"]
     for u in users:
         db_account = db_by_phone.get(u.phone)

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -9,6 +9,14 @@ from claude_agent_sdk import tool
 from src.agent.tools._registry import _text_response
 
 
+def _daily_stat_value(row: object, attr: str, legacy_key: str | None = None, default: int | str = 0) -> object:
+    if hasattr(row, attr):
+        return getattr(row, attr)
+    if isinstance(row, dict):
+        return row.get(legacy_key or attr, default)
+    return default
+
+
 def register(db, client_pool, embedding_service, **kwargs):
     tools = []
 
@@ -86,7 +94,10 @@ def register(db, client_pool, embedding_service, **kwargs):
                 return _text_response("Нет данных за указанный период.")
             lines = [f"Ежедневная статистика за {days} дней:"]
             for row in rows:
-                lines.append(f"- {row['date']}: генераций={row.get('count', 0)}, опубл.={row.get('published', 0)}")
+                date = _daily_stat_value(row, "date", default="")
+                generations = _daily_stat_value(row, "generations", "count")
+                publications = _daily_stat_value(row, "publications", "published")
+                lines.append(f"- {date}: генераций={generations}, опубл.={publications}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения дневной статистики: {e}")
@@ -140,7 +151,8 @@ def register(db, client_pool, embedding_service, **kwargs):
                 return _text_response("Данные о каналах не найдены.")
             lines = [f"Топ каналов за {days} дней:"]
             for ch in channels:
-                lines.append(f"- {ch.title} (id={ch.channel_id}): {ch.count} сообщений")
+                message_count = getattr(ch, "message_count", getattr(ch, "count", 0))
+                lines.append(f"- {ch.title} (id={ch.channel_id}): {message_count} сообщений")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения трендов каналов: {e}")

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -69,7 +69,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     )
     async def get_channel_stats(args):
         try:
-            stats = await db.repos.channels.get_latest_stats_for_all()
+            stats = await db.get_latest_stats_for_all()
             if not stats:
                 return _text_response("Статистика каналов пока не собрана.")
             lines = [f"Статистика каналов ({len(stats)}):"]

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -123,7 +123,7 @@ def build_deepagents_tools(
     def get_channel_stats() -> str:
         """Get subscriber counts and statistics for all channels."""
         try:
-            stats = _run_sync("get_channel_stats", db.repos.channels.get_latest_stats_for_all)
+            stats = _run_sync("get_channel_stats", db.get_latest_stats_for_all)
         except Exception as exc:
             return f"Ошибка статистики каналов: {exc}"
         if not stats:
@@ -629,7 +629,8 @@ def build_deepagents_tools(
             return "Данные не найдены."
         lines = [f"Топ каналов за {days} дней:"]
         for ch in channels:
-            lines.append(f"- {ch.title}: {ch.count} сообщений")
+            message_count = getattr(ch, "message_count", getattr(ch, "count", 0))
+            lines.append(f"- {ch.title}: {message_count} сообщений")
         return "\n".join(lines)
 
     tools.append(get_trending_channels)
@@ -701,7 +702,13 @@ def build_deepagents_tools(
             return "Нет данных."
         lines = [f"Статистика за {days} дней:"]
         for r in rows:
-            lines.append(f"- {r['date']}: {r.get('count', 0)} генераций")
+            if isinstance(r, dict):
+                date = r.get("date", "")
+                generations = r.get("generations", r.get("count", 0))
+            else:
+                date = getattr(r, "date", "")
+                generations = getattr(r, "generations", 0)
+            lines.append(f"- {date}: {generations} генераций")
         return "\n".join(lines)
 
     tools.append(get_daily_stats)
@@ -711,10 +718,12 @@ def build_deepagents_tools(
     def get_scheduler_status() -> str:
         """Get scheduler status and job info."""
         try:
-            from src.scheduler.service import SchedulerManager
-
-            mgr = SchedulerManager(db)
-            _run_sync("sched_load", mgr.load_settings)
+            mgr = runtime_context.scheduler_manager
+            if mgr is None:
+                return (
+                    "Ошибка: Планировщик недоступен — live SchedulerManager не передан. "
+                    "Эта операция доступна только через web-интерфейс."
+                )
             running = mgr.is_running
             return f"Планировщик: {'запущен' if running else 'остановлен'}, интервал={mgr.interval_minutes}мин"
         except Exception as exc:
@@ -725,10 +734,12 @@ def build_deepagents_tools(
     def toggle_scheduler_job(job_id: str) -> str:
         """Toggle a scheduler job on/off."""
         try:
-            from src.scheduler.service import SchedulerManager
-
-            mgr = SchedulerManager(db)
-            _run_sync("sched_load2", mgr.load_settings)
+            mgr = runtime_context.scheduler_manager
+            if mgr is None:
+                return (
+                    "Ошибка: Планировщик недоступен — live SchedulerManager не передан. "
+                    "Эта операция доступна только через web-интерфейс."
+                )
             current = _run_sync("sched_check", lambda: mgr.is_job_enabled(job_id))
             _run_sync("sched_toggle", lambda: mgr.sync_job_state(job_id, not current))
             return f"Задача '{job_id}' {'выключена' if current else 'включена'}."

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -6,6 +6,8 @@ import json
 import logging
 from datetime import datetime, timezone
 
+from src.agent.runtime_context import AgentRuntimeContext
+from src.agent.tools.accounts import get_live_account_info_text
 from src.cli import runtime
 from src.models import Account
 from src.settings_utils import parse_int_setting
@@ -36,6 +38,9 @@ def run(args: argparse.Namespace) -> None:
         config, db = await runtime.init_db(args.config)
         pool = None
         try:
+            if args.account_action == "add":
+                args.account_action = "verify-code" if getattr(args, "code", None) else "send-code"
+
             if args.account_action == "send-code":
                 phone = args.phone
                 api_id, api_hash = await _resolve_credentials(args, config, db)
@@ -128,24 +133,8 @@ def run(args: argparse.Namespace) -> None:
 
             elif args.account_action == "info":
                 _, pool = await runtime.init_pool(config, db)
-                users = await pool.get_users_info(include_avatar=False)
-                phone_filter = getattr(args, "phone", None)
-                if phone_filter:
-                    users = [u for u in users if u.phone == phone_filter]
-                if not users:
-                    print("No connected accounts found.")
-                    return
-                db_accounts = await db.get_accounts()
-                active_by_phone = {a.phone: a.is_active for a in db_accounts}
-                fmt = "{:<16} {:<25} {:<20} {:<9} {:<8}"
-                print(fmt.format("Phone", "Name", "Username", "Premium", "Active"))
-                print("-" * 82)
-                for u in users:
-                    name = f"{u.first_name} {u.last_name}".strip() or "—"
-                    username = f"@{u.username}" if u.username else "—"
-                    premium = "Yes" if u.is_premium else "No"
-                    active = "Yes" if active_by_phone.get(u.phone, False) else "No"
-                    print(fmt.format(u.phone, name[:25], username[:20], premium, active))
+                ctx = AgentRuntimeContext.build(db=db, config=config, client_pool=pool)
+                print(await get_live_account_info_text(ctx, getattr(args, "phone", None) or ""))
                 return
             if args.account_action == "list":
                 accounts = await db.get_accounts()

--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -107,7 +107,15 @@ def run(args: argparse.Namespace) -> None:
                 print(fmt.format("Date", "Generated", "Published"))
                 print("-" * 38)
                 for row in rows:
-                    print(fmt.format(str(row["date"]), str(row.get("count", 0)), str(row.get("published", 0))))
+                    if isinstance(row, dict):
+                        date = row.get("date", "")
+                        generated = row.get("generations", row.get("count", 0))
+                        published = row.get("publications", row.get("published", 0))
+                    else:
+                        date = getattr(row, "date", "")
+                        generated = getattr(row, "generations", 0)
+                        published = getattr(row, "publications", 0)
+                    print(fmt.format(str(date), str(generated), str(published)))
 
             elif action == "trending-topics":
                 from src.services.trend_service import TrendService
@@ -139,7 +147,8 @@ def run(args: argparse.Namespace) -> None:
                 print(fmt.format("#", "Channel", "Messages"))
                 print("-" * 54)
                 for i, ch in enumerate(channels, 1):
-                    print(fmt.format(str(i), str(ch.title)[:40], str(ch.count)))
+                    message_count = getattr(ch, "message_count", getattr(ch, "count", 0))
+                    print(fmt.format(str(i), str(ch.title)[:40], str(message_count)))
 
             elif action == "velocity":
                 from src.services.trend_service import TrendService

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -59,6 +59,27 @@ def run_with_dependencies(
                         )
                     )
 
+            elif args.dialogs_action == "resolve":
+                try:
+                    entity = await pool.resolve_any_entity(args.identifier, phone=args.phone)
+                except RuntimeError as exc:
+                    if "no_client" in str(exc):
+                        print("No connected accounts.")
+                        return
+                    print(f"Error resolving entity: {exc}")
+                    return
+                except Exception as exc:
+                    print(f"Error resolving entity: {exc}")
+                    return
+                if not entity:
+                    print(f"Entity '{args.identifier}' not found.")
+                    return
+                print(f"Title: {entity['title']}")
+                print(f"Type: {entity['channel_type']}")
+                print(f"ID: {entity['channel_id']}")
+                if entity.get("username"):
+                    print(f"Username: @{entity['username']}")
+
             elif args.dialogs_action == "leave":
                 accounts = sorted(pool.clients.keys())
                 if not accounts:

--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 
+from src.cli import runtime
 from src.services.image_generation_service import ImageGenerationService
 
 
@@ -47,7 +48,24 @@ def run(args: argparse.Namespace) -> None:
             for name in names:
                 print(f"  {name}")
 
+        elif action == "generated":
+            _, db = await runtime.init_db(args.config)
+            try:
+                images = await db.repos.generated_images.list_recent(limit=args.limit)
+                if not images:
+                    print("No generated images found.")
+                    return
+                for img in images:
+                    prompt = (img.prompt[:60] + "...") if len(img.prompt) > 60 else img.prompt
+                    print(f"[{img.id}] {img.created_at} — {prompt}")
+                    if img.local_path:
+                        print(f"    file=/{img.local_path}")
+                    if img.model:
+                        print(f"    model={img.model}")
+            finally:
+                await db.close()
+
         else:
-            print("Usage: image {generate|models|providers}")
+            print("Usage: image {generate|models|providers|generated}")
 
     asyncio.run(_run())

--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -102,6 +102,18 @@ def run(args: argparse.Namespace) -> None:
                     )
                 return
 
+            if action == "items":
+                if args.batch_id is not None:
+                    items = await bundle.list_items_for_batch(args.batch_id, limit=args.limit)
+                else:
+                    items = await tasks.list_items(limit=args.limit)
+                for item in items:
+                    print(
+                        f"#{item.id} batch={item.batch_id or '-'} phone={item.phone} "
+                        f"target={item.target_dialog_id} status={item.status}"
+                    )
+                return
+
             if action == "batch-cancel":
                 ok = await tasks.cancel_item(args.id)
                 print("Cancelled" if ok else "Not cancelled")

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -565,6 +565,38 @@ def run(args: argparse.Namespace) -> None:
                         f"{created_at:<19} {_preview_text(run.generated_text)}"
                     )
 
+            elif args.pipeline_action == "moderation-list":
+                runs = await db.repos.generation_runs.list_pending_moderation(
+                    pipeline_id=args.pipeline_id,
+                    limit=args.limit,
+                )
+                if not runs:
+                    print("No pending moderation runs.")
+                    return
+                print(f"{'Run ID':<8} {'Pipeline':<8} {'Status':<12} {'Created':<19} Preview")
+                print("-" * 90)
+                for run in runs:
+                    created_at = (
+                        run.created_at.strftime("%Y-%m-%d %H:%M:%S") if run.created_at else "—"
+                    )
+                    print(
+                        f"{run.id or 0:<8} {run.pipeline_id or 0:<8} {run.moderation_status:<12} "
+                        f"{created_at:<19} {_preview_text(run.generated_text)}"
+                    )
+
+            elif args.pipeline_action == "moderation-view":
+                run = await db.repos.generation_runs.get(args.run_id)
+                if run is None:
+                    print(f"Run id={args.run_id} not found")
+                    return
+                print(f"Run id={run.id} (pipeline_id={run.pipeline_id})")
+                print(f"Status: {run.status}")
+                print(f"Moderation: {run.moderation_status}")
+                print(f"Created: {run.created_at}")
+                print("")
+                print("Generated text:")
+                print(run.generated_text or "(empty)")
+
             elif args.pipeline_action == "approve":
                 run = await db.repos.generation_runs.get(args.run_id)
                 if run is None:

--- a/src/cli/commands/search_query.py
+++ b/src/cli/commands/search_query.py
@@ -36,6 +36,22 @@ def run(args: argparse.Namespace) -> None:
                         )
                     )
 
+            elif args.search_query_action == "get":
+                sq = await svc.get(args.id)
+                if not sq:
+                    print(f"Search query id={args.id} not found")
+                    return
+                print(f"ID: {sq.id}")
+                print(f"Query: {sq.query}")
+                print(f"Interval: {sq.interval_minutes}m")
+                print(f"Active: {sq.is_active}")
+                print(f"Regex: {sq.is_regex}")
+                print(f"FTS: {sq.is_fts}")
+                print(f"Notify: {sq.notify_on_collect}")
+                print(f"Track stats: {sq.track_stats}")
+                print(f"Max length: {sq.max_length if sq.max_length is not None else '—'}")
+                print(f"Exclude patterns: {sq.exclude_patterns or '—'}")
+
             elif args.search_query_action == "add":
                 exclude = (
                     args.exclude_patterns.replace("\\n", "\n") if args.exclude_patterns else ""

--- a/src/cli/parser_domains/account.py
+++ b/src/cli/parser_domains/account.py
@@ -33,6 +33,18 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     acc_verify.add_argument("--api-hash", default=None, dest="api_hash",
                             help="Telegram API hash (uses stored if omitted)")
 
+    acc_add = acc_sub.add_parser(
+        "add",
+        help="Compatibility alias for send-code / verify-code account onboarding",
+    )
+    acc_add.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_add.add_argument("--code", default=None, help="Auth code received in Telegram")
+    acc_add.add_argument("--password", default=None, help="2FA password (if required)")
+    acc_add.add_argument("--api-id", type=int, default=None, dest="api_id",
+                         help="Telegram API ID (uses stored if omitted)")
+    acc_add.add_argument("--api-hash", default=None, dest="api_hash",
+                         help="Telegram API hash (uses stored if omitted)")
+
     acc_sub.add_parser("flood-status", help="Show flood wait timers for all accounts")
 
     acc_flood_clear = acc_sub.add_parser("flood-clear", help="Clear flood wait for an account")

--- a/src/cli/parser_domains/dialogs.py
+++ b/src/cli/parser_domains/dialogs.py
@@ -17,6 +17,10 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         "--phone", default=None, help="Account phone (default: first connected)"
     )
 
+    dialogs_resolve = dialogs_sub.add_parser("resolve", help="Resolve @username, t.me link, or numeric ID")
+    dialogs_resolve.add_argument("identifier", help="Identifier to resolve")
+    dialogs_resolve.add_argument("--phone", default=None, help="Preferred account phone")
+
     dialogs_leave = dialogs_sub.add_parser("leave", help="Leave dialogs by ID")
     dialogs_leave.add_argument(
         "dialog_ids",

--- a/src/cli/parser_domains/image.py
+++ b/src/cli/parser_domains/image.py
@@ -17,3 +17,6 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     image_models.add_argument("--query", default="", help="Search query")
 
     image_sub.add_parser("providers", help="List configured image providers")
+
+    image_generated = image_sub.add_parser("generated", help="List generated images")
+    image_generated.add_argument("--limit", type=int, default=20, help="Max images to show")

--- a/src/cli/parser_domains/photo_loader.py
+++ b/src/cli/parser_domains/photo_loader.py
@@ -36,6 +36,10 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
 
     photo_sub.add_parser("batch-list", help="List photo batches")
 
+    photo_items = photo_sub.add_parser("items", help="List photo batch items")
+    photo_items.add_argument("--batch-id", type=int, default=None, help="Filter by batch id")
+    photo_items.add_argument("--limit", type=int, default=100, help="Max items to show")
+
     photo_cancel = photo_sub.add_parser("batch-cancel", help="Cancel a photo batch item")
     photo_cancel.add_argument("id", type=int, help="Photo item id")
 

--- a/src/cli/parser_domains/pipeline.py
+++ b/src/cli/parser_domains/pipeline.py
@@ -214,6 +214,13 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     pipeline_queue.add_argument("id", type=int, help="Pipeline id")
     pipeline_queue.add_argument("--limit", type=int, default=20, help="Max runs to show")
 
+    moderation_list = pipeline_sub.add_parser("moderation-list", help="Show pending moderation runs")
+    moderation_list.add_argument("--pipeline-id", type=int, default=None, help="Filter by pipeline id")
+    moderation_list.add_argument("--limit", type=int, default=20, help="Max runs to show")
+
+    moderation_view = pipeline_sub.add_parser("moderation-view", help="Show moderation run details")
+    moderation_view.add_argument("run_id", type=int, help="Run id")
+
     pipeline_publish = pipeline_sub.add_parser("publish", help="Publish a generation run")
     pipeline_publish.add_argument("run_id", type=int, help="Run id to publish")
 

--- a/src/cli/parser_domains/search_query.py
+++ b/src/cli/parser_domains/search_query.py
@@ -8,6 +8,9 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     sq_sub = sq_parser.add_subparsers(dest="search_query_action")
     sq_sub.add_parser("list", help="List search queries")
 
+    sq_get = sq_sub.add_parser("get", help="Show search query details")
+    sq_get.add_argument("id", type=int, help="Search query id")
+
     sq_add = sq_sub.add_parser("add", help="Add search query")
     sq_add.add_argument("query", help="FTS5 search query text")
     sq_add.add_argument("--interval", type=int, default=60, help="Run interval in minutes")

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -563,8 +563,8 @@ class PhotoLoaderBundle:
     async def list_items(self, limit: int = 100) -> list[PhotoBatchItem]:
         return await self.photo_loader.list_items(limit)
 
-    async def list_items_for_batch(self, batch_id: int) -> list[PhotoBatchItem]:
-        return await self.photo_loader.list_items_for_batch(batch_id)
+    async def list_items_for_batch(self, batch_id: int, limit: int | None = None) -> list[PhotoBatchItem]:
+        return await self.photo_loader.list_items_for_batch(batch_id, limit=limit)
 
     async def update_item(
         self,

--- a/src/database/repositories/photo_loader.py
+++ b/src/database/repositories/photo_loader.py
@@ -189,11 +189,13 @@ class PhotoLoaderRepository:
         )
         return [self._to_item(row) for row in await cur.fetchall()]
 
-    async def list_items_for_batch(self, batch_id: int) -> list[PhotoBatchItem]:
-        cur = await self._db.execute(
-            "SELECT * FROM photo_batch_items WHERE batch_id = ? ORDER BY id ASC",
-            (batch_id,),
-        )
+    async def list_items_for_batch(self, batch_id: int, limit: int | None = None) -> list[PhotoBatchItem]:
+        sql = "SELECT * FROM photo_batch_items WHERE batch_id = ? ORDER BY id ASC"
+        params: tuple[object, ...] = (batch_id,)
+        if limit is not None:
+            sql += " LIMIT ?"
+            params += (limit,)
+        cur = await self._db.execute(sql, params)
         return [self._to_item(row) for row in await cur.fetchall()]
 
     async def update_item(

--- a/src/services/content_analytics_service.py
+++ b/src/services/content_analytics_service.py
@@ -9,6 +9,13 @@ from src.database import Database
 logger = logging.getLogger(__name__)
 
 
+def _parse_db_datetime(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 @dataclass
 class PipelineStats:
     pipeline_id: int
@@ -159,18 +166,18 @@ class ContentAnalyticsService:
             generations = sum(
                 1 for r in runs
                 if r["created_at"]
-                and day_start <= datetime.fromisoformat(r["created_at"]) < day_end
+                and day_start <= _parse_db_datetime(r["created_at"]) < day_end
             )
             publications = sum(
                 1 for r in runs
                 if r["published_at"]
-                and day_start <= datetime.fromisoformat(r["published_at"]) < day_end
+                and day_start <= _parse_db_datetime(r["published_at"]) < day_end
             )
             rejections = sum(
                 1 for r in runs
                 if r["moderation_status"] == "rejected"
                 and r["updated_at"]
-                and day_start <= datetime.fromisoformat(r["updated_at"]) < day_end
+                and day_start <= _parse_db_datetime(r["updated_at"]) < day_end
             )
 
             results.append(DailyStats(

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -171,32 +171,44 @@ class TrendService:
         )
         return [TrendingEmoji(emoji=r["emoji"], count=int(r["total"])) for r in rows]
 
-    async def get_message_velocity(self, channel_id: int, days: int = 30) -> list[MessageVelocity]:
-        """Return daily message count for a specific channel."""
+    async def get_message_velocity(self, channel_id: int | None = None, days: int = 30) -> list[MessageVelocity]:
+        """Return daily message count for one channel or all channels."""
+        channel_filter = "AND m.channel_id = ?" if channel_id is not None else ""
+        params: tuple[object, ...]
+        if channel_id is not None:
+            params = (f"-{days} days", channel_id)
+        else:
+            params = (f"-{days} days",)
         rows = await self._db.execute_fetchall(
-            """
+            f"""
             SELECT date(m.date) AS day, COUNT(*) AS cnt
             FROM messages m
-            WHERE m.channel_id = ?
-              AND m.date >= date('now', ?)
+            WHERE m.date >= date('now', ?)
+              {channel_filter}
             GROUP BY day
             ORDER BY day ASC
             """,
-            (channel_id, f"-{days} days"),
+            params,
         )
         return [MessageVelocity(date=r["day"], count=int(r["cnt"])) for r in rows]
 
-    async def get_peak_hours(self, channel_id: int, days: int = 30) -> list[PeakHour]:
-        """Return message count distribution by hour of day for a channel."""
+    async def get_peak_hours(self, channel_id: int | None = None, days: int = 30) -> list[PeakHour]:
+        """Return message count distribution by hour for one channel or all channels."""
+        channel_filter = "AND m.channel_id = ?" if channel_id is not None else ""
+        params: tuple[object, ...]
+        if channel_id is not None:
+            params = (f"-{days} days", channel_id)
+        else:
+            params = (f"-{days} days",)
         rows = await self._db.execute_fetchall(
-            """
+            f"""
             SELECT CAST(strftime('%H', m.date) AS INTEGER) AS hour, COUNT(*) AS cnt
             FROM messages m
-            WHERE m.channel_id = ?
-              AND m.date >= date('now', ?)
+            WHERE m.date >= date('now', ?)
+              {channel_filter}
             GROUP BY hour
             ORDER BY hour ASC
             """,
-            (channel_id, f"-{days} days"),
+            params,
         )
         return [PeakHour(hour=int(r["hour"]), count=int(r["cnt"])) for r in rows]

--- a/src/web/runtime_shims.py
+++ b/src/web/runtime_shims.py
@@ -14,6 +14,9 @@ class SnapshotClientPool:
     def clients(self) -> dict[str, object]:
         return getattr(self, "_clients_cache", {})
 
+    def connected_phones(self) -> set[str]:
+        return set(self.clients.keys())
+
     async def refresh(self) -> None:
         snapshot = await self._db.repos.runtime_snapshots.get_snapshot("accounts_status")
         payload = snapshot.payload if snapshot is not None else {}

--- a/tests/repositories/test_photo_loader_repository.py
+++ b/tests/repositories/test_photo_loader_repository.py
@@ -97,6 +97,7 @@ async def test_list_items_for_batch(db):
     await repo.create_item(PhotoBatchItem(batch_id=b1, phone="+1", target_dialog_id=1, file_paths=["/b"]))
     await repo.create_item(PhotoBatchItem(batch_id=b2, phone="+2", target_dialog_id=2, file_paths=["/c"]))
     assert len(await repo.list_items_for_batch(b1)) == 2
+    assert len(await repo.list_items_for_batch(b1, limit=1)) == 1
     assert len(await repo.list_items_for_batch(b2)) == 1
 
 

--- a/tests/test_agent_tool_smoke_contract.py
+++ b/tests/test_agent_tool_smoke_contract.py
@@ -1,0 +1,69 @@
+"""Smoke tests for read-only agent tool contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from src.agent.tools import _PIPELINE_SAFE_TOOLS, build_agent_tools_dict
+from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+
+def _assert_no_formatter_contract_error(tool_name: str, text: str) -> None:
+    lowered = text.lower()
+    assert "object is not subscriptable" not in lowered, tool_name
+    assert "has no attribute" not in lowered, tool_name
+
+
+@pytest.mark.anyio
+async def test_pipeline_safe_agent_tools_smoke_on_empty_db(db):
+    tools = build_agent_tools_dict(db, client_pool=None)
+
+    assert _PIPELINE_SAFE_TOOLS - set(tools) == set()
+    for tool_name in sorted(_PIPELINE_SAFE_TOOLS):
+        result = await tools[tool_name]()
+        assert isinstance(result, str), tool_name
+        _assert_no_formatter_contract_error(tool_name, result)
+
+
+def test_deepagents_read_only_tools_smoke_on_empty_db(cli_db):
+    tool_map: dict[str, Callable] = {tool.__name__: tool for tool in build_deepagents_tools(cli_db)}
+    calls: dict[str, dict] = {
+        "search_messages": {"query_text": "smoke"},
+        "semantic_search": {"query_text": "smoke"},
+        "list_channels": {},
+        "get_channel_stats": {},
+        "list_pipelines": {},
+        "get_pipeline_detail": {"pipeline_id": 1},
+        "list_pipeline_runs": {"pipeline_id": 1},
+        "get_pipeline_run": {"run_id": 1},
+        "list_pending_moderation": {},
+        "list_search_queries": {},
+        "list_accounts": {},
+        "get_flood_status": {},
+        "get_account_info": {},
+        "analyze_filters": {},
+        "get_analytics_summary": {},
+        "get_pipeline_stats": {},
+        "get_trending_topics": {},
+        "get_trending_channels": {},
+        "get_message_velocity": {},
+        "get_peak_hours": {},
+        "get_calendar": {},
+        "get_daily_stats": {},
+        "get_scheduler_status": {},
+        "get_notification_status": {},
+        "list_image_providers": {},
+        "get_settings": {},
+        "get_system_info": {},
+        "list_agent_threads": {},
+        "get_thread_messages": {"thread_id": 1},
+    }
+
+    missing = set(calls) - set(tool_map)
+    assert missing == set()
+    for tool_name, kwargs in calls.items():
+        result = tool_map[tool_name](**kwargs)
+        assert isinstance(result, str), tool_name
+        _assert_no_formatter_contract_error(tool_name, result)

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -536,8 +536,7 @@ class TestPipelineStatsTool:
 class TestChannelStatsTool:
     @pytest.mark.anyio
     async def test_with_stats(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(
+        mock_db.get_latest_stats_for_all = AsyncMock(
             return_value={100: SimpleNamespace(channel_id=100, subscriber_count=5000, avg_views=1200)}
         )
         handlers = _get_tool_handlers(mock_db)
@@ -549,8 +548,7 @@ class TestChannelStatsTool:
 
     @pytest.mark.anyio
     async def test_empty(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={})
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["get_channel_stats"]({})
@@ -883,6 +881,52 @@ class TestGetAccountInfoTool:
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["get_account_info"]({})
         assert "не найдены" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_connected_runtime_with_empty_profiles_is_not_reported_as_disconnected(self, mock_db):
+        mock_pool = MagicMock()
+        mock_pool.clients = {
+            "+66982102247": object(),
+            "+66990712629": object(),
+            "+8613392919509": object(),
+            "+66824602531": object(),
+        }
+        mock_pool.get_users_info = AsyncMock(return_value=[])
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(id=1, phone="+66982102247", is_active=True, is_primary=True, session_string="s"),
+            SimpleNamespace(id=2, phone="+66990712629", is_active=True, is_primary=False, session_string="s"),
+            SimpleNamespace(id=3, phone="+8613392919509", is_active=True, is_primary=False, session_string="s"),
+            SimpleNamespace(id=4, phone="+66824602531", is_active=True, is_primary=False, session_string="s"),
+        ])
+
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["get_account_info"]({})
+        text = _text(result)
+
+        assert "Runtime connected phones" in text
+        assert "+66982102247" in text
+        assert "+66824602531" in text
+        assert "DB active accounts: 4" in text
+        assert "do not treat this as disconnected" in text
+        assert "not found" not in text.lower()
+
+    @pytest.mark.anyio
+    async def test_phone_filter_reports_connected_phone_when_profile_unavailable(self, mock_db):
+        mock_pool = MagicMock()
+        mock_pool.clients = {"+8613392919509": object(), "+66824602531": object()}
+        mock_pool.get_users_info = AsyncMock(return_value=[])
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(id=1, phone="+8613392919509", is_active=True, is_primary=False, session_string="s"),
+            SimpleNamespace(id=2, phone="+66824602531", is_active=True, is_primary=False, session_string="s"),
+        ])
+
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["get_account_info"]({"phone": "+8613*"})
+        text = _text(result)
+
+        assert "+8613392919509" in text
+        assert "+66824602531" not in text
+        assert "profiles unavailable" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tools_accounts.py
+++ b/tests/test_agent_tools_accounts.py
@@ -184,12 +184,14 @@ class TestGetAccountInfoTool:
     @pytest.mark.anyio
     async def test_snapshot_runtime_is_explicitly_unavailable(self, mock_db):
         class SnapshotClientPool:
-            pass
+            clients = {"+71112223344": object()}
 
         handlers = _get_tool_handlers(mock_db, client_pool=SnapshotClientPool())
         result = await handlers["get_account_info"]({})
         text = _text(result)
-        assert text == "live Telegram runtime unavailable"
+        assert "live Telegram runtime unavailable" in text
+        assert "Web snapshot runtime" in text
+        assert "+71112223344" in text
         lowered = text.lower()
         assert "disabled" not in lowered
         assert "not connected" not in lowered

--- a/tests/test_agent_tools_analytics.py
+++ b/tests/test_agent_tools_analytics.py
@@ -121,8 +121,8 @@ class TestAnalyticsToolGetTrendingChannels:
     @pytest.mark.anyio
     async def test_with_channels(self, mock_db):
         channels = [
-            SimpleNamespace(title="TechChannel", channel_id=100, count=200),
-            SimpleNamespace(title="NewsChannel", channel_id=200, count=150),
+            SimpleNamespace(title="TechChannel", channel_id=100, message_count=200),
+            SimpleNamespace(title="NewsChannel", channel_id=200, message_count=150),
         ]
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_trending_channels = AsyncMock(return_value=channels)
@@ -248,9 +248,11 @@ class TestAnalyticsToolGetDailyStats:
 
     @pytest.mark.anyio
     async def test_with_data(self, mock_db):
+        from src.services.content_analytics_service import DailyStats
+
         rows = [
-            {"date": "2026-01-01", "count": 10, "published": 8},
-            {"date": "2026-01-02", "count": 15, "published": 12},
+            DailyStats(date="2026-01-01", generations=10, publications=8, rejections=1),
+            DailyStats(date="2026-01-02", generations=15, publications=12, rejections=0),
         ]
         with patch("src.services.content_analytics_service.ContentAnalyticsService") as mock_svc:
             mock_svc.return_value.get_daily_stats = AsyncMock(return_value=rows)

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -40,8 +40,7 @@ class TestDeepagentsSyncGetChannelStats:
     def test_empty(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={})
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
         result = tool_map["get_channel_stats"]()
@@ -51,8 +50,7 @@ class TestDeepagentsSyncGetChannelStats:
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
         stat = SimpleNamespace(subscriber_count=9999)
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={42: stat})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={42: stat})
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
         result = tool_map["get_channel_stats"]()
@@ -111,7 +109,7 @@ class TestDeepagentsSyncGetAccountInfo:
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
         result = tool_map["get_account_info"]()
-        assert result == "live Telegram runtime unavailable"
+        assert "live Telegram runtime unavailable" in result
         lowered = result.lower()
         assert "disabled" not in lowered
         assert "sms" not in lowered
@@ -146,6 +144,38 @@ class TestDeepagentsSyncGetAccountInfo:
         assert "Live Pool" in result
         assert "db_primary=да" in result
         pool.get_users_info.assert_awaited_once_with(include_avatar=False)
+
+    def test_connected_runtime_with_empty_profiles_via_sync_bridge(self, mock_db):
+        from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+        pool = MagicMock()
+        pool.clients = {"+66982102247": object(), "+66824602531": object()}
+        pool.get_users_info = AsyncMock(return_value=[])
+        mock_db.get_accounts = AsyncMock(return_value=[
+            SimpleNamespace(
+                id=1,
+                phone="+66982102247",
+                is_active=True,
+                is_primary=True,
+                session_string="s",
+            ),
+            SimpleNamespace(
+                id=2,
+                phone="+66824602531",
+                is_active=True,
+                is_primary=False,
+                session_string="s",
+            ),
+        ])
+
+        tools = build_deepagents_tools(mock_db, client_pool=pool)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_account_info"]()
+
+        assert "Runtime connected phones" in result
+        assert "+66982102247" in result
+        assert "+66824602531" in result
+        assert "do not treat this as disconnected" in result
 
 
 class TestDeepagentsSyncAgentThreads:
@@ -248,25 +278,24 @@ class TestDeepagentsSyncListSearchQueries:
 
 class TestDeepagentsSyncGetSchedulerStatus:
     def test_returns_status(self, mock_db):
+        from src.agent.runtime_context import AgentRuntimeContext
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
         mgr_mock = MagicMock()
-        mgr_mock.load_settings = AsyncMock(return_value=None)
         mgr_mock.is_running = True
         mgr_mock.interval_minutes = 15
-        with patch("src.scheduler.service.SchedulerManager", return_value=mgr_mock):
-            tools = build_deepagents_tools(mock_db)
-            tool_map = {t.__name__: t for t in tools}
-            result = tool_map["get_scheduler_status"]()
+        runtime_context = AgentRuntimeContext.build(db=mock_db, scheduler_manager=mgr_mock)
+        tools = build_deepagents_tools(mock_db, runtime_context=runtime_context)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_scheduler_status"]()
         assert "Планировщик" in result
 
     def test_error_returns_text(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        with patch("src.scheduler.service.SchedulerManager", side_effect=Exception("no sched")):
-            tools = build_deepagents_tools(mock_db)
-            tool_map = {t.__name__: t for t in tools}
-            result = tool_map["get_scheduler_status"]()
+        tools = build_deepagents_tools(mock_db)
+        tool_map = {t.__name__: t for t in tools}
+        result = tool_map["get_scheduler_status"]()
         assert "Ошибка" in result
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,8 +87,8 @@ class TestCLIAccount:
         run(_ns(account_action="delete", id=pk))
         assert "Deleted" in capsys.readouterr().out
 
-    def test_info_shows_table(self, cli_env_with_pool, capsys):
-        """account info: shows table with connected account profile data."""
+    def test_info_shows_live_account_profile(self, cli_env_with_pool, capsys):
+        """account info: shows connected account profile diagnostics."""
         from src.models import TelegramUserInfo
 
         db = cli_env_with_pool
@@ -118,7 +118,7 @@ class TestCLIAccount:
         assert phone in out
         assert "Alice Smith" in out
         assert "@alice" in out
-        assert "Phone" in out
+        assert "Live Telegram accounts (1)" in out
 
     def test_info_filter_by_phone(self, cli_env_with_pool, capsys):
         """account info --phone: only shows matching account."""
@@ -151,7 +151,7 @@ class TestCLIAccount:
         assert phone2 not in out
 
     def test_info_no_connected_accounts(self, cli_env_with_pool, capsys):
-        """account info: prints message when no accounts are connected."""
+        """account info: prints shared no-live-profile diagnostics."""
         fake_pool = AsyncMock(
             clients={},
             get_users_info=AsyncMock(return_value=[]),
@@ -163,7 +163,27 @@ class TestCLIAccount:
 
             run(_ns(account_action="info", phone=None))
 
-        assert "No connected accounts found." in capsys.readouterr().out
+        assert "Live Telegram accounts not found" in capsys.readouterr().out
+
+    def test_info_connected_runtime_with_empty_profiles(self, cli_env_with_pool, capsys):
+        """account info does not treat connected phones as disconnected when profile fetch is empty."""
+        phone = "+10009998877"
+        _add_account(cli_env_with_pool, phone=phone)
+        fake_pool = AsyncMock(
+            clients={phone: MagicMock()},
+            get_users_info=AsyncMock(return_value=[]),
+            disconnect_all=AsyncMock(),
+        )
+        init_pool_mock = AsyncMock(return_value=(MagicMock(), fake_pool))
+        with patch("src.cli.runtime.init_pool", new=init_pool_mock):
+            from src.cli.commands.account import run
+
+            run(_ns(account_action="info", phone=None))
+
+        out = capsys.readouterr().out
+        assert "Runtime connected phones" in out
+        assert phone in out
+        assert "do not treat this as disconnected" in out
 
     def test_flood_status_no_flood(self, cli_env, capsys):
         _add_account(cli_env, phone="+10001112233")
@@ -1389,3 +1409,45 @@ class TestCLIDialogsTopics:
         )
         assert args.channel_id == 456
         assert args.phone == "+10001112233"
+
+
+class TestCLIParityParser:
+    def test_new_parity_subcommands_parse(self):
+        from src.cli.parser import build_parser
+
+        parser = build_parser()
+
+        args = parser.parse_args(["account", "add", "--phone", "+1000"])
+        assert args.account_action == "add"
+        assert args.phone == "+1000"
+        assert args.code is None
+
+        args = parser.parse_args(["account", "add", "--phone", "+1000", "--code", "12345"])
+        assert args.account_action == "add"
+        assert args.code == "12345"
+
+        args = parser.parse_args(["search-query", "get", "7"])
+        assert args.search_query_action == "get"
+        assert args.id == 7
+
+        args = parser.parse_args(["pipeline", "moderation-list", "--pipeline-id", "3", "--limit", "5"])
+        assert args.pipeline_action == "moderation-list"
+        assert args.pipeline_id == 3
+        assert args.limit == 5
+
+        args = parser.parse_args(["pipeline", "moderation-view", "9"])
+        assert args.pipeline_action == "moderation-view"
+        assert args.run_id == 9
+
+        args = parser.parse_args(["photo-loader", "items", "--batch-id", "4"])
+        assert args.photo_loader_action == "items"
+        assert args.batch_id == 4
+
+        args = parser.parse_args(["dialogs", "resolve", "@example", "--phone", "+1000"])
+        assert args.dialogs_action == "resolve"
+        assert args.identifier == "@example"
+        assert args.phone == "+1000"
+
+        args = parser.parse_args(["image", "generated", "--limit", "3"])
+        assert args.image_action == "generated"
+        assert args.limit == 3

--- a/tests/test_cli_agent_parity.py
+++ b/tests/test_cli_agent_parity.py
@@ -1,0 +1,59 @@
+"""Guard the documented CLI / Web / Agent parity contract."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _actual_agent_tools() -> set[str]:
+    names: set[str] = set()
+    for path in (ROOT / "src/agent/tools").glob("*.py"):
+        if path.name.startswith("_") or path.name == "__init__.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                if (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Name)
+                    and decorator.func.id == "tool"
+                    and decorator.args
+                    and isinstance(decorator.args[0], ast.Constant)
+                    and isinstance(decorator.args[0].value, str)
+                ):
+                    names.add(decorator.args[0].value)
+    return names
+
+
+def _parity_rows() -> list[tuple[str, str, list[str]]]:
+    rows: list[tuple[str, str, list[str]]] = []
+    for line in (ROOT / "docs/reference/parity.md").read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|") or line.startswith("|---") or "Операция" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 4:
+            continue
+        agent_tools = re.findall(r"`([^`]+)`", cells[3])
+        if agent_tools:
+            rows.append((cells[0], cells[1], agent_tools))
+    return rows
+
+
+def test_all_agent_tools_are_documented_in_parity_table():
+    documented = {tool for _, _, tools in _parity_rows() for tool in tools}
+    assert _actual_agent_tools() - documented == set()
+
+
+def test_documented_agent_operations_have_cli_entrypoint():
+    missing_cli = [
+        (operation, tools)
+        for operation, cli, tools in _parity_rows()
+        if cli in {"", "—"}
+    ]
+    assert missing_cli == []

--- a/tests/test_cli_analytics_commands.py
+++ b/tests/test_cli_analytics_commands.py
@@ -147,8 +147,10 @@ def test_daily_empty(capsys):
 
 
 def test_daily_with_data(capsys):
+    from src.services.content_analytics_service import DailyStats
+
     db = make_cli_db()
-    rows = [{"date": "2024-01-01", "count": 5, "published": 3}]
+    rows = [DailyStats(date="2024-01-01", generations=5, publications=3, rejections=0)]
     mock_svc = MagicMock()
     mock_svc.get_daily_stats = AsyncMock(return_value=rows)
     with _init_patches(db)[0], _init_patches(db)[1], \
@@ -190,7 +192,7 @@ def test_trending_topics_with_data(capsys):
 
 def test_trending_channels_with_data(capsys):
     db = make_cli_db()
-    ch = MagicMock(title="NewsCh", count=100)
+    ch = MagicMock(title="NewsCh", message_count=100)
     mock_svc = MagicMock()
     mock_svc.get_trending_channels = AsyncMock(return_value=[ch])
     with _init_patches(db)[0], _init_patches(db)[1], \

--- a/tests/test_content_analytics_service.py
+++ b/tests/test_content_analytics_service.py
@@ -130,3 +130,32 @@ async def test_content_analytics_daily_stats_aggregate_all_pipelines(db):
     assert stats[1].generations == 1
     assert stats[1].publications == 0
     assert stats[1].rejections == 1
+
+
+@pytest.mark.anyio
+async def test_content_analytics_daily_stats_accepts_naive_db_timestamps(db):
+    analytics = ContentAnalyticsService(db)
+    pipeline_id = await _create_pipeline(db, "Pipeline Naive")
+    now = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
+
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "rejected")
+    await db.repos.generation_runs.save_result(run_id, "post")
+    await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
+    await db.execute(
+        """
+        UPDATE generation_runs
+        SET created_at = ?, updated_at = ?
+        WHERE id = ?
+        """,
+        (
+            now.replace(tzinfo=None).isoformat(),
+            (now + timedelta(hours=1)).replace(tzinfo=None).isoformat(),
+            run_id,
+        ),
+    )
+    await db.db.commit()
+
+    stats = await analytics.get_daily_stats(days=1)
+
+    assert stats[0].generations == 1
+    assert stats[0].rejections == 1

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -22,10 +22,13 @@ def mock_db():
     return db
 
 
-def _build_sync_tools(mock_db, config=None):
+def _build_sync_tools(mock_db, config=None, runtime_context=None):
     from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-    return {t.__name__: t for t in build_deepagents_tools(mock_db, config=config)}
+    return {
+        t.__name__: t
+        for t in build_deepagents_tools(mock_db, config=config, runtime_context=runtime_context)
+    }
 
 
 def _get_tool_handlers(mock_db, client_pool=None, config=None, **kwargs):
@@ -581,7 +584,7 @@ class TestDeepagentsSyncGetTrendingChannels:
         assert "не найдены" in result
 
     def test_with_channels(self, mock_db):
-        ch = SimpleNamespace(title="TechNews", count=100)
+        ch = SimpleNamespace(title="TechNews", message_count=100)
         svc_mock = MagicMock()
         svc_mock.get_trending_channels = AsyncMock(return_value=[ch])
         with patch("src.services.trend_service.TrendService", return_value=svc_mock):
@@ -709,7 +712,9 @@ class TestDeepagentsSyncGetDailyStats:
         assert "Нет данных" in result
 
     def test_with_stats(self, mock_db):
-        row = {"date": "2026-01-01", "count": 5}
+        from src.services.content_analytics_service import DailyStats
+
+        row = DailyStats(date="2026-01-01", generations=5, publications=3, rejections=0)
         svc_mock = MagicMock()
         svc_mock.get_daily_stats = AsyncMock(return_value=[row])
         with patch(
@@ -737,30 +742,31 @@ class TestDeepagentsSyncGetDailyStats:
 
 class TestDeepagentsSyncToggleSchedulerJob:
     def test_disable_job(self, mock_db):
+        from src.agent.runtime_context import AgentRuntimeContext
+
         mgr_mock = MagicMock()
-        mgr_mock.load_settings = AsyncMock(return_value=None)
         mgr_mock.is_job_enabled = AsyncMock(return_value=True)
         mgr_mock.sync_job_state = AsyncMock(return_value=None)
-        with patch("src.scheduler.service.SchedulerManager", return_value=mgr_mock):
-            tool_map = _build_sync_tools(mock_db)
-            result = tool_map["toggle_scheduler_job"](job_id="collect_all")
+        runtime_context = AgentRuntimeContext.build(db=mock_db, scheduler_manager=mgr_mock)
+        tool_map = _build_sync_tools(mock_db, runtime_context=runtime_context)
+        result = tool_map["toggle_scheduler_job"](job_id="collect_all")
         assert "collect_all" in result
         assert "выключена" in result
 
     def test_enable_job(self, mock_db):
+        from src.agent.runtime_context import AgentRuntimeContext
+
         mgr_mock = MagicMock()
-        mgr_mock.load_settings = AsyncMock(return_value=None)
         mgr_mock.is_job_enabled = AsyncMock(return_value=False)
         mgr_mock.sync_job_state = AsyncMock(return_value=None)
-        with patch("src.scheduler.service.SchedulerManager", return_value=mgr_mock):
-            tool_map = _build_sync_tools(mock_db)
-            result = tool_map["toggle_scheduler_job"](job_id="collect_all")
+        runtime_context = AgentRuntimeContext.build(db=mock_db, scheduler_manager=mgr_mock)
+        tool_map = _build_sync_tools(mock_db, runtime_context=runtime_context)
+        result = tool_map["toggle_scheduler_job"](job_id="collect_all")
         assert "включена" in result
 
     def test_error(self, mock_db):
-        with patch("src.scheduler.service.SchedulerManager", side_effect=Exception("sched err")):
-            tool_map = _build_sync_tools(mock_db)
-            result = tool_map["toggle_scheduler_job"](job_id="x")
+        tool_map = _build_sync_tools(mock_db)
+        result = tool_map["toggle_scheduler_job"](job_id="x")
         assert "Ошибка" in result
 
 

--- a/tests/test_messaging_deepagents_provider_paths.py
+++ b/tests/test_messaging_deepagents_provider_paths.py
@@ -553,20 +553,20 @@ class TestDeepagentsSyncChannels:
         assert "Ошибка" in result
 
     def test_get_channel_stats_empty(self, mock_db):
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={})
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["get_channel_stats"]()
         assert "не собрана" in result.lower()
 
     def test_get_channel_stats_with_data(self, mock_db):
         stat = SimpleNamespace(subscriber_count=500)
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={10: stat})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={10: stat})
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["get_channel_stats"]()
         assert "500" in result
 
     def test_get_channel_stats_error(self, mock_db):
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(side_effect=Exception("oops"))
+        mock_db.get_latest_stats_for_all = AsyncMock(side_effect=Exception("oops"))
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["get_channel_stats"]()
         assert "Ошибка" in result

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -887,8 +887,7 @@ class TestListChannelsTool:
 class TestGetChannelStatsTool:
     @pytest.mark.anyio
     async def test_no_stats_returns_empty_message(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={})
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["get_channel_stats"]({})
         assert "не собрана" in _text(result)
@@ -898,8 +897,7 @@ class TestGetChannelStatsTool:
         stat = MagicMock()
         stat.subscriber_count = 5000
         stat.avg_views = 200
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(return_value={100: stat})
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={100: stat})
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["get_channel_stats"]({})
         text = _text(result)
@@ -908,8 +906,7 @@ class TestGetChannelStatsTool:
 
     @pytest.mark.anyio
     async def test_error_handling(self, mock_db):
-        mock_db.repos = MagicMock()
-        mock_db.repos.channels.get_latest_stats_for_all = AsyncMock(side_effect=Exception("stats fail"))
+        mock_db.get_latest_stats_for_all = AsyncMock(side_effect=Exception("stats fail"))
         handlers = _get_channel_tool_handlers(mock_db)
         result = await handlers["get_channel_stats"]({})
         assert "Ошибка" in _text(result)

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -294,6 +294,20 @@ async def test_get_message_velocity_by_channel(service, mock_db):
     assert result[0].count == 5
     assert result[1].date == "2024-01-02"
     assert result[1].count == 10
+    assert mock_db.execute_fetchall.await_args.args[1] == ("-30 days", 123)
+
+
+@pytest.mark.anyio
+async def test_get_message_velocity_all_channels_when_channel_id_omitted(service, mock_db):
+    """get_message_velocity aggregates all channels when channel_id is omitted."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[{"day": "2024-01-01", "cnt": 15}])
+
+    result = await service.get_message_velocity(days=7)
+
+    sql = mock_db.execute_fetchall.await_args.args[0]
+    assert "m.channel_id = ?" not in sql
+    assert mock_db.execute_fetchall.await_args.args[1] == ("-7 days",)
+    assert result[0].count == 15
 
 
 # === get_peak_hours tests ===
@@ -326,6 +340,21 @@ async def test_get_peak_hours_distribution(service, mock_db):
     assert result[0].count == 5
     assert result[1].hour == 18
     assert result[1].count == 10
+    assert mock_db.execute_fetchall.await_args.args[1] == ("-30 days", 123)
+
+
+@pytest.mark.anyio
+async def test_get_peak_hours_all_channels_when_channel_id_omitted(service, mock_db):
+    """get_peak_hours aggregates all channels when channel_id is omitted."""
+    mock_db.execute_fetchall = AsyncMock(return_value=[{"hour": 9, "cnt": 7}])
+
+    result = await service.get_peak_hours(days=7)
+
+    sql = mock_db.execute_fetchall.await_args.args[0]
+    assert "m.channel_id = ?" not in sql
+    assert mock_db.execute_fetchall.await_args.args[1] == ("-7 days",)
+    assert result[0].hour == 9
+    assert result[0].count == 7
 
 
 # === Dataclass tests ===

--- a/tests/test_web_runtime_shims.py
+++ b/tests/test_web_runtime_shims.py
@@ -30,6 +30,7 @@ async def test_snapshot_pool_refresh():
     pool = SnapshotClientPool(db)
     await pool.refresh()
     assert set(pool.clients.keys()) == {"+1", "+2"}
+    assert pool.connected_phones() == {"+1", "+2"}
 
 
 async def test_snapshot_pool_refresh_no_snapshot():


### PR DESCRIPTION
## Summary
- fix `get_account_info` so connected runtime phones are not reported as disconnected when profile fetch returns empty
- make CLI `account info` use the same runtime-aware diagnostic path as the agent tool
- add missing CLI parity commands and update CLI/parity reference docs
- add a parity guard that checks actual agent tools against `docs/reference/parity.md`

Closes #537

## Tests
- `ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_cli.py tests/test_cli_agent_parity.py tests/test_cli_pipeline_commands.py tests/test_cli_photo_loader.py tests/test_cli_image_scheduler_web_routes.py tests/test_cli_dialogs.py tests/test_cli_search_commands.py tests/test_cli_provider_commands.py -v`
- `python3 -m pytest tests/test_agent_tools.py tests/test_agent_tools_accounts.py tests/test_agent_tools_deepagents_sync.py tests/test_web_runtime_shims.py tests/test_agent_manager_runtime_paths.py -v`