### PR TITLE
Очередь агентских реакций с учетом flood-wait

### DIFF
--- a/src/agent/tools/messaging_write.py
+++ b/src/agent/tools/messaging_write.py
@@ -10,6 +10,9 @@ from src.agent.tools._registry import (
     _text_response,
     arg_csv_ints,
     arg_str,
+    get_accounts_with_flood_cleanup,
+    is_flood_wait_active,
+    normalize_flood_wait_until,
     require_confirmation,
 )
 from src.agent.tools._telegram_runtime import prepare_telegram_tool
@@ -21,6 +24,45 @@ from src.agent.tools.messaging_schemas import (
     SEND_REACTION_SCHEMA,
 )
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
+from src.services.telegram_command_service import TelegramCommandService
+
+
+def _command_status_text(status: object) -> str:
+    value = getattr(status, "value", status)
+    return str(value or "unknown")
+
+
+def _explicit_pool_method(client_pool: Any, name: str) -> Any | None:
+    instance_attrs = getattr(client_pool, "__dict__", {})
+    if isinstance(instance_attrs, dict) and name in instance_attrs:
+        candidate = instance_attrs[name]
+    elif callable(getattr(type(client_pool), name, None)):
+        candidate = getattr(client_pool, name)
+    else:
+        return None
+    return candidate if callable(candidate) else None
+
+
+async def _reaction_queue_status_hint(ctx: Any, phone: str, client_pool: Any) -> str:
+    lines: list[str] = []
+    try:
+        accounts = await get_accounts_with_flood_cleanup(ctx.db)
+    except Exception:
+        accounts = []
+    account = next((item for item in accounts if str(getattr(item, "phone", "")) == phone), None)
+    if account is not None and is_flood_wait_active(account):
+        flood_until = normalize_flood_wait_until(getattr(account, "flood_wait_until", None))
+        if flood_until is not None:
+            lines.append(f"Аккаунт сейчас во flood-wait до {flood_until.isoformat()}; задача подождёт.")
+
+    is_warming = _explicit_pool_method(client_pool, "is_warming")
+    if callable(is_warming):
+        try:
+            if bool(is_warming()):
+                lines.append("Сейчас идёт прогрев диалогов; задача останется в очереди до готовности аккаунта.")
+        except Exception:
+            pass
+    return "\n".join(lines)
 
 
 def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
@@ -182,9 +224,15 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         SEND_REACTION_SCHEMA,
     )
     async def send_reaction(args):
-        phone, err = await prepare_telegram_tool(ctx, args, tool_name="send_reaction", action="Реакция на сообщение")
+        pool_gate = ctx.require_pool("Реакция на сообщение")
+        if pool_gate:
+            return pool_gate
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
+        perm_gate = await ctx.require_phone_permission(phone, "send_reaction")
+        if perm_gate:
+            return perm_gate
         try:
             chat_id = arg_str(args, "chat_id", required=True)
             emoji = arg_str(args, "emoji", required=True)
@@ -204,19 +252,30 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         if gate:
             return gate
         try:
-            await TelegramActionService(client_pool).send_reaction(
-                phone=phone,
-                chat_id=chat_id,
-                message_id=message_id_int,
-                emoji=emoji,
-                native=True,
-                resolve_entity=True,
+            payload = {
+                "phone": phone,
+                "chat_id": chat_id,
+                "message_id": message_id_int,
+                "emoji": emoji,
+            }
+            command_id = await TelegramCommandService(ctx.db).enqueue(
+                "dialogs.react",
+                payload=payload,
+                requested_by="agent:send_reaction",
+                deduplicate=True,
             )
-            return _text_response(f"Реакция {emoji!r} поставлена на сообщение #{message_id_int} в {chat_id}.")
-        except TelegramActionClientUnavailableError:
-            return _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            command = await TelegramCommandService(ctx.db).get(command_id)
+            status = _command_status_text(getattr(command, "status", None))
+            suffix = await _reaction_queue_status_hint(ctx, phone, client_pool)
+            lines = [
+                f"Реакция {emoji!r} принята в очередь: задача #{command_id}, статус {status}.",
+                "Если такая же реакция уже ждала выполнения, использована существующая задача.",
+            ]
+            if suffix:
+                lines.append(suffix)
+            return _text_response("\n".join(lines))
         except Exception as e:
-            return _text_response(f"Ошибка отправки реакции: {e}")
+            return _text_response(f"Ошибка постановки реакции в очередь: {e}")
 
     tools.append(send_reaction)
     return tools

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -57,6 +57,9 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "payload": "payload TEXT",
         "parent_task_id": "parent_task_id INTEGER",
     },
+    "telegram_commands": {
+        "run_after": "run_after TEXT",
+    },
     "search_queries": {
         "is_regex": "is_regex INTEGER DEFAULT 0",
         "is_fts": "is_fts INTEGER DEFAULT 0",
@@ -145,6 +148,10 @@ SCHEMA_REPAIR_INDEXES: Sequence[str] = (
     """
     CREATE INDEX IF NOT EXISTS idx_collection_tasks_type_status_run_after
     ON collection_tasks(task_type, status, run_after)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_telegram_commands_status_run_after_id
+    ON telegram_commands(status, run_after, id)
     """,
     """
     CREATE INDEX IF NOT EXISTS idx_generation_runs_pipeline_status

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -45,6 +45,7 @@ class TelegramCommandsRepository:
             requested_by=row["requested_by"],
             created_at=parse_datetime(row["created_at"]),
             started_at=parse_datetime(row["started_at"]),
+            run_after=parse_datetime(row["run_after"]),
             finished_at=parse_datetime(row["finished_at"]),
             error=row["error"],
             result_payload=_parse_json(row["result_payload"]),
@@ -54,14 +55,17 @@ class TelegramCommandsRepository:
         cur = await self._database.execute_write(
             """
             INSERT INTO telegram_commands (
-                command_type, payload, status, requested_by, result_payload
-            ) VALUES (?, ?, ?, ?, ?)
+                command_type, payload, status, requested_by, run_after, result_payload
+            ) VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
                 command.command_type,
                 safe_json_dumps(command.payload),
                 command.status.value,
                 command.requested_by,
+                command.run_after.astimezone(timezone.utc).isoformat()
+                if command.run_after is not None
+                else None,
                 safe_json_dumps(command.result_payload) if command.result_payload is not None else None,
             ),
         )
@@ -139,10 +143,11 @@ class TelegramCommandsRepository:
                 """
                 SELECT * FROM telegram_commands
                 WHERE status = ?
-                ORDER BY id ASC
+                  AND (run_after IS NULL OR run_after <= ?)
+                ORDER BY COALESCE(run_after, ''), id ASC
                 LIMIT 1
                 """,
-                (TelegramCommandStatus.PENDING.value,),
+                (TelegramCommandStatus.PENDING.value, now),
             )
             row = await cur.fetchone()
             if row is None:
@@ -171,6 +176,7 @@ class TelegramCommandsRepository:
         error: str | None = None,
         result_payload: dict[str, Any] | None = None,
         payload: dict[str, Any] | None = None,
+        run_after: datetime | None = None,
     ) -> None:
         finished_at = None
         if status in {
@@ -180,17 +186,32 @@ class TelegramCommandsRepository:
         }:
             finished_at = datetime.now(timezone.utc).isoformat()
         payload_json = safe_json_dumps(payload) if payload is not None else None
+        run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after is not None else None
         if status == TelegramCommandStatus.PENDING:
             # Reset started_at when re-queueing so a retried command shows
             # a fresh run timestamp rather than the interrupted attempt's.
-            sets = ["status = ?", "error = ?", "result_payload = ?", "started_at = NULL", "finished_at = NULL"]
+            sets = [
+                "status = ?",
+                "error = ?",
+                "result_payload = ?",
+                "run_after = ?",
+                "started_at = NULL",
+                "finished_at = NULL",
+            ]
             params: list[Any] = [
                 status.value,
                 error,
                 safe_json_dumps(result_payload) if result_payload is not None else None,
+                run_after_iso,
             ]
         else:
-            sets = ["status = ?", "error = ?", "result_payload = ?", "finished_at = COALESCE(?, finished_at)"]
+            sets = [
+                "status = ?",
+                "error = ?",
+                "result_payload = ?",
+                "run_after = NULL",
+                "finished_at = COALESCE(?, finished_at)",
+            ]
             params = [
                 status.value,
                 error,

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS telegram_commands (
     requested_by TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     started_at TEXT,
+    run_after TEXT,
     finished_at TEXT,
     error TEXT,
     result_payload TEXT
@@ -96,6 +97,8 @@ CREATE TABLE IF NOT EXISTS telegram_commands (
 
 CREATE INDEX IF NOT EXISTS idx_telegram_commands_status_id
     ON telegram_commands(status, id);
+CREATE INDEX IF NOT EXISTS idx_telegram_commands_status_run_after_id
+    ON telegram_commands(status, run_after, id);
 
 CREATE TABLE IF NOT EXISTS runtime_snapshots (
     snapshot_type TEXT NOT NULL,

--- a/src/models.py
+++ b/src/models.py
@@ -136,6 +136,7 @@ class TelegramCommand(BaseModel):
     requested_by: str | None = None
     created_at: datetime | None = None
     started_at: datetime | None = None
+    run_after: datetime | None = None
     finished_at: datetime | None = None
     error: str | None = None
     result_payload: dict[str, Any] | None = None

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -72,6 +72,13 @@ async def _publish_snapshots(container) -> None:
                 available_phones.append(phone)
     else:
         available_phones = list(connected_phones)
+    is_warming_method = None
+    pool_attrs = getattr(container.pool, "__dict__", {})
+    if isinstance(pool_attrs, dict) and "is_warming" in pool_attrs:
+        is_warming_method = pool_attrs["is_warming"]
+    elif callable(getattr(type(container.pool), "is_warming", None)):
+        is_warming_method = getattr(container.pool, "is_warming")
+    is_warming = bool(is_warming_method()) if callable(is_warming_method) else False
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="worker_heartbeat",
@@ -86,6 +93,7 @@ async def _publish_snapshots(container) -> None:
                 "connected_count": len(connected_phones),
                 "available_phones": sorted(available_phones),
                 "flood_waits": flood_waits,
+                "is_warming": is_warming,
                 "timestamp": now.isoformat(),
             },
         )

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from inspect import isawaitable
 from pathlib import Path
 from typing import Any
 
@@ -26,9 +29,20 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.flood_wait import HandledFloodWaitError
 from src.telegram.notifier import Notifier
+from src.telegram.utils import normalize_utc
 from src.utils.datetime import parse_required_datetime, parse_required_schedule_datetime
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class TelegramCommandRetryLaterError(RuntimeError):
+    run_after: datetime
+    reason: str
+    result_payload: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.reason
 
 
 class TelegramCommandDispatcher:
@@ -50,6 +64,8 @@ class TelegramCommandDispatcher:
         self._auth = auth
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
+        self._reaction_min_interval_sec = 30.0
+        self._last_reaction_at_monotonic: dict[str, float] = {}
 
     async def start(self) -> None:
         if self._task and not self._task.done():
@@ -92,6 +108,45 @@ class TelegramCommandDispatcher:
                     error="cancelled while running; reset for retry",
                 )
                 raise
+            except TelegramCommandRetryLaterError as exc:
+                logger.info(
+                    "Telegram command delayed: id=%s type=%s run_after=%s reason=%s",
+                    command.id,
+                    command.command_type,
+                    exc.run_after.isoformat(),
+                    exc.reason,
+                )
+                await self._db.repos.telegram_commands.update_command(
+                    command.id,
+                    status=TelegramCommandStatus.PENDING,
+                    error=exc.reason,
+                    result_payload=exc.result_payload or {},
+                    payload=command.payload,
+                    run_after=exc.run_after,
+                )
+            except HandledFloodWaitError as exc:
+                run_after = exc.info.next_available_at_utc + timedelta(seconds=1)
+                logger.info(
+                    "Telegram command delayed by flood-wait: id=%s type=%s run_after=%s reason=%s",
+                    command.id,
+                    command.command_type,
+                    run_after.isoformat(),
+                    exc.info.detail,
+                )
+                await self._db.repos.telegram_commands.update_command(
+                    command.id,
+                    status=TelegramCommandStatus.PENDING,
+                    error=exc.info.detail,
+                    result_payload={
+                        "state": "waiting_flood_wait",
+                        "operation": exc.info.operation,
+                        "phone": exc.info.phone,
+                        "wait_seconds": exc.info.wait_seconds,
+                        "next_available_at_utc": exc.info.next_available_at_utc.isoformat(),
+                    },
+                    payload=command.payload,
+                    run_after=run_after,
+                )
             except Exception as exc:
                 duration_ms = int((time.monotonic() - started_at) * 1000)
                 if is_auth_command:
@@ -167,6 +222,16 @@ class TelegramCommandDispatcher:
         from src.database.bundles import NotificationBundle
 
         return NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
+
+    def _pool_method(self, name: str) -> Any | None:
+        instance_attrs = getattr(self._pool, "__dict__", {})
+        if isinstance(instance_attrs, dict) and name in instance_attrs:
+            candidate = instance_attrs[name]
+        elif callable(getattr(type(self._pool), name, None)):
+            candidate = getattr(self._pool, name)
+        else:
+            return None
+        return candidate if callable(candidate) else None
 
     async def _handle_auth_send_code(self, payload: dict[str, Any]) -> dict[str, Any]:
         if self._auth is None or not self._auth.is_configured:
@@ -285,6 +350,79 @@ class TelegramCommandDispatcher:
         )
         return {"phone": result.phone, "forwarded": result.count}
 
+    async def _account_flood_until(self, phone: str) -> datetime | None:
+        accounts: list[Any] = []
+        for getter_name in ("get_account_summaries", "get_accounts"):
+            getter = getattr(self._db, getter_name, None)
+            if not callable(getter):
+                continue
+            try:
+                result = getter(active_only=True)
+            except TypeError:
+                result = getter()
+            if isawaitable(result):
+                result = await result
+            if isinstance(result, (list, tuple)):
+                accounts = list(result)
+                break
+        now = datetime.now(timezone.utc)
+        for account in accounts:
+            if str(getattr(account, "phone", "")) != phone:
+                continue
+            flood_until = normalize_utc(getattr(account, "flood_wait_until", None))
+            if flood_until is not None and flood_until > now:
+                return flood_until
+        return None
+
+    async def _ensure_reaction_can_run(self, phone: str) -> None:
+        is_warming = self._pool_method("is_warming")
+        if callable(is_warming):
+            try:
+                warming = bool(is_warming())
+            except Exception:
+                warming = False
+            if warming:
+                run_after = datetime.now(timezone.utc) + timedelta(seconds=5)
+                raise TelegramCommandRetryLaterError(
+                    run_after=run_after,
+                    reason="account dialog warm-up is still running",
+                    result_payload={
+                        "state": "waiting_warmup",
+                        "phone": phone,
+                        "next_available_at_utc": run_after.isoformat(),
+                    },
+                )
+
+        flood_until = await self._account_flood_until(phone)
+        if flood_until is not None:
+            raise TelegramCommandRetryLaterError(
+                run_after=flood_until + timedelta(seconds=1),
+                reason=f"account {phone} is flood-waited until {flood_until.isoformat()}",
+                result_payload={
+                    "state": "waiting_flood_wait",
+                    "phone": phone,
+                    "next_available_at_utc": flood_until.isoformat(),
+                },
+            )
+
+        last = self._last_reaction_at_monotonic.get(phone)
+        if last is None:
+            return
+        elapsed = time.monotonic() - last
+        remaining = self._reaction_min_interval_sec - elapsed
+        if remaining > 0:
+            run_after = datetime.now(timezone.utc) + timedelta(seconds=remaining)
+            raise TelegramCommandRetryLaterError(
+                run_after=run_after,
+                reason=f"reaction rate limit for {phone}; waiting {int(remaining) + 1}s",
+                result_payload={
+                    "state": "waiting_rate_limit",
+                    "phone": phone,
+                    "retry_after_sec": int(remaining) + 1,
+                    "next_available_at_utc": run_after.isoformat(),
+                },
+            )
+
     async def _handle_dialogs_pin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
         result = await TelegramActionService(self._pool).pin_message(
             phone=str(payload["phone"]),
@@ -295,14 +433,17 @@ class TelegramCommandDispatcher:
         return {"phone": result.phone}
 
     async def _handle_dialogs_react(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload["phone"])
+        await self._ensure_reaction_can_run(phone)
         result = await TelegramActionService(self._pool).send_reaction(
-            phone=str(payload["phone"]),
+            phone=phone,
             chat_id=payload["chat_id"],
             message_id=int(payload["message_id"]),
             emoji=str(payload["emoji"]),
             native=True,
             resolve_entity=True,
         )
+        self._last_reaction_at_monotonic[result.phone] = time.monotonic()
         return {"phone": result.phone}
 
     async def _handle_dialogs_unpin_message(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/services/telegram_command_service.py
+++ b/src/services/telegram_command_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 from src.database import Database
 from src.models import TelegramCommand
 
@@ -15,6 +17,7 @@ class TelegramCommandService:
         payload: dict,
         requested_by: str | None = None,
         deduplicate: bool = True,
+        run_after: datetime | None = None,
     ) -> int:
         """Enqueue a telegram command.
 
@@ -35,6 +38,7 @@ class TelegramCommandService:
                 command_type=command_type,
                 payload=payload,
                 requested_by=requested_by,
+                run_after=run_after,
             )
         )
 

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -327,6 +327,11 @@ class ClientPool:
         target_type: str | None = None,
     ):
         session = adapt_transport_session(session, disconnect_on_close=False)
+        if target_type is None:
+            dialog = await self._get_cached_dialog(phone, dialog_id)
+            cached_type = str(dialog.get("channel_type") or "") if dialog else ""
+            if cached_type in {"dm", "bot", "saved"}:
+                target_type = cached_type
         peer = PeerUser(dialog_id) if target_type in ("dm", "bot", "saved") else PeerChannel(abs(dialog_id))
         try:
             return await run_with_flood_wait(

--- a/src/web/runtime_shims.py
+++ b/src/web/runtime_shims.py
@@ -12,6 +12,7 @@ class SnapshotClientPool:
         self.available_phones: set[str] = set()
         self.flood_waits: dict[str, str] = {}
         self.timestamp: str | None = None
+        self._is_warming = False
 
     @property
     def clients(self) -> dict[str, object]:
@@ -39,12 +40,16 @@ class SnapshotClientPool:
         )
         timestamp = payload.get("timestamp")
         self.timestamp = str(timestamp) if timestamp is not None else None
+        self._is_warming = bool(payload.get("is_warming", False))
 
     async def initialize(self) -> None:
         await self.refresh()
 
     async def warm_all_dialogs(self) -> None:
         return None
+
+    def is_warming(self) -> bool:
+        return self._is_warming
 
     async def disconnect_all(self) -> None:
         return None

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
 
 from src.database import Database
 from src.models import RuntimeSnapshot, TelegramCommand, TelegramCommandStatus
+from src.services.telegram_command_service import TelegramCommandService
 
 
 @pytest.mark.anyio
@@ -91,6 +92,78 @@ async def test_claim_next_command_recovers_from_stale_transaction(tmp_path):
         claimed = await db.repos.telegram_commands.claim_next_command()
         assert claimed is not None
         assert claimed.status == TelegramCommandStatus.RUNNING
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_claim_next_command_skips_future_run_after(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        future_id = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.react",
+                payload={"phone": "+1", "message_id": 1},
+                requested_by="test",
+                run_after=datetime.now(timezone.utc) + timedelta(minutes=5),
+            )
+        )
+        due_id = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.react",
+                payload={"phone": "+1", "message_id": 2},
+                requested_by="test",
+            )
+        )
+
+        claimed = await db.repos.telegram_commands.claim_next_command()
+
+        assert claimed is not None
+        assert claimed.id == due_id
+        future = await db.repos.telegram_commands.get_command(future_id)
+        assert future is not None
+        assert future.status == TelegramCommandStatus.PENDING
+        assert future.run_after is not None
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_command_service_queues_distinct_reactions_and_deduplicates_exact_payload(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        service = TelegramCommandService(db)
+        ids = []
+        for message_id in range(10):
+            ids.append(
+                await service.enqueue(
+                    "dialogs.react",
+                    payload={
+                        "phone": "+1",
+                        "chat_id": "5832576119",
+                        "message_id": message_id,
+                        "emoji": "👍",
+                    },
+                    requested_by="test",
+                )
+            )
+        duplicate_id = await service.enqueue(
+            "dialogs.react",
+            payload={
+                "phone": "+1",
+                "chat_id": "5832576119",
+                "message_id": 3,
+                "emoji": "👍",
+            },
+            requested_by="test",
+        )
+
+        assert len(set(ids)) == 10
+        assert duplicate_id == ids[3]
     finally:
         await db.close()
 

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -126,6 +126,12 @@ async def test_deepagents_send_reaction_permission_allow_reaches_action_service(
     mock_db.get_account_summaries = AsyncMock(return_value=[
         SimpleNamespace(phone="+79001234567", is_primary=True, session_status="ok")
     ])
+    command_repo = MagicMock()
+    command_repo.find_active_by_type = AsyncMock(return_value=None)
+    command_repo.create_command = AsyncMock(return_value=55)
+    command_repo.get_command = AsyncMock(return_value=SimpleNamespace(id=55, status="pending"))
+    mock_db.repos = MagicMock()
+    mock_db.repos.telegram_commands = command_repo
     runtime_context = AgentRuntimeContext.build(
         db=mock_db,
         client_pool=MagicMock(),
@@ -147,34 +153,25 @@ async def test_deepagents_send_reaction_permission_allow_reaches_action_service(
     set_gate(gate)
     token = set_request_context(ctx)
     try:
-        with patch("src.agent.tools.messaging_write.TelegramActionService") as service_cls:
-            service = service_cls.return_value
-            service.send_reaction = AsyncMock()
-            task = asyncio.create_task(
-                asyncio.to_thread(
-                    tool_map["send_reaction"],
-                    chat_id="@chat",
-                    message_id=1,
-                    emoji="👍",
-                    confirm=True,
-                )
+        task = asyncio.create_task(
+            asyncio.to_thread(
+                tool_map["send_reaction"],
+                chat_id="@chat",
+                message_id=1,
+                emoji="👍",
+                confirm=True,
             )
-            event = await asyncio.wait_for(queue.get(), timeout=2)
-            payload = json.loads(event.removeprefix("data: ").strip())
-            assert payload["tool"] == "send_reaction"
-            assert payload["phone"] == "+79001234567"
-            gate.resolve(payload["request_id"], choice)
-            result = await asyncio.wait_for(task, timeout=2)
-
-        assert "Реакция '👍' поставлена" in result
-        service.send_reaction.assert_awaited_once_with(
-            phone="+79001234567",
-            chat_id="@chat",
-            message_id=1,
-            emoji="👍",
-            native=True,
-            resolve_entity=True,
         )
+        event = await asyncio.wait_for(queue.get(), timeout=2)
+        payload = json.loads(event.removeprefix("data: ").strip())
+        assert payload["tool"] == "send_reaction"
+        assert payload["phone"] == "+79001234567"
+        gate.resolve(payload["request_id"], choice)
+        result = await asyncio.wait_for(task, timeout=2)
+
+        assert "Реакция '👍' принята в очередь" in result
+        assert "задача #55" in result
+        command_repo.create_command.assert_awaited_once()
         if choice == "session":
             assert gate.is_session_approved("send_reaction", ctx.session_id, "+79001234567")
     finally:

--- a/tests/test_agent_tools_messaging.py
+++ b/tests/test_agent_tools_messaging.py
@@ -1,11 +1,12 @@
 """Tests for agent tools: messaging.py."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import Account
+from src.models import Account, TelegramCommandStatus
 from tests.agent_tools_helpers import _get_tool_handlers, _text, assert_tool_text
 
 
@@ -43,6 +44,16 @@ def _make_mock_pool():
     mock_pool.get_client_by_phone = AsyncMock(return_value=(mock_session, None))
     mock_pool.resolve_dialog_entity = AsyncMock(return_value=MagicMock(id=123456))
     return mock_pool, mock_client
+
+
+def _setup_command_queue(mock_db, *, command_id: int = 41, status=TelegramCommandStatus.PENDING):
+    repo = MagicMock()
+    repo.find_active_by_type = AsyncMock(return_value=None)
+    repo.create_command = AsyncMock(return_value=command_id)
+    repo.get_command = AsyncMock(return_value=SimpleNamespace(id=command_id, status=status))
+    mock_db.repos = MagicMock()
+    mock_db.repos.telegram_commands = repo
+    return repo
 
 
 class TestSendMessage:
@@ -116,22 +127,34 @@ class TestSendReaction:
     async def test_with_confirm_success(self, mock_db):
         mock_pool, mock_client = _make_mock_pool()
         mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        repo = _setup_command_queue(mock_db)
         handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
         result = await handlers["send_reaction"](
             {"phone": "+79001234567", "chat_id": "@chat", "message_id": 5, "emoji": "🔥", "confirm": True}
         )
 
-        # The producer formats the emoji via {emoji!r}, so the literal
-        # representation in the output is "'🔥'", not the bare glyph.
-        assert "Реакция '🔥' поставлена" in _text(result)
-        mock_client.get_entity.assert_awaited_with("@chat")
-        mock_client.send_reaction.assert_awaited_once()
-        # Verify call arguments — guards against accidental positional swap
-        # (e.g. emoji ↔ message_id) that assert_awaited_once would miss.
-        call_args = mock_client.send_reaction.await_args
-        assert call_args.args[1] == 5
-        assert call_args.args[2] == "🔥"
-        assert call_args.args[0] is mock_client.get_entity.return_value
+        assert "Реакция '🔥' принята в очередь" in _text(result)
+        assert "задача #41" in _text(result)
+        repo.create_command.assert_awaited_once()
+        mock_client.get_entity.assert_not_awaited()
+        mock_client.send_reaction.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_with_confirm_reuses_existing_queue_item(self, mock_db):
+        mock_pool, mock_client = _make_mock_pool()
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+        repo = _setup_command_queue(mock_db, command_id=77, status=TelegramCommandStatus.RUNNING)
+        repo.find_active_by_type.return_value = SimpleNamespace(id=77)
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+        result = await handlers["send_reaction"](
+            {"phone": "+79001234567", "chat_id": "@chat", "message_id": 5, "emoji": "🔥", "confirm": True}
+        )
+
+        assert "задача #77" in _text(result)
+        assert "статус running" in _text(result)
+        repo.create_command.assert_not_awaited()
+        mock_client.send_reaction.assert_not_awaited()
 
 
 class TestEditMessage:

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -29,6 +29,7 @@ from telethon.tl.types import (
     MessageMediaGeo,
     MessageMediaGeoLive,
     MessageMediaWebPage,
+    PeerUser,
 )
 
 from src.config import SchedulerConfig, TelegramRuntimeConfig
@@ -88,6 +89,26 @@ def mock_auth():
 @pytest.fixture
 def pool(mock_auth, mock_db):
     return ClientPool(mock_auth, mock_db)
+
+
+@pytest.mark.anyio
+async def test_resolve_dialog_entity_uses_cached_dm_type_before_warm(pool, mock_db):
+    client = AsyncMock()
+    client.get_input_entity = AsyncMock(return_value="dm-entity")
+    client.get_dialogs = AsyncMock(return_value=[])
+    mock_db.repos.dialog_cache.get_dialog.return_value = {
+        "channel_id": 5832576119,
+        "title": "Work1nw",
+        "username": "Work1nw",
+        "channel_type": "dm",
+    }
+
+    result = await pool.resolve_dialog_entity(client, "+1", 5832576119)
+
+    assert result == "dm-entity"
+    peer = client.get_input_entity.await_args.args[0]
+    assert isinstance(peer, PeerUser)
+    client.get_dialogs.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from src.database import Database
-from src.models import Account, AccountSessionStatus, AccountSummary
+from src.models import Account, AccountSessionStatus, AccountSummary, TelegramCommand, TelegramCommandStatus
 from src.services import telegram_command_dispatcher as mod
-from src.services.telegram_command_dispatcher import TelegramCommandDispatcher
+from src.services.telegram_command_dispatcher import TelegramCommandDispatcher, TelegramCommandRetryLaterError
+from src.telegram.flood_wait import FloodWaitInfo, HandledFloodWaitError
 
 
 class _FakeClient:
@@ -420,6 +422,70 @@ async def test_dialogs_forward():
         "phone": "+1", "from_chat": -100, "to_chat": -200, "message_ids": [1],
     })
     assert r["forwarded"] == 1
+
+
+async def test_dialogs_react_waits_while_pool_is_warming():
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=True)
+    d = _dispatcher(pool=pool)
+
+    with pytest.raises(TelegramCommandRetryLaterError, match="warm-up"):
+        await d._handle_dialogs_react({"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"})
+
+    pool.get_native_client_by_phone.assert_not_awaited()
+
+
+async def test_dialogs_react_waits_when_account_is_flooded():
+    db = _mock_db()
+    db.get_account_summaries.return_value = [
+        AccountSummary(
+            id=1,
+            phone="+1",
+            session_status=AccountSessionStatus.OK,
+            is_active=True,
+            flood_wait_until=datetime.now(timezone.utc) + timedelta(minutes=1),
+        )
+    ]
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=False)
+    d = _dispatcher(db=db, pool=pool)
+
+    with pytest.raises(TelegramCommandRetryLaterError, match="flood-waited"):
+        await d._handle_dialogs_react({"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"})
+
+    pool.get_native_client_by_phone.assert_not_awaited()
+
+
+async def test_run_loop_requeues_handled_flood_wait():
+    db = _mock_db()
+    command = TelegramCommand(
+        id=9,
+        command_type="dialogs.react",
+        payload={"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"},
+    )
+    db.repos.telegram_commands.claim_next_command = AsyncMock(return_value=command)
+    d = _dispatcher(db=db)
+    info = FloodWaitInfo(
+        operation="telegram_send_reaction",
+        phone="+1",
+        wait_seconds=21,
+        next_available_at_utc=datetime.now(timezone.utc) + timedelta(seconds=21),
+        detail="Flood wait 21s for +1",
+    )
+    d._dispatch = AsyncMock(side_effect=HandledFloodWaitError(info))
+
+    async def _update_and_stop(*args, **kwargs):
+        d._stop_event.set()
+
+    db.repos.telegram_commands.update_command = AsyncMock(side_effect=_update_and_stop)
+
+    await d._run_loop()
+
+    db.repos.telegram_commands.update_command.assert_awaited_once()
+    kwargs = db.repos.telegram_commands.update_command.await_args.kwargs
+    assert kwargs["status"] == TelegramCommandStatus.PENDING
+    assert kwargs["run_after"] > datetime.now(timezone.utc)
+    assert kwargs["result_payload"]["state"] == "waiting_flood_wait"
 
 
 async def test_dialogs_pin_unpin():


### PR DESCRIPTION
## Что изменено
- `send_reaction` теперь ставит реакцию в очередь команд и возвращает агенту номер задачи и текущий статус.
- Диспетчер команд сам выдерживает паузы между реакциями, учитывает flood-wait аккаунта и прогрев диалогов, а временные ограничения возвращает в ожидание вместо неожиданного сбоя.
- В очередь добавлен `run_after`, чтобы отложенные команды не забирались раньше времени.
- При известном кэше личного диалога числовой chat id не пробуется сначала как канал.

## Проверки
- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto`
- `python3 -m pytest tests/ -v -m aiosqlite_serial`

Fixes #601