### PR TITLE
fix(security): degrade wrong session key state

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -479,6 +479,8 @@ class ProviderRuntimeConfig:
     plain_fields: dict[str, str] = field(default_factory=dict)
     secret_fields: dict[str, str] = field(default_factory=dict)
     last_validation_error: str = ""
+    secret_status: str = "ok"
+    secret_fields_enc_preserved: dict[str, str] = field(default_factory=dict)
 
     @property
     def model_name(self) -> str:

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -267,6 +267,11 @@ def flood_waited_phones_from_pool(client_pool: object | None) -> set[str]:
     return set()
 
 
+def account_session_status(account: object) -> str:
+    status = getattr(account, "session_status", "ok")
+    return status if isinstance(status, str) else "ok"
+
+
 def _pool_reports_connections(client_pool: object | None) -> bool:
     """Whether an empty connected set is a reliable runtime signal."""
     if client_pool is None:
@@ -285,16 +290,19 @@ def _pool_reports_connections(client_pool: object | None) -> bool:
 
 
 async def _get_accounts(db: object, *, active_only: bool = False) -> list[object]:
-    getter = getattr(db, "get_accounts", None)
-    if not callable(getter):
-        return []
-    try:
-        result = getter(active_only=active_only)
-    except TypeError:
-        result = getter()
-    if isawaitable(result):
-        result = await result
-    return list(result) if isinstance(result, (list, tuple)) else []
+    for getter_name in ("get_account_summaries", "get_accounts"):
+        getter = getattr(db, getter_name, None)
+        if not callable(getter):
+            continue
+        try:
+            result = getter(active_only=active_only)
+        except TypeError:
+            result = getter()
+        if isawaitable(result):
+            result = await result
+        if isinstance(result, (list, tuple)):
+            return list(result)
+    return []
 
 
 async def _clear_account_flood(db: object, phone: str) -> None:
@@ -377,6 +385,8 @@ def available_live_read_phones(
         if not phone:
             continue
         if not getattr(account, "is_active", True):
+            continue
+        if account_session_status(account) != "ok":
             continue
         if connected_filter is not None and phone not in connected_filter:
             continue
@@ -504,12 +514,23 @@ async def resolve_phone(db: object, raw_phone: object) -> tuple[str, dict | None
     if phone:
         return phone, None
     try:
-        accounts = await db.get_accounts()
+        getter = getattr(db, "get_account_summaries", None)
+        result = getter() if callable(getter) else None
+        if isawaitable(result):
+            result = await result
+        if not isinstance(result, (list, tuple)):
+            result = await db.get_accounts()
+        accounts = list(result)
     except Exception:
         return "", _text_response("Ошибка: не удалось получить список аккаунтов.")
-    if not accounts:
+    usable_accounts = [
+        account
+        for account in accounts
+        if account_session_status(account) == "ok"
+    ]
+    if not usable_accounts:
         return "", _text_response("Ошибка: нет подключённых аккаунтов.")
-    primary = next((a for a in accounts if a.is_primary), accounts[0])
+    primary = next((a for a in usable_accounts if a.is_primary), usable_accounts[0])
     return primary.phone, None
 
 

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from inspect import isawaitable
 from typing import Annotated
 
 from claude_agent_sdk import tool
@@ -10,6 +11,7 @@ from mcp.types import ToolAnnotations
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools._registry import (
     _text_response,
+    account_session_status,
     available_live_read_phones,
     connected_phones_from_pool,
     get_accounts_with_flood_cleanup,
@@ -74,6 +76,19 @@ def _diagnostic_lines(accounts: list[object], client_pool: object | None) -> lis
     ]
 
 
+async def _get_account_summaries(db: object) -> list[object]:
+    for getter_name in ("get_account_summaries", "get_accounts"):
+        getter = getattr(db, getter_name, None)
+        if not callable(getter):
+            continue
+        result = getter()
+        if isawaitable(result):
+            result = await result
+        if isinstance(result, (list, tuple)):
+            return list(result)
+    return []
+
+
 async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: object = "") -> str:
     """Return account info with DB/runtime/profile-fetch states kept separate."""
     phone_filter = normalize_phone(phone)
@@ -124,7 +139,8 @@ async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: object
         premium = "да" if u.is_premium else "нет"
         active = "да" if getattr(db_account, "is_active", False) else "нет"
         primary = "да" if getattr(db_account, "is_primary", False) else "нет"
-        session_present = "да" if getattr(db_account, "session_string", "") else "нет"
+        session_status = account_session_status(db_account) if db_account else "missing"
+        session_present = "да" if db_account and session_status == "ok" else session_status
         lines.append(
             f"- {u.phone}: {name} ({username}), premium={premium}, "
             f"db_active={active}, db_primary={primary}, session-present={session_present}"
@@ -157,7 +173,9 @@ def register(db, client_pool, embedding_service, **kwargs):
                     remaining = _remaining_seconds(a)
                     suffix = f", remaining={remaining}s" if remaining is not None else ""
                     flood = f" [flood_wait до {a.flood_wait_until}{suffix}]"
-                lines.append(f"- id={a.id}, phone={a.phone}, {status}{flood}")
+                session_status = account_session_status(a)
+                session_suffix = "" if session_status == "ok" else f", session_status={session_status}"
+                lines.append(f"- id={a.id}, phone={a.phone}, {status}{session_suffix}{flood}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения аккаунтов: {e}")
@@ -174,7 +192,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if account_id is None:
             return _text_response("Ошибка: account_id обязателен.")
         try:
-            accounts = await db.get_accounts()
+            accounts = await _get_account_summaries(db)
             acc = next((a for a in accounts if a.id == int(account_id)), None)
             if acc is None:
                 return _text_response(f"Аккаунт id={account_id} не найден.")
@@ -202,7 +220,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if account_id is None:
             return _text_response("Ошибка: account_id обязателен.")
         try:
-            accounts = await db.get_accounts()
+            accounts = await _get_account_summaries(db)
             acc = next((a for a in accounts if a.id == int(account_id)), None)
             name = acc.phone if acc else f"id={account_id}"
             gate = require_confirmation(f"удалит аккаунт '{name}' из системы", args)
@@ -252,7 +270,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            accounts = await db.get_accounts()
+            accounts = await _get_account_summaries(db)
             acc = next((a for a in accounts if a.phone == phone), None)
             if acc is None:
                 return _text_response(f"Аккаунт {phone} не найден.")

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -7,6 +7,7 @@ import logging
 import time
 from collections import OrderedDict
 from enum import Enum
+from inspect import isawaitable
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,19 @@ _permissions_cache: tuple[dict[str, bool], float] | None = None
 TOOL_PERMISSIONS_SETTING = "agent_tool_permissions"
 MCP_PREFIX = "mcp__telegram_db__"
 BUILTIN_TOOLS = ["WebSearch", "WebFetch"]
+
+
+async def _load_account_records(db) -> list[object]:
+    for getter_name in ("get_account_summaries", "get_accounts"):
+        getter = getattr(db, getter_name, None)
+        if not callable(getter):
+            continue
+        result = getter()
+        if isawaitable(result):
+            result = await result
+        if isinstance(result, (list, tuple)):
+            return list(result)
+    return []
 
 
 class ToolCategory(str, Enum):
@@ -342,7 +356,7 @@ async def load_tool_permissions(db, phone: str | None = None) -> dict[str, bool]
             phone_perms = saved[phone]
         else:
             if phone is None:
-                accounts = await db.get_accounts()
+                accounts = await _load_account_records(db)
                 if accounts:
                     primary = next((a for a in accounts if a.is_primary), accounts[0])
                     phone_used = primary.phone
@@ -403,7 +417,7 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     # Seed unsaved accounts with all-enabled defaults so they are not implicitly denied
     defaults = _default_permissions()
     try:
-        accounts = await db.get_accounts()
+        accounts = await _load_account_records(db)
         for acc in accounts:
             if acc.phone not in saved:
                 saved[acc.phone] = dict(defaults)

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -24,6 +24,7 @@ from src.database.repositories.settings import SettingsRepository
 from src.database.repositories.telegram_commands import TelegramCommandsRepository
 from src.models import (
     Account,
+    AccountSummary,
     Channel,
     ChannelStats,
     CollectionTask,
@@ -79,6 +80,9 @@ class AccountBundle:
 
     async def list_accounts(self, active_only: bool = False) -> list[Account]:
         return await self.accounts.get_accounts(active_only)
+
+    async def list_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        return await self.accounts.get_account_summaries(active_only)
 
     async def add_account(self, account: Account) -> int:
         return await self.accounts.add_account(account)
@@ -506,6 +510,9 @@ class NotificationBundle:
     async def list_accounts(self, active_only: bool = False) -> list[Account]:
         return await self.accounts.get_accounts(active_only)
 
+    async def list_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        return await self.accounts.get_account_summaries(active_only)
+
     async def get_setting(self, key: str) -> str | None:
         return await self.settings.get_setting(key)
 
@@ -868,6 +875,9 @@ class PipelineBundle:
 
     async def list_accounts(self, active_only: bool = False):
         return await self.accounts.get_accounts(active_only)
+
+    async def list_account_summaries(self, active_only: bool = False):
+        return await self.accounts.get_account_summaries(active_only)
 
     async def get_cached_dialog(self, phone: str, dialog_id: int) -> dict | None:
         return await self.dialog_cache.get_dialog(phone, dialog_id)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -32,6 +32,7 @@ from src.database.repositories.telegram_commands import TelegramCommandsReposito
 from src.database.schema import SCHEMA_SQL
 from src.models import (
     Account,
+    AccountSummary,
     Channel,
     ChannelStats,
     CollectionTask,
@@ -96,14 +97,6 @@ class Database:
         if not self._fts_available:
             logger.warning(
                 "FTS5 full-text search is unavailable; text queries will use LIKE fallback"
-            )
-
-        if not self._session_encryption_secret and await self._has_encrypted_sessions():
-            await self._connection.close()
-            self._db = None
-            raise RuntimeError(
-                "Encrypted account sessions found in DB but SESSION_ENCRYPTION_KEY is not set. "
-                "Set SESSION_ENCRYPTION_KEY to start the application."
             )
 
         session_cipher = None
@@ -220,6 +213,10 @@ class Database:
     async def get_accounts(self, active_only: bool = False) -> list[Account]:
         self._require()
         return await self._accounts.get_accounts(active_only)
+
+    async def get_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        self._require()
+        return await self._accounts.get_account_summaries(active_only)
 
     async def update_account_flood(self, phone: str, until) -> None:
         self._require()

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -5,10 +5,25 @@ from datetime import datetime
 
 import aiosqlite
 
-from src.models import Account
-from src.security import SessionCipher
+from src.models import Account, AccountSessionStatus, AccountSummary
+from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
 
 logger = logging.getLogger(__name__)
+
+_RESTORE_ACCOUNT_ACTION = "restore_key_or_relogin"
+
+
+class AccountSessionDecryptError(RuntimeError):
+    def __init__(self, *, phone: str, status: str):
+        super().__init__(
+            "Failed to decrypt Telegram account session "
+            f"for phone={phone} status={status}. "
+            "Restore the original SESSION_ENCRYPTION_KEY or re-login this account."
+        )
+        self.resource = "telegram_account"
+        self.identifier = phone
+        self.status = status
+        self.action = _RESTORE_ACCOUNT_ACTION
 
 
 class AccountsRepository:
@@ -58,9 +73,15 @@ class AccountsRepository:
                 try:
                     migrated_value = self._session_cipher.encrypt(raw_session)
                 except ValueError as exc:
-                    raise RuntimeError(
-                        f"Failed to migrate session for phone={row['phone']}"
-                    ) from exc
+                    status = decrypt_failure_status(exc)
+                    log_expected_decrypt_failure(
+                        logger,
+                        resource="telegram_account",
+                        identifier=str(row["phone"]),
+                        status=status,
+                        action=_RESTORE_ACCOUNT_ACTION,
+                    )
+                    continue
 
                 if migrated_value != raw_session:
                     await self._db.execute(
@@ -76,6 +97,142 @@ class AccountsRepository:
 
         return migrated
 
+    def _parse_dt(self, raw: str | None) -> datetime | None:
+        return datetime.fromisoformat(raw) if raw else None
+
+    def _row_to_summary(
+        self,
+        row: aiosqlite.Row,
+        *,
+        session_status: AccountSessionStatus,
+    ) -> AccountSummary:
+        return AccountSummary(
+            id=row["id"],
+            phone=row["phone"],
+            is_primary=bool(row["is_primary"]),
+            is_active=bool(row["is_active"]),
+            is_premium=bool(row["is_premium"]) if row["is_premium"] is not None else False,
+            flood_wait_until=self._parse_dt(row["flood_wait_until"]),
+            created_at=self._parse_dt(row["created_at"]),
+            session_status=session_status,
+        )
+
+    def _classify_session_status(self, raw_session: str, phone: str) -> AccountSessionStatus:
+        version = SessionCipher.encryption_version(raw_session)
+        if version is None:
+            if raw_session.startswith("enc:v"):
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="telegram_account",
+                    identifier=phone,
+                    status="unsupported_version",
+                    action=_RESTORE_ACCOUNT_ACTION,
+                )
+                return AccountSessionStatus.UNSUPPORTED_VERSION
+            if raw_session.startswith("enc:"):
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="telegram_account",
+                    identifier=phone,
+                    status="encrypted_unknown",
+                    action=_RESTORE_ACCOUNT_ACTION,
+                )
+                return AccountSessionStatus.ENCRYPTED_UNKNOWN
+            return AccountSessionStatus.OK
+
+        if self._session_cipher is None:
+            log_expected_decrypt_failure(
+                logger,
+                resource="telegram_account",
+                identifier=phone,
+                status="missing_key",
+                action=_RESTORE_ACCOUNT_ACTION,
+            )
+            return AccountSessionStatus.MISSING_KEY
+
+        try:
+            self._session_cipher.decrypt(raw_session)
+        except ValueError as exc:
+            status = decrypt_failure_status(exc)
+            log_expected_decrypt_failure(
+                logger,
+                resource="telegram_account",
+                identifier=phone,
+                status=status,
+                action=_RESTORE_ACCOUNT_ACTION,
+            )
+            if status == "unsupported_version":
+                return AccountSessionStatus.UNSUPPORTED_VERSION
+            return AccountSessionStatus.DECRYPT_FAILED
+        return AccountSessionStatus.OK
+
+    def _decrypt_session_for_live_use(self, raw_session: str, phone: str) -> str:
+        version = SessionCipher.encryption_version(raw_session)
+        if version is None:
+            if raw_session.startswith("enc:v"):
+                status = "unsupported_version"
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="telegram_account",
+                    identifier=phone,
+                    status=status,
+                    action=_RESTORE_ACCOUNT_ACTION,
+                )
+                raise AccountSessionDecryptError(phone=phone, status=status)
+            if raw_session.startswith("enc:"):
+                status = "encrypted_unknown"
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="telegram_account",
+                    identifier=phone,
+                    status=status,
+                    action=_RESTORE_ACCOUNT_ACTION,
+                )
+                raise AccountSessionDecryptError(phone=phone, status=status)
+            return raw_session
+
+        if self._session_cipher is None:
+            status = "missing_key"
+            log_expected_decrypt_failure(
+                logger,
+                resource="telegram_account",
+                identifier=phone,
+                status=status,
+                action=_RESTORE_ACCOUNT_ACTION,
+            )
+            raise AccountSessionDecryptError(phone=phone, status=status)
+
+        try:
+            return self._session_cipher.decrypt(raw_session)
+        except ValueError as exc:
+            status = decrypt_failure_status(exc)
+            log_expected_decrypt_failure(
+                logger,
+                resource="telegram_account",
+                identifier=phone,
+                status=status,
+                action=_RESTORE_ACCOUNT_ACTION,
+            )
+            raise AccountSessionDecryptError(phone=phone, status=status) from exc
+
+    async def get_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        sql = "SELECT * FROM accounts"
+        if active_only:
+            sql += " WHERE is_active = 1"
+        sql += " ORDER BY is_primary DESC, id ASC"
+        cur = await self._db.execute(sql)
+        rows = await cur.fetchall()
+        return [
+            self._row_to_summary(
+                row,
+                session_status=self._classify_session_status(
+                    str(row["session_string"] or ""),
+                    str(row["phone"]),
+                ),
+            )
+            for row in rows
+        ]
+
     async def get_accounts(self, active_only: bool = False) -> list[Account]:
         sql = "SELECT * FROM accounts"
         if active_only:
@@ -86,18 +243,8 @@ class AccountsRepository:
         accounts: list[Account] = []
 
         for row in rows:
-            raw_session = row["session_string"]
-            session_string = raw_session
-            if self._session_cipher:
-                if self._session_cipher.is_encrypted(raw_session):
-                    try:
-                        session_string = self._session_cipher.decrypt(raw_session)
-                    except ValueError as exc:
-                        raise RuntimeError(
-                            f"Failed to decrypt session for phone={row['phone']}"
-                        ) from exc
-                # If plaintext is still in DB, use it as-is (migrate_sessions
-                # should have been called during initialize).
+            raw_session = str(row["session_string"] or "")
+            session_string = self._decrypt_session_for_live_use(raw_session, str(row["phone"]))
 
             accounts.append(
                 Account(
@@ -107,14 +254,8 @@ class AccountsRepository:
                     is_primary=bool(row["is_primary"]),
                     is_active=bool(row["is_active"]),
                     is_premium=bool(row["is_premium"]) if row["is_premium"] is not None else False,
-                    flood_wait_until=(
-                        datetime.fromisoformat(row["flood_wait_until"])
-                        if row["flood_wait_until"]
-                        else None
-                    ),
-                    created_at=(
-                        datetime.fromisoformat(row["created_at"]) if row["created_at"] else None
-                    ),
+                    flood_wait_until=self._parse_dt(row["flood_wait_until"]),
+                    created_at=self._parse_dt(row["created_at"]),
                 )
             )
 

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -128,6 +128,7 @@ class AccountsRepository:
                     identifier=phone,
                     status="unsupported_version",
                     action=_RESTORE_ACCOUNT_ACTION,
+                    level=logging.DEBUG,
                 )
                 return AccountSessionStatus.UNSUPPORTED_VERSION
             if raw_session.startswith("enc:"):
@@ -137,6 +138,7 @@ class AccountsRepository:
                     identifier=phone,
                     status="encrypted_unknown",
                     action=_RESTORE_ACCOUNT_ACTION,
+                    level=logging.DEBUG,
                 )
                 return AccountSessionStatus.ENCRYPTED_UNKNOWN
             return AccountSessionStatus.OK
@@ -148,6 +150,7 @@ class AccountsRepository:
                 identifier=phone,
                 status="missing_key",
                 action=_RESTORE_ACCOUNT_ACTION,
+                level=logging.DEBUG,
             )
             return AccountSessionStatus.MISSING_KEY
 
@@ -161,6 +164,7 @@ class AccountsRepository:
                 identifier=phone,
                 status=status,
                 action=_RESTORE_ACCOUNT_ACTION,
+                level=logging.DEBUG,
             )
             if status == "unsupported_version":
                 return AccountSessionStatus.UNSUPPORTED_VERSION

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import aiosqlite
 
+from src.database.repositories._transactions import begin_immediate
 from src.models import Account, AccountSessionStatus, AccountSummary
 from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
 
@@ -282,5 +283,28 @@ class AccountsRepository:
         await self._db.commit()
 
     async def delete_account(self, account_id: int) -> None:
-        await self._db.execute("DELETE FROM accounts WHERE id = ?", (account_id,))
-        await self._db.commit()
+        try:
+            await begin_immediate(self._db)
+            cur = await self._db.execute("DELETE FROM accounts WHERE id = ?", (account_id,))
+            if (cur.rowcount or 0) > 0:
+                await self._db.execute(
+                    """
+                    UPDATE accounts
+                    SET is_primary = 1
+                    WHERE id = (
+                        SELECT id
+                        FROM accounts
+                        ORDER BY id ASC
+                        LIMIT 1
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM accounts
+                        WHERE is_primary = 1
+                    )
+                    """
+                )
+            await self._db.commit()
+        except Exception:
+            await self._db.rollback()
+            raise

--- a/src/models.py
+++ b/src/models.py
@@ -20,6 +20,25 @@ class Account(BaseModel):
     created_at: datetime | None = None
 
 
+class AccountSessionStatus(StrEnum):
+    OK = "ok"
+    ENCRYPTED_UNKNOWN = "encrypted_unknown"
+    DECRYPT_FAILED = "decrypt_failed"
+    MISSING_KEY = "missing_key"
+    UNSUPPORTED_VERSION = "unsupported_version"
+
+
+class AccountSummary(BaseModel):
+    id: int | None = None
+    phone: str
+    is_primary: bool = False
+    is_active: bool = True
+    is_premium: bool = False
+    flood_wait_until: datetime | None = None
+    created_at: datetime | None = None
+    session_status: AccountSessionStatus = AccountSessionStatus.OK
+
+
 class TelegramUserInfo(BaseModel):
     phone: str
     first_name: str = ""

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -5,8 +5,10 @@ import logging
 import signal
 from dataclasses import asdict
 from datetime import datetime, timezone
+from inspect import isawaitable
 
 from src.config import AppConfig
+from src.database.repositories.accounts import AccountSessionDecryptError
 from src.models import RuntimeSnapshot
 from src.services.notification_service import NotificationService
 from src.telegram.utils import normalize_utc
@@ -16,20 +18,52 @@ from src.web.log_handler import LogBuffer
 logger = logging.getLogger(__name__)
 
 
+def _worker_decrypt_failure_payload(exc: AccountSessionDecryptError) -> dict[str, str]:
+    return {
+        "status": "worker_down",
+        "reason": "telegram_session_decrypt_failed",
+        "resource": exc.resource,
+        "identifier": exc.identifier,
+        "decrypt_status": exc.status,
+        "action": exc.action,
+        "detail": str(exc),
+    }
+
+
+async def _publish_worker_down_snapshot(container, exc: AccountSessionDecryptError) -> None:
+    await container.db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload=_worker_decrypt_failure_payload(exc),
+        )
+    )
+
+
 async def _publish_snapshots(container) -> None:
     now = datetime.now(timezone.utc)
     connected_phones = sorted(getattr(container.pool, "clients", {}).keys())
     active_accounts = []
-    try:
-        active_accounts = await container.db.get_accounts(active_only=True)
-    except Exception:
-        logger.debug("Failed to load accounts while publishing account status snapshot", exc_info=True)
+    for getter_name in ("get_account_summaries", "get_accounts"):
+        getter = getattr(container.db, getter_name, None)
+        if not callable(getter):
+            continue
+        try:
+            result = getter(active_only=True)
+            if isawaitable(result):
+                result = await result
+            if isinstance(result, (list, tuple)):
+                active_accounts = list(result)
+                break
+        except Exception:
+            logger.debug("Failed to load accounts while publishing account status snapshot", exc_info=True)
     flood_waits = {}
     available_phones = []
     if active_accounts:
         connected_set = set(connected_phones)
         for account in active_accounts:
             phone = getattr(account, "phone", "")
+            if str(getattr(account, "session_status", "ok")) != "ok":
+                continue
             flood_until = normalize_utc(getattr(account, "flood_wait_until", None))
             if flood_until is not None and flood_until > now:
                 flood_waits[phone] = flood_until.isoformat()
@@ -154,7 +188,19 @@ async def _run_worker_async(config: AppConfig) -> None:
         except NotImplementedError:
             pass
 
-    await start_container(container)
+    try:
+        await start_container(container)
+    except AccountSessionDecryptError as exc:
+        logger.error(
+            "worker startup blocked: resource=%s identifier=%s status=%s action=%s",
+            exc.resource,
+            exc.identifier,
+            exc.status,
+            exc.action,
+        )
+        await _publish_worker_down_snapshot(container, exc)
+        await stop_container(container)
+        return
     try:
         while not stop_event.is_set():
             await _publish_snapshots(container)

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,3 +1,13 @@
-from src.security.session_cipher import SessionCipher
+from src.security.session_cipher import (
+    EncryptedPayloadError,
+    SessionCipher,
+    decrypt_failure_status,
+    log_expected_decrypt_failure,
+)
 
-__all__ = ["SessionCipher"]
+__all__ = [
+    "EncryptedPayloadError",
+    "SessionCipher",
+    "decrypt_failure_status",
+    "log_expected_decrypt_failure",
+]

--- a/src/security/session_cipher.py
+++ b/src/security/session_cipher.py
@@ -38,8 +38,10 @@ def log_expected_decrypt_failure(
     identifier: str,
     status: str,
     action: str,
+    level: int = logging.ERROR,
 ) -> None:
-    logger.error(
+    logger.log(
+        level,
         "decrypt failed: resource=%s identifier=%s status=%s action=%s",
         resource,
         identifier,

--- a/src/security/session_cipher.py
+++ b/src/security/session_cipher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 
 from cryptography.fernet import Fernet, InvalidToken
 
@@ -9,6 +10,42 @@ _ENCRYPTED_PREFIX_V1 = "enc:v1:"
 _ENCRYPTED_PREFIX_V2 = "enc:v2:"
 _PBKDF2_SALT = b"tg_session_key_v2"
 _PBKDF2_ITERATIONS = 200_000
+
+
+class EncryptedPayloadError(ValueError):
+    def __init__(self, message: str, *, status: str):
+        super().__init__(message)
+        self.status = status
+
+
+def decrypt_failure_status(exc: BaseException) -> str:
+    if isinstance(exc, EncryptedPayloadError):
+        return exc.status
+    message = str(exc)
+    if "SESSION_ENCRYPTION_KEY" in message:
+        return "missing_key"
+    if "unsupported encrypted session version" in message:
+        return "unsupported_version"
+    if "invalid encrypted session payload" in message:
+        return "key_mismatch"
+    return "decrypt_failed"
+
+
+def log_expected_decrypt_failure(
+    logger: logging.Logger,
+    *,
+    resource: str,
+    identifier: str,
+    status: str,
+    action: str,
+) -> None:
+    logger.error(
+        "decrypt failed: resource=%s identifier=%s status=%s action=%s",
+        resource,
+        identifier,
+        status,
+        action,
+    )
 
 
 def _derive_fernet_key_v1(secret: str) -> bytes:
@@ -49,7 +86,10 @@ class SessionCipher:
         if version == 2:
             return value
         if version is None and value.startswith("enc:v"):
-            raise ValueError("unsupported encrypted session version")
+            raise EncryptedPayloadError(
+                "unsupported encrypted session version",
+                status="unsupported_version",
+            )
 
         plaintext = value
         if version == 1:
@@ -62,7 +102,10 @@ class SessionCipher:
         version = self.encryption_version(value)
         if version is None:
             if value.startswith("enc:v"):
-                raise ValueError("unsupported encrypted session version")
+                raise EncryptedPayloadError(
+                    "unsupported encrypted session version",
+                    status="unsupported_version",
+                )
             return value
 
         if version == 1:
@@ -75,6 +118,9 @@ class SessionCipher:
         try:
             decrypted = fernet.decrypt(token.encode("ascii"))
         except InvalidToken as exc:
-            raise ValueError("invalid encrypted session payload") from exc
+            raise EncryptedPayloadError(
+                "invalid encrypted session payload",
+                status="key_mismatch",
+            ) from exc
 
         return decrypted.decode("utf-8")

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -31,7 +31,7 @@ from src.agent.provider_registry import (
 )
 from src.config import AppConfig, resolve_session_encryption_secret
 from src.database import Database
-from src.security import SessionCipher
+from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
 from src.utils.json import safe_json_dumps
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ _PYPROJECT_PATH = _PROJECT_ROOT / "pyproject.toml"
 COMMUNITY_COMPATIBILITY_CATALOG_PATH = (
     _PROJECT_ROOT / "data" / "deepagents_model_compatibility_catalog.json"
 )
+_PROVIDER_SECRET_ACTION = "restore_key_or_reenter_secret"
 
 @dataclass(slots=True)
 class ProviderModelCompatibilityRecord:
@@ -106,15 +107,12 @@ class AgentProviderService:
                 for field in spec.plain_fields
             }
             last_validation_error = str(item.get("last_validation_error", "")).strip()
-            try:
-                secret_fields = self._decrypt_secret_fields(item.get("secret_fields_enc", {}), spec)
-            except ValueError:
-                logger.warning(
-                    "Failed to decrypt provider secrets for %s",
-                    provider,
-                    exc_info=True,
-                )
-                secret_fields = {}
+            secret_fields, secret_fields_enc_preserved, secret_status = self._decrypt_secret_fields(
+                item.get("secret_fields_enc", {}),
+                spec,
+                provider,
+            )
+            if secret_status != "ok":
                 last_validation_error = (
                     "Saved secret values could not be decrypted. "
                     "Re-enter them with the current SESSION_ENCRYPTION_KEY."
@@ -128,6 +126,8 @@ class AgentProviderService:
                     plain_fields=plain_fields,
                     secret_fields=secret_fields,
                     last_validation_error=last_validation_error,
+                    secret_status=secret_status,
+                    secret_fields_enc_preserved=secret_fields_enc_preserved,
                 )
             )
         return sorted(configs, key=self._config_sort_key)
@@ -148,7 +148,11 @@ class AgentProviderService:
                         field.name: cfg.plain_fields.get(field.name, "").strip()
                         for field in spec.plain_fields
                     },
-                    "secret_fields_enc": self._encrypt_secret_fields(cfg.secret_fields, spec),
+                    "secret_fields_enc": self._encrypt_secret_fields(
+                        cfg.secret_fields,
+                        spec,
+                        preserved=cfg.secret_fields_enc_preserved,
+                    ),
                     "last_validation_error": cfg.last_validation_error,
                 }
             )
@@ -316,8 +320,20 @@ class AgentProviderService:
                             "required": field.required,
                             "placeholder": field.placeholder,
                             "help_text": field.help_text,
-                            "masked": "••••••••" if cfg.secret_fields.get(field.name) else "",
-                            "has_value": bool(cfg.secret_fields.get(field.name)),
+                            "masked": (
+                                "••••••••"
+                                if (
+                                    cfg.secret_fields.get(field.name)
+                                    or cfg.secret_fields_enc_preserved.get(field.name)
+                                )
+                                else ""
+                            ),
+                            "has_value": bool(
+                                cfg.secret_fields.get(field.name)
+                                or cfg.secret_fields_enc_preserved.get(field.name)
+                            ),
+                            "decrypt_failed": bool(cfg.secret_fields_enc_preserved.get(field.name))
+                            and not cfg.secret_fields.get(field.name),
                         }
                         for field in spec.secret_fields
                     ],
@@ -332,6 +348,8 @@ class AgentProviderService:
                         cache_entry,
                     ),
                     "last_validation_error": cfg.last_validation_error,
+                    "secret_status": cfg.secret_status,
+                    "requires_secret_reentry": cfg.secret_status != "ok",
                 }
             )
         return views
@@ -409,12 +427,19 @@ class AgentProviderService:
             selected_model=default_model,
             plain_fields={field.name: "" for field in spec.plain_fields},
             secret_fields={},
+            secret_status="ok",
+            secret_fields_enc_preserved={},
         )
 
     def validate_provider_config(self, cfg: ProviderRuntimeConfig) -> str:
         spec = provider_spec(cfg.provider)
         if spec is None:
             return f"Unknown provider: {cfg.provider}"
+        if cfg.secret_status != "ok":
+            return (
+                "Saved secret values could not be decrypted. "
+                "Restore SESSION_ENCRYPTION_KEY or re-enter provider secrets."
+            )
         if cfg.provider == "zai":
             base_url = cfg.plain_fields.get("base_url", "").strip()
             if is_zai_legacy_anthropic_base_url(base_url):
@@ -913,14 +938,22 @@ class AgentProviderService:
             if f"provider_priority__{provider_name}" not in form:
                 priority = current.priority
         secret_fields: dict[str, str] = {}
+        secret_fields_enc_preserved: dict[str, str] = {}
         if current is not None:
             secret_fields.update(current.secret_fields)
+            secret_fields_enc_preserved.update(current.secret_fields_enc_preserved)
         for spec_field in spec.secret_fields:
             submitted = str(
                 form.get(f"provider_secret__{provider_name}__{spec_field.name}", "")
             ).strip()
             if submitted:
                 secret_fields[spec_field.name] = submitted
+                secret_fields_enc_preserved.pop(spec_field.name, None)
+        secret_status = (
+            "ok"
+            if not secret_fields_enc_preserved
+            else (current.secret_status if current is not None else "decrypt_failed")
+        )
         plain_fields = {}
         for spec_field in spec.plain_fields:
             key = f"provider_field__{provider_name}__{spec_field.name}"
@@ -951,33 +984,73 @@ class AgentProviderService:
             selected_model=selected_model,
             plain_fields=plain_fields,
             secret_fields=secret_fields,
+            secret_status=secret_status,
+            secret_fields_enc_preserved=secret_fields_enc_preserved,
         )
 
-    def _encrypt_secret_fields(self, values: dict[str, str], spec: ProviderSpec) -> dict[str, str]:
+    def _encrypt_secret_fields(
+        self,
+        values: dict[str, str],
+        spec: ProviderSpec,
+        *,
+        preserved: dict[str, str] | None = None,
+    ) -> dict[str, str]:
         assert self._cipher is not None
-        return {
-            field.name: self._cipher.encrypt(values.get(field.name, "").strip())
-            for field in spec.secret_fields
-            if values.get(field.name, "").strip()
-        }
+        encrypted: dict[str, str] = {}
+        preserved = preserved or {}
+        for spec_field in spec.secret_fields:
+            value = values.get(spec_field.name, "").strip()
+            if value:
+                encrypted[spec_field.name] = self._cipher.encrypt(value)
+            elif preserved.get(spec_field.name):
+                encrypted[spec_field.name] = preserved[spec_field.name]
+        return encrypted
 
     def _decrypt_secret_fields(
         self,
         payload: dict[str, Any],
         spec: ProviderSpec,
-    ) -> dict[str, str]:
+        provider: str | None = None,
+    ) -> tuple[dict[str, str], dict[str, str], str]:
         values: dict[str, str] = {}
+        preserved: dict[str, str] = {}
+        secret_status = "ok"
+        legacy_raise = provider is None
+        provider_name = provider or spec.name
         for spec_field in spec.secret_fields:
             raw = str(payload.get(spec_field.name, "")).strip() if isinstance(payload, dict) else ""
             if not raw:
                 continue
             if self._cipher is None:
-                raise ValueError(
-                    "SESSION_ENCRYPTION_KEY is not configured; "
-                    "cannot decrypt saved provider secrets."
+                if legacy_raise:
+                    raise ValueError(
+                        "SESSION_ENCRYPTION_KEY is not configured; "
+                        "cannot decrypt saved provider secrets."
+                    )
+                preserved[spec_field.name] = raw
+                secret_status = "missing_key"
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="agent_provider",
+                    identifier=provider_name,
+                    status=secret_status,
+                    action=_PROVIDER_SECRET_ACTION,
                 )
-            values[spec_field.name] = self._cipher.decrypt(raw)
-        return values
+                continue
+            try:
+                values[spec_field.name] = self._cipher.decrypt(raw)
+            except ValueError as exc:
+                preserved[spec_field.name] = raw
+                status = decrypt_failure_status(exc)
+                secret_status = "decrypt_failed" if status == "key_mismatch" else status
+                log_expected_decrypt_failure(
+                    logger,
+                    resource="agent_provider",
+                    identifier=provider_name,
+                    status=status,
+                    action=_PROVIDER_SECRET_ACTION,
+                )
+        return values, preserved, secret_status
 
     def _app_version(self) -> str:
         try:

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -1035,6 +1035,7 @@ class AgentProviderService:
                     identifier=provider_name,
                     status=secret_status,
                     action=_PROVIDER_SECRET_ACTION,
+                    level=logging.DEBUG,
                 )
                 continue
             try:
@@ -1049,6 +1050,7 @@ class AgentProviderService:
                     identifier=provider_name,
                     status=status,
                     action=_PROVIDER_SECRET_ACTION,
+                    level=logging.DEBUG,
                 )
         return values, preserved, secret_status
 

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -995,12 +995,12 @@ class AgentProviderService:
         *,
         preserved: dict[str, str] | None = None,
     ) -> dict[str, str]:
-        assert self._cipher is not None
         encrypted: dict[str, str] = {}
         preserved = preserved or {}
         for spec_field in spec.secret_fields:
             value = values.get(spec_field.name, "").strip()
             if value:
+                assert self._cipher is not None
                 encrypted[spec_field.name] = self._cipher.encrypt(value)
             elif preserved.get(spec_field.name):
                 encrypted[spec_field.name] = preserved[spec_field.name]

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.config import AppConfig, resolve_session_encryption_secret
 from src.database import Database
-from src.security import SessionCipher
+from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
 from src.utils.json import safe_json_dumps
 
 if TYPE_CHECKING:
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SETTINGS_KEY = "image_providers_v1"
+_IMAGE_SECRET_ACTION = "restore_key_or_reenter_secret"
 
 
 @dataclass(slots=True)
@@ -49,6 +50,7 @@ class ImageProviderConfig:
     enabled: bool = True
     api_key: str = ""
     _api_key_enc_preserved: str = ""  # raw encrypted value kept on decrypt failure
+    secret_status: str = "ok"
 
 
 def image_provider_spec(name: str) -> ImageProviderSpec | None:
@@ -88,19 +90,40 @@ class ImageProviderService:
                 continue
             api_key = ""
             preserved_enc = ""
+            secret_status = "ok"
             enc_key = str(item.get("api_key_enc", "")).strip()
             if enc_key:
-                try:
-                    api_key = self._cipher.decrypt(enc_key) if self._cipher else ""
-                except ValueError:
-                    logger.warning("Failed to decrypt image provider key for %s", provider, exc_info=True)
-                    preserved_enc = enc_key  # keep raw so save doesn't destroy it
+                if self._cipher is None:
+                    preserved_enc = enc_key
+                    secret_status = "missing_key"
+                    log_expected_decrypt_failure(
+                        logger,
+                        resource="image_provider",
+                        identifier=provider,
+                        status=secret_status,
+                        action=_IMAGE_SECRET_ACTION,
+                    )
+                else:
+                    try:
+                        api_key = self._cipher.decrypt(enc_key)
+                    except ValueError as exc:
+                        preserved_enc = enc_key  # keep raw so save doesn't destroy it
+                        status = decrypt_failure_status(exc)
+                        secret_status = "decrypt_failed" if status == "key_mismatch" else status
+                        log_expected_decrypt_failure(
+                            logger,
+                            resource="image_provider",
+                            identifier=provider,
+                            status=status,
+                            action=_IMAGE_SECRET_ACTION,
+                        )
             configs.append(
                 ImageProviderConfig(
                     provider=provider,
                     enabled=bool(item.get("enabled", True)),
                     api_key=api_key,
                     _api_key_enc_preserved=preserved_enc,
+                    secret_status=secret_status,
                 )
             )
         return configs
@@ -142,6 +165,8 @@ class ImageProviderService:
                     "display_name": spec.display_name,
                     "enabled": cfg.enabled,
                     "has_key": bool(cfg.api_key.strip()),
+                    "secret_status": cfg.secret_status,
+                    "requires_secret_reentry": cfg.secret_status != "ok",
                     "env_var_set": env_var_set,
                     "env_var_names": ", ".join(spec.env_vars),
                 }
@@ -164,14 +189,21 @@ class ImageProviderService:
             preserved = ""
             if new_key:
                 api_key = new_key
+                secret_status = "ok"
             elif old_cfg:
                 api_key = old_cfg.api_key
                 preserved = old_cfg._api_key_enc_preserved
+                secret_status = old_cfg.secret_status if preserved else "ok"
             else:
                 api_key = ""
+                secret_status = "ok"
             configs.append(
                 ImageProviderConfig(
-                    provider=name, enabled=enabled, api_key=api_key, _api_key_enc_preserved=preserved,
+                    provider=name,
+                    enabled=enabled,
+                    api_key=api_key,
+                    _api_key_enc_preserved=preserved,
+                    secret_status=secret_status,
                 )
             )
         return configs

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -102,6 +102,7 @@ class ImageProviderService:
                         identifier=provider,
                         status=secret_status,
                         action=_IMAGE_SECRET_ACTION,
+                        level=logging.DEBUG,
                     )
                 else:
                     try:
@@ -116,6 +117,7 @@ class ImageProviderService:
                             identifier=provider,
                             status=status,
                             action=_IMAGE_SECRET_ACTION,
+                            level=logging.DEBUG,
                         )
             configs.append(
                 ImageProviderConfig(

--- a/src/services/notification_target_service.py
+++ b/src/services/notification_target_service.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from inspect import isawaitable
 
 from src.database import Database
 from src.database.bundles import NotificationBundle
-from src.models import Account
+from src.models import Account, AccountSessionStatus, AccountSummary
 from src.telegram.client_pool import ClientPool
 from src.telegram.utils import normalize_utc
 
@@ -37,7 +38,7 @@ class NotificationTargetService:
         await self._notifications.set_setting(SETTING_KEY, phone or "")
 
     async def describe_target(self) -> NotificationTargetStatus:
-        accounts = await self._notifications.list_accounts()
+        accounts = await self._list_account_records()
         configured_phone = await self.get_configured_phone()
 
         if configured_phone:
@@ -59,7 +60,7 @@ class NotificationTargetService:
 
     def _describe_account(
         self,
-        account: Account | None,
+        account: Account | AccountSummary | None,
         *,
         configured_phone: str | None,
         mode: str,
@@ -81,6 +82,23 @@ class NotificationTargetService:
                 mode=mode,
                 state="inactive",
                 message=f"Аккаунт {account.phone} отключён.",
+                configured_phone=configured_phone,
+                effective_phone=account.phone,
+            )
+        raw_session_status = getattr(account, "session_status", AccountSessionStatus.OK)
+        session_status = (
+            raw_session_status
+            if isinstance(raw_session_status, str)
+            else AccountSessionStatus.OK
+        )
+        if session_status != AccountSessionStatus.OK:
+            return NotificationTargetStatus(
+                mode=mode,
+                state="session_unavailable",
+                message=(
+                    f"Сессия аккаунта {account.phone} недоступна: {session_status}. "
+                    "Восстановите SESSION_ENCRYPTION_KEY или выполните повторный вход."
+                ),
                 configured_phone=configured_phone,
                 effective_phone=account.phone,
             )
@@ -114,6 +132,18 @@ class NotificationTargetService:
             configured_phone=configured_phone,
             effective_phone=account.phone,
         )
+
+    async def _list_account_records(self) -> list[Account | AccountSummary]:
+        for method_name in ("list_account_summaries", "list_accounts"):
+            getter = getattr(self._notifications, method_name, None)
+            if not callable(getter):
+                continue
+            result = getter()
+            if isawaitable(result):
+                result = await result
+            if isinstance(result, (list, tuple)):
+                return list(result)
+        return []
 
     @asynccontextmanager
     async def use_client(self):

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -662,6 +662,7 @@ class TelegramCommandDispatcher:
     async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:
         account_id = int(payload["account_id"])
         phone = str(payload.get("phone") or "").strip()
+        delete_from_db = not phone
         if not phone:
             accounts = await self._db.get_account_summaries(active_only=False)
             account = next((a for a in accounts if a.id == account_id), None)
@@ -671,8 +672,13 @@ class TelegramCommandDispatcher:
                 await self._pool.remove_client(phone)
             except Exception as exc:
                 logger.warning("accounts.delete: failed to remove client %s: %s", phone, exc)
-        await self._db.delete_account(account_id)
-        return {"account_id": account_id, "deleted": True}
+        if delete_from_db:
+            await self._db.delete_account(account_id)
+        return {
+            "account_id": account_id,
+            "deleted": delete_from_db,
+            "client_removed": bool(phone),
+        }
 
     async def _handle_notifications_setup_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
         bot = await self._notification_service().setup_bot()

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -661,13 +661,16 @@ class TelegramCommandDispatcher:
 
     async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:
         account_id = int(payload["account_id"])
-        accounts = await self._db.get_accounts()
-        account = next((a for a in accounts if a.id == account_id), None)
-        if account is not None:
+        phone = str(payload.get("phone") or "").strip()
+        if not phone:
+            accounts = await self._db.get_account_summaries(active_only=False)
+            account = next((a for a in accounts if a.id == account_id), None)
+            phone = account.phone if account is not None else ""
+        if phone:
             try:
-                await self._pool.remove_client(account.phone)
+                await self._pool.remove_client(phone)
             except Exception as exc:
-                logger.warning("accounts.delete: failed to remove client %s: %s", account.phone, exc)
+                logger.warning("accounts.delete: failed to remove client %s: %s", phone, exc)
         await self._db.delete_account(account_id)
         return {"account_id": account_id, "deleted": True}
 

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -30,7 +30,8 @@ import asyncio
 import logging
 
 from src.config import AppConfig
-from src.runtime.worker import _publish_snapshots
+from src.database.repositories.accounts import AccountSessionDecryptError
+from src.runtime.worker import _publish_snapshots, _publish_worker_down_snapshot
 from src.web.bootstrap import build_worker_container, start_container, stop_container
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
@@ -118,11 +119,26 @@ class EmbeddedWorker:
             )
             await start_container(self._container)
             self._agent_ready_event.set()
+        except AccountSessionDecryptError as exc:
+            self._startup_error = str(exc)
+            logger.error(
+                "[embedded-worker] startup blocked: resource=%s identifier=%s status=%s action=%s",
+                exc.resource,
+                exc.identifier,
+                exc.status,
+                exc.action,
+            )
+            if self._container is not None:
+                try:
+                    await _publish_worker_down_snapshot(self._container, exc)
+                except Exception:
+                    logger.debug("[embedded-worker] failed to publish worker_down snapshot", exc_info=True)
         except Exception:
             self._startup_error = "Embedded worker failed to start. Check server logs for details."
             logger.exception(
                 "[embedded-worker] failed to start; UI will show worker_down banner"
             )
+        if self._startup_error is not None:
             if self._container is not None:
                 try:
                     await stop_container(self._container)

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -39,7 +39,7 @@ async def delete_account(request: Request, account_id: int):
 @router.get("/flood-status")
 async def flood_status(request: Request):
     db = deps.get_db(request)
-    accounts = await db.get_accounts()
+    accounts = await db.get_account_summaries()
     now = datetime.now(timezone.utc)
     result = []
     for acc in accounts:
@@ -67,7 +67,7 @@ async def flood_status(request: Request):
 @router.post("/{account_id}/flood-clear")
 async def flood_clear(request: Request, account_id: int):
     db = deps.get_db(request)
-    accounts = await db.get_accounts()
+    accounts = await db.get_account_summaries()
     acc = next((a for a in accounts if a.id == account_id), None)
     if not acc:
         return RedirectResponse(url="/settings?error=account_not_found", status_code=303)

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -25,13 +25,20 @@ async def toggle_account(request: Request, account_id: int):
 
 @router.post("/{account_id}/delete")
 async def delete_account(request: Request, account_id: int):
+    db = deps.get_db(request)
+    accounts = await db.get_account_summaries(active_only=False)
+    account = next((a for a in accounts if a.id == account_id), None)
+    if account is None:
+        return RedirectResponse(url="/settings?error=invalid_account", status_code=303)
+
     command_id = await deps.telegram_command_service(request).enqueue(
         "accounts.delete",
-        payload={"account_id": account_id},
+        payload={"account_id": account_id, "phone": account.phone},
         requested_by="web:accounts.delete",
     )
+    await db.delete_account(account_id)
     return RedirectResponse(
-        url=f"/settings?msg=account_delete_queued&command_id={command_id}",
+        url=f"/settings?msg=account_deleted&command_id={command_id}",
         status_code=303,
     )
 

--- a/src/web/routes/dashboard.py
+++ b/src/web/routes/dashboard.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
+from src.models import AccountSessionStatus
 from src.web import deps
 
 router = APIRouter()
@@ -33,7 +34,7 @@ async def dashboard(request: Request):
         return RedirectResponse(url="/settings", status_code=303)
 
     db = deps.get_db(request)
-    accounts = await db.get_accounts(active_only=False)
+    accounts = await db.get_account_summaries(active_only=False)
     if not accounts:
         return RedirectResponse(url="/settings?msg=no_accounts", status_code=303)
 
@@ -51,7 +52,11 @@ async def dashboard(request: Request):
                 until = until.replace(tzinfo=timezone.utc)
             if until > now:
                 flood_wait_count += 1
-        if a.is_active and a.phone in deps.get_pool(request).clients:
+        if (
+            a.is_active
+            and a.session_status == AccountSessionStatus.OK
+            and a.phone in deps.get_pool(request).clients
+        ):
             until = a.flood_wait_until
             if until is None:
                 all_connected_flooded = False

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from src.models import AccountSessionStatus
 from src.web import deps
 
 router = APIRouter()
@@ -51,7 +52,11 @@ async def dialogs_page(
 ):
     started_at = time.perf_counter()
     db = deps.get_db(request)
-    accounts = sorted(account.phone for account in await db.get_accounts(active_only=False))
+    accounts = sorted(
+        account.phone
+        for account in await db.get_account_summaries(active_only=False)
+        if account.session_status == AccountSessionStatus.OK
+    )
     selected_phone = phone if phone in accounts else None
     dialogs = []
     dialogs_cached_at = None
@@ -458,7 +463,11 @@ async def mark_read(request: Request):
 @router.get("/create-channel", response_class=HTMLResponse)
 async def create_channel_page(request: Request):
     db = deps.get_db(request)
-    accounts = sorted(account.phone for account in await db.get_accounts(active_only=False))
+    accounts = sorted(
+        account.phone
+        for account in await db.get_account_summaries(active_only=False)
+        if account.session_status == AccountSessionStatus.OK
+    )
     command = await _get_command_state(request, request.query_params.get("command_id"))
     return deps.get_templates(request).TemplateResponse(
         request,

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from src.models import AccountSessionStatus
 from src.services.pipeline_result import result_kind_label
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
@@ -53,7 +54,7 @@ def _compute_load_level(
     available_accounts_now: int,
     state: str,
 ) -> str:
-    if state in {"worker_down", "all_flooded", "no_clients"}:
+    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
         return "overload"
     capacity_accounts = max(1, available_accounts_now)
     pressure = active_unfiltered_channels / capacity_accounts
@@ -85,6 +86,10 @@ def _collector_health_recommendations(
         recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
     if state == "no_clients":
         recommendations.append("Проверить активность аккаунтов и переподключить хотя бы один рабочий клиент.")
+    if state == "session_degraded":
+        recommendations.append(
+            "Восстановить прежний SESSION_ENCRYPTION_KEY или повторно войти в Telegram-аккаунты."
+        )
     if load_level in {"high", "overload"}:
         recommendations.append(
             f"Поднять интервал автосбора выше текущих {interval_minutes} мин, чтобы снизить частоту обращений."
@@ -98,7 +103,7 @@ def _collector_health_recommendations(
     return recommendations
 
 
-async def _is_worker_alive(db) -> bool:
+async def _worker_status(db) -> tuple[bool, str]:
     """Return True when the worker-process heartbeat snapshot is fresh.
 
     The worker publishes `worker_heartbeat` every ~5s
@@ -111,26 +116,43 @@ async def _is_worker_alive(db) -> bool:
         snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
-        return True
+        return True, ""
     if snapshot is None or snapshot.updated_at is None:
-        return False
+        return False, ""
+    payload = snapshot.payload if isinstance(snapshot.payload, dict) else {}
+    status = str(payload.get("status", "alive"))
+    if status not in {"alive", "ok"}:
+        reason = str(payload.get("reason", "") or payload.get("detail", ""))
+        return False, reason
     updated_at = snapshot.updated_at
     if updated_at.tzinfo is None:
         updated_at = updated_at.replace(tzinfo=timezone.utc)
     age = (datetime.now(timezone.utc) - updated_at).total_seconds()
-    return age <= WORKER_HEARTBEAT_STALE_AFTER_SEC
+    if age > WORKER_HEARTBEAT_STALE_AFTER_SEC:
+        return False, ""
+    return True, ""
+
+
+async def _is_worker_alive(db) -> bool:
+    alive, _ = await _worker_status(db)
+    return alive
 
 
 async def _build_collector_health_context(request: Request) -> dict[str, object]:
     db = deps.get_db(request)
     pool = deps.get_pool(request)
     collector = deps.get_collector(request)
-    accounts = await db.get_accounts(active_only=False)
+    accounts = await db.get_account_summaries(active_only=False)
     connected_phones = set(pool.clients.keys())
-    active_accounts = [acc for acc in accounts if acc.is_active]
+    degraded_session_accounts = [
+        acc for acc in accounts if acc.is_active and acc.session_status != AccountSessionStatus.OK
+    ]
+    active_accounts = [
+        acc for acc in accounts if acc.is_active and acc.session_status == AccountSessionStatus.OK
+    ]
     connected_active_accounts = [acc for acc in active_accounts if acc.phone in connected_phones]
     now = datetime.now(timezone.utc)
-    worker_alive = await _is_worker_alive(db)
+    worker_alive, worker_reason = await _worker_status(db)
 
     flooded_accounts = []
     next_available_at = None
@@ -179,6 +201,8 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         # Worker-process absent dominates: without it `no_clients` /
         # `all_flooded` are symptoms, not the root cause.
         state = "worker_down"
+    elif degraded_session_accounts and not active_accounts:
+        state = "session_degraded"
     elif not connected_active_accounts:
         state = "no_clients"
     elif availability_state == "all_flooded" or available_accounts_now == 0:
@@ -203,6 +227,8 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         "state": state,
         "connected_accounts": len(connected_phones),
         "active_accounts": len(active_accounts),
+        "session_degraded_accounts": len(degraded_session_accounts),
+        "worker_reason": worker_reason,
         "available_accounts_now": available_accounts_now,
         "flooded_accounts": flooded_accounts,
         "flooded_accounts_count": len(flooded_accounts),

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -122,7 +122,7 @@ async def _worker_status(db) -> tuple[bool, str]:
     payload = snapshot.payload if isinstance(snapshot.payload, dict) else {}
     status = str(payload.get("status", "alive"))
     if status not in {"alive", "ok"}:
-        reason = str(payload.get("reason", "") or payload.get("detail", ""))
+        reason = str(payload.get("detail", "") or payload.get("reason", ""))
         return False, reason
     updated_at = snapshot.updated_at
     if updated_at.tzinfo is None:

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -50,7 +50,7 @@ async def _render_search_page(
     if not auth.is_configured:
         return RedirectResponse(url="/settings", status_code=303)
     db = deps.get_db(request)
-    if not await db.get_accounts(active_only=False):
+    if not await db.get_account_summaries(active_only=False):
         return RedirectResponse(url="/settings?msg=no_accounts", status_code=303)
 
     result = None

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -18,6 +18,7 @@ from src.agent.prompt_template import (
 )
 from src.agent.provider_registry import PROVIDER_ORDER, ProviderRuntimeConfig
 from src.agent.provider_registry import provider_spec as deepagents_provider_spec
+from src.models import AccountSessionStatus
 from src.services.agent_provider_service import (
     AgentProviderService,
     ProviderModelCacheEntry,
@@ -455,7 +456,10 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
         default=config.scheduler.collect_interval_minutes,
         logger=logger,
     )
-    accounts = await db.get_accounts()
+    accounts = await db.get_account_summaries()
+    telegram_session_warning = any(
+        account.session_status != AccountSessionStatus.OK for account in accounts
+    )
     now = datetime.now(UTC)
     for account in accounts:
         if account.flood_wait_until is not None:
@@ -470,7 +474,10 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
     flooded_connected = []
     for account in accounts:
         connected = account.phone in connected_phones
-        if not account.is_active:
+        if account.session_status != AccountSessionStatus.OK:
+            state = "session_unavailable"
+            remaining_seconds = 0
+        elif not account.is_active:
             state = "inactive"
             remaining_seconds = 0
         elif not connected:
@@ -495,7 +502,13 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
             "remaining_minutes": max(1, remaining_seconds // 60) if remaining_seconds else 0,
         }
     all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
-        [acc for acc in accounts if acc.is_active and acc.phone in connected_phones]
+        [
+            acc
+            for acc in accounts
+            if acc.is_active
+            and acc.phone in connected_phones
+            and acc.session_status == AccountSessionStatus.OK
+        ]
     )
     next_available_at = min(flooded_connected) if flooded_connected else None
     notification_target = await deps.get_notification_target_service(request).describe_target()
@@ -546,6 +559,7 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
         "auto_delete_filtered": auto_delete_filtered,
         "auto_delete_on_collect": auto_delete_on_collect,
         "accounts": accounts,
+        "telegram_session_warning": telegram_session_warning,
         "account_status": account_status,
         "account_phones": [acc.phone for acc in accounts],
         "connected_phones": connected_phones,
@@ -770,6 +784,8 @@ async def handle_save_agent_providers(request: Request, form: ProviderConfigForm
                 plain_fields=cfg.plain_fields,
                 secret_fields=cfg.secret_fields,
                 last_validation_error=validation_error,
+                secret_status=cfg.secret_status,
+                secret_fields_enc_preserved=cfg.secret_fields_enc_preserved,
             )
         )
     await service.save_provider_configs(validated)
@@ -1027,7 +1043,7 @@ async def handle_save_notification_account(
     form: NotificationAccountForm,
 ) -> SettingsFlash:
     db = deps.get_db(request)
-    valid_phones = {acc.phone for acc in await db.get_accounts()}
+    valid_phones = {acc.phone for acc in await db.get_account_summaries()}
     if form.selected_phone and form.selected_phone not in valid_phones:
         return SettingsFlash(error="notification_account_invalid")
 

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -73,7 +73,7 @@
 </div>
 
 {% if collector_health.state != 'healthy' or collector_health.load_level != 'ok' %}
-<div class="card mb-4 border-{% if collector_health.state in ['worker_down', 'all_flooded', 'no_clients'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
+<div class="card mb-4 border-{% if collector_health.state in ['worker_down', 'all_flooded', 'no_clients', 'session_degraded'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
     <div class="card-header fw-semibold">
         Здоровье коллектора
         {% if collector_health.state == 'worker_down' %}
@@ -82,6 +82,8 @@
         <span class="badge text-bg-danger ms-2">Все аккаунты во Flood Wait</span>
         {% elif collector_health.state == 'no_clients' %}
         <span class="badge text-bg-danger ms-2">Нет доступных клиентов</span>
+        {% elif collector_health.state == 'session_degraded' %}
+        <span class="badge text-bg-danger ms-2">SESSION_ENCRYPTION_KEY не подходит</span>
         {% elif collector_health.state == 'degraded' %}
         <span class="badge text-bg-warning ms-2">Частичная деградация</span>
         {% endif %}
@@ -97,6 +99,9 @@
                 <div class="small text-muted">Аккаунты</div>
                 <div><strong>{{ collector_health.available_accounts_now }}</strong> доступно сейчас</div>
                 <div><strong>{{ collector_health.connected_accounts }}</strong> подключено</div>
+                {% if collector_health.session_degraded_accounts %}
+                <div><strong>{{ collector_health.session_degraded_accounts }}</strong> требуют ключ</div>
+                {% endif %}
             </div>
             <div class="col-6 col-md-3">
                 <div class="small text-muted">Flood Wait</div>
@@ -126,8 +131,15 @@
 
         {% if collector_health.state == 'worker_down' %}
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> веб-процесс принимает задачи и пишет их в БД, но Telegram-коннекты держит отдельный воркер-процесс — он сейчас не запущен (нет свежего heartbeat в <code>runtime_snapshots</code>). Задачи из <code>collection_tasks</code> копятся в статусе <em>pending</em>, но никто их не исполняет.</p>
+        {% if collector_health.worker_reason %}
+        <p class="mb-2"><strong>Причина:</strong> {{ collector_health.worker_reason }}</p>
+        {% endif %}
         <p class="mb-2"><strong>Как починить:</strong> запустите воркер во втором терминале — он подхватит все накопившиеся задачи автоматически:</p>
         <pre class="mb-2"><code>python -m src.main worker</code></pre>
+        {% endif %}
+
+        {% if collector_health.state == 'session_degraded' %}
+        <p class="mb-2"><strong>Почему сейчас не собираем:</strong> активные Telegram-сессии сохранены, но не расшифровываются текущим <code>SESSION_ENCRYPTION_KEY</code>. Live-операции заблокированы до восстановления ключа или повторного входа.</p>
         {% endif %}
 
         {% if collector_health.flooded_accounts %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -10,8 +10,8 @@
     <ul class="mb-0">
         {% if telegram_session_warning %}
         <li>
-            Saved Telegram logins cannot be decrypted with the current <code>SESSION_ENCRYPTION_KEY</code>.
-            Restore the old <code>SESSION_ENCRYPTION_KEY</code> or re-login accounts.
+            Saved Telegram logins are unavailable.
+            Restore <code>SESSION_ENCRYPTION_KEY</code> if it changed, upgrade the app if needed, or re-login accounts.
         </li>
         {% endif %}
         {% if failed_agent_providers %}

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -3,9 +3,30 @@
 {% block content %}
 <h1 class="mb-4">Настройки</h1>
 
-{% if telegram_session_warning or agent_provider_views|selectattr("requires_secret_reentry")|list or img_provider_views|selectattr("requires_secret_reentry")|list %}
+{% set failed_agent_providers = agent_provider_views|selectattr("requires_secret_reentry")|list %}
+{% set failed_img_providers = img_provider_views|selectattr("requires_secret_reentry")|list %}
+{% if telegram_session_warning or failed_agent_providers or failed_img_providers %}
 <div class="alert alert-warning" role="alert">
-    Saved Telegram logins and provider API keys cannot be decrypted with the current <code>SESSION_ENCRYPTION_KEY</code>.
+    <ul class="mb-0">
+        {% if telegram_session_warning %}
+        <li>
+            Saved Telegram logins cannot be decrypted with the current <code>SESSION_ENCRYPTION_KEY</code>.
+            Restore the old <code>SESSION_ENCRYPTION_KEY</code> or re-login accounts.
+        </li>
+        {% endif %}
+        {% if failed_agent_providers %}
+        <li>
+            Agent provider API keys cannot be decrypted:{% for item in failed_agent_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
+            Re-enter the provider API key or restore the old <code>SESSION_ENCRYPTION_KEY</code>.
+        </li>
+        {% endif %}
+        {% if failed_img_providers %}
+        <li>
+            Image provider API keys cannot be decrypted:{% for item in failed_img_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
+            Re-enter the provider API key or restore the old <code>SESSION_ENCRYPTION_KEY</code>.
+        </li>
+        {% endif %}
+    </ul>
 </div>
 {% endif %}
 

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -3,6 +3,12 @@
 {% block content %}
 <h1 class="mb-4">Настройки</h1>
 
+{% if telegram_session_warning or agent_provider_views|selectattr("requires_secret_reentry")|list or img_provider_views|selectattr("requires_secret_reentry")|list %}
+<div class="alert alert-warning" role="alert">
+    Saved Telegram logins and provider API keys cannot be decrypted with the current <code>SESSION_ENCRYPTION_KEY</code>.
+</div>
+{% endif %}
+
 <ul class="nav nav-pills mb-4" id="settings-tabs" role="tablist">
     <li class="nav-item" role="presentation">
         <button class="nav-link active" id="tab-accounts" data-bs-toggle="pill"

--- a/src/web/templates/settings/_accounts.html
+++ b/src/web/templates/settings/_accounts.html
@@ -34,6 +34,7 @@
             <td class="text-center">
                 {% if account_status[acc.phone].state == 'available' %}<span class="badge text-bg-success">OK</span>
                 {% elif account_status[acc.phone].state == 'flood' %}<span class="badge text-bg-warning">Flood</span>
+                {% elif account_status[acc.phone].state == 'session_unavailable' %}<span class="badge text-bg-danger">{{ acc.session_status }}</span>
                 {% elif account_status[acc.phone].state == 'disconnected' %}<span class="badge text-bg-secondary">Нет соединения</span>
                 {% else %}<span class="badge text-bg-secondary">Неактивен</span>{% endif %}
             </td>
@@ -80,6 +81,7 @@
                 {% if account_status[acc.phone].state == 'available' %}&middot; Доступен{% endif %}
                 {% if account_status[acc.phone].state == 'disconnected' %}&middot; Не подключён{% endif %}
                 {% if account_status[acc.phone].state == 'flood' %}&middot; Flood до {{ acc.flood_wait_until|local_dt("time") }} ({{ account_status[acc.phone].remaining_minutes }} мин){% endif %}
+                {% if account_status[acc.phone].state == 'session_unavailable' %}&middot; {{ acc.session_status }}{% endif %}
                 {% if acc.created_at %}&middot; {{ acc.created_at|local_dt("date") }}{% endif %}
             </small>
             <div class="card-actions">

--- a/src/web/templates/settings/_devmode.html
+++ b/src/web/templates/settings/_devmode.html
@@ -157,6 +157,12 @@
                 </div>
             </div>
 
+            {% if item.requires_secret_reentry %}
+            <div class="alert alert-warning py-2 mb-3">
+                Saved provider secrets cannot be decrypted. Re-enter the secret or restore <code>SESSION_ENCRYPTION_KEY</code>.
+            </div>
+            {% endif %}
+
             <div class="row g-3 mb-3">
                 <div class="col-12 col-md-2">
                     <label class="form-label" for="provider_priority__{{ item.provider }}">Приоритет</label>
@@ -237,7 +243,7 @@
                            placeholder="{{ field.masked or 'Введите новое значение' }}"
                            {% if not agent_provider_writes_enabled %}disabled{% endif %}>
                     <div class="form-text">
-                        {% if field.has_value %}Значение сохранено и скрыто. Оставьте пустым, чтобы не менять.{% else %}Значение ещё не задано.{% endif %}
+                        {% if field.decrypt_failed %}Сохранённое значение требует повторного ввода.{% elif field.has_value %}Значение сохранено и скрыто. Оставьте пустым, чтобы не менять.{% else %}Значение ещё не задано.{% endif %}
                     </div>
                 </div>
                 {% endfor %}

--- a/src/web/templates/settings/_image_providers.html
+++ b/src/web/templates/settings/_image_providers.html
@@ -47,6 +47,12 @@
                 </button>
             </div>
 
+            {% if item.requires_secret_reentry %}
+            <div class="alert alert-warning py-2 mb-3">
+                Saved image provider secret cannot be decrypted. Re-enter the API key or restore <code>SESSION_ENCRYPTION_KEY</code>.
+            </div>
+            {% endif %}
+
             <div class="row g-3 mb-2">
                 <div class="col-12 col-md-3">
                     <label class="form-label" for="img_provider_enabled__{{ item.provider }}">Статус</label>
@@ -64,7 +70,7 @@
                            placeholder="{{ '••••••••' if item.has_key else 'Введите API ключ' }}"
                            {% if not img_provider_writes_enabled %}disabled{% endif %}>
                     <div class="form-text">
-                        {% if item.has_key %}Ключ сохранён и скрыт. Оставьте пустым, чтобы не менять.{% elif item.env_var_set %}Ключ из env будет использован как fallback.{% else %}Значение ещё не задано.{% endif %}
+                        {% if item.requires_secret_reentry %}Сохранённый ключ требует повторного ввода.{% elif item.has_key %}Ключ сохранён и скрыт. Оставьте пустым, чтобы не менять.{% elif item.env_var_set %}Ключ из env будет использован как fallback.{% else %}Значение ещё не задано.{% endif %}
                     </div>
                 </div>
             </div>

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -6,8 +6,8 @@ from datetime import datetime, timezone
 
 import pytest
 
-from src.database.repositories.accounts import AccountsRepository
-from src.models import Account
+from src.database.repositories.accounts import AccountSessionDecryptError, AccountsRepository
+from src.models import Account, AccountSessionStatus
 from src.security.session_cipher import SessionCipher
 
 
@@ -113,6 +113,43 @@ async def test_get_accounts_decrypts_sessions(repo_with_cipher, cipher):
     accounts = await repo_with_cipher.get_accounts()
     assert len(accounts) == 1
     assert accounts[0].session_string == "my_secret"
+
+
+async def test_get_account_summaries_reports_decrypt_failed_without_session(repo_with_cipher):
+    writer_cipher = SessionCipher("correct-key")
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+1234567890", writer_cipher.encrypt("live-session")),
+    )
+    await repo_with_cipher._db.commit()
+
+    wrong_key_repo = AccountsRepository(
+        repo_with_cipher._db,
+        session_cipher=SessionCipher("wrong-key"),
+    )
+
+    summaries = await wrong_key_repo.get_account_summaries()
+
+    assert len(summaries) == 1
+    assert summaries[0].phone == "+1234567890"
+    assert summaries[0].session_status == AccountSessionStatus.DECRYPT_FAILED
+
+
+async def test_get_accounts_wrong_key_still_fails_for_live_use(repo_with_cipher):
+    writer_cipher = SessionCipher("correct-key")
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+1234567890", writer_cipher.encrypt("live-session")),
+    )
+    await repo_with_cipher._db.commit()
+
+    wrong_key_repo = AccountsRepository(
+        repo_with_cipher._db,
+        session_cipher=SessionCipher("wrong-key"),
+    )
+
+    with pytest.raises(AccountSessionDecryptError, match="status=key_mismatch"):
+        await wrong_key_repo.get_accounts()
 
 
 async def test_get_accounts_handles_plaintext_when_cipher_set(repo_with_cipher):

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 import pytest
@@ -115,7 +116,7 @@ async def test_get_accounts_decrypts_sessions(repo_with_cipher, cipher):
     assert accounts[0].session_string == "my_secret"
 
 
-async def test_get_account_summaries_reports_decrypt_failed_without_session(repo_with_cipher):
+async def test_get_account_summaries_reports_decrypt_failed_without_session(repo_with_cipher, caplog):
     writer_cipher = SessionCipher("correct-key")
     await repo_with_cipher._db.execute(
         "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
@@ -128,11 +129,18 @@ async def test_get_account_summaries_reports_decrypt_failed_without_session(repo
         session_cipher=SessionCipher("wrong-key"),
     )
 
-    summaries = await wrong_key_repo.get_account_summaries()
+    with caplog.at_level(logging.DEBUG, logger="src.database.repositories.accounts"):
+        summaries = await wrong_key_repo.get_account_summaries()
 
     assert len(summaries) == 1
     assert summaries[0].phone == "+1234567890"
     assert summaries[0].session_status == AccountSessionStatus.DECRYPT_FAILED
+    assert any(
+        record.levelno == logging.DEBUG
+        and "decrypt failed: resource=telegram_account identifier=+1234567890 status=key_mismatch" in record.message
+        for record in caplog.records
+    )
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 async def test_get_accounts_wrong_key_still_fails_for_live_use(repo_with_cipher):

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -260,6 +260,85 @@ async def test_delete_account_nonexistent(accounts_repo):
     await accounts_repo.delete_account(999)  # Should not raise
 
 
+async def test_delete_primary_promotes_lowest_id_remaining_account(accounts_repo):
+    """Deleting the primary promotes the next account in repository order."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    next_id = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+    later_id = await accounts_repo.add_account(make_account("+3333333333", is_primary=False))
+
+    await accounts_repo.delete_account(primary_id)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert [acc.id for acc in summaries] == [next_id, later_id]
+    assert summaries[0].is_primary is True
+    assert summaries[1].is_primary is False
+
+
+async def test_delete_non_primary_keeps_existing_primary(accounts_repo):
+    """Deleting a secondary account leaves the current primary unchanged."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    secondary_id = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+    later_id = await accounts_repo.add_account(make_account("+3333333333", is_primary=False))
+
+    await accounts_repo.delete_account(secondary_id)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert [acc.id for acc in summaries] == [primary_id, later_id]
+    assert summaries[0].is_primary is True
+    assert summaries[1].is_primary is False
+
+
+async def test_delete_last_account_leaves_empty_table(accounts_repo):
+    """Deleting the only account does not attempt promotion."""
+    account_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+
+    await accounts_repo.delete_account(account_id)
+
+    assert await accounts_repo.get_account_summaries(active_only=False) == []
+
+
+async def test_delete_missing_account_is_noop(accounts_repo):
+    """Deleting a missing ID must not repair or otherwise mutate account rows."""
+    first_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=False))
+    second_id = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+
+    await accounts_repo.delete_account(999)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert [(acc.id, acc.is_primary) for acc in summaries] == [
+        (first_id, False),
+        (second_id, False),
+    ]
+
+
+async def test_delete_primary_promotes_with_wrong_session_key(repo_with_cipher):
+    """Promotion uses summaries only and does not require decrypting sessions."""
+    writer_cipher = SessionCipher("correct-key")
+    primary_cur = await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 1, 1)",
+        ("+1111111111", writer_cipher.encrypt("primary-session")),
+    )
+    next_cur = await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+2222222222", writer_cipher.encrypt("next-session")),
+    )
+    await repo_with_cipher._db.commit()
+
+    wrong_key_repo = AccountsRepository(
+        repo_with_cipher._db,
+        session_cipher=SessionCipher("wrong-key"),
+    )
+
+    await wrong_key_repo.delete_account(primary_cur.lastrowid)
+
+    summaries = await wrong_key_repo.get_account_summaries(active_only=False)
+    assert len(summaries) == 1
+    assert summaries[0].id == next_cur.lastrowid
+    assert summaries[0].phone == "+2222222222"
+    assert summaries[0].is_primary is True
+    assert summaries[0].session_status == AccountSessionStatus.DECRYPT_FAILED
+
+
 # migrate_sessions tests
 
 

--- a/tests/routes/test_accounts_agent_web_mode.py
+++ b/tests/routes/test_accounts_agent_web_mode.py
@@ -104,21 +104,22 @@ async def test_account_toggle_in_web_mode_enqueues_command(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_account_delete_in_web_mode_enqueues_command(tmp_path):
-    """POST /settings/{id}/delete in real web bootstrap: DB row untouched, command enqueued."""
+async def test_account_delete_in_web_mode_removes_row_and_enqueues_cleanup(tmp_path):
+    """POST /settings/{id}/delete in real web bootstrap: DB row removed, cleanup command enqueued."""
     async with _web_mode_client(tmp_path) as (client, container):
         accounts = await container.db.get_accounts(active_only=False)
         acc = accounts[0]
 
         resp = await client.post(f"/settings/{acc.id}/delete")
         assert resp.status_code == 303
-        assert "account_delete_queued" in resp.headers["location"]
+        assert "account_deleted" in resp.headers["location"]
 
         remaining = await container.db.get_accounts(active_only=False)
-        assert any(a.id == acc.id for a in remaining)
+        assert not any(a.id == acc.id for a in remaining)
 
         commands = await container.db.repos.telegram_commands.list_commands(limit=1)
         assert commands[0].command_type == "accounts.delete"
+        assert commands[0].payload == {"account_id": acc.id, "phone": acc.phone}
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -57,11 +57,35 @@ async def test_delete_account_removes_row_and_enqueues_cleanup(route_client, bas
 
 
 @pytest.mark.anyio
+async def test_delete_primary_account_promotes_next_visible_account(route_client, base_app):
+    """Deleting the primary account updates the remaining visible primary immediately."""
+    _, db, _ = base_app
+    assert db.db is not None
+    await db.db.execute("UPDATE accounts SET is_primary = 1 WHERE phone = ?", ("+1234567890",))
+    await db.db.commit()
+    await db.add_account(Account(phone="+9999999997", session_string="session_next"))
+    await db.add_account(Account(phone="+9999999996", session_string="session_later"))
+
+    accounts = await db.get_account_summaries(active_only=False)
+    to_delete = next(a for a in accounts if a.phone == "+1234567890")
+
+    resp = await route_client.post(f"/settings/{to_delete.id}/delete", follow_redirects=False)
+    assert resp.status_code in (303, 302)
+    assert "account_deleted" in resp.headers.get("location", "")
+
+    remaining = await db.get_account_summaries(active_only=False)
+    assert not any(a.id == to_delete.id for a in remaining)
+    assert remaining[0].phone == "+9999999997"
+    assert remaining[0].is_primary is True
+    assert all(a.is_primary is False for a in remaining[1:])
+
+
+@pytest.mark.anyio
 async def test_delete_account_works_when_session_key_is_wrong(route_client, base_app):
     """Deleting an account is a recovery action and must not require session decryption."""
-    app, db, pool = base_app
+    _, db, _ = base_app
     encrypted = SessionCipher("correct-session-key").encrypt("session_del")
-    await db.add_account(Account(phone="+9999999998", session_string=encrypted))
+    await db.add_account(Account(phone="+9999999998", session_string=encrypted, is_primary=True))
     db._accounts._session_cipher = SessionCipher("wrong-session-key")
 
     accounts = await db.get_account_summaries(active_only=False)
@@ -73,6 +97,8 @@ async def test_delete_account_works_when_session_key_is_wrong(route_client, base
 
     remaining = await db.get_account_summaries(active_only=False)
     assert not any(a.phone == "+9999999998" for a in remaining)
+    promoted = next(a for a in remaining if a.phone == "+1234567890")
+    assert promoted.is_primary is True
 
     commands = await db.repos.telegram_commands.list_commands(limit=1)
     assert commands[0].command_type == "accounts.delete"

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from src.models import Account
+from src.security import SessionCipher
 
 
 @pytest.mark.anyio
@@ -32,8 +33,8 @@ async def test_toggle_account_enqueues_command(route_client, base_app):
 
 
 @pytest.mark.anyio
-async def test_delete_account_enqueues_command(route_client, base_app):
-    """Web delete only enqueues `accounts.delete`; the DB row survives until the worker runs."""
+async def test_delete_account_removes_row_and_enqueues_cleanup(route_client, base_app):
+    """Web delete removes the DB row immediately and enqueues live pool cleanup."""
     app, db, pool = base_app
     await db.add_account(Account(phone="+9999999999", session_string="session_del"))
     accounts = await db.get_accounts(active_only=False)
@@ -43,18 +44,50 @@ async def test_delete_account_enqueues_command(route_client, base_app):
     assert resp.status_code in (303, 302)
     location = resp.headers.get("location", "")
     assert "/settings" in location
-    assert "account_delete_queued" in location
+    assert "account_deleted" in location
     assert "command_id=" in location
 
-    # Web must not have touched the DB row directly — only a worker running
-    # `accounts.delete` is allowed to delete.
     pool.remove_client.assert_not_called()
     remaining = await db.get_accounts(active_only=False)
-    assert any(a.phone == "+9999999999" for a in remaining)
+    assert not any(a.phone == "+9999999999" for a in remaining)
 
     commands = await db.repos.telegram_commands.list_commands(limit=1)
     assert commands[0].command_type == "accounts.delete"
-    assert commands[0].payload == {"account_id": to_delete.id}
+    assert commands[0].payload == {"account_id": to_delete.id, "phone": "+9999999999"}
+
+
+@pytest.mark.anyio
+async def test_delete_account_works_when_session_key_is_wrong(route_client, base_app):
+    """Deleting an account is a recovery action and must not require session decryption."""
+    app, db, pool = base_app
+    encrypted = SessionCipher("correct-session-key").encrypt("session_del")
+    await db.add_account(Account(phone="+9999999998", session_string=encrypted))
+    db._accounts._session_cipher = SessionCipher("wrong-session-key")
+
+    accounts = await db.get_account_summaries(active_only=False)
+    to_delete = next(a for a in accounts if a.phone == "+9999999998")
+
+    resp = await route_client.post(f"/settings/{to_delete.id}/delete", follow_redirects=False)
+    assert resp.status_code in (303, 302)
+    assert "account_deleted" in resp.headers.get("location", "")
+
+    remaining = await db.get_account_summaries(active_only=False)
+    assert not any(a.phone == "+9999999998" for a in remaining)
+
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands[0].command_type == "accounts.delete"
+    assert commands[0].payload == {"account_id": to_delete.id, "phone": "+9999999998"}
+
+
+@pytest.mark.anyio
+async def test_delete_account_missing_redirects_without_command(route_client, base_app):
+    app, db, pool = base_app
+    resp = await route_client.post("/settings/999999/delete", follow_redirects=False)
+    assert resp.status_code in (303, 302)
+    assert "error=invalid_account" in resp.headers.get("location", "")
+
+    commands = await db.repos.telegram_commands.list_commands(limit=1)
+    assert commands == []
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -78,7 +78,7 @@ async def test_settings_degrades_when_account_session_key_is_wrong(route_client,
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Saved Telegram logins cannot be decrypted" in resp.text
+    assert "Saved Telegram logins are unavailable" in resp.text
     assert "provider API keys cannot be decrypted" not in resp.text
     assert "decrypt_failed" in resp.text
 
@@ -98,7 +98,7 @@ async def test_settings_degrades_for_image_provider_only_key_failure(route_clien
 
     assert resp.status_code == 200
     assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
-    assert "Saved Telegram logins cannot be decrypted" not in resp.text
+    assert "Saved Telegram logins are unavailable" not in resp.text
     assert "Saved Telegram logins and provider API keys cannot be decrypted" not in resp.text
 
 
@@ -123,7 +123,7 @@ async def test_settings_degrades_with_separate_telegram_and_image_warnings(route
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Saved Telegram logins cannot be decrypted" in resp.text
+    assert "Saved Telegram logins are unavailable" in resp.text
     assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
 
 

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.models import RuntimeSnapshot
+from src.security import SessionCipher
 
 
 @pytest.fixture
@@ -45,6 +46,45 @@ async def test_settings_shows_accounts(route_client):
         resp = await route_client.get("/settings/")
         assert resp.status_code == 200
         assert "+1234567890" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_degrades_when_account_session_key_is_wrong(route_client, db):
+    encrypted = SessionCipher("correct-session-key").encrypt("test_session")
+    await db.execute(
+        "UPDATE accounts SET session_string = ? WHERE phone = ?",
+        (encrypted, "+1234567890"),
+    )
+    await db.db.commit()
+    db._accounts._session_cipher = SessionCipher("wrong-session-key")
+
+    with patch(
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
+        AsyncMock(return_value={}),
+    ):
+        resp = await route_client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert "Saved Telegram logins and provider API keys cannot be decrypted" in resp.text
+    assert "decrypt_failed" in resp.text
+
+
+@pytest.mark.anyio
+async def test_readonly_routes_do_not_crash_when_account_session_key_is_wrong(route_client, db):
+    encrypted = SessionCipher("correct-session-key").encrypt("test_session")
+    await db.execute(
+        "UPDATE accounts SET session_string = ? WHERE phone = ?",
+        (encrypted, "+1234567890"),
+    )
+    await db.db.commit()
+    db._accounts._session_cipher = SessionCipher("wrong-session-key")
+
+    for path in ("/dashboard/", "/dialogs/", "/scheduler/", "/settings/flood-status"):
+        resp = await route_client.get(path)
+        assert resp.status_code == 200, path
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -185,17 +185,18 @@ async def test_toggle_account_enqueues_command(route_client):
 
 
 @pytest.mark.anyio
-async def test_delete_account_enqueues_command(route_client):
-    """Web route only enqueues a telegram command; worker removes the route_client and deletes the row."""
+async def test_delete_account_removes_row_and_enqueues_cleanup(route_client):
+    """Web route deletes the row immediately and enqueues worker cleanup."""
     resp = await route_client.post("/settings/1/delete", follow_redirects=False)
     assert resp.status_code == 303
-    assert "msg=account_delete_queued" in resp.headers["location"]
+    assert "msg=account_deleted" in resp.headers["location"]
     assert "command_id=" in resp.headers["location"]
 
     db = route_client._transport.app.state.db
     commands = await db.repos.telegram_commands.list_commands(limit=1)
     assert commands[0].command_type == "accounts.delete"
-    assert commands[0].payload == {"account_id": 1}
+    assert commands[0].payload["account_id"] == 1
+    assert commands[0].payload["phone"]
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.models import RuntimeSnapshot
 from src.security import SessionCipher
+from src.services.image_provider_service import ImageProviderConfig, ImageProviderService
 
 
 @pytest.fixture
@@ -17,6 +18,15 @@ async def db(base_app):
     """Get db from base_app."""
     _, db, _ = base_app
     return db
+
+
+async def _seed_image_provider_for_decrypt_failure(route_client, db, provider: str = "replicate") -> None:
+    config = route_client._transport_app.state.config
+    config.security.session_encryption_key = "correct-session-key"
+    await ImageProviderService(db, config).save_provider_configs(
+        [ImageProviderConfig(provider=provider, enabled=True, api_key="test-api-key")]
+    )
+    config.security.session_encryption_key = "wrong-session-key"
 
 
 @pytest.mark.anyio
@@ -68,8 +78,53 @@ async def test_settings_degrades_when_account_session_key_is_wrong(route_client,
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Saved Telegram logins and provider API keys cannot be decrypted" in resp.text
+    assert "Saved Telegram logins cannot be decrypted" in resp.text
+    assert "provider API keys cannot be decrypted" not in resp.text
     assert "decrypt_failed" in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_degrades_for_image_provider_only_key_failure(route_client, db):
+    await _seed_image_provider_for_decrypt_failure(route_client, db)
+
+    with patch(
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
+        AsyncMock(return_value={}),
+    ):
+        resp = await route_client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
+    assert "Saved Telegram logins cannot be decrypted" not in resp.text
+    assert "Saved Telegram logins and provider API keys cannot be decrypted" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_settings_degrades_with_separate_telegram_and_image_warnings(route_client, db):
+    encrypted = SessionCipher("correct-session-key").encrypt("test_session")
+    await db.execute(
+        "UPDATE accounts SET session_string = ? WHERE phone = ?",
+        (encrypted, "+1234567890"),
+    )
+    await db.db.commit()
+    db._accounts._session_cipher = SessionCipher("wrong-session-key")
+    await _seed_image_provider_for_decrypt_failure(route_client, db)
+
+    with patch(
+        "src.web.settings.handlers.AgentProviderService.load_provider_configs",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "src.web.settings.handlers.AgentProviderService.load_model_cache",
+        AsyncMock(return_value={}),
+    ):
+        resp = await route_client.get("/settings/")
+
+    assert resp.status_code == 200
+    assert "Saved Telegram logins cannot be decrypted" in resp.text
+    assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -105,7 +106,7 @@ async def test_save_provider_configs_preserves_encrypted_secret_after_decrypt_fa
     read_config = AppConfig()
     read_config.security.session_encryption_key = "different-secret"
     reader = AgentProviderService(db, read_config)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.DEBUG, logger="src.services.agent_provider_service"):
         loaded = await reader.load_provider_configs()
     await reader.save_provider_configs(loaded)
 
@@ -113,11 +114,12 @@ async def test_save_provider_configs_preserves_encrypted_secret_after_decrypt_fa
 
     assert reloaded[0].secret_fields["api_key"] == "sk-test"
     assert any(
-        record.levelname == "ERROR"
+        record.levelno == logging.DEBUG
         and "decrypt failed: resource=agent_provider identifier=openai status=key_mismatch" in record.message
         and record.exc_info is None
         for record in caplog.records
     )
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -81,7 +81,43 @@ async def test_load_provider_configs_tolerates_undecryptable_secrets(db):
     assert len(loaded) == 1
     assert loaded[0].provider == "openai"
     assert loaded[0].secret_fields == {}
+    assert loaded[0].secret_status == "decrypt_failed"
     assert "could not be decrypted" in loaded[0].last_validation_error
+
+
+@pytest.mark.anyio
+async def test_save_provider_configs_preserves_encrypted_secret_after_decrypt_failure(db, caplog):
+    write_config = AppConfig()
+    write_config.security.session_encryption_key = "provider-secret"
+    writer = AgentProviderService(db, write_config)
+    await writer.save_provider_configs(
+        [
+            ProviderRuntimeConfig(
+                provider="openai",
+                enabled=True,
+                priority=0,
+                selected_model="gpt-4.1-mini",
+                secret_fields={"api_key": "sk-test"},
+            )
+        ]
+    )
+
+    read_config = AppConfig()
+    read_config.security.session_encryption_key = "different-secret"
+    reader = AgentProviderService(db, read_config)
+    with caplog.at_level("ERROR"):
+        loaded = await reader.load_provider_configs()
+    await reader.save_provider_configs(loaded)
+
+    reloaded = await writer.load_provider_configs()
+
+    assert reloaded[0].secret_fields["api_key"] == "sk-test"
+    assert any(
+        record.levelname == "ERROR"
+        and "decrypt failed: resource=agent_provider identifier=openai status=key_mismatch" in record.message
+        and record.exc_info is None
+        for record in caplog.records
+    )
 
 
 @pytest.mark.anyio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,6 +9,7 @@ from cryptography.fernet import Fernet
 from src.database import Database
 from src.models import (
     Account,
+    AccountSessionStatus,
     Channel,
     CollectionTaskStatus,
     CollectionTaskType,
@@ -159,8 +160,8 @@ async def test_legacy_v1_sessions_migrate_to_v2_on_init(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_migrate_sessions_rollback_on_bad_row(tmp_path):
-    """Migration rolls back when a row has an unsupported encryption version."""
+async def test_migrate_sessions_skips_bad_row_without_blocking_readonly_startup(tmp_path):
+    """Unsupported encrypted rows stay visible through the metadata API."""
     db_path = str(tmp_path / "rollback_migration.db")
 
     db = Database(db_path)
@@ -176,24 +177,26 @@ async def test_migrate_sessions_rollback_on_bad_row(tmp_path):
 
     encrypted_db = Database(db_path, session_encryption_secret="some-key")
     try:
-        with pytest.raises(RuntimeError, match="Failed to migrate session"):
-            await encrypted_db.initialize()
+        await encrypted_db.initialize()
+        summaries = await encrypted_db.get_account_summaries()
+        by_phone = {item.phone: item for item in summaries}
+        assert by_phone["+71230000011"].session_status == AccountSessionStatus.UNSUPPORTED_VERSION
     finally:
         await encrypted_db.close()
 
-    # Verify rollback: both rows should be unchanged
+    # Verify the bad row was left untouched while the plaintext row migrated.
     async with aiosqlite.connect(db_path) as conn:
         conn.row_factory = aiosqlite.Row
         cur = await conn.execute("SELECT phone, session_string FROM accounts ORDER BY phone")
         rows = await cur.fetchall()
         assert len(rows) == 2
-        assert rows[0]["session_string"] == "good_session"
+        assert rows[0]["session_string"].startswith("enc:v2:")
         assert rows[1]["session_string"] == "enc:v99:garbage"
 
 
 @pytest.mark.anyio
-async def test_initialize_fails_without_key_when_encrypted_sessions_exist(tmp_path):
-    db_path = str(tmp_path / "no_key_fail_fast.db")
+async def test_initialize_without_key_reports_encrypted_sessions_as_degraded(tmp_path):
+    db_path = str(tmp_path / "no_key_degraded.db")
 
     encrypted_db = Database(db_path, session_encryption_secret="strict-key")
     await encrypted_db.initialize()
@@ -202,8 +205,11 @@ async def test_initialize_fails_without_key_when_encrypted_sessions_exist(tmp_pa
 
     db_without_key = Database(db_path)
     try:
-        with pytest.raises(RuntimeError, match="SESSION_ENCRYPTION_KEY"):
-            await db_without_key.initialize()
+        await db_without_key.initialize()
+        summaries = await db_without_key.get_account_summaries()
+        assert summaries[0].session_status == AccountSessionStatus.MISSING_KEY
+        with pytest.raises(RuntimeError, match="SESSION_ENCRYPTION_KEY|status=missing_key"):
+            await db_without_key.get_accounts()
     finally:
         await db_without_key.close()
 

--- a/tests/test_image_provider_service.py
+++ b/tests/test_image_provider_service.py
@@ -81,6 +81,7 @@ async def test_save_preserves_encrypted_on_decrypt_failure(db):
     assert len(loaded) == 1
     assert loaded[0].api_key == ""  # decrypt failed
     assert loaded[0]._api_key_enc_preserved != ""  # raw preserved
+    assert loaded[0].secret_status == "decrypt_failed"
 
     # Save back — should keep the preserved encrypted value
     await _make_service(db).save_provider_configs(loaded)

--- a/tests/test_image_provider_service.py
+++ b/tests/test_image_provider_service.py
@@ -1,5 +1,7 @@
 """Tests for ImageProviderService — DB-backed image provider management."""
 
+import logging
+
 import pytest
 
 from src.config import AppConfig
@@ -68,7 +70,7 @@ async def test_save_without_key_omits_encrypted_field(db):
 
 
 @pytest.mark.anyio
-async def test_save_preserves_encrypted_on_decrypt_failure(db):
+async def test_save_preserves_encrypted_on_decrypt_failure(db, caplog):
     """When api_key is empty but _api_key_enc_preserved has a value, it's written to DB."""
     svc = _make_service(db)
     # First save a real key
@@ -77,11 +79,18 @@ async def test_save_preserves_encrypted_on_decrypt_failure(db):
 
     # Load with wrong key (simulates decrypt failure)
     svc2 = _make_service(db, encryption_key="wrong-key")
-    loaded = await svc2.load_provider_configs()
+    with caplog.at_level(logging.DEBUG, logger="src.services.image_provider_service"):
+        loaded = await svc2.load_provider_configs()
     assert len(loaded) == 1
     assert loaded[0].api_key == ""  # decrypt failed
     assert loaded[0]._api_key_enc_preserved != ""  # raw preserved
     assert loaded[0].secret_status == "decrypt_failed"
+    assert any(
+        record.levelno == logging.DEBUG
+        and "decrypt failed: resource=image_provider identifier=together status=key_mismatch" in record.message
+        for record in caplog.records
+    )
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
     # Save back — should keep the preserved encrypted value
     await _make_service(db).save_provider_configs(loaded)

--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from src.runtime.worker import _publish_snapshots
+from src.database.repositories.accounts import AccountSessionDecryptError
+from src.runtime.worker import _publish_snapshots, _publish_worker_down_snapshot
 from src.services.notification_target_service import NotificationTargetStatus
 
 
@@ -187,3 +188,17 @@ async def test_publish_snapshots_notification_bot_exception():
     notif_call = [c for c in calls if c[0][0].snapshot_type == "notification_target_status"][0]
     bot_payload = notif_call[0][0].payload["bot"]
     assert bot_payload["configured"] is False
+
+
+async def test_publish_worker_down_snapshot_for_decrypt_failure():
+    container = _make_container()
+    exc = AccountSessionDecryptError(phone="+1234", status="key_mismatch")
+
+    await _publish_worker_down_snapshot(container, exc)
+
+    snapshot = container.db.repos.runtime_snapshots.upsert_snapshot.call_args[0][0]
+    assert snapshot.snapshot_type == "worker_heartbeat"
+    assert snapshot.payload["status"] == "worker_down"
+    assert snapshot.payload["reason"] == "telegram_session_decrypt_failed"
+    assert snapshot.payload["decrypt_status"] == "key_mismatch"
+    assert snapshot.payload["action"] == "restore_key_or_relogin"

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -181,6 +181,7 @@ async def test_notification_service_without_config_uses_defaults(tmp_path):
 def _mock_db():
     db = MagicMock()
     db.get_accounts = AsyncMock(return_value=[])
+    db.get_account_summaries = AsyncMock(return_value=[])
     db.add_account = AsyncMock()
     db.get_setting = AsyncMock(return_value=None)
     db.set_account_active = AsyncMock()
@@ -606,14 +607,29 @@ async def test_accounts_toggle_not_found():
 
 
 async def test_accounts_delete():
-    from src.models import Account
-
     db = _mock_db()
     pool = _mock_pool()
-    db.get_accounts.return_value = [Account(id=1, phone="+1", session_string="s")]
+    db.get_accounts.side_effect = AssertionError("delete must not decrypt sessions")
+    d = _dispatcher(db=db, pool=pool)
+    r = await d._handle_accounts_delete({"account_id": 1, "phone": "+1"})
+    assert r["deleted"] is True
+    pool.remove_client.assert_awaited_once_with("+1")
+    db.delete_account.assert_awaited_once_with(1)
+    db.get_accounts.assert_not_awaited()
+
+
+async def test_accounts_delete_legacy_payload_uses_summary_fallback():
+    db = _mock_db()
+    pool = _mock_pool()
+    db.get_accounts.side_effect = AssertionError("delete must not decrypt sessions")
+    db.get_account_summaries.return_value = [Account(id=1, phone="+1", session_string="")]
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_accounts_delete({"account_id": 1})
     assert r["deleted"] is True
+    db.get_account_summaries.assert_awaited_once_with(active_only=False)
+    pool.remove_client.assert_awaited_once_with("+1")
+    db.delete_account.assert_awaited_once_with(1)
+    db.get_accounts.assert_not_awaited()
 
 
 async def test_forum_topics_refresh():
@@ -1543,16 +1559,15 @@ async def test_accounts_toggle_activate_add_failure():
 
 
 async def test_accounts_delete_remove_failure():
-    from src.models import Account
-
     db = _mock_db()
     pool = _mock_pool()
-    db.get_accounts.return_value = [Account(id=1, phone="+1", session_string="s")]
+    db.get_accounts.side_effect = AssertionError("delete must not decrypt sessions")
     pool.remove_client = AsyncMock(side_effect=Exception("err"))
     d = _dispatcher(db=db, pool=pool)
-    r = await d._handle_accounts_delete({"account_id": 1})
+    r = await d._handle_accounts_delete({"account_id": 1, "phone": "+1"})
     assert r["deleted"] is True
     db.delete_account.assert_awaited_once_with(1)
+    db.get_accounts.assert_not_awaited()
 
 
 # --- _handle_accounts_delete: account not found (still deletes by id) ---
@@ -1561,12 +1576,14 @@ async def test_accounts_delete_remove_failure():
 async def test_accounts_delete_not_found():
     db = _mock_db()
     pool = _mock_pool()
-    db.get_accounts.return_value = []
+    db.get_accounts.side_effect = AssertionError("delete must not decrypt sessions")
+    db.get_account_summaries.return_value = []
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_accounts_delete({"account_id": 99})
     assert r["deleted"] is True
     pool.remove_client.assert_not_awaited()
     db.delete_account.assert_awaited_once_with(99)
+    db.get_accounts.assert_not_awaited()
 
 
 # --- _handle_moderation_publish_run: pipeline not found ---

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -612,9 +612,10 @@ async def test_accounts_delete():
     db.get_accounts.side_effect = AssertionError("delete must not decrypt sessions")
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_accounts_delete({"account_id": 1, "phone": "+1"})
-    assert r["deleted"] is True
+    assert r["deleted"] is False
+    assert r["client_removed"] is True
     pool.remove_client.assert_awaited_once_with("+1")
-    db.delete_account.assert_awaited_once_with(1)
+    db.delete_account.assert_not_awaited()
     db.get_accounts.assert_not_awaited()
 
 
@@ -626,6 +627,7 @@ async def test_accounts_delete_legacy_payload_uses_summary_fallback():
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_accounts_delete({"account_id": 1})
     assert r["deleted"] is True
+    assert r["client_removed"] is True
     db.get_account_summaries.assert_awaited_once_with(active_only=False)
     pool.remove_client.assert_awaited_once_with("+1")
     db.delete_account.assert_awaited_once_with(1)
@@ -1565,8 +1567,9 @@ async def test_accounts_delete_remove_failure():
     pool.remove_client = AsyncMock(side_effect=Exception("err"))
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_accounts_delete({"account_id": 1, "phone": "+1"})
-    assert r["deleted"] is True
-    db.delete_account.assert_awaited_once_with(1)
+    assert r["deleted"] is False
+    assert r["client_removed"] is True
+    db.delete_account.assert_not_awaited()
     db.get_accounts.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
- Add account session metadata with degraded session_status values while keeping live decrypted account access fail-closed.
- Move read-only web surfaces, scheduler/dashboard/dialogs/settings guards, and agent account/status tools to degraded metadata paths.
- Preserve encrypted provider secrets on decrypt failure, surface re-entry warnings in settings, and log expected decrypt failures compactly.
- Publish controlled worker_down/degraded snapshots when the embedded worker starts with the wrong key.

## Tests
- python3 -m ruff check src/ tests/ conftest.py
- python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto
- python3 -m pytest tests/ -v -m aiosqlite_serial