### PR TITLE
test(cli): real-Telegram integration suite + facade fix

### DIFF
--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -371,6 +371,19 @@ class Database:
         self._require()
         await self._channels.update_channel_meta(channel_id, username=username, title=title)
 
+    async def update_channel_full_meta(
+        self,
+        channel_id: int,
+        *,
+        about: str | None,
+        linked_chat_id: int | None,
+        has_comments: bool,
+    ) -> None:
+        self._require()
+        await self._channels.update_channel_full_meta(
+            channel_id, about=about, linked_chat_id=linked_chat_id, has_comments=has_comments
+        )
+
     async def create_rename_event(
         self,
         channel_id: int,

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT_ENV = "TG_CONTENT_FACTORY_ROOT"
+
+
+@dataclass(frozen=True)
+class CliEnv:
+    repo_root: Path
+    config_path: Path
+    db_path: Path
+
+
+def _detect_repo_root() -> Path:
+    """Return the project root where config.yaml lives.
+
+    Priority: TG_CONTENT_FACTORY_ROOT env var → pytest invocation cwd → walk up
+    from this file looking for config.yaml outside any worktree.
+    """
+    env_root = os.environ.get(REPO_ROOT_ENV)
+    if env_root:
+        return Path(env_root).resolve()
+
+    cwd = Path.cwd().resolve()
+    if (cwd / "config.yaml").exists() and "worktrees" not in cwd.parts:
+        return cwd
+
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if parent.name == "worktrees":
+            continue
+        if (parent / "config.yaml").exists() and "worktrees" not in parent.parts:
+            return parent
+
+    return cwd
+
+
+@pytest.fixture(scope="session")
+def cli_env() -> CliEnv:
+    root = _detect_repo_root()
+    config_path = root / "config.yaml"
+    if not config_path.exists():
+        pytest.skip(
+            f"config.yaml not found under {root}. Set {REPO_ROOT_ENV} to the project root."
+        )
+
+    try:
+        cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        pytest.skip(f"failed to parse {config_path}: {exc}")
+
+    db_rel = (cfg.get("database") or {}).get("path")
+    if not db_rel:
+        pytest.skip(f"{config_path} has no database.path entry")
+
+    db_path = (root / db_rel).resolve()
+    if not db_path.exists():
+        pytest.skip(f"database file not found at {db_path}")
+    if db_path.stat().st_size == 0:
+        pytest.skip(f"database file at {db_path} is empty")
+
+    return CliEnv(repo_root=root, config_path=config_path, db_path=db_path)
+
+
+_WORKTREE_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def run_cli(cli_env: CliEnv):
+    def _run(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+        # cwd = основной репо (там config.yaml + data/). PYTHONPATH ведёт на
+        # текущий чекаут (worktree или main), а PYTHONSAFEPATH=1 убирает cwd из
+        # sys.path → subprocess грузит `src/` из тестируемого кода, а не из
+        # живого репозитория по cwd. Без этого worktree-правки в src/ невидимы.
+        env = os.environ.copy()
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = (
+            f"{_WORKTREE_ROOT}{os.pathsep}{existing}" if existing else str(_WORKTREE_ROOT)
+        )
+        env["PYTHONSAFEPATH"] = "1"
+        return subprocess.run(
+            [sys.executable, "-m", "src.main", *args],
+            cwd=str(cli_env.repo_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+
+    return _run
+
+
+_FLOOD_WAIT_RE = re.compile(r"FloodWaitError|FLOOD_?WAIT", re.IGNORECASE)
+_AUTH_RE = re.compile(
+    r"AuthKeyError|AuthKeyUnregistered|session\s+expired|UnauthorizedError", re.IGNORECASE
+)
+
+
+@pytest.fixture
+def assert_cli_ok():
+    def _assert(result: subprocess.CompletedProcess) -> None:
+        # FLOOD_WAIT и auth-проблемы — это поводы для skip только если CLI упал.
+        # При успешном returncode упоминание «flood wait» в выводе (например, в
+        # заголовке таблицы `account flood-status`) — это легитимный текст, не ошибка.
+        if result.returncode != 0:
+            combined = (result.stdout or "") + "\n" + (result.stderr or "")
+            if _FLOOD_WAIT_RE.search(combined):
+                pytest.skip("Telegram FLOOD_WAIT; retry later")
+            if _AUTH_RE.search(combined):
+                pytest.skip("Telegram session not authorized; re-auth account")
+            pytest.fail(
+                f"CLI exited with {result.returncode}\n"
+                f"--- stdout ---\n{result.stdout}\n"
+                f"--- stderr ---\n{result.stderr}",
+                pytrace=False,
+            )
+
+    return _assert
+
+
+_CHANNEL_LIST_ROW_RE = re.compile(r"^\s*(\d+)\s+(-?\d+)\s+", re.MULTILINE)
+
+
+@pytest.fixture
+def discover_first_channel(run_cli, assert_cli_ok):
+    """Run `channel list` and return (pk, channel_id) for the first row, or skip."""
+
+    def _discover() -> tuple[str, str]:
+        result = run_cli("channel", "list")
+        assert_cli_ok(result)
+        match = _CHANNEL_LIST_ROW_RE.search(result.stdout)
+        if not match:
+            pytest.skip("no channels in data.db — `channel list` returned no rows")
+        return match.group(1), match.group(2)
+
+    return _discover
+
+
+_DIALOG_USERNAME_RE = re.compile(r"@([A-Za-z0-9_]{4,})")
+
+
+@pytest.fixture
+def discover_first_dialog_username(run_cli, assert_cli_ok):
+    """Run `dialogs list` and return the first @username, or skip."""
+
+    def _discover() -> str:
+        result = run_cli("dialogs", "list")
+        assert_cli_ok(result)
+        match = _DIALOG_USERNAME_RE.search(result.stdout)
+        if not match:
+            pytest.skip("no @username in `dialogs list` output")
+        return "@" + match.group(1)
+
+    return _discover
+
+
+_ACCOUNT_LIST_ROW_RE = re.compile(
+    r"^\s*\d+\s+(\+?\d{6,})\s",
+    re.MULTILINE,
+)
+
+
+@pytest.fixture
+def discover_first_phone(run_cli, assert_cli_ok):
+    """Run `account list` and return the first phone, or skip."""
+
+    def _discover() -> str:
+        result = run_cli("account", "list")
+        assert_cli_ok(result)
+        match = _ACCOUNT_LIST_ROW_RE.search(result.stdout)
+        if not match:
+            pytest.skip("no accounts in data.db — `account list` returned no rows")
+        return match.group(1)
+
+    return _discover

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -36,8 +36,6 @@ def _detect_repo_root() -> Path:
 
     here = Path(__file__).resolve()
     for parent in here.parents:
-        if parent.name == "worktrees":
-            continue
         if (parent / "config.yaml").exists() and "worktrees" not in parent.parts:
             return parent
 

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -90,6 +90,8 @@ def run_cli(cli_env: CliEnv):
             cwd=str(cli_env.repo_root),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=env,
         )

--- a/tests/cli_real_tg_integration/heavy/conftest.py
+++ b/tests/cli_real_tg_integration/heavy/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+HEAVY_GATE_ENV = "RUN_CLI_REAL_TG_HEAVY"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if os.environ.get(HEAVY_GATE_ENV) == "1":
+        return
+
+    skip_marker = pytest.mark.skip(
+        reason=f"heavy CLI tests disabled; set {HEAVY_GATE_ENV}=1 to run them"
+    )
+    here = os.path.dirname(os.path.abspath(__file__))
+    for item in items:
+        if os.path.abspath(str(item.fspath)).startswith(here):
+            item.add_marker(skip_marker)

--- a/tests/cli_real_tg_integration/heavy/test_channel_collect_first.py
+++ b/tests/cli_real_tg_integration/heavy/test_channel_collect_first.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_collect_first(run_cli, assert_cli_ok, discover_first_channel):
+    """Full collection одного канала — много API запросов (iter_messages)."""
+    pk, _channel_id = discover_first_channel()
+    result = run_cli("channel", "collect", pk, timeout=900)
+    assert_cli_ok(result)
+    assert result.stdout.strip() or result.stderr.strip()

--- a/tests/cli_real_tg_integration/heavy/test_channel_refresh_meta_all.py
+++ b/tests/cli_real_tg_integration/heavy/test_channel_refresh_meta_all.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_refresh_meta_all(run_cli, assert_cli_ok):
+    """N-channel refresh-meta — foreach activeChannels, риск FLOOD_WAIT."""
+    result = run_cli("channel", "refresh-meta", "--all", timeout=600)
+    assert_cli_ok(result)
+    assert result.stdout.strip() or result.stderr.strip()

--- a/tests/cli_real_tg_integration/heavy/test_channel_refresh_types.py
+++ b/tests/cli_real_tg_integration/heavy/test_channel_refresh_types.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_refresh_types(run_cli, assert_cli_ok):
+    result = run_cli("channel", "refresh-types", timeout=300)
+    assert_cli_ok(result)
+    assert result.stdout.strip() or result.stderr.strip(), (
+        "`channel refresh-types` produced no output at all"
+    )

--- a/tests/cli_real_tg_integration/heavy/test_channel_stats_all.py
+++ b/tests/cli_real_tg_integration/heavy/test_channel_stats_all.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_stats_all(run_cli, assert_cli_ok):
+    """N-channel stats — foreach activeChannels, риск FLOOD_WAIT."""
+    result = run_cli("channel", "stats", "--all", timeout=900)
+    assert_cli_ok(result)
+    assert result.stdout.strip() or result.stderr.strip()

--- a/tests/cli_real_tg_integration/heavy/test_dialogs_refresh.py
+++ b/tests/cli_real_tg_integration/heavy/test_dialogs_refresh.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_refresh(run_cli, assert_cli_ok):
+    result = run_cli("dialogs", "refresh", timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`dialogs refresh` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_account_flood_status.py
+++ b/tests/cli_real_tg_integration/test_account_flood_status.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_account_flood_status(run_cli, assert_cli_ok):
+    result = run_cli("account", "flood-status")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`account flood-status` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_account_info.py
+++ b/tests/cli_real_tg_integration/test_account_info.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_account_info(run_cli, assert_cli_ok):
+    result = run_cli("account", "info")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`account info` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_account_list.py
+++ b/tests/cli_real_tg_integration/test_account_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_account_list(run_cli, assert_cli_ok):
+    result = run_cli("account", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`account list` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_analytics_top.py
+++ b/tests/cli_real_tg_integration/test_analytics_top.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_analytics_top(run_cli, assert_cli_ok):
+    result = run_cli("analytics", "top", "--limit", "5", timeout=60)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`analytics top` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_channel_add_first.py
+++ b/tests/cli_real_tg_integration/test_channel_add_first.py
@@ -6,9 +6,11 @@ pytestmark = pytest.mark.real_tg_safe
 def test_channel_add_already_existing(run_cli, assert_cli_ok, discover_first_dialog_username):
     """Smoke: вызвать `channel add @username` для уже существующего канала.
 
-    `channel add` идемпотентна — повторное добавление существующего канала
-    не дублирует строку, лишь обновляет meta. Это даёт нам реальный API call
-    (resolve_channel + fetch_channel_meta) без mutating-эффектов в DB.
+    `channel add` идемпотентна на уровне строк — повторное добавление
+    существующего канала не плодит дубликаты, а делает ON CONFLICT DO UPDATE
+    с обновлением title/username/channel_type/is_active (см.
+    src/database/repositories/channels.py:29-37). DB-эффект benign, цель теста —
+    реальный TG API call (resolve_channel + fetch_channel_meta).
     """
     username = discover_first_dialog_username()
     result = run_cli("channel", "add", username, timeout=120)

--- a/tests/cli_real_tg_integration/test_channel_add_first.py
+++ b/tests/cli_real_tg_integration/test_channel_add_first.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_add_already_existing(run_cli, assert_cli_ok, discover_first_dialog_username):
+    """Smoke: вызвать `channel add @username` для уже существующего канала.
+
+    `channel add` идемпотентна — повторное добавление существующего канала
+    не дублирует строку, лишь обновляет meta. Это даёт нам реальный API call
+    (resolve_channel + fetch_channel_meta) без mutating-эффектов в DB.
+    """
+    username = discover_first_dialog_username()
+    result = run_cli("channel", "add", username, timeout=120)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`channel add` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_channel_list.py
+++ b/tests/cli_real_tg_integration/test_channel_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_list(run_cli, assert_cli_ok):
+    result = run_cli("channel", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`channel list` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_channel_refresh_meta_first.py
+++ b/tests/cli_real_tg_integration/test_channel_refresh_meta_first.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_refresh_meta_first(run_cli, assert_cli_ok, discover_first_channel):
+    """Single-channel refresh-meta — 1-2 API calls, lightweight."""
+    pk, _channel_id = discover_first_channel()
+    result = run_cli("channel", "refresh-meta", pk, timeout=120)
+    assert_cli_ok(result)
+    assert result.stdout.strip() or result.stderr.strip(), (
+        "`channel refresh-meta <pk>` produced no output at all"
+    )

--- a/tests/cli_real_tg_integration/test_channel_stats_first.py
+++ b/tests/cli_real_tg_integration/test_channel_stats_first.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_stats_first(run_cli, assert_cli_ok, discover_first_channel):
+    pk, _channel_id = discover_first_channel()
+    result = run_cli("channel", "stats", pk, timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`channel stats` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_debug_memory.py
+++ b/tests/cli_real_tg_integration/test_debug_memory.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_debug_memory(run_cli, assert_cli_ok):
+    result = run_cli("debug", "memory")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`debug memory` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_debug_timing.py
+++ b/tests/cli_real_tg_integration/test_debug_timing.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_debug_timing(run_cli, assert_cli_ok):
+    result = run_cli("debug", "timing")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`debug timing` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_dialogs_broadcast_stats_first.py
+++ b/tests/cli_real_tg_integration/test_dialogs_broadcast_stats_first.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_broadcast_stats_first(run_cli, assert_cli_ok, discover_first_dialog_username):
+    username = discover_first_dialog_username()
+    result = run_cli("dialogs", "broadcast-stats", username, timeout=120)
+    # broadcast-stats может вернуть не-zero для не-broadcast чатов — assert_cli_ok
+    # тогда зафейлит и покажет stderr. Это ок для smoke: один из первых найденных
+    # @-чатов должен быть broadcast-каналом. Если падает стабильно — `discover`
+    # надо уточнить, чтобы выбирал именно channel.
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`dialogs broadcast-stats` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_dialogs_list.py
+++ b/tests/cli_real_tg_integration/test_dialogs_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_list(run_cli, assert_cli_ok):
+    result = run_cli("dialogs", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`dialogs list` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_dialogs_resolve_first.py
+++ b/tests/cli_real_tg_integration/test_dialogs_resolve_first.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_resolve_first(run_cli, assert_cli_ok, discover_first_dialog_username):
+    username = discover_first_dialog_username()
+    result = run_cli("dialogs", "resolve", username, timeout=120)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`dialogs resolve` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_dialogs_topics_first.py
+++ b/tests/cli_real_tg_integration/test_dialogs_topics_first.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_topics_first(run_cli, assert_cli_ok, discover_first_channel):
+    _pk, channel_id = discover_first_channel()
+    result = run_cli("dialogs", "topics", "--channel-id", channel_id, timeout=120)
+    assert_cli_ok(result)
+    # Если канал не форум — выведет «No forum topics found», exit 0 — это валидно
+    out_lower = result.stdout.lower()
+    assert (
+        result.stdout.strip()
+        and ("title" in out_lower or "no forum topics" in out_lower)
+    ), f"unexpected `dialogs topics` output: {result.stdout!r}"

--- a/tests/cli_real_tg_integration/test_export_json.py
+++ b/tests/cli_real_tg_integration/test_export_json.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_export_json(run_cli, assert_cli_ok):
+    result = run_cli("export", "json", "--limit", "5", timeout=60)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`export json` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_filter_analyze.py
+++ b/tests/cli_real_tg_integration/test_filter_analyze.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_filter_analyze(run_cli, assert_cli_ok):
+    result = run_cli("filter", "analyze", timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`filter analyze` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_messages_read_first.py
+++ b/tests/cli_real_tg_integration/test_messages_read_first.py
@@ -1,0 +1,12 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_messages_read_first(run_cli, assert_cli_ok, discover_first_channel):
+    pk, _channel_id = discover_first_channel()
+    result = run_cli(
+        "messages", "read", pk, "--live", "--limit", "3", timeout=180
+    )
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`messages read --live` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_photo_loader_dialogs.py
+++ b/tests/cli_real_tg_integration/test_photo_loader_dialogs.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_photo_loader_dialogs(run_cli, assert_cli_ok, discover_first_phone):
+    phone = discover_first_phone()
+    result = run_cli("photo-loader", "dialogs", "--phone", phone, timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`photo-loader dialogs` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_pipeline_list.py
+++ b/tests/cli_real_tg_integration/test_pipeline_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_pipeline_list(run_cli, assert_cli_ok):
+    result = run_cli("pipeline", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip() or "no" in (result.stdout + result.stderr).lower()

--- a/tests/cli_real_tg_integration/test_provider_list.py
+++ b/tests/cli_real_tg_integration/test_provider_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_provider_list(run_cli, assert_cli_ok):
+    result = run_cli("provider", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip() or "no" in (result.stdout + result.stderr).lower()

--- a/tests/cli_real_tg_integration/test_scheduler_status.py
+++ b/tests/cli_real_tg_integration/test_scheduler_status.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_scheduler_status(run_cli, assert_cli_ok):
+    result = run_cli("scheduler", "status")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`scheduler status` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_search_basic.py
+++ b/tests/cli_real_tg_integration/test_search_basic.py
@@ -1,0 +1,11 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_search_basic(run_cli, assert_cli_ok):
+    # Local mode — пользуется FTS5, не дёргает Telegram, безопасно
+    result = run_cli("search", "test", "--limit", "5", "--mode", "local", timeout=60)
+    assert_cli_ok(result)
+    # Может быть «No results» — это валидно, главное что команда не упала
+    assert result.stdout.strip() or "no results" in (result.stderr or "").lower()

--- a/tests/cli_real_tg_integration/test_search_query_list.py
+++ b/tests/cli_real_tg_integration/test_search_query_list.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_search_query_list(run_cli, assert_cli_ok):
+    result = run_cli("search-query", "list")
+    assert_cli_ok(result)
+    assert result.stdout.strip() or "no" in (result.stdout + result.stderr).lower()

--- a/tests/cli_real_tg_integration/test_settings_get.py
+++ b/tests/cli_real_tg_integration/test_settings_get.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_settings_get_all(run_cli, assert_cli_ok):
+    result = run_cli("settings", "get")
+    assert_cli_ok(result)
+    assert result.stdout.strip() or "no" in (result.stdout + result.stderr).lower()

--- a/tests/cli_real_tg_integration/test_settings_info.py
+++ b/tests/cli_real_tg_integration/test_settings_info.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_settings_info(run_cli, assert_cli_ok):
+    result = run_cli("settings", "info")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`settings info` produced empty stdout"

--- a/tests/cli_real_tg_integration/test_translate_stats.py
+++ b/tests/cli_real_tg_integration/test_translate_stats.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_translate_stats(run_cli, assert_cli_ok):
+    result = run_cli("translate", "stats")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`translate stats` produced empty stdout"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,10 +178,14 @@ def _evaluate_real_tg_policy(
             f"{REAL_TG_LIVE_FIXTURE} requires @{REAL_TG_SAFE_MARK} or @{REAL_TG_MANUAL_MARK}.",
         )
 
+    # Only safe-mode CLI-integration tests are allowed to skip the live fixture
+    # (they bring their own pool via the live CLI subprocess). Manual-mode is
+    # always sandbox-required because manual tests are the mutating category.
+    safe_bypass = is_cli_integration and mode == REAL_TG_SAFE_MARK
     if (
         mode in {REAL_TG_SAFE_MARK, REAL_TG_MANUAL_MARK}
         and not uses_live_fixture
-        and not is_cli_integration
+        and not safe_bypass
     ):
         return (
             "fail",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,7 @@ def _evaluate_real_tg_policy(
     mode: str | None,
     fixturenames: Collection[str],
     environ: Mapping[str, str],
+    is_cli_integration: bool = False,
 ) -> tuple[str | None, str | None]:
     uses_live_fixture = REAL_TG_LIVE_FIXTURE in fixturenames
 
@@ -177,7 +178,11 @@ def _evaluate_real_tg_policy(
             f"{REAL_TG_LIVE_FIXTURE} requires @{REAL_TG_SAFE_MARK} or @{REAL_TG_MANUAL_MARK}.",
         )
 
-    if mode in {REAL_TG_SAFE_MARK, REAL_TG_MANUAL_MARK} and not uses_live_fixture:
+    if (
+        mode in {REAL_TG_SAFE_MARK, REAL_TG_MANUAL_MARK}
+        and not uses_live_fixture
+        and not is_cli_integration
+    ):
         return (
             "fail",
             f"@{mode} tests must use the {REAL_TG_LIVE_FIXTURE} fixture.",
@@ -324,12 +329,21 @@ async def real_telegram_sandbox():
         await client.disconnect()
 
 
+CLI_REAL_TG_INTEGRATION_DIR = "cli_real_tg_integration"
+
+
+def _is_cli_real_tg_integration(item) -> bool:
+    path = Path(str(item.fspath))
+    return CLI_REAL_TG_INTEGRATION_DIR in path.parts
+
+
 def pytest_runtest_setup(item):
     mode = _resolve_real_tg_mode(item)
     action, message = _evaluate_real_tg_policy(
         mode=mode,
         fixturenames=item.fixturenames,
         environ=os.environ,
+        is_cli_integration=_is_cli_real_tg_integration(item),
     )
     if action == "skip":
         pytest.skip(message)

--- a/tests/test_real_telegram_policy.py
+++ b/tests/test_real_telegram_policy.py
@@ -79,6 +79,20 @@ def test_real_tg_policy_allows_safe_mode_without_fixture_for_cli_integration():
     assert message is None
 
 
+def test_real_tg_policy_rejects_manual_mode_without_fixture_for_cli_integration():
+    """Manual-mode (mutating) tests must always use the sandbox fixture, even
+    inside cli_real_tg_integration/. The bypass is safe-only by design."""
+    action, message = _evaluate_real_tg_policy(
+        mode=REAL_TG_MANUAL_MARK,
+        fixturenames=(),
+        environ={REAL_TG_MANUAL_GATE_ENV: "1"},
+        is_cli_integration=True,
+    )
+
+    assert action == "fail"
+    assert REAL_TG_LIVE_FIXTURE in message
+
+
 def test_real_tg_policy_skips_safe_mode_without_gate():
     action, message = _evaluate_real_tg_policy(
         mode=REAL_TG_SAFE_MARK,
@@ -161,7 +175,7 @@ def test_real_tg_sandbox_config_parses_required_and_optional_fields():
 def test_real_tg_safe_marker_is_not_used_in_mutating_test_files():
     violations: list[str] = []
 
-    for path in _TESTS_DIR.glob("test_*.py"):
+    for path in _TESTS_DIR.rglob("test_*.py"):
         if path.name in _AUDIT_EXCLUDED_FILES:
             continue
         content = path.read_text(encoding="utf-8")
@@ -177,7 +191,7 @@ def test_real_tg_safe_marker_is_not_used_in_mutating_test_files():
 def test_real_tg_never_marker_does_not_request_live_fixture():
     violations: list[str] = []
 
-    for path in _TESTS_DIR.glob("test_*.py"):
+    for path in _TESTS_DIR.rglob("test_*.py"):
         if path.name in _AUDIT_EXCLUDED_FILES:
             continue
         content = path.read_text(encoding="utf-8")
@@ -192,7 +206,7 @@ def test_real_tg_never_marker_does_not_request_live_fixture():
 def test_live_fixture_is_not_used_without_real_tg_policy_marker():
     violations: list[str] = []
 
-    for path in _TESTS_DIR.glob("test_*.py"):
+    for path in _TESTS_DIR.rglob("test_*.py"):
         if path.name in _AUDIT_EXCLUDED_FILES:
             continue
         content = path.read_text(encoding="utf-8")

--- a/tests/test_real_telegram_policy.py
+++ b/tests/test_real_telegram_policy.py
@@ -67,6 +67,18 @@ def test_real_tg_policy_requires_live_fixture_for_safe_mode():
     assert REAL_TG_LIVE_FIXTURE in message
 
 
+def test_real_tg_policy_allows_safe_mode_without_fixture_for_cli_integration():
+    action, message = _evaluate_real_tg_policy(
+        mode=REAL_TG_SAFE_MARK,
+        fixturenames=(),
+        environ={REAL_TG_SAFE_GATE_ENV: "1"},
+        is_cli_integration=True,
+    )
+
+    assert action is None
+    assert message is None
+
+
 def test_real_tg_policy_skips_safe_mode_without_gate():
     action, message = _evaluate_real_tg_policy(
         mode=REAL_TG_SAFE_MARK,


### PR DESCRIPTION
## Summary

- Add `tests/cli_real_tg_integration/` — manual integration suite that exercises read-only CLI commands as a black box (`python -m src.main …`) against the live `config.yaml` and `data/tg_search.db`. 26 base tests + 5 heavy tests behind an extra `RUN_CLI_REAL_TG_HEAVY=1` gate so FLOOD_WAIT-prone foreach-channel flows don't poison the base run.
- Fix `src/database/facade.py`: `update_channel_full_meta` was missing on the `Database` facade, so `channel refresh-meta <pk>` crashed with `AttributeError` (caught by the new suite).
- Extend `tests/conftest.py` `_evaluate_real_tg_policy` with `is_cli_integration` so suite tests don't need the `real_telegram_sandbox` fixture (they bring the real pool through the live CLI). Policy test added for the new branch.

## Test plan
- [x] Base run: `RUN_REAL_TELEGRAM_SAFE=1 pytest tests/cli_real_tg_integration/ --ignore=tests/cli_real_tg_integration/heavy -v` → 26 passed
- [x] Policy: `pytest tests/test_real_telegram_policy.py -q` → 12 passed
- [ ] Heavy on demand: `RUN_REAL_TELEGRAM_SAFE=1 RUN_CLI_REAL_TG_HEAVY=1 pytest tests/cli_real_tg_integration/heavy/ -v --timeout=600` (skipped/FLOOD_WAIT is normal)
- [ ] Default `pytest tests/` stays unaffected (suite skips without `RUN_REAL_TELEGRAM_SAFE=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)