### PR TITLE
fix(auth): retry startup with degraded sessions

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -103,7 +103,7 @@ def run(args: argparse.Namespace) -> None:
 
                 await db.set_setting(_pending_key(phone), "")
 
-                existing = await db.get_accounts()
+                existing = await db.get_account_summaries(active_only=False)
                 is_primary = len(existing) == 0
 
                 _, pool = await runtime.init_pool(config, db)
@@ -137,7 +137,7 @@ def run(args: argparse.Namespace) -> None:
                 print(await get_live_account_info_text(ctx, getattr(args, "phone", None) or ""))
                 return
             if args.account_action == "list":
-                accounts = await db.get_accounts()
+                accounts = await db.get_account_summaries(active_only=False)
                 if not accounts:
                     print("No accounts found.")
                     return
@@ -155,7 +155,7 @@ def run(args: argparse.Namespace) -> None:
                         )
                     )
             elif args.account_action == "toggle":
-                accounts = await db.get_accounts()
+                accounts = await db.get_account_summaries(active_only=False)
                 acc = next((a for a in accounts if a.id == args.id), None)
                 if not acc:
                     print(f"Account id={args.id} not found")
@@ -167,7 +167,7 @@ def run(args: argparse.Namespace) -> None:
                 await db.delete_account(args.id)
                 print(f"Deleted account id={args.id}")
             elif args.account_action == "flood-status":
-                accounts = await db.get_accounts()
+                accounts = await db.get_account_summaries(active_only=False)
                 if not accounts:
                     print("No accounts found.")
                     return
@@ -192,7 +192,7 @@ def run(args: argparse.Namespace) -> None:
                             remaining_str = ""
                     print(fmt.format(acc.phone, until_str, remaining_str))
             elif args.account_action == "flood-clear":
-                accounts = await db.get_accounts()
+                accounts = await db.get_account_summaries(active_only=False)
                 acc = next((a for a in accounts if a.phone == args.phone), None)
                 if not acc:
                     print(f"Account {args.phone} not found")

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -81,6 +81,9 @@ class AccountBundle:
     async def list_accounts(self, active_only: bool = False) -> list[Account]:
         return await self.accounts.get_accounts(active_only)
 
+    async def list_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
+        return await self.accounts.get_live_usable_accounts(active_only)
+
     async def list_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
         return await self.accounts.get_account_summaries(active_only)
 

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -214,6 +214,10 @@ class Database:
         self._require()
         return await self._accounts.get_accounts(active_only)
 
+    async def get_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
+        self._require()
+        return await self._accounts.get_live_usable_accounts(active_only)
+
     async def get_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
         self._require()
         return await self._accounts.get_account_summaries(active_only)

--- a/src/database/live_accounts.py
+++ b/src/database/live_accounts.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import Any
+
+from src.models import Account
+
+
+def _has_explicit_attr(target: object, name: str) -> bool:
+    try:
+        if name in vars(target):
+            return True
+    except TypeError:
+        pass
+    return hasattr(type(target), name)
+
+
+async def load_live_usable_accounts(db: Any, *, active_only: bool = False) -> list[Account]:
+    """Load decryptable accounts when the DB facade supports it.
+
+    Some tests use unspecced MagicMock databases, where getattr() fabricates
+    attributes. Require an explicit instance or class attribute before using the
+    safe loader, then fall back to the historical strict get_accounts() method.
+    """
+    getter = None
+    if _has_explicit_attr(db, "get_live_usable_accounts"):
+        getter = getattr(db, "get_live_usable_accounts", None)
+    if not callable(getter):
+        getter = getattr(db, "get_accounts")
+
+    result = getter(active_only=active_only)
+    if isawaitable(result):
+        result = await result
+    return list(result or [])

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -266,6 +266,44 @@ class AccountsRepository:
 
         return accounts
 
+    async def get_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
+        """Return accounts whose sessions can be decrypted for live Telegram use."""
+        sql = "SELECT * FROM accounts"
+        if active_only:
+            sql += " WHERE is_active = 1"
+        sql += " ORDER BY is_primary DESC, id ASC"
+        cur = await self._db.execute(sql)
+        rows = await cur.fetchall()
+        accounts: list[Account] = []
+
+        for row in rows:
+            raw_session = str(row["session_string"] or "")
+            phone = str(row["phone"])
+            try:
+                session_string = self._decrypt_session_for_live_use(raw_session, phone)
+            except AccountSessionDecryptError as exc:
+                logger.warning(
+                    "Skipping degraded Telegram account for live use: phone=%s status=%s",
+                    exc.identifier,
+                    exc.status,
+                )
+                continue
+
+            accounts.append(
+                Account(
+                    id=row["id"],
+                    phone=row["phone"],
+                    session_string=session_string,
+                    is_primary=bool(row["is_primary"]),
+                    is_active=bool(row["is_active"]),
+                    is_premium=bool(row["is_premium"]) if row["is_premium"] is not None else False,
+                    flood_wait_until=self._parse_dt(row["flood_wait_until"]),
+                    created_at=self._parse_dt(row["created_at"]),
+                )
+            )
+
+        return accounts
+
     async def update_account_flood(self, phone: str, until: datetime | None) -> None:
         await self._db.execute(
             "UPDATE accounts SET flood_wait_until = ? WHERE phone = ?",

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Any
 
@@ -65,6 +66,16 @@ class TelegramCommandDispatcher:
             if command is None:
                 await asyncio.sleep(1.0)
                 continue
+            started_at = time.monotonic()
+            is_auth_command = command.command_type.startswith("auth.")
+            phone = str(command.payload.get("phone", "")).strip()
+            if is_auth_command:
+                logger.info(
+                    "telegram_auth_command start command_id=%s command_type=%s phone=%s",
+                    command.id,
+                    command.command_type,
+                    phone,
+                )
             try:
                 result = await self._dispatch(command.command_type, command.payload)
             except asyncio.CancelledError:
@@ -75,7 +86,18 @@ class TelegramCommandDispatcher:
                 )
                 raise
             except Exception as exc:
-                logger.exception("Telegram command failed: id=%s type=%s", command.id, command.command_type)
+                duration_ms = int((time.monotonic() - started_at) * 1000)
+                if is_auth_command:
+                    logger.exception(
+                        "telegram_auth_command error command_id=%s command_type=%s phone=%s duration_ms=%d error=%s",
+                        command.id,
+                        command.command_type,
+                        phone,
+                        duration_ms,
+                        str(exc),
+                    )
+                else:
+                    logger.exception("Telegram command failed: id=%s type=%s", command.id, command.command_type)
                 await self._db.repos.telegram_commands.update_command(
                     command.id,
                     status=TelegramCommandStatus.FAILED,
@@ -83,6 +105,15 @@ class TelegramCommandDispatcher:
                     payload=command.payload,
                 )
             else:
+                if is_auth_command:
+                    duration_ms = int((time.monotonic() - started_at) * 1000)
+                    logger.info(
+                        "telegram_auth_command success command_id=%s command_type=%s phone=%s duration_ms=%d",
+                        command.id,
+                        command.command_type,
+                        phone,
+                        duration_ms,
+                    )
                 await self._db.repos.telegram_commands.update_command(
                     command.id,
                     status=TelegramCommandStatus.SUCCEEDED,

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from src.config import AppConfig
 from src.database import Database
+from src.database.live_accounts import load_live_usable_accounts
 from src.models import Account, RuntimeSnapshot, TelegramCommandStatus
 from src.scheduler.service import SchedulerManager
 from src.services.notification_service import NotificationService
@@ -134,14 +135,14 @@ class TelegramCommandDispatcher:
             raise RuntimeError("auth_not_configured")
         phone = str(payload["phone"]).strip()
         result = await self._auth.send_code(phone)
-        return {"phone": phone, **result}
+        return {"result": {"phone": phone, **result}}
 
     async def _handle_auth_resend_code(self, payload: dict[str, Any]) -> dict[str, Any]:
         if self._auth is None or not self._auth.is_configured:
             raise RuntimeError("auth_not_configured")
         phone = str(payload["phone"]).strip()
         result = await self._auth.resend_code(phone)
-        return {"phone": phone, **result}
+        return {"result": {"phone": phone, **result}}
 
     async def _handle_auth_verify_code(self, payload: dict[str, Any]) -> dict[str, Any]:
         if self._auth is None or not self._auth.is_configured:
@@ -155,7 +156,7 @@ class TelegramCommandDispatcher:
             str(payload["phone_code_hash"]),
             password_2fa,
         )
-        existing = await self._db.get_accounts()
+        existing = await self._db.get_account_summaries(active_only=False)
         account = Account(
             phone=phone,
             session_string=session_string,
@@ -622,9 +623,14 @@ class TelegramCommandDispatcher:
 
     async def _handle_accounts_connect(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])
-        accounts = await self._db.get_accounts()
+        accounts = await load_live_usable_accounts(self._db, active_only=False)
         account = next((a for a in accounts if a.phone == phone), None)
         if account is None:
+            summaries = await self._db.get_account_summaries(active_only=False)
+            summary = next((a for a in summaries if a.phone == phone), None)
+            if summary is not None:
+                status = getattr(summary, "session_status", "unavailable")
+                raise RuntimeError(f"account_session_unavailable:{phone}:{status}")
             raise RuntimeError(f"account_not_found:{phone}")
         await self._pool.add_client(phone, account.session_string)
         result = await self._pool.get_client_by_phone(phone)
@@ -641,22 +647,36 @@ class TelegramCommandDispatcher:
 
     async def _handle_accounts_toggle(self, payload: dict[str, Any]) -> dict[str, Any]:
         account_id = int(payload["account_id"])
-        accounts = await self._db.get_accounts()
-        account = next((a for a in accounts if a.id == account_id), None)
-        if account is None:
+        summaries = await self._db.get_account_summaries(active_only=False)
+        account_summary = next((a for a in summaries if a.id == account_id), None)
+        live_account: Account | None = None
+        if account_summary is None:
+            accounts = await load_live_usable_accounts(self._db, active_only=False)
+            live_account = next((a for a in accounts if a.id == account_id), None)
+            account_summary = live_account
+        if account_summary is None:
             raise RuntimeError(f"account_not_found:{account_id}")
-        new_active = not account.is_active
+        new_active = not account_summary.is_active
         await self._db.set_account_active(account_id, new_active)
         if new_active:
             try:
-                await self._pool.add_client(account.phone, account.session_string)
+                if live_account is None:
+                    accounts = await load_live_usable_accounts(self._db, active_only=False)
+                    live_account = next((a for a in accounts if a.id == account_id), None)
+                if live_account is None:
+                    logger.warning(
+                        "accounts.toggle: account session unavailable for %s",
+                        account_summary.phone,
+                    )
+                else:
+                    await self._pool.add_client(live_account.phone, live_account.session_string)
             except Exception as exc:
-                logger.warning("accounts.toggle: failed to add client %s: %s", account.phone, exc)
+                logger.warning("accounts.toggle: failed to add client %s: %s", account_summary.phone, exc)
         else:
             try:
-                await self._pool.remove_client(account.phone)
+                await self._pool.remove_client(account_summary.phone)
             except Exception as exc:
-                logger.warning("accounts.toggle: failed to remove client %s: %s", account.phone, exc)
+                logger.warning("accounts.toggle: failed to remove client %s: %s", account_summary.phone, exc)
         return {"account_id": account_id, "is_active": new_active}
 
     async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/telegram/account_lease_pool.py
+++ b/src/telegram/account_lease_pool.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from src.database import Database
+from src.database.live_accounts import load_live_usable_accounts
 from src.models import Account
 from src.telegram.utils import normalize_utc
 
@@ -27,7 +28,7 @@ class AccountLeasePool:
     async def acquire_available(self, connected_phones: set[str]) -> AccountLease | None:
         async with self._lock:
             now = datetime.now(timezone.utc)
-            accounts = await self._db.get_accounts(active_only=True)
+            accounts = await load_live_usable_accounts(self._db, active_only=True)
 
             # Proactively clear flood_wait_until values that have already expired.
             for account in accounts:
@@ -80,7 +81,7 @@ class AccountLeasePool:
         blocked_phones: set[str] | None = None,
     ) -> AccountLease | None:
         async with self._lock:
-            accounts = await self._db.get_accounts(active_only=True)
+            accounts = await load_live_usable_accounts(self._db, active_only=True)
             blocked_phones = blocked_phones or set()
 
             for account in accounts:
@@ -103,11 +104,11 @@ class AccountLeasePool:
             return None
 
     async def get_connected_accounts(self, connected_phones: set[str]) -> list[Account]:
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         return [account for account in accounts if account.phone in connected_phones]
 
     async def get_account(self, phone: str, *, active_only: bool = True) -> Account | None:
-        accounts = await self._db.get_accounts(active_only=active_only)
+        accounts = await load_live_usable_accounts(self._db, active_only=active_only)
         for account in accounts:
             if account.phone == phone:
                 return account

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+from collections.abc import Awaitable
+from typing import TypeVar
 
 from telethon import TelegramClient
 from telethon.errors import SessionPasswordNeededError
@@ -26,6 +30,34 @@ from telethon.tl.types.auth import (
 )
 
 logger = logging.getLogger(__name__)
+
+AUTH_CONNECT_TIMEOUT_SECONDS = 30
+AUTH_RPC_TIMEOUT_SECONDS = 60
+
+_T = TypeVar("_T")
+
+
+class TelegramAuthTimeoutError(TimeoutError):
+    """Raised when a Telegram auth operation exceeds its explicit timeout."""
+
+
+def _format_timeout(seconds: float) -> str:
+    if float(seconds).is_integer():
+        return f"{int(seconds)}s"
+    return f"{seconds:g}s"
+
+
+async def _with_auth_timeout(
+    awaitable: Awaitable[_T],
+    operation: str,
+    timeout_seconds: float,
+) -> _T:
+    try:
+        return await asyncio.wait_for(awaitable, timeout=timeout_seconds)
+    except TimeoutError as exc:
+        raise TelegramAuthTimeoutError(
+            f"telegram_auth_timeout: {operation} timed out after {_format_timeout(timeout_seconds)}"
+        ) from exc
 
 
 def _describe_code_type(sent_code_type: object) -> str:
@@ -100,21 +132,41 @@ class TelegramAuth:
 
     async def send_code(self, phone: str) -> dict:
         """Send auth code to phone. Returns dict with hash, type info, timeout."""
+        started_at = time.monotonic()
+        logger.info("auth.send_code start phone=%s", phone)
         await self._disconnect_pending_client(phone)
         client = TelegramClient(StringSession(), self._api_id, self._api_hash)
-        await client.connect()
         try:
-            result = await client.send_code_request(phone)
+            logger.info(
+                "auth.send_code connect start phone=%s timeout_s=%s",
+                phone,
+                AUTH_CONNECT_TIMEOUT_SECONDS,
+            )
+            await _with_auth_timeout(client.connect(), "connect", AUTH_CONNECT_TIMEOUT_SECONDS)
+            logger.info(
+                "auth.send_code rpc start phone=%s rpc=send_code_request timeout_s=%s",
+                phone,
+                AUTH_RPC_TIMEOUT_SECONDS,
+            )
+            result = await _with_auth_timeout(
+                client.send_code_request(phone),
+                "send_code_request",
+                AUTH_RPC_TIMEOUT_SECONDS,
+            )
         except Exception:
             try:
                 await client.disconnect()
             except Exception:
                 logger.warning("Failed to disconnect temporary auth client for %s", phone)
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.exception("auth.send_code error phone=%s duration_ms=%d", phone, duration_ms)
             raise
         self._pending[phone] = (client, result.phone_code_hash)
+        duration_ms = int((time.monotonic() - started_at) * 1000)
         logger.info(
-            "Auth code sent to %s: type=%s, next_type=%s, timeout=%s",
+            "auth.send_code success phone=%s duration_ms=%d code_type=%s next_type=%s timeout=%s",
             phone,
+            duration_ms,
             type(result.type).__name__,
             type(getattr(result, "next_type", None)).__name__,
             getattr(result, "timeout", None),
@@ -129,26 +181,45 @@ class TelegramAuth:
 
     async def resend_code(self, phone: str) -> dict:
         """Resend auth code via next delivery method. Returns same dict as send_code."""
+        started_at = time.monotonic()
+        logger.info("auth.resend_code start phone=%s", phone)
         if phone not in self._pending:
             raise ValueError(f"No pending auth for {phone}. Send code first.")
         client, phone_code_hash = self._pending[phone]
-        result = await client(
-            ResendCodeRequest(
-                phone_number=phone,
-                phone_code_hash=phone_code_hash,
+        try:
+            logger.info(
+                "auth.resend_code rpc start phone=%s rpc=resend_code timeout_s=%s",
+                phone,
+                AUTH_RPC_TIMEOUT_SECONDS,
             )
-        )
+            result = await _with_auth_timeout(
+                client(
+                    ResendCodeRequest(
+                        phone_number=phone,
+                        phone_code_hash=phone_code_hash,
+                    )
+                ),
+                "resend_code",
+                AUTH_RPC_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.exception("auth.resend_code error phone=%s duration_ms=%d", phone, duration_ms)
+            raise
         new_hash = result.phone_code_hash
         self._pending[phone] = (client, new_hash)
+        duration_ms = int((time.monotonic() - started_at) * 1000)
         logger.info(
-            "Auth code resent to %s: type=%s, next_type=%s, timeout=%s",
+            "auth.resend_code success phone=%s duration_ms=%d code_type=%s next_type=%s timeout=%s",
             phone,
+            duration_ms,
             type(result.type).__name__,
             type(getattr(result, "next_type", None)).__name__,
             getattr(result, "timeout", None),
         )
         return {
             "phone_code_hash": new_hash,
+            "session_str": client.session.save(),
             "code_type": _describe_code_type(result.type),
             "next_type": _describe_next_type(getattr(result, "next_type", None)),
             "timeout": getattr(result, "timeout", None),
@@ -162,6 +233,8 @@ class TelegramAuth:
         password_2fa: str | None = None,
     ) -> str:
         """Verify code and return session string."""
+        started_at = time.monotonic()
+        logger.info("auth.verify_code start phone=%s", phone)
         if phone not in self._pending:
             raise ValueError(f"No pending auth for {phone}. Send code first.")
 
@@ -172,13 +245,35 @@ class TelegramAuth:
         needs_2fa = False
         try:
             try:
-                await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
+                logger.info(
+                    "auth.verify_code rpc start phone=%s rpc=sign_in timeout_s=%s",
+                    phone,
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
+                await _with_auth_timeout(
+                    client.sign_in(phone, code, phone_code_hash=phone_code_hash),
+                    "sign_in",
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
             except SessionPasswordNeededError:
                 if not password_2fa:
                     needs_2fa = True
                     raise ValueError("2FA password required")
-                await client.sign_in(password=password_2fa)
+                logger.info(
+                    "auth.verify_code rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
+                    phone,
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
+                await _with_auth_timeout(
+                    client.sign_in(password=password_2fa),
+                    "sign_in",
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
             session_string = client.session.save()
+        except Exception:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.exception("auth.verify_code error phone=%s duration_ms=%d", phone, duration_ms)
+            raise
         finally:
             if not needs_2fa:
                 del self._pending[phone]
@@ -187,7 +282,8 @@ class TelegramAuth:
                 except Exception:
                     logger.warning("Failed to disconnect temporary auth client for %s", phone)
 
-        logger.info("Successfully authenticated %s", phone)
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        logger.info("auth.verify_code success phone=%s duration_ms=%d", phone, duration_ms)
         return session_string
 
     async def sign_in_fresh(
@@ -204,27 +300,66 @@ class TelegramAuth:
         Pass session_str from the send_code result to reuse the same MTProto session —
         required because Telegram binds phone_code_hash to the session that sent the request.
         """
+        started_at = time.monotonic()
+        logger.info("auth.sign_in_fresh start phone=%s", phone)
         client = TelegramClient(StringSession(session_str), self._api_id, self._api_hash)
-        await client.connect()
         try:
+            logger.info(
+                "auth.sign_in_fresh connect start phone=%s timeout_s=%s",
+                phone,
+                AUTH_CONNECT_TIMEOUT_SECONDS,
+            )
+            await _with_auth_timeout(client.connect(), "connect", AUTH_CONNECT_TIMEOUT_SECONDS)
             if code_consumed:
                 if not password_2fa:
                     raise ValueError("2FA password required")
-                await client.sign_in(password=password_2fa)
+                logger.info(
+                    "auth.sign_in_fresh rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
+                    phone,
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
+                await _with_auth_timeout(
+                    client.sign_in(password=password_2fa),
+                    "sign_in",
+                    AUTH_RPC_TIMEOUT_SECONDS,
+                )
             else:
                 try:
-                    await client.sign_in(phone, code, phone_code_hash=phone_code_hash)
+                    logger.info(
+                        "auth.sign_in_fresh rpc start phone=%s rpc=sign_in timeout_s=%s",
+                        phone,
+                        AUTH_RPC_TIMEOUT_SECONDS,
+                    )
+                    await _with_auth_timeout(
+                        client.sign_in(phone, code, phone_code_hash=phone_code_hash),
+                        "sign_in",
+                        AUTH_RPC_TIMEOUT_SECONDS,
+                    )
                 except SessionPasswordNeededError:
                     if not password_2fa:
                         raise ValueError("2FA password required")
-                    await client.sign_in(password=password_2fa)
+                    logger.info(
+                        "auth.sign_in_fresh rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
+                        phone,
+                        AUTH_RPC_TIMEOUT_SECONDS,
+                    )
+                    await _with_auth_timeout(
+                        client.sign_in(password=password_2fa),
+                        "sign_in",
+                        AUTH_RPC_TIMEOUT_SECONDS,
+                    )
             session_string = client.session.save()
+        except Exception:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.exception("auth.sign_in_fresh error phone=%s duration_ms=%d", phone, duration_ms)
+            raise
         finally:
             try:
                 await client.disconnect()
             except Exception:
                 logger.warning("Failed to disconnect fresh auth client for %s", phone)
-        logger.info("Successfully authenticated %s", phone)
+        duration_ms = int((time.monotonic() - started_at) * 1000)
+        logger.info("auth.sign_in_fresh success phone=%s duration_ms=%d", phone, duration_ms)
         return session_string
 
     async def create_client_from_session(self, session_string: str) -> TelegramClient:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -21,6 +21,7 @@ from telethon.tl.types import ChannelForbidden, Chat, PeerChannel, PeerUser
 
 from src.config import TelegramRuntimeConfig
 from src.database import Database
+from src.database.live_accounts import load_live_usable_accounts
 from src.models import Account, TelegramUserInfo
 from src.telegram.account_lease_pool import AccountLease, AccountLeasePool
 from src.telegram.auth import TelegramAuth
@@ -77,7 +78,7 @@ class ClientPool:
         self._max_flood_wait_sec = max_flood_wait_sec
         self._runtime_config = self._normalize_runtime_config(runtime_config)
         self.clients: dict[str, object] = {}
-        self.init_timeout: float = 15.0
+        self.init_timeout: float = 45.0
         self._lock = asyncio.Lock()
         self._in_use: set[str] = set()
         self._lease_pool = AccountLeasePool(db, self._in_use)
@@ -153,7 +154,7 @@ class ClientPool:
         now = datetime.now(timezone.utc)
         flood_waited: set[str] = set()
         try:
-            accounts = await self._db.get_accounts(active_only=True)
+            accounts = await load_live_usable_accounts(self._db, active_only=True)
             flood_waited = {
                 account.phone
                 for account in accounts
@@ -382,32 +383,36 @@ class ClientPool:
 
     async def initialize(self) -> None:
         """Load active accounts and validate that their sessions are usable."""
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         new_accounts = [acc for acc in accounts if acc.phone not in self.clients]
         if not new_accounts:
             return
 
-        async def _init_one(acc: Account) -> None:
-            lease: BackendClientLease | None = None
+        async def _connect_one(acc: Account) -> BackendClientLease | None:
             try:
                 lease = await self._connect_account(acc)
-                session = lease.session
                 logger.info("Connected account: %s (primary=%s)", acc.phone, acc.is_primary)
-                try:
-                    me = await asyncio.wait_for(session.fetch_me(), timeout=10.0)
-                    is_premium = bool(getattr(me, "premium", False))
-                    if is_premium != acc.is_premium:
-                        await self._db.update_account_premium(acc.phone, is_premium)
-                except Exception as e:
-                    logger.warning("Failed to fetch premium status for %s: %s", acc.phone, e)
-                finally:
-                    if lease is not None:
-                        await self._backend_router.release(lease)
+                return lease
             except Exception as e:
                 logger.error("Failed to connect %s: %s", acc.phone, e)
+                return None
 
-        tasks = {asyncio.create_task(_init_one(acc)): acc for acc in new_accounts}
+        tasks = {asyncio.create_task(_connect_one(acc)): acc for acc in new_accounts}
         done, pending = await asyncio.wait(tasks.keys(), timeout=self.init_timeout)
+        for task in done:
+            acc = tasks[task]
+            lease = task.result()
+            if lease is None:
+                continue
+            try:
+                me = await asyncio.wait_for(lease.session.fetch_me(), timeout=5.0)
+                is_premium = bool(getattr(me, "premium", False))
+                if is_premium != acc.is_premium:
+                    await self._db.update_account_premium(acc.phone, is_premium)
+            except Exception as e:
+                logger.warning("Failed to fetch premium status for %s: %s", acc.phone, e)
+            finally:
+                await self._backend_router.release(lease)
         if pending:
             phones = []
             for task in pending:
@@ -485,7 +490,7 @@ class ClientPool:
         return None
 
     async def get_premium_unavailability_reason(self) -> str:
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         premium = [acc for acc in accounts if acc.is_premium]
         if not premium:
             return "Нет аккаунтов с Telegram Premium. Добавьте Premium-аккаунт в настройках."
@@ -515,7 +520,7 @@ class ClientPool:
 
     async def get_premium_stats_availability(self) -> StatsClientAvailability:
         """Describe premium client availability including premium-only flood waits."""
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         now = datetime.now(timezone.utc)
         connected_premium = [
             acc
@@ -825,7 +830,7 @@ class ClientPool:
             include_avatar: If True (default), download and encode profile photos as base64.
                            Set to False for CLI usage to skip unnecessary 15s I/O per account.
         """
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         primary_phones = {a.phone for a in accounts if a.is_primary}
         result: list[TelegramUserInfo] = []
 
@@ -1475,7 +1480,7 @@ class ClientPool:
 
     async def get_dialogs(self) -> list[dict]:
         """Get list of subscribed channels and groups."""
-        accounts = await self._db.get_accounts(active_only=True)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
         now = datetime.now(timezone.utc)
         for acc in accounts:
             flood_until = normalize_utc(acc.flood_wait_until)

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -24,6 +24,7 @@ from src.database.bundles import (
     SearchBundle,
     SearchQueryBundle,
 )
+from src.database.repositories.accounts import AccountSessionDecryptError
 from src.scheduler.service import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
@@ -49,8 +50,77 @@ from src.web.timing import TimingBuffer
 logger = logging.getLogger(__name__)
 _is_dev = os.environ.get("ENV", "PROD").upper() == "DEV"
 _POOL_INIT_TIMEOUT = 20
+_POOL_RETRY_INTERVAL_SEC = 60.0
 _SHUTDOWN_DEFAULT_TIMEOUT = 15.0
 _SHUTDOWN_COLLECTION_QUEUE_TIMEOUT = 140.0
+
+
+def _connected_pool_count(pool: object) -> int:
+    clients = getattr(pool, "clients", {})
+    try:
+        return len(clients)
+    except TypeError:
+        return 0
+
+
+async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
+    while _connected_pool_count(container.pool) == 0 and getattr(
+        container, "shutting_down", False
+    ) is not True:
+        try:
+            await asyncio.wait_for(
+                asyncio.sleep(_POOL_RETRY_INTERVAL_SEC),
+                timeout=_POOL_RETRY_INTERVAL_SEC + 1,
+            )
+        except asyncio.CancelledError:
+            raise
+        if (
+            getattr(container, "shutting_down", False) is True
+            or _connected_pool_count(container.pool) > 0
+        ):
+            return
+        try:
+            await asyncio.wait_for(container.pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "startup: telegram pool retry timed out after %ds; connected_count=0",
+                _POOL_INIT_TIMEOUT,
+            )
+        except AccountSessionDecryptError as exc:
+            logger.warning(
+                "startup: telegram pool retry degraded by session decrypt failure "
+                "resource=%s identifier=%s status=%s action=%s",
+                exc.resource,
+                exc.identifier,
+                exc.status,
+                exc.action,
+            )
+        except Exception:
+            logger.exception("startup: telegram pool retry failed")
+        else:
+            connected_count = _connected_pool_count(container.pool)
+            if connected_count > 0:
+                logger.info(
+                    "startup: telegram pool recovered after retry; connected_count=%d",
+                    connected_count,
+                )
+                return
+
+
+def _schedule_telegram_pool_retry(container: AppContainer) -> None:
+    bg_tasks = getattr(container, "bg_tasks", None)
+    if not isinstance(bg_tasks, set):
+        bg_tasks = set()
+        setattr(container, "bg_tasks", bg_tasks)
+    for task in bg_tasks:
+        if not task.done() and task.get_name() == "telegram_pool_reconnect_retry":
+            return
+    task = asyncio.create_task(
+        _retry_telegram_pool_until_connected(container),
+        name="telegram_pool_reconnect_retry",
+    )
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
 
 
 async def load_telegram_credentials(db: Database, config: AppConfig) -> tuple[int, str]:
@@ -310,6 +380,7 @@ async def start_container(container: AppContainer) -> None:
         t1 = time.monotonic()
 
     if runtime_mode == "worker" and container.auth.is_configured:
+        telegram_pool_degraded = False
         try:
             await asyncio.wait_for(container.pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
         except asyncio.TimeoutError:
@@ -317,9 +388,28 @@ async def start_container(container: AppContainer) -> None:
                 "startup: telegram pool timed out after %ds — continuing without full init",
                 _POOL_INIT_TIMEOUT,
             )
+        except AccountSessionDecryptError as exc:
+            telegram_pool_degraded = True
+            logger.warning(
+                "startup: telegram pool degraded by session decrypt failure "
+                "resource=%s identifier=%s status=%s action=%s — continuing",
+                exc.resource,
+                exc.identifier,
+                exc.status,
+                exc.action,
+            )
+        connected_count = _connected_pool_count(container.pool)
+        if connected_count == 0:
+            telegram_pool_degraded = True
+            logger.warning(
+                "startup: telegram pool degraded; connected_count=0 — pending collection tasks "
+                "will stay in DB until a client connects"
+            )
+            if container.collection_queue is not None:
+                _schedule_telegram_pool_retry(container)
         # Warm entity cache + preferred_phone map for all accounts in background.
         # Store the task so the collector can wait on it during a race condition.
-        if hasattr(container.pool, "warm_all_dialogs"):
+        if not telegram_pool_degraded and hasattr(container.pool, "warm_all_dialogs"):
             _warm_task = asyncio.create_task(
                 container.pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
             )
@@ -329,9 +419,14 @@ async def start_container(container: AppContainer) -> None:
         logger.info("startup/start: telegram_pool %.2fs", time.monotonic() - t1)
 
     if runtime_mode == "worker" and container.collection_queue is not None:
-        requeued = await container.collection_queue.requeue_startup_tasks()
-        if requeued:
-            logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
+        if container.auth.is_configured and _connected_pool_count(container.pool) == 0:
+            logger.warning(
+                "Skipping startup collection requeue because telegram pool has no connected clients"
+            )
+        else:
+            requeued = await container.collection_queue.requeue_startup_tasks()
+            if requeued:
+                logger.info("Re-enqueued %d pending collection tasks on startup", requeued)
         # Periodically re-check the DB for new PENDING tasks created by the
         # web container in split / embedded-worker setups (CollectionService
         # falls back to a DB-only insert when collection_queue is None).

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -9,6 +10,8 @@ from src.web import deps
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+AUTH_PENDING_WARNING_SECONDS = 30
 
 
 def _render(request: Request, name: str, context: dict):
@@ -24,6 +27,16 @@ async def _auth_command(request: Request):
     if not raw.isdigit():
         return None
     return await deps.telegram_command_service(request).get(int(raw))
+
+
+def _elapsed_seconds(since: datetime | None) -> int:
+    if since is None:
+        return 0
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=timezone.utc)
+    else:
+        since = since.astimezone(timezone.utc)
+    return max(0, int((datetime.now(timezone.utc) - since).total_seconds()))
 
 
 def _auth_redirect(request: Request, command_id: int, *, phone: str = "") -> RedirectResponse:
@@ -44,11 +57,15 @@ async def login_page(request: Request):
         result = command.result_payload or {}
         context["phone"] = payload.get("phone", request.query_params.get("phone", ""))
         if command.status in {TelegramCommandStatus.PENDING, TelegramCommandStatus.RUNNING}:
+            pending_elapsed_seconds = _elapsed_seconds(command.started_at or command.created_at)
             context.update(
                 {
                     "step": "pending",
                     "command_id": command.id,
                     "pending_action": command.command_type,
+                    "pending_status": command.status.value,
+                    "pending_elapsed_seconds": pending_elapsed_seconds,
+                    "pending_slow": pending_elapsed_seconds >= AUTH_PENDING_WARNING_SECONDS,
                 }
             )
         elif command.command_type in {"auth.send_code", "auth.resend_code"}:

--- a/src/web/routes/telegram_commands.py
+++ b/src/web/routes/telegram_commands.py
@@ -11,6 +11,7 @@ router = APIRouter()
 
 _SENSITIVE_KEYS = {
     "session_string",
+    "session_str",
     "password",
     "passcode",
     "secret",

--- a/src/web/templates/login.html
+++ b/src/web/templates/login.html
@@ -32,6 +32,18 @@
 <div class="card mb-4">
     <div class="card-body">
         <p class="mb-2">Команда отправлена в worker и сейчас обрабатывается.</p>
+        <p class="text-muted small mb-2">
+            {% if pending_status == 'running' %}
+            Выполняется {{ pending_elapsed_seconds or 0 }} сек.
+            {% else %}
+            Ожидает worker {{ pending_elapsed_seconds or 0 }} сек.
+            {% endif %}
+        </p>
+        {% if pending_slow %}
+        <div class="alert alert-warning mb-2" role="alert">
+            запрос к Telegram занял слишком много времени, worker завершит его ошибкой.
+        </div>
+        {% endif %}
         <p class="text-muted small mb-0">Страница обновится автоматически, когда команда завершится.</p>
     </div>
 </div>

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -160,6 +160,56 @@ async def test_get_accounts_wrong_key_still_fails_for_live_use(repo_with_cipher)
         await wrong_key_repo.get_accounts()
 
 
+async def test_get_live_usable_accounts_skips_degraded_rows(repo_with_cipher):
+    runtime_cipher = SessionCipher("runtime-key")
+    bad_cipher = SessionCipher("other-key")
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+10000000001", bad_cipher.encrypt("bad-session")),
+    )
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 1, 1)",
+        ("+10000000002", runtime_cipher.encrypt("good-session")),
+    )
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+10000000003", "enc:v999:unsupported"),
+    )
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+10000000004", "plaintext-session"),
+    )
+    await repo_with_cipher._db.commit()
+
+    runtime_repo = AccountsRepository(repo_with_cipher._db, session_cipher=runtime_cipher)
+
+    accounts = await runtime_repo.get_live_usable_accounts(active_only=True)
+
+    assert [account.phone for account in accounts] == ["+10000000002", "+10000000004"]
+    assert accounts[0].session_string == "good-session"
+    assert accounts[1].session_string == "plaintext-session"
+
+
+async def test_get_live_usable_accounts_returns_empty_when_all_degraded(repo_with_cipher):
+    bad_cipher = SessionCipher("other-key")
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+10000000001", bad_cipher.encrypt("bad-session")),
+    )
+    await repo_with_cipher._db.execute(
+        "INSERT INTO accounts (phone, session_string, is_primary, is_active) VALUES (?, ?, 0, 1)",
+        ("+10000000002", "enc:v999:unsupported"),
+    )
+    await repo_with_cipher._db.commit()
+
+    runtime_repo = AccountsRepository(
+        repo_with_cipher._db,
+        session_cipher=SessionCipher("runtime-key"),
+    )
+
+    assert await runtime_repo.get_live_usable_accounts(active_only=True) == []
+
+
 async def test_get_accounts_handles_plaintext_when_cipher_set(repo_with_cipher):
     """Test that plaintext sessions work when cipher is configured."""
     # Insert plaintext directly

--- a/tests/routes/test_auth_routes.py
+++ b/tests/routes/test_auth_routes.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.models import TelegramCommand, TelegramCommandStatus
+from src.services.telegram_command_dispatcher import TelegramCommandDispatcher
 
 
 @pytest.fixture
@@ -63,6 +66,18 @@ async def client_unconfigured(base_app):
     ) as c:
         yield c
 
+
+async def _run_dispatcher_once(db, pool, auth, monkeypatch):
+    dispatcher = TelegramCommandDispatcher(db, pool, auth=auth)
+    original_claim = db.repos.telegram_commands.claim_next_command
+
+    async def claim_once():
+        command = await original_claim()
+        dispatcher._stop_event.set()
+        return command
+
+    monkeypatch.setattr(db.repos.telegram_commands, "claim_next_command", claim_once)
+    await dispatcher._run_loop()
 
 
 @pytest.mark.anyio
@@ -401,6 +416,109 @@ async def test_send_code_returns_code_info(client):
     assert resp.status_code == 200
     text_lower = resp.text.lower()
     assert "code" in text_lower or "код" in text_lower
+
+
+@pytest.mark.anyio
+async def test_send_code_happy_path_dispatcher_result_shows_code_step(client, monkeypatch):
+    """Queued send-code result must persist phone_code_hash for the login page."""
+    app = client._transport.app
+    db = app.state.db
+    pool = app.state.pool
+    auth = app.state.auth
+    auth.send_code = AsyncMock(
+        return_value={
+            "phone_code_hash": "hash_dispatch",
+            "session_str": "session_pending",
+            "code_type": "SMS",
+            "next_type": "звонок",
+            "timeout": 60,
+        }
+    )
+
+    resp = await client.post(
+        "/auth/send-code",
+        data={"phone": "+1234567890"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    command_id = int(resp.headers["location"].split("command_id=", 1)[1].split("&", 1)[0])
+
+    await _run_dispatcher_once(db, pool, auth, monkeypatch)
+
+    command = await db.repos.telegram_commands.get_command(command_id)
+    assert command is not None
+    assert command.status == TelegramCommandStatus.SUCCEEDED
+    assert command.result_payload is not None
+    assert command.result_payload["phone_code_hash"] == "hash_dispatch"
+    assert command.result_payload["session_str"] == "session_pending"
+
+    page = await client.get(f"/auth/login?command_id={command_id}")
+    assert page.status_code == 200
+    assert "Код подтверждения" in page.text
+    assert 'value="hash_dispatch"' in page.text
+
+
+@pytest.mark.anyio
+async def test_send_code_connect_timeout_marks_failed_and_shows_error(client, monkeypatch):
+    """A hanging Telethon connect must fail the command with a visible timeout."""
+    app = client._transport.app
+    db = app.state.db
+    pool = app.state.pool
+    auth = app.state.auth
+    monkeypatch.setattr("src.telegram.auth.AUTH_CONNECT_TIMEOUT_SECONDS", 0.01)
+
+    async def hang_forever():
+        await asyncio.Event().wait()
+
+    mock_client = MagicMock()
+    mock_client.connect = AsyncMock(side_effect=hang_forever)
+    mock_client.disconnect = AsyncMock()
+    mock_client.send_code_request = AsyncMock()
+
+    with patch("src.telegram.auth.TelegramClient", return_value=mock_client):
+        resp = await client.post(
+            "/auth/send-code",
+            data={"phone": "+1234567890"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        command_id = int(resp.headers["location"].split("command_id=", 1)[1].split("&", 1)[0])
+
+        await _run_dispatcher_once(db, pool, auth, monkeypatch)
+
+    command = await db.repos.telegram_commands.get_command(command_id)
+    assert command is not None
+    assert command.status == TelegramCommandStatus.FAILED
+    assert command.error == "telegram_auth_timeout: connect timed out after 0.01s"
+    mock_client.send_code_request.assert_not_awaited()
+
+    page = await client.get(f"/auth/login?command_id={command_id}")
+    assert page.status_code == 200
+    assert "telegram_auth_timeout: connect timed out after 0.01s" in page.text
+
+
+@pytest.mark.anyio
+async def test_login_pending_shows_elapsed_and_slow_warning(client):
+    """Pending auth commands show elapsed time and a slow Telegram warning."""
+    db = client._transport.app.state.db
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="auth.send_code",
+            payload={"phone": "+1234567890"},
+        )
+    )
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=45)).isoformat()
+    await db.execute(
+        "UPDATE telegram_commands SET status = ?, started_at = ? WHERE id = ?",
+        (TelegramCommandStatus.RUNNING.value, started_at, command_id),
+    )
+    assert db.db is not None
+    await db.db.commit()
+
+    resp = await client.get(f"/auth/login?command_id={command_id}")
+    assert resp.status_code == 200
+    assert "Выполняется" in resp.text
+    assert "запрос к Telegram занял слишком много времени, worker завершит его ошибкой" in resp.text
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_telegram_commands_routes.py
+++ b/tests/routes/test_telegram_commands_routes.py
@@ -32,7 +32,7 @@ async def test_get_command_status_redacts_sensitive_payload(client, base_app):
         payload={"phone": "+123", "session_string": "SECRET_SESSION"},
         status=TelegramCommandStatus.SUCCEEDED,
         requested_by="test",
-        result_payload={"phone": "+123", "token": "xxx", "is_premium": True},
+        result_payload={"phone": "+123", "token": "xxx", "session_str": "SECRET_PENDING", "is_premium": True},
     )
     cid = await db.repos.telegram_commands.create_command(cmd)
 
@@ -42,6 +42,7 @@ async def test_get_command_status_redacts_sensitive_payload(client, base_app):
     assert body["payload"]["phone"] == "+123"
     assert body["payload"]["session_string"] == "[REDACTED]"
     assert body["result_payload"]["token"] == "[REDACTED]"
+    assert body["result_payload"]["session_str"] == "[REDACTED]"
     assert body["result_payload"]["is_premium"] is True
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -127,6 +127,7 @@ class TestResendCode:
     async def test_resend_code_calls_resend_request(self):
         auth = TelegramAuth(api_id=123, api_hash="abc")
         mock_client = AsyncMock()
+        mock_client.session = SimpleNamespace(save=lambda: "session_str_resend")
         auth._pending["+1234567890"] = (mock_client, "old_hash")
 
         fake_type = FakeSentCodeTypeSms()
@@ -142,6 +143,7 @@ class TestResendCode:
             info = await auth.resend_code("+1234567890")
 
         assert info["phone_code_hash"] == "new_hash"
+        assert info["session_str"] == "session_str_resend"
         assert info["code_type"] == "SMS"
         assert info["next_type"] is None
         assert info["timeout"] == 120

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,6 +1,7 @@
 """Tests for start_container bootstrap behavior."""
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8,6 +9,7 @@ from telethon import TelegramClient
 
 from src.config import AppConfig, DatabaseConfig
 from src.database import Database
+from src.database.repositories.accounts import AccountSessionDecryptError
 from src.search.engine import SearchEngine
 from src.web.bootstrap import build_web_container, start_container
 from src.web.log_handler import LogBuffer
@@ -170,6 +172,68 @@ async def test_start_container_worker_mode_initializes_runtime(tmp_path):
         container.pool.initialize.assert_awaited_once()
         container.unified_dispatcher.start.assert_awaited_once()
         container.scheduler.load_settings.assert_awaited_once()
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_start_container_empty_pool_skips_collection_requeue_and_schedules_retry(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    container = _make_container(db)
+    container.runtime_mode = "worker"
+    container.auth.is_configured = True
+    container.pool.initialize = AsyncMock()
+    container.pool.clients = {}
+    container.pool.warm_all_dialogs = AsyncMock()
+    container.collection_queue = MagicMock()
+    container.collection_queue.requeue_startup_tasks = AsyncMock(return_value=0)
+    container.collection_queue.start_db_pull = MagicMock()
+    container.bg_tasks = set()
+    container.scheduler = AsyncMock()
+    container.scheduler.load_settings = AsyncMock()
+    container.unified_dispatcher = AsyncMock()
+    container.unified_dispatcher.start = AsyncMock()
+
+    try:
+        await start_container(container)
+        container.collection_queue.requeue_startup_tasks.assert_not_called()
+        container.collection_queue.start_db_pull.assert_called_once()
+        assert any(task.get_name() == "telegram_pool_reconnect_retry" for task in container.bg_tasks)
+    finally:
+        for task in list(container.bg_tasks):
+            task.cancel()
+        await asyncio.gather(*container.bg_tasks, return_exceptions=True)
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_start_container_continues_when_pool_init_decrypt_fails(tmp_path, caplog):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    container = _make_container(db)
+    container.runtime_mode = "worker"
+    container.auth.is_configured = True
+    container.pool.initialize = AsyncMock(
+        side_effect=AccountSessionDecryptError(phone="+7000", status="key_mismatch")
+    )
+    container.pool.warm_all_dialogs = AsyncMock()
+    container.scheduler = AsyncMock()
+    container.scheduler.load_settings = AsyncMock()
+    container.unified_dispatcher = AsyncMock()
+    container.unified_dispatcher.start = AsyncMock()
+    container.agent_manager = MagicMock()
+    container.agent_manager.refresh_settings_cache = AsyncMock()
+
+    try:
+        with caplog.at_level("WARNING"):
+            await start_container(container)
+        assert "telegram pool degraded by session decrypt failure" in caplog.text
+        container.agent_manager.refresh_settings_cache.assert_awaited_once_with(preflight=True)
+        container.agent_manager.initialize.assert_called_once()
+        container.pool.warm_all_dialogs.assert_not_called()
     finally:
         await db.close()
 

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from telethon.errors import FloodWaitError
 
+from src.database.repositories.accounts import AccountSessionDecryptError
+from src.models import Account
+from src.telegram.client_pool import ClientPool
 from tests.helpers import FakeCliTelethonClient, make_channel_entity
 
 
@@ -23,6 +27,41 @@ async def test_pool_initialize_no_accounts(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     await harness.initialize_connected_accounts()
     assert len(harness.pool.clients) == 0
+
+
+@pytest.mark.anyio
+async def test_pool_initialize_with_only_degraded_accounts_does_not_raise():
+    db = MagicMock()
+    db.get_live_usable_accounts = AsyncMock(return_value=[])
+    db.get_accounts = AsyncMock(side_effect=AccountSessionDecryptError(phone="+7000", status="key_mismatch"))
+    db.update_account_premium = AsyncMock()
+    auth = MagicMock(api_id=12345, api_hash="hash")
+
+    pool = ClientPool(auth, db)
+
+    await pool.initialize()
+
+    assert pool.clients == {}
+    db.get_live_usable_accounts.assert_awaited_once_with(active_only=True)
+    db.get_accounts.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_pool_initialize_with_mixed_degraded_and_good_connects_good(telethon_cli_spy):
+    good = Account(phone="+70000000001", session_string="s1", is_active=True, is_primary=True)
+    db = MagicMock()
+    db.get_live_usable_accounts = AsyncMock(return_value=[good])
+    db.get_accounts = AsyncMock(side_effect=AccountSessionDecryptError(phone="+bad", status="key_mismatch"))
+    db.update_account_premium = AsyncMock()
+    auth = MagicMock(api_id=12345, api_hash="hash")
+    telethon_cli_spy.bind("+70000000001", FakeCliTelethonClient())
+
+    pool = ClientPool(auth, db)
+
+    await pool.initialize()
+
+    assert "+70000000001" in pool.clients
+    db.get_accounts.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.database import Database
-from src.models import Account
+from src.models import Account, AccountSessionStatus, AccountSummary
 from src.services import telegram_command_dispatcher as mod
 from src.services.telegram_command_dispatcher import TelegramCommandDispatcher
 
@@ -279,7 +279,8 @@ async def test_auth_send_code_ok():
     auth.send_code = AsyncMock(return_value={"phone_code_hash": "h"})
     d = _dispatcher(auth=auth)
     r = await d._handle_auth_send_code({"phone": "+1"})
-    assert r["phone_code_hash"] == "h"
+    assert r["result"]["phone_code_hash"] == "h"
+    assert r["result"]["phone"] == "+1"
 
 
 async def test_auth_resend_code_not_configured():
@@ -935,8 +936,8 @@ async def test_auth_resend_code_ok():
     auth.resend_code = AsyncMock(return_value={"phone_code_hash": "h2"})
     d = _dispatcher(auth=auth)
     r = await d._handle_auth_resend_code({"phone": "+1"})
-    assert r["phone_code_hash"] == "h2"
-    assert r["phone"] == "+1"
+    assert r["result"]["phone_code_hash"] == "h2"
+    assert r["result"]["phone"] == "+1"
 
 
 # --- _handle_auth_verify_code: first account is_primary ---
@@ -947,16 +948,44 @@ async def test_auth_verify_code_first_account_primary():
     auth.verify_code = AsyncMock(return_value="session_new")
     db = _mock_db()
     pool = _mock_pool()
-    # First call returns empty (for add_account logic), second call returns the
-    # newly added account (for _handle_accounts_connect which looks it up).
     new_account = Account(id=2, phone="+1", session_string="session_new", is_primary=True)
-    db.get_accounts = AsyncMock(side_effect=[[], [new_account]])
+    db.get_account_summaries = AsyncMock(return_value=[])
+    db.get_live_usable_accounts = AsyncMock(return_value=[new_account])
+    db.get_accounts = AsyncMock(side_effect=AssertionError("auth verify must not decrypt unrelated sessions"))
     pool.get_client_by_phone = AsyncMock(return_value=None)
     d = _dispatcher(db=db, pool=pool, auth=auth)
     r = await d._handle_auth_verify_code({"phone": "+1", "code": "123", "phone_code_hash": "h"})
     add_call = db.add_account.call_args
     assert add_call[0][0].is_primary is True
     assert r["result"]["phone"] == "+1"
+
+
+async def test_auth_verify_code_uses_summaries_when_unrelated_session_degraded():
+    auth = MagicMock(is_configured=True)
+    auth.verify_code = AsyncMock(return_value="session_new")
+    db = _mock_db()
+    pool = _mock_pool()
+    db.get_account_summaries = AsyncMock(
+        return_value=[
+            AccountSummary(
+                id=1,
+                phone="+bad",
+                session_status=AccountSessionStatus.DECRYPT_FAILED,
+            )
+        ]
+    )
+    db.get_live_usable_accounts = AsyncMock(
+        return_value=[Account(id=2, phone="+1", session_string="session_new")]
+    )
+    db.get_accounts = AsyncMock(side_effect=AssertionError("must not decrypt summaries"))
+    pool.get_client_by_phone = AsyncMock(return_value=None)
+    d = _dispatcher(db=db, pool=pool, auth=auth)
+
+    await d._handle_auth_verify_code({"phone": "+1", "code": "123", "phone_code_hash": "h"})
+
+    add_call = db.add_account.call_args
+    assert add_call[0][0].is_primary is False
+    db.get_accounts.assert_not_awaited()
 
 
 # --- _handle_auth_verify_code: with 2fa password ---
@@ -968,7 +997,9 @@ async def test_auth_verify_code_with_2fa():
     db = _mock_db()
     pool = _mock_pool()
     new_account = Account(id=2, phone="+1", session_string="session_2fa", is_primary=True)
-    db.get_accounts = AsyncMock(side_effect=[[], [new_account]])
+    db.get_account_summaries = AsyncMock(return_value=[])
+    db.get_live_usable_accounts = AsyncMock(return_value=[new_account])
+    db.get_accounts = AsyncMock(side_effect=AssertionError("auth verify must not decrypt unrelated sessions"))
     pool.get_client_by_phone = AsyncMock(return_value=None)
     d = _dispatcher(db=db, pool=pool, auth=auth)
     r = await d._handle_auth_verify_code({


### PR DESCRIPTION
## Summary
- add a safe live-account loader so runtime paths can skip degraded sessions without decrypting unrelated accounts
- add explicit auth operation timeouts/logging and surface slow pending auth commands in the login UI
- let worker startup continue and retry Telegram pool initialization when sessions are degraded or no clients connect

## Tests
- python3 -m ruff check src/ tests/ conftest.py
- python3 -m pytest tests/test_auth.py tests/routes/test_auth_routes.py tests/test_bootstrap.py tests/test_client_pool.py tests/repositories/test_accounts_repository.py tests/test_telegram_command_dispatcher.py -q
- python3 -m pytest tests/ -v