### PR TITLE
fix(agent): scope permission gate to interactive requests

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -583,9 +583,9 @@ class ClaudeSdkBackend:
         access_policy = await load_tool_access_policy(self._db, use_cache=True)
         # With PermissionGate active, requestable tools stay visible so the
         # runtime gate can ask; explicit denies remain hidden.
-        from src.agent.permission_gate import get_gate
+        from src.agent.permission_gate import get_gate, get_request_context
 
-        gate_active = get_gate() is not None
+        gate_active = get_gate() is not None and get_request_context() is not None
         allowed = visible_tools_for_llm(all_tools, access_policy, gate_active=gate_active)
         if len(allowed) < len(all_tools):
             denied = [t.removeprefix(MCP_PREFIX) for t in all_tools if t not in allowed]
@@ -2029,7 +2029,13 @@ class AgentManager:
         return await self._deepagents_backend.probe_config(cfg, probe_kind=probe_kind)
 
     async def chat_stream(
-        self, thread_id: int, message: str, model: str | None = None, session_id: str = "web",
+        self,
+        thread_id: int,
+        message: str,
+        model: str | None = None,
+        session_id: str = "web",
+        *,
+        interactive_permissions: bool = False,
     ) -> AsyncGenerator[str, None]:
         history = await self._db.get_agent_messages(thread_id)
         assert (
@@ -2094,14 +2100,12 @@ class AgentManager:
         # so the actual set/reset happens inside _run_backend (not in the generator).
         from src.agent.permission_gate import (
             AgentRequestContext,
-            get_gate,
             reset_request_context,
             set_request_context,
         )
 
-        _gate = get_gate()
         _req_ctx: AgentRequestContext | None = None
-        if _gate is not None:
+        if interactive_permissions:
             from src.agent.tools.permissions import load_tool_access_policy
 
             _access_policy = await load_tool_access_policy(self._db, use_cache=True)
@@ -2110,6 +2114,7 @@ class AgentManager:
                 thread_id=thread_id,
                 queue=queue,
                 tool_access_policy=_access_policy,
+                permission_gate=self._permission_gate,
                 permission_timeout=self._config.agent.permission_timeout,
             )
 

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -36,6 +36,7 @@ class AgentRequestContext:
     queue: asyncio.Queue              # SSE queue for this request
     db_permissions: dict[str, bool] | None = None  # legacy boolean view
     tool_access_policy: dict[str, object] | None = None
+    permission_gate: PermissionGate | None = None
     permission_timeout: int = 120     # seconds to wait for user response
 
 
@@ -68,6 +69,9 @@ _active_gate: PermissionGate | None = None
 
 def get_gate() -> PermissionGate | None:
     """Return the active PermissionGate, or None if not in use."""
+    ctx = get_request_context()
+    if ctx is not None and ctx.permission_gate is not None:
+        return ctx.permission_gate
     return _active_gate
 
 

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -426,11 +426,6 @@ class AgentTuiApp(App):
         self.agent_manager = agent_manager
         self._stream_worker = None
         self._session_id = str(uuid.uuid4())
-        # Activate interactive permission dialogs for TUI mode
-        self.agent_manager.enable_permission_gate()
-
-    def on_unmount(self) -> None:
-        self.agent_manager.disable_permission_gate()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -567,7 +562,11 @@ class AgentTuiApp(App):
         full_text = ""
         try:
             async for chunk in self.agent_manager.chat_stream(
-                thread_id, message, model=model, session_id=self._session_id
+                thread_id,
+                message,
+                model=model,
+                session_id=self._session_id,
+                interactive_permissions=True,
             ):
                 raw = chunk.removeprefix("data: ").strip()
                 try:

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -296,7 +296,13 @@ async def chat(request: Request, thread_id: int):
     session_id = request.cookies.get("session", "web")
 
     async def generate():
-        async for chunk in agent_manager.chat_stream(thread_id, message, model=model, session_id=session_id):
+        async for chunk in agent_manager.chat_stream(
+            thread_id,
+            message,
+            model=model,
+            session_id=session_id,
+            interactive_permissions=True,
+        ):
             try:
                 data_str = chunk.removeprefix("data: ").strip()
                 data = json.loads(data_str)

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -326,6 +326,29 @@ async def test_chat_with_model_parameter(client, db):
     assert resp.status_code == 200
 
 
+@pytest.mark.anyio
+async def test_chat_enables_interactive_permissions(client, db):
+    """Web chat requests opt into request-scoped PermissionGate prompts."""
+    thread_id = await db.create_agent_thread("Chat")
+    captured = {}
+
+    async def fake_stream(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        yield 'data: {"done": true, "full_text": "ok"}\n\n'
+
+    client._transport_app.state.agent_manager.chat_stream = fake_stream
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hello"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200
+    assert captured["kwargs"]["interactive_permissions"] is True
+
+
 # ── delete_thread: lines 86-88 (permission gate clearing) ──────────────
 
 

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -13,6 +13,7 @@ import pytest
 
 from src.agent.manager import (
     AgentManager,
+    AgentRuntimeStatus,
     DeepagentsBackend,
     _await_with_countdown,
     _embed_history_in_prompt,
@@ -1998,6 +1999,164 @@ class TestAgentManagerPermissionGate:
         """permission_gate property returns the gate instance."""
         mgr = AgentManager(db)
         assert mgr.permission_gate is not None
+
+    @pytest.mark.anyio
+    async def test_interactive_permissions_exposes_requestable_deepagents_tool(self, db):
+        from src.agent.permission_gate import get_gate, set_gate
+        from src.agent.tools.permissions import save_tool_permissions
+
+        def named_tool(name: str):
+            def _tool():
+                return name
+
+            _tool.__name__ = name
+            return _tool
+
+        await save_tool_permissions(
+            db,
+            {"pin_message": False, "list_channels": True},
+            phone="+66982102247",
+        )
+        set_gate(None)
+        mgr = AgentManager(db)
+        status = AgentRuntimeStatus(
+            claude_available=False,
+            deepagents_available=True,
+            dev_mode_enabled=False,
+            backend_override="auto",
+            selected_backend="deepagents",
+            fallback_model="openai:gpt-4",
+            fallback_provider="openai",
+            using_override=False,
+            error=None,
+        )
+        mgr.get_runtime_status = AsyncMock(return_value=status)  # type: ignore[method-assign]
+
+        fake_tools = [
+            named_tool("send_reaction"),
+            named_tool("pin_message"),
+            named_tool("list_channels"),
+        ]
+        configs = [
+            ProviderRuntimeConfig(
+                provider="openai",
+                enabled=True,
+                priority=0,
+                selected_model="gpt-4",
+                plain_fields={},
+                secret_fields={"api_key": "test"},
+            )
+        ]
+        captured_tools: list[list[str]] = []
+
+        def fake_run_agent(_prompt, _cfg, **kwargs):
+            tools = mgr._deepagents_backend._default_tools(
+                access_policy=kwargs.get("access_policy"),
+                gate_active=bool(kwargs.get("gate_active")),
+            )
+            captured_tools.append([tool.__name__ for tool in tools])
+            assert get_gate() is mgr.permission_gate
+            return "ok"
+
+        thread_id = await db.create_agent_thread("interactive-tools")
+        await db.save_agent_message(thread_id, "user", "test")
+        try:
+            with (
+                patch("src.agent.tools.deepagents_sync.build_deepagents_tools", return_value=fake_tools),
+                patch.object(mgr._deepagents_backend, "_candidate_configs", AsyncMock(return_value=configs)),
+                patch.object(mgr._deepagents_backend, "_validation_error", return_value=""),
+                patch.object(mgr._deepagents_backend, "_run_agent", side_effect=fake_run_agent),
+            ):
+                chunks = [
+                    chunk
+                    async for chunk in mgr.chat_stream(
+                        thread_id,
+                        "test",
+                        interactive_permissions=True,
+                    )
+                ]
+        finally:
+            await mgr.close_all()
+            set_gate(None)
+
+        assert captured_tools
+        assert captured_tools[-1] == ["send_reaction", "list_channels"]
+        assert any('"done": true' in chunk for chunk in chunks)
+
+    @pytest.mark.anyio
+    async def test_noninteractive_permissions_hide_requestable_deepagents_tool(self, db):
+        from src.agent.permission_gate import set_gate
+        from src.agent.tools.permissions import save_tool_permissions
+
+        def named_tool(name: str):
+            def _tool():
+                return name
+
+            _tool.__name__ = name
+            return _tool
+
+        await save_tool_permissions(
+            db,
+            {"pin_message": False, "list_channels": True},
+            phone="+66982102247",
+        )
+        mgr = AgentManager(db)
+        mgr.enable_permission_gate()
+        status = AgentRuntimeStatus(
+            claude_available=False,
+            deepagents_available=True,
+            dev_mode_enabled=False,
+            backend_override="auto",
+            selected_backend="deepagents",
+            fallback_model="openai:gpt-4",
+            fallback_provider="openai",
+            using_override=False,
+            error=None,
+        )
+        mgr.get_runtime_status = AsyncMock(return_value=status)  # type: ignore[method-assign]
+
+        fake_tools = [
+            named_tool("send_reaction"),
+            named_tool("pin_message"),
+            named_tool("list_channels"),
+        ]
+        configs = [
+            ProviderRuntimeConfig(
+                provider="openai",
+                enabled=True,
+                priority=0,
+                selected_model="gpt-4",
+                plain_fields={},
+                secret_fields={"api_key": "test"},
+            )
+        ]
+        captured_tools: list[list[str]] = []
+
+        def fake_run_agent(_prompt, _cfg, **kwargs):
+            tools = mgr._deepagents_backend._default_tools(
+                access_policy=kwargs.get("access_policy"),
+                gate_active=bool(kwargs.get("gate_active")),
+            )
+            captured_tools.append([tool.__name__ for tool in tools])
+            return "ok"
+
+        thread_id = await db.create_agent_thread("noninteractive-tools")
+        await db.save_agent_message(thread_id, "user", "test")
+        try:
+            with (
+                patch("src.agent.tools.deepagents_sync.build_deepagents_tools", return_value=fake_tools),
+                patch.object(mgr._deepagents_backend, "_candidate_configs", AsyncMock(return_value=configs)),
+                patch.object(mgr._deepagents_backend, "_validation_error", return_value=""),
+                patch.object(mgr._deepagents_backend, "_run_agent", side_effect=fake_run_agent),
+            ):
+                chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "test")]
+        finally:
+            await mgr.close_all()
+            set_gate(None)
+
+        assert captured_tools
+        assert captured_tools[-1] == ["list_channels"]
+        assert any('"done": true' in chunk for chunk in chunks)
 
 
 class TestAgentManagerCloseAll:

--- a/tests/test_agent_tui.py
+++ b/tests/test_agent_tui.py
@@ -226,6 +226,7 @@ async def test_tui_send_message_calls_chat_stream(db, app_factory):
     mgr.chat_stream.assert_called_once()
     call_args = mgr.chat_stream.call_args
     assert call_args[0][1] == "test message" or call_args[1].get("message") == "test message"
+    assert call_args.kwargs["interactive_permissions"] is True
     # thread_id and message are positional args
     assert "test message" in str(call_args)
 
@@ -786,3 +787,4 @@ async def test_tui_stream_shows_tool_status(db, app_factory):
         await pilot.pause(0.3)
 
     mgr.chat_stream.assert_called_once()
+    assert mgr.chat_stream.call_args.kwargs["interactive_permissions"] is True

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -309,6 +309,52 @@ def test_set_and_get_gate():
     assert get_gate() is None
 
 
+def test_get_gate_returns_request_scoped_gate_without_global_gate():
+    request_gate = PermissionGate()
+    ctx = AgentRequestContext(
+        session_id="request-scoped",
+        thread_id=1,
+        queue=asyncio.Queue(),
+        permission_gate=request_gate,
+        permission_timeout=10,
+    )
+    set_gate(None)
+    token = set_request_context(ctx)
+    try:
+        assert get_gate() is request_gate
+    finally:
+        reset_request_context(token)
+
+
+def test_get_gate_prefers_request_scoped_gate_over_global_gate():
+    request_gate = PermissionGate()
+    global_gate = PermissionGate()
+    ctx = AgentRequestContext(
+        session_id="request-scoped",
+        thread_id=1,
+        queue=asyncio.Queue(),
+        permission_gate=request_gate,
+        permission_timeout=10,
+    )
+    set_gate(global_gate)
+    token = set_request_context(ctx)
+    try:
+        assert get_gate() is request_gate
+    finally:
+        reset_request_context(token)
+        set_gate(None)
+
+
+def test_get_gate_falls_back_to_global_without_request_context():
+    gate = PermissionGate()
+    set_gate(gate)
+    try:
+        assert get_request_context() is None
+        assert get_gate() is gate
+    finally:
+        set_gate(None)
+
+
 # ── ContextVar get/set/reset ────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Add request-scoped `interactive_permissions` to agent chat streaming so Web/TUI sessions activate `PermissionGate` for that request only.
- Carry the active `PermissionGate` on `AgentRequestContext`, while preserving the legacy global fallback for older call sites.
- Make Claude SDK and Deepagents visibility treat requestable tools as visible only when both a gate and an active request context exist.
- Pass `interactive_permissions=True` from the Web chat route and TUI, while leaving CLI one-shot and background generation noninteractive.

## Why

After #595, missing ACL entries correctly became requestable, but the Web/TUI chat path still evaluated visibility with `gate_active=False`. That hid tools such as `send_reaction` before the model could request permission.

## Validation

- `python3 -m pytest tests/test_permission_gate.py tests/test_tool_permissions.py tests/test_agent_manager_runtime_paths.py tests/test_agent_tools_deepagents_sync.py tests/routes/test_agent_routes_threads.py tests/test_agent_tui.py -q` — 347 passed
- `python3 -m pytest tests/test_agent.py tests/routes/test_agent_routes_streaming.py tests/routes/test_agent_routes.py -q` — 138 passed
- `python3 -m pytest tests/test_agent_provider_service.py tests/test_content_generation_service_edge_cases.py -q` — 79 passed
- `python3 -m pytest tests/test_agent_tui.py -q` — 37 passed
- `python3 -m ruff check src tests conftest.py`
- `lint-imports --config .importlinter`
- Live TUI smoke with real `AgentManager`: agent replied `TUI_REAL_OK`
- Live TUI regression check: asking whether `send_reaction` is available returned that the tool is available

Follow-up to #594 / #595.