### PR TITLE
fix(agent): harden read-only tool contracts

### DIFF
--- a/src/agent/tools/_formatters.py
+++ b/src/agent/tools/_formatters.py
@@ -1,0 +1,99 @@
+"""Shared formatters for read-only agent tool output."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def _value(obj: object, name: str, default: object = None) -> object:
+    if isinstance(obj, Mapping):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def format_notification_status(bot: object | None, target_status: object | None = None) -> str:
+    lines: list[str]
+    if bot is None:
+        lines = ["Бот уведомлений не настроен."]
+    else:
+        bot_username = _value(bot, "bot_username", "")
+        username = f"@{bot_username}" if bot_username else "неизвестен"
+        lines = [
+            "Бот уведомлений:",
+            f"- Username: {username}",
+            f"- Bot ID: {_value(bot, 'bot_id', 'неизвестен') or 'неизвестен'}",
+            f"- Target user ID: {_value(bot, 'tg_user_id', 'неизвестен')}",
+        ]
+        tg_username = _value(bot, "tg_username")
+        if tg_username:
+            lines.append(f"- Target username: @{tg_username}")
+        created_at = _value(bot, "created_at")
+        if created_at:
+            lines.append(f"- Создан: {created_at}")
+
+    if target_status is not None:
+        lines.extend(
+            [
+                "",
+                "Целевой аккаунт:",
+                f"- Mode: {_value(target_status, 'mode', 'unknown')}",
+                f"- Status: {_value(target_status, 'state', 'unknown')}",
+            ]
+        )
+        configured_phone = _value(target_status, "configured_phone")
+        effective_phone = _value(target_status, "effective_phone")
+        if configured_phone:
+            lines.append(f"- Configured phone: {configured_phone}")
+        if effective_phone:
+            lines.append(f"- Effective phone: {effective_phone}")
+        message = _value(target_status, "message")
+        if message:
+            lines.append(f"- Diagnostic: {message}")
+
+    return "\n".join(lines)
+
+
+def format_filter_report(report: object) -> str:
+    results = list(_value(report, "results", []) or [])
+    if not results:
+        return "Нет каналов для анализа фильтров. 0 каналов проверено, 0 рекомендовано к фильтрации."
+
+    flagged = [result for result in results if bool(_value(result, "is_filtered", False))]
+    lines = [
+        f"Анализ фильтров: {len(results)} каналов проверено, "
+        f"{len(flagged)} рекомендовано к фильтрации."
+    ]
+    for result in flagged:
+        flags_value = _value(result, "flags", []) or []
+        flags = ", ".join(str(flag) for flag in flags_value) if flags_value else "—"
+        title = _value(result, "title") or "Без названия"
+        lines.append(f"- {title} (id={_value(result, 'channel_id', '?')}): {flags}")
+    return "\n".join(lines)
+
+
+def format_channel_stats(stats: Mapping[int, object], channels: Iterable[object] | None = None) -> str:
+    if not stats:
+        return "Статистика каналов пока не собрана."
+
+    channels_by_id = {
+        int(channel_id): channel
+        for channel in channels or []
+        if (channel_id := _value(channel, "channel_id")) is not None
+    }
+    lines = [f"Статистика каналов ({len(stats)}):"]
+    for cid, stat in stats.items():
+        channel = channels_by_id.get(int(cid))
+        title = _value(channel, "title") if channel is not None else None
+        username = _value(channel, "username") if channel is not None else None
+        label = f"{title or 'Без названия'} "
+        if username:
+            label += f"(@{username}, "
+        else:
+            label += "("
+        label += f"channel_id={cid})"
+        lines.append(
+            f"- {label}: "
+            f"subscribers={_value(stat, 'subscriber_count') or '?'}, "
+            f"avg_views={_value(stat, 'avg_views') or '?'}"
+        )
+    return "\n".join(lines)

--- a/src/agent/tools/_formatters.py
+++ b/src/agent/tools/_formatters.py
@@ -11,10 +11,18 @@ def _value(obj: object, name: str, default: object = None) -> object:
     return getattr(obj, name, default)
 
 
+def _display_metric(value: object) -> object:
+    return "?" if value is None else value
+
+
 def format_notification_status(bot: object | None, target_status: object | None = None) -> str:
     lines: list[str]
     if bot is None:
-        lines = ["Бот уведомлений не настроен."]
+        target_state = _value(target_status, "state") if target_status is not None else None
+        if target_status is not None and target_state != "available":
+            lines = ["Статус бота уведомлений невозможно проверить: целевой аккаунт недоступен."]
+        else:
+            lines = ["Бот уведомлений не настроен."]
     else:
         bot_username = _value(bot, "bot_username", "")
         username = f"@{bot_username}" if bot_username else "неизвестен"
@@ -93,7 +101,7 @@ def format_channel_stats(stats: Mapping[int, object], channels: Iterable[object]
         label += f"channel_id={cid})"
         lines.append(
             f"- {label}: "
-            f"subscribers={_value(stat, 'subscriber_count') or '?'}, "
-            f"avg_views={_value(stat, 'avg_views') or '?'}"
+            f"subscribers={_display_metric(_value(stat, 'subscriber_count'))}, "
+            f"avg_views={_display_metric(_value(stat, 'avg_views'))}"
         )
     return "\n".join(lines)

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
+from src.agent.tools._formatters import format_channel_stats
 from src.agent.tools._registry import (
     ToolInputError,
     _text_response,
@@ -70,16 +71,8 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def get_channel_stats(args):
         try:
             stats = await db.get_latest_stats_for_all()
-            if not stats:
-                return _text_response("Статистика каналов пока не собрана.")
-            lines = [f"Статистика каналов ({len(stats)}):"]
-            for cid, s in stats.items():
-                lines.append(
-                    f"- channel_id={cid}: "
-                    f"subscribers={s.subscriber_count or '?'}, "
-                    f"avg_views={s.avg_views or '?'}"
-                )
-            return _text_response("\n".join(lines))
+            channels = await db.get_channels(active_only=False, include_filtered=True)
+            return _text_response(format_channel_stats(stats, channels))
         except Exception as e:
             return _text_response(f"Ошибка получения статистики каналов: {e}")
 

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -7,11 +7,17 @@ These wrappers bridge async DB/service calls via asyncio.run().
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
 from src.agent.runtime_context import AgentRuntimeContext
+from src.agent.tools._formatters import (
+    format_channel_stats,
+    format_filter_report,
+    format_notification_status,
+)
 
 _T = TypeVar("_T")
 logger = logging.getLogger(__name__)
@@ -124,14 +130,13 @@ def build_deepagents_tools(
         """Get subscriber counts and statistics for all channels."""
         try:
             stats = _run_sync("get_channel_stats", db.get_latest_stats_for_all)
+            channels = _run_sync(
+                "get_channel_stats_channels",
+                lambda: db.get_channels(active_only=False, include_filtered=True),
+            )
         except Exception as exc:
             return f"Ошибка статистики каналов: {exc}"
-        if not stats:
-            return "Статистика каналов не собрана."
-        lines = [f"Статистика ({len(stats)} каналов):"]
-        for cid, s in stats.items():
-            lines.append(f"- channel_id={cid}: subscribers={s.subscriber_count or '?'}")
-        return "\n".join(lines)
+        return format_channel_stats(stats, channels)
 
     tools.append(get_channel_stats)
 
@@ -512,8 +517,7 @@ def build_deepagents_tools(
 
             analyzer = ChannelAnalyzer(db)
             report = _run_sync("analyze_filters", analyzer.analyze_all)
-            flagged = [r for r in report.results if r.should_filter]
-            return f"Анализ: {len(report.results)} проверено, {len(flagged)} к фильтрации."
+            return format_filter_report(report)
         except Exception as exc:
             return f"Ошибка: {exc}"
 
@@ -755,11 +759,22 @@ def build_deepagents_tools(
         try:
             from src.services.notification_service import NotificationService
             from src.services.notification_target_service import NotificationTargetService
-            svc = NotificationService(db, NotificationTargetService(db, client_pool))
+
+            target_service = NotificationTargetService(db, client_pool)
+            describe = getattr(target_service, "describe_target", None)
+            target_status = None
+            if callable(describe):
+                if inspect.iscoroutinefunction(describe):
+                    target_status = _run_sync("notif_target", describe)
+                else:
+                    candidate = describe()
+                    if inspect.isawaitable(candidate):
+                        target_status = _run_sync("notif_target", lambda: candidate)
+            if target_status is not None and getattr(target_status, "state", None) != "available":
+                return format_notification_status(None, target_status)
+            svc = NotificationService(db, target_service)
             bot = _run_sync("notif_status", svc.get_status)
-            if not bot:
-                return "Бот уведомлений не настроен."
-            return f"Бот: @{bot.bot_username}, chat_id={bot.chat_id}"
+            return format_notification_status(bot, target_status)
         except Exception as exc:
             return f"Ошибка: {exc}"
 

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
+from src.agent.tools._formatters import format_filter_report
 from src.agent.tools._registry import _text_response, require_confirmation
 
 
@@ -25,17 +26,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             analyzer = ChannelAnalyzer(db)
             report = await analyzer.analyze_all()
-            if not report.results:
-                return _text_response("Нет каналов для анализа фильтров.")
-            flagged = [r for r in report.results if r.should_filter]
-            lines = [
-                f"Анализ фильтров: {len(report.results)} каналов проверено, "
-                f"{len(flagged)} рекомендовано к фильтрации."
-            ]
-            for r in flagged:
-                flags = ", ".join(r.flags) if r.flags else "—"
-                lines.append(f"- {r.title} (id={r.channel_id}): {flags}")
-            return _text_response("\n".join(lines))
+            return _text_response(format_filter_report(report))
         except Exception as e:
             return _text_response(f"Ошибка анализа фильтров: {e}")
 

--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Annotated
 
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
+from src.agent.tools._formatters import format_notification_status
 from src.agent.tools._registry import _text_response, require_confirmation, require_pool
+
+
+async def _describe_target(target_service):
+    describe = getattr(target_service, "describe_target", None)
+    if not callable(describe):
+        return None
+    status = describe()
+    if inspect.isawaitable(status):
+        return await status
+    return None
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -19,16 +31,13 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.notification_service import NotificationService
             from src.services.notification_target_service import NotificationTargetService
 
-            svc = NotificationService(db, NotificationTargetService(db, client_pool))
+            target_service = NotificationTargetService(db, client_pool)
+            target_status = await _describe_target(target_service)
+            if target_status is not None and getattr(target_status, "state", None) != "available":
+                return _text_response(format_notification_status(None, target_status))
+            svc = NotificationService(db, target_service)
             bot = await svc.get_status()
-            if bot is None:
-                return _text_response("Бот уведомлений не настроен.")
-            return _text_response(
-                f"Бот уведомлений:\n"
-                f"- Username: @{bot.bot_username}\n"
-                f"- Chat ID: {bot.chat_id}\n"
-                f"- Создан: {bot.created_at}"
-            )
+            return _text_response(format_notification_status(bot, target_status))
         except Exception as e:
             return _text_response(f"Ошибка получения статуса бота: {e}")
 
@@ -56,7 +65,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(
                 f"Бот уведомлений создан!\n"
                 f"- Username: @{bot.bot_username}\n"
-                f"- Chat ID: {bot.chat_id}"
+                f"- Bot ID: {bot.bot_id or 'неизвестен'}\n"
+                f"- Target user ID: {bot.tg_user_id}"
             )
         except Exception as e:
             return _text_response(f"Ошибка настройки бота: {e}")

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
+import re
 from collections import Counter
 from dataclasses import dataclass
 
@@ -50,6 +52,84 @@ class TrendService:
 
     _TOPIC_BATCH_SIZE = 5000
     _MAX_TOPIC_DOCUMENTS = 10000
+    _URL_RE = re.compile(r"https?://\S+|www\.\S+|t\.me/\S+", re.IGNORECASE)
+    _HTML_TAG_RE = re.compile(r"<[^>]+>")
+    _TECH_TOKEN_RE = re.compile(
+        r"\b(?:https?|www|html?|amp|nbsp|quot|lt|gt|href|target|blank|utm_[a-z]+)\b",
+        re.IGNORECASE,
+    )
+    _STOP_WORDS = frozenset({
+        "about",
+        "after",
+        "again",
+        "also",
+        "because",
+        "been",
+        "before",
+        "being",
+        "between",
+        "could",
+        "from",
+        "have",
+        "into",
+        "more",
+        "most",
+        "only",
+        "other",
+        "over",
+        "some",
+        "than",
+        "that",
+        "their",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "through",
+        "under",
+        "very",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "while",
+        "with",
+        "would",
+        "если",
+        "или",
+        "как",
+        "для",
+        "при",
+        "про",
+        "что",
+        "это",
+        "этот",
+        "эти",
+        "они",
+        "она",
+        "оно",
+        "уже",
+        "еще",
+        "ещё",
+        "были",
+        "было",
+        "будет",
+        "после",
+        "перед",
+        "только",
+        "очень",
+        "можно",
+        "когда",
+        "где",
+        "или",
+        "также",
+        "которые",
+        "который",
+        "которая",
+    })
 
     def __init__(self, db: Database) -> None:
         self._db = db
@@ -95,13 +175,26 @@ class TrendService:
                 self._MAX_TOPIC_DOCUMENTS,
             )
 
-        return await asyncio.to_thread(self._rank_trending_topics, texts, limit)
+        cleaned_texts = [cleaned for text in texts if (cleaned := self._cleanup_topic_text(text))]
+        if not cleaned_texts:
+            return []
+
+        return await asyncio.to_thread(self._rank_trending_topics, cleaned_texts, limit)
+
+    @classmethod
+    def _cleanup_topic_text(cls, text: str) -> str:
+        text = html.unescape(text)
+        text = cls._URL_RE.sub(" ", text)
+        text = cls._HTML_TAG_RE.sub(" ", text)
+        text = cls._TECH_TOKEN_RE.sub(" ", text)
+        return text
 
     def _rank_trending_topics(self, texts: list[str], limit: int) -> list[TrendingTopic]:
         vectorizer = TfidfVectorizer(
             token_pattern=r"(?u)\b[а-яёa-z]{4,}\b",
             max_df=0.85,
             min_df=2,
+            stop_words=sorted(self._STOP_WORDS),
         )
         try:
             tfidf_matrix = vectorizer.fit_transform(texts)

--- a/tests/test_agent_tool_smoke_contract.py
+++ b/tests/test_agent_tool_smoke_contract.py
@@ -3,17 +3,42 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime, timedelta
 
 import pytest
 
 from src.agent.tools import _PIPELINE_SAFE_TOOLS, build_agent_tools_dict
 from src.agent.tools.deepagents_sync import build_deepagents_tools
+from src.models import Channel, ChannelStats, Message
+from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 def _assert_no_formatter_contract_error(tool_name: str, text: str) -> None:
     lowered = text.lower()
     assert "object is not subscriptable" not in lowered, tool_name
     assert "has no attribute" not in lowered, tool_name
+    assert "keyerror" not in lowered, tool_name
+    assert "required positional" not in lowered, tool_name
+
+
+async def _seed_read_only_contract_data(db) -> None:
+    now = datetime.now()
+    await db.add_channel(Channel(channel_id=1001, title="Named Contract", username="named_contract"))
+    await db.add_channel(Channel(channel_id=1002, title=None, username=None))
+    await db.save_channel_stats(ChannelStats(channel_id=1001, subscriber_count=101, avg_views=12.5))
+    await db.save_channel_stats(ChannelStats(channel_id=1002, subscriber_count=202))
+    await db.insert_messages_batch(
+        [
+            Message(channel_id=1001, message_id=1, text="quantum рынок https://example.com", date=now),
+            Message(
+                channel_id=1001,
+                message_id=2,
+                text="<b>quantum</b> рынок &amp; news",
+                date=now - timedelta(minutes=1),
+            ),
+            Message(channel_id=1002, message_id=1, text="quantum рынок after before", date=now - timedelta(minutes=2)),
+        ]
+    )
 
 
 @pytest.mark.anyio
@@ -25,6 +50,23 @@ async def test_pipeline_safe_agent_tools_smoke_on_empty_db(db):
         result = await tools[tool_name]()
         assert isinstance(result, str), tool_name
         _assert_no_formatter_contract_error(tool_name, result)
+
+
+@pytest.mark.anyio
+async def test_pipeline_safe_agent_tools_smoke_on_seeded_db(db):
+    await _seed_read_only_contract_data(db)
+    tools = build_agent_tools_dict(db, client_pool=None)
+
+    for tool_name in ["get_channel_stats", "get_trending_topics"]:
+        result = await tools[tool_name]()
+        assert isinstance(result, str), tool_name
+        _assert_no_formatter_contract_error(tool_name, result)
+
+    handlers = _get_tool_handlers(db, client_pool=None)
+    result = await handlers["analyze_filters"]({})
+    text = _text(result)
+    assert isinstance(text, str)
+    _assert_no_formatter_contract_error("analyze_filters", text)
 
 
 def test_deepagents_read_only_tools_smoke_on_empty_db(cli_db):
@@ -63,6 +105,24 @@ def test_deepagents_read_only_tools_smoke_on_empty_db(cli_db):
 
     missing = set(calls) - set(tool_map)
     assert missing == set()
+    for tool_name, kwargs in calls.items():
+        result = tool_map[tool_name](**kwargs)
+        assert isinstance(result, str), tool_name
+        _assert_no_formatter_contract_error(tool_name, result)
+
+
+def test_deepagents_read_only_tools_smoke_on_seeded_db(cli_db):
+    import asyncio
+
+    asyncio.run(_seed_read_only_contract_data(cli_db))
+    tool_map: dict[str, Callable] = {tool.__name__: tool for tool in build_deepagents_tools(cli_db)}
+
+    calls: dict[str, dict] = {
+        "get_channel_stats": {},
+        "analyze_filters": {},
+        "get_trending_topics": {},
+        "get_notification_status": {},
+    }
     for tool_name, kwargs in calls.items():
         result = tool_map[tool_name](**kwargs)
         assert isinstance(result, str), tool_name

--- a/tests/test_agent_tools_channels.py
+++ b/tests/test_agent_tools_channels.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.models import ChannelStats
 from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
@@ -26,6 +27,39 @@ def _make_channel(
     ch.is_filtered = is_filtered
     ch.channel_type = channel_type
     return ch
+
+
+class TestGetChannelStatsTool:
+    @pytest.mark.anyio
+    async def test_empty(self, mock_db):
+        mock_db.get_latest_stats_for_all = AsyncMock(return_value={})
+        mock_db.get_channels = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_stats"]({})
+        assert "пока не собрана" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_named_and_unnamed_channels(self, mock_db):
+        mock_db.get_latest_stats_for_all = AsyncMock(
+            return_value={
+                100: ChannelStats(channel_id=100, subscriber_count=10, avg_views=2.5),
+                200: ChannelStats(channel_id=200, subscriber_count=20),
+            }
+        )
+        mock_db.get_channels = AsyncMock(
+            return_value=[
+                _make_channel(channel_id=100, title="Named", username="named"),
+                _make_channel(channel_id=200, title=None, username=None),
+            ]
+        )
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_stats"]({})
+        text = _text(result)
+        assert "Named" in text
+        assert "@named" in text
+        assert "channel_id=100" in text
+        assert "Без названия" in text
+        assert "channel_id=200" in text
 
 
 class TestAddChannelTool:

--- a/tests/test_agent_tools_channels.py
+++ b/tests/test_agent_tools_channels.py
@@ -43,7 +43,7 @@ class TestGetChannelStatsTool:
         mock_db.get_latest_stats_for_all = AsyncMock(
             return_value={
                 100: ChannelStats(channel_id=100, subscriber_count=10, avg_views=2.5),
-                200: ChannelStats(channel_id=200, subscriber_count=20),
+                200: ChannelStats(channel_id=200, subscriber_count=0, avg_views=0.0),
             }
         )
         mock_db.get_channels = AsyncMock(
@@ -60,6 +60,8 @@ class TestGetChannelStatsTool:
         assert "channel_id=100" in text
         assert "Без названия" in text
         assert "channel_id=200" in text
+        assert "subscribers=0" in text
+        assert "avg_views=0.0" in text
 
 
 class TestAddChannelTool:

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from src.filters.models import ChannelFilterResult
+from src.models import NotificationBot
+
 
 class TestDeepagentsSyncListChannels:
     def test_empty(self, mock_db):
@@ -51,11 +54,13 @@ class TestDeepagentsSyncGetChannelStats:
 
         stat = SimpleNamespace(subscriber_count=9999)
         mock_db.get_latest_stats_for_all = AsyncMock(return_value={42: stat})
+        mock_db.get_channels = AsyncMock(return_value=[SimpleNamespace(channel_id=42, title="Named", username="named")])
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
         result = tool_map["get_channel_stats"]()
         assert "9999" in result
         assert "channel_id=42" in result
+        assert "Named" in result
 
 
 class TestDeepagentsSyncListAccounts:
@@ -319,7 +324,7 @@ class TestDeepagentsSyncGetNotificationStatus:
     def test_configured(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
-        bot = SimpleNamespace(bot_username="mybot", chat_id=12345)
+        bot = NotificationBot(tg_user_id=12345, bot_id=67890, bot_username="mybot", bot_token="token")
         svc_mock = MagicMock()
         svc_mock.get_status = AsyncMock(return_value=bot)
         target_svc_mock = MagicMock()
@@ -332,6 +337,7 @@ class TestDeepagentsSyncGetNotificationStatus:
                 tool_map = {t.__name__: t for t in tools}
                 result = tool_map["get_notification_status"]()
         assert "@mybot" in result
+        assert "67890" in result
         assert "12345" in result
 
 
@@ -369,16 +375,16 @@ class TestDeepagentsSyncAnalyzeFilters:
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
         analyzer_mock = MagicMock()
-        result_item = SimpleNamespace(should_filter=True)
-        report = SimpleNamespace(results=[result_item, SimpleNamespace(should_filter=False)])
+        result_item = ChannelFilterResult(channel_id=1, title="Bad", is_filtered=True)
+        report = SimpleNamespace(results=[result_item, ChannelFilterResult(channel_id=2, is_filtered=False)])
         analyzer_mock.analyze_all = AsyncMock(return_value=report)
         with patch("src.filters.analyzer.ChannelAnalyzer", return_value=analyzer_mock):
             tools = build_deepagents_tools(mock_db)
             tool_map = {t.__name__: t for t in tools}
             result = tool_map["analyze_filters"]()
         assert "Анализ" in result
-        assert "2 проверено" in result
-        assert "1 к фильтрации" in result
+        assert "2 каналов проверено" in result
+        assert "1 рекомендовано" in result
 
     def test_error_returns_text(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools

--- a/tests/test_agent_tools_filters.py
+++ b/tests/test_agent_tools_filters.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.filters.models import ChannelFilterResult
 from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
@@ -30,11 +31,12 @@ class TestAnalyzeFiltersTool:
     @pytest.mark.anyio
     async def test_report_with_flagged_channels(self, mock_db):
         """Flagged channels are listed with their flags."""
-        r = MagicMock()
-        r.should_filter = True
-        r.title = "SpamChan"
-        r.channel_id = 100
-        r.flags = ["low_uniqueness", "spam"]
+        r = ChannelFilterResult(
+            channel_id=100,
+            title="SpamChan",
+            flags=["low_uniqueness", "spam"],
+            is_filtered=True,
+        )
         report = MagicMock()
         report.results = [r]
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:
@@ -52,12 +54,12 @@ class TestAnalyzeFiltersTool:
         """More than 30 flagged channels are all shown without truncation."""
 
         def _make_result(i):
-            r = MagicMock()
-            r.should_filter = True
-            r.title = f"Chan{i}"
-            r.channel_id = i
-            r.flags = ["low_uniqueness"]
-            return r
+            return ChannelFilterResult(
+                channel_id=i,
+                title=f"Chan{i}",
+                flags=["low_uniqueness"],
+                is_filtered=True,
+            )
 
         report = MagicMock()
         report.results = [_make_result(i) for i in range(35)]
@@ -72,11 +74,7 @@ class TestAnalyzeFiltersTool:
     @pytest.mark.anyio
     async def test_report_non_flagged_not_listed(self, mock_db):
         """Non-flagged channels don't appear in the flagged list."""
-        ok = MagicMock()
-        ok.should_filter = False
-        ok.title = "GoodChan"
-        ok.channel_id = 1
-        ok.flags = []
+        ok = ChannelFilterResult(channel_id=1, title="GoodChan", is_filtered=False)
         report = MagicMock()
         report.results = [ok]
         with patch("src.filters.analyzer.ChannelAnalyzer") as mock_analyzer:

--- a/tests/test_agent_tools_notifications.py
+++ b/tests/test_agent_tools_notifications.py
@@ -48,6 +48,32 @@ class TestGetNotificationStatusTool:
         assert "не настроен" in _text(result)
 
     @pytest.mark.anyio
+    async def test_target_unavailable_returns_unknown_status(self, mock_db):
+        target_status = SimpleNamespace(
+            mode="primary",
+            state="disconnected",
+            message="Аккаунт +100 не подключён.",
+            effective_phone="+100",
+            configured_phone=None,
+        )
+        target_svc = MagicMock()
+        target_svc.describe_target = AsyncMock(return_value=target_status)
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch(
+                "src.services.notification_target_service.NotificationTargetService",
+                return_value=target_svc,
+            ),
+        ):
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_notification_status"]({})
+        text = _text(result)
+        assert "невозможно проверить" in text
+        assert "не настроен" not in text
+        assert "disconnected" in text
+        mock_ns.return_value.get_status.assert_not_called()
+
+    @pytest.mark.anyio
     async def test_configured_shows_bot_info(self, mock_db):
         bot = NotificationBot(
             tg_user_id=12345,

--- a/tests/test_agent_tools_notifications.py
+++ b/tests/test_agent_tools_notifications.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.models import NotificationBot
 from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
@@ -48,7 +49,14 @@ class TestGetNotificationStatusTool:
 
     @pytest.mark.anyio
     async def test_configured_shows_bot_info(self, mock_db):
-        bot = SimpleNamespace(bot_username="mybot", chat_id=12345, created_at="2025-01-01")
+        bot = NotificationBot(
+            tg_user_id=12345,
+            tg_username="target",
+            bot_id=67890,
+            bot_username="mybot",
+            bot_token="token",
+            created_at="2025-01-01",
+        )
         with (
             patch("src.services.notification_service.NotificationService") as mock_ns,
             patch("src.services.notification_target_service.NotificationTargetService"),
@@ -58,6 +66,7 @@ class TestGetNotificationStatusTool:
             result = await handlers["get_notification_status"]({})
         text = _text(result)
         assert "@mybot" in text
+        assert "67890" in text
         assert "12345" in text
 
     @pytest.mark.anyio
@@ -85,10 +94,13 @@ class TestGetNotificationStatusTool:
     @pytest.mark.anyio
     async def test_configured_shows_bot_details_with_pool(self, mock_db):
         notif_svc = MagicMock()
-        bot = MagicMock()
-        bot.bot_username = "my_bot"
-        bot.chat_id = 123456
-        bot.created_at = "2025-01-01"
+        bot = NotificationBot(
+            tg_user_id=123456,
+            bot_id=987654,
+            bot_username="my_bot",
+            bot_token="token",
+            created_at="2025-01-01",
+        )
         notif_svc.get_status = AsyncMock(return_value=bot)
         mock_pool = _make_mock_pool()
 
@@ -97,6 +109,7 @@ class TestGetNotificationStatusTool:
             result = await handlers["get_notification_status"]({})
         text = _text(result)
         assert "my_bot" in text
+        assert "987654" in text
         assert "123456" in text
 
 
@@ -117,7 +130,7 @@ class TestSetupNotificationBotTool:
     @pytest.mark.anyio
     async def test_with_confirm_creates_bot(self, mock_db):
         pool = MagicMock()
-        bot = SimpleNamespace(bot_username="newbot", chat_id=99999)
+        bot = SimpleNamespace(bot_username="newbot", bot_id=99999, tg_user_id=111)
         with (
             patch("src.services.notification_service.NotificationService") as mock_ns,
             patch("src.services.notification_target_service.NotificationTargetService"),
@@ -140,7 +153,8 @@ class TestSetupNotificationBotTool:
         notif_svc = MagicMock()
         bot = MagicMock()
         bot.bot_username = "test_notify_bot"
-        bot.chat_id = 789
+        bot.bot_id = 789
+        bot.tg_user_id = 111
         notif_svc.setup_bot = AsyncMock(return_value=bot)
         mock_pool = _make_mock_pool()
 
@@ -211,7 +225,7 @@ class TestTestNotificationTool:
     @pytest.mark.anyio
     async def test_sends_notification(self, mock_db):
         pool = MagicMock()
-        bot = SimpleNamespace(bot_username="testbot", chat_id=1)
+        bot = SimpleNamespace(bot_username="testbot", bot_id=1, tg_user_id=111)
         with (
             patch("src.services.notification_service.NotificationService") as mock_ns,
             patch("src.services.notification_target_service.NotificationTargetService"),

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -427,3 +427,26 @@ async def test_get_trending_topics_tfidf_suppresses_noise(service, mock_db):
 
     assert "криптовалюта" in keywords
     assert "hello" not in keywords  # in 100% documents → filtered by max_df
+
+
+@pytest.mark.anyio
+async def test_get_trending_topics_cleans_urls_html_and_stop_words(service, mock_db):
+    """Regression #539: URL/HTML noise should not outrank meaningful keywords."""
+    messages = [
+        {"text": "<a href='https://t.me/news'>Read this</a> quantum рынок &amp;nbsp;"},
+        {"text": "www.example.com/?utm_source=x quantum рынок after before"},
+        {"text": "<b>AI</b> quantum рынок https://example.com/page"},
+        {"text": "daily update product launch"},
+    ]
+    mock_db.execute_fetchall = AsyncMock(return_value=messages)
+
+    result = await service.get_trending_topics(days=7, limit=20)
+    keywords = [t.keyword for t in result]
+
+    assert "quantum" in keywords
+    assert "рынок" in keywords
+    assert "href" not in keywords
+    assert "https" not in keywords
+    assert "example" not in keywords
+    assert "after" not in keywords
+    assert "before" not in keywords


### PR DESCRIPTION
## Summary
- fix read-only agent/deepagents formatter contracts for notification status, filter analysis, and channel stats
- clean trending-topic inputs from URLs, HTML, technical tokens, and local EN/RU stop words
- add seeded regression smoke coverage for non-empty read-only tool paths

## Tests
- ruff check src/ tests/ conftest.py
- python3 -m pytest tests/test_agent_tools_notifications.py tests/test_agent_tools_filters.py tests/test_agent_tools_analytics.py tests/test_agent_tools_channels.py tests/test_agent_tools.py tests/test_agent_tools_deepagents_sync.py tests/test_trend_service.py tests/test_agent_tool_smoke_contract.py -v
- python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto
- python3 -m pytest tests/ -v -m aiosqlite_serial

Fixes #539