### PR TITLE
fix(agent): harden permission dialog resolution

### DIFF
--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -142,14 +142,23 @@ class PermissionGate:
             ensure_ascii=False,
         )
         await ctx.queue.put(f"data: {event}\n\n")
+        logger.info(
+            "Permission request emitted: request_id=%s tool=%s phone=%s thread=%d session=%s timeout=%ds",
+            request_id,
+            tool_name,
+            phone or "(none)",
+            ctx.thread_id,
+            ctx.session_id,
+            timeout,
+        )
 
         try:
             choice: str = await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
             self._pending.pop(request_id, None)
             logger.warning(
-                "Permission timeout %ds fired for tool '%s' (thread %d, session %s)",
-                timeout, tool_name, ctx.thread_id, ctx.session_id,
+                "Permission timeout %ds fired for request_id=%s tool '%s' (thread %d, session %s)",
+                timeout, request_id, tool_name, ctx.thread_id, ctx.session_id,
             )
             mins = timeout // 60
             return _text_response(f"❌ Таймаут запроса разрешения для '{tool_name}' ({mins} мин).")
@@ -188,6 +197,7 @@ class PermissionGate:
             return False
         if not future.done():
             future.set_result(choice)
+            logger.info("Permission request resolved: request_id=%s choice=%s", request_id, choice)
         return True
 
     def clear_session(self, session_id: str) -> None:

--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -57,6 +57,11 @@ class AgentRuntimeContext:
                 owner_loop = asyncio.get_running_loop()
             except RuntimeError:
                 owner_loop = None
+        sync_timeout_sec = 120.0
+        agent_config = getattr(config, "agent", None)
+        permission_timeout = getattr(agent_config, "permission_timeout", None)
+        if isinstance(permission_timeout, (int, float)):
+            sync_timeout_sec = max(sync_timeout_sec, float(permission_timeout) + 5.0)
         return cls(
             db=db,
             config=config,
@@ -64,6 +69,7 @@ class AgentRuntimeContext:
             scheduler_manager=scheduler_manager,
             runtime_kind=runtime_kind or detect_runtime_kind(client_pool),
             owner_loop=owner_loop,
+            sync_timeout_sec=sync_timeout_sec,
         )
 
     @property

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -578,7 +578,8 @@ class AgentTuiApp(App):
                     # Show interactive permission menu; tool handler is awaiting the Future
                     dialog = PermissionDialog(payload["tool"], payload.get("phone", ""))
                     choice = await self.push_screen_wait(dialog)
-                    self.agent_manager.permission_gate.resolve(payload["request_id"], choice)
+                    if not self.agent_manager.permission_gate.resolve(payload["request_id"], choice):
+                        widget._append_log("  ⚠️ Запрос разрешения уже истёк или был обработан.")
                     continue
                 if event_type == "thinking":
                     widget.set_pending_status("Думает...")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -235,7 +235,16 @@ async def resolve_permission(request: Request, thread_id: int, request_id: str):
     if agent_manager is None:
         return _agent_unavailable_response(agent_runtime_state)
     ok = agent_manager.permission_gate.resolve(request_id, choice)
-    return JSONResponse({"ok": ok})
+    logger.info(
+        "Permission resolve from web: thread_id=%s request_id=%s choice=%s ok=%s",
+        thread_id,
+        request_id,
+        choice,
+        ok,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Permission request not found or already resolved")
+    return JSONResponse({"ok": True})
 
 
 @router.post("/threads/{thread_id}/stop")

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -744,6 +744,9 @@
 
     function showPermissionDialog(toolName, phone) {
         return new Promise(function(resolve) {
+            document.querySelectorAll('#permission-modal').forEach(function(el) {
+                if (el.parentNode) el.parentNode.removeChild(el);
+            });
             var phoneStr = phone ? ' (' + escapeHtml(phone) + ')' : '';
             var modal = document.createElement('div');
             modal.id = 'permission-modal';
@@ -753,8 +756,8 @@
                 '<div class="perm-tool">' + escapeHtml(toolName) + phoneStr + '</div>' +
                 '<div class="perm-menu">' +
                 '<div class="perm-item" data-choice="once" tabindex="0"><span class="perm-cursor">&gt;</span> 1. Разрешить один раз</div>' +
-                '<div class="perm-item" data-choice="session" tabindex="0">  2. Разрешить в этой сессии</div>' +
-                '<div class="perm-item" data-choice="deny" tabindex="0">  3. Запретить</div>' +
+                '<div class="perm-item" data-choice="session" tabindex="0"><span class="perm-cursor"> </span> 2. Разрешить в этой сессии</div>' +
+                '<div class="perm-item" data-choice="deny" tabindex="0"><span class="perm-cursor"> </span> 3. Запретить</div>' +
                 '</div>' +
                 '<div class="perm-hint">↑↓ навигация &nbsp;·&nbsp; Enter выбор &nbsp;·&nbsp; Esc = Запретить</div>' +
                 '</div>';
@@ -762,6 +765,7 @@
 
             var items = modal.querySelectorAll('.perm-item');
             var selected = 0;
+            var settled = false;
 
             function highlight() {
                 items.forEach(function(el, i) {
@@ -771,28 +775,68 @@
             }
 
             function pick(choice) {
-                document.body.removeChild(modal);
-                document.removeEventListener('keydown', onKey);
+                if (settled) return;
+                settled = true;
+                if (modal.parentNode) modal.parentNode.removeChild(modal);
+                document.removeEventListener('keydown', onKey, true);
                 resolve(choice);
             }
 
+            function consume(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+            }
+
             function onKey(e) {
-                if (e.key === 'ArrowUp' || e.key === 'k') { selected = (selected + 2) % 3; highlight(); e.preventDefault(); }
-                else if (e.key === 'ArrowDown' || e.key === 'j') { selected = (selected + 1) % 3; highlight(); e.preventDefault(); }
-                else if (e.key === 'Enter') { pick(items[selected].dataset.choice); e.preventDefault(); }
-                else if (e.key === 'Escape') { pick('deny'); e.preventDefault(); }
-                else if (e.key === '1') pick('once');
-                else if (e.key === '2') pick('session');
-                else if (e.key === '3') pick('deny');
+                var key = e.key || '';
+                var code = e.code || '';
+                if (key === 'ArrowUp' || key === 'k') {
+                    selected = (selected + items.length - 1) % items.length;
+                    highlight();
+                    consume(e);
+                } else if (key === 'ArrowDown' || key === 'j') {
+                    selected = (selected + 1) % items.length;
+                    highlight();
+                    consume(e);
+                } else if (key === 'Enter') {
+                    pick(items[selected].dataset.choice);
+                    consume(e);
+                } else if (key === 'Escape') {
+                    pick('deny');
+                    consume(e);
+                } else if (key === '1' || code === 'Digit1' || code === 'Numpad1') {
+                    pick('once');
+                    consume(e);
+                } else if (key === '2' || code === 'Digit2' || code === 'Numpad2') {
+                    pick('session');
+                    consume(e);
+                } else if (key === '3' || code === 'Digit3' || code === 'Numpad3') {
+                    pick('deny');
+                    consume(e);
+                }
             }
 
             items.forEach(function(el, i) {
                 el.addEventListener('click', function() { pick(el.dataset.choice); });
             });
 
-            document.addEventListener('keydown', onKey);
+            document.addEventListener('keydown', onKey, true);
             highlight();
         });
+    }
+
+    async function resolvePermissionRequest(requestId, choice) {
+        console.info('Resolving permission request', requestId, choice);
+        var permissionResp = await fetch('/agent/threads/' + threadId + '/permission/' + requestId, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({choice: choice})
+        });
+        var permissionResult = await permissionResp.json().catch(function() { return {}; });
+        if (!permissionResp.ok || !permissionResult.ok) {
+            throw new Error(permissionResult.detail || ('Permission resolve failed: HTTP ' + permissionResp.status));
+        }
     }
 
     // Render existing assistant messages loaded from DB
@@ -1082,20 +1126,12 @@
                         if (data.type === 'permission_request') {
                             var choice = await showPermissionDialog(data.tool, data.phone || '');
                             try {
-                                await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
-                                    method: 'POST',
-                                    headers: {'Content-Type': 'application/json'},
-                                    body: JSON.stringify({choice: choice})
-                                });
+                                await resolvePermissionRequest(data.request_id, choice);
                             } catch (fetchErr) {
-                                console.error('Permission POST failed, sending deny:', fetchErr);
-                                try {
-                                    await fetch('/agent/threads/' + threadId + '/permission/' + data.request_id, {
-                                        method: 'POST',
-                                        headers: {'Content-Type': 'application/json'},
-                                        body: JSON.stringify({choice: 'deny'})
-                                    });
-                                } catch (_) { /* server-side timeout will handle it */ }
+                                console.error('Permission POST failed:', fetchErr);
+                                statusTracker.onWarning(
+                                    'Не удалось отправить выбор разрешения. Запрос разрешения истечёт по таймауту.'
+                                );
                             }
                         } else if (data.type === 'thinking') {
                             statusTracker.onThinking();

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -202,6 +204,67 @@ async def test_resolve_permission_valid_choices(client, db):
         assert data["ok"] is True
 
 
+@pytest.mark.anyio
+async def test_resolve_permission_unknown_request_returns_404(client, db):
+    """Unknown or already-resolved permission requests must not look successful."""
+    thread_id = await db.create_agent_thread("Perm")
+    gate = MagicMock()
+    gate.resolve = MagicMock(return_value=False)
+    client._transport_app.state.agent_manager.permission_gate = gate
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/permission/missing-request-id",
+        content=json.dumps({"choice": "session"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 404
+    gate.resolve.assert_called_once_with("missing-request-id", "session")
+
+
+@pytest.mark.anyio
+async def test_resolve_permission_session_choice_updates_gate(client, db):
+    """Web resolve route stores a real session approval when the browser POST arrives."""
+    from src.agent.permission_gate import (
+        AgentRequestContext,
+        PermissionGate,
+        reset_request_context,
+        set_request_context,
+    )
+
+    thread_id = await db.create_agent_thread("Perm")
+    gate = PermissionGate()
+    session_id = "web-session"
+    phone = "+66982102247"
+    client._transport_app.state.agent_manager.permission_gate = gate
+    ctx = AgentRequestContext(
+        session_id=session_id,
+        thread_id=thread_id,
+        queue=asyncio.Queue(),
+        permission_gate=gate,
+        permission_timeout=5,
+    )
+    token = set_request_context(ctx)
+    try:
+        pending = asyncio.create_task(gate.check("send_reaction", phone))
+        event = await asyncio.wait_for(ctx.queue.get(), timeout=1)
+        payload = json.loads(event.removeprefix("data: ").strip())
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/permission/{payload['request_id']}",
+            content=json.dumps({"choice": "session"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert await asyncio.wait_for(pending, timeout=1) is None
+    finally:
+        reset_request_context(token)
+
+    assert gate.is_session_approved("send_reaction", session_id, phone)
+
+
 # ── stop_chat: lines 211-213 ───────────────────────────────────────────
 
 
@@ -347,6 +410,31 @@ async def test_chat_enables_interactive_permissions(client, db):
 
     assert resp.status_code == 200
     assert captured["kwargs"]["interactive_permissions"] is True
+
+
+def test_permission_dialog_items_all_have_cursor_span():
+    """Every permission menu item must satisfy highlight()'s .perm-cursor lookup."""
+    template = Path("src/web/templates/agent.html").read_text(encoding="utf-8")
+    for choice in ("once", "session", "deny"):
+        marker = f'class="perm-item" data-choice="{choice}"'
+        start = template.index(marker)
+        end = template.index("</div>", start)
+        item_markup = template[start:end]
+        assert 'class="perm-cursor"' in item_markup
+
+
+def test_permission_dialog_keyboard_and_post_contract():
+    """Pressing 2 must map to session and POST failures must not auto-deny."""
+    template = Path("src/web/templates/agent.html").read_text(encoding="utf-8")
+
+    assert "document.addEventListener('keydown', onKey, true)" in template
+    assert "document.removeEventListener('keydown', onKey, true)" in template
+    assert "code === 'Digit2' || code === 'Numpad2'" in template
+    assert "pick('session')" in template
+    assert "resolvePermissionRequest(data.request_id, choice)" in template
+    assert "!permissionResp.ok || !permissionResult.ok" in template
+    assert "body: JSON.stringify({choice: 'deny'})" not in template
+    assert "sending deny" not in template
 
 
 # ── delete_thread: lines 86-88 (permission gate clearing) ──────────────

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -1086,6 +1086,21 @@ class TestAgentRuntimeContextRunSync:
         result = AgentRuntimeContext.build(db=MagicMock()).run_sync("test_tool", _op)
         assert result == 42
 
+    def test_sync_timeout_exceeds_permission_timeout(self):
+        from src.agent.runtime_context import AgentRuntimeContext
+
+        config = MagicMock()
+        config.agent.permission_timeout = 77
+
+        ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
+
+        assert ctx.sync_timeout_sec == 120.0
+
+        config.agent.permission_timeout = 130
+        ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
+
+        assert ctx.sync_timeout_sec == 135.0
+
     @pytest.mark.anyio
     async def test_inside_event_loop_raises(self):
         from src.agent.runtime_context import AgentRuntimeContext


### PR DESCRIPTION
## Summary

- harden the Web permission dialog so keyboard choice `2` resolves to session approval reliably
- remove the automatic fallback that silently POSTed `deny` when permission resolution failed
- make the permission resolve route fail closed with `404` for unknown or already-resolved request ids
- log emitted/resolved permission request ids and keep the sync bridge timeout above the permission timeout
- surface stale permission resolve failures in the TUI instead of ignoring them

## Follow-up

- Created tracking issue for Telegram action rate limiting / flood handling: #597

## Tests

```bash
python3 -m ruff check src tests conftest.py
python3 -m pytest tests/test_permission_gate.py tests/test_agent_tools_deepagents_sync.py tests/routes/test_agent_routes_threads.py -q
python3 -m pytest tests/test_agent_manager_runtime_paths.py tests/test_agent_tui.py tests/test_cli_telegram_agent_dispatcher_paths.py -q
```

Results:

- ruff: passed
- permission/deepagents/routes: 97 passed
- runtime/TUI/dispatcher: 298 passed
