### PR TITLE
fix(collector): defer queue when no clients

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 from src.database import Database
 from src.database.bundles import ChannelBundle
@@ -23,9 +23,11 @@ class CollectionQueue:
     # How often the worker re-checks the DB for new PENDING channel-collect tasks
     # written by the web container in split / embedded-worker setups (#491 follow-up).
     DB_PULL_INTERVAL_SEC = 3.0
+    NO_CLIENTS_RETRY_DELAY_SEC = 120
     GRACEFUL_SHUTDOWN_TIMEOUT_SEC = 120.0
     FORCE_CANCEL_TIMEOUT_SEC = 10.0
     SHUTDOWN_REQUEUE_NOTE = "Остановка сервиса во время сбора; задача будет продолжена после запуска."
+    NO_CLIENTS_REQUEUE_NOTE = "Отложено: нет подключённых активных аккаунтов для сбора."
 
     def __init__(self, collector: Collector, channels: ChannelBundle | Database):
         self._collector = collector
@@ -227,6 +229,7 @@ class CollectionQueue:
                 self._queue.task_done()
                 continue
 
+            stop_after_no_clients = False
             try:
                 self._current_task_id = task_id
                 await self._channels.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
@@ -316,17 +319,27 @@ class CollectionQueue:
                     channel.channel_id,
                     run_after.isoformat(),
                 )
-            except NoActiveCollectionClientsError as exc:
-                self._retried_tasks.discard(task_id)
-                await self._channels.update_collection_task(
-                    task_id,
-                    CollectionTaskStatus.FAILED,
-                    error=str(exc)[:500],
-                    note="Нет подключённых активных аккаунтов для сбора.",
+            except NoActiveCollectionClientsError:
+                run_after = datetime.now(timezone.utc) + timedelta(
+                    seconds=self.NO_CLIENTS_RETRY_DELAY_SEC
                 )
-                logger.error(
-                    "Collection failed for channel %d: no active connected clients",
+                self._retried_tasks.discard(task_id)
+                await self._channels.reschedule_collection_task(
+                    task_id,
+                    run_after=run_after,
+                    note=self.NO_CLIENTS_REQUEUE_NOTE,
+                )
+                drained_task_ids = self._drain_memory_queue()
+                for drained_task_id in drained_task_ids:
+                    self._known_task_ids.discard(drained_task_id)
+                stop_after_no_clients = True
+                logger.warning(
+                    "Deferred collection task %d for channel %d until %s: no active connected clients; "
+                    "left %d queued task(s) pending in DB",
+                    task_id,
                     channel.channel_id,
+                    run_after.isoformat(),
+                    len(drained_task_ids),
                 )
             except ConnectionError as exc:
                 requeued = await self._try_reconnect_and_requeue(task_id, channel, full, force, exc)
@@ -352,6 +365,8 @@ class CollectionQueue:
                 self._current_task_id = None
                 self._known_task_ids.discard(task_id)
                 self._queue.task_done()
+                if stop_after_no_clients:
+                    break
 
     async def _reset_task_to_pending_after_shutdown(self, task_id: int) -> None:
         reset = getattr(self._channels, "reset_collection_task_to_pending", None)
@@ -404,6 +419,17 @@ class CollectionQueue:
         `_known_task_ids` so tasks already sitting in the queue or scheduled
         for delayed requeue are not pushed twice.
         """
+        availability_getter = getattr(self._collector, "get_collection_availability", None)
+        if callable(availability_getter):
+            availability = availability_getter()
+            if asyncio.iscoroutine(availability):
+                availability = await availability
+            if getattr(availability, "state", None) == "no_connected_active":
+                logger.warning(
+                    "[collection-queue] Pending-task ingest throttled: no active connected clients"
+                )
+                return 0
+
         pending = await self._channels.get_pending_channel_tasks()
         count = 0
         for task in pending:
@@ -505,15 +531,15 @@ class CollectionQueue:
             except asyncio.TimeoutError:
                 continue
 
-    def _drain_memory_queue(self) -> int:
-        drained = 0
+    def _drain_memory_queue(self) -> set[int]:
+        drained: set[int] = set()
         while True:
             try:
-                self._queue.get_nowait()
+                queued_task_id, *_ = self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
             self._queue.task_done()
-            drained += 1
+            drained.add(queued_task_id)
         return drained
 
     async def _cancel_delayed_requeues(self) -> None:
@@ -576,7 +602,7 @@ class CollectionQueue:
         if drained:
             logger.info(
                 "Left %d queued collection task(s) pending in DB for the next worker start",
-                drained,
+                len(drained),
             )
         if self._current_task_id is not None:
             try:

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -67,6 +67,38 @@ def _compute_load_level(
     return "ok"
 
 
+def _current_status_presentation(state: str, *, is_running: bool) -> tuple[str, str, str]:
+    if state == "worker_down":
+        return "Telegram-воркер не запущен", "Задачи копятся в БД, но воркер их не исполняет.", "danger"
+    if state == "all_flooded":
+        return "Все аккаунты во Flood Wait", "Сбор заблокирован до ближайшего окна доступности.", "danger"
+    if state == "no_clients":
+        return "Нет доступных клиентов", "Нет подключенного активного Telegram-аккаунта для сбора.", "danger"
+    if state == "session_degraded":
+        return "SESSION_ENCRYPTION_KEY не подходит", "Активные сессии не расшифровываются текущим ключом.", "danger"
+    if state == "degraded":
+        return "Частичная деградация", "Часть аккаунтов временно ограничена, но сбор может продолжаться.", "warning"
+    if is_running:
+        return "Сбор идёт", "Коллектор выполняет текущую задачу.", "success"
+    return "Коллектор ждёт", "Блокеров сбора сейчас нет.", "success"
+
+
+def _load_presentation(load_level: str) -> tuple[str, str]:
+    if load_level == "overload":
+        return "Риск перегрузки", "warning"
+    if load_level == "high":
+        return "Высокая нагрузка", "warning"
+    return "Нагрузка в норме", "success"
+
+
+def _collector_health_border_severity(*, state: str, load_level: str) -> str:
+    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
+        return "danger"
+    if state == "degraded" or load_level in {"high", "overload"}:
+        return "warning"
+    return "success"
+
+
 def _collector_health_recommendations(
     *,
     state: str,
@@ -74,6 +106,8 @@ def _collector_health_recommendations(
     interval_minutes: int,
     active_unfiltered_channels: int,
     available_accounts_now: int,
+    is_running: bool = False,
+    pending_count: int = 0,
 ) -> list[str]:
     recommendations: list[str] = []
     if state == "worker_down":
@@ -100,7 +134,46 @@ def _collector_health_recommendations(
         )
     if available_accounts_now <= 1:
         recommendations.append("Добавить ещё Telegram-аккаунты, чтобы распределить нагрузку по чтению.")
+    if is_running and pending_count > 0:
+        recommendations.append(
+            "Дождаться завершения текущего первичного сбора; "
+            "не запускать collect-all вручную, пока очередь не разгребётся."
+        )
     return recommendations
+
+
+def _dedupe_recent_unavailability_events(recent_tasks) -> list[dict[str, object]]:
+    events: dict[str, dict[str, object]] = {}
+    for task in recent_tasks:
+        message = ""
+        if task.note and "Flood Wait" in task.note:
+            message = task.note
+        elif task.note and "нет подключённых активных аккаунтов" in task.note:
+            message = task.note
+        elif task.error and "No active connected clients" in task.error:
+            message = task.error
+        if not message:
+            continue
+        item = events.setdefault(message, {"message": message, "count": 0, "latest_at": None})
+        item["count"] = int(item["count"]) + 1
+        occurred_at = _as_utc_datetime(task.completed_at or task.started_at or task.created_at)
+        if occurred_at is not None:
+            latest_at = item["latest_at"]
+            if latest_at is None or occurred_at > latest_at:
+                item["latest_at"] = occurred_at
+    return sorted(
+        events.values(),
+        key=lambda item: item["latest_at"] or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )[:5]
+
+
+def _as_utc_datetime(value) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 async def _worker_status(db) -> tuple[bool, str]:
@@ -190,11 +263,16 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         and task.status == "completed"
         and task.messages_collected == 0
     )
-    recent_unavailability_events = [
-        task.note or task.error or ""
-        for task in recent_tasks
-        if (task.note and "Flood Wait" in task.note) or (task.error and "No active connected clients" in task.error)
-    ][:5]
+    recent_unavailability_events = _dedupe_recent_unavailability_events(recent_tasks)
+    pending_channel_tasks = await db.get_pending_channel_tasks()
+    running_task = next(
+        (
+            task
+            for task in recent_tasks
+            if task.task_type.value == "channel_collect" and task.status.value == "running"
+        ),
+        None,
+    )
 
     state = "healthy"
     if not worker_alive:
@@ -216,6 +294,20 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         active_unfiltered_channels=active_unfiltered_channels,
         available_accounts_now=available_accounts_now,
         state=state,
+    )
+    current_status_label, current_status_detail, current_status_severity = _current_status_presentation(
+        state, is_running=collector.is_running
+    )
+    load_label, load_severity = _load_presentation(load_level)
+    capacity_accounts = max(1, available_accounts_now)
+    channels_per_account = active_unfiltered_channels // capacity_accounts
+    capacity_label = (
+        f"{active_unfiltered_channels} каналов на {capacity_accounts} "
+        f"{'аккаунт' if capacity_accounts == 1 else 'аккаунта'}, интервал {interval_minutes} мин"
+    )
+    capacity_detail = (
+        f"Около {channels_per_account} каналов на доступный аккаунт; "
+        f"в очереди {len(pending_channel_tasks)} задач."
     )
     # Compute retry_after_sec from next_available_at if available
     computed_retry_after_sec = availability_retry_after
@@ -243,7 +335,20 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
             interval_minutes=interval_minutes,
             active_unfiltered_channels=active_unfiltered_channels,
             available_accounts_now=available_accounts_now,
+            is_running=collector.is_running,
+            pending_count=len(pending_channel_tasks),
         ),
+        "current_status_label": current_status_label,
+        "current_status_detail": current_status_detail,
+        "current_status_severity": current_status_severity,
+        "health_border_severity": _collector_health_border_severity(state=state, load_level=load_level),
+        "load_label": load_label,
+        "load_severity": load_severity,
+        "capacity_label": capacity_label,
+        "capacity_detail": capacity_detail,
+        "queue_pending_count": len(pending_channel_tasks),
+        "running_task_title": running_task.channel_title if running_task else "",
+        "running_task_messages_collected": running_task.messages_collected if running_task else 0,
         "recent_zero_collect_count": recent_zero_collect_count,
         "recent_unavailability_events": recent_unavailability_events,
         "is_running": collector.is_running,

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -73,24 +73,12 @@
 </div>
 
 {% if collector_health.state != 'healthy' or collector_health.load_level != 'ok' %}
-<div class="card mb-4 border-{% if collector_health.state in ['worker_down', 'all_flooded', 'no_clients', 'session_degraded'] or collector_health.load_level == 'overload' %}danger{% else %}warning{% endif %}">
+<div class="card mb-4 border-{{ collector_health.health_border_severity }}">
     <div class="card-header fw-semibold">
         Здоровье коллектора
-        {% if collector_health.state == 'worker_down' %}
-        <span class="badge text-bg-danger ms-2">Telegram-воркер не запущен</span>
-        {% elif collector_health.state == 'all_flooded' %}
-        <span class="badge text-bg-danger ms-2">Все аккаунты во Flood Wait</span>
-        {% elif collector_health.state == 'no_clients' %}
-        <span class="badge text-bg-danger ms-2">Нет доступных клиентов</span>
-        {% elif collector_health.state == 'session_degraded' %}
-        <span class="badge text-bg-danger ms-2">SESSION_ENCRYPTION_KEY не подходит</span>
-        {% elif collector_health.state == 'degraded' %}
-        <span class="badge text-bg-warning ms-2">Частичная деградация</span>
-        {% endif %}
-        {% if collector_health.load_level == 'overload' %}
-        <span class="badge text-bg-danger ms-1">Перегрузка</span>
-        {% elif collector_health.load_level == 'high' %}
-        <span class="badge text-bg-warning ms-1">Высокая нагрузка</span>
+        <span class="badge text-bg-{{ collector_health.current_status_severity }} ms-2">{{ collector_health.current_status_label }}</span>
+        {% if collector_health.load_level != 'ok' %}
+        <span class="badge text-bg-{{ collector_health.load_severity }} ms-1">{{ collector_health.load_label }}</span>
         {% endif %}
     </div>
     <div class="card-body">
@@ -102,6 +90,16 @@
                 {% if collector_health.session_degraded_accounts %}
                 <div><strong>{{ collector_health.session_degraded_accounts }}</strong> требуют ключ</div>
                 {% endif %}
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Очередь</div>
+                <div><strong>{{ collector_health.queue_pending_count }}</strong> ожидает</div>
+                <div class="small">{{ collector_health.current_status_detail }}</div>
+            </div>
+            <div class="col-6 col-md-3">
+                <div class="small text-muted">Нагрузка</div>
+                <div><strong>{{ collector_health.active_unfiltered_channels }}</strong> активных каналов</div>
+                <div class="small">{{ collector_health.capacity_label }}</div>
             </div>
             <div class="col-6 col-md-3">
                 <div class="small text-muted">Flood Wait</div>
@@ -117,17 +115,11 @@
                 </div>
                 {% endif %}
             </div>
-            <div class="col-6 col-md-3">
-                <div class="small text-muted">Нагрузка</div>
-                <div><strong>{{ collector_health.active_unfiltered_channels }}</strong> активных каналов</div>
-                <div class="small">Интервал: {{ collector_health.collect_interval_minutes }} мин</div>
-            </div>
-            <div class="col-6 col-md-3">
-                <div class="small text-muted">Симптом</div>
-                <div><strong>{{ collector_health.recent_zero_collect_count }}</strong> недавних задач с нулевым результатом</div>
-                <div class="small">{% if collector_health.is_running %}Коллектор занят{% else %}Коллектор ждёт{% endif %}</div>
-            </div>
         </div>
+
+        {% if collector_health.is_running and collector_health.running_task_title %}
+        <p class="mb-2"><strong>Сейчас собирается:</strong> {{ collector_health.running_task_title }}, собрано {{ collector_health.running_task_messages_collected }} сообщений; остальные задачи ждут.</p>
+        {% endif %}
 
         {% if collector_health.state == 'worker_down' %}
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> веб-процесс принимает задачи и пишет их в БД, но Telegram-коннекты держит отдельный воркер-процесс — он сейчас не запущен (нет свежего heartbeat в <code>runtime_snapshots</code>). Задачи из <code>collection_tasks</code> копятся в статусе <em>pending</em>, но никто их не исполняет.</p>
@@ -142,7 +134,7 @@
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> активные Telegram-сессии сохранены, но не расшифровываются текущим <code>SESSION_ENCRYPTION_KEY</code>. Live-операции заблокированы до восстановления ключа или повторного входа.</p>
         {% endif %}
 
-        {% if collector_health.flooded_accounts %}
+        {% if collector_health.state == 'all_flooded' and collector_health.flooded_accounts %}
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> доступных аккаунтов нет или их недостаточно. Flood Wait активен для:
         {% for item in collector_health.flooded_accounts %}
             <code>{{ item.phone }}</code>{% if not loop.last %}, {% endif %}
@@ -160,10 +152,10 @@
         {% endif %}
 
         {% if collector_health.recent_unavailability_events %}
-        <p class="mb-1"><strong>Последние причины недоступности:</strong></p>
+        <p class="mb-1"><strong>Недавние события недоступности:</strong></p>
         <ul class="mb-0">
             {% for item in collector_health.recent_unavailability_events %}
-            <li><small>{{ item }}</small></li>
+            <li><small>{{ item["message"] }}{% if item["count"] > 1 %} ×{{ item["count"] }}{% endif %}</small></li>
             {% endfor %}
         </ul>
         {% endif %}

--- a/tests/e2e/test_collection_flow.py
+++ b/tests/e2e/test_collection_flow.py
@@ -21,6 +21,7 @@ import asyncio
 import base64
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -150,6 +151,9 @@ async def test_trigger_collection_persists_messages_via_embedded_worker(tmp_path
     with patch(
         "src.telegram.collector.Collector.collect_single_channel",
         new=_fake_collect_single_channel,
+    ), patch(
+        "src.telegram.collector.Collector.get_collection_availability",
+        return_value=SimpleNamespace(state="available"),
     ):
         async with _serve_app(tmp_path, embed_worker=True) as (client, config):
             resp = await client.post("/scheduler/trigger")

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -239,6 +239,61 @@ async def test_scheduler_shows_collector_health_card_when_all_accounts_flooded(c
 
 
 @pytest.mark.anyio
+async def test_scheduler_overload_running_is_warning_not_flood_blocker(client):
+    db = client._transport.app.state.db
+    pool = client._transport.app.state.pool
+    collector = client._transport.app.state.collector
+    scheduler = client._transport.app.state.scheduler
+    pool.clients = {"+1234567890": MagicMock()}
+    collector._running = True
+    scheduler.update_interval(15)
+    for i in range(101, 317):
+        await db.add_channel(Channel(channel_id=i, title=f"Channel {i}"))
+    task_id = await db.create_collection_task(channel_id=100, channel_title="Running Channel")
+    await db.update_collection_task(task_id, CollectionTaskStatus.RUNNING, messages_collected=12)
+    old_note = "Flood Wait: account +1234567890 unavailable"
+    for i in range(2):
+        old_task_id = await db.create_collection_task(channel_id=200 + i, channel_title=f"Old {i}")
+        await db.update_collection_task(old_task_id, CollectionTaskStatus.COMPLETED, note=old_note)
+
+    resp = await client.get("/scheduler/")
+
+    assert resp.status_code == 200
+    assert "Риск перегрузки" in resp.text
+    assert "border-warning" in resp.text
+    assert "border-danger" not in resp.text
+    assert "Сейчас собирается:" in resp.text
+    assert "Running Channel" in resp.text
+    assert "собрано 12 сообщений" in resp.text
+    assert "Недавние события недоступности" in resp.text
+    assert "×2" in resp.text
+    active_flood_reason = (
+        "Почему сейчас не собираем:</strong> доступных аккаунтов нет или их недостаточно. Flood Wait активен"
+    )
+    assert active_flood_reason not in resp.text
+
+
+@pytest.mark.anyio
+async def test_scheduler_all_flooded_keeps_danger_current_reason(client):
+    db = client._transport.app.state.db
+    pool = client._transport.app.state.pool
+    pool.clients = {"+1234567890": MagicMock()}
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    for acc in await db.get_accounts(active_only=False):
+        await db.update_account_flood(acc.phone, future)
+
+    resp = await client.get("/scheduler/")
+
+    assert resp.status_code == 200
+    assert "border-danger" in resp.text
+    assert "Все аккаунты во Flood Wait" in resp.text
+    active_flood_reason = (
+        "Почему сейчас не собираем:</strong> доступных аккаунтов нет или их недостаточно. Flood Wait активен"
+    )
+    assert active_flood_reason in resp.text
+
+
+@pytest.mark.anyio
 async def test_scheduler_shows_interval(client):
     """Test scheduler page shows collection interval."""
     resp = await client.get("/scheduler/")

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -32,6 +32,19 @@ class _FakeCollector:
         return None
 
 
+class _NoClientsCollector(_FakeCollector):
+    async def get_collection_availability(self):
+        return type(
+            "Availability",
+            (),
+            {
+                "state": "no_connected_active",
+                "retry_after_sec": None,
+                "next_available_at_utc": None,
+            },
+        )()
+
+
 class _UsernameResolveFloodCollector(_FakeCollector):
     def __init__(self, next_available_at: datetime):
         super().__init__()
@@ -107,6 +120,30 @@ async def test_db_pull_picks_up_pending_task_added_after_startup(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_db_pull_does_not_ingest_when_no_clients(tmp_path, caplog):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+
+        collector = _NoClientsCollector()
+        queue = CollectionQueue(collector, db)
+        task_id = await _create_pending_task(db)
+
+        caplog.set_level(logging.WARNING, logger="src.collection_queue")
+        assert await queue._ingest_pending_tasks() == 0
+
+        task = await db.get_collection_task(task_id)
+        assert task.status == "pending"
+        assert collector.calls == []
+        assert queue._known_task_ids == set()
+        assert "Pending-task ingest throttled" in caplog.text
+    finally:
+        await queue.shutdown()
+        await db.close()
+
+
+@pytest.mark.anyio
 async def test_username_resolve_flood_defer_keeps_task_pending(tmp_path):
     db = Database(str(tmp_path / "queue.db"))
     await db.initialize()
@@ -132,7 +169,6 @@ async def test_username_resolve_flood_defer_keeps_task_pending(tmp_path):
         assert task.run_after is not None
         assert task.run_after > next_available_at
         assert "Flood Wait на resolve_username" in (task.note or "")
-        assert task.run_after.astimezone(timezone.utc).isoformat() in (task.note or "")
     finally:
         await queue.shutdown()
         await db.close()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1306,9 +1306,10 @@ async def test_collection_queue_fails_when_no_active_clients(db):
 
     task = await db.get_collection_task(task_id)
     assert task is not None
-    assert task.status == CollectionTaskStatus.FAILED
-    assert task.error == "No active connected clients"
-    assert task.note == "Нет подключённых активных аккаунтов для сбора."
+    assert task.status == CollectionTaskStatus.PENDING
+    assert task.error is None
+    assert task.note == "Отложено: нет подключённых активных аккаунтов для сбора."
+    assert task.run_after is not None
 
     await queue.shutdown()
 
@@ -1337,8 +1338,10 @@ async def test_requeue_startup_tasks(db):
     await asyncio.sleep(0.5)
 
     task = await db.get_collection_task(task_id)
-    # Task was picked up: either completed (0 messages) or failed
-    assert task.status in ("completed", "failed")
+    # Task was picked up but deferred because no client is currently connected.
+    assert task.status == CollectionTaskStatus.PENDING
+    assert task.note == "Отложено: нет подключённых активных аккаунтов для сбора."
+    assert task.run_after is not None
 
     await queue.shutdown()
 

--- a/tests/test_web_scheduler_helpers.py
+++ b/tests/test_web_scheduler_helpers.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from src.web.routes.scheduler import (
+    _collector_health_border_severity,
     _collector_health_recommendations,
     _compute_load_level,
+    _dedupe_recent_unavailability_events,
     _format_retry_hint,
     _job_label,
 )
@@ -51,6 +54,30 @@ def test_format_retry_hint_datetime():
     assert "UTC" in result
 
 
+def test_dedupe_recent_unavailability_events_handles_mixed_timezone_datetimes():
+    events = _dedupe_recent_unavailability_events(
+        [
+            SimpleNamespace(
+                note="Отложено: нет подключённых активных аккаунтов для сбора.",
+                error=None,
+                completed_at=None,
+                started_at=None,
+                created_at=datetime(2026, 5, 2, 17, 10, 24),
+            ),
+            SimpleNamespace(
+                note="Отложено: все аккаунты во Flood Wait до 2026-05-02T17:12:00+00:00",
+                error=None,
+                completed_at=datetime(2026, 5, 2, 17, 10, 25, tzinfo=timezone.utc),
+                started_at=None,
+                created_at=datetime(2026, 5, 2, 17, 10, 24),
+            ),
+        ]
+    )
+
+    assert len(events) == 2
+    assert events[0]["latest_at"].tzinfo is not None
+
+
 # --- _compute_load_level ---
 
 
@@ -94,6 +121,24 @@ def test_compute_load_ok():
         interval_minutes=60, active_unfiltered_channels=10,
         available_accounts_now=5, state="healthy",
     ) == "ok"
+
+
+def test_collector_health_overload_while_healthy_is_warning():
+    assert _compute_load_level(
+        interval_minutes=15,
+        active_unfiltered_channels=216,
+        available_accounts_now=1,
+        state="healthy",
+    ) == "overload"
+    assert _collector_health_border_severity(state="healthy", load_level="overload") == "warning"
+
+
+def test_collector_health_all_flooded_is_danger():
+    assert _collector_health_border_severity(state="all_flooded", load_level="overload") == "danger"
+
+
+def test_collector_health_worker_down_is_danger():
+    assert _collector_health_border_severity(state="worker_down", load_level="overload") == "danger"
 
 
 # --- _collector_health_recommendations ---


### PR DESCRIPTION
## Summary
- keep collection tasks pending and reschedule them when no active Telegram clients are connected
- throttle DB pending-task ingest while collection availability reports no connected active clients
- expand scheduler health UI with queue, capacity, running-task, and deduped unavailability context

## Tests
- python3 -m ruff check src/ tests/ conftest.py
- python3 -m pytest tests/e2e/test_collection_flow.py::test_trigger_collection_persists_messages_via_embedded_worker tests/test_collector.py::test_collection_queue_fails_when_no_active_clients tests/test_collector.py::test_requeue_startup_tasks tests/test_collection_queue_db_pull.py tests/routes/test_scheduler_routes.py tests/test_web_scheduler_helpers.py -q
- python3 -m pytest tests/ -v