### PR TITLE
[codex] Add chat filters to search queries

### DIFF
--- a/docs/features/search.md
+++ b/docs/features/search.md
@@ -42,11 +42,14 @@ python -m src.main agent chat "найди сообщения про блокче
     ```bash
     python -m src.main search-query list
     python -m src.main search-query add "ключевое слово"
+    python -m src.main search-query add "ключевое слово" --chats "@chat1, -1001234567890"
     python -m src.main search-query run 1         # разовый запуск
     python -m src.main search-query stats 1       # статистика совпадений
     ```
 
 === "Web"
     `GET /search-queries/` · `POST /search-queries/add`
+
+Поле `Чаты` у сохранённого запроса необязательно. Пустое значение ищет по всем чатам; непустое ограничивает поиск списком `channel_id`, `@username`, `username` или ссылок `t.me`, разделённых пробелами или запятыми.
 
 Уведомления содержат ссылку на оригинальное сообщение (`t.me/channel/message_id`).

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -42,9 +42,10 @@ def register(db, client_pool, embedding_service, **kwargs):
                 if getattr(sq, "notify_on_collect", False):
                     flags.append("notify")
                 flags_str = f" [{', '.join(flags)}]" if flags else ""
+                chats_str = f" chats={sq.chat_filter}" if getattr(sq, "chat_filter", "") else " chats=all"
                 lines.append(
                     f"- id={sq.id}: '{sq.query}' interval={sq.interval_minutes}m "
-                    f"{status}{flags_str}"
+                    f"{status}{flags_str}{chats_str}"
                 )
             return _text_response("\n".join(lines))
         except Exception as e:
@@ -76,7 +77,11 @@ def register(db, client_pool, embedding_service, **kwargs):
                 f"is_regex: {sq.is_regex}",
                 f"is_fts: {sq.is_fts}",
                 f"notify_on_collect: {sq.notify_on_collect}",
+                f"chat_filter: {sq.chat_filter or 'all'}",
             ]
+            warning = (await svc.validate_chat_filter(sq.chat_filter)).warning_text()
+            if warning:
+                lines.append(f"warning: {warning}")
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка получения поискового запроса: {e}")
@@ -101,6 +106,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             "track_stats": Annotated[bool, "Записывать ежедневную статистику совпадений"],
             "exclude_patterns": Annotated[str, "Паттерны исключения через запятую"],
             "max_length": Annotated[int, "Максимальная длина сообщения для совпадения"],
+            "chat_filter": Annotated[str, "Список чатов через запятую или пробел"],
             "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
@@ -122,6 +128,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             track_stats = bool(args.get("track_stats", True))
             exclude_patterns = args.get("exclude_patterns", "")
             max_length = args.get("max_length")
+            chat_filter = args.get("chat_filter", args.get("chats", ""))
             sq_id = await svc.add(
                 query,
                 interval_minutes=interval,
@@ -131,8 +138,13 @@ def register(db, client_pool, embedding_service, **kwargs):
                 track_stats=track_stats,
                 exclude_patterns=exclude_patterns or "",
                 max_length=int(max_length) if max_length is not None else None,
+                chat_filter=chat_filter or "",
             )
-            return _text_response(f"Поисковый запрос создан (id={sq_id}).")
+            warning = (await svc.validate_chat_filter(chat_filter or "")).warning_text()
+            text = f"Поисковый запрос создан (id={sq_id})."
+            if warning:
+                text += f"\nПредупреждение: {warning}"
+            return _text_response(text)
         except Exception as e:
             return _text_response(f"Ошибка добавления поискового запроса: {e}")
 
@@ -151,6 +163,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             "track_stats": Annotated[bool, "Записывать ежедневную статистику совпадений"],
             "exclude_patterns": Annotated[str, "Паттерны исключения через запятую"],
             "max_length": Annotated[int, "Максимальная длина сообщения для совпадения"],
+            "chat_filter": Annotated[str, "Список чатов через запятую или пробел"],
             "confirm": Annotated[bool, "Установите true для подтверждения действия"],
         },
     )
@@ -176,6 +189,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             track_stats = bool(args.get("track_stats", getattr(existing, "track_stats", True)))
             exclude_patterns = args.get("exclude_patterns", getattr(existing, "exclude_patterns", ""))
             max_length_raw = args.get("max_length", getattr(existing, "max_length", None))
+            chat_filter = args.get("chat_filter", args.get("chats", getattr(existing, "chat_filter", "")))
             ok = await svc.update(
                 int(sq_id),
                 query,
@@ -186,9 +200,14 @@ def register(db, client_pool, embedding_service, **kwargs):
                 track_stats=track_stats,
                 exclude_patterns=exclude_patterns or "",
                 max_length=int(max_length_raw) if max_length_raw is not None else None,
+                chat_filter=chat_filter or "",
             )
             if ok:
-                return _text_response(f"Поисковый запрос id={sq_id} обновлён.")
+                warning = (await svc.validate_chat_filter(chat_filter or "")).warning_text()
+                text = f"Поисковый запрос id={sq_id} обновлён."
+                if warning:
+                    text += f"\nПредупреждение: {warning}"
+                return _text_response(text)
             return _text_response(f"Не удалось обновить запрос id={sq_id}.")
         except Exception as e:
             return _text_response(f"Ошибка редактирования поискового запроса: {e}")

--- a/src/cli/commands/search_query.py
+++ b/src/cli/commands/search_query.py
@@ -2,12 +2,27 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
 
 from pydantic import ValidationError
 
 from src.cli import runtime
 from src.database.bundles import SearchQueryBundle
 from src.services.search_query_service import SearchQueryService
+
+
+async def _chat_filter_warning(svc: SearchQueryService, chat_filter: str) -> str:
+    validator = getattr(svc, "validate_chat_filter", None)
+    if validator is None:
+        return ""
+    try:
+        result = validator(chat_filter)
+        validation = await result if inspect.isawaitable(result) else result
+        warning_text = getattr(validation, "warning_text", None)
+        text = warning_text() if callable(warning_text) else ""
+        return text if isinstance(text, str) else ""
+    except Exception:
+        return ""
 
 
 def run(args: argparse.Namespace) -> None:
@@ -35,6 +50,11 @@ def run(args: argparse.Namespace) -> None:
                             (item["last_run"] or "—")[:20],
                         )
                     )
+                    chat_filter = getattr(sq, "chat_filter", "")
+                    if chat_filter:
+                        print(f"      chats: {chat_filter}")
+                        if item.get("chat_filter_warnings"):
+                            print(f"      warning: {item['chat_filter_warnings']}")
 
             elif args.search_query_action == "get":
                 sq = await svc.get(args.id)
@@ -51,6 +71,11 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Track stats: {sq.track_stats}")
                 print(f"Max length: {sq.max_length if sq.max_length is not None else '—'}")
                 print(f"Exclude patterns: {sq.exclude_patterns or '—'}")
+                chat_filter = getattr(sq, "chat_filter", "")
+                print(f"Chats: {chat_filter or 'all'}")
+                warning = await _chat_filter_warning(svc, chat_filter)
+                if warning:
+                    print(f"Warning: {warning}")
 
             elif args.search_query_action == "add":
                 exclude = (
@@ -66,11 +91,15 @@ def run(args: argparse.Namespace) -> None:
                         track_stats=args.track_stats,
                         exclude_patterns=exclude,
                         max_length=args.max_length,
+                        chat_filter=getattr(args, "chats", ""),
                     )
                 except ValidationError as e:
                     print(f"Error: {e.errors()[0]['msg']}")
                     return
                 print(f"Added search query id={sq_id}: {args.query}")
+                warning = await _chat_filter_warning(svc, getattr(args, "chats", ""))
+                if warning:
+                    print(f"Warning: {warning}")
 
             elif args.search_query_action == "edit":
                 sq = await svc.get(args.id)
@@ -101,11 +130,24 @@ def run(args: argparse.Namespace) -> None:
                         track_stats=tstats,
                         exclude_patterns=exclude,
                         max_length=max_len,
+                        chat_filter=(
+                            args.chats
+                            if getattr(args, "chats", None) is not None
+                            else getattr(sq, "chat_filter", "")
+                        ),
                     )
                 except ValidationError as e:
                     print(f"Error: {e.errors()[0]['msg']}")
                     return
                 print(f"Updated search query id={args.id}")
+                warning = await _chat_filter_warning(
+                    svc,
+                    args.chats
+                    if getattr(args, "chats", None) is not None
+                    else getattr(sq, "chat_filter", ""),
+                )
+                if warning:
+                    print(f"Warning: {warning}")
 
             elif args.search_query_action == "delete":
                 await svc.delete(args.id)

--- a/src/cli/parser_domains/search_query.py
+++ b/src/cli/parser_domains/search_query.py
@@ -22,6 +22,7 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         "--exclude-patterns", default="", help="Exclude patterns, one per line (use \\n)"
     )
     sq_add.add_argument("--max-length", type=int, default=None, help="Max message text length")
+    sq_add.add_argument("--chats", default="", help="Chat filter: IDs, usernames or t.me links")
 
     sq_edit = sq_sub.add_parser("edit", help="Edit search query")
     sq_edit.add_argument("id", type=int, help="Search query id")
@@ -38,6 +39,8 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     sq_edit.add_argument("--exclude-patterns", default=None, help="Exclude patterns (use \\n)")
     sq_edit.add_argument("--max-length", type=int, default=None, help="Max message text length")
     sq_edit.add_argument("--no-max-length", dest="max_length", action="store_const", const=-1)
+    sq_edit.add_argument("--chats", default=None, help="Chat filter: IDs, usernames or t.me links")
+    sq_edit.add_argument("--clear-chats", dest="chats", action="store_const", const="")
 
     sq_del = sq_sub.add_parser("delete", help="Delete search query")
     sq_del.add_argument("id", type=int, help="Search query id")

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -757,11 +757,12 @@ class SchedulerBundle:
 class SearchQueryBundle:
     search_queries: SearchQueriesRepository
     messages: MessagesRepository
+    channels: ChannelsRepository | None = None
 
     @classmethod
     def from_database(cls, db: "Database") -> "SearchQueryBundle":
         repos = db.repos
-        return cls(repos.search_queries, repos.messages)
+        return cls(repos.search_queries, repos.messages, repos.channels)
 
     async def add(self, sq: SearchQuery) -> int:
         return await self.search_queries.add(sq)
@@ -808,6 +809,11 @@ class SearchQueryBundle:
 
     async def get_last_recorded_at_all(self) -> dict[int, str]:
         return await self.search_queries.get_last_recorded_at_all()
+
+    async def get_channels(self) -> list[Channel]:
+        if self.channels is None:
+            return []
+        return await self.channels.get_channels()
 
 
 @dataclass(frozen=True)

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -64,6 +64,7 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "track_stats": "track_stats INTEGER DEFAULT 1",
         "exclude_patterns": "exclude_patterns TEXT DEFAULT ''",
         "max_length": "max_length INTEGER DEFAULT NULL",
+        "chat_filter": "chat_filter TEXT DEFAULT ''",
     },
     "notification_bots": {
         "tg_username": "tg_username TEXT",

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -10,6 +10,7 @@ import aiosqlite
 
 from src.models import Message, SearchQuery
 from src.utils.datetime import parse_datetime, parse_required_datetime
+from src.utils.search_query_chat_filter import parse_chat_filter
 
 logger = logging.getLogger(__name__)
 _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
@@ -767,6 +768,23 @@ class MessagesRepository:
                 continue
             conditions.append("m.text NOT LIKE ?")
             params.append(f"%{stripped}%")
+        chat_filter = parse_chat_filter(sq.chat_filter)
+        if chat_filter.has_filter:
+            chat_parts = []
+            if chat_filter.numeric_values:
+                placeholders = ", ".join("?" for _ in chat_filter.numeric_values)
+                chat_parts.append(f"m.channel_id IN ({placeholders})")
+                params.extend(chat_filter.numeric_values)
+                chat_parts.append(f"c.id IN ({placeholders})")
+                params.extend(chat_filter.numeric_values)
+            if chat_filter.usernames:
+                placeholders = ", ".join("?" for _ in chat_filter.usernames)
+                chat_parts.append(f"LOWER(c.username) IN ({placeholders})")
+                params.extend(chat_filter.usernames)
+            if chat_parts:
+                conditions.append("(" + " OR ".join(chat_parts) + ")")
+            else:
+                conditions.append("0 = 1")
         return conditions, params
 
     def _build_sq_parts(self, sq: SearchQuery) -> tuple[str, list[str], list]:

--- a/src/database/repositories/search_queries.py
+++ b/src/database/repositories/search_queries.py
@@ -14,8 +14,8 @@ class SearchQueriesRepository:
         cur = await self._db.execute(
             "INSERT INTO search_queries "
             "(name, query, is_regex, is_fts, is_active, notify_on_collect, "
-            "track_stats, interval_minutes, exclude_patterns, max_length) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "track_stats, interval_minutes, exclude_patterns, max_length, chat_filter) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 sq.name,
                 sq.query,
@@ -27,6 +27,7 @@ class SearchQueriesRepository:
                 sq.interval_minutes,
                 sq.exclude_patterns,
                 sq.max_length,
+                sq.chat_filter,
             ),
         )
         await self._db.commit()
@@ -56,7 +57,7 @@ class SearchQueriesRepository:
         await self._db.execute(
             "UPDATE search_queries SET name = ?, query = ?, is_regex = ?, is_fts = ?, "
             "notify_on_collect = ?, track_stats = ?, interval_minutes = ?, "
-            "exclude_patterns = ?, max_length = ? "
+            "exclude_patterns = ?, max_length = ?, chat_filter = ? "
             "WHERE id = ?",
             (
                 sq.name,
@@ -68,6 +69,7 @@ class SearchQueriesRepository:
                 sq.interval_minutes,
                 sq.exclude_patterns,
                 sq.max_length,
+                sq.chat_filter,
                 sq_id,
             ),
         )
@@ -163,5 +165,6 @@ class SearchQueriesRepository:
             interval_minutes=row["interval_minutes"],
             exclude_patterns=row["exclude_patterns"] or "",
             max_length=row["max_length"],
+            chat_filter=row["chat_filter"] if "chat_filter" in row.keys() and row["chat_filter"] else "",
             created_at=parse_datetime(row["created_at"]),
         )

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -161,6 +161,7 @@ CREATE TABLE IF NOT EXISTS search_queries (
     interval_minutes INTEGER NOT NULL DEFAULT 60,
     exclude_patterns TEXT DEFAULT '',
     max_length       INTEGER DEFAULT NULL,
+    chat_filter      TEXT DEFAULT '',
     created_at       TEXT DEFAULT (datetime('now'))
 );
 

--- a/src/models.py
+++ b/src/models.py
@@ -363,6 +363,7 @@ class SearchQuery(BaseModel):
     interval_minutes: int = Field(60, ge=1)
     exclude_patterns: str = ""
     max_length: int | None = None
+    chat_filter: str = ""
     created_at: datetime | None = None
 
     @model_validator(mode="after")

--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import logging
 import re
 
-from src.models import Message, SearchQuery
+from src.models import Channel, Message, SearchQuery
 from src.telegram.notifier import Notifier
+from src.utils.search_query_chat_filter import chat_filter_matches_message
 
 logger = logging.getLogger(__name__)
 
@@ -12,8 +13,9 @@ logger = logging.getLogger(__name__)
 class NotificationMatcher:
     """Match messages against notification queries and send batched notifications."""
 
-    def __init__(self, notifier: Notifier):
+    def __init__(self, notifier: Notifier, *, channels: list[Channel] | None = None):
         self._notifier = notifier
+        self._channels = channels or []
 
     async def match_and_notify(
         self,
@@ -30,6 +32,8 @@ class NotificationMatcher:
             if not msg.text:
                 continue
             for sq in queries:
+                if not chat_filter_matches_message(sq.chat_filter, msg, channels=self._channels):
+                    continue
                 if sq.max_length is not None and len(msg.text) >= sq.max_length:
                     continue
                 if any(p.lower() in msg.text.lower() for p in sq.exclude_patterns_list):

--- a/src/services/search_query_service.py
+++ b/src/services/search_query_service.py
@@ -7,6 +7,11 @@ from datetime import timedelta
 from src.database import Database
 from src.database.bundles import SearchQueryBundle
 from src.models import SearchQuery, SearchQueryDailyStat
+from src.utils.search_query_chat_filter import (
+    ChatFilterValidation,
+    single_resolved_channel_id,
+    validate_chat_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +33,7 @@ class SearchQueryService:
         track_stats: bool = True,
         exclude_patterns: str = "",
         max_length: int | None = None,
+        chat_filter: str = "",
     ) -> int:
         sq = SearchQuery(
             query=query,
@@ -38,6 +44,7 @@ class SearchQueryService:
             track_stats=track_stats,
             exclude_patterns=exclude_patterns,
             max_length=max_length,
+            chat_filter=chat_filter,
         )
         return await self._bundle.add(sq)
 
@@ -64,6 +71,7 @@ class SearchQueryService:
         track_stats: bool = True,
         exclude_patterns: str = "",
         max_length: int | None = None,
+        chat_filter: str | None = None,
     ) -> bool:
         existing = await self._bundle.get_by_id(sq_id)
         if not existing:
@@ -78,6 +86,7 @@ class SearchQueryService:
             track_stats=track_stats,
             exclude_patterns=exclude_patterns,
             max_length=max_length,
+            chat_filter=chat_filter if chat_filter is not None else existing.chat_filter,
         )
         await self._bundle.update(sq_id, sq)
         return True
@@ -103,9 +112,14 @@ class SearchQueryService:
     async def get_daily_stats(self, sq_id: int, days: int = 30) -> list[SearchQueryDailyStat]:
         return await self._bundle.get_daily_stats(sq_id, days)
 
+    async def validate_chat_filter(self, chat_filter: str) -> ChatFilterValidation:
+        channels = await self._get_channels()
+        return validate_chat_filter(chat_filter, channels)
+
     async def get_with_stats(self, days: int = 30) -> list[dict]:
         queries = await self._bundle.get_all()
         last_runs = await self._bundle.get_last_recorded_at_all()
+        channels = await self._get_channels()
         # Regex queries can't be counted via FTS5; exclude them from FTS stats batch
         tracked = [sq for sq in queries if sq.track_stats and not sq.is_regex]
         tracked_ids = {sq.id for sq in tracked}
@@ -116,12 +130,15 @@ class SearchQueryService:
             raw = stats_map.get(sq.id, []) if sq.id in tracked_ids else None
             daily = self._fill_missing_days(raw, days)
             total = sum(s.count for s in daily)
+            chat_validation = validate_chat_filter(sq.chat_filter, channels)
             result.append(
                 {
                     "query": sq,
                     "total_30d": total,
                     "last_run": last_runs.get(sq.id),
                     "daily_stats": daily,
+                    "chat_filter_warnings": chat_validation.warning_text(),
+                    "chat_filter_channel_id": single_resolved_channel_id(sq.chat_filter, channels),
                 }
             )
         return result
@@ -147,3 +164,9 @@ class SearchQueryService:
         day_str = today.isoformat()
         filled.append(existing.get(day_str, SearchQueryDailyStat(day=day_str, count=0)))
         return filled
+
+    async def _get_channels(self):
+        get_channels = getattr(self._bundle, "get_channels", None)
+        if get_channels is None:
+            return []
+        return await get_channels()

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1136,7 +1136,16 @@ class Collector:
 
         from src.services.notification_matcher import NotificationMatcher
 
-        matcher = NotificationMatcher(self._notifier)
+        get_channels = getattr(self._db, "get_channels", None)
+        channels = []
+        if get_channels:
+            import inspect
+
+            maybe_channels = get_channels()
+            channels = await maybe_channels if inspect.isawaitable(maybe_channels) else maybe_channels
+            if not isinstance(channels, list):
+                channels = []
+        matcher = NotificationMatcher(self._notifier, channels=channels)
         await matcher.match_and_notify(messages, queries)
 
     async def _channel_still_exists(self, channel_id: int) -> bool:

--- a/src/utils/search_query_chat_filter.py
+++ b/src/utils/search_query_chat_filter.py
@@ -190,6 +190,10 @@ def _normalize_token(token: str) -> str | None:
         parts = [part for part in parsed.path.split("/") if part]
         if not parts:
             return None
+        if parts[0] == "s":
+            parts = parts[1:]
+            if not parts:
+                return None
         if parts[0] == "c" and len(parts) > 1 and parts[1].isdigit():
             return f"-100{parts[1]}"
         return parts[0].strip().lstrip("@")

--- a/src/utils/search_query_chat_filter.py
+++ b/src/utils/search_query_chat_filter.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import parse_qs, urlsplit
+
+from src.models import Channel, Message
+
+ChatFilterTokenKind = Literal["numeric", "username", "invalid"]
+
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+_SPLIT_RE = re.compile(r"[\s,]+")
+
+
+@dataclass(frozen=True)
+class ChatFilterToken:
+    raw: str
+    kind: ChatFilterTokenKind
+    value: int | str | None = None
+
+
+@dataclass(frozen=True)
+class ParsedChatFilter:
+    entries: tuple[ChatFilterToken, ...]
+
+    @property
+    def has_filter(self) -> bool:
+        return bool(self.entries)
+
+    @property
+    def numeric_values(self) -> tuple[int, ...]:
+        return tuple(entry.value for entry in self.entries if entry.kind == "numeric" and isinstance(entry.value, int))
+
+    @property
+    def usernames(self) -> tuple[str, ...]:
+        return tuple(entry.value for entry in self.entries if entry.kind == "username" and isinstance(entry.value, str))
+
+    @property
+    def invalid_tokens(self) -> tuple[str, ...]:
+        return tuple(entry.raw for entry in self.entries if entry.kind == "invalid")
+
+    @property
+    def has_valid_tokens(self) -> bool:
+        return bool(self.numeric_values or self.usernames)
+
+
+@dataclass(frozen=True)
+class ChatFilterValidation:
+    invalid_tokens: tuple[str, ...] = ()
+    unknown_tokens: tuple[str, ...] = ()
+    matched_channel_ids: tuple[int, ...] = ()
+
+    @property
+    def has_warnings(self) -> bool:
+        return bool(self.invalid_tokens or self.unknown_tokens)
+
+    def warning_text(self) -> str:
+        parts = []
+        if self.invalid_tokens:
+            parts.append("некорректные: " + ", ".join(self.invalid_tokens))
+        if self.unknown_tokens:
+            parts.append("не найдены: " + ", ".join(self.unknown_tokens))
+        return "Чаты в фильтре сохранены, но есть предупреждения: " + "; ".join(parts) if parts else ""
+
+
+def parse_chat_filter(raw_filter: str | None) -> ParsedChatFilter:
+    entries: list[ChatFilterToken] = []
+    seen: set[tuple[ChatFilterTokenKind, int | str | None]] = set()
+    for raw in _SPLIT_RE.split((raw_filter or "").strip()):
+        token = raw.strip().strip(",;")
+        if not token:
+            continue
+        entry = _parse_token(token)
+        key = (entry.kind, entry.value if entry.kind != "invalid" else entry.raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append(entry)
+    return ParsedChatFilter(tuple(entries))
+
+
+def validate_chat_filter(raw_filter: str | None, channels: list[Channel]) -> ChatFilterValidation:
+    parsed = parse_chat_filter(raw_filter)
+    if not parsed.has_filter:
+        return ChatFilterValidation()
+
+    matched_ids: set[int] = set()
+    unknown: list[str] = []
+    invalid = list(parsed.invalid_tokens)
+
+    channels_by_username = {
+        (ch.username or "").lower(): ch
+        for ch in channels
+        if ch.username
+    }
+    for entry in parsed.entries:
+        if entry.kind == "invalid":
+            continue
+        if entry.kind == "numeric" and isinstance(entry.value, int):
+            matches = [
+                ch
+                for ch in channels
+                if ch.channel_id == entry.value or ch.id == entry.value
+            ]
+        elif entry.kind == "username" and isinstance(entry.value, str):
+            match = channels_by_username.get(entry.value)
+            matches = [match] if match else []
+        else:
+            matches = []
+
+        if matches:
+            matched_ids.update(ch.channel_id for ch in matches)
+        else:
+            unknown.append(entry.raw)
+
+    return ChatFilterValidation(
+        invalid_tokens=tuple(invalid),
+        unknown_tokens=tuple(unknown),
+        matched_channel_ids=tuple(sorted(matched_ids)),
+    )
+
+
+def chat_filter_matches_message(
+    raw_filter: str | None,
+    msg: Message,
+    *,
+    channels: list[Channel] | None = None,
+) -> bool:
+    parsed = parse_chat_filter(raw_filter)
+    if not parsed.has_filter:
+        return True
+    if not parsed.has_valid_tokens:
+        return False
+
+    numeric_values = set(parsed.numeric_values)
+    usernames = set(parsed.usernames)
+    if msg.channel_id in numeric_values:
+        return True
+    if msg.channel_username and msg.channel_username.lower() in usernames:
+        return True
+
+    for ch in channels or []:
+        if ch.channel_id != msg.channel_id:
+            continue
+        if ch.id in numeric_values or ch.channel_id in numeric_values:
+            return True
+        if ch.username and ch.username.lower() in usernames:
+            return True
+    return False
+
+
+def single_resolved_channel_id(raw_filter: str | None, channels: list[Channel]) -> int | None:
+    validation = validate_chat_filter(raw_filter, channels)
+    if validation.invalid_tokens or validation.unknown_tokens:
+        return None
+    if len(validation.matched_channel_ids) == 1:
+        return validation.matched_channel_ids[0]
+    return None
+
+
+def _parse_token(token: str) -> ChatFilterToken:
+    normalized = _normalize_token(token)
+    if not normalized:
+        return ChatFilterToken(raw=token, kind="invalid")
+    try:
+        return ChatFilterToken(raw=token, kind="numeric", value=int(normalized))
+    except ValueError:
+        pass
+    if _USERNAME_RE.match(normalized):
+        return ChatFilterToken(raw=token, kind="username", value=normalized.lower())
+    return ChatFilterToken(raw=token, kind="invalid")
+
+
+def _normalize_token(token: str) -> str | None:
+    token = token.strip()
+    if not token:
+        return None
+    if token.startswith("@"):
+        return token[1:].strip()
+    if token.startswith(("https://", "http://", "t.me/", "telegram.me/")):
+        url = token if token.startswith(("https://", "http://")) else f"https://{token}"
+        parsed = urlsplit(url)
+        host = parsed.netloc.lower()
+        if host not in {"t.me", "telegram.me", "www.t.me", "www.telegram.me"}:
+            return None
+        query_domain = parse_qs(parsed.query).get("domain")
+        if query_domain:
+            return query_domain[0].strip().lstrip("@")
+        parts = [part for part in parsed.path.split("/") if part]
+        if not parts:
+            return None
+        if parts[0] == "c" and len(parts) > 1 and parts[1].isdigit():
+            return f"-100{parts[1]}"
+        return parts[0].strip().lstrip("@")
+    return token

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -254,7 +254,7 @@ async def build_container_with_templates(
         search_pool = None
     search_engine = SearchEngine(search_bundle, search_pool, config=config)
     ai_search = AISearchEngine(config.llm, search_bundle)
-    search_query_bundle = SearchQueryBundle(repos.search_queries, repos.messages)
+    search_query_bundle = SearchQueryBundle(repos.search_queries, repos.messages, repos.channels)
 
     from src.services.collection_service import CollectionService
 

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -28,6 +28,7 @@ async def add_search_query(
     track_stats: bool = Form(False),
     exclude_patterns: str = Form(""),
     max_length: int | None = Form(None),
+    chat_filter: str = Form(""),
 ):
     if not query.strip():
         return flash_redirect("/search-queries", error="invalid_value")
@@ -42,13 +43,19 @@ async def add_search_query(
             track_stats=track_stats,
             exclude_patterns=exclude_patterns,
             max_length=max_length,
+            chat_filter=chat_filter,
         )
     except ValidationError:
         return flash_redirect("/search-queries", error="invalid_value")
+    chat_validation = await svc.validate_chat_filter(chat_filter)
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return flash_redirect("/search-queries", msg="sq_added")
+    return flash_redirect(
+        "/search-queries",
+        msg="sq_added",
+        extra={"warning": chat_validation.warning_text() or None},
+    )
 
 
 @router.post("/{sq_id}/toggle")
@@ -73,6 +80,7 @@ async def edit_search_query(
     track_stats: bool = Form(False),
     exclude_patterns: str = Form(""),
     max_length: int | None = Form(None),
+    chat_filter: str = Form(""),
 ):
     if not query.strip():
         return flash_redirect("/search-queries", error="invalid_value")
@@ -88,13 +96,19 @@ async def edit_search_query(
             track_stats=track_stats,
             exclude_patterns=exclude_patterns,
             max_length=max_length,
+            chat_filter=chat_filter,
         )
     except ValidationError:
         return flash_redirect("/search-queries", error="invalid_value")
+    chat_validation = await svc.validate_chat_filter(chat_filter)
     scheduler = deps.get_scheduler(request)
     if scheduler.is_running:
         await scheduler.sync_search_query_jobs()
-    return flash_redirect("/search-queries", msg="sq_edited")
+    return flash_redirect(
+        "/search-queries",
+        msg="sq_edited",
+        extra={"warning": chat_validation.warning_text() or None},
+    )
 
 
 @router.post("/{sq_id}/delete")

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -4,6 +4,7 @@
     var params = new URLSearchParams(window.location.search);
     var code = params.get("msg");
     var errCode = params.get("error");
+    var warningText = params.get("warning");
     if (code) window.__flashMsg = code;
     if (errCode) window.__flashError = errCode;
     var container = document.getElementById("flash-container");
@@ -22,9 +23,17 @@
             }
             container.appendChild(errDiv);
         }
-        if (code || errCode) {
+        if (warningText) {
+            var warnDiv = document.createElement("div");
+            warnDiv.className = "alert alert-warning";
+            warnDiv.setAttribute("role", "alert");
+            warnDiv.textContent = warningText;
+            container.appendChild(warnDiv);
+        }
+        if (code || errCode || warningText) {
             params.delete("msg");
             params.delete("error");
+            params.delete("warning");
             var qs = params.toString();
             var url = window.location.pathname + (qs ? "?" + qs : "") + window.location.hash;
             window.history.replaceState(null, "", url);

--- a/src/web/templates/search_queries.html
+++ b/src/web/templates/search_queries.html
@@ -22,6 +22,10 @@
                 </div>
             </div>
             <div class="mb-3">
+                <label class="form-label">Чаты <span class="hint" data-tooltip="Необязательный список чатов через запятую или пробел: channel_id, @username, username или ссылка t.me. Пусто = искать по всем чатам">?</span></label>
+                <input type="text" class="form-control" name="chat_filter" placeholder="@channel1, -1001234567890">
+            </div>
+            <div class="mb-3">
                 <div class="form-check form-check-inline">
                     <input class="form-check-input" type="checkbox" name="is_regex" value="true" id="add-is-regex" onchange="if(this.checked) document.getElementById('add-is-fts').checked=false">
                     <label class="form-check-label" for="add-is-regex">Regex <span class="hint" data-tooltip="Интерпретировать запрос как регулярное выражение (re.IGNORECASE)">?</span></label>
@@ -61,6 +65,7 @@
     <thead>
         <tr>
             <th>Запрос</th>
+            <th>Чаты</th>
             <th>Режим</th>
             <th>Интервал</th>
             <th>Активен</th>
@@ -75,6 +80,14 @@
         <tr id="row-{{ sq.id }}">
             <td title="{{ sq.query }}"><code>{{ sq.query }}</code>{% if sq.is_regex %} <small>(regex)</small>{% endif %}{% if sq.is_fts %} <small>(fts)</small>{% endif %}</td>
             <td>
+                {% if sq.chat_filter %}
+                <code title="{{ sq.chat_filter }}">{{ sq.chat_filter }}</code>
+                {% if item.chat_filter_warnings %}<div class="text-warning small">{{ item.chat_filter_warnings }}</div>{% endif %}
+                {% else %}
+                <span class="text-muted">Все</span>
+                {% endif %}
+            </td>
+            <td>
                 {% if sq.notify_on_collect %}<span title="Уведомления при сборе">{{ icon("notification") }}</span>{% endif %}
                 {% if sq.track_stats %}<span title="Отслеживание статистики">{{ icon("stats") }}</span>{% endif %}
             </td>
@@ -86,7 +99,7 @@
                 {% if sq.is_regex %}
                 <span class="btn btn-outline-secondary btn-sm emoji-btn opacity-50" style="cursor:default" title="Regex-запросы нельзя открыть в поиске">{{ icon("search") }}</span>
                 {% else %}
-                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
+                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if item.chat_filter_channel_id %}&channel_id={{ item.chat_filter_channel_id }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">{{ icon("search") }}</a>
                 {% endif %}
                 <button type="button" class="btn btn-outline-secondary btn-sm emoji-btn" title="Редактировать" onclick="toggleEdit({{ sq.id }})">{{ icon("edit") }}</button>
@@ -104,7 +117,7 @@
             </td>
         </tr>
         <tr id="edit-{{ sq.id }}" class="d-none">
-            <td colspan="7">
+            <td colspan="8">
                 <form method="post" action="/search-queries/{{ sq.id }}/edit" data-busy>
                     <div class="row g-3 mb-3">
                         <div class="col-12 col-md-8">
@@ -115,6 +128,10 @@
                             <label class="form-label">Интервал (мин) <span class="hint" data-tooltip="Как часто запускать поиск по новым сообщениям (минимум 5 минут)">?</span></label>
                             <input type="number" class="form-control" name="interval_minutes" value="{{ sq.interval_minutes }}" min="5">
                         </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Чаты</label>
+                        <input type="text" class="form-control" name="chat_filter" value="{{ sq.chat_filter }}" placeholder="@channel1, -1001234567890">
                     </div>
                     <div class="mb-3">
                         <div class="form-check form-check-inline">
@@ -151,7 +168,7 @@
         </tr>
         {% if item.daily_stats %}
         <tr>
-            <td colspan="7">
+            <td colspan="8">
                 <details>
                     <summary>График по дням ({{ item.daily_stats | length }} дн.)</summary>
                     <div style="position:relative;height:200px;margin:0.5rem 0">
@@ -207,9 +224,17 @@
                 &middot; {{ item.total_30d }} за 30д
                 {% if item.last_run %}&middot; {{ item.last_run[:16] }}{% endif %}
             </small>
+            <div class="small mt-1">
+                {% if sq.chat_filter %}
+                <span class="text-muted">Чаты:</span> <code>{{ sq.chat_filter }}</code>
+                {% if item.chat_filter_warnings %}<div class="text-warning">{{ item.chat_filter_warnings }}</div>{% endif %}
+                {% else %}
+                <span class="text-muted">Все чаты</span>
+                {% endif %}
+            </div>
             <div class="card-actions">
                 {% if not sq.is_regex %}
-                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
+                <a href="/search?q={{ sq.query|urlencode }}{% if sq.max_length %}+len%3C{{ sq.max_length }}{% endif %}{% if item.chat_filter_channel_id %}&channel_id={{ item.chat_filter_channel_id }}{% endif %}{% if sq.is_fts %}&is_fts=1{% endif %}"
                    class="btn btn-outline-secondary btn-sm emoji-btn" title="Найти посты">{{ icon("search") }}</a>
                 {% endif %}
                 <form method="post" action="/search-queries/{{ sq.id }}/run" class="d-inline" data-busy>

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -525,6 +525,21 @@ async def test_count_fts_matches_for_query_with_exclude_patterns(messages_repo):
     assert count == 1
 
 
+async def test_count_fts_matches_for_query_with_chat_filter(messages_repo):
+    """Test counting FTS matches restricted to selected chats."""
+    sq = SearchQuery(query="hello", is_fts=True, chat_filter="1")
+
+    await messages_repo.insert_messages_batch(
+        [
+            make_message(1, 100, "Hello world"),
+            make_message(2, 101, "Hello there"),
+        ]
+    )
+
+    count = await messages_repo.count_fts_matches_for_query(sq)
+    assert count == 1
+
+
 # get_fts_daily_stats_for_query tests
 
 
@@ -567,6 +582,24 @@ async def test_get_fts_daily_stats_batch(messages_repo):
 
     assert 1 in result
     assert 2 in result
+
+
+async def test_get_fts_daily_stats_batch_with_chat_filter(messages_repo):
+    """Test batch FTS daily stats respects chat filters per query."""
+    sq1 = SearchQuery(id=1, query="hello", is_fts=True, chat_filter="10")
+    sq2 = SearchQuery(id=2, query="hello", is_fts=True, chat_filter="20")
+
+    await messages_repo.insert_messages_batch(
+        [
+            make_message(10, 100, "Hello one"),
+            make_message(20, 101, "Hello two"),
+        ]
+    )
+
+    result = await messages_repo.get_fts_daily_stats_batch([sq1, sq2], days=7)
+
+    assert sum(s.count for s in result[1]) == 1
+    assert sum(s.count for s in result[2]) == 1
 
 
 async def test_get_fts_daily_stats_batch_empty(messages_repo):

--- a/tests/repositories/test_search_queries_repository.py
+++ b/tests/repositories/test_search_queries_repository.py
@@ -47,6 +47,7 @@ async def test_add_with_all_fields(search_queries_repo):
         interval_minutes=30,
         exclude_patterns="spam\njunk",
         max_length=500,
+        chat_filter="@chat_one, -1001",
     )
     pk = await search_queries_repo.add(sq)
 
@@ -58,6 +59,7 @@ async def test_add_with_all_fields(search_queries_repo):
     assert result.interval_minutes == 30
     assert result.exclude_patterns == "spam\njunk"
     assert result.max_length == 500
+    assert result.chat_filter == "@chat_one, -1001"
 
 
 # get_all tests
@@ -151,13 +153,14 @@ async def test_update_query(search_queries_repo):
     """Test updating a query."""
     pk = await search_queries_repo.add(make_query("old query"))
 
-    updated = make_query("new query", is_regex=True, interval_minutes=120)
+    updated = make_query("new query", is_regex=True, interval_minutes=120, chat_filter="@updated")
     await search_queries_repo.update(pk, updated)
 
     result = await search_queries_repo.get_by_id(pk)
     assert result.query == "new query"
     assert result.is_regex is True
     assert result.interval_minutes == 120
+    assert result.chat_filter == "@updated"
 
 
 async def test_update_preserves_id(search_queries_repo):

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -67,6 +67,22 @@ async def test_add_search_query_with_all_fields(route_client):
 
 
 @pytest.mark.anyio
+async def test_add_search_query_with_chat_filter_saves_and_warns(route_client, db):
+    """Chat filter is saved even when it cannot be resolved locally."""
+    resp = await route_client.post(
+        "/search-queries/add",
+        data={"query": "scoped query", "interval_minutes": "60", "chat_filter": "@missing_chat"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    assert "msg=sq_added" in resp.headers["location"]
+    assert "warning=" in resp.headers["location"]
+    queries = await db.repos.search_queries.get_all()
+    assert queries[0].chat_filter == "@missing_chat"
+
+
+@pytest.mark.anyio
 async def test_toggle_search_query(route_client):
     """Test toggle search query."""
     await route_client.post(

--- a/tests/test_agent_tools_search_queries.py
+++ b/tests/test_agent_tools_search_queries.py
@@ -77,6 +77,7 @@ class TestGetSearchQueryTool:
         assert f"id: {sq_id}" in text
         assert "is_active" in text
         assert "interval_minutes" in text
+        assert "chat_filter" in text
 
 
 class TestAddSearchQueryTool:
@@ -103,6 +104,15 @@ class TestAddSearchQueryTool:
             {"query": "custom interval", "interval_minutes": 120, "confirm": True}
         )
         assert "создан" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_chat_filter_creates_and_warns(self, sq_handlers):
+        result = await sq_handlers["add_search_query"](
+            {"query": "chat scoped", "chat_filter": "@missing_chat", "confirm": True}
+        )
+        text = _text(result)
+        assert "создан" in text
+        assert "Предупреждение" in text
 
 
 class TestEditSearchQueryTool:
@@ -136,6 +146,16 @@ class TestEditSearchQueryTool:
             {"sq_id": sq_id, "interval_minutes": 90, "confirm": True}
         )
         assert "обновлён" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_updates_chat_filter(self, db, sq_handlers):
+        sq_id = await _add_query(db, "some query")
+        result = await sq_handlers["edit_search_query"](
+            {"sq_id": sq_id, "chat_filter": "@missing_chat", "confirm": True}
+        )
+        text = _text(result)
+        assert "обновлён" in text
+        assert "Предупреждение" in text
 
 
 class TestDeleteSearchQueryTool:

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -1117,6 +1117,7 @@ async def test_migrations_search_queries_columns():
         assert "is_regex" in cols
         assert "notify_on_collect" in cols
         assert "is_fts" in cols
+        assert "chat_filter" in cols
 
 
 @pytest.mark.anyio

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -288,6 +288,7 @@ async def test_run_migrations_adds_search_query_columns(fresh_db):
     assert "is_fts" in cols
     assert "exclude_patterns" in cols
     assert "max_length" in cols
+    assert "chat_filter" in cols
 
 
 @pytest.mark.anyio

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -36,6 +36,7 @@ def make_query(
     is_fts: bool = False,
     exclude_patterns: str = "",
     max_length: int | None = None,
+    chat_filter: str = "",
 ) -> SearchQuery:
     return SearchQuery(
         id=sq_id,
@@ -44,6 +45,7 @@ def make_query(
         is_fts=is_fts,
         exclude_patterns=exclude_patterns,
         max_length=max_length,
+        chat_filter=chat_filter,
     )
 
 
@@ -207,6 +209,37 @@ async def test_match_and_notify_max_length_filter():
 
     # Only short message should match
     assert result == {1: 1}
+
+
+@pytest.mark.anyio
+async def test_match_and_notify_respects_chat_filter():
+    """Chat filters limit live notification matches."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("hello one", channel_id=1, message_id=1),
+        make_message("hello two", channel_id=2, message_id=2),
+    ]
+    queries = [make_query("hello", chat_filter="2")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+
+
+@pytest.mark.anyio
+async def test_match_and_notify_unknown_chat_filter_matches_nothing():
+    """A non-empty unknown chat filter must not fall back to all chats."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message("hello one", channel_id=1, message_id=1)]
+    queries = [make_query("hello", chat_filter="missing_chat")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {}
 
 
 @pytest.mark.anyio

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -229,6 +229,23 @@ async def test_match_and_notify_respects_chat_filter():
 
 
 @pytest.mark.anyio
+async def test_match_and_notify_tme_s_link_chat_filter():
+    """t.me/s/{username} chat filters match the referenced channel."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [
+        make_message("hello one", channel_id=1, message_id=1, channel_username="public_chat"),
+        make_message("hello two", channel_id=2, message_id=2, channel_username="other_chat"),
+    ]
+    queries = [make_query("hello", chat_filter="https://t.me/s/public_chat/123")]
+
+    result = await matcher.match_and_notify(messages, queries)
+
+    assert result == {1: 1}
+
+
+@pytest.mark.anyio
 async def test_match_and_notify_unknown_chat_filter_matches_nothing():
     """A non-empty unknown chat filter must not fall back to all chats."""
     notifier = AsyncMock()

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -19,11 +19,11 @@ def svc(bundle):
     return SearchQueryService(bundle)
 
 
-async def _insert_messages(db, texts, channel_id=100, base_date=None):
+async def _insert_messages(db, texts, channel_id=100, base_date=None, username=None):
     """Helper: add a channel and insert messages with given texts."""
     if base_date is None:
         base_date = datetime.now()
-    ch = Channel(channel_id=channel_id, title="test")
+    ch = Channel(channel_id=channel_id, title="test", username=username)
     await db.repos.channels.add_channel(ch)
     for i, text in enumerate(texts):
         msg = Message(
@@ -253,6 +253,30 @@ async def test_chat_filter_limits_fts_stats(bundle, db):
     stats = await bundle.get_fts_daily_stats_for_query(sq, days=30)
 
     assert sum(s.count for s in stats) == 1
+
+
+@pytest.mark.anyio
+async def test_chat_filter_tme_s_link_limits_fts_stats(bundle, db):
+    await _insert_messages(db, ["target in public"], channel_id=405, username="public_chat")
+    await _insert_messages(db, ["target in other"], channel_id=406, username="other_chat")
+
+    sq = SearchQuery(query="target", chat_filter="https://t.me/s/public_chat/123")
+    sq_id = await bundle.add(sq)
+    sq = await bundle.get_by_id(sq_id)
+    stats = await bundle.get_fts_daily_stats_for_query(sq, days=30)
+
+    assert sum(s.count for s in stats) == 1
+
+
+@pytest.mark.anyio
+async def test_validate_chat_filter_tme_s_link_resolves_channel(svc, db):
+    await db.repos.channels.add_channel(Channel(channel_id=407, title="Public", username="public_chat"))
+
+    validation = await svc.validate_chat_filter("https://t.me/s/public_chat/123")
+
+    assert validation.invalid_tokens == ()
+    assert validation.unknown_tokens == ()
+    assert validation.matched_channel_ids == (407,)
 
 
 @pytest.mark.anyio

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -243,6 +243,31 @@ async def test_max_length_filter(bundle, db):
 
 
 @pytest.mark.anyio
+async def test_chat_filter_limits_fts_stats(bundle, db):
+    await _insert_messages(db, ["target in one"], channel_id=401)
+    await _insert_messages(db, ["target in two"], channel_id=402)
+
+    sq = SearchQuery(query="target", chat_filter="401")
+    sq_id = await bundle.add(sq)
+    sq = await bundle.get_by_id(sq_id)
+    stats = await bundle.get_fts_daily_stats_for_query(sq, days=30)
+
+    assert sum(s.count for s in stats) == 1
+
+
+@pytest.mark.anyio
+async def test_unknown_chat_filter_matches_nothing(bundle, db):
+    await _insert_messages(db, ["target in one"], channel_id=411)
+
+    sq = SearchQuery(query="target", chat_filter="definitely_unknown")
+    sq_id = await bundle.add(sq)
+    sq = await bundle.get_by_id(sq_id)
+    stats = await bundle.get_fts_daily_stats_for_query(sq, days=30)
+
+    assert sum(s.count for s in stats) == 0
+
+
+@pytest.mark.anyio
 async def test_fts_collector_matching():
     """Test the _fts_query_matches function."""
     from src.services.notification_matcher import _fts_query_matches

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -98,6 +98,7 @@ async def test_add_creates_search_query(service, bundle):
         track_stats=True,
         exclude_patterns="spam",
         max_length=500,
+        chat_filter="@chat_one",
     )
 
     assert sq_id == 1
@@ -109,6 +110,7 @@ async def test_add_creates_search_query(service, bundle):
     assert stored.notify_on_collect is True
     assert stored.exclude_patterns == "spam"
     assert stored.max_length == 500
+    assert stored.chat_filter == "@chat_one"
 
 
 @pytest.mark.anyio
@@ -195,6 +197,7 @@ async def test_update_modifies_query(service, bundle):
         track_stats=False,
         exclude_patterns="",
         max_length=None,
+        chat_filter="@chat_two",
     )
 
     assert result is True
@@ -203,6 +206,7 @@ async def test_update_modifies_query(service, bundle):
     assert stored.query == "new query"
     assert stored.interval_minutes == 120
     assert stored.is_active is False  # Preserved
+    assert stored.chat_filter == "@chat_two"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What changed

- Added an optional chat filter to search queries so a query can target one or more chats instead of always matching all chats.
- Reused the same parser/validation path across web, CLI, agent tools, repository matching, notification matching, and search-query bundles.
- Added schema/migration/model support for `chat_filter` and tests covering valid filters, validation errors, persistence, search matching, and notifications.
- Fixed Telegram preview links like `https://t.me/s/<channel>` so they resolve to the real channel instead of `s`.

## Behavior

Validation reports errors to the user but does not block saving/search-query execution. Invalid chat tokens are ignored for matching, preserving the requested non-blocking behavior.

## Validation

- `ruff check src/ tests/ conftest.py`
- `pytest tests/test_search_queries.py tests/test_notification_matcher.py -v`: 43 passed
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto`: 6947 passed, 2 skipped
- `pytest tests/ -v -m aiosqlite_serial`: 821 passed