### PR TITLE
[codex] Show reactions in read message outputs

### DIFF
--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -18,6 +18,7 @@ from src.agent.tools.messaging_schemas import (
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.identity import extract_message_sender_identity
+from src.telegram.reactions import format_message_reactions
 
 
 def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
@@ -265,7 +266,9 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
                     sender = f" {format_sender_identity(sender_identity)}"
                     date_str = msg.date.strftime("%Y-%m-%d %H:%M") if msg.date else ""
                     preview = msg.text[:500]
-                    line = f"#{msg.id} {date_str}{sender}: {preview}"
+                    reactions = format_message_reactions(msg)
+                    reaction_suffix = f" | реакции: {reactions}" if reactions else ""
+                    line = f"#{msg.id} {date_str}{sender}: {preview}{reaction_suffix}"
                     lines.append(line)
                     total_chars += len(line)
                     count += 1

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -10,6 +10,7 @@ from src.cli import runtime
 from src.cli.commands.common import resolve_channel
 from src.models import Message
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.telegram.reactions import format_message_reactions, format_reactions_json, parse_reactions_json
 
 
 def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
@@ -24,18 +25,20 @@ def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
                 "text": msg.text,
                 "views": msg.views,
                 "forwards": msg.forwards,
+                "reactions": parse_reactions_json(msg.reactions_json),
             })
         print(json.dumps(items, ensure_ascii=False, indent=2))
     elif fmt == "csv":
         buf = io.StringIO()
         writer = csv.writer(buf)
-        writer.writerow(["id", "channel_id", "message_id", "date", "text", "views", "forwards"])
+        writer.writerow(["id", "channel_id", "message_id", "date", "text", "views", "forwards", "reactions"])
         for msg in messages:
             writer.writerow([
                 msg.id, msg.channel_id, msg.message_id,
                 str(msg.date) if msg.date else "",
                 (msg.text or "")[:500],
                 msg.views, msg.forwards,
+                format_reactions_json(msg.reactions_json),
             ])
         print(buf.getvalue(), end="")
     else:
@@ -46,8 +49,13 @@ def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
             preview = text[:200].replace("\n", " ")
             if len(text) > 200:
                 preview += "..."
-            views = f"views={msg.views}" if msg.views else ""
-            print(f"[{date_str}] #{msg.message_id} {views}")
+            reactions = format_reactions_json(msg.reactions_json)
+            fields = [f"#{msg.message_id}"]
+            if msg.views:
+                fields.append(f"views={msg.views}")
+            if reactions:
+                fields.append(f"reactions: {reactions}")
+            print(f"[{date_str}] {' '.join(fields)}")
             print(f"  {preview}")
             print()
 
@@ -63,7 +71,9 @@ def _print_live_messages(collected: list) -> None:
         text = (msg.text or "").strip()
         if not text and msg.media:
             text = f"[media: {type(msg.media).__name__}]"
-        print(f"[{date_str}] #{msg.id}{sender}")
+        reactions = format_message_reactions(msg)
+        reaction_suffix = f" reactions: {reactions}" if reactions else ""
+        print(f"[{date_str}] #{msg.id}{sender}{reaction_suffix}")
         if text:
             print(f"  {text[:500]}")
         print()

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import aiosqlite
 
 from src.models import Message, SearchQuery
+from src.telegram.reactions import parse_reactions_json
 from src.utils.datetime import parse_datetime, parse_required_datetime
 from src.utils.search_query_chat_filter import parse_chat_filter
 
@@ -23,11 +24,7 @@ _EMBEDDING_DIMENSIONS_SETTING = "semantic_embedding_dimensions"
 
 def _parse_reactions_json(reactions_json: str) -> list[dict]:
     """Parse reactions_json string into a list of {emoji, count} dicts."""
-    try:
-        items = json.loads(reactions_json)
-        return [r for r in items if isinstance(r, dict) and "emoji" in r]
-    except (json.JSONDecodeError, TypeError):
-        return []
+    return parse_reactions_json(reactions_json)
 
 
 def _normalize_date_to(date_to: str) -> tuple[str, str]:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -42,6 +42,7 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.identity import extract_message_sender_identity
 from src.telegram.notifier import Notifier
+from src.telegram.reactions import extract_message_reactions_json
 
 logger = logging.getLogger(__name__)
 
@@ -1431,28 +1432,7 @@ class Collector:
     @staticmethod
     def _extract_reactions(msg) -> str | None:
         """Extract reactions from a Telethon message as JSON string."""
-        reactions = getattr(msg, "reactions", None)
-        if not reactions:
-            return None
-        results = getattr(reactions, "results", None)
-        if not results:
-            return None
-        items = []
-        for r in results:
-            reaction = getattr(r, "reaction", None)
-            if reaction is None:
-                continue
-            emoticon = getattr(reaction, "emoticon", None)
-            if emoticon:
-                emoji = emoticon
-            else:
-                document_id = getattr(reaction, "document_id", None)
-                if document_id is not None:
-                    emoji = f"custom:{document_id}"
-                else:
-                    continue
-            items.append({"emoji": emoji, "count": getattr(r, "count", 0)})
-        return json.dumps(items, ensure_ascii=False) if items else None
+        return extract_message_reactions_json(msg)
 
     @staticmethod
     def _get_sender_name(msg) -> str | None:

--- a/src/telegram/reactions.py
+++ b/src/telegram/reactions.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+ReactionItem = dict[str, str | int]
+
+
+def _coerce_count(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _reaction_label(reaction: Any) -> str | None:
+    if reaction is None:
+        return None
+
+    emoticon = getattr(reaction, "emoticon", None)
+    if emoticon:
+        return str(emoticon)
+
+    document_id = getattr(reaction, "document_id", None)
+    if document_id is not None:
+        return f"custom:{document_id}"
+
+    if reaction.__class__.__name__ == "ReactionPaid":
+        return "paid"
+
+    return None
+
+
+def extract_message_reactions(message: Any) -> list[ReactionItem]:
+    reactions = getattr(message, "reactions", None)
+    results = getattr(reactions, "results", None)
+    if not results:
+        return []
+
+    items: list[ReactionItem] = []
+    for result in results:
+        label = _reaction_label(getattr(result, "reaction", None))
+        if label is None:
+            continue
+        items.append({"emoji": label, "count": _coerce_count(getattr(result, "count", 0))})
+    return items
+
+
+def extract_message_reactions_json(message: Any) -> str | None:
+    items = extract_message_reactions(message)
+    return json.dumps(items, ensure_ascii=False) if items else None
+
+
+def parse_reactions_json(reactions_json: str | None) -> list[ReactionItem]:
+    try:
+        raw_items = json.loads(reactions_json or "")
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(raw_items, list):
+        return []
+
+    items: list[ReactionItem] = []
+    for item in raw_items:
+        if not isinstance(item, Mapping):
+            continue
+        emoji = item.get("emoji")
+        if not emoji:
+            continue
+        items.append({"emoji": str(emoji), "count": _coerce_count(item.get("count", 0))})
+    return items
+
+
+def format_reaction_counts(items: Iterable[Mapping[str, Any]]) -> str:
+    parts: list[str] = []
+    for item in items:
+        emoji = item.get("emoji")
+        if not emoji:
+            continue
+        parts.append(f"{emoji} {_coerce_count(item.get('count', 0))}")
+    return " ".join(parts)
+
+
+def format_message_reactions(message: Any) -> str:
+    return format_reaction_counts(extract_message_reactions(message))
+
+
+def format_reactions_json(reactions_json: str | None) -> str:
+    return format_reaction_counts(parse_reactions_json(reactions_json))

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -810,6 +810,40 @@ class TestReadMessagesTool:
         text = _text(result)
         assert "Hello world" in text
         assert "1 сообщений" in text
+        assert "реакции:" not in text
+
+    @pytest.mark.anyio
+    async def test_with_message_reactions(self, mock_db, mock_pool):
+        client = _make_client()
+        _setup_resolve_entity(mock_pool, client)
+
+        msg = SimpleNamespace(
+            id=1,
+            sender_id=42,
+            date=None,
+            text="Popular post",
+            reactions=SimpleNamespace(
+                results=[
+                    SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+                    SimpleNamespace(reaction=SimpleNamespace(emoticon="❤️"), count=2),
+                ]
+            ),
+        )
+
+        async def iter_msgs(*a, **kw):
+            yield msg
+
+        client.iter_messages = iter_msgs
+
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["read_messages"]({
+            "phone": "+79001234567",
+            "chat_id": "@test",
+            "limit": 10,
+        })
+
+        text = _text(result)
+        assert "Popular post | реакции: 👍 5 ❤️ 2" in text
 
     @pytest.mark.anyio
     async def test_none_phone_uses_available_connected_account(self, mock_db, mock_pool):

--- a/tests/test_cli_commands_edge_cases.py
+++ b/tests/test_cli_commands_edge_cases.py
@@ -72,6 +72,12 @@ class TestPrintMessages:
         out = capsys.readouterr().out
         assert "views=" not in out
 
+    def test_text_format_with_reactions(self, capsys):
+        msgs = [self._make_msg(reactions_json='[{"emoji": "👍", "count": 5}]')]
+        _print_messages(msgs, "text", total=1)
+        out = capsys.readouterr().out
+        assert "reactions: 👍 5" in out
+
     def test_text_format_empty_text(self, capsys):
         msgs = [self._make_msg(text="")]
         _print_messages(msgs, "text", total=1)
@@ -84,6 +90,14 @@ class TestPrintMessages:
         out = capsys.readouterr().out
         assert '"message_id": 500' in out
         assert '"text": "Hello world"' in out
+        assert '"reactions": []' in out
+
+    def test_json_format_with_reactions(self, capsys):
+        msgs = [self._make_msg(reactions_json='[{"emoji": "❤️", "count": 2}]')]
+        _print_messages(msgs, "json", total=1)
+        out = capsys.readouterr().out
+        assert '"emoji": "❤️"' in out
+        assert '"count": 2' in out
 
     def test_json_format_date_present(self, capsys):
         """JSON output includes date string."""
@@ -98,7 +112,14 @@ class TestPrintMessages:
         _print_messages(msgs, "csv", total=1)
         out = capsys.readouterr().out
         assert "id,channel_id,message_id" in out
+        assert "reactions" in out.splitlines()[0]
         assert "Hello world" in out
+
+    def test_csv_format_with_reactions(self, capsys):
+        msgs = [self._make_msg(reactions_json='[{"emoji": "custom:42", "count": 3}]')]
+        _print_messages(msgs, "csv", total=1)
+        out = capsys.readouterr().out
+        assert "custom:42 3" in out
 
     def test_csv_format_date_present(self, capsys):
         """CSV output includes date in row."""
@@ -195,6 +216,18 @@ class TestPrintLiveMessages:
         _print_live_messages(msgs)
         out = capsys.readouterr().out
         assert "—" in out
+
+    def test_with_reactions(self, capsys):
+        reactions = SimpleNamespace(
+            results=[
+                SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+                SimpleNamespace(reaction=SimpleNamespace(emoticon="❤️"), count=2),
+            ]
+        )
+        msgs = [self._make_live_msg(reactions=reactions)]
+        _print_live_messages(msgs)
+        out = capsys.readouterr().out
+        assert "reactions: 👍 5 ❤️ 2" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_messages.py
+++ b/tests/test_cli_messages.py
@@ -15,10 +15,16 @@ NOW = __import__("datetime").datetime(
 pytestmark = pytest.mark.aiosqlite_serial
 
 
-def _add_message(db, channel_id=100, message_id=1, text="hello"):
+def _add_message(db, channel_id=100, message_id=1, text="hello", reactions_json=None):
     __import__("asyncio").run(
         db.insert_message(
-            Message(channel_id=channel_id, message_id=message_id, text=text, date=NOW)
+            Message(
+                channel_id=channel_id,
+                message_id=message_id,
+                text=text,
+                date=NOW,
+                reactions_json=reactions_json,
+            )
         )
     )
 
@@ -45,11 +51,48 @@ def test_messages_read_text_format(cli_env, capsys):
     out = capsys.readouterr().out
     assert "test message" in out
     assert "Total:" in out
+    assert "reactions:" not in out
+
+
+def test_messages_read_text_format_with_reactions(cli_env, capsys):
+    _add_channel(cli_env, channel_id=100, title="MsgCh")
+    _add_message(
+        cli_env,
+        channel_id=100,
+        message_id=1,
+        text="reacted message",
+        reactions_json='[{"emoji": "👍", "count": 5}, {"emoji": "❤️", "count": 2}]',
+    )
+
+    from src.cli.commands.messages import run
+
+    run(_ns(
+        messages_action="read",
+        identifier="100",
+        limit=50,
+        live=False,
+        phone=None,
+        query="",
+        date_from=None,
+        date_to=None,
+        topic_id=None,
+        offset_id=None,
+        output_format="text",
+    ))
+    out = capsys.readouterr().out
+    assert "reacted message" in out
+    assert "reactions: 👍 5 ❤️ 2" in out
 
 
 def test_messages_read_json_format(cli_env, capsys):
     _add_channel(cli_env, channel_id=100, title="MsgCh")
-    _add_message(cli_env, channel_id=100, message_id=1, text="json msg")
+    _add_message(
+        cli_env,
+        channel_id=100,
+        message_id=1,
+        text="json msg",
+        reactions_json='[{"emoji": "🔥", "count": 7}]',
+    )
 
     from src.cli.commands.messages import run
 
@@ -70,11 +113,18 @@ def test_messages_read_json_format(cli_env, capsys):
     data = json.loads(out)
     assert isinstance(data, list)
     assert any(m["text"] == "json msg" for m in data)
+    assert any(m["reactions"] == [{"emoji": "🔥", "count": 7}] for m in data)
 
 
 def test_messages_read_csv_format(cli_env, capsys):
     _add_channel(cli_env, channel_id=100, title="MsgCh")
-    _add_message(cli_env, channel_id=100, message_id=1, text="csv msg")
+    _add_message(
+        cli_env,
+        channel_id=100,
+        message_id=1,
+        text="csv msg",
+        reactions_json='[{"emoji": "custom:42", "count": 3}]',
+    )
 
     from src.cli.commands.messages import run
 
@@ -94,6 +144,8 @@ def test_messages_read_csv_format(cli_env, capsys):
     out = capsys.readouterr().out
     assert "csv msg" in out
     assert "channel_id" in out
+    assert "reactions" in out.splitlines()[0]
+    assert "custom:42 3" in out
 
 
 def test_messages_read_with_query_filter(cli_env, capsys):

--- a/tests/test_telegram_reactions.py
+++ b/tests/test_telegram_reactions.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from telethon.tl.types import ReactionPaid
+
+from src.telegram.reactions import (
+    extract_message_reactions,
+    extract_message_reactions_json,
+    format_message_reactions,
+    format_reaction_counts,
+    format_reactions_json,
+    parse_reactions_json,
+)
+from tests.helpers import make_mock_reactions
+
+
+def test_extract_message_reactions_none():
+    msg = SimpleNamespace(reactions=None)
+
+    assert extract_message_reactions(msg) == []
+    assert extract_message_reactions_json(msg) is None
+    assert format_message_reactions(msg) == ""
+
+
+def test_extract_message_reactions_multiple_emoji():
+    msg = SimpleNamespace(reactions=make_mock_reactions([("👍", 5), ("❤️", 2)]))
+
+    assert extract_message_reactions(msg) == [
+        {"emoji": "👍", "count": 5},
+        {"emoji": "❤️", "count": 2},
+    ]
+    assert format_message_reactions(msg) == "👍 5 ❤️ 2"
+
+
+def test_extract_message_reactions_custom_emoji():
+    msg = SimpleNamespace(reactions=make_mock_reactions([(12345678, 2)]))
+
+    assert extract_message_reactions(msg) == [{"emoji": "custom:12345678", "count": 2}]
+    assert format_message_reactions(msg) == "custom:12345678 2"
+
+
+def test_extract_message_reactions_paid_and_unknown():
+    msg = SimpleNamespace(
+        reactions=SimpleNamespace(
+            results=[
+                SimpleNamespace(reaction=ReactionPaid(), count=4),
+                SimpleNamespace(reaction=SimpleNamespace(), count=9),
+            ]
+        )
+    )
+
+    assert extract_message_reactions(msg) == [{"emoji": "paid", "count": 4}]
+    assert format_message_reactions(msg) == "paid 4"
+
+
+def test_parse_reactions_json_valid_and_format():
+    items = parse_reactions_json('[{"emoji": "🔥", "count": 7}, {"emoji": "custom:42", "count": "3"}]')
+
+    assert items == [{"emoji": "🔥", "count": 7}, {"emoji": "custom:42", "count": 3}]
+    assert format_reaction_counts(items) == "🔥 7 custom:42 3"
+    assert format_reactions_json('[{"emoji": "🔥", "count": 7}]') == "🔥 7"
+
+
+def test_parse_reactions_json_invalid():
+    assert parse_reactions_json("not json") == []
+    assert parse_reactions_json(None) == []
+    assert parse_reactions_json('{"emoji": "👍", "count": 1}') == []


### PR DESCRIPTION
## Summary
- add shared Telegram reaction parsing and formatting helpers
- show compact emoji/count reactions in agent `read_messages` and CLI live reads
- include stored DB reactions in `messages read` text, JSON, and CSV output
- keep reaction-user lists out of this PR; tracked separately in #605

## Validation
- `ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_telegram_reactions.py tests/test_agent_tools_messaging_errors.py::TestReadMessagesTool tests/test_cli_messages.py tests/test_cli_commands_edge_cases.py::TestPrintMessages tests/test_cli_commands_edge_cases.py::TestPrintLiveMessages -v`
- `python3 -m pytest tests/test_collector.py -k reactions -v`
- `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto`
- `python3 -m pytest tests/ -v -m aiosqlite_serial`

Closes #604
