### PR TITLE
[codex] Retry locked SQLite writes for agent chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,23 @@ jobs:
     steps:
       - name: Reject branch names with "+"
         if: contains(github.head_ref, '+')
-        run: |
-          echo "::error::Branch name contains '+', which is not allowed. Use '-' or '.' instead."
-          exit 1
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⛔ Символ `+` недопустим в названии ветки (`' + context.payload.pull_request.head.ref + '`). Переименуйте ветку без `+` (используйте `-` или `.`).'
+            });
+            core.setFailed('Branch name contains "+", which is not allowed.');
 
   lint-and-test:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository without GitHub token
-        run: |
-          git init .
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            ref="refs/pull/${{ github.event.pull_request.number }}/merge"
-          else
-            ref="${GITHUB_REF}"
-          fi
-          git fetch --no-tags --depth=1 origin "+${ref}:refs/remotes/origin/ci"
-          git checkout --detach refs/remotes/origin/ci
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -41,10 +39,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: python -m pip install -e ".[dev]"
+        run: pip install -e ".[dev]"
 
       - name: Ruff
-        run: python -m ruff check src tests conftest.py
+        run: ruff check src tests conftest.py
 
       - name: Import architecture contracts
         run: lint-imports --config .importlinter
@@ -66,6 +64,4 @@ jobs:
           PY
 
       - name: Pytest
-        run: |
-          python -m pytest tests -q -m "not aiosqlite_serial" -n auto
-          python -m pytest tests -q -m aiosqlite_serial
+        run: pytest tests -q -m "not aiosqlite_serial" -n auto && pytest tests -q -m aiosqlite_serial

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,25 @@ jobs:
     steps:
       - name: Reject branch names with "+"
         if: contains(github.head_ref, '+')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '⛔ Символ `+` недопустим в названии ветки (`' + context.payload.pull_request.head.ref + '`). Переименуйте ветку без `+` (используйте `-` или `.`).'
-            });
-            core.setFailed('Branch name contains "+", which is not allowed.');
+        run: |
+          echo "::error::Branch name contains '+', which is not allowed. Use '-' or '.' instead."
+          exit 1
 
   lint-and-test:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository without GitHub token
+        run: |
+          git init .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            ref="refs/pull/${{ github.event.pull_request.number }}/merge"
+          else
+            ref="${GITHUB_REF}"
+          fi
+          git fetch --no-tags --depth=1 origin "+${ref}:refs/remotes/origin/ci"
+          git checkout --detach refs/remotes/origin/ci
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,10 +41,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: python -m pip install -e ".[dev]"
 
       - name: Ruff
-        run: ruff check src tests conftest.py
+        run: python -m ruff check src tests conftest.py
 
       - name: Import architecture contracts
         run: lint-imports --config .importlinter
@@ -64,4 +66,6 @@ jobs:
           PY
 
       - name: Pytest
-        run: pytest tests -q -m "not aiosqlite_serial" -n auto && pytest tests -q -m aiosqlite_serial
+        run: |
+          python -m pytest tests -q -m "not aiosqlite_serial" -n auto
+          python -m pytest tests -q -m aiosqlite_serial

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,3 +1,3 @@
-from src.database.facade import Database
+from src.database.facade import Database, DatabaseBusyError
 
-__all__ = ["Database"]
+__all__ = ["Database", "DatabaseBusyError"]

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from collections.abc import AsyncIterator, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
@@ -48,6 +48,22 @@ from src.security import SessionCipher
 
 logger = logging.getLogger(__name__)
 
+_SQLITE_BUSY_MESSAGES = (
+    "database is locked",
+    "database table is locked",
+    "database is busy",
+)
+_BUSY_RETRY_DELAYS_SEC = (0.05, 0.2)
+
+
+class DatabaseBusyError(RuntimeError):
+    """Raised when SQLite stays locked after short write retries."""
+
+
+def _is_sqlite_busy_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(part in message for part in _SQLITE_BUSY_MESSAGES)
+
 
 class Database:
     def __init__(
@@ -67,6 +83,7 @@ class Database:
         # BEGIN IMMEDIATE block (which would otherwise commit our open
         # transaction prematurely under isolation_level=None).
         self._write_lock: asyncio.Lock = asyncio.Lock()
+        self._busy_retry_delays_sec = _BUSY_RETRY_DELAYS_SEC
         self._accounts: AccountsRepository | None = None
         self._channels: ChannelsRepository | None = None
         self._messages: MessagesRepository | None = None
@@ -173,6 +190,39 @@ class Database:
     async def execute_fetchall(self, sql: str, params: tuple = ()) -> list:
         return await self._connection.execute_fetchall(sql, params)
 
+    async def _with_busy_retry(
+        self,
+        operation: str,
+        action: Callable[[], Awaitable[aiosqlite.Cursor | None]],
+    ) -> aiosqlite.Cursor | None:
+        delays = self._busy_retry_delays_sec
+        for attempt in range(len(delays) + 1):
+            try:
+                return await action()
+            except sqlite3.OperationalError as exc:
+                if not _is_sqlite_busy_error(exc):
+                    raise
+                if attempt >= len(delays):
+                    logger.warning(
+                        "Database stayed locked during %s after %d attempts",
+                        operation,
+                        attempt + 1,
+                    )
+                    raise DatabaseBusyError(
+                        "Database is busy. Retry the request in a few seconds."
+                    ) from exc
+                delay = delays[attempt]
+                logger.warning(
+                    "Database locked during %s; retrying in %.2fs (%d/%d)",
+                    operation,
+                    delay,
+                    attempt + 1,
+                    len(delays) + 1,
+                )
+                if delay > 0:
+                    await asyncio.sleep(delay)
+        return None
+
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[aiosqlite.Connection]:
         """Acquire the connection-wide write lock and run BEGIN IMMEDIATE.
@@ -187,7 +237,10 @@ class Database:
         """
         assert self._db is not None
         async with self._write_lock:
-            await begin_immediate(self._db)
+            await self._with_busy_retry(
+                "transaction begin",
+                lambda: begin_immediate(self._db),
+            )
             committed = False
             try:
                 yield self._db
@@ -211,8 +264,13 @@ class Database:
         """
         assert self._db is not None
         async with self._write_lock:
-            cur = await self._db.execute(sql, params)
-            await self._db.commit()
+            async def _write_once() -> aiosqlite.Cursor:
+                cur = await self._db.execute(sql, params)
+                await self._db.commit()
+                return cur
+
+            cur = await self._with_busy_retry("execute_write", _write_once)
+            assert cur is not None
             return cur
 
     async def executemany_write(
@@ -224,8 +282,13 @@ class Database:
         """
         assert self._db is not None
         async with self._write_lock:
-            cur = await self._db.executemany(sql, seq)
-            await self._db.commit()
+            async def _write_once() -> aiosqlite.Cursor:
+                cur = await self._db.executemany(sql, seq)
+                await self._db.commit()
+                return cur
+
+            cur = await self._with_busy_retry("executemany_write", _write_once)
+            assert cur is not None
             return cur
 
     @property

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -13,9 +13,10 @@ from urllib.parse import parse_qs, urlparse
 from fastapi import FastAPI, Request
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import HTMLResponse, RedirectResponse, Response
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 from src.config import AppConfig, load_config
+from src.database import DatabaseBusyError
 from src.web.assembly import (
     build_log_buffer,
     build_timing_buffer,
@@ -313,6 +314,40 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.add_middleware(ActionLogMiddleware)
     app.add_middleware(ErrorRedirectLogMiddleware)
     app.add_middleware(TimingMiddleware)
+
+    @app.exception_handler(DatabaseBusyError)
+    async def database_busy_exception_handler(request: Request, exc: DatabaseBusyError):
+        logger.warning("Database busy on %s %s: %s", request.method, request.url.path, exc)
+        headers = {"Retry-After": "2"}
+        detail = "База данных занята. Повторите попытку через несколько секунд."
+
+        if request.headers.get("HX-Request") == "true":
+            return HTMLResponse(
+                f'<div class="alert alert-warning">{detail}</div>',
+                status_code=503,
+                headers=headers,
+            )
+
+        accept = request.headers.get("Accept", "")
+        content_type = request.headers.get("Content-Type", "")
+        wants_json = (
+            request.url.path.startswith("/agent/")
+            or "application/json" in accept
+            or "application/json" in content_type
+        )
+        if wants_json:
+            return JSONResponse({"detail": detail}, status_code=503, headers=headers)
+
+        try:
+            tpl = app.state.templates.env.get_template("error.html")
+            body = tpl.render({
+                "request": request,
+                "status_code": 503,
+                "detail": detail,
+            })
+            return HTMLResponse(body, status_code=503, headers=headers)
+        except Exception:
+            return HTMLResponse(detail, status_code=503, headers=headers)
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):

--- a/tests/routes/test_agent_routes_streaming.py
+++ b/tests/routes/test_agent_routes_streaming.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+from src.database import DatabaseBusyError
+
 
 @pytest.fixture
 async def client(route_client, agent_manager_mock):
@@ -63,6 +65,26 @@ async def test_chat_streaming_saves_assistant_message(client, db):
     assistant_msgs = [m for m in messages if m["role"] == "assistant"]
     assert len(assistant_msgs) == 1
     assert assistant_msgs[0]["content"] == "hi"
+
+
+@pytest.mark.anyio
+async def test_chat_database_busy_returns_retryable_503(client, db):
+    thread_id = await db.create_agent_thread("Chat")
+
+    with patch.object(
+        db,
+        "save_agent_message",
+        side_effect=DatabaseBusyError("Database is busy. Retry the request in a few seconds."),
+    ):
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat",
+            content=json.dumps({"message": "hello"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 503
+    assert resp.headers["retry-after"] == "2"
+    assert "База данных занята" in resp.json()["detail"]
 
 
 # === chat: generate() — IntegrityError on save (line 284-285) ===

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,12 +1,13 @@
 import base64
 import hashlib
+import sqlite3
 from datetime import datetime, timezone
 
 import aiosqlite
 import pytest
 from cryptography.fernet import Fernet
 
-from src.database import Database
+from src.database import Database, DatabaseBusyError
 from src.models import (
     Account,
     AccountSessionStatus,
@@ -74,6 +75,57 @@ async def test_account_upsert_reactivates_without_overwriting_primary(db):
     assert accounts[0].session_string == "session2"
     assert accounts[0].is_active is True
     assert accounts[0].is_primary is True
+
+
+@pytest.mark.anyio
+async def test_agent_message_write_retries_when_database_is_locked_once(db, monkeypatch):
+    thread_id = await db.create_agent_thread("Retry")
+    assert db.db is not None
+
+    real_execute = db.db.execute
+    calls = 0
+
+    async def flaky_execute(sql, params=()):
+        nonlocal calls
+        if sql.startswith("INSERT INTO agent_messages"):
+            calls += 1
+            if calls == 1:
+                raise sqlite3.OperationalError("database is locked")
+        return await real_execute(sql, params)
+
+    db._busy_retry_delays_sec = (0,)
+    monkeypatch.setattr(db.db, "execute", flaky_execute)
+
+    await db.save_agent_message(thread_id, "user", "hello")
+
+    messages = await db.get_agent_messages(thread_id)
+    assert calls == 2
+    assert [m["content"] for m in messages] == ["hello"]
+
+
+@pytest.mark.anyio
+async def test_agent_message_write_raises_database_busy_after_retries(db, monkeypatch):
+    thread_id = await db.create_agent_thread("Retry")
+    assert db.db is not None
+
+    real_execute = db.db.execute
+    calls = 0
+
+    async def locked_execute(sql, params=()):
+        nonlocal calls
+        if sql.startswith("INSERT INTO agent_messages"):
+            calls += 1
+            raise sqlite3.OperationalError("database is locked")
+        return await real_execute(sql, params)
+
+    db._busy_retry_delays_sec = (0, 0)
+    monkeypatch.setattr(db.db, "execute", locked_execute)
+
+    with pytest.raises(DatabaseBusyError, match="Database is busy"):
+        await db.save_agent_message(thread_id, "user", "hello")
+
+    assert calls == 3
+    assert await db.get_agent_messages(thread_id) == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- retry transient SQLite busy/locked write failures in the shared database write helpers
- convert exhausted database-busy failures into a controlled 503 response in the web app
- cover agent chat message persistence retry and persistent-lock failure paths

Fixes #599.

## Validation

- `ruff check src/ tests/ conftest.py`
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` — 7087 passed, 103 skipped
- `pytest tests/ -v -m aiosqlite_serial` — 832 passed, 7190 deselected
- `git diff --check`