### PR TITLE
test(cli): close TG-R coverage gaps for issue #578

### DIFF
--- a/tests/cli_real_tg_integration/heavy/test_collect_default_all.py
+++ b/tests/cli_real_tg_integration/heavy/test_collect_default_all.py
@@ -1,0 +1,33 @@
+"""`python -m src.main collect` (no args) — enqueue all eligible channels.
+
+The bare `collect` invocation (no `--channel-id`, no `sample` sub) calls
+`TaskEnqueuer.enqueue_all_channels()` which writes pending rows into the
+`collection_tasks` table for every non-filtered channel (see
+src/cli/commands/collect.py:48-58). The actual TG-iter_messages work is
+deferred until a worker drains the queue, so this test does NOT itself
+fetch messages. Still placed in heavy/ because the queue write touches
+every channel in the live DB and aligns with how the issue groups
+collection commands.
+
+Per user instruction, this PR is paired with the matching
+`scheduler clear-pending` cleanup invocation (already covered by the
+existing mutating/test_proc_scheduler_trigger test). Operators who run
+this test sequentially with that one will leave the queue clean.
+"""
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_collect_default_enqueues_all(run_cli, assert_cli_ok):
+    result = run_cli("collect", timeout=300)
+    assert_cli_ok(result)
+    combined = result.stdout + result.stderr
+    # Possible outcomes:
+    # - "Enqueued N channels (skipped M, total K)..." — normal path.
+    # - "No connected accounts..." — pool empty, the handler short-circuits
+    #   before reaching the enqueue branch.
+    assert (
+        "Enqueued" in combined
+        or "No connected accounts" in combined
+    ), f"unexpected bare `collect` output: {combined!r}"

--- a/tests/cli_real_tg_integration/heavy/test_collect_default_all.py
+++ b/tests/cli_real_tg_integration/heavy/test_collect_default_all.py
@@ -6,28 +6,56 @@ The bare `collect` invocation (no `--channel-id`, no `sample` sub) calls
 src/cli/commands/collect.py:48-58). The actual TG-iter_messages work is
 deferred until a worker drains the queue, so this test does NOT itself
 fetch messages. Still placed in heavy/ because the queue write touches
-every channel in the live DB and aligns with how the issue groups
-collection commands.
+every channel in the live DB.
 
-Per user instruction, this PR is paired with the matching
-`scheduler clear-pending` cleanup invocation (already covered by the
-existing mutating/test_proc_scheduler_trigger test). Operators who run
-this test sequentially with that one will leave the queue clean.
+Self-contained cleanup: every successful invocation is followed by
+`scheduler clear-pending` in `finally` to drain the queue this test
+created. The cleanup goes through `cli_run_direct` (not `run_cli`) so a
+timeout in clear-pending raises TimeoutExpired (which we catch) instead
+of pytest.skip() — that would replace any in-flight AssertionError from
+the try block and silently leak the queued rows.
 """
+import subprocess
+import sys
+
 import pytest
+
+from tests.cli_real_tg_integration.conftest import cli_run_direct
 
 pytestmark = pytest.mark.real_tg_safe
 
 
-def test_collect_default_enqueues_all(run_cli, assert_cli_ok):
-    result = run_cli("collect", timeout=300)
-    assert_cli_ok(result)
-    combined = result.stdout + result.stderr
-    # Possible outcomes:
-    # - "Enqueued N channels (skipped M, total K)..." — normal path.
-    # - "No connected accounts..." — pool empty, the handler short-circuits
-    #   before reaching the enqueue branch.
-    assert (
-        "Enqueued" in combined
-        or "No connected accounts" in combined
-    ), f"unexpected bare `collect` output: {combined!r}"
+def test_collect_default_enqueues_all(run_cli, assert_cli_ok, cli_env):
+    leak_msg: str | None = None
+    try:
+        result = run_cli("collect", timeout=300)
+        assert_cli_ok(result)
+        combined = result.stdout + result.stderr
+        # Possible outcomes:
+        # - "Enqueued N channels (skipped M, total K)..." — normal path.
+        # - "No connected accounts..." — pool empty, the handler short-circuits
+        #   before reaching the enqueue branch.
+        assert (
+            "Enqueued" in combined
+            or "No connected accounts" in combined
+        ), f"unexpected bare `collect` output: {combined!r}"
+    finally:
+        # Drain the queue this test created. Same self-contained pattern as
+        # mutating/test_proc_scheduler_trigger.py:test_proc_scheduler_trigger_enqueues.
+        try:
+            cleanup = cli_run_direct(cli_env, "scheduler", "clear-pending", timeout=30)
+        except subprocess.TimeoutExpired:
+            leak_msg = (
+                "cleanup `scheduler clear-pending` timed out; pending "
+                "collection_tasks rows may be leaked — inspect the DB manually."
+            )
+        else:
+            if cleanup.returncode != 0:
+                leak_msg = (
+                    f"cleanup `scheduler clear-pending` failed; pending "
+                    f"collection tasks may be leaked: stderr={cleanup.stderr!r}"
+                )
+
+        # Only raise on cleanup if the try block didn't already raise.
+        if leak_msg and sys.exc_info()[0] is None:
+            pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/safe_ro/test_collect_sample_first.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_collect_sample_first.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_collect_sample_first(run_cli, assert_cli_ok, discover_first_channel):
+    """`collect sample <channel_id> --limit 5` — read-only preview.
+
+    Calls collector.sample_channel() against the real Telegram API without
+    writing anything to the DB (see src/cli/commands/collect.py:64-91).
+    """
+    _pk, channel_id = discover_first_channel()
+    result = run_cli("collect", "sample", channel_id, "--limit", "5", timeout=120)
+    assert_cli_ok(result)
+    combined = result.stdout + result.stderr
+    # The handler prints either a sampling header + per-message rows, or
+    # "No messages found." when the channel is empty. Both are legitimate.
+    assert "Sampling" in combined or "No messages found" in combined, (
+        f"unexpected `collect sample` output: {combined!r}"
+    )

--- a/tests/cli_real_tg_integration/safe_ro/test_dialogs_participants_first.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_dialogs_participants_first.py
@@ -1,0 +1,17 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_dialogs_participants_first(
+    run_cli, assert_cli_ok, discover_first_dialog_username
+):
+    """`dialogs participants @username --limit 10` — read participants list.
+
+    Real Telegram API call (GetParticipantsRequest) without DB writes.
+    `chat_id` is positional and accepts @username (see parser_domains/dialogs.py:113-114).
+    """
+    username = discover_first_dialog_username()
+    result = run_cli("dialogs", "participants", username, "--limit", "10", timeout=120)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`dialogs participants` produced empty stdout"

--- a/tests/cli_real_tg_integration/safe_ro/test_photo_loader_refresh.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_photo_loader_refresh.py
@@ -1,0 +1,16 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_photo_loader_refresh(run_cli, assert_cli_ok, discover_first_phone):
+    """`photo-loader refresh --phone +X` — refresh dialog cache from Telegram.
+
+    Same shape as the existing `photo-loader dialogs` smoke; the only
+    difference is the `refresh` action which forces a TG round-trip rather
+    than reading the local dialog_cache.
+    """
+    phone = discover_first_phone()
+    result = run_cli("photo-loader", "refresh", "--phone", phone, timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`photo-loader refresh` produced empty stdout"

--- a/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
@@ -1,0 +1,22 @@
+"""`python -m src.main test telegram` — live TG self-check on a temp DB copy.
+
+src/cli/commands/test.py copies the live DB into a tempfile before running
+telegram-side checks (_init_db_copy → tg_iter_messages → cleanup), so this
+test never mutates the operator's real DB. Stays in safe_ro despite the
+"telegram" name.
+"""
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_proc_test_telegram(run_cli, assert_cli_ok):
+    result = run_cli("test", "telegram", timeout=300)
+    assert_cli_ok(result)
+    combined = result.stdout + result.stderr
+    # `test telegram` emits PASS/SKIP/FAIL lines per check. We require at
+    # least one PASS — every probe SKIP means the suite ran but couldn't
+    # do anything (typically no accounts).
+    assert "PASS" in combined or "SKIP" in combined, (
+        f"unexpected `test telegram` output: {combined!r}"
+    )

--- a/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
@@ -14,9 +14,21 @@ def test_proc_test_telegram(run_cli, assert_cli_ok):
     result = run_cli("test", "telegram", timeout=300)
     assert_cli_ok(result)
     combined = result.stdout + result.stderr
-    # `test telegram` emits PASS/SKIP/FAIL lines per check. We require at
-    # least one PASS — every probe SKIP means the suite ran but couldn't
-    # do anything (typically no accounts).
-    assert "PASS" in combined or "SKIP" in combined, (
-        f"unexpected `test telegram` output: {combined!r}"
-    )
+
+    # `test telegram` emits PASS/SKIP/FAIL lines per check. Reviewers caught
+    # two issues with the prior `"PASS" in combined or "SKIP" in combined`:
+    #   - all-SKIP (no accounts) silently passed the assertion.
+    #   - mixed PASS+FAIL silently passed when "PASS" was present.
+    # Real-world deployments DO legitimately produce FAIL lines on transient
+    # session/auth issues, so a blanket `FAIL not in combined` would over-reject.
+    # Compromise: require at least one PASS (smoke that something live actually
+    # worked). If there are zero PASS lines but the run reached its summary,
+    # turn it into a skip — the suite cannot tell us anything useful then.
+    if "PASS" in combined:
+        return
+    if "SKIP" in combined or "No accounts" in combined or "no accounts" in combined.lower():
+        pytest.skip(
+            "`test telegram` produced only SKIP/'No accounts' lines — "
+            "nothing to smoke-check (typically no connected accounts)"
+        )
+    pytest.fail(f"`test telegram` produced no PASS and no recognizable SKIP: {combined!r}")

--- a/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_proc_test_telegram.py
@@ -15,15 +15,24 @@ def test_proc_test_telegram(run_cli, assert_cli_ok):
     assert_cli_ok(result)
     combined = result.stdout + result.stderr
 
-    # `test telegram` emits PASS/SKIP/FAIL lines per check. Reviewers caught
-    # two issues with the prior `"PASS" in combined or "SKIP" in combined`:
-    #   - all-SKIP (no accounts) silently passed the assertion.
-    #   - mixed PASS+FAIL silently passed when "PASS" was present.
-    # Real-world deployments DO legitimately produce FAIL lines on transient
-    # session/auth issues, so a blanket `FAIL not in combined` would over-reject.
-    # Compromise: require at least one PASS (smoke that something live actually
-    # worked). If there are zero PASS lines but the run reached its summary,
-    # turn it into a skip — the suite cannot tell us anything useful then.
+    # `test telegram` emits PASS/SKIP/FAIL lines per check. Round-2 review
+    # caught that `tg_db_copy` (a filesystem-only DB-copy probe — no Telegram
+    # involved) always emits "[PASS]" and would mask a "[FAIL] tg_pool_init"
+    # right after it, letting the test pass without ever opening a Telegram
+    # socket. So check the two critical-path probes explicitly:
+    #
+    #   - tg_db_copy   FAIL → environment broken before TG ever runs.
+    #   - tg_pool_init FAIL → no Telegram session was established.
+    #
+    # See src/cli/commands/test.py:730-772 for the check order.
+    if "[FAIL] tg_db_copy" in combined or "[FAIL] tg_pool_init" in combined:
+        pytest.fail(
+            f"`test telegram` critical check failed:\n{combined}"
+        )
+
+    # Beyond those two, individual probe FAILs are tolerated — they often
+    # reflect legitimate transient prod issues (SessionExpired on one client
+    # of many, etc.) rather than test regressions.
     if "PASS" in combined:
         return
     if "SKIP" in combined or "No accounts" in combined or "no accounts" in combined.lower():

--- a/tests/cli_real_tg_integration/safe_write/test_channel_add_bulk_first.py
+++ b/tests/cli_real_tg_integration/safe_write/test_channel_add_bulk_first.py
@@ -1,0 +1,40 @@
+"""`channel add-bulk --phone +X --dialog-ids N` — idempotent bulk INSERT.
+
+The CLI handler matches each provided id against `pool.get_my_dialogs(phone)`
+(via ChannelService.get_my_dialogs). If the channel_id already exists in the
+DB the handler prints "SKIP: ... — already exists" and does NOT touch the
+row — exactly the idempotency we need for a tier-safe_write smoke.
+
+We reuse channel_id (numeric) from discover_first_channel(): the
+add-bulk handler's `info_map` is keyed by channel_id (see
+src/cli/commands/channel.py:391), not by Telethon dialog.id, so this is
+the correct value to pass.
+"""
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_channel_add_bulk_idempotent_first(
+    run_cli, assert_cli_ok, discover_first_phone, discover_first_channel
+):
+    phone = discover_first_phone()
+    _pk, channel_id = discover_first_channel()
+    result = run_cli(
+        "channel",
+        "add-bulk",
+        "--phone",
+        phone,
+        "--dialog-ids",
+        channel_id,
+        timeout=180,
+    )
+    assert_cli_ok(result)
+    combined = result.stdout + result.stderr
+    # First-time channel will say "Added"; already-known channel will say
+    # "SKIP ... already exists". Either is a legitimate idempotent outcome.
+    assert (
+        "Added" in combined
+        or "already exists" in combined
+        or "not found in dialogs" in combined
+    ), f"unexpected `channel add-bulk` output: {combined!r}"


### PR DESCRIPTION
## Summary

Closes #578.

After the `cli_real_tg_integration/` reorg in PR #586, 12 of the 14 acceptance commands in issue #578 (TG-R, real Telegram read-only) were already covered by existing files. This PR fills the 6 remaining gaps and explicitly defers `account add` to issue #580 (TG-DANGER) because its auth flow requires SMS and cannot be automated against a sandbox account without burning real codes.

### 6 new test files

| Tier | File | Command |
|------|------|---------|
| safe_ro | `test_collect_sample_first.py` | `collect sample <channel_id> --limit 5` |
| safe_ro | `test_dialogs_participants_first.py` | `dialogs participants @username --limit 10` |
| safe_ro | `test_photo_loader_refresh.py` | `photo-loader refresh --phone +X` |
| safe_ro | `test_proc_test_telegram.py` | `test telegram` (runs on temp DB copy) |
| safe_write | `test_channel_add_bulk_first.py` | `channel add-bulk --phone +X --dialog-ids N` |
| heavy | `test_collect_default_all.py` | bare `collect` — enqueues all channels |

All tests follow the existing pattern: ~10 LOC, `pytestmark = pytest.mark.real_tg_safe`, gated behind `RUN_REAL_TELEGRAM_SAFE=1` + (where applicable) the tier-specific env var (`RUN_CLI_REAL_TG_HEAVY=1` for heavy/).

### Acceptance #578 — 14 commands

- [x] `account info` → safe_ro/test_account_info.py
- [ ] `account add` → **DEFERRED to #580** (SMS auth flow)
- [x] `channel add` → safe_write/test_channel_add_first.py
- [x] `channel collect` → heavy/test_channel_collect_first.py
- [x] `channel stats` → safe_ro/test_channel_stats_first.py + heavy/test_channel_stats_all.py
- [x] `channel refresh-types` → heavy/test_channel_refresh_types.py
- [x] `channel refresh-meta` → mutating/test_channel_refresh_meta_first.py + heavy/test_channel_refresh_meta_all.py
- [x] `channel add-bulk` → **NEW** safe_write/test_channel_add_bulk_first.py
- [x] `collect` (default) → **NEW** heavy/test_collect_default_all.py
- [x] `collect sample` → **NEW** safe_ro/test_collect_sample_first.py
- [x] `dialogs list` → safe_ro/test_dialogs_list.py
- [x] `dialogs refresh` → heavy/test_dialogs_refresh.py
- [x] `dialogs resolve` → safe_ro/test_dialogs_resolve_first.py
- [x] `dialogs topics` → safe_ro/test_dialogs_topics_first.py
- [x] `dialogs participants` → **NEW** safe_ro/test_dialogs_participants_first.py
- [x] `dialogs broadcast-stats` → safe_ro/test_dialogs_broadcast_stats_first.py
- [x] `filter analyze` → safe_ro/test_filter_analyze.py
- [x] `messages read --live` → safe_ro/test_messages_read_first.py
- [x] `photo-loader dialogs` → safe_ro/test_photo_loader_dialogs.py
- [x] `photo-loader refresh` → **NEW** safe_ro/test_photo_loader_refresh.py
- [x] `test telegram` → **NEW** safe_ro/test_proc_test_telegram.py

20 COVERED, 1 DEFERRED, 0 GAP.

### Why no new fixture in conftest

The initial plan called for a `discover_first_dialog_id` fixture, but reading the `channel add-bulk` handler (src/cli/commands/channel.py:391) showed that `--dialog-ids` is keyed by `channel_id` (not Telethon's `Dialog.id`). The existing `discover_first_channel()` already returns `(pk, channel_id)`, so the second tuple element is the right value. No new fixture needed.

## Test plan

- [x] `ruff check tests/cli_real_tg_integration/` — passed.
- [x] `pytest tests/cli_real_tg_integration/ --collect-only -q` — 87 tests collected (was 81 in PR #586).
- [ ] Local smoke (operator-driven, when sandbox is available):
  - `RUN_REAL_TELEGRAM_SAFE=1 pytest tests/cli_real_tg_integration/safe_ro/` — every test PASS or SKIP, no FAIL.
  - `RUN_REAL_TELEGRAM_SAFE=1 RUN_CLI_REAL_TG_HEAVY=1 pytest tests/cli_real_tg_integration/heavy/test_collect_default_all.py` — enqueue path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
