### PR TITLE
[codex] Centralize Telegram action contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Ruff
         run: ruff check src tests conftest.py
 
+      - name: Import architecture contracts
+        run: lint-imports --config .importlinter
+
       - name: Enforce pytest warnings as errors
         run: |
           python - <<'PY'

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,18 @@
+[importlinter]
+root_package = src
+include_external_packages = True
+
+[importlinter:contract:telegram_actions_no_raw_telethon_functions_in_entrypoints]
+name = Telegram entrypoints do not import Telethon directly outside allowed pipeline errors
+type = forbidden
+source_modules =
+    src.cli
+    src.web
+    src.agent.tools
+    src.services.pipeline_nodes
+    src.services.telegram_command_dispatcher
+forbidden_modules =
+    telethon
+allow_indirect_imports = True
+ignore_imports =
+    src.services.pipeline_nodes.handlers -> telethon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "import-linter>=2.0",
+]
 docs = ["mkdocs-material>=9.5"]
 
 [project.urls]

--- a/src/agent/tools/dialogs.py
+++ b/src/agent/tools/dialogs.py
@@ -21,6 +21,7 @@ from src.agent.tools._registry import (
     resolve_phone,
 )
 from src.parsers import normalize_identifier
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 
 logger = logging.getLogger(__name__)
 
@@ -211,13 +212,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            from src.services.channel_service import ChannelService
-
-            svc = ChannelService(db, client_pool, None)
             dialog_ids = [(int(x.strip()), "") for x in dialog_ids_str.split(",") if x.strip()]
-            results = await svc.leave_dialogs(phone, dialog_ids)
-            success = sum(1 for v in results.values() if v)
-            return _text_response(f"Выход завершён: {success}/{len(results)} диалогов покинуты.")
+            result = await TelegramActionService(client_pool).leave_dialogs(
+                phone=phone,
+                dialogs=dialog_ids,
+            )
+            return _text_response(
+                f"Выход завершён: {result.success_count}/{len(result.results)} диалогов покинуты."
+            )
         except Exception as e:
             return _text_response(f"Ошибка выхода из диалогов: {e}")
 
@@ -254,30 +256,23 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             about = args.get("about", "")
             username = args.get("username", "")
-            result = await client_pool.get_native_client_by_phone(phone)
-            if result is None:
-                return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-            client, _ = result
-            from telethon.tl.functions.channels import CreateChannelRequest
-
-            result = await client(CreateChannelRequest(
+            result = await TelegramActionService(client_pool).create_channel(
+                phone=phone,
                 title=title,
                 about=about,
-                broadcast=True,
-            ))
-            channel = result.chats[0]
+                username=username,
+            )
             username_note = ""
             if username:
-                try:
-                    from telethon.tl.functions.channels import UpdateUsernameRequest
-
-                    await client(UpdateUsernameRequest(channel, username))
+                if result.channel_username == username:
                     username_note = f"\n- Username: @{username}"
-                except Exception as ue:
-                    username_note = f"\n- Username: не удалось установить ({ue})"
+                elif result.username_error:
+                    username_note = f"\n- Username: не удалось установить ({result.username_error})"
             return _text_response(
-                f"Канал создан!\n- ID: {channel.id}\n- Title: {title}{username_note}"
+                f"Канал создан!\n- ID: {result.channel_id}\n- Title: {title}{username_note}"
             )
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка создания канала: {e}")
 

--- a/src/agent/tools/messaging_admin.py
+++ b/src/agent/tools/messaging_admin.py
@@ -5,7 +5,7 @@ from typing import Any
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, arg_str, require_confirmation, resolve_entity
+from src.agent.tools._registry import _text_response, arg_str, require_confirmation
 from src.agent.tools._telegram_runtime import prepare_telegram_tool
 from src.agent.tools.messaging_schemas import (
     EDIT_ADMIN_SCHEMA,
@@ -13,6 +13,7 @@ from src.agent.tools.messaging_schemas import (
     GET_PARTICIPANTS_SCHEMA,
     KICK_PARTICIPANT_SCHEMA,
 )
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 from src.utils.datetime import parse_datetime
 
 
@@ -41,10 +42,13 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            participants = await client.get_participants(entity, limit=limit, search=search)
+            result = await TelegramActionService(client_pool).get_participants(
+                phone=phone,
+                chat_id=chat_id,
+                limit=limit,
+                search=search,
+            )
+            participants = result.participants
             if not participants:
                 return _text_response("Участники не найдены.")
             lines = [f"Участники {chat_id} ({len(participants)}):"]
@@ -61,6 +65,8 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
                 username = f" (@{p.username})" if getattr(p, "username", None) else ""
                 lines.append(f"  {p.id}: {name}{username}")
             return _text_response("\n".join(lines))
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка получения участников: {e}")
 
@@ -93,17 +99,16 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
-            if err:
-                return err
-            kwargs = {"is_admin": is_admin}
-            if title:
-                kwargs["title"] = title
-            await client.edit_admin(entity, user, **kwargs)
+            await TelegramActionService(client_pool).edit_admin(
+                phone=phone,
+                chat_id=chat_id,
+                user_id=user_id,
+                is_admin=is_admin,
+                title=title,
+            )
             return _text_response(f"Права администратора обновлены для {user_id} в {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка изменения прав администратора: {e}")
 
@@ -138,19 +143,17 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
-            if err:
-                return err
-            kwargs = {"until_date": parse_datetime(until_date_str)}
-            if send_messages is not None:
-                kwargs["send_messages"] = send_messages
-            if send_media is not None:
-                kwargs["send_media"] = send_media
-            await client.edit_permissions(entity, user, **kwargs)
+            await TelegramActionService(client_pool).edit_permissions(
+                phone=phone,
+                chat_id=chat_id,
+                user_id=user_id,
+                until_date=parse_datetime(until_date_str),
+                send_messages=send_messages,
+                send_media=send_media,
+            )
             return _text_response(f"Ограничения обновлены для {user_id} в {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка изменения ограничений: {e}")
 
@@ -180,14 +183,14 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            _, user, err = await resolve_entity(client_pool, phone, user_id, is_user=True)
-            if err:
-                return err
-            await client.kick_participant(entity, user)
+            await TelegramActionService(client_pool).kick_participant(
+                phone=phone,
+                chat_id=chat_id,
+                user_id=user_id,
+            )
             return _text_response(f"{user_id} исключён из {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка исключения участника: {e}")
 

--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -15,6 +15,7 @@ from src.agent.tools.messaging_schemas import (
     READ_MESSAGES_SCHEMA,
     UNARCHIVE_CHAT_SCHEMA,
 )
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.identity import extract_message_sender_identity
 
@@ -42,10 +43,11 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            stats = await client.get_broadcast_stats(entity)
+            result = await TelegramActionService(client_pool).get_broadcast_stats(
+                phone=phone,
+                chat_id=chat_id,
+            )
+            stats = result.stats
             fields = {}
             for attr in ("followers", "views_per_post", "shares_per_post", "reactions_per_post", "forwards_per_post"):
                 val = getattr(stats, attr, None)
@@ -70,6 +72,8 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
             for k, v in fields.items():
                 lines.append(f"  {k}: {v}")
             return _text_response("\n".join(lines))
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка получения статистики: {e}")
 
@@ -98,11 +102,14 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.edit_folder(entity, 1)
+            await TelegramActionService(client_pool).set_dialog_folder(
+                phone=phone,
+                chat_id=chat_id,
+                folder_id=1,
+            )
             return _text_response(f"Чат {chat_id} архивирован.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка архивирования: {e}")
 
@@ -131,11 +138,14 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.edit_folder(entity, 0)
+            await TelegramActionService(client_pool).set_dialog_folder(
+                phone=phone,
+                chat_id=chat_id,
+                folder_id=0,
+            )
             return _text_response(f"Чат {chat_id} разархивирован.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка разархивирования: {e}")
 
@@ -162,11 +172,14 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.send_read_acknowledge(entity, max_id=max_id)
+            await TelegramActionService(client_pool).mark_read(
+                phone=phone,
+                chat_id=chat_id,
+                max_id=max_id,
+            )
             return _text_response(f"Сообщения отмечены как прочитанные в {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка отметки сообщений: {e}")
 

--- a/src/agent/tools/messaging_media.py
+++ b/src/agent/tools/messaging_media.py
@@ -4,9 +4,16 @@ from typing import Any
 
 from claude_agent_sdk import tool
 
-from src.agent.tools._registry import _text_response, require_confirmation, resolve_entity
+from src.agent.tools._registry import _text_response, require_confirmation
 from src.agent.tools.messaging_schemas import DOWNLOAD_MEDIA_SCHEMA, PIN_MESSAGE_SCHEMA, UNPIN_MESSAGE_SCHEMA
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.services.telegram_actions import (
+    TelegramActionClientUnavailableError,
+    TelegramActionMessageNotFoundError,
+    TelegramActionNoMediaError,
+    TelegramActionPathEscapeError,
+    TelegramActionService,
+)
+from src.telegram.flood_wait import HandledFloodWaitError
 
 
 def register_pin_media_tools(ctx: Any, client_pool: Any) -> list[Any]:
@@ -37,11 +44,15 @@ def register_pin_media_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.pin_message(entity, int(message_id), notify=notify)
+            await TelegramActionService(client_pool).pin_message(
+                phone=phone,
+                chat_id=chat_id,
+                message_id=int(message_id),
+                notify=notify,
+            )
             return _text_response(f"Сообщение #{message_id} закреплено в {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка закрепления сообщения: {e}")
 
@@ -72,11 +83,14 @@ def register_pin_media_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.unpin_message(entity, message_id)
+            await TelegramActionService(client_pool).unpin_message(
+                phone=phone,
+                chat_id=chat_id,
+                message_id=int(message_id) if message_id is not None else None,
+            )
             return _text_response(f"Сообщение(я) откреплено в {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка открепления сообщения: {e}")
 
@@ -105,44 +119,25 @@ def register_pin_media_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if not chat_id or not message_id:
             return _text_response("Ошибка: chat_id и message_id обязательны.")
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            msg = None
-
-            async def _lookup_message() -> None:
-                nonlocal msg
-                async for m in client.iter_messages(entity, ids=int(message_id)):
-                    msg = m
-                    break
-
-            try:
-                await run_with_flood_wait(
-                    _lookup_message(),
-                    operation="agent_download_media_lookup",
-                    phone=phone,
-                    pool=client_pool,
-                )
-            except HandledFloodWaitError as exc:
-                return _text_response(f"Flood wait: {exc.info.detail}")
-            if msg is None:
-                return _text_response(f"Сообщение #{message_id} не найдено.")
             output_dir = pathlib.Path(__file__).resolve().parents[3] / "data" / "downloads"
-            try:
-                path = await run_with_flood_wait(
-                    client.download_media(msg, file=str(output_dir)),
-                    operation="agent_download_media",
-                    phone=phone,
-                    pool=client_pool,
-                )
-            except HandledFloodWaitError as exc:
-                return _text_response(f"Flood wait: {exc.info.detail}")
-            if not path:
-                return _text_response("В сообщении нет медиа.")
-            resolved = pathlib.Path(path).resolve()
-            if not resolved.is_relative_to(output_dir.resolve()):
-                return _text_response("Ошибка: путь загрузки вне допустимой директории.")
-            return _text_response(f"Медиа загружено: {path}")
+            result = await TelegramActionService(client_pool).download_media(
+                phone=phone,
+                chat_id=chat_id,
+                message_id=int(message_id),
+                output_dir=output_dir,
+                operation_prefix="agent_download_media",
+            )
+            return _text_response(f"Медиа загружено: {result.path}")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+        except TelegramActionMessageNotFoundError:
+            return _text_response(f"Сообщение #{message_id} не найдено.")
+        except TelegramActionNoMediaError:
+            return _text_response("В сообщении нет медиа.")
+        except TelegramActionPathEscapeError:
+            return _text_response("Ошибка: путь загрузки вне допустимой директории.")
+        except HandledFloodWaitError as exc:
+            return _text_response(f"Flood wait: {exc.info.detail}")
         except Exception as e:
             return _text_response(f"Ошибка загрузки медиа: {e}")
 

--- a/src/agent/tools/messaging_write.py
+++ b/src/agent/tools/messaging_write.py
@@ -11,7 +11,6 @@ from src.agent.tools._registry import (
     arg_csv_ints,
     arg_str,
     require_confirmation,
-    resolve_entity,
 )
 from src.agent.tools._telegram_runtime import prepare_telegram_tool
 from src.agent.tools.messaging_schemas import (
@@ -20,6 +19,7 @@ from src.agent.tools.messaging_schemas import (
     FORWARD_MESSAGES_SCHEMA,
     SEND_MESSAGE_SCHEMA,
 )
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 
 
 def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
@@ -45,11 +45,14 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, recipient)
-            if err:
-                return err
-            await client.send_message(entity, text)
+            await TelegramActionService(client_pool).send_message(
+                phone=phone,
+                recipient=recipient,
+                text=text,
+            )
             return _text_response(f"Сообщение отправлено: {recipient}")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка отправки сообщения: {e}")
 
@@ -81,11 +84,15 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.edit_message(entity, int(message_id), text)
+            await TelegramActionService(client_pool).edit_message(
+                phone=phone,
+                chat_id=chat_id,
+                message_id=int(message_id),
+                text=text,
+            )
             return _text_response(f"Сообщение #{message_id} отредактировано.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка редактирования сообщения: {e}")
 
@@ -116,11 +123,14 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
-            if err:
-                return err
-            await client.delete_messages(entity, ids)
+            await TelegramActionService(client_pool).delete_messages(
+                phone=phone,
+                chat_id=chat_id,
+                message_ids=ids,
+            )
             return _text_response(f"Удалено {len(ids)} сообщений из чата {chat_id}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка удаления сообщений: {e}")
 
@@ -150,14 +160,15 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            client, from_entity, err = await resolve_entity(client_pool, phone, from_chat)
-            if err:
-                return err
-            _, to_entity, err = await resolve_entity(client_pool, phone, to_chat)
-            if err:
-                return err
-            await client.forward_messages(to_entity, ids, from_entity)
+            await TelegramActionService(client_pool).forward_messages(
+                phone=phone,
+                from_chat=from_chat,
+                to_chat=to_chat,
+                message_ids=ids,
+            )
             return _text_response(f"Переслано {len(ids)} сообщений из {from_chat} в {to_chat}.")
+        except TelegramActionClientUnavailableError:
+            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
         except Exception as e:
             return _text_response(f"Ошибка пересылки сообщений: {e}")
 

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -6,7 +6,13 @@ import time
 
 from src.cli import runtime
 from src.services.channel_service import ChannelService
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.services.telegram_actions import (
+    TelegramActionClientUnavailableError,
+    TelegramActionMessageNotFoundError,
+    TelegramActionNoMediaError,
+    TelegramActionService,
+)
+from src.telegram.flood_wait import HandledFloodWaitError
 from src.utils.datetime import parse_required_datetime
 
 
@@ -124,12 +130,12 @@ def run_with_dependencies(
                         print("Aborted.")
                         return
 
-                results = await svc.leave_dialogs(phone, dialogs)
-                for channel_id, ok in results.items():
+                result = await TelegramActionService(pool).leave_dialogs(phone=phone, dialogs=dialogs)
+                for channel_id, ok in result.results.items():
                     status = "left" if ok else "failed"
                     print(f"  {channel_id}: {status}")
-                left = sum(1 for value in results.values() if value)
-                failed = len(results) - left
+                left = result.success_count
+                failed = result.failed_count
                 print(f"\nDone: {left} left, {failed} failed.")
 
             elif args.dialogs_action == "topics":
@@ -176,15 +182,15 @@ def run_with_dependencies(
                         print("Aborted.")
                         return
 
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(recipient)
-                    await client.send_message(entity, text)
+                    await TelegramActionService(pool).send_message(
+                        phone=phone,
+                        recipient=recipient,
+                        text=text,
+                    )
                     print(f"Message sent to {recipient}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
                 except Exception as exc:
                     print(f"Error sending message: {exc}")
 
@@ -210,16 +216,16 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
-                    return
-                client, _ = result
                 try:
-                    from_entity = await client.get_entity(args.from_chat)
-                    to_entity = await client.get_entity(args.to_chat)
-                    await client.forward_messages(to_entity, ids, from_entity)
+                    await TelegramActionService(pool).forward_messages(
+                        phone=phone,
+                        from_chat=args.from_chat,
+                        to_chat=args.to_chat,
+                        message_ids=ids,
+                    )
                     print(f"Forwarded {len(ids)} message(s) from {args.from_chat} to {args.to_chat}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
                 except Exception as exc:
                     print(f"Error forwarding messages: {exc}")
 
@@ -240,15 +246,16 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.edit_message(entity, args.message_id, args.text)
+                    await TelegramActionService(pool).edit_message(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_id=args.message_id,
+                        text=args.text,
+                    )
                     print(f"Message #{args.message_id} edited.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
                 except Exception as exc:
                     print(f"Error editing message: {exc}")
 
@@ -274,15 +281,15 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.delete_messages(entity, ids)
+                    await TelegramActionService(pool).delete_messages(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_ids=ids,
+                    )
                     print(f"Deleted {len(ids)} message(s).")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable (flood-wait or not connected).")
                 except Exception as exc:
                     print(f"Error deleting messages: {exc}")
 
@@ -308,31 +315,23 @@ def run_with_dependencies(
                             f"{acc.flood_wait_until.isoformat()}."
                         )
                         return
-                native_result = await pool.get_native_client_by_phone(phone)
-                if native_result is None:
-                    print(f"Client for {phone} unavailable (no lease could be acquired).")
-                    return
-                client, acquired_phone = native_result
                 try:
-                    from telethon.tl.functions.messages import SendReactionRequest
-                    from telethon.tl.types import ReactionEmoji
-
-                    entity = await client.get_entity(args.chat_id)
-                    await client(
-                        SendReactionRequest(
-                            peer=entity,
-                            msg_id=args.message_id,
-                            reaction=[ReactionEmoji(emoticon=args.emoji)],
-                        )
+                    result = await TelegramActionService(pool).send_reaction(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_id=args.message_id,
+                        emoji=args.emoji,
+                        native=True,
+                        resolve_entity=True,
                     )
                     print(
                         f"Reaction {args.emoji!r} sent to message #{args.message_id} "
-                        f"in {args.chat_id} (account {acquired_phone})"
+                        f"in {args.chat_id} (account {result.phone})"
                     )
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable (no lease could be acquired).")
                 except Exception as exc:
                     print(f"Error sending reaction: {type(exc).__name__}: {exc}")
-                finally:
-                    await pool.release_client(acquired_phone)
 
             elif args.dialogs_action == "pin-message":
                 accounts = sorted(pool.clients.keys())
@@ -349,15 +348,16 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.pin_message(entity, args.message_id, notify=args.notify)
+                    await TelegramActionService(pool).pin_message(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_id=args.message_id,
+                        notify=args.notify,
+                    )
                     print(f"Message #{args.message_id} pinned.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error pinning message: {exc}")
 
@@ -377,15 +377,15 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.unpin_message(entity, args.message_id)
+                    await TelegramActionService(pool).unpin_message(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_id=args.message_id,
+                    )
                     print("Message(s) unpinned.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error unpinning message: {exc}")
 
@@ -398,50 +398,23 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    message = None
-
-                    async def _lookup_message() -> None:
-                        nonlocal message
-                        async for current_message in client.iter_messages(
-                            entity, ids=args.message_id
-                        ):
-                            message = current_message
-                            break
-
-                    try:
-                        await run_with_flood_wait(
-                            _lookup_message(),
-                            operation="cli_dialogs_download_media_lookup",
-                            phone=phone,
-                            pool=pool,
-                        )
-                    except HandledFloodWaitError as exc:
-                        print(f"Flood wait: {exc.info.detail}")
-                        return
-                    if message is None:
-                        print(f"Message #{args.message_id} not found.")
-                        return
-                    try:
-                        path = await run_with_flood_wait(
-                            client.download_media(message, file=args.output_dir),
-                            operation="cli_dialogs_download_media",
-                            phone=phone,
-                            pool=pool,
-                        )
-                    except HandledFloodWaitError as exc:
-                        print(f"Flood wait: {exc.info.detail}")
-                        return
-                    if path:
-                        print(f"Downloaded: {path}")
-                    else:
-                        print("No media in this message.")
+                    result = await TelegramActionService(pool).download_media(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        message_id=args.message_id,
+                        output_dir=args.output_dir,
+                        operation_prefix="cli_dialogs_download_media",
+                    )
+                    print(f"Downloaded: {result.path}")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
+                except TelegramActionMessageNotFoundError:
+                    print(f"Message #{args.message_id} not found.")
+                except TelegramActionNoMediaError:
+                    print("No media in this message.")
+                except HandledFloodWaitError as exc:
+                    print(f"Flood wait: {exc.info.detail}")
                 except Exception as exc:
                     print(f"Error downloading media: {exc}")
 
@@ -454,18 +427,14 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    participants = await client.get_participants(
-                        entity,
+                    result = await TelegramActionService(pool).get_participants(
+                        phone=phone,
+                        chat_id=args.chat_id,
                         limit=args.limit,
                         search=args.search,
                     )
+                    participants = result.participants
                     if not participants:
                         print("No participants found.")
                         return
@@ -482,6 +451,8 @@ def run_with_dependencies(
                             )
                         )
                     print(f"\nTotal: {len(participants)}")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error fetching participants: {exc}")
 
@@ -500,19 +471,17 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    user = await client.get_entity(args.user_id)
-                    kwargs = {"is_admin": args.is_admin}
-                    if args.title:
-                        kwargs["title"] = args.title
-                    await client.edit_admin(entity, user, **kwargs)
+                    await TelegramActionService(pool).edit_admin(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        user_id=args.user_id,
+                        is_admin=args.is_admin,
+                        title=args.title or None,
+                    )
                     print(f"Admin rights updated for {args.user_id}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error editing admin: {exc}")
 
@@ -531,27 +500,32 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    user = await client.get_entity(args.user_id)
                     if args.send_messages is None and args.send_media is None:
                         print("Error: specify at least one flag (--send-messages or --send-media).")
                         return
                     until_date = None
                     if args.until_date:
                         until_date = parse_required_datetime(args.until_date)
-                    kwargs = {"until_date": until_date}
-                    if args.send_messages is not None:
-                        kwargs["send_messages"] = args.send_messages.lower() in ("1", "true", "on")
-                    if args.send_media is not None:
-                        kwargs["send_media"] = args.send_media.lower() in ("1", "true", "on")
-                    await client.edit_permissions(entity, user, **kwargs)
+                    await TelegramActionService(pool).edit_permissions(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        user_id=args.user_id,
+                        until_date=until_date,
+                        send_messages=(
+                            args.send_messages.lower() in ("1", "true", "on")
+                            if args.send_messages is not None
+                            else None
+                        ),
+                        send_media=(
+                            args.send_media.lower() in ("1", "true", "on")
+                            if args.send_media is not None
+                            else None
+                        ),
+                    )
                     print(f"Permissions updated for {args.user_id}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error editing permissions: {exc}")
 
@@ -570,16 +544,15 @@ def run_with_dependencies(
                     if answer != "y":
                         print("Aborted.")
                         return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    user = await client.get_entity(args.user_id)
-                    await client.kick_participant(entity, user)
+                    await TelegramActionService(pool).kick_participant(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        user_id=args.user_id,
+                    )
                     print(f"{args.user_id} kicked from {args.chat_id}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error kicking participant: {exc}")
 
@@ -592,14 +565,12 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    stats = await client.get_broadcast_stats(entity)
+                    result = await TelegramActionService(pool).get_broadcast_stats(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                    )
+                    stats = result.stats
                     print(f"Broadcast stats for {args.chat_id}:")
                     for attr in (
                         "followers",
@@ -624,6 +595,8 @@ def run_with_dependencies(
                     enabled_notifications = getattr(stats, "enabled_notifications", None)
                     if enabled_notifications is not None:
                         print(f"  enabled_notifications: {enabled_notifications}")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error fetching broadcast stats: {exc}")
 
@@ -636,15 +609,15 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.edit_folder(entity, 1)
+                    await TelegramActionService(pool).set_dialog_folder(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        folder_id=1,
+                    )
                     print(f"{args.chat_id} archived.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error archiving: {exc}")
 
@@ -657,15 +630,15 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.edit_folder(entity, 0)
+                    await TelegramActionService(pool).set_dialog_folder(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        folder_id=0,
+                    )
                     print(f"{args.chat_id} unarchived.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error unarchiving: {exc}")
 
@@ -678,15 +651,15 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                result = await pool.get_native_client_by_phone(phone)
-                if result is None:
-                    print(f"Client for {phone} unavailable.")
-                    return
-                client, _ = result
                 try:
-                    entity = await client.get_entity(args.chat_id)
-                    await client.send_read_acknowledge(entity, max_id=args.max_id)
+                    await TelegramActionService(pool).mark_read(
+                        phone=phone,
+                        chat_id=args.chat_id,
+                        max_id=args.max_id,
+                    )
                     print(f"Messages marked as read in {args.chat_id}.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                 except Exception as exc:
                     print(f"Error marking messages as read: {exc}")
 
@@ -710,35 +683,28 @@ def run_with_dependencies(
                 if phone not in pool.clients:
                     print(f"Account {phone} not connected.")
                     return
-                client = pool.clients[phone]
-                from telethon.tl.functions.channels import CreateChannelRequest
-
-                result = await client(
-                    CreateChannelRequest(
+                try:
+                    result = await TelegramActionService(pool).create_channel(
+                        phone=phone,
                         title=args.title,
                         about=args.about or "",
-                        broadcast=True,
-                        megagroup=False,
+                        username=args.username or "",
                     )
-                )
-                channel = result.chats[0] if result.chats else None
-                if channel is None:
-                    print("Error: Telegram returned empty response — channel may not have been created.")
+                except TelegramActionClientUnavailableError:
+                    print(f"Client for {phone} unavailable.")
                     return
-                channel_id = channel.id
-                channel_username = getattr(channel, "username", None) or ""
-                print(f"Created channel id={channel_id} title={args.title!r}")
-                if args.username and channel_id:
-                    try:
-                        from telethon.tl.functions.channels import UpdateUsernameRequest
-
-                        await client(UpdateUsernameRequest(channel, args.username))
-                        channel_username = args.username
-                        print(f"Username set: @{channel_username}")
-                    except Exception as exc:
-                        print(f"Could not set username: {exc}")
-                if channel_username:
-                    print(f"Channel link: https://t.me/{channel_username}")
+                except RuntimeError as exc:
+                    if "Telegram returned empty response" in str(exc):
+                        print("Error: Telegram returned empty response — channel may not have been created.")
+                        return
+                    raise
+                print(f"Created channel id={result.channel_id} title={args.title!r}")
+                if args.username and result.channel_username == args.username:
+                    print(f"Username set: @{result.channel_username}")
+                elif args.username and result.username_error:
+                    print(f"Could not set username: {result.username_error}")
+                if result.channel_username:
+                    print(f"Channel link: {result.invite_link}")
 
             elif args.dialogs_action == "cache-status":
                 phones = await db.repos.dialog_cache.get_all_phones()

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -148,7 +148,10 @@ class ChannelService:
         await self._channels.delete_channel(pk)
 
     async def leave_dialogs(self, phone: str, dialogs: list[tuple[int, str]]) -> dict[int, bool]:
-        return await self._pool.leave_channels(phone, dialogs)
+        from src.services.telegram_actions import TelegramActionService
+
+        result = await TelegramActionService(self._pool).leave_dialogs(phone=phone, dialogs=dialogs)
+        return result.results
 
     async def get_by_pk(self, pk: int) -> Channel | None:
         return await self._channels.get_by_pk(pk)

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -9,6 +9,7 @@ import re
 from src.services.pipeline_filters import filter_messages
 from src.services.pipeline_nodes.base import BaseNodeHandler, NodeContext
 from src.services.pipeline_result import increment_action_count
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 
 try:  # telethon is an optional dependency at test-time
     from telethon.errors import (
@@ -330,29 +331,32 @@ class ReactHandler(BaseNodeHandler):
         emoji = node_config.get("emoji") or "👍"
         random_emoji_list = node_config.get("random_emojis", [])
         resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
+        action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
 
         for message in messages:
-            acquired_phone: str | None = None
             try:
-                if resolved_phone:
-                    result = await client_pool.get_client_by_phone(resolved_phone)
-                else:
-                    result = await client_pool.get_available_client()
-                if result is None:
-                    context.record_error(
-                        node_id=node_id,
-                        code="no_available_client",
-                        detail=(
-                            f"no client_pool slot available for phone={resolved_phone}"
-                            if resolved_phone
-                            else "all accounts are flood-waited or disconnected"
-                        ),
-                    )
-                    break
-                session, acquired_phone = result
                 chosen_emoji = random.choice(random_emoji_list) if random_emoji_list else emoji
-                await session.send_reaction(message.channel_id, message.message_id, chosen_emoji)
+                await action_service.send_reaction(
+                    phone=resolved_phone,
+                    chat_id=message.channel_id,
+                    message_id=message.message_id,
+                    emoji=chosen_emoji,
+                    native=False,
+                    allow_any=resolved_phone is None,
+                    resolve_entity=False,
+                )
                 increment_action_count(context, "react")
+            except TelegramActionClientUnavailableError:
+                context.record_error(
+                    node_id=node_id,
+                    code="no_available_client",
+                    detail=(
+                        f"no client_pool slot available for phone={resolved_phone}"
+                        if resolved_phone
+                        else "all accounts are flood-waited or disconnected"
+                    ),
+                )
+                break
             except FloodWaitError as exc:
                 context.record_error(
                     node_id=node_id,
@@ -386,9 +390,6 @@ class ReactHandler(BaseNodeHandler):
                     message.message_id,
                     exc_info=True,
                 )
-            finally:
-                if acquired_phone is not None:
-                    await client_pool.release_client(acquired_phone)
 
 
 class ForwardHandler(BaseNodeHandler):
@@ -408,28 +409,35 @@ class ForwardHandler(BaseNodeHandler):
 
         messages = context.get_global("context_messages", [])
         targets = node_config.get("targets", [])
+        action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
 
         for target in targets:
             phone = target.get("phone", "")
             dialog_id = target.get("dialog_id")
             if not phone or not dialog_id:
                 continue
-            acquired_phone: str | None = None
             try:
-                result = await client_pool.get_client_by_phone(phone)
-                if result is None:
-                    context.record_error(
-                        node_id=node_id,
-                        code="no_available_client",
-                        detail=(
-                            f"no client_pool slot available for phone={phone}"
-                        ),
-                    )
+                if not messages:
+                    await action_service.ensure_client(phone=phone, native=False)
                     continue
-                session, acquired_phone = result
                 for message in messages:
-                    await session.forward_messages(dialog_id, message.message_id, message.channel_id)
+                    await action_service.forward_messages(
+                        phone=phone,
+                        from_chat=message.channel_id,
+                        to_chat=dialog_id,
+                        message_ids=[message.message_id],
+                        native=False,
+                        resolve_entities=False,
+                        collapse_single_message_id=True,
+                    )
                     increment_action_count(context, "forward")
+            except TelegramActionClientUnavailableError:
+                context.record_error(
+                    node_id=node_id,
+                    code="no_available_client",
+                    detail=f"no client_pool slot available for phone={phone}",
+                )
+                continue
             except FloodWaitError as exc:
                 context.record_error(
                     node_id=node_id,
@@ -455,9 +463,6 @@ class ForwardHandler(BaseNodeHandler):
                     dialog_id,
                     exc_info=True,
                 )
-            finally:
-                if acquired_phone is not None:
-                    await client_pool.release_client(acquired_phone)
 
 
 class DeleteMessageHandler(BaseNodeHandler):
@@ -477,28 +482,30 @@ class DeleteMessageHandler(BaseNodeHandler):
 
         messages = context.get_global("context_messages", [])
         resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
+        action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
 
         for message in messages:
-            acquired_phone: str | None = None
             try:
-                if resolved_phone:
-                    result = await client_pool.get_client_by_phone(resolved_phone)
-                else:
-                    result = await client_pool.get_available_client()
-                if result is None:
-                    context.record_error(
-                        node_id=node_id,
-                        code="no_available_client",
-                        detail=(
-                            f"no client_pool slot available for phone={resolved_phone}"
-                            if resolved_phone
-                            else "all accounts are flood-waited or disconnected"
-                        ),
-                    )
-                    break
-                session, acquired_phone = result
-                await session.delete_messages(message.channel_id, [message.message_id])
+                await action_service.delete_messages(
+                    phone=resolved_phone,
+                    chat_id=message.channel_id,
+                    message_ids=[message.message_id],
+                    native=False,
+                    allow_any=resolved_phone is None,
+                    resolve_entity=False,
+                )
                 increment_action_count(context, "delete_message")
+            except TelegramActionClientUnavailableError:
+                context.record_error(
+                    node_id=node_id,
+                    code="no_available_client",
+                    detail=(
+                        f"no client_pool slot available for phone={resolved_phone}"
+                        if resolved_phone
+                        else "all accounts are flood-waited or disconnected"
+                    ),
+                )
+                break
             except FloodWaitError as exc:
                 context.record_error(
                     node_id=node_id,
@@ -526,9 +533,6 @@ class DeleteMessageHandler(BaseNodeHandler):
                     message.message_id,
                     exc_info=True,
                 )
-            finally:
-                if acquired_phone is not None:
-                    await client_pool.release_client(acquired_phone)
 
 
 class ConditionHandler(BaseNodeHandler):

--- a/src/services/telegram_action_inventory.py
+++ b/src/services/telegram_action_inventory.py
@@ -1,0 +1,147 @@
+"""Canonical inventory of Telegram business actions and their entrypoints."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TelegramActionInventoryItem:
+    """Known Telegram business action surface in the application."""
+
+    action: str
+    cli: str | None = None
+    web_command: str | None = None
+    agent_tool: str | None = None
+    pipeline_node: str | None = None
+    backend_method: str | None = None
+
+
+TELEGRAM_ACTION_INVENTORY: tuple[TelegramActionInventoryItem, ...] = (
+    TelegramActionInventoryItem(
+        action="send_reaction",
+        cli="dialogs react",
+        pipeline_node="react",
+        backend_method="send_reaction",
+    ),
+    TelegramActionInventoryItem(
+        action="create_channel",
+        cli="dialogs create-channel",
+        web_command="dialogs.create_channel",
+        agent_tool="create_telegram_channel",
+        backend_method="create_channel",
+    ),
+    TelegramActionInventoryItem(
+        action="leave_dialogs",
+        cli="dialogs leave",
+        web_command="dialogs.leave",
+        agent_tool="leave_dialogs",
+        backend_method="leave_channels",
+    ),
+    TelegramActionInventoryItem(
+        action="send_message",
+        cli="dialogs send",
+        web_command="dialogs.send",
+        agent_tool="send_message",
+        backend_method="send_message",
+    ),
+    TelegramActionInventoryItem(
+        action="edit_message",
+        cli="dialogs edit-message",
+        web_command="dialogs.edit_message",
+        agent_tool="edit_message",
+        backend_method="edit_message",
+    ),
+    TelegramActionInventoryItem(
+        action="delete_messages",
+        cli="dialogs delete-message",
+        web_command="dialogs.delete_message",
+        agent_tool="delete_message",
+        pipeline_node="delete_message",
+        backend_method="delete_messages",
+    ),
+    TelegramActionInventoryItem(
+        action="forward_messages",
+        cli="dialogs forward",
+        web_command="dialogs.forward_messages",
+        agent_tool="forward_messages",
+        pipeline_node="forward",
+        backend_method="forward_messages",
+    ),
+    TelegramActionInventoryItem(
+        action="pin_message",
+        cli="dialogs pin-message",
+        web_command="dialogs.pin_message",
+        agent_tool="pin_message",
+        backend_method="pin_message",
+    ),
+    TelegramActionInventoryItem(
+        action="unpin_message",
+        cli="dialogs unpin-message",
+        web_command="dialogs.unpin_message",
+        agent_tool="unpin_message",
+        backend_method="unpin_message",
+    ),
+    TelegramActionInventoryItem(
+        action="download_media",
+        cli="dialogs download-media",
+        web_command="dialogs.download_media",
+        agent_tool="download_media",
+        backend_method="download_media",
+    ),
+    TelegramActionInventoryItem(
+        action="edit_admin",
+        cli="dialogs edit-admin",
+        web_command="dialogs.edit_admin",
+        agent_tool="edit_admin",
+        backend_method="edit_admin",
+    ),
+    TelegramActionInventoryItem(
+        action="edit_permissions",
+        cli="dialogs edit-permissions",
+        web_command="dialogs.edit_permissions",
+        agent_tool="edit_permissions",
+        backend_method="edit_permissions",
+    ),
+    TelegramActionInventoryItem(
+        action="kick_participant",
+        cli="dialogs kick",
+        web_command="dialogs.kick",
+        agent_tool="kick_participant",
+        backend_method="kick_participant",
+    ),
+    TelegramActionInventoryItem(
+        action="mark_read",
+        cli="dialogs mark-read",
+        web_command="dialogs.mark_read",
+        agent_tool="mark_read",
+        backend_method="send_read_acknowledge",
+    ),
+    TelegramActionInventoryItem(
+        action="archive_chat",
+        cli="dialogs archive",
+        web_command="dialogs.archive",
+        agent_tool="archive_chat",
+        backend_method="edit_folder",
+    ),
+    TelegramActionInventoryItem(
+        action="unarchive_chat",
+        cli="dialogs unarchive",
+        web_command="dialogs.unarchive",
+        agent_tool="unarchive_chat",
+        backend_method="edit_folder",
+    ),
+    TelegramActionInventoryItem(
+        action="get_participants",
+        cli="dialogs participants",
+        web_command="dialogs.participants",
+        agent_tool="get_participants",
+        backend_method="get_participants",
+    ),
+    TelegramActionInventoryItem(
+        action="get_broadcast_stats",
+        cli="dialogs broadcast-stats",
+        web_command="dialogs.broadcast_stats",
+        agent_tool="get_broadcast_stats",
+        backend_method="get_broadcast_stats",
+    ),
+)

--- a/src/services/telegram_actions.py
+++ b/src/services/telegram_actions.py
@@ -1,0 +1,540 @@
+"""Shared Telegram business actions used by CLI, web, agent tools, and pipelines."""
+from __future__ import annotations
+
+import inspect
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.telegram.client_pool import ClientPool
+from src.telegram.flood_wait import run_with_flood_wait
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramActionError(RuntimeError):
+    """Base exception for shared Telegram action failures."""
+
+
+class TelegramActionClientUnavailableError(TelegramActionError):
+    """Raised when no usable Telegram client can be acquired."""
+
+
+class TelegramActionEntityResolutionError(TelegramActionError):
+    """Raised when a chat/user identifier cannot be resolved for an action."""
+
+
+class TelegramActionMessageNotFoundError(TelegramActionError):
+    """Raised when a requested Telegram message cannot be found."""
+
+
+class TelegramActionNoMediaError(TelegramActionError):
+    """Raised when a requested Telegram message has no downloadable media."""
+
+
+class TelegramActionPathEscapeError(TelegramActionError):
+    """Raised when a media download returns a path outside the requested directory."""
+
+
+@dataclass(frozen=True)
+class TelegramActionResult:
+    phone: str
+
+
+@dataclass(frozen=True)
+class SendMessageResult:
+    phone: str
+    message_id: int | None
+
+
+@dataclass(frozen=True)
+class CountActionResult:
+    phone: str
+    count: int
+
+
+@dataclass(frozen=True)
+class ParticipantsResult:
+    phone: str
+    participants: list[Any]
+
+
+@dataclass(frozen=True)
+class BroadcastStatsResult:
+    phone: str
+    stats: Any
+
+
+@dataclass(frozen=True)
+class CreateChannelResult:
+    phone: str
+    channel_id: int | None
+    channel_title: str
+    channel_username: str
+    invite_link: str
+    username_error: str | None = None
+
+
+@dataclass(frozen=True)
+class DownloadMediaResult:
+    phone: str
+    path: str
+
+
+@dataclass(frozen=True)
+class LeaveDialogsResult:
+    phone: str
+    results: dict[Any, bool]
+
+    @property
+    def success_count(self) -> int:
+        return sum(1 for value in self.results.values() if value)
+
+    @property
+    def failed_count(self) -> int:
+        return len(self.results) - self.success_count
+
+
+class TelegramActionService:
+    """Typed facade for Telegram-side business actions.
+
+    Interface layers should adapt inputs/outputs and delegate Telegram execution
+    here instead of directly assembling raw Telethon requests.
+    """
+
+    def __init__(self, pool: ClientPool):
+        self._pool = pool
+
+    @staticmethod
+    def _require_explicit_operation(client: Any, name: str) -> Any:
+        operation = getattr(client, name, None)
+        if operation is None:
+            raise AttributeError(f"client does not implement {name}")
+        if not hasattr(type(client), name) and name not in getattr(client, "__dict__", {}):
+            raise AttributeError(f"client does not implement {name}")
+        return operation
+
+    @staticmethod
+    def _has_explicit_pool_operation(pool: Any, name: str) -> bool:
+        return hasattr(type(pool), name) or name in getattr(pool, "__dict__", {})
+
+    @staticmethod
+    def _looks_numeric_identifier(value: Any) -> bool:
+        if not isinstance(value, str):
+            return isinstance(value, int)
+        stripped = value.strip()
+        if not stripped:
+            return False
+        if stripped[0] in ("+", "-"):
+            return stripped[1:].isdigit()
+        return stripped.isdigit()
+
+    @asynccontextmanager
+    async def _client(
+        self,
+        *,
+        phone: str | None,
+        native: bool,
+        allow_any: bool = False,
+    ):
+        acquired_phone: str | None = None
+        if phone:
+            if native and self._has_explicit_pool_operation(self._pool, "get_native_client_by_phone"):
+                result = await self._pool.get_native_client_by_phone(phone)
+            elif self._has_explicit_pool_operation(self._pool, "get_client_by_phone"):
+                result = await self._pool.get_client_by_phone(phone)
+            else:
+                result = None
+        elif allow_any and self._has_explicit_pool_operation(self._pool, "get_available_client"):
+            result = await self._pool.get_available_client()
+        else:
+            result = None
+        if result is None:
+            raise TelegramActionClientUnavailableError("client unavailable")
+        session, acquired_phone = result
+        try:
+            yield session, acquired_phone
+        finally:
+            if acquired_phone is not None:
+                release = getattr(self._pool, "release_client", None)
+                if release is not None:
+                    result = release(acquired_phone)
+                    if inspect.isawaitable(result):
+                        await result
+
+    async def _resolve_entity(
+        self,
+        client: Any,
+        *,
+        phone: str,
+        identifier: Any,
+        is_user: bool = False,
+    ) -> Any:
+        """Resolve an action entity through one shared path.
+
+        Numeric dialog IDs use ClientPool.resolve_dialog_entity when the pool
+        exposes it explicitly, so CLI/web/agent behavior can share the same
+        cache-warming path. Other identifiers fall back to Telethon's get_entity.
+        """
+        if self._looks_numeric_identifier(identifier) and self._has_explicit_pool_operation(
+            self._pool, "resolve_dialog_entity"
+        ):
+            get_client_by_phone = getattr(self._pool, "get_client_by_phone", None)
+            if callable(get_client_by_phone):
+                session_result = await get_client_by_phone(phone)
+                if session_result is not None:
+                    session, _ = session_result
+                    dialog_id = int(str(identifier).strip())
+                    target_types = ("dm",) if is_user else (None, "dm")
+                    for target_type in target_types:
+                        try:
+                            entity = await self._pool.resolve_dialog_entity(
+                                session,
+                                phone,
+                                dialog_id,
+                                target_type,
+                            )
+                        except (ValueError, TypeError, KeyError):
+                            continue
+                        except Exception as exc:
+                            raise TelegramActionEntityResolutionError(
+                                f"Ошибка: не удалось получить entity для {identifier}: {exc}"
+                            ) from exc
+                        if entity is not None:
+                            return entity
+
+        try:
+            return await client.get_entity(identifier)
+        except Exception as exc:
+            raise TelegramActionEntityResolutionError(
+                f"Ошибка: не удалось найти чат/пользователя '{identifier}': {exc}"
+            ) from exc
+
+    async def send_reaction(
+        self,
+        *,
+        phone: str | None,
+        chat_id: Any,
+        message_id: int,
+        emoji: str,
+        native: bool = True,
+        allow_any: bool = False,
+        resolve_entity: bool = True,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=native, allow_any=allow_any) as (client, acquired_phone):
+            entity = (
+                await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+                if resolve_entity
+                else chat_id
+            )
+            await client.send_reaction(entity, int(message_id), emoji)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def ensure_client(
+        self,
+        *,
+        phone: str,
+        native: bool = True,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=native) as (_client, acquired_phone):
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def send_message(
+        self,
+        *,
+        phone: str,
+        recipient: Any,
+        text: str,
+    ) -> SendMessageResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=recipient)
+            message = await client.send_message(entity, text)
+            return SendMessageResult(phone=acquired_phone, message_id=getattr(message, "id", None))
+
+    async def edit_message(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        message_id: int,
+        text: str,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            await client.edit_message(entity, int(message_id), text)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def delete_messages(
+        self,
+        *,
+        phone: str | None,
+        chat_id: Any,
+        message_ids: list[int],
+        native: bool = True,
+        allow_any: bool = False,
+        resolve_entity: bool = True,
+    ) -> CountActionResult:
+        async with self._client(phone=phone, native=native, allow_any=allow_any) as (client, acquired_phone):
+            entity = (
+                await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+                if resolve_entity
+                else chat_id
+            )
+            ids = [int(value) for value in message_ids]
+            await client.delete_messages(entity, ids)
+            return CountActionResult(phone=acquired_phone, count=len(ids))
+
+    async def forward_messages(
+        self,
+        *,
+        phone: str,
+        from_chat: Any,
+        to_chat: Any,
+        message_ids: list[int],
+        native: bool = True,
+        resolve_entities: bool = True,
+        collapse_single_message_id: bool = False,
+    ) -> CountActionResult:
+        async with self._client(phone=phone, native=native) as (client, acquired_phone):
+            from_entity = (
+                await self._resolve_entity(client, phone=acquired_phone, identifier=from_chat)
+                if resolve_entities
+                else from_chat
+            )
+            to_entity = (
+                await self._resolve_entity(client, phone=acquired_phone, identifier=to_chat)
+                if resolve_entities
+                else to_chat
+            )
+            ids = [int(value) for value in message_ids]
+            messages: Any = ids[0] if collapse_single_message_id and len(ids) == 1 else ids
+            await client.forward_messages(to_entity, messages, from_entity)
+            return CountActionResult(phone=acquired_phone, count=len(ids))
+
+    async def pin_message(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        message_id: int,
+        notify: bool = False,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            await client.pin_message(entity, int(message_id), notify=notify)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def unpin_message(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        message_id: int | None = None,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            await client.unpin_message(entity, int(message_id) if message_id is not None else None)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def mark_read(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        max_id: int | None = None,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            await client.send_read_acknowledge(entity, max_id=int(max_id) if max_id is not None else None)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def set_dialog_folder(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        folder_id: int,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            await client.edit_folder(entity, int(folder_id))
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def get_participants(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        limit: int = 200,
+        search: str = "",
+    ) -> ParticipantsResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            participants = await client.get_participants(entity, limit=int(limit), search=search)
+            return ParticipantsResult(phone=acquired_phone, participants=list(participants))
+
+    async def get_broadcast_stats(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+    ) -> BroadcastStatsResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            stats = await client.get_broadcast_stats(entity)
+            return BroadcastStatsResult(phone=acquired_phone, stats=stats)
+
+    async def edit_admin(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        user_id: Any,
+        is_admin: bool,
+        title: str | None = None,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            user = await self._resolve_entity(client, phone=acquired_phone, identifier=user_id, is_user=True)
+            kwargs: dict[str, Any] = {"is_admin": bool(is_admin)}
+            if title:
+                kwargs["title"] = title
+            await client.edit_admin(entity, user, **kwargs)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def edit_permissions(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        user_id: Any,
+        until_date: Any = None,
+        send_messages: bool | None = None,
+        send_media: bool | None = None,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            user = await self._resolve_entity(client, phone=acquired_phone, identifier=user_id, is_user=True)
+            kwargs: dict[str, Any] = {}
+            if until_date is not None:
+                kwargs["until_date"] = until_date
+            if send_messages is not None:
+                kwargs["send_messages"] = send_messages
+            if send_media is not None:
+                kwargs["send_media"] = send_media
+            await client.edit_permissions(entity, user, **kwargs)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def kick_participant(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        user_id: Any,
+    ) -> TelegramActionResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            user = await self._resolve_entity(client, phone=acquired_phone, identifier=user_id, is_user=True)
+            await client.kick_participant(entity, user)
+            return TelegramActionResult(phone=acquired_phone)
+
+    async def download_media(
+        self,
+        *,
+        phone: str,
+        chat_id: Any,
+        message_id: int,
+        output_dir: str | Path,
+        operation_prefix: str = "telegram_action_download_media",
+    ) -> DownloadMediaResult:
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        output_resolved = output_path.resolve()
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
+            message = None
+
+            async def _lookup_message() -> None:
+                nonlocal message
+                async for current_message in client.iter_messages(entity, ids=int(message_id)):
+                    message = current_message
+                    break
+
+            await run_with_flood_wait(
+                _lookup_message(),
+                operation=f"{operation_prefix}_lookup",
+                phone=acquired_phone,
+                pool=self._pool,
+            )
+            if message is None:
+                raise TelegramActionMessageNotFoundError("message_not_found")
+            path = await run_with_flood_wait(
+                client.download_media(message, file=str(output_resolved)),
+                operation=operation_prefix,
+                phone=acquired_phone,
+                pool=self._pool,
+            )
+            if not path:
+                raise TelegramActionNoMediaError("no_media")
+            resolved = Path(path).resolve()
+            if resolved != output_resolved and output_resolved not in resolved.parents:
+                raise TelegramActionPathEscapeError("path_escape")
+            return DownloadMediaResult(phone=acquired_phone, path=str(path))
+
+    async def leave_dialogs(
+        self,
+        *,
+        phone: str,
+        dialogs: list[tuple[int, str]],
+    ) -> LeaveDialogsResult:
+        leave_channels = getattr(self._pool, "leave_channels")
+        results = leave_channels(phone, dialogs)
+        if inspect.isawaitable(results):
+            results = await results
+        return LeaveDialogsResult(phone=phone, results=dict(results))
+
+    async def create_channel(
+        self,
+        *,
+        phone: str,
+        title: str,
+        about: str = "",
+        username: str = "",
+    ) -> CreateChannelResult:
+        async with self._client(phone=phone, native=True) as (client, acquired_phone):
+            create_channel = self._require_explicit_operation(client, "create_channel")
+            result = await create_channel(
+                title=title,
+                about=about or "",
+                broadcast=True,
+                megagroup=False,
+            )
+            channel = result.chats[0] if getattr(result, "chats", None) else None
+            if channel is None:
+                raise RuntimeError("Telegram returned empty response")
+            channel_id = getattr(channel, "id", None)
+            channel_username = getattr(channel, "username", None) or ""
+            requested_username = (username or "").strip()
+            username_error: str | None = None
+            if requested_username and channel_id:
+                try:
+                    update_channel_username = self._require_explicit_operation(client, "update_channel_username")
+                    await update_channel_username(channel, requested_username)
+                    channel_username = requested_username
+                except Exception as exc:
+                    username_error = str(exc)
+                    logger.warning(
+                        "Could not set username %r for new channel id=%s",
+                        requested_username,
+                        channel_id,
+                    )
+            return CreateChannelResult(
+                phone=acquired_phone,
+                channel_id=channel_id,
+                channel_title=title,
+                channel_username=channel_username,
+                invite_link=f"https://t.me/{channel_username}" if channel_username else "",
+                username_error=username_error,
+            )

--- a/src/services/telegram_actions.py
+++ b/src/services/telegram_actions.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from src.telegram.client_pool import ClientPool
-from src.telegram.flood_wait import run_with_flood_wait
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 
 logger = logging.getLogger(__name__)
 
@@ -181,32 +181,31 @@ class TelegramActionService:
         if self._looks_numeric_identifier(identifier) and self._has_explicit_pool_operation(
             self._pool, "resolve_dialog_entity"
         ):
-            get_client_by_phone = getattr(self._pool, "get_client_by_phone", None)
-            if callable(get_client_by_phone):
-                session_result = await get_client_by_phone(phone)
-                if session_result is not None:
-                    session, _ = session_result
-                    dialog_id = int(str(identifier).strip())
-                    target_types = ("dm",) if is_user else (None, "dm")
-                    for target_type in target_types:
-                        try:
-                            entity = await self._pool.resolve_dialog_entity(
-                                session,
-                                phone,
-                                dialog_id,
-                                target_type,
-                            )
-                        except (ValueError, TypeError, KeyError):
-                            continue
-                        except Exception as exc:
-                            raise TelegramActionEntityResolutionError(
-                                f"Ошибка: не удалось получить entity для {identifier}: {exc}"
-                            ) from exc
-                        if entity is not None:
-                            return entity
+            dialog_id = int(str(identifier).strip())
+            target_types = ("dm",) if is_user else (None, "dm")
+            for target_type in target_types:
+                try:
+                    entity = await self._pool.resolve_dialog_entity(
+                        client,
+                        phone,
+                        dialog_id,
+                        target_type,
+                    )
+                except HandledFloodWaitError:
+                    raise
+                except (ValueError, TypeError, KeyError):
+                    continue
+                except Exception as exc:
+                    raise TelegramActionEntityResolutionError(
+                        f"Ошибка: не удалось получить entity для {identifier}: {exc}"
+                    ) from exc
+                if entity is not None:
+                    return entity
 
         try:
             return await client.get_entity(identifier)
+        except HandledFloodWaitError:
+            raise
         except Exception as exc:
             raise TelegramActionEntityResolutionError(
                 f"Ошибка: не удалось найти чат/пользователя '{identifier}': {exc}"
@@ -481,7 +480,7 @@ class TelegramActionService:
             resolved = Path(path).resolve()
             if resolved != output_resolved and output_resolved not in resolved.parents:
                 raise TelegramActionPathEscapeError("path_escape")
-            return DownloadMediaResult(phone=acquired_phone, path=str(path))
+            return DownloadMediaResult(phone=acquired_phone, path=str(resolved))
 
     async def leave_dialogs(
         self,
@@ -489,7 +488,11 @@ class TelegramActionService:
         phone: str,
         dialogs: list[tuple[int, str]],
     ) -> LeaveDialogsResult:
-        leave_channels = getattr(self._pool, "leave_channels")
+        leave_channels = getattr(self._pool, "leave_channels", None)
+        if leave_channels is None:
+            raise TelegramActionClientUnavailableError(
+                "client pool does not implement leave_channels"
+            )
         results = leave_channels(phone, dialogs)
         if inspect.isawaitable(results):
             results = await results

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -15,10 +15,16 @@ from src.services.notification_service import NotificationService
 from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+from src.services.telegram_actions import (
+    TelegramActionMessageNotFoundError,
+    TelegramActionNoMediaError,
+    TelegramActionPathEscapeError,
+    TelegramActionService,
+)
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.telegram.flood_wait import HandledFloodWaitError
 from src.telegram.notifier import Notifier
 from src.utils.datetime import parse_required_datetime, parse_required_schedule_datetime
 
@@ -242,146 +248,133 @@ class TelegramCommandDispatcher:
     async def _handle_dialogs_leave(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])
         dialogs = [(int(item["dialog_id"]), str(item["title"])) for item in payload.get("dialogs", [])]
-        results = await self._pool.leave_channels(phone, dialogs)
-        left = sum(1 for ok in results.values() if ok)
-        failed = len(results) - left
-        return {"left": left, "failed": failed}
+        result = await TelegramActionService(self._pool).leave_dialogs(phone=phone, dialogs=dialogs)
+        return {"left": result.success_count, "failed": result.failed_count}
 
     async def _handle_dialogs_send(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["recipient"])
-            message = await client.send_message(entity, payload["text"])
-            return {"phone": phone, "message_id": getattr(message, "id", None)}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).send_message(
+            phone=str(payload["phone"]),
+            recipient=payload["recipient"],
+            text=payload["text"],
+        )
+        return {"phone": result.phone, "message_id": result.message_id}
 
     async def _handle_dialogs_edit_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            await client.edit_message(entity, int(payload["message_id"]), payload["text"])
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).edit_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(payload["message_id"]),
+            text=payload["text"],
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_delete_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            ids = [int(value) for value in payload["message_ids"]]
-            await client.delete_messages(entity, ids)
-            return {"phone": phone, "deleted": len(ids)}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).delete_messages(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_ids=[int(value) for value in payload["message_ids"]],
+        )
+        return {"phone": result.phone, "deleted": result.count}
 
     async def _handle_dialogs_forward_messages(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            from_entity = await client.get_entity(payload["from_chat"])
-            to_entity = await client.get_entity(payload["to_chat"])
-            ids = [int(value) for value in payload["message_ids"]]
-            await client.forward_messages(to_entity, ids, from_entity)
-            return {"phone": phone, "forwarded": len(ids)}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).forward_messages(
+            phone=str(payload["phone"]),
+            from_chat=payload["from_chat"],
+            to_chat=payload["to_chat"],
+            message_ids=[int(value) for value in payload["message_ids"]],
+        )
+        return {"phone": result.phone, "forwarded": result.count}
 
     async def _handle_dialogs_pin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            await client.pin_message(entity, int(payload["message_id"]), notify=bool(payload.get("notify", False)))
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).pin_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(payload["message_id"]),
+            notify=bool(payload.get("notify", False)),
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_unpin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            message_id = payload.get("message_id")
-            await client.unpin_message(entity, int(message_id) if message_id is not None else None)
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        message_id = payload.get("message_id")
+        result = await TelegramActionService(self._pool).unpin_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(message_id) if message_id is not None else None,
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_participants(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            participants = await client.get_participants(
-                entity,
-                limit=int(payload.get("limit", 200)),
-                search=str(payload.get("search", "")),
-            )
-            data = [
-                {
-                    "id": p.id,
-                    "first_name": getattr(p, "first_name", None) or "",
-                    "last_name": getattr(p, "last_name", None) or "",
-                    "username": getattr(p, "username", None) or "",
-                }
-                for p in participants
-            ]
-            scope = f"dialogs_participants:{phone}:{payload['chat_id']}"
-            search_value = str(payload.get("search", ""))
-            # Only cache unfiltered (full) participant lists. A search-filtered
-            # result would otherwise overwrite the shared snapshot, so later
-            # no-search GETs would return only the filtered subset.
-            if not search_value:
-                await self._db.repos.runtime_snapshots.upsert_snapshot(
-                    RuntimeSnapshot(
-                        snapshot_type="dialogs_participants",
-                        scope=scope,
-                        payload={"participants": data, "total": len(data)},
-                    )
-                )
-            result = {"phone": phone, "scope": scope, "total": len(data)}
-            if search_value:
-                # Search results are intentionally not cached; return them
-                # inline so the client can read them via GET /telegram-commands/{id}.
-                result["participants"] = data
-            return result
-        finally:
-            await self._pool.release_client(phone)
-
-    async def _handle_dialogs_broadcast_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            stats = await client.get_broadcast_stats(entity)
-            fields: dict[str, Any] = {}
-            for attr in ("followers", "views_per_post", "shares_per_post", "reactions_per_post", "forwards_per_post"):
-                val = getattr(stats, attr, None)
-                if val is not None:
-                    current = getattr(val, "current", None)
-                    previous = getattr(val, "previous", None)
-                    if current is not None:
-                        fields[attr] = {"current": current, "previous": previous}
-                    else:
-                        fields[attr] = str(val)
-            period = getattr(stats, "period", None)
-            if period is not None:
-                fields["period"] = {
-                    "min_date": period.min_date.isoformat() if getattr(period, "min_date", None) else None,
-                    "max_date": period.max_date.isoformat() if getattr(period, "max_date", None) else None,
-                }
-            enabled_notifications = getattr(stats, "enabled_notifications", None)
-            if enabled_notifications is not None:
-                fields["enabled_notifications"] = enabled_notifications
-            if not fields:
-                fields["raw"] = str(stats)
-            scope = f"dialogs_broadcast_stats:{phone}:{payload['chat_id']}"
+        action_result = await TelegramActionService(self._pool).get_participants(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            limit=int(payload.get("limit", 200)),
+            search=str(payload.get("search", "")),
+        )
+        data = [
+            {
+                "id": p.id,
+                "first_name": getattr(p, "first_name", None) or "",
+                "last_name": getattr(p, "last_name", None) or "",
+                "username": getattr(p, "username", None) or "",
+            }
+            for p in action_result.participants
+        ]
+        scope = f"dialogs_participants:{action_result.phone}:{payload['chat_id']}"
+        search_value = str(payload.get("search", ""))
+        # Only cache unfiltered (full) participant lists. A search-filtered
+        # result would otherwise overwrite the shared snapshot, so later
+        # no-search GETs would return only the filtered subset.
+        if not search_value:
             await self._db.repos.runtime_snapshots.upsert_snapshot(
                 RuntimeSnapshot(
-                    snapshot_type="dialogs_broadcast_stats",
+                    snapshot_type="dialogs_participants",
                     scope=scope,
-                    payload={"stats": fields},
+                    payload={"participants": data, "total": len(data)},
                 )
             )
-            return {"phone": phone, "scope": scope}
-        finally:
-            await self._pool.release_client(phone)
+        result = {"phone": action_result.phone, "scope": scope, "total": len(data)}
+        if search_value:
+            # Search results are intentionally not cached; return them
+            # inline so the client can read them via GET /telegram-commands/{id}.
+            result["participants"] = data
+        return result
+
+    async def _handle_dialogs_broadcast_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
+        action_result = await TelegramActionService(self._pool).get_broadcast_stats(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+        )
+        stats = action_result.stats
+        fields: dict[str, Any] = {}
+        for attr in ("followers", "views_per_post", "shares_per_post", "reactions_per_post", "forwards_per_post"):
+            val = getattr(stats, attr, None)
+            if val is not None:
+                current = getattr(val, "current", None)
+                previous = getattr(val, "previous", None)
+                if current is not None:
+                    fields[attr] = {"current": current, "previous": previous}
+                else:
+                    fields[attr] = str(val)
+        period = getattr(stats, "period", None)
+        if period is not None:
+            fields["period"] = {
+                "min_date": period.min_date.isoformat() if getattr(period, "min_date", None) else None,
+                "max_date": period.max_date.isoformat() if getattr(period, "max_date", None) else None,
+            }
+        enabled_notifications = getattr(stats, "enabled_notifications", None)
+        if enabled_notifications is not None:
+            fields["enabled_notifications"] = enabled_notifications
+        if not fields:
+            fields["raw"] = str(stats)
+        scope = f"dialogs_broadcast_stats:{action_result.phone}:{payload['chat_id']}"
+        await self._db.repos.runtime_snapshots.upsert_snapshot(
+            RuntimeSnapshot(
+                snapshot_type="dialogs_broadcast_stats",
+                scope=scope,
+                payload={"stats": fields},
+            )
+        )
+        return {"phone": action_result.phone, "scope": scope}
 
     async def _handle_dialogs_archive(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._set_dialog_folder(payload, folder_id=1)
@@ -390,98 +383,65 @@ class TelegramCommandDispatcher:
         return await self._set_dialog_folder(payload, folder_id=0)
 
     async def _set_dialog_folder(self, payload: dict[str, Any], *, folder_id: int) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            await client.edit_folder(entity, folder_id)
-            return {"phone": phone, "folder_id": folder_id}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).set_dialog_folder(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            folder_id=folder_id,
+        )
+        return {"phone": result.phone, "folder_id": folder_id}
 
     async def _handle_dialogs_mark_read(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            max_id = payload.get("max_id")
-            await client.send_read_acknowledge(entity, max_id=int(max_id) if max_id is not None else None)
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        max_id = payload.get("max_id")
+        result = await TelegramActionService(self._pool).mark_read(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            max_id=int(max_id) if max_id is not None else None,
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_edit_admin(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            user = await client.get_entity(payload["user_id"])
-            kwargs = {"is_admin": bool(payload.get("is_admin", False))}
-            if payload.get("title"):
-                kwargs["title"] = payload["title"]
-            await client.edit_admin(entity, user, **kwargs)
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).edit_admin(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+            is_admin=bool(payload.get("is_admin", False)),
+            title=payload.get("title") or None,
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_edit_permissions(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            user = await client.get_entity(payload["user_id"])
-            kwargs: dict[str, Any] = {}
-            if payload.get("until_date"):
-                kwargs["until_date"] = parse_required_datetime(str(payload["until_date"]))
-            if "send_messages" in payload:
-                kwargs["send_messages"] = bool(payload["send_messages"])
-            if "send_media" in payload:
-                kwargs["send_media"] = bool(payload["send_media"])
-            await client.edit_permissions(entity, user, **kwargs)
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).edit_permissions(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+            until_date=parse_required_datetime(str(payload["until_date"])) if payload.get("until_date") else None,
+            send_messages=bool(payload["send_messages"]) if "send_messages" in payload else None,
+            send_media=bool(payload["send_media"]) if "send_media" in payload else None,
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_kick(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            entity = await client.get_entity(payload["chat_id"])
-            user = await client.get_entity(payload["user_id"])
-            await client.kick_participant(entity, user)
-            return {"phone": phone}
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).kick_participant(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+        )
+        return {"phone": result.phone}
 
     async def _handle_dialogs_create_channel(self, payload: dict[str, Any]) -> dict[str, Any]:
-        from telethon.tl.functions.channels import CreateChannelRequest, UpdateUsernameRequest
-
-        client, phone = await self._get_client(str(payload["phone"]))
-        try:
-            result = await client(
-                CreateChannelRequest(
-                    title=str(payload["title"]).strip(),
-                    about=str(payload.get("about", "")).strip(),
-                    broadcast=True,
-                    megagroup=False,
-                )
-            )
-            channel = result.chats[0] if result.chats else None
-            if channel is None:
-                raise RuntimeError("Telegram returned empty response")
-            channel_id = getattr(channel, "id", None)
-            channel_username = getattr(channel, "username", None) or ""
-            requested_username = str(payload.get("username", "")).strip()
-            if requested_username and channel_id:
-                try:
-                    await client(UpdateUsernameRequest(channel, requested_username))
-                    channel_username = requested_username
-                except Exception:
-                    logger.warning("Could not set username %r for new channel id=%s", requested_username, channel_id)
-            return {
-                "phone": phone,
-                "channel_id": channel_id,
-                "channel_title": payload["title"],
-                "channel_username": channel_username,
-                "invite_link": f"https://t.me/{channel_username}" if channel_username else "",
-            }
-        finally:
-            await self._pool.release_client(phone)
+        result = await TelegramActionService(self._pool).create_channel(
+            phone=str(payload["phone"]),
+            title=str(payload["title"]).strip(),
+            about=str(payload.get("about", "")).strip(),
+            username=str(payload.get("username", "")).strip(),
+        )
+        return {
+            "phone": result.phone,
+            "channel_id": result.channel_id,
+            "channel_title": payload["title"],
+            "channel_username": result.channel_username,
+            "invite_link": result.invite_link,
+        }
 
     async def _handle_agent_forum_topics_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
         channel_id = int(payload["channel_id"])
@@ -606,50 +566,25 @@ class TelegramCommandDispatcher:
         return {"added": added, "skipped": skipped, "failed": failed, "details": details}
 
     async def _handle_dialogs_download_media(self, payload: dict[str, Any]) -> dict[str, Any]:
-        client, phone = await self._get_client(str(payload["phone"]))
+        phone = str(payload["phone"])
         try:
-            entity = await client.get_entity(payload["chat_id"])
-            msg = None
-
-            async def _lookup_message() -> None:
-                nonlocal msg
-                async for item in client.iter_messages(
-                    entity, ids=int(payload["message_id"])
-                ):
-                    msg = item
-                    break
-
-            try:
-                await run_with_flood_wait(
-                    _lookup_message(),
-                    operation="dispatcher_dialogs_download_media_lookup",
-                    phone=phone,
-                    pool=self._pool,
-                )
-            except HandledFloodWaitError as exc:
-                raise RuntimeError(f"flood_wait:{exc.info.wait_seconds}") from exc
-            if msg is None:
-                raise RuntimeError("message_not_found")
             output_dir = Path(__file__).resolve().parents[2] / "data" / "downloads"
-            output_dir.mkdir(parents=True, exist_ok=True)
-            output_dir_resolved = output_dir.resolve()
-            try:
-                path = await run_with_flood_wait(
-                    client.download_media(msg, file=str(output_dir_resolved)),
-                    operation="dispatcher_dialogs_download_media",
-                    phone=phone,
-                    pool=self._pool,
-                )
-            except HandledFloodWaitError as exc:
-                raise RuntimeError(f"flood_wait:{exc.info.wait_seconds}") from exc
-            if not path:
-                raise RuntimeError("no_media")
-            resolved = Path(path).resolve()
-            if output_dir_resolved not in resolved.parents:
-                raise RuntimeError("path_escape")
-            return {"phone": phone, "path": str(resolved)}
-        finally:
-            await self._pool.release_client(phone)
+            result = await TelegramActionService(self._pool).download_media(
+                phone=phone,
+                chat_id=payload["chat_id"],
+                message_id=int(payload["message_id"]),
+                output_dir=output_dir,
+                operation_prefix="dispatcher_dialogs_download_media",
+            )
+            return {"phone": result.phone, "path": result.path}
+        except HandledFloodWaitError as exc:
+            raise RuntimeError(f"flood_wait:{exc.info.wait_seconds}") from exc
+        except TelegramActionMessageNotFoundError as exc:
+            raise RuntimeError("message_not_found") from exc
+        except TelegramActionNoMediaError as exc:
+            raise RuntimeError("no_media") from exc
+        except TelegramActionPathEscapeError as exc:
+            raise RuntimeError("path_escape") from exc
 
     async def _handle_accounts_connect(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -438,7 +438,7 @@ class TelegramCommandDispatcher:
         return {
             "phone": result.phone,
             "channel_id": result.channel_id,
-            "channel_title": payload["title"],
+            "channel_title": result.channel_title,
             "channel_username": result.channel_username,
             "invite_link": result.invite_link,
         }

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -249,6 +249,32 @@ class TelegramTransportSession:
             # Telethon not available (e.g. test env with stub backend)
             return None
 
+    async def create_channel(
+        self,
+        *,
+        title: str,
+        about: str = "",
+        broadcast: bool = True,
+        megagroup: bool = False,
+    ) -> Any:
+        """Create a Telegram channel/chat using the Telethon raw API."""
+        from telethon.tl.functions.channels import CreateChannelRequest
+
+        return await self.invoke_request(
+            CreateChannelRequest(
+                title=title,
+                about=about,
+                broadcast=broadcast,
+                megagroup=megagroup,
+            )
+        )
+
+    async def update_channel_username(self, channel: Any, username: str) -> Any:
+        """Set a public username for a channel using the Telethon raw API."""
+        from telethon.tl.functions.channels import UpdateUsernameRequest
+
+        return await self.invoke_request(UpdateUsernameRequest(channel, username))
+
     async def download_media(self, message: Any, *, file: Any = None) -> Any:
         return await self._run(
             "telegram_download_media",

--- a/tests/test_agent_threads_moderation_runtime_paths.py
+++ b/tests/test_agent_threads_moderation_runtime_paths.py
@@ -586,12 +586,11 @@ class TestLeaveDialogs:
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
         )
-        with patch("src.services.channel_service.ChannelService") as mock_svc:
-            mock_svc.return_value.leave_dialogs = AsyncMock(return_value={100: True, 200: True})
-            handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["leave_dialogs"](
-                {"phone": "+79001234567", "dialog_ids": "100,200", "confirm": True}
-            )
+        pool.leave_channels = AsyncMock(return_value={100: True, 200: True})
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["leave_dialogs"](
+            {"phone": "+79001234567", "dialog_ids": "100,200", "confirm": True}
+        )
         assert "2/2" in _text(result)
 
     @pytest.mark.anyio
@@ -600,12 +599,11 @@ class TestLeaveDialogs:
         mock_db.get_accounts = AsyncMock(
             return_value=[SimpleNamespace(phone="+79001234567", is_primary=True)]
         )
-        with patch("src.services.channel_service.ChannelService") as mock_svc:
-            mock_svc.return_value.leave_dialogs = AsyncMock(side_effect=Exception("net"))
-            handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["leave_dialogs"](
-                {"phone": "+79001234567", "dialog_ids": "100", "confirm": True}
-            )
+        pool.leave_channels = AsyncMock(side_effect=Exception("net"))
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["leave_dialogs"](
+            {"phone": "+79001234567", "dialog_ids": "100", "confirm": True}
+        )
         assert "Ошибка выхода" in _text(result)
 
 

--- a/tests/test_cli_dialogs_notifications_scheduler.py
+++ b/tests/test_cli_dialogs_notifications_scheduler.py
@@ -202,16 +202,11 @@ class TestMyTelegramCommand:
                 "username": None,
             },
         ]
+        fake_pool.leave_channels = AsyncMock(return_value={-100123456: True})
 
         with (
             patch.object(
                 ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=dialogs_info
-            ),
-            patch.object(
-                ChannelService,
-                "leave_dialogs",
-                new_callable=AsyncMock,
-                return_value={-100123456: True},
             ),
         ):
             from src.cli.commands.dialogs import run
@@ -235,15 +230,10 @@ class TestMyTelegramCommand:
         fake_pool.clients = {"+10001112233": AsyncMock()}
 
         from src.services.channel_service import ChannelService
+        fake_pool.leave_channels = AsyncMock(return_value={-100111: True, -100222: False})
 
         with (
             patch.object(ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=[]),
-            patch.object(
-                ChannelService,
-                "leave_dialogs",
-                new_callable=AsyncMock,
-                return_value={-100111: True, -100222: False},
-            ) as mock_leave,
         ):
             from src.cli.commands.dialogs import run
 
@@ -256,7 +246,7 @@ class TestMyTelegramCommand:
                 )
             )
 
-        called_dialogs = mock_leave.call_args[0][1]
+        called_dialogs = fake_pool.leave_channels.call_args[0][1]
         assert (-100111, "channel") in called_dialogs
         assert (-100222, "channel") in called_dialogs
 
@@ -311,16 +301,11 @@ class TestMyTelegramCommand:
                 "username": None,
             },
         ]
+        fake_pool.leave_channels = AsyncMock(return_value={-100123456: True})
 
         with (
             patch.object(
                 ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=dialogs_info
-            ),
-            patch.object(
-                ChannelService,
-                "leave_dialogs",
-                new_callable=AsyncMock,
-                return_value={-100123456: True},
             ),
             patch("builtins.input", return_value="y"),
         ):
@@ -347,23 +332,18 @@ class TestMyTelegramCommand:
         }
 
         from src.services.channel_service import ChannelService
+        fake_pool.leave_channels = AsyncMock(return_value={-100123456: True})
 
         with (
             patch.object(ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=[]),
-            patch.object(
-                ChannelService,
-                "leave_dialogs",
-                new_callable=AsyncMock,
-                return_value={-100123456: True},
-            ) as mock_leave,
         ):
             from src.cli.commands.dialogs import run
 
             run(_ns(dialogs_action="leave", phone=None, dialog_ids=["-100123456"], yes=True))
 
         # First account alphabetically should be used
-        mock_leave.assert_awaited_once()
-        called_phone = mock_leave.call_args[0][0]
+        fake_pool.leave_channels.assert_awaited_once()
+        called_phone = fake_pool.leave_channels.call_args[0][0]
         assert called_phone == "+10001112233"
 
     def test_leave_dm_uses_dm_type(self, cli_env_with_pool, capsys):
@@ -372,15 +352,10 @@ class TestMyTelegramCommand:
         fake_pool.clients = {"+10001112233": AsyncMock()}
 
         from src.services.channel_service import ChannelService
+        fake_pool.leave_channels = AsyncMock(return_value={123456: True})
 
         with (
             patch.object(ChannelService, "get_my_dialogs", new_callable=AsyncMock, return_value=[]),
-            patch.object(
-                ChannelService,
-                "leave_dialogs",
-                new_callable=AsyncMock,
-                return_value={123456: True},
-            ) as mock_leave,
         ):
             from src.cli.commands.dialogs import run
 
@@ -393,7 +368,7 @@ class TestMyTelegramCommand:
                 )
             )
 
-        called_dialogs = mock_leave.call_args[0][1]
+        called_dialogs = fake_pool.leave_channels.call_args[0][1]
         assert (123456, "dm") in called_dialogs
 
     def test_cache_clear_all(self, cli_env_with_pool, capsys):

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -2065,13 +2065,12 @@ class TestMyTelegramToolErrors:
         assert "ошибка" in _text(result).lower()
 
     async def test_leave_dialogs_exception(self, mytg_setup):
-        handlers, _, _ = mytg_setup
-        with patch("src.services.channel_service.ChannelService.leave_dialogs",
-                    new_callable=AsyncMock, side_effect=RuntimeError("fail")):
-            result = await handlers["leave_dialogs"]({
-                "phone": "+1111", "dialog_ids": "1,2", "confirm": True,
-            })
-            assert "ошибка" in _text(result).lower()
+        handlers, _, pool = mytg_setup
+        pool.leave_channels = AsyncMock(side_effect=RuntimeError("fail"))
+        result = await handlers["leave_dialogs"]({
+            "phone": "+1111", "dialog_ids": "1,2", "confirm": True,
+        })
+        assert "ошибка" in _text(result).lower()
 
     async def test_get_forum_topics_exception(self, mytg_setup):
         handlers, mock_db, _ = mytg_setup

--- a/tests/test_dialogs_cli_and_web_actions.py
+++ b/tests/test_dialogs_cli_and_web_actions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -696,7 +697,8 @@ class TestCliDownloadMedia:
         _run_cli("download-media", pool, cli_db, {
             "phone": _PHONE, "chat_id": "@ch", "message_id": 1, "output_dir": "/tmp",
         })
-        assert "Downloaded: /tmp/photo.jpg" in capsys.readouterr().out
+        expected_path = str(Path("/tmp/photo.jpg").resolve())
+        assert f"Downloaded: {expected_path}" in capsys.readouterr().out
 
     def test_download_media_no_media(self, cli_db, capsys):
         pool, client = _mock_pool()

--- a/tests/test_dialogs_cli_and_web_actions.py
+++ b/tests/test_dialogs_cli_and_web_actions.py
@@ -17,7 +17,6 @@ from tests.helpers import build_web_app, cli_ns, make_auth_client
 
 _PHONE = "+79001234567"
 _SVC_DIALOGS = "src.services.channel_service.ChannelService.get_my_dialogs"
-_SVC_LEAVE = "src.services.channel_service.ChannelService.leave_dialogs"
 
 _FAKE_DIALOGS = [
     {
@@ -48,6 +47,7 @@ def _mock_pool(*, clients=None, native_result=None, get_forum_topics=None):
         return_value=(mock_client, _PHONE) if native_result is None else native_result,
     )
     pool.invalidate_dialogs_cache = MagicMock()
+    pool.leave_channels = AsyncMock(return_value={})
     pool.get_forum_topics = AsyncMock(
         return_value=get_forum_topics if get_forum_topics is not None else [],
     )
@@ -781,9 +781,9 @@ class TestCliLeave:
 
     def test_leave_ok(self, cli_db, capsys):
         pool, _ = _mock_pool()
+        pool.leave_channels = AsyncMock(return_value={-100111: True})
         with (
             patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS),
-            patch(_SVC_LEAVE, new_callable=AsyncMock, return_value={-100111: True}),
         ):
             _run_cli("leave", pool, cli_db, {
                 "phone": _PHONE, "dialog_ids": ["-100111"], "yes": True,
@@ -812,9 +812,9 @@ class TestCliLeave:
 
     def test_leave_partial_invalid_ids(self, cli_db, capsys):
         pool, _ = _mock_pool()
+        pool.leave_channels = AsyncMock(return_value={-100111: True})
         with (
             patch(_SVC_DIALOGS, new_callable=AsyncMock, return_value=_FAKE_DIALOGS),
-            patch(_SVC_LEAVE, new_callable=AsyncMock, return_value={-100111: True}),
         ):
             _run_cli("leave", pool, cli_db, {
                 "phone": _PHONE, "dialog_ids": ["-100111,abc"], "yes": True,
@@ -835,18 +835,11 @@ class TestCliCreateChannel:
     """CLI dialogs create-channel."""
 
     def test_create_channel_ok(self, cli_db, capsys):
-        pool, _ = _mock_pool()
-        mock_client = MagicMock()
+        pool, client = _mock_pool()
         channel = SimpleNamespace(id=12345, username="newchan")
         mock_result = SimpleNamespace(chats=[channel])
-        mock_client.__call__ = AsyncMock(return_value=mock_result)
-        pool.clients = {_PHONE: mock_client}
-
-        # Replace the client's __call__ to handle CreateChannelRequest
-        async def fake_call(req):
-            return mock_result
-
-        mock_client.side_effect = fake_call
+        client.create_channel = AsyncMock(return_value=mock_result)
+        client.update_channel_username = AsyncMock()
 
         with patch("src.cli.commands.dialogs.pool", pool, create=True):
             _run_cli("create-channel", pool, cli_db, {

--- a/tests/test_telegram_action_contract.py
+++ b/tests/test_telegram_action_contract.py
@@ -1,0 +1,122 @@
+"""Architecture tests for the Telegram action contract."""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from src.services.telegram_action_inventory import TELEGRAM_ACTION_INVENTORY
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+RAW_TELETHON_ALLOWED = {
+    Path("src/telegram/backends.py"),
+    Path("src/telegram/auth.py"),
+}
+
+ENTRYPOINT_ROOTS = (
+    Path("src/cli"),
+    Path("src/web"),
+    Path("src/agent/tools"),
+    Path("src/services/pipeline_nodes"),
+)
+ENTRYPOINT_FILES = {
+    Path("src/services/telegram_command_dispatcher.py"),
+}
+ENTRYPOINT_FORBIDDEN_ACTION_CALLS = {
+    "send_message",
+    "edit_message",
+    "delete_messages",
+    "forward_messages",
+    "pin_message",
+    "unpin_message",
+    "get_participants",
+    "get_broadcast_stats",
+    "edit_admin",
+    "edit_permissions",
+    "kick_participant",
+    "send_read_acknowledge",
+    "edit_folder",
+    "download_media",
+    "leave_channels",
+}
+
+
+def test_telegram_action_inventory_has_unique_complete_actions():
+    actions = [item.action for item in TELEGRAM_ACTION_INVENTORY]
+    assert len(actions) == len(set(actions))
+    assert "send_reaction" in actions
+    assert "create_channel" in actions
+    assert "download_media" in actions
+    assert "leave_dialogs" in actions
+    for item in TELEGRAM_ACTION_INVENTORY:
+        assert item.backend_method, item.action
+        assert any((item.cli, item.web_command, item.agent_tool, item.pipeline_node)), item.action
+
+
+def _is_entrypoint_path(relative: Path) -> bool:
+    return relative in ENTRYPOINT_FILES or any(relative.is_relative_to(root) for root in ENTRYPOINT_ROOTS)
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _is_telegram_action_service_receiver(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name) and node.id == "action_service":
+        return True
+    if isinstance(node, ast.Call):
+        return _call_name(node.func) == "TelegramActionService"
+    return False
+
+
+def test_raw_telethon_function_imports_stay_in_backend_allowlist():
+    offenders: list[str] = []
+    for path in sorted((PROJECT_ROOT / "src").rglob("*.py")):
+        relative = path.relative_to(PROJECT_ROOT)
+        if relative in RAW_TELETHON_ALLOWED:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(relative))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("telethon.tl.functions"):
+                offenders.append(f"{relative}:{node.lineno} imports {node.module}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("telethon.tl.functions"):
+                        offenders.append(f"{relative}:{node.lineno} imports {alias.name}")
+    assert offenders == []
+
+
+def test_raw_telethon_request_constructors_stay_in_backend_allowlist():
+    offenders: list[str] = []
+    for path in sorted((PROJECT_ROOT / "src").rglob("*.py")):
+        relative = path.relative_to(PROJECT_ROOT)
+        if relative in RAW_TELETHON_ALLOWED:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(relative))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                name = _call_name(node.func)
+                if name and name != "Request" and name.endswith("Request"):
+                    offenders.append(f"{relative}:{node.lineno} constructs {name}")
+    assert offenders == []
+
+
+def test_entrypoints_delegate_telegram_actions_to_service_contract():
+    offenders: list[str] = []
+    for path in sorted((PROJECT_ROOT / "src").rglob("*.py")):
+        relative = path.relative_to(PROJECT_ROOT)
+        if not _is_entrypoint_path(relative):
+            continue
+        tree = ast.parse(path.read_text(), filename=str(relative))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if _is_telegram_action_service_receiver(node.func.value):
+                continue
+            if node.func.attr in ENTRYPOINT_FORBIDDEN_ACTION_CALLS:
+                offenders.append(f"{relative}:{node.lineno} calls .{node.func.attr}() directly")
+    assert offenders == []

--- a/tests/test_telegram_actions_service.py
+++ b/tests/test_telegram_actions_service.py
@@ -1,0 +1,118 @@
+"""Tests for the shared TelegramActionService contract."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
+
+
+def _pool_with_client(client):
+    pool = MagicMock()
+    pool.get_native_client_by_phone = AsyncMock(return_value=(client, "+1"))
+    pool.get_available_client = AsyncMock(return_value=(client, "+1"))
+    pool.get_client_by_phone = AsyncMock(return_value=(client, "+1"))
+    pool.release_client = AsyncMock()
+    return pool
+
+
+@pytest.mark.anyio
+async def test_send_reaction_resolves_entity_and_releases_client():
+    client = AsyncMock()
+    client.get_entity = AsyncMock(return_value="entity")
+    client.send_reaction = AsyncMock()
+    pool = _pool_with_client(client)
+
+    result = await TelegramActionService(pool).send_reaction(
+        phone="+1",
+        chat_id="@chat",
+        message_id=42,
+        emoji="🔥",
+    )
+
+    assert result.phone == "+1"
+    client.get_entity.assert_awaited_once_with("@chat")
+    client.send_reaction.assert_awaited_once_with("entity", 42, "🔥")
+    pool.release_client.assert_awaited_once_with("+1")
+
+
+@pytest.mark.anyio
+async def test_create_channel_sets_username_and_returns_link():
+    client = AsyncMock()
+    channel = SimpleNamespace(id=123, username="")
+    client.create_channel = AsyncMock(return_value=SimpleNamespace(chats=[channel]))
+    client.update_channel_username = AsyncMock()
+    pool = _pool_with_client(client)
+
+    result = await TelegramActionService(pool).create_channel(
+        phone="+1",
+        title="Title",
+        about="About",
+        username="public_name",
+    )
+
+    assert result.channel_id == 123
+    assert result.channel_username == "public_name"
+    assert result.invite_link == "https://t.me/public_name"
+    client.create_channel.assert_awaited_once_with(
+        title="Title",
+        about="About",
+        broadcast=True,
+        megagroup=False,
+    )
+    client.update_channel_username.assert_awaited_once_with(channel, "public_name")
+
+
+@pytest.mark.anyio
+async def test_download_media_looks_up_message_checks_path_and_releases_client(tmp_path):
+    client = AsyncMock()
+    client.get_entity = AsyncMock(return_value="entity")
+    message = SimpleNamespace(id=7)
+
+    async def _iter_messages(entity, ids):
+        assert entity == "entity"
+        assert ids == 7
+        yield message
+
+    media_path = tmp_path / "media.jpg"
+    media_path.write_text("x")
+    client.iter_messages = MagicMock(return_value=_iter_messages("entity", 7))
+    client.download_media = AsyncMock(return_value=str(media_path))
+    pool = _pool_with_client(client)
+
+    result = await TelegramActionService(pool).download_media(
+        phone="+1",
+        chat_id="@chat",
+        message_id=7,
+        output_dir=tmp_path,
+    )
+
+    assert result.path == str(media_path)
+    client.download_media.assert_awaited_once_with(message, file=str(tmp_path.resolve()))
+    pool.release_client.assert_awaited_once_with("+1")
+
+
+@pytest.mark.anyio
+async def test_leave_dialogs_delegates_to_pool_leave_channels():
+    pool = MagicMock()
+    pool.leave_channels = AsyncMock(return_value={100: True, 200: False})
+
+    result = await TelegramActionService(pool).leave_dialogs(
+        phone="+1",
+        dialogs=[(100, "channel"), (200, "supergroup")],
+    )
+
+    assert result.success_count == 1
+    assert result.failed_count == 1
+    pool.leave_channels.assert_awaited_once_with("+1", [(100, "channel"), (200, "supergroup")])
+
+
+@pytest.mark.anyio
+async def test_action_service_raises_when_client_unavailable():
+    pool = MagicMock()
+    pool.get_native_client_by_phone = AsyncMock(return_value=None)
+
+    with pytest.raises(TelegramActionClientUnavailableError):
+        await TelegramActionService(pool).send_message(phone="+1", recipient="@u", text="hi")

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -56,10 +56,10 @@ async def test_download_media_creates_output_dir(tmp_path, monkeypatch):
 
         pool = MagicMock()
         pool.release_client = AsyncMock()
-        dispatcher = TelegramCommandDispatcher(db, pool)
-        dispatcher._get_client = AsyncMock(
+        pool.get_native_client_by_phone = AsyncMock(
             return_value=(_FakeClient(download_return=str(expected_file)), "+123")
         )
+        dispatcher = TelegramCommandDispatcher(db, pool)
 
         result = await dispatcher._handle_dialogs_download_media(
             {"phone": "+123", "chat_id": 1, "message_id": 42}
@@ -87,10 +87,10 @@ async def test_download_media_rejects_path_escape(tmp_path, monkeypatch):
 
         pool = MagicMock()
         pool.release_client = AsyncMock()
-        dispatcher = TelegramCommandDispatcher(db, pool)
-        dispatcher._get_client = AsyncMock(
+        pool.get_native_client_by_phone = AsyncMock(
             return_value=(_FakeClient(download_return=str(escape_file)), "+123")
         )
+        dispatcher = TelegramCommandDispatcher(db, pool)
 
         with pytest.raises(RuntimeError, match="path_escape"):
             await dispatcher._handle_dialogs_download_media(
@@ -728,14 +728,11 @@ async def test_dialogs_create_channel():
     channel_obj.username = ""
     result_mock = MagicMock()
     result_mock.chats = [channel_obj]
-    c.return_value = result_mock
-    c.get_entity = AsyncMock(return_value="entity")
+    c.create_channel = AsyncMock(return_value=result_mock)
+    c.update_channel_username = AsyncMock()
     pool.get_native_client_by_phone.return_value = (c, "+1")
     d = _dispatcher(pool=pool)
-    with patch("telethon.tl.functions.channels.CreateChannelRequest") as mock_req, \
-         patch("telethon.tl.functions.channels.UpdateUsernameRequest"):
-        mock_req.return_value = "req"
-        r = await d._handle_dialogs_create_channel({"phone": "+1", "title": "Test Channel", "about": "desc"})
+    r = await d._handle_dialogs_create_channel({"phone": "+1", "title": "Test Channel", "about": "desc"})
     assert r["phone"] == "+1"
 
 
@@ -1272,16 +1269,13 @@ async def test_dialogs_create_channel_with_username():
     channel_obj.username = ""
     result_mock = MagicMock()
     result_mock.chats = [channel_obj]
-    c.return_value = result_mock
-    c.get_entity = AsyncMock(return_value="entity")
+    c.create_channel = AsyncMock(return_value=result_mock)
+    c.update_channel_username = AsyncMock()
     pool.get_native_client_by_phone.return_value = (c, "+1")
     d = _dispatcher(pool=pool)
-    with patch("telethon.tl.functions.channels.CreateChannelRequest") as mock_req, \
-         patch("telethon.tl.functions.channels.UpdateUsernameRequest"):
-        mock_req.return_value = "req"
-        r = await d._handle_dialogs_create_channel({
-            "phone": "+1", "title": "Test Channel", "about": "desc", "username": "my_channel",
-        })
+    r = await d._handle_dialogs_create_channel({
+        "phone": "+1", "title": "Test Channel", "about": "desc", "username": "my_channel",
+    })
     assert r["channel_username"] == "my_channel"
     assert "t.me/my_channel" in r["invite_link"]
 
@@ -1298,17 +1292,13 @@ async def test_dialogs_create_channel_username_fails():
     result_mock = MagicMock()
     result_mock.chats = [channel_obj]
 
-    # First call = CreateChannelRequest, second call = UpdateUsernameRequest (fails)
-    c.side_effect = [result_mock, Exception("username taken")]
-    c.get_entity = AsyncMock(return_value="entity")
+    c.create_channel = AsyncMock(return_value=result_mock)
+    c.update_channel_username = AsyncMock(side_effect=Exception("username taken"))
     pool.get_native_client_by_phone.return_value = (c, "+1")
     d = _dispatcher(pool=pool)
-    with patch("telethon.tl.functions.channels.CreateChannelRequest") as mock_req, \
-         patch("telethon.tl.functions.channels.UpdateUsernameRequest"):
-        mock_req.return_value = "req"
-        r = await d._handle_dialogs_create_channel({
-            "phone": "+1", "title": "Test Channel", "username": "taken_name",
-        })
+    r = await d._handle_dialogs_create_channel({
+        "phone": "+1", "title": "Test Channel", "username": "taken_name",
+    })
     # Username remains empty since update failed
     assert r["channel_username"] == ""
     assert r["invite_link"] == ""
@@ -1322,14 +1312,12 @@ async def test_dialogs_create_channel_no_chats():
     c = AsyncMock()
     result_mock = MagicMock()
     result_mock.chats = []
-    c.return_value = result_mock
-    c.get_entity = AsyncMock(return_value="entity")
+    c.create_channel = AsyncMock(return_value=result_mock)
+    c.update_channel_username = AsyncMock()
     pool.get_native_client_by_phone.return_value = (c, "+1")
     d = _dispatcher(pool=pool)
-    with patch("telethon.tl.functions.channels.CreateChannelRequest") as mock_req:
-        mock_req.return_value = "req"
-        with pytest.raises(RuntimeError, match="Telegram returned empty response"):
-            await d._handle_dialogs_create_channel({"phone": "+1", "title": "Test"})
+    with pytest.raises(RuntimeError, match="Telegram returned empty response"):
+        await d._handle_dialogs_create_channel({"phone": "+1", "title": "Test"})
 
 
 # --- _handle_dialogs_edit_admin: with title ---
@@ -1730,9 +1718,9 @@ async def test_download_media_message_not_found(tmp_path, monkeypatch):
 
         client.iter_messages = lambda entity, ids: empty_iter()
         client.get_entity = AsyncMock(return_value=MagicMock())
+        pool.get_native_client_by_phone = AsyncMock(return_value=(client, "+123"))
 
         dispatcher = TelegramCommandDispatcher(db, pool)
-        dispatcher._get_client = AsyncMock(return_value=(client, "+123"))
 
         with pytest.raises(RuntimeError, match="message_not_found"):
             await dispatcher._handle_dialogs_download_media(
@@ -1768,9 +1756,9 @@ async def test_download_media_no_media(tmp_path, monkeypatch):
         client.iter_messages = lambda entity, ids: single_msg()
         client.download_media = AsyncMock(return_value=None)
         client.get_entity = AsyncMock(return_value=MagicMock())
+        pool.get_native_client_by_phone = AsyncMock(return_value=(client, "+123"))
 
         dispatcher = TelegramCommandDispatcher(db, pool)
-        dispatcher._get_client = AsyncMock(return_value=(client, "+123"))
 
         with pytest.raises(RuntimeError, match="no_media"):
             await dispatcher._handle_dialogs_download_media(

--- a/tests/test_tool_permissions.py
+++ b/tests/test_tool_permissions.py
@@ -528,14 +528,13 @@ class TestEndToEndPermissionFlow:
     async def test_allowed_and_confirmed(self, mock_db):
         mock_db.get_setting = AsyncMock(return_value=None)
         pool = MagicMock()
-        with patch("src.services.channel_service.ChannelService") as mock_svc_cls:
-            mock_svc_cls.return_value.leave_dialogs = AsyncMock(return_value={123: True})
-            handlers = _get_tool_handlers(mock_db, client_pool=pool)
-            result = await handlers["leave_dialogs"]({
-                "phone": "+79990001111",
-                "dialog_ids": "123",
-                "confirm": True,
-            })
+        pool.leave_channels = AsyncMock(return_value={123: True})
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["leave_dialogs"]({
+            "phone": "+79990001111",
+            "dialog_ids": "123",
+            "confirm": True,
+        })
         assert "покинут" in _text(result)
 
     async def test_no_confirm_returns_warning(self, mock_db):
@@ -556,13 +555,12 @@ class TestEndToEndPermissionFlow:
         r1 = await handlers["leave_dialogs"]({"phone": "+79990001111", "dialog_ids": "123"})
         assert "Подтвердите" in _text(r1)
         # Retry with confirm
-        with patch("src.services.channel_service.ChannelService") as mock_svc_cls:
-            mock_svc_cls.return_value.leave_dialogs = AsyncMock(return_value={123: True})
-            r2 = await handlers["leave_dialogs"]({
-                "phone": "+79990001111",
-                "dialog_ids": "123",
-                "confirm": True,
-            })
+        pool.leave_channels = AsyncMock(return_value={123: True})
+        r2 = await handlers["leave_dialogs"]({
+            "phone": "+79990001111",
+            "dialog_ids": "123",
+            "confirm": True,
+        })
         assert "покинут" in _text(r2)
 
     async def test_phone_not_allowed(self, mock_db):


### PR DESCRIPTION
## Summary

Closes #557.

This PR centralizes Telegram action behavior behind a shared `TelegramActionService` so CLI commands, agent tools, pipeline handlers, and the web/command dispatcher stop carrying duplicated Telethon action logic.

## What changed

- Added a shared Telegram action service and inventory for actions such as reactions, message send/edit/delete/forward, pin/unpin, read/archive, participants/stats, media download, admin/permissions, leaving dialogs, and channel creation.
- Migrated CLI dialogs, agent tools, pipeline handlers, dispatcher paths, and channel service to reuse the shared service/backends instead of duplicating raw action calls.
- Added contract tests and import-linter enforcement so entrypoints do not directly depend on Telethon action APIs outside the allowed backend/service boundary.
- Kept Semgrep out of the required toolchain per follow-up direction; the required guards are pytest contract tests plus import-linter.

## Validation

- `lint-imports --config .importlinter`
- `python3 -m pytest tests/test_telegram_action_contract.py -q`
- `python3 -m ruff check src/ tests/ conftest.py`
- `git diff --check`
- Full validation previously run for the implementation:
  - `python3 -m pytest tests/ -q -m "not aiosqlite_serial" -n auto`
  - `python3 -m pytest tests/ -q -m aiosqlite_serial`