### PR TITLE
feat(analytics): support Chinese/CJK trending topics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "aiohttp==3.13.3",
     "numpy==2.2.6",
     "scikit-learn>=1.4",
+    "jieba==0.42.1",
     "langdetect==1.0.9",
     "textual[syntax]>=1.0.0",
     "claude-agent-sdk==0.1.52",

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -14,12 +14,12 @@ from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS, TfidfVectorizer
 from src.database import Database
 
 logger = logging.getLogger(__name__)
-# jieba imports pkg_resources on Python 3.12; pytest treats that deprecation as an error.
+# jieba imports pkg_resources; pytest treats that deprecation as an error.
 with warnings.catch_warnings():
     warnings.filterwarnings(
         "ignore",
         message="pkg_resources is deprecated as an API.*",
-        category=UserWarning,
+        category=Warning,
     )
     jieba = importlib.import_module("jieba")
 jieba.setLogLevel(logging.WARNING)

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -70,7 +70,8 @@ class TrendService:
         re.IGNORECASE,
     )
     _LATIN_CYRILLIC_TOKEN_RE = re.compile(r"(?u)\b[а-яёa-z]{4,}\b")
-    _CJK_TOKEN_RE = re.compile(r"^[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]{2,}$")
+    _HAN_CHAR_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
+    _HAN_TOKEN_RE = re.compile(r"^[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]{2,}$")
     _TOPIC_NOISE_WORDS = frozenset({
         "content",
         "data",
@@ -253,24 +254,27 @@ class TrendService:
         return text
 
     def _rank_trending_topics(self, texts: list[str], limit: int) -> list[TrendingTopic]:
+        tokenized_texts = [self._analyze_topic_text(text) for text in texts]
+        if not any(tokenized_texts):
+            return []
+
         vectorizer = TfidfVectorizer(
-            analyzer=self._analyze_topic_text,
+            analyzer=self._identity_analyzer,
             token_pattern=None,
             max_df=0.85,
             min_df=2,
         )
         try:
-            tfidf_matrix = vectorizer.fit_transform(texts)
+            tfidf_matrix = vectorizer.fit_transform(tokenized_texts)
         except ValueError:
             return []
 
         feature_names = vectorizer.get_feature_names_out()
         scores = tfidf_matrix.sum(axis=0).A1
         mention_counts: Counter[str] = Counter()
-        analyzer = vectorizer.build_analyzer()
 
-        for text in texts:
-            mention_counts.update(analyzer(text))
+        for tokens in tokenized_texts:
+            mention_counts.update(tokens)
 
         top_indices = scores.argsort()[::-1]
         topics: list[TrendingTopic] = []
@@ -281,6 +285,10 @@ class TrendService:
                 break
         return topics
 
+    @staticmethod
+    def _identity_analyzer(tokens: list[str]) -> list[str]:
+        return tokens
+
     @classmethod
     def _analyze_topic_text(cls, text: str) -> list[str]:
         text = text.lower()
@@ -290,11 +298,14 @@ class TrendService:
             if token not in cls._STOP_WORDS
         ]
 
+        if not cls._HAN_CHAR_RE.search(text):
+            return tokens
+
         for token in jieba.cut(text):
             token = token.strip()
             if token in cls._CHINESE_STOP_WORDS:
                 continue
-            if cls._CJK_TOKEN_RE.fullmatch(token):
+            if cls._HAN_TOKEN_RE.fullmatch(token):
                 tokens.append(token)
 
         return tokens

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -2,16 +2,27 @@ from __future__ import annotations
 
 import asyncio
 import html
+import importlib
 import logging
 import re
+import warnings
 from collections import Counter
 from dataclasses import dataclass
 
-from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.feature_extraction.text import ENGLISH_STOP_WORDS, TfidfVectorizer
 
 from src.database import Database
 
 logger = logging.getLogger(__name__)
+# jieba imports pkg_resources on Python 3.12; pytest treats that deprecation as an error.
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message="pkg_resources is deprecated as an API.*",
+        category=UserWarning,
+    )
+    jieba = importlib.import_module("jieba")
+jieba.setLogLevel(logging.WARNING)
 
 
 @dataclass
@@ -58,7 +69,23 @@ class TrendService:
         r"\b(?:https?|www|html?|amp|nbsp|quot|lt|gt|href|target|blank|utm_[a-z]+)\b",
         re.IGNORECASE,
     )
-    _STOP_WORDS = frozenset({
+    _LATIN_CYRILLIC_TOKEN_RE = re.compile(r"(?u)\b[а-яёa-z]{4,}\b")
+    _CJK_TOKEN_RE = re.compile(r"^[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]{2,}$")
+    _TOPIC_NOISE_WORDS = frozenset({
+        "content",
+        "data",
+        "need",
+        "needed",
+        "needs",
+        "page",
+        "pages",
+        "require",
+        "required",
+        "requires",
+        "site",
+        "sites",
+    })
+    _STOP_WORDS = ENGLISH_STOP_WORDS | _TOPIC_NOISE_WORDS | frozenset({
         "about",
         "after",
         "again",
@@ -130,6 +157,42 @@ class TrendService:
         "который",
         "которая",
     })
+    _CHINESE_STOP_WORDS = frozenset({
+        "一个",
+        "一些",
+        "以及",
+        "他们",
+        "但是",
+        "你们",
+        "因为",
+        "为了",
+        "什么",
+        "今天",
+        "只是",
+        "可以",
+        "可能",
+        "已经",
+        "并且",
+        "我们",
+        "所以",
+        "时候",
+        "明天",
+        "然后",
+        "现在",
+        "由于",
+        "自己",
+        "这个",
+        "这些",
+        "这样",
+        "这种",
+        "这里",
+        "进行",
+        "还是",
+        "那些",
+        "那么",
+        "那里",
+        "需要",
+    })
 
     def __init__(self, db: Database) -> None:
         self._db = db
@@ -191,10 +254,10 @@ class TrendService:
 
     def _rank_trending_topics(self, texts: list[str], limit: int) -> list[TrendingTopic]:
         vectorizer = TfidfVectorizer(
-            token_pattern=r"(?u)\b[а-яёa-z]{4,}\b",
+            analyzer=self._analyze_topic_text,
+            token_pattern=None,
             max_df=0.85,
             min_df=2,
-            stop_words=sorted(self._STOP_WORDS),
         )
         try:
             tfidf_matrix = vectorizer.fit_transform(texts)
@@ -217,6 +280,24 @@ class TrendService:
             if len(topics) >= limit:
                 break
         return topics
+
+    @classmethod
+    def _analyze_topic_text(cls, text: str) -> list[str]:
+        text = text.lower()
+        tokens = [
+            token
+            for token in cls._LATIN_CYRILLIC_TOKEN_RE.findall(text)
+            if token not in cls._STOP_WORDS
+        ]
+
+        for token in jieba.cut(text):
+            token = token.strip()
+            if token in cls._CHINESE_STOP_WORDS:
+                continue
+            if cls._CJK_TOKEN_RE.fullmatch(token):
+                tokens.append(token)
+
+        return tokens
 
     async def get_trending_channels(self, days: int = 7, limit: int = 10) -> list[TrendingChannel]:
         """Return channels with the highest average views in the last N days."""

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.services import trend_service as trend_service_module
 from src.services.trend_service import (
     MessageVelocity,
     PeakHour,
@@ -143,6 +144,17 @@ async def test_get_trending_topics_non_alpha_only(service, mock_db):
     assert "123numeric" not in words
     assert "test123" not in words
     assert "keepword" in words
+
+
+def test_analyze_topic_text_skips_jieba_for_ru_en_text(monkeypatch):
+    """RU/EN-only analysis should not call the Chinese segmenter."""
+
+    def fail_cut(_text):
+        raise AssertionError("jieba.cut should not run without Han characters")
+
+    monkeypatch.setattr(trend_service_module.jieba, "cut", fail_cut)
+
+    assert TrendService._analyze_topic_text("quantum рынок keepword") == ["quantum", "рынок", "keepword"]
 
 
 @pytest.mark.anyio

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -146,6 +146,72 @@ async def test_get_trending_topics_non_alpha_only(service, mock_db):
 
 
 @pytest.mark.anyio
+async def test_get_trending_topics_segments_chinese_keywords(service, mock_db):
+    """get_trending_topics returns segmented Chinese topic keywords."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "人工智能 推动 芯片 市场 增长"},
+            {"text": "人工智能 芯片 公司 发布 新产品"},
+            {"text": "芯片 市场 需求 上升"},
+            {"text": "新能源汽车 出口 增长"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=20)
+    keywords = [t.keyword for t in result]
+
+    assert result
+    assert "人工智能" in keywords
+    assert "芯片" in keywords
+    chip = next(t for t in result if t.keyword == "芯片")
+    assert chip.count == 3
+
+
+@pytest.mark.anyio
+async def test_get_trending_topics_filters_chinese_stop_words(service, mock_db):
+    """get_trending_topics filters common Chinese stop words."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "这个 我们 可以 因为 人工智能 芯片"},
+            {"text": "这个 我们 可以 因为 人工智能 市场"},
+            {"text": "芯片 市场 需求 增长"},
+            {"text": "新能源汽车 出口 增长"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=20)
+    keywords = [t.keyword for t in result]
+
+    assert "人工智能" in keywords
+    assert "芯片" in keywords
+    assert "这个" not in keywords
+    assert "我们" not in keywords
+    assert "可以" not in keywords
+    assert "因为" not in keywords
+
+
+@pytest.mark.anyio
+async def test_get_trending_topics_mixed_ru_en_chinese_corpus(service, mock_db):
+    """get_trending_topics keeps meaningful RU, EN, and Chinese keywords together."""
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[
+            {"text": "quantum рынок 人工智能 芯片"},
+            {"text": "quantum рынок 人工智能 市场"},
+            {"text": "robotics криптовалюта 芯片"},
+            {"text": "analytics финансы 出口"},
+        ]
+    )
+
+    result = await service.get_trending_topics(days=7, limit=20)
+    keywords = [t.keyword for t in result]
+
+    assert "quantum" in keywords
+    assert "рынок" in keywords
+    assert "人工智能" in keywords
+    assert "芯片" in keywords
+
+
+@pytest.mark.anyio
 async def test_get_trending_topics_respects_days(service, mock_db):
     """get_trending_topics respects days parameter."""
     mock_db.execute_fetchall = AsyncMock(
@@ -450,3 +516,29 @@ async def test_get_trending_topics_cleans_urls_html_and_stop_words(service, mock
     assert "example" not in keywords
     assert "after" not in keywords
     assert "before" not in keywords
+
+
+@pytest.mark.anyio
+async def test_get_trending_topics_filters_english_and_generic_topic_noise(service, mock_db):
+    """Regression #541 follow-up: generic English words should not become trends."""
+    messages = [
+        {"text": "your will need content data robotics"},
+        {"text": "your will need page site robotics"},
+        {"text": "machinelearning neural insights"},
+        {"text": "machinelearning neural trends"},
+    ]
+    mock_db.execute_fetchall = AsyncMock(return_value=messages)
+
+    result = await service.get_trending_topics(days=7, limit=20)
+    keywords = [t.keyword for t in result]
+
+    assert "robotics" in keywords
+    assert "machinelearning" in keywords
+    assert "neural" in keywords
+    assert "your" not in keywords
+    assert "will" not in keywords
+    assert "need" not in keywords
+    assert "content" not in keywords
+    assert "data" not in keywords
+    assert "page" not in keywords
+    assert "site" not in keywords


### PR DESCRIPTION
## Summary

- Add `jieba`-based Chinese/Han tokenization for `get_trending_topics`.
- Keep existing RU/EN trend extraction behavior while filtering common Chinese stop words.
- Reuse pre-tokenized documents for TF-IDF and mention counting, with a fast path for RU/EN-only text.
- Add regression coverage for Chinese-only, Chinese stop-word, and mixed RU/EN/ZH corpora.

Closes #542.

## Tests

- `python3 -m pytest tests/test_trend_service.py -v`
- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto`
- `python3 -m pytest tests/ -v -m aiosqlite_serial`
