### PR TITLE
feat(agent): показать статус очереди Telegram-заданий

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -191,6 +191,7 @@
 | `read_messages` | READ | Читать сообщения из чата |
 | `send_message` | WRITE | Отправить сообщение |
 | `send_reaction` | WRITE | Поставить emoji-реакцию на сообщение |
+| `get_telegram_queue_status` | READ | Статус очереди Telegram-заданий и реакций |
 | `forward_messages` | WRITE | Переслать сообщения |
 | `edit_message` | WRITE | Редактировать |
 | `delete_message` | DELETE | Удалить (⚠️ destructive) |

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -242,6 +242,7 @@
 | Переименовать | `agent thread-rename` | `POST /agent/threads/{id}/rename` | `rename_agent_thread` |
 | Сообщения треда | `agent messages` | — | `get_thread_messages` |
 | Чат | `agent chat` | `POST /agent/threads/{id}/chat` | — |
+| Статус Telegram-очереди | `agent chat` | `POST /agent/threads/{id}/chat` | `get_telegram_queue_status` |
 | Контекст | `agent context` | `POST /agent/threads/{id}/context` | — |
 | Остановить | — | `POST /agent/threads/{id}/stop` | — |
 

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -12,6 +12,7 @@ from src.agent.tools.messaging_admin import register_admin_moderation_tools
 from src.agent.tools.messaging_chat_state import register_chat_state_read_tools
 from src.agent.tools.messaging_media import register_pin_media_tools
 from src.agent.tools.messaging_write import register_message_write_tools
+from src.agent.tools.telegram_queue import register_queue_status_tools
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -21,4 +22,5 @@ def register(db, client_pool, embedding_service, **kwargs):
     tools.extend(register_pin_media_tools(ctx, client_pool))
     tools.extend(register_admin_moderation_tools(ctx, client_pool))
     tools.extend(register_chat_state_read_tools(db, ctx, client_pool))
+    tools.extend(register_queue_status_tools(db))
     return tools

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -222,6 +222,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     # Messaging
     "send_message": ToolCategory.WRITE,
     "send_reaction": ToolCategory.WRITE,
+    "get_telegram_queue_status": ToolCategory.READ,
     "forward_messages": ToolCategory.WRITE,
     "edit_message": ToolCategory.WRITE,
     "delete_message": ToolCategory.DELETE,
@@ -330,6 +331,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Сообщения", [
         "send_message", "send_reaction", "forward_messages", "edit_message", "delete_message",
         "pin_message", "unpin_message", "download_media", "read_messages",
+        "get_telegram_queue_status",
     ]),
     ("Управление чатом", [
         "get_participants", "edit_admin", "edit_permissions", "kick_participant",

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -41,6 +41,7 @@ PHONE_BINDED_TOOLS: frozenset[str] = frozenset({
     "forward_messages",
     "get_broadcast_stats",
     "get_participants",
+    "get_telegram_queue_status",
     "kick_participant",
     "leave_dialogs",
     "list_photo_dialogs",

--- a/src/agent/tools/telegram_queue.py
+++ b/src/agent/tools/telegram_queue.py
@@ -1,0 +1,199 @@
+"""Agent read tools for Telegram command queue diagnostics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from claude_agent_sdk import tool
+
+from src.agent.tools._registry import ToolInputError, _text_response, arg_int, arg_str, normalize_phone
+from src.models import TelegramCommand, TelegramCommandStatus
+from src.services.telegram_command_service import TelegramCommandService
+
+_STATUS_LABELS = {
+    TelegramCommandStatus.PENDING: "ждёт",
+    TelegramCommandStatus.RUNNING: "выполняется",
+    TelegramCommandStatus.SUCCEEDED: "выполнено",
+    TelegramCommandStatus.FAILED: "ошибка",
+    TelegramCommandStatus.CANCELLED: "отменено",
+}
+
+_WAIT_REASON_LABELS = {
+    "waiting_flood_wait": "из-за flood-wait",
+    "waiting_warmup": "из-за прогрева",
+    "waiting_rate_limit": "из-за паузы между реакциями",
+}
+
+GET_TELEGRAM_QUEUE_STATUS_SCHEMA = {
+    "command_type": Annotated[str, "Тип задания, например dialogs.react"],
+    "phone": Annotated[str, "Телефон аккаунта для фильтра"],
+    "status": Annotated[str, "Статус: pending, running, succeeded, failed, cancelled"],
+    "limit": Annotated[int, "Сколько последних заданий показать, максимум 100"],
+}
+
+
+def _parse_status(raw: str) -> TelegramCommandStatus | None:
+    if not raw:
+        return None
+    try:
+        return TelegramCommandStatus(raw)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in TelegramCommandStatus)
+        raise ToolInputError(f"status должен быть одним из: {allowed}.") from exc
+
+
+def _format_time(value: datetime | None) -> str:
+    if value is None:
+        return "-"
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _summary_line(title: str, counts: dict[TelegramCommandStatus, int]) -> str:
+    total = sum(counts.values())
+    return (
+        f"{title}: Всего: {total}. "
+        f"Ждёт: {counts.get(TelegramCommandStatus.PENDING, 0)}. "
+        f"Выполняется: {counts.get(TelegramCommandStatus.RUNNING, 0)}. "
+        f"Выполнено: {counts.get(TelegramCommandStatus.SUCCEEDED, 0)}. "
+        f"Ошибок: {counts.get(TelegramCommandStatus.FAILED, 0)}. "
+        f"Отменено: {counts.get(TelegramCommandStatus.CANCELLED, 0)}."
+    )
+
+
+def _command_phone(command: TelegramCommand) -> str:
+    return str(command.payload.get("phone") or "-")
+
+
+def _command_target(command: TelegramCommand) -> str:
+    payload = command.payload
+    if command.command_type == "dialogs.react":
+        emoji = payload.get("emoji") or ""
+        chat_id = payload.get("chat_id", "-")
+        message_id = payload.get("message_id", "-")
+        return f"reaction {emoji} в чат {chat_id}, сообщение {message_id}"
+    if "recipient" in payload:
+        return f"получатель {payload.get('recipient')}"
+    if "chat_id" in payload:
+        parts = [f"чат {payload.get('chat_id')}"]
+        if "message_id" in payload:
+            parts.append(f"сообщение {payload.get('message_id')}")
+        if "message_ids" in payload:
+            parts.append(f"сообщения {payload.get('message_ids')}")
+        return ", ".join(parts)
+    if "target" in payload:
+        return f"цель {payload.get('target')}"
+    if "channel_id" in payload:
+        return f"канал {payload.get('channel_id')}"
+    return "-"
+
+
+def _command_status_text(command: TelegramCommand, now: datetime) -> str:
+    label = _STATUS_LABELS.get(command.status, str(command.status))
+    if command.status == TelegramCommandStatus.PENDING and command.run_after is not None:
+        run_after = command.run_after.astimezone(timezone.utc)
+        if run_after > now:
+            return f"{label} до {_format_time(run_after)}"
+    return label
+
+
+def _command_reason(command: TelegramCommand) -> str:
+    result_payload = command.result_payload or {}
+    state = str(result_payload.get("state") or "")
+    reason = _WAIT_REASON_LABELS.get(state)
+    if reason:
+        return reason
+    if command.error:
+        return command.error
+    detail = result_payload.get("detail")
+    return str(detail) if detail else ""
+
+
+def _format_command_line(command: TelegramCommand, now: datetime) -> str:
+    reason = _command_reason(command)
+    suffix = f" ({reason})" if reason else ""
+    return (
+        f"#{command.id} {command.command_type}: {_command_target(command)}; "
+        f"телефон {_command_phone(command)} — {_command_status_text(command, now)}{suffix}; "
+        f"создано {_format_time(command.created_at)}"
+    )
+
+
+def _reaction_wait_line(state_counts: dict[str, int]) -> str | None:
+    parts = [
+        f"{count} {_WAIT_REASON_LABELS[state]}"
+        for state in _WAIT_REASON_LABELS
+        if (count := state_counts.get(state, 0)) > 0
+    ]
+    if not parts:
+        return None
+    return "Ожидание реакций: " + ", ".join(parts) + "."
+
+
+def register_queue_status_tools(db: Any) -> list[Any]:
+    tools: list[Any] = []
+
+    @tool(
+        "get_telegram_queue_status",
+        "Show Telegram command queue status for the agent: totals, reaction delivery status, "
+        "recent tasks, delay reasons, and failures. Read-only.",
+        GET_TELEGRAM_QUEUE_STATUS_SCHEMA,
+    )
+    async def get_telegram_queue_status(args):
+        try:
+            command_type = arg_str(args, "command_type")
+            phone = normalize_phone(arg_str(args, "phone"))
+            status = _parse_status(arg_str(args, "status"))
+            raw_limit = arg_int(args, "limit", 20) or 20
+        except ToolInputError as exc:
+            return exc.to_response()
+
+        limit = max(1, min(raw_limit, 100))
+        service = TelegramCommandService(db)
+        try:
+            commands = await service.list(
+                command_type=command_type or None,
+                phone=phone or None,
+                status=status,
+                limit=limit,
+            )
+            summary = await service.summary(
+                command_type=command_type or None,
+                phone=phone or None,
+                status=status,
+            )
+            show_reactions = command_type in {"", "dialogs.react"}
+            reaction_summary: dict[TelegramCommandStatus, int] | None = None
+            reaction_states: dict[str, int] = {}
+            if show_reactions:
+                reaction_summary = await service.summary(
+                    command_type="dialogs.react",
+                    phone=phone or None,
+                    status=status,
+                )
+                reaction_states = await service.result_state_summary(
+                    command_type="dialogs.react",
+                    phone=phone or None,
+                    status=TelegramCommandStatus.PENDING if status is None else status,
+                )
+        except Exception as exc:
+            return _text_response(f"Ошибка получения статуса очереди: {exc}")
+
+        now = datetime.now(timezone.utc)
+        lines = [_summary_line("Очередь Telegram-заданий", summary)]
+        if show_reactions and reaction_summary is not None:
+            lines.append("")
+            lines.append(_summary_line("Реакции", reaction_summary))
+            reaction_wait = _reaction_wait_line(reaction_states)
+            if reaction_wait:
+                lines.append(reaction_wait)
+        lines.append("")
+        if commands:
+            lines.append(f"Последние задания ({len(commands)}):")
+            lines.extend(_format_command_line(command, now) for command in commands)
+        else:
+            lines.append("Последние задания: нет.")
+        return _text_response("\n".join(lines))
+
+    tools.append(get_telegram_queue_status)
+    return tools

--- a/src/agent/tools/telegram_queue.py
+++ b/src/agent/tools/telegram_queue.py
@@ -7,7 +7,14 @@ from typing import Annotated, Any
 
 from claude_agent_sdk import tool
 
-from src.agent.tools._registry import ToolInputError, _text_response, arg_int, arg_str, normalize_phone
+from src.agent.tools._registry import (
+    ToolInputError,
+    _text_response,
+    arg_int,
+    arg_str,
+    normalize_phone,
+    require_phone_permission,
+)
 from src.models import TelegramCommand, TelegramCommandStatus
 from src.services.telegram_command_service import TelegramCommandService
 
@@ -147,6 +154,10 @@ def register_queue_status_tools(db: Any) -> list[Any]:
             raw_limit = arg_int(args, "limit", 20) or 20
         except ToolInputError as exc:
             return exc.to_response()
+
+        perm_gate = await require_phone_permission(db, phone, "get_telegram_queue_status")
+        if perm_gate:
+            return perm_gate
 
         limit = max(1, min(raw_limit, 100))
         service = TelegramCommandService(db)

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -79,13 +79,85 @@ class TelegramCommandsRepository:
         row = await cur.fetchone()
         return self._to_command(row) if row else None
 
-    async def list_commands(self, *, limit: int = 100) -> list[TelegramCommand]:
+    @staticmethod
+    def _filtered_query(
+        *,
+        command_type: str | None = None,
+        status: TelegramCommandStatus | None = None,
+        phone: str | None = None,
+    ) -> tuple[str, list[Any]]:
+        where: list[str] = []
+        params: list[Any] = []
+        if command_type:
+            where.append("command_type = ?")
+            params.append(command_type)
+        if status is not None:
+            where.append("status = ?")
+            params.append(status.value)
+        if phone:
+            where.append("json_extract(payload, '$.phone') = ?")
+            params.append(phone)
+        clause = f"WHERE {' AND '.join(where)}" if where else ""
+        return clause, params
+
+    async def list_commands(
+        self,
+        *,
+        limit: int = 100,
+        command_type: str | None = None,
+        status: TelegramCommandStatus | None = None,
+        phone: str | None = None,
+    ) -> list[TelegramCommand]:
+        where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
         cur = await self._db.execute(
-            "SELECT * FROM telegram_commands ORDER BY id DESC LIMIT ?",
-            (limit,),
+            f"SELECT * FROM telegram_commands {where} ORDER BY id DESC LIMIT ?",
+            (*params, limit),
         )
         rows = await cur.fetchall()
         return [self._to_command(row) for row in rows]
+
+    async def count_by_status(
+        self,
+        *,
+        command_type: str | None = None,
+        status: TelegramCommandStatus | None = None,
+        phone: str | None = None,
+    ) -> dict[TelegramCommandStatus, int]:
+        where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
+        cur = await self._db.execute(
+            f"""
+            SELECT status, COUNT(*) AS count
+            FROM telegram_commands
+            {where}
+            GROUP BY status
+            """,
+            tuple(params),
+        )
+        rows = await cur.fetchall()
+        result = {status_value: 0 for status_value in TelegramCommandStatus}
+        for row in rows:
+            result[TelegramCommandStatus(row["status"])] = int(row["count"] or 0)
+        return result
+
+    async def count_result_states(
+        self,
+        *,
+        command_type: str | None = None,
+        status: TelegramCommandStatus | None = None,
+        phone: str | None = None,
+    ) -> dict[str, int]:
+        where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
+        cur = await self._db.execute(
+            f"""
+            SELECT COALESCE(json_extract(result_payload, '$.state'), '') AS state, COUNT(*) AS count
+            FROM telegram_commands
+            {where}
+            GROUP BY state
+            """,
+            tuple(params),
+        )
+        rows = await cur.fetchall()
+        return {str(row["state"]): int(row["count"] or 0) for row in rows if row["state"]}
 
     async def find_active_by_type(
         self, command_type: str, *, payload: dict[str, Any] | None = None

--- a/src/services/telegram_command_service.py
+++ b/src/services/telegram_command_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from src.database import Database
-from src.models import TelegramCommand
+from src.models import TelegramCommand, TelegramCommandStatus
 
 
 class TelegramCommandService:
@@ -44,3 +44,44 @@ class TelegramCommandService:
 
     async def get(self, command_id: int):
         return await self._db.repos.telegram_commands.get_command(command_id)
+
+    async def list(
+        self,
+        *,
+        command_type: str | None = None,
+        phone: str | None = None,
+        status: TelegramCommandStatus | None = None,
+        limit: int = 100,
+    ) -> list[TelegramCommand]:
+        return await self._db.repos.telegram_commands.list_commands(
+            command_type=command_type,
+            phone=phone,
+            status=status,
+            limit=limit,
+        )
+
+    async def summary(
+        self,
+        *,
+        command_type: str | None = None,
+        phone: str | None = None,
+        status: TelegramCommandStatus | None = None,
+    ) -> dict[TelegramCommandStatus, int]:
+        return await self._db.repos.telegram_commands.count_by_status(
+            command_type=command_type,
+            phone=phone,
+            status=status,
+        )
+
+    async def result_state_summary(
+        self,
+        *,
+        command_type: str | None = None,
+        phone: str | None = None,
+        status: TelegramCommandStatus | None = None,
+    ) -> dict[str, int]:
+        return await self._db.repos.telegram_commands.count_result_states(
+            command_type=command_type,
+            phone=phone,
+            status=status,
+        )

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -169,6 +169,54 @@ async def test_command_service_queues_distinct_reactions_and_deduplicates_exact_
 
 
 @pytest.mark.anyio
+async def test_command_service_lists_and_summarizes_with_filters(tmp_path):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        service = TelegramCommandService(db)
+        react_id = await service.enqueue(
+            "dialogs.react",
+            payload={"phone": "+1", "chat_id": "5832576119", "message_id": 1, "emoji": "👍"},
+            requested_by="test",
+        )
+        await service.enqueue(
+            "dialogs.react",
+            payload={"phone": "+2", "chat_id": "5832576119", "message_id": 2, "emoji": "🔥"},
+            requested_by="test",
+        )
+        send_id = await service.enqueue(
+            "dialogs.send_message",
+            payload={"phone": "+1", "recipient": "@chat", "text": "hello"},
+            requested_by="test",
+        )
+        await db.repos.telegram_commands.update_command(
+            send_id,
+            status=TelegramCommandStatus.SUCCEEDED,
+            payload={"phone": "+1", "recipient": "@chat", "text": "hello"},
+            result_payload={"phone": "+1"},
+        )
+        await db.repos.telegram_commands.update_command(
+            react_id,
+            status=TelegramCommandStatus.PENDING,
+            payload={"phone": "+1", "chat_id": "5832576119", "message_id": 1, "emoji": "👍"},
+            result_payload={"state": "waiting_flood_wait"},
+            run_after=datetime.now(timezone.utc) + timedelta(minutes=1),
+        )
+
+        phone_commands = await service.list(phone="+1", limit=10)
+        react_summary = await service.summary(command_type="dialogs.react")
+        state_summary = await service.result_state_summary(command_type="dialogs.react")
+
+        assert {item.command_type for item in phone_commands} == {"dialogs.react", "dialogs.send_message"}
+        assert react_summary[TelegramCommandStatus.PENDING] == 2
+        assert react_summary[TelegramCommandStatus.SUCCEEDED] == 0
+        assert state_summary["waiting_flood_wait"] == 1
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
 async def test_runtime_snapshots_repository_upsert_and_get(tmp_path):
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()

--- a/tests/test_agent_tools_telegram_queue.py
+++ b/tests/test_agent_tools_telegram_queue.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.database import Database
+from src.models import TelegramCommand, TelegramCommandStatus
+from tests.agent_tools_helpers import _get_tool_handlers, _text
+
+
+async def _open_db(tmp_path) -> Database:
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    return db
+
+
+async def _create_reaction(
+    db: Database,
+    *,
+    phone: str = "+1",
+    message_id: int = 1,
+    emoji: str = "👍",
+    status: TelegramCommandStatus = TelegramCommandStatus.PENDING,
+    run_after=None,
+    result_payload=None,
+    error: str | None = None,
+) -> int:
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="dialogs.react",
+            payload={"phone": phone, "chat_id": "5832576119", "message_id": message_id, "emoji": emoji},
+            status=TelegramCommandStatus.PENDING,
+            requested_by="test",
+            run_after=run_after,
+            result_payload=result_payload,
+        )
+    )
+    if status != TelegramCommandStatus.PENDING or error is not None:
+        await db.repos.telegram_commands.update_command(
+            command_id,
+            status=status,
+            payload={"phone": phone, "chat_id": "5832576119", "message_id": message_id, "emoji": emoji},
+            result_payload=result_payload,
+            error=error,
+            run_after=run_after,
+        )
+    return command_id
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_shows_reaction_summary(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        await _create_reaction(db, message_id=1, status=TelegramCommandStatus.SUCCEEDED)
+        await _create_reaction(db, message_id=2, status=TelegramCommandStatus.RUNNING, emoji="🔥")
+        await _create_reaction(db, message_id=3, emoji="🎉")
+        handlers = _get_tool_handlers(db)
+
+        result = await handlers["get_telegram_queue_status"]({})
+        text = _text(result)
+
+        assert "Очередь Telegram-заданий: Всего: 3" in text
+        assert "Реакции: Всего: 3" in text
+        assert "Выполнено: 1" in text
+        assert "Выполняется: 1" in text
+        assert "Ждёт: 1" in text
+        assert "reaction 🎉 в чат 5832576119, сообщение 3" in text
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_shows_flood_wait_reason(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        run_after = datetime.now(timezone.utc) + timedelta(minutes=2)
+        await _create_reaction(
+            db,
+            run_after=run_after,
+            result_payload={"state": "waiting_flood_wait", "phone": "+1"},
+            error="Flood wait 30s for +1",
+        )
+        handlers = _get_tool_handlers(db)
+
+        result = await handlers["get_telegram_queue_status"]({"command_type": "dialogs.react"})
+        text = _text(result)
+
+        assert "Ожидание реакций: 1 из-за flood-wait." in text
+        assert "ждёт до" in text
+        assert "из-за flood-wait" in text
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_does_not_create_commands(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        await _create_reaction(db)
+        before = await db.repos.telegram_commands.list_commands(limit=10)
+        handlers = _get_tool_handlers(db)
+
+        await handlers["get_telegram_queue_status"]({})
+
+        after = await db.repos.telegram_commands.list_commands(limit=10)
+        assert [item.id for item in after] == [item.id for item in before]
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_filters_by_command_type(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        await _create_reaction(db, message_id=1)
+        await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.send_message",
+                payload={"phone": "+1", "recipient": "@chat", "text": "hello"},
+                requested_by="test",
+            )
+        )
+        handlers = _get_tool_handlers(db)
+
+        result = await handlers["get_telegram_queue_status"]({"command_type": "dialogs.react"})
+        text = _text(result)
+
+        assert "dialogs.react" in text
+        assert "dialogs.send_message" not in text
+        assert "Очередь Telegram-заданий: Всего: 1" in text
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_clamps_limit_to_100(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        for message_id in range(105):
+            await _create_reaction(db, message_id=message_id)
+        handlers = _get_tool_handlers(db)
+
+        result = await handlers["get_telegram_queue_status"]({"limit": 500})
+        text = _text(result)
+
+        assert "Последние задания (100):" in text
+    finally:
+        await db.close()

--- a/tests/test_agent_tools_telegram_queue.py
+++ b/tests/test_agent_tools_telegram_queue.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -129,6 +130,35 @@ async def test_get_telegram_queue_status_filters_by_command_type(tmp_path):
         assert "dialogs.react" in text
         assert "dialogs.send_message" not in text
         assert "Очередь Telegram-заданий: Всего: 1" in text
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_telegram_queue_status_requires_phone_when_acl_is_phone_scoped(tmp_path):
+    db = await _open_db(tmp_path)
+    try:
+        await db.set_setting(
+            "agent_tool_permissions",
+            json.dumps({
+                "+1": {"get_telegram_queue_status": True},
+                "+2": {"get_telegram_queue_status": False},
+            }),
+        )
+        await _create_reaction(db, phone="+1", message_id=1)
+        await _create_reaction(db, phone="+2", message_id=2)
+        handlers = _get_tool_handlers(db)
+
+        missing_phone = await handlers["get_telegram_queue_status"]({})
+        assert "укажи параметр phone" in _text(missing_phone)
+
+        allowed_phone = await handlers["get_telegram_queue_status"]({"phone": "+1"})
+        text = _text(allowed_phone)
+        assert "сообщение 1" in text
+        assert "сообщение 2" not in text
+
+        denied_phone = await handlers["get_telegram_queue_status"]({"phone": "+2"})
+        assert "не разрешён" in _text(denied_phone)
     finally:
         await db.close()
 


### PR DESCRIPTION
## Что изменилось
- Добавлен read-only инструмент агента `get_telegram_queue_status`.
- Очередь Telegram-заданий теперь можно читать с фильтрами `command_type`, `phone`, `status`, `limit`.
- Для реакций выводится отдельная сводка: отправлено, ожидает, выполняется, ошибки и причины ожидания вроде flood-wait.
- Обновлены справочники agent tools и parity-таблица.

Closes #606.

## Проверки
- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_agent_tools_telegram_queue.py tests/repositories/test_runtime_repositories.py::test_command_service_lists_and_summarizes_with_filters tests/test_agent_tool_smoke_contract.py::test_agent_registry_matches_permission_contract tests/test_agent_tool_smoke_contract.py::test_agent_tools_reference_docs_cover_registry -q`
- `python3 -m pytest tests/test_cli_agent_parity.py tests/test_agent_tool_smoke_contract.py::test_agent_registry_matches_permission_contract tests/test_agent_tool_smoke_contract.py::test_agent_tools_reference_docs_cover_registry -q`
- `python3 -m pytest tests/ -v -m aiosqlite_serial`

Примечание: полный `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto` проходил один раз до единственного отказа parity-теста, после исправления parity отдельный тест прошёл. Повторный полный `-n auto` дал старые случайные pytest-timeout отказы в `image_providers`/`dialogs`/`agent_provider`; несколько этих тестов отдельно проходят.