### PR TITLE
fix(collector): defer username resolve flood waits

### DIFF
--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -8,7 +8,7 @@ from src.cli import runtime
 from src.database.bundles import ChannelBundle
 from src.services.collection_service import CollectionService
 from src.services.task_enqueuer import TaskEnqueuer
-from src.telegram.collector import Collector
+from src.telegram.collector import Collector, UsernameResolveFloodWaitDeferredError
 
 
 def run(args: argparse.Namespace) -> None:
@@ -37,7 +37,12 @@ def run(args: argparse.Namespace) -> None:
                 if channel.is_filtered:
                     print(f"Channel {args.channel_id} is filtered and excluded from collection")
                     return
-                count = await collector.collect_single_channel(channel, full=True)
+                try:
+                    count = await collector.collect_single_channel(channel, full=True)
+                except UsernameResolveFloodWaitDeferredError as exc:
+                    retry_at = exc.next_available_at.astimezone().isoformat()
+                    print(f"Username resolve Flood Wait active until {retry_at}; try again later.")
+                    return
                 print(f"Collected {count} messages from channel {args.channel_id}")
             else:
                 channel_bundle = ChannelBundle.from_database(db)

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -295,7 +295,7 @@ class CollectionQueue:
                 )
                 note = (
                     "Отложено: Flood Wait на resolve_username до "
-                    f"{exc.next_available_at.astimezone(timezone.utc).isoformat()}"
+                    f"{run_after.astimezone(timezone.utc).isoformat()}"
                 )
                 self._retried_tasks.discard(task_id)
                 await self._channels.reschedule_collection_task(

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -9,9 +9,11 @@ from src.database import Database
 from src.database.bundles import ChannelBundle
 from src.models import Channel, CollectionTaskStatus
 from src.telegram.collector import (
+    RESOLVE_USERNAME_BACKOFF_BUFFER_SEC,
     AllCollectionClientsFloodedError,
     Collector,
     NoActiveCollectionClientsError,
+    UsernameResolveFloodWaitDeferredError,
 )
 
 logger = logging.getLogger(__name__)
@@ -283,6 +285,33 @@ class CollectionQueue:
                 )
                 logger.warning(
                     "Rescheduled collection task %d for channel %d until %s: all clients flooded",
+                    task_id,
+                    channel.channel_id,
+                    run_after.isoformat(),
+                )
+            except UsernameResolveFloodWaitDeferredError as exc:
+                run_after = exc.next_available_at + timedelta(
+                    seconds=RESOLVE_USERNAME_BACKOFF_BUFFER_SEC
+                )
+                note = (
+                    "Отложено: Flood Wait на resolve_username до "
+                    f"{exc.next_available_at.astimezone(timezone.utc).isoformat()}"
+                )
+                self._retried_tasks.discard(task_id)
+                await self._channels.reschedule_collection_task(
+                    task_id,
+                    run_after=run_after,
+                    note=note,
+                )
+                self._schedule_requeue_after_delay(
+                    task_id=task_id,
+                    channel=channel,
+                    force=force,
+                    full=full,
+                    run_after=run_after,
+                )
+                logger.warning(
+                    "Rescheduled collection task %d for channel %d until %s: username resolve flood wait",
                     task_id,
                     channel.channel_id,
                     run_after.isoformat(),

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -147,6 +147,18 @@ class TelegramTransportSession:
     async def get_input_entity(self, peer: Any) -> Any:
         return await self.resolve_input_entity(peer)
 
+    async def resolve_cached_input_entity(self, peer: Any) -> Any:
+        """Resolve an InputPeer from Telethon's local session cache only."""
+        try:
+            session = object.__getattribute__(self._client, "session")
+            resolver = session.get_input_entity
+        except AttributeError as exc:
+            raise ValueError("No local entity cache is available") from exc
+        result = resolver(peer)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def warm_dialog_cache(self) -> Any:
         return await self._run("telegram_warm_dialog_cache", self._client.get_dialogs())
 

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -375,10 +375,15 @@ class Collector:
         if isinstance(getattr(type(session), "raw_client", None), property):
             raw_client = session.raw_client
         live_input_resolver = getattr(raw_client, "get_input_entity", None)
+        def _session_resolver(name: str):
+            if getattr(type(session), name, None) is not None:
+                return getattr(session, name)
+            return vars(session).get(name)
+
         if live_input_resolver is None:
-            live_input_resolver = vars(session).get("get_input_entity")
+            live_input_resolver = _session_resolver("get_input_entity")
         if live_input_resolver is None:
-            live_input_resolver = vars(session).get("resolve_input_entity")
+            live_input_resolver = _session_resolver("resolve_input_entity")
         if live_input_resolver is None:
             live_input_resolver = session.get_entity
         return await run_with_flood_wait(

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -46,8 +46,7 @@ from src.telegram.notifier import Notifier
 logger = logging.getLogger(__name__)
 
 RESOLVE_USERNAME_OPERATION = "collect_channel_resolve_username"
-RESOLVE_USERNAME_GLOBAL_BACKOFF_THRESHOLD_SEC = 300
-RESOLVE_USERNAME_GLOBAL_BACKOFF_MAX_SEC = 3600
+RESOLVE_USERNAME_BACKOFF_BUFFER_SEC = 5
 
 
 class NoActiveStatsClientsError(RuntimeError):
@@ -79,6 +78,18 @@ class AllCollectionClientsFloodedError(RuntimeError):
             f"{next_available_at.isoformat()} (retry in {retry_after_sec}s)"
         )
         self.retry_after_sec = retry_after_sec
+        self.next_available_at = next_available_at
+
+
+class UsernameResolveFloodWaitDeferredError(RuntimeError):
+    """Raised when username resolution is deferred by Flood Wait backoff."""
+
+    def __init__(self, wait_seconds: int, next_available_at: datetime):
+        super().__init__(
+            "Username resolve is flood-waited until "
+            f"{next_available_at.isoformat()} (retry in {wait_seconds}s)"
+        )
+        self.wait_seconds = wait_seconds
         self.next_available_at = next_available_at
 
 
@@ -130,12 +141,20 @@ class Collector:
             return 0
         return int(remaining)
 
-    def _set_resolve_username_backoff(self, wait_seconds: int) -> int:
-        backoff_seconds = min(wait_seconds, RESOLVE_USERNAME_GLOBAL_BACKOFF_MAX_SEC)
+    def _set_resolve_username_backoff(self, wait_seconds: int) -> datetime:
         self._resolve_username_backoff_until_utc = datetime.now(timezone.utc) + timedelta(
-            seconds=backoff_seconds
+            seconds=wait_seconds
         )
-        return backoff_seconds
+        return self._resolve_username_backoff_until_utc
+
+    def _raise_resolve_username_deferred(self) -> None:
+        remaining = self._get_resolve_username_backoff_remaining_sec()
+        if remaining <= 0 or self._resolve_username_backoff_until_utc is None:
+            return
+        raise UsernameResolveFloodWaitDeferredError(
+            wait_seconds=remaining,
+            next_available_at=self._resolve_username_backoff_until_utc,
+        )
 
     async def get_collection_availability(self):
         availability_fn = getattr(self._pool, "get_stats_availability", None)
@@ -332,6 +351,44 @@ class Collector:
             logger.exception("Failed to auto-purge channel %d", channel_id)
             return False
 
+    async def _resolve_channel_input_entity(
+        self,
+        session,
+        *,
+        channel_id: int,
+        username: str,
+        phone: str,
+    ):
+        try:
+            return await session.resolve_cached_input_entity(PeerChannel(channel_id))
+        except (AttributeError, ValueError, TypeError):
+            pass
+
+        try:
+            cached = await session.resolve_cached_input_entity(username)
+        except (AttributeError, ValueError, TypeError):
+            cached = None
+        if cached is not None and getattr(cached, "channel_id", None) == channel_id:
+            return cached
+
+        try:
+            no_report_session = session.with_flood_context(
+                phone=phone,
+                pool=self._pool,
+                logger_=logger,
+                report_flood_wait=False,
+            )
+        except AttributeError:
+            no_report_session = session
+        return await run_with_flood_wait(
+            no_report_session.resolve_input_entity(username),
+            operation=RESOLVE_USERNAME_OPERATION,
+            phone=phone,
+            pool=None,
+            logger_=logger,
+            timeout=30.0,
+        )
+
     async def collect_single_channel(
         self,
         channel: Channel,
@@ -475,7 +532,7 @@ class Collector:
                         RESOLVE_USERNAME_OPERATION,
                         backoff_remaining_sec,
                     )
-                    return total_collected
+                    self._raise_resolve_username_deferred()
 
             # For private groups (no username):
             #   1. preferred_phone from DB (persists across restarts)
@@ -584,17 +641,15 @@ class Collector:
             try:
                 if channel.username:
                     try:
-                        entity = await run_with_flood_wait(
-                            session.resolve_entity(channel.username),
-                            operation=RESOLVE_USERNAME_OPERATION,
+                        entity = await self._resolve_channel_input_entity(
+                            session,
+                            channel_id=channel_id,
+                            username=channel.username,
                             phone=phone,
-                            pool=self._pool,
-                            logger_=logger,
-                            timeout=30.0,
                         )
                     except asyncio.TimeoutError:
                         logger.warning(
-                            "get_entity timed out for channel %d, skipping",
+                            "get_input_entity timed out for channel %d, skipping",
                             channel_id,
                         )
                         return total_collected
@@ -926,28 +981,29 @@ class Collector:
             # Rotate regular collection FloodWaits to another account
             # regardless of wait duration — report_flood() was already
             # called, so the next get_available_client() call will skip
-            # the flooded account. Long username-resolve FloodWaits are
-            # handled below with a process-local backoff instead.
+            # the flooded account. Username-resolve FloodWaits are handled
+            # below with a process-local backoff instead.
             # Only skip the channel if the channel no longer exists in DB.
             if flood_wait_sec is not None:
-                if (
-                    flood_wait_operation == RESOLVE_USERNAME_OPERATION
-                    and flood_wait_sec > RESOLVE_USERNAME_GLOBAL_BACKOFF_THRESHOLD_SEC
-                ):
-                    backoff_seconds = self._set_resolve_username_backoff(flood_wait_sec)
+                if flood_wait_operation == RESOLVE_USERNAME_OPERATION:
+                    next_available_at = self._set_resolve_username_backoff(flood_wait_sec)
                     logger.warning(
-                        "%s got long FloodWait %ss on %s; pausing username resolves for %ss",
+                        "%s got FloodWait %ss on %s; pausing username resolves until %s",
                         RESOLVE_USERNAME_OPERATION,
                         flood_wait_sec,
                         phone,
-                        backoff_seconds,
+                        next_available_at.isoformat(),
                     )
                     if self._notifier:
                         await self._notifier.notify(
                             f"FloodWait {flood_wait_sec}s on {phone}, "
-                            f"channel {channel_id} — pausing username resolves for {backoff_seconds}s"
+                            f"channel {channel_id} — pausing username resolves until "
+                            f"{next_available_at.isoformat()}"
                         )
-                    return total_collected + len(all_messages)
+                    raise UsernameResolveFloodWaitDeferredError(
+                        wait_seconds=flood_wait_sec,
+                        next_available_at=next_available_at,
+                    )
 
                 if self._notifier and flood_wait_sec > self._config.max_flood_wait_sec:
                     await self._notifier.notify(

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -371,17 +371,18 @@ class Collector:
         if cached is not None and getattr(cached, "channel_id", None) == channel_id:
             return cached
 
-        try:
-            no_report_session = session.with_flood_context(
-                phone=phone,
-                pool=self._pool,
-                logger_=logger,
-                report_flood_wait=False,
-            )
-        except AttributeError:
-            no_report_session = session
+        raw_client = None
+        if isinstance(getattr(type(session), "raw_client", None), property):
+            raw_client = session.raw_client
+        live_input_resolver = getattr(raw_client, "get_input_entity", None)
+        if live_input_resolver is None:
+            live_input_resolver = vars(session).get("get_input_entity")
+        if live_input_resolver is None:
+            live_input_resolver = vars(session).get("resolve_input_entity")
+        if live_input_resolver is None:
+            live_input_resolver = session.get_entity
         return await run_with_flood_wait(
-            no_report_session.resolve_input_entity(username),
+            live_input_resolver(username),
             operation=RESOLVE_USERNAME_OPERATION,
             phone=phone,
             pool=None,
@@ -453,6 +454,13 @@ class Collector:
                         await asyncio.sleep(self._config.delay_between_channels_sec)
                     except (AllCollectionClientsFloodedError, NoActiveCollectionClientsError) as e:
                         logger.error("Stopping collection: %s", e)
+                        stats["errors"] += 1
+                        break
+                    except UsernameResolveFloodWaitDeferredError as e:
+                        logger.warning(
+                            "Stopping collection until %s: username resolve flood wait",
+                            e.next_available_at.isoformat(),
+                        )
                         stats["errors"] += 1
                         break
                     except Exception as e:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -154,18 +154,39 @@ class FakeTelethonClient:
         self,
         *,
         entity_resolver=None,
+        input_entity_resolver=None,
+        cached_input_entity_resolver=None,
         dialogs=None,
         iter_messages_factory=None,
     ):
         self._entity_resolver = entity_resolver or (lambda arg: SimpleNamespace())
+        self._input_entity_resolver = input_entity_resolver or self._entity_resolver
+        self._cached_input_entity_resolver = cached_input_entity_resolver
         self._dialogs = [] if dialogs is None else dialogs
         self._iter_messages_factory = iter_messages_factory or (lambda *a, **kw: AsyncIterEmpty())
         self.get_entity = AsyncMock(side_effect=self._get_entity)
+        self.get_input_entity = AsyncMock(side_effect=self._get_input_entity)
         self.get_dialogs = AsyncMock(side_effect=self._get_dialogs)
         self.iter_messages = MagicMock(side_effect=self._iter_messages)
+        if cached_input_entity_resolver is not None:
+            self.session = SimpleNamespace(
+                get_input_entity=MagicMock(side_effect=self._get_cached_input_entity)
+            )
 
     async def _get_entity(self, arg):
         result = self._entity_resolver(arg)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def _get_input_entity(self, arg):
+        result = self._input_entity_resolver(arg)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def _get_cached_input_entity(self, arg):
+        result = self._cached_input_entity_resolver(arg)
         if isinstance(result, Exception):
             raise result
         return result

--- a/tests/test_cli_dialogs_notifications_scheduler.py
+++ b/tests/test_cli_dialogs_notifications_scheduler.py
@@ -776,6 +776,29 @@ class TestCollectCommand:
         out = capsys.readouterr().out
         assert "100" in out or "complete" in out.lower()
 
+    def test_collect_single_channel_username_resolve_deferred(self, cli_env_with_pool, capsys):
+        """Username resolve backoff should print a CLI message, not a traceback."""
+        from datetime import datetime, timedelta, timezone
+
+        from src.telegram.collector import Collector, UsernameResolveFloodWaitDeferredError
+
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+        _add_channel(cli_env, channel_id=100, title="Test Channel")
+
+        exc = UsernameResolveFloodWaitDeferredError(
+            wait_seconds=60,
+            next_available_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        )
+        with patch.object(Collector, "collect_single_channel", new_callable=AsyncMock, side_effect=exc):
+            from src.cli.commands.collect import run
+
+            run(_ns(channel_id=100, full=True))
+
+        out = capsys.readouterr().out
+        assert "Username resolve Flood Wait active until" in out
+        assert "try again later" in out
+
 
 def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
     return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -132,6 +132,7 @@ async def test_username_resolve_flood_defer_keeps_task_pending(tmp_path):
         assert task.run_after is not None
         assert task.run_after > next_available_at
         assert "Flood Wait на resolve_username" in (task.note or "")
+        assert task.run_after.astimezone(timezone.utc).isoformat() in (task.note or "")
     finally:
         await queue.shutdown()
         await db.close()

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from src.collection_queue import CollectionQueue
 from src.database import Database
 from src.models import Channel
+from src.telegram.collector import UsernameResolveFloodWaitDeferredError
 
 
 class _FakeCollector:
@@ -29,6 +30,19 @@ class _FakeCollector:
 
     async def cancel(self):
         return None
+
+
+class _UsernameResolveFloodCollector(_FakeCollector):
+    def __init__(self, next_available_at: datetime):
+        super().__init__()
+        self.next_available_at = next_available_at
+
+    async def collect_single_channel(self, channel, *, full=False, progress_callback=None, force=False):
+        self.calls.append(channel.channel_id)
+        raise UsernameResolveFloodWaitDeferredError(
+            wait_seconds=120,
+            next_available_at=self.next_available_at,
+        )
 
 
 class _BlockingCollector:
@@ -89,6 +103,37 @@ async def test_db_pull_picks_up_pending_task_added_after_startup(tmp_path):
             await queue.stop_db_pull()
             await queue.shutdown()
     finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_username_resolve_flood_defer_keeps_task_pending(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+        next_available_at = datetime.now(timezone.utc) + timedelta(minutes=2)
+
+        collector = _UsernameResolveFloodCollector(next_available_at)
+        queue = CollectionQueue(collector, db)
+        channel = (await db.get_channels(active_only=True))[0]
+        task_id = await queue.enqueue(channel)
+
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while asyncio.get_event_loop().time() < deadline:
+            task = await db.get_collection_task(task_id)
+            if task.status == "pending" and task.run_after is not None:
+                break
+            await asyncio.sleep(0.05)
+
+        task = await db.get_collection_task(task_id)
+        assert task.status == "pending"
+        assert task.error is None
+        assert task.run_after is not None
+        assert task.run_after > next_available_at
+        assert "Flood Wait на resolve_username" in (task.note or "")
+    finally:
+        await queue.shutdown()
         await db.close()
 
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -325,6 +325,25 @@ async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
 
 
 @pytest.mark.anyio
+async def test_collect_all_channels_stops_on_username_resolve_backoff(db):
+    await db.add_channel(
+        Channel(channel_id=1970788987, title="Backoff Active 1", username="backoff_active_1")
+    )
+    await db.add_channel(
+        Channel(channel_id=1970788988, title="Backoff Active 2", username="backoff_active_2")
+    )
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(AsyncMock(), "+7001")))
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+    collector._set_resolve_username_backoff(600)
+
+    stats = await collector.collect_all_channels()
+
+    assert stats == {"channels": 0, "messages": 0, "errors": 1}
+    pool.get_available_client.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_no_username_channel_fetches_dialogs_once(db):
     """For no-username channels get_dialogs() is called once per process to warm entity cache."""
     ch = Channel(channel_id=123, title="No Username")

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from telethon.errors import FloodWaitError, UsernameNotOccupiedError
-from telethon.tl.types import PeerChannel
+from telethon.tl.types import InputPeerChannel, PeerChannel
 
 from src.config import SchedulerConfig
 from src.models import Channel, ChannelStats, CollectionTaskStatus, Message, StatsAllTaskPayload
@@ -14,6 +14,7 @@ from src.telegram.collector import (
     AllCollectionClientsFloodedError,
     Collector,
     NoActiveCollectionClientsError,
+    UsernameResolveFloodWaitDeferredError,
 )
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
@@ -162,32 +163,36 @@ async def test_collect_channel_uses_peer_channel_without_username(db):
 
 @pytest.mark.anyio
 async def test_collect_channel_uses_username_when_available(db):
-    """_collect_channel resolves by username when it is stored."""
+    """_collect_channel uses cache-only PeerChannel before live username resolve."""
     ch = Channel(channel_id=1970788983, title="Test Channel", username="test_chan")
     await db.add_channel(ch)
 
-    mock_client = AsyncMock()
-    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
-    mock_client.iter_messages = MagicMock(return_value=_AsyncIterEmpty())
+    input_peer = InputPeerChannel(channel_id=1970788983, access_hash=123)
+    mock_client = FakeTelethonClient(cached_input_entity_resolver=lambda _arg: input_peer)
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
 
     collector = Collector(pool, db, SchedulerConfig())
     await collector._collect_channel(ch)
 
-    call_arg = mock_client.get_entity.call_args[0][0]
-    assert call_arg == "test_chan"
+    call_arg = mock_client.session.get_input_entity.call_args[0][0]
+    assert isinstance(call_arg, PeerChannel)
+    assert call_arg.channel_id == 1970788983
+    mock_client.get_entity.assert_not_awaited()
+    mock_client.get_input_entity.assert_not_awaited()
 
 
 @pytest.mark.anyio
 async def test_collect_positive_id_end_to_end(db):
-    """End-to-end: collect_all_channels with username resolves by username."""
+    """End-to-end: collect_all_channels falls back to live InputPeer username resolve."""
     ch = Channel(channel_id=1970788983, title="Positive ID Channel", username="my_chan")
     await db.add_channel(ch)
 
-    mock_client = AsyncMock()
-    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
-    mock_client.iter_messages = MagicMock(return_value=_AsyncIterEmpty())
+    input_peer = InputPeerChannel(channel_id=1970788983, access_hash=123)
+    mock_client = FakeTelethonClient(
+        input_entity_resolver=lambda arg: input_peer if arg == "my_chan" else ValueError("cache miss"),
+        cached_input_entity_resolver=lambda _arg: ValueError("cache miss"),
+    )
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
 
@@ -195,7 +200,7 @@ async def test_collect_positive_id_end_to_end(db):
     stats = await collector.collect_all_channels()
 
     assert stats["channels"] == 1
-    call_arg = mock_client.get_entity.call_args[0][0]
+    call_arg = mock_client.get_input_entity.call_args[0][0]
     assert call_arg == "my_chan"
 
 
@@ -239,18 +244,18 @@ async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_
         SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
     )
 
-    count = await collector._collect_channel(stored)
+    with pytest.raises(UsernameResolveFloodWaitDeferredError):
+        await collector._collect_channel(stored)
 
-    assert count == 0
-    pool.report_flood.assert_awaited_once_with("+7001", 7200)
+    pool.report_flood.assert_not_awaited()
     pool.get_available_client.assert_awaited_once()
-    raw_client2.get_entity.assert_not_awaited()
+    raw_client2.get_input_entity.assert_not_awaited()
     remaining = collector._get_resolve_username_backoff_remaining_sec()
-    assert 3500 < remaining <= 3600
+    assert 7100 < remaining <= 7200
 
 
 @pytest.mark.anyio
-async def test_collect_channel_short_username_resolve_flood_still_rotates(db):
+async def test_collect_channel_username_resolve_flood_does_not_rotate(db):
     ch = Channel(
         channel_id=1970788985,
         title="Short Username Flood",
@@ -289,13 +294,13 @@ async def test_collect_channel_short_username_resolve_flood_still_rotates(db):
         SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
     )
 
-    count = await collector._collect_channel(stored)
+    with pytest.raises(UsernameResolveFloodWaitDeferredError):
+        await collector._collect_channel(stored)
 
-    assert count == 0
-    pool.report_flood.assert_awaited_once_with("+7001", 120)
-    assert pool.get_available_client.await_count == 2
-    raw_client2.get_entity.assert_awaited_once_with("short_flood")
-    assert collector._get_resolve_username_backoff_remaining_sec() == 0
+    pool.report_flood.assert_not_awaited()
+    assert pool.get_available_client.await_count == 1
+    raw_client2.get_input_entity.assert_not_awaited()
+    assert 0 < collector._get_resolve_username_backoff_remaining_sec() <= 120
 
 
 @pytest.mark.anyio
@@ -314,9 +319,8 @@ async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
     collector._set_resolve_username_backoff(600)
 
-    count = await collector._collect_channel(stored)
-
-    assert count == 0
+    with pytest.raises(UsernameResolveFloodWaitDeferredError):
+        await collector._collect_channel(stored)
     pool.get_available_client.assert_not_awaited()
 
 
@@ -346,28 +350,52 @@ async def test_collect_no_username_channel_fetches_dialogs_once(db):
 
 @pytest.mark.anyio
 async def test_collect_channel_falls_back_to_username_on_cache_miss(db):
-    """When PeerChannel fails (entity not cached), fall back to username."""
+    """When cache-only lookups fail, fall back to live username InputPeer."""
     ch = Channel(channel_id=1970788983, title="Test", username="agipdoom")
     await db.add_channel(ch)
 
-    mock_entity = MagicMock()
-    mock_client = AsyncMock()
-
-    async def _get_entity(arg):
-        if isinstance(arg, str):
-            return mock_entity
-        raise ValueError("Could not find the input entity")
-
-    mock_client.get_entity = AsyncMock(side_effect=_get_entity)
-    mock_client.iter_messages = MagicMock(return_value=_AsyncIterEmpty())
+    input_peer = InputPeerChannel(channel_id=1970788983, access_hash=123)
+    mock_client = FakeTelethonClient(
+        input_entity_resolver=lambda arg: input_peer if arg == "agipdoom" else ValueError("cache miss"),
+        cached_input_entity_resolver=lambda _arg: ValueError("cache miss"),
+    )
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
 
     collector = Collector(pool, db, SchedulerConfig())
     await collector._collect_channel(ch)
 
-    # Username-first: should resolve by username directly
-    mock_client.get_entity.assert_awaited_once_with("agipdoom")
+    mock_client.get_input_entity.assert_awaited_once_with("agipdoom")
+    mock_client.get_entity.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_collect_channel_uses_cached_username_only_when_channel_id_matches(db):
+    ch = Channel(channel_id=1970788983, title="Test", username="agipdoom")
+    await db.add_channel(ch)
+
+    wrong_cached_peer = InputPeerChannel(channel_id=111, access_hash=1)
+    live_peer = InputPeerChannel(channel_id=1970788983, access_hash=2)
+
+    def _cached(arg):
+        if isinstance(arg, PeerChannel):
+            raise ValueError("numeric cache miss")
+        if arg == "agipdoom":
+            return wrong_cached_peer
+        raise ValueError("cache miss")
+
+    mock_client = FakeTelethonClient(
+        input_entity_resolver=lambda arg: live_peer if arg == "agipdoom" else ValueError("live miss"),
+        cached_input_entity_resolver=_cached,
+    )
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
+
+    collector = Collector(pool, db, SchedulerConfig())
+    await collector._collect_channel(ch)
+
+    assert mock_client.session.get_input_entity.call_count == 2
+    mock_client.get_input_entity.assert_awaited_once_with("agipdoom")
 
 
 @pytest.mark.anyio
@@ -1785,12 +1813,12 @@ async def test_precheck_skipped_when_force_and_first_run(db):
 
 @pytest.mark.anyio
 async def test_get_entity_timeout_returns_zero(db):
-    """get_entity hanging → TimeoutError → _collect_channel returns 0."""
+    """get_input_entity hanging → TimeoutError → _collect_channel returns 0."""
     ch = Channel(channel_id=-100400, title="Hanging Channel", username="hang_chan")
     await db.add_channel(ch)
 
     mock_client = AsyncMock()
-    mock_client.get_entity = AsyncMock(side_effect=asyncio.TimeoutError)
+    mock_client.get_input_entity = AsyncMock(side_effect=asyncio.TimeoutError)
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
     collector = Collector(pool, db, SchedulerConfig())
@@ -1928,12 +1956,13 @@ async def test_username_changed_marks_filtered(db):
     fallback_entity = SimpleNamespace(username="new_username", title="New Title")
 
     async def _get_entity(arg):
-        if isinstance(arg, str):
-            raise ValueError('No user has "raketa_nanobanana4" as username')
         return fallback_entity
 
     mock_client = AsyncMock()
     mock_client.get_entity = AsyncMock(side_effect=_get_entity)
+    mock_client.get_input_entity = AsyncMock(
+        side_effect=ValueError('No user has "raketa_nanobanana4" as username')
+    )
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
     collector = Collector(pool, db, SchedulerConfig())
@@ -1958,6 +1987,7 @@ async def test_username_not_found_deactivates(db):
 
     mock_client = AsyncMock()
     mock_client.get_entity = AsyncMock(side_effect=ValueError("No user has username"))
+    mock_client.get_input_entity = AsyncMock(side_effect=ValueError("No user has username"))
 
     pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
     collector = Collector(pool, db, SchedulerConfig())

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -219,7 +219,7 @@ async def test_collect_channel_entity_timeout(collector, mock_pool):
     channel = Channel(channel_id=123, username="user")
     client = AsyncMock()
     mock_pool.get_available_client.return_value = (client, "+7999")
-    client.get_entity.side_effect = asyncio.TimeoutError()
+    client.get_input_entity = AsyncMock(side_effect=asyncio.TimeoutError())
 
     res = await collector._collect_channel(channel)
     assert res == 0
@@ -232,10 +232,8 @@ async def test_collect_channel_username_changed(collector, mock_pool, mock_db):
     mock_pool.get_available_client.return_value = (client, "+7999")
 
     # Fails by username, succeeds by numeric ID
-    client.get_entity.side_effect = [
-        ValueError(),
-        MagicMock(id=123, username="new_user", title="New"),
-    ]
+    client.get_input_entity = AsyncMock(side_effect=ValueError())
+    client.get_entity = AsyncMock(return_value=MagicMock(id=123, username="new_user", title="New"))
 
     res = await collector._collect_channel(channel)
     assert res == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -611,7 +611,7 @@ class TestFloodWaitRotation:
 
         from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 
-        ch = Channel(channel_id=-100777, title="Flood Test", username="flood_test")
+        ch = Channel(channel_id=-100777, title="Flood Test")
         await test_db.add_channel(ch)
 
         flood_err = FloodWaitError(request=None, capture=0)


### PR DESCRIPTION
## Summary
- resolve username channels from Telethon's local InputPeer cache before live API fallback
- use live get_input_entity only on cache miss and validate cached username channel_id
- defer resolve_username Flood Waits back to pending queue tasks instead of completing with 0 messages or rotating accounts

## Tests
- python3 -m pytest tests/test_collector.py tests/test_collection_queue_db_pull.py -q
- python3 -m ruff check src/ tests/ conftest.py