### PR TITLE
[codex] Fix live CLI pin/unpin target selection

### DIFF
--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -72,6 +72,7 @@ class LiveCliMessageTarget:
 
 _SOURCE_ROOT = Path(__file__).resolve().parents[2]
 CliEnv = CliRealCliEnv
+_PIN_CAPABLE_DIALOG_TYPES = frozenset({"group", "supergroup", "gigagroup", "forum"})
 
 
 def _resolve_live_root() -> Path:
@@ -158,6 +159,7 @@ def _fetch_live_message_target(
     phones: tuple[str, ...],
     *,
     require_own_dialog: bool = False,
+    require_pin_capable_dialog: bool = False,
 ) -> LiveCliMessageTarget | None:
     phone_set = set(phones)
     with sqlite3.connect(db_path) as conn:
@@ -169,7 +171,8 @@ def _fetch_live_message_target(
                 m.message_id,
                 NULLIF(c.preferred_phone, '') AS preferred_phone,
                 d.phone AS dialog_phone,
-                COALESCE(d.is_own, 0) AS is_own
+                COALESCE(d.is_own, 0) AS is_own,
+                LOWER(COALESCE(NULLIF(d.channel_type, ''), NULLIF(c.channel_type, ''), '')) AS dialog_type
             FROM messages m
             JOIN channels c ON c.channel_id = m.channel_id
             LEFT JOIN dialog_cache d
@@ -200,7 +203,10 @@ def _fetch_live_message_target(
         preferred_phone = str(row["preferred_phone"]) if row["preferred_phone"] else None
         dialog_phone = str(row["dialog_phone"]) if row["dialog_phone"] else None
         is_own = bool(row["is_own"])
+        dialog_type = str(row["dialog_type"] or "").lower()
         if require_own_dialog and (not is_own or dialog_phone not in phone_set):
+            continue
+        if require_pin_capable_dialog and dialog_type not in _PIN_CAPABLE_DIALOG_TYPES:
             continue
 
         if preferred_phone in phone_set:
@@ -485,6 +491,8 @@ _SILENT_FAILURE_PATTERNS = (
     ("Failed to initialize", re.compile(r"Failed to initialize", re.IGNORECASE)),
     ("Failed to load", re.compile(r"Failed to load", re.IGNORECASE)),
     ("Error sending reaction", re.compile(r"Error sending reaction", re.IGNORECASE)),
+    ("Error pinning", re.compile(r"Error pinning", re.IGNORECASE)),
+    ("Error unpinning", re.compile(r"Error unpinning", re.IGNORECASE)),
     ("RuntimeError", re.compile(r"RuntimeError", re.IGNORECASE)),
 )
 _DEFAULT_ALLOWED_ERROR_TEXTS = frozenset({"No connected accounts"})
@@ -610,6 +618,22 @@ def live_owned_mutation_message(cli_real_cli_env: CliRealCliEnv) -> LiveCliMessa
         pytest.skip(f"failed to discover live owned mutation message from {cli_real_cli_env.db_path}: {exc}")
     if target is None:
         pytest.skip("live CLI database has no own cached dialog with a collected message target")
+    return target
+
+
+@pytest.fixture
+def live_pin_mutation_message(cli_real_cli_env: CliRealCliEnv) -> LiveCliMessageTarget:
+    try:
+        target = _fetch_live_message_target(
+            cli_real_cli_env.db_path,
+            cli_real_cli_env.phones,
+            require_own_dialog=True,
+            require_pin_capable_dialog=True,
+        )
+    except sqlite3.Error as exc:
+        pytest.skip(f"failed to discover live pin-capable mutation message from {cli_real_cli_env.db_path}: {exc}")
+    if target is None:
+        pytest.skip("live CLI database has no own cached group/supergroup/forum with a collected message target")
     return target
 
 

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -510,6 +510,33 @@ def _normalize_allowed_error_texts(
     return frozenset(allow_error_text)
 
 
+def cli_result_failure_summary(
+    result: subprocess.CompletedProcess,
+    *,
+    allow_error_text: bool | str | tuple[str, ...] = False,
+) -> str | None:
+    combined = (result.stdout or "") + "\n" + (result.stderr or "")
+    if result.returncode != 0:
+        return (
+            f"CLI exited with {result.returncode}\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+
+    allowed_error_texts = _normalize_allowed_error_texts(allow_error_text)
+    for failure_text, pattern in _SILENT_FAILURE_PATTERNS:
+        if failure_text in allowed_error_texts:
+            continue
+        if pattern.search(combined):
+            return (
+                "CLI returned zero but printed a failure-looking message "
+                f"({failure_text})\n"
+                f"--- stdout ---\n{result.stdout}\n"
+                f"--- stderr ---\n{result.stderr}"
+            )
+    return None
+
+
 def _assert_cli_result_ok(
     result: subprocess.CompletedProcess,
     *,
@@ -521,24 +548,9 @@ def _assert_cli_result_ok(
             pytest.skip("Telegram FLOOD_WAIT; retry later")
         if _AUTH_RE.search(combined):
             pytest.skip("Telegram session not authorized; re-auth account")
-        pytest.fail(
-            f"CLI exited with {result.returncode}\n"
-            f"--- stdout ---\n{result.stdout}\n"
-            f"--- stderr ---\n{result.stderr}",
-            pytrace=False,
-        )
-    allowed_error_texts = _normalize_allowed_error_texts(allow_error_text)
-    for failure_text, pattern in _SILENT_FAILURE_PATTERNS:
-        if failure_text in allowed_error_texts:
-            continue
-        if pattern.search(combined):
-            pytest.fail(
-                "CLI returned zero but printed a failure-looking message "
-                f"({failure_text})\n"
-                f"--- stdout ---\n{result.stdout}\n"
-                f"--- stderr ---\n{result.stderr}",
-                pytrace=False,
-            )
+    failure_summary = cli_result_failure_summary(result, allow_error_text=allow_error_text)
+    if failure_summary is not None:
+        pytest.fail(failure_summary, pytrace=False)
 
 
 @pytest.fixture
@@ -633,7 +645,10 @@ def live_pin_mutation_message(cli_real_cli_env: CliRealCliEnv) -> LiveCliMessage
     except sqlite3.Error as exc:
         pytest.skip(f"failed to discover live pin-capable mutation message from {cli_real_cli_env.db_path}: {exc}")
     if target is None:
-        pytest.skip("live CLI database has no own cached group/supergroup/forum with a collected message target")
+        pytest.skip(
+            "live CLI database has no own cached group/supergroup/gigagroup/forum "
+            "with a collected message target"
+        )
     return target
 
 

--- a/tests/cli_real_tg_integration/mutation_safe/test_dialogs_pin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_dialogs_pin_message_target.py
@@ -11,10 +11,10 @@ pytestmark = pytest.mark.real_tg_mutation_safe
 
 
 @pytest.mark.timeout(120)
-def test_dialogs_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_owned_mutation_message):
-    chat_id = live_owned_mutation_message.chat_ref
-    message_id = live_owned_mutation_message.message_id
-    phone = live_owned_mutation_message.phone
+def test_dialogs_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_pin_mutation_message):
+    chat_id = live_pin_mutation_message.chat_ref
+    message_id = live_pin_mutation_message.message_id
+    phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
 
     try:

--- a/tests/cli_real_tg_integration/mutation_safe/test_dialogs_pin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_dialogs_pin_message_target.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from tests.cli_real_tg_integration.conftest import cli_run_direct
+from tests.cli_real_tg_integration.conftest import cli_result_failure_summary, cli_run_direct
 
 pytestmark = pytest.mark.real_tg_mutation_safe
 
@@ -47,11 +47,9 @@ def test_dialogs_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_
         except subprocess.TimeoutExpired:
             leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
         else:
-            if cleanup.returncode != 0:
-                leak_msg = (
-                    f"message {message_id} in {chat_id} may be left pinned: "
-                    f"cleanup stderr={cleanup.stderr!r}"
-                )
+            cleanup_failure = cli_result_failure_summary(cleanup)
+            if cleanup_failure is not None:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
@@ -11,10 +11,10 @@ pytestmark = pytest.mark.real_tg_mutation_safe
 
 
 @pytest.mark.timeout(120)
-def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_owned_mutation_message):
-    chat_id = live_owned_mutation_message.chat_ref
-    message_id = live_owned_mutation_message.message_id
-    phone = live_owned_mutation_message.phone
+def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_pin_mutation_message):
+    chat_id = live_pin_mutation_message.chat_ref
+    message_id = live_pin_mutation_message.message_id
+    phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
 
     try:

--- a/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
@@ -16,6 +16,7 @@ def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cl
     message_id = live_pin_mutation_message.message_id
     phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
+    message_pinned = False
 
     try:
         setup = run_cli(
@@ -29,6 +30,7 @@ def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cl
             timeout=60,
         )
         assert_cli_ok(setup)
+        message_pinned = True
 
         result = run_cli(
             "dialogs",
@@ -43,26 +45,28 @@ def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cl
         )
         assert_cli_ok(result)
         assert "Message(s) unpinned." in result.stdout
+        message_pinned = False
     finally:
-        try:
-            cleanup = cli_run_direct(
-                cli_real_cli_env,
-                "dialogs",
-                "unpin-message",
-                "--message-id",
-                message_id,
-                "--yes",
-                "--phone",
-                phone,
-                chat_id,
-                timeout=60,
-            )
-        except subprocess.TimeoutExpired:
-            leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
-        else:
-            cleanup_failure = cli_result_failure_summary(cleanup)
-            if cleanup_failure is not None:
-                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
+        if message_pinned:
+            try:
+                cleanup = cli_run_direct(
+                    cli_real_cli_env,
+                    "dialogs",
+                    "unpin-message",
+                    "--message-id",
+                    message_id,
+                    "--yes",
+                    "--phone",
+                    phone,
+                    chat_id,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
+            else:
+                cleanup_failure = cli_result_failure_summary(cleanup)
+                if cleanup_failure is not None:
+                    leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from tests.cli_real_tg_integration.conftest import cli_run_direct
+from tests.cli_real_tg_integration.conftest import cli_result_failure_summary, cli_run_direct
 
 pytestmark = pytest.mark.real_tg_mutation_safe
 
@@ -60,11 +60,9 @@ def test_dialogs_unpin_message_owned_message(run_cli, assert_cli_ok, cli_real_cl
         except subprocess.TimeoutExpired:
             leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
         else:
-            if cleanup.returncode != 0:
-                leak_msg = (
-                    f"message {message_id} in {chat_id} may be left pinned: "
-                    f"cleanup stderr={cleanup.stderr!r}"
-                )
+            cleanup_failure = cli_result_failure_summary(cleanup)
+            if cleanup_failure is not None:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_pin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_pin_message_target.py
@@ -11,10 +11,10 @@ pytestmark = pytest.mark.real_tg_mutation_safe
 
 
 @pytest.mark.timeout(120)
-def test_my_telegram_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_owned_mutation_message):
-    chat_id = live_owned_mutation_message.chat_ref
-    message_id = live_owned_mutation_message.message_id
-    phone = live_owned_mutation_message.phone
+def test_my_telegram_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_cli_env, live_pin_mutation_message):
+    chat_id = live_pin_mutation_message.chat_ref
+    message_id = live_pin_mutation_message.message_id
+    phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
 
     try:

--- a/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_pin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_pin_message_target.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from tests.cli_real_tg_integration.conftest import cli_run_direct
+from tests.cli_real_tg_integration.conftest import cli_result_failure_summary, cli_run_direct
 
 pytestmark = pytest.mark.real_tg_mutation_safe
 
@@ -47,11 +47,9 @@ def test_my_telegram_pin_message_owned_message(run_cli, assert_cli_ok, cli_real_
         except subprocess.TimeoutExpired:
             leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
         else:
-            if cleanup.returncode != 0:
-                leak_msg = (
-                    f"message {message_id} in {chat_id} may be left pinned: "
-                    f"cleanup stderr={cleanup.stderr!r}"
-                )
+            cleanup_failure = cli_result_failure_summary(cleanup)
+            if cleanup_failure is not None:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from tests.cli_real_tg_integration.conftest import cli_run_direct
+from tests.cli_real_tg_integration.conftest import cli_result_failure_summary, cli_run_direct
 
 pytestmark = pytest.mark.real_tg_mutation_safe
 
@@ -65,11 +65,9 @@ def test_my_telegram_unpin_message_owned_message(
         except subprocess.TimeoutExpired:
             leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
         else:
-            if cleanup.returncode != 0:
-                leak_msg = (
-                    f"message {message_id} in {chat_id} may be left pinned: "
-                    f"cleanup stderr={cleanup.stderr!r}"
-                )
+            cleanup_failure = cli_result_failure_summary(cleanup)
+            if cleanup_failure is not None:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
@@ -21,6 +21,7 @@ def test_my_telegram_unpin_message_owned_message(
     message_id = live_pin_mutation_message.message_id
     phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
+    message_pinned = False
 
     try:
         setup = run_cli(
@@ -34,6 +35,7 @@ def test_my_telegram_unpin_message_owned_message(
             timeout=60,
         )
         assert_cli_ok(setup)
+        message_pinned = True
 
         result = run_cli(
             "my-telegram",
@@ -48,26 +50,28 @@ def test_my_telegram_unpin_message_owned_message(
         )
         assert_cli_ok(result)
         assert "Message(s) unpinned." in result.stdout
+        message_pinned = False
     finally:
-        try:
-            cleanup = cli_run_direct(
-                cli_real_cli_env,
-                "my-telegram",
-                "unpin-message",
-                "--message-id",
-                message_id,
-                "--yes",
-                "--phone",
-                phone,
-                chat_id,
-                timeout=60,
-            )
-        except subprocess.TimeoutExpired:
-            leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
-        else:
-            cleanup_failure = cli_result_failure_summary(cleanup)
-            if cleanup_failure is not None:
-                leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
+        if message_pinned:
+            try:
+                cleanup = cli_run_direct(
+                    cli_real_cli_env,
+                    "my-telegram",
+                    "unpin-message",
+                    "--message-id",
+                    message_id,
+                    "--yes",
+                    "--phone",
+                    phone,
+                    chat_id,
+                    timeout=60,
+                )
+            except subprocess.TimeoutExpired:
+                leak_msg = f"message {message_id} in {chat_id} may be left pinned: cleanup timed out"
+            else:
+                cleanup_failure = cli_result_failure_summary(cleanup)
+                if cleanup_failure is not None:
+                    leak_msg = f"message {message_id} in {chat_id} may be left pinned: {cleanup_failure}"
 
         if leak_msg and sys.exc_info()[0] is None:
             pytest.fail(leak_msg)

--- a/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py
@@ -15,11 +15,11 @@ def test_my_telegram_unpin_message_owned_message(
     run_cli,
     assert_cli_ok,
     cli_real_cli_env,
-    live_owned_mutation_message,
+    live_pin_mutation_message,
 ):
-    chat_id = live_owned_mutation_message.chat_ref
-    message_id = live_owned_mutation_message.message_id
-    phone = live_owned_mutation_message.phone
+    chat_id = live_pin_mutation_message.chat_ref
+    message_id = live_pin_mutation_message.message_id
+    phone = live_pin_mutation_message.phone
     leak_msg: str | None = None
 
     try:


### PR DESCRIPTION
## Summary

- Add a pin-capable live CLI message fixture that selects only own group-like dialogs for `pin-message` / `unpin-message` smoke tests.
- Keep the broader owned-message fixture available for other mutation-safe commands.
- Treat `Error pinning` and `Error unpinning` as silent CLI failures even when the subprocess exits with code 0.

## Root Cause

The live pin/unpin tests reused the generic owned-message fixture, which could select an owned broadcast channel. Telegram can reject pin/unpin for that target while the CLI still prints an error-looking message with a zero exit code.

## Validation

- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_real_telegram_policy.py -q`
- `python3 -m pytest tests/cli_real_tg_integration/mutation_safe --collect-only -q`
- `RUN_CLI_REAL_TG_LIVE=1 RUN_REAL_TELEGRAM_MUTATION_SAFE=1 python3 -m pytest tests/cli_real_tg_integration/mutation_safe/test_dialogs_pin_message_target.py tests/cli_real_tg_integration/mutation_safe/test_dialogs_unpin_message_target.py tests/cli_real_tg_integration/mutation_safe/test_my_telegram_pin_message_target.py tests/cli_real_tg_integration/mutation_safe/test_my_telegram_unpin_message_target.py -v`