### PR TITLE
[codex] read_messages: show reaction users behind flag

### DIFF
--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -6,7 +6,13 @@ from typing import Any
 from claude_agent_sdk import tool
 
 from src.agent.tools._formatters import format_sender_identity
-from src.agent.tools._registry import _text_response, require_confirmation, resolve_entity, resolve_live_read_phone
+from src.agent.tools._registry import (
+    _text_response,
+    arg_bool,
+    require_confirmation,
+    resolve_entity,
+    resolve_live_read_phone,
+)
 from src.agent.tools._telegram_runtime import find_single_dialog_id_by_title
 from src.agent.tools.messaging_schemas import (
     ARCHIVE_CHAT_SCHEMA,
@@ -18,7 +24,12 @@ from src.agent.tools.messaging_schemas import (
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.identity import extract_message_sender_identity
-from src.telegram.reactions import format_message_reactions
+from src.telegram.reactions import (
+    fetch_message_reaction_users,
+    format_message_reactions,
+    format_reaction_users_result,
+    normalize_reaction_users_limit,
+)
 
 
 def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
@@ -208,6 +219,8 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
             limit = max(1, min(int(args.get("limit") or 100), 500))
         except (TypeError, ValueError):
             limit = 100
+        include_reaction_users = arg_bool(args, "include_reaction_users", False)
+        reaction_users_limit = normalize_reaction_users_limit(args.get("reaction_users_limit"))
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
         try:
@@ -268,7 +281,21 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
                     preview = msg.text[:500]
                     reactions = format_message_reactions(msg)
                     reaction_suffix = f" | реакции: {reactions}" if reactions else ""
-                    line = f"#{msg.id} {date_str}{sender}: {preview}{reaction_suffix}"
+                    reaction_users_suffix = ""
+                    if include_reaction_users and reactions:
+                        reaction_users = await fetch_message_reaction_users(
+                            client,
+                            entity,
+                            msg.id,
+                            limit=reaction_users_limit,
+                        )
+                        formatted_users = format_reaction_users_result(reaction_users)
+                        if formatted_users:
+                            if reaction_users.unavailable:
+                                reaction_users_suffix = f" | {formatted_users}"
+                            else:
+                                reaction_users_suffix = f" | поставили: {formatted_users}"
+                    line = f"#{msg.id} {date_str}{sender}: {preview}{reaction_suffix}{reaction_users_suffix}"
                     lines.append(line)
                     total_chars += len(line)
                     count += 1

--- a/src/agent/tools/messaging_schemas.py
+++ b/src/agent/tools/messaging_schemas.py
@@ -129,4 +129,6 @@ READ_MESSAGES_SCHEMA = {
     "phone": PHONE_ARG,
     "chat_id": CHAT_ID_ARG,
     "limit": Annotated[int, "Максимальное количество результатов"],
+    "include_reaction_users": Annotated[bool, "Показать пользователей, поставивших реакции"],
+    "reaction_users_limit": Annotated[int, "Максимальное количество пользователей реакций на сообщение"],
 }

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -10,7 +10,14 @@ from src.cli import runtime
 from src.cli.commands.common import resolve_channel
 from src.models import Message
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
-from src.telegram.reactions import format_message_reactions, format_reactions_json, parse_reactions_json
+from src.telegram.reactions import (
+    fetch_message_reaction_users,
+    format_message_reactions,
+    format_reaction_users_result,
+    format_reactions_json,
+    normalize_reaction_users_limit,
+    parse_reactions_json,
+)
 
 
 def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
@@ -60,7 +67,8 @@ def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
             print()
 
 
-def _print_live_messages(collected: list) -> None:
+def _print_live_messages(collected: list, reaction_users_by_message_id: dict[int, str] | None = None) -> None:
+    reaction_users_by_message_id = reaction_users_by_message_id or {}
     for msg in reversed(collected):
         date_str = str(msg.date)[:19] if msg.date else "—"
         sender = ""
@@ -76,6 +84,9 @@ def _print_live_messages(collected: list) -> None:
         print(f"[{date_str}] #{msg.id}{sender}{reaction_suffix}")
         if text:
             print(f"  {text[:500]}")
+        reaction_users = reaction_users_by_message_id.get(msg.id)
+        if reaction_users:
+            print(f"  reaction users: {reaction_users}")
         print()
 
 
@@ -86,6 +97,8 @@ def run(args: argparse.Namespace) -> None:
         try:
             if args.messages_action == "read":
                 identifier = args.identifier
+                include_reaction_users = bool(getattr(args, "include_reaction_users", False))
+                reaction_users_limit = normalize_reaction_users_limit(getattr(args, "reaction_users_limit", None))
 
                 if args.live:
                     # Live mode: read from Telegram
@@ -134,10 +147,39 @@ def run(args: argparse.Namespace) -> None:
                         if not collected:
                             print("No messages found.")
                             return
-                        _print_live_messages(collected)
+                        reaction_users_by_message_id: dict[int, str] = {}
+                        if include_reaction_users:
+                            async def _read_reaction_users() -> None:
+                                for msg in collected:
+                                    if not format_message_reactions(msg):
+                                        continue
+                                    result = await fetch_message_reaction_users(
+                                        client,
+                                        entity,
+                                        msg.id,
+                                        limit=reaction_users_limit,
+                                    )
+                                    formatted = format_reaction_users_result(result)
+                                    if formatted:
+                                        reaction_users_by_message_id[msg.id] = formatted
+
+                            try:
+                                await run_with_flood_wait(
+                                    _read_reaction_users(),
+                                    operation="cli_messages_reaction_users",
+                                    phone=phone,
+                                    pool=pool,
+                                )
+                            except HandledFloodWaitError as exc:
+                                print(f"Flood wait: {exc.info.detail}")
+                                return
+                        _print_live_messages(collected, reaction_users_by_message_id)
                     except Exception as exc:
                         print(f"Error reading messages: {exc}")
                 else:
+                    if include_reaction_users:
+                        print("--include-reaction-users works only with --live.")
+                        return
                     # DB mode: read collected messages
                     channels = await db.get_channels()
                     ch = resolve_channel(channels, identifier)

--- a/src/cli/parser_domains/messages.py
+++ b/src/cli/parser_domains/messages.py
@@ -19,6 +19,17 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     msg_read.add_argument("--offset-id", type=int, default=None, dest="offset_id",
                           help="Read messages before this message ID (--live)")
     msg_read.add_argument(
+        "--include-reaction-users",
+        action="store_true",
+        help="Show users who reacted (live mode only)",
+    )
+    msg_read.add_argument(
+        "--reaction-users-limit",
+        type=int,
+        default=20,
+        help="Max reaction users per message for --include-reaction-users (default: 20)",
+    )
+    msg_read.add_argument(
         "--format", choices=["text", "json", "csv"], default="text", dest="output_format",
         help="Output format (default: text)",
     )

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -20,6 +20,19 @@ from src.telegram.session_materializer import SessionMaterializer
 logger = logging.getLogger(__name__)
 
 
+async def fetch_message_reaction_users_raw(client: Any, peer: Any, message_id: int, *, limit: int) -> Any:
+    """Fetch raw Telegram reaction-user rows for a message."""
+    from telethon.tl.functions.messages import GetMessageReactionsListRequest
+
+    return await client(
+        GetMessageReactionsListRequest(
+            peer=peer,
+            id=int(message_id),
+            limit=limit,
+        )
+    )
+
+
 class BackendAcquireError(RuntimeError):
     """Raised when a backend cannot provide a usable authorized client."""
 

--- a/src/telegram/reactions.py
+++ b/src/telegram/reactions.py
@@ -2,9 +2,20 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 ReactionItem = dict[str, str | int]
+ReactionUserItem = dict[str, str | int]
+DEFAULT_REACTION_USERS_LIMIT = 20
+MAX_REACTION_USERS_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class ReactionUsersResult:
+    items: list[ReactionUserItem]
+    unavailable: str | None = None
+    limited: bool = False
 
 
 def _coerce_count(value: Any) -> int:
@@ -30,6 +41,60 @@ def _reaction_label(reaction: Any) -> str | None:
         return "paid"
 
     return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _peer_key(peer_id: Any) -> tuple[str | None, int | None]:
+    for kind, attr in (("user", "user_id"), ("channel", "channel_id"), ("chat", "chat_id"), (None, "id")):
+        value = _coerce_int(getattr(peer_id, attr, None))
+        if value is not None:
+            return kind, value
+    return None, None
+
+
+def _index_by_id(items: Iterable[Any]) -> dict[int, Any]:
+    indexed: dict[int, Any] = {}
+    for item in items:
+        item_id = _coerce_int(getattr(item, "id", None))
+        if item_id is not None:
+            indexed[item_id] = item
+    return indexed
+
+
+def _display_peer(entity: Any, peer_id: int | None) -> str:
+    if entity is not None:
+        username = getattr(entity, "username", None)
+        if username:
+            return f"@{str(username).strip().lstrip('@')}"
+
+        first_name = str(getattr(entity, "first_name", "") or "").strip()
+        last_name = str(getattr(entity, "last_name", "") or "").strip()
+        full_name = " ".join(part for part in (first_name, last_name) if part)
+        if full_name:
+            return full_name
+
+        title = str(getattr(entity, "title", "") or "").strip()
+        if title:
+            return title
+
+    if peer_id is not None:
+        return f"id={peer_id}"
+    return "unknown"
+
+
+def normalize_reaction_users_limit(value: Any, *, default: int = DEFAULT_REACTION_USERS_LIMIT) -> int:
+    limit = _coerce_int(value)
+    if limit is None:
+        limit = default
+    return max(1, min(limit, MAX_REACTION_USERS_LIMIT))
 
 
 def extract_message_reactions(message: Any) -> list[ReactionItem]:
@@ -71,6 +136,60 @@ def parse_reactions_json(reactions_json: str | None) -> list[ReactionItem]:
     return items
 
 
+def extract_reaction_users(result: Any) -> list[ReactionUserItem]:
+    users_by_id = _index_by_id(getattr(result, "users", None) or [])
+    chats_by_id = _index_by_id(getattr(result, "chats", None) or [])
+
+    items: list[ReactionUserItem] = []
+    for peer_reaction in getattr(result, "reactions", None) or []:
+        label = _reaction_label(getattr(peer_reaction, "reaction", None))
+        if label is None:
+            continue
+
+        kind, peer_id = _peer_key(getattr(peer_reaction, "peer_id", None))
+        if kind == "user":
+            entity = users_by_id.get(peer_id) if peer_id is not None else None
+        elif kind in {"chat", "channel"}:
+            entity = chats_by_id.get(peer_id) if peer_id is not None else None
+        else:
+            entity = (users_by_id.get(peer_id) or chats_by_id.get(peer_id)) if peer_id is not None else None
+
+        item: ReactionUserItem = {
+            "emoji": label,
+            "display": _display_peer(entity, peer_id),
+        }
+        if peer_id is not None:
+            item["peer_id"] = peer_id
+        items.append(item)
+    return items
+
+
+async def fetch_message_reaction_users(
+    client: Any,
+    peer: Any,
+    message_id: int,
+    *,
+    limit: Any = DEFAULT_REACTION_USERS_LIMIT,
+) -> ReactionUsersResult:
+    safe_limit = normalize_reaction_users_limit(limit)
+    try:
+        from src.telegram.backends import fetch_message_reaction_users_raw
+    except ImportError as exc:
+        return ReactionUsersResult([], unavailable=str(exc))
+
+    try:
+        result = await fetch_message_reaction_users_raw(client, peer, int(message_id), limit=safe_limit)
+    except Exception as exc:
+        if exc.__class__.__name__ == "FloodWaitError":
+            raise
+        return ReactionUsersResult([], unavailable=str(exc))
+
+    items = extract_reaction_users(result)
+    total = _coerce_count(getattr(result, "count", len(items)))
+    limited = bool(getattr(result, "next_offset", None)) or total > len(items)
+    return ReactionUsersResult(items, limited=limited)
+
+
 def format_reaction_counts(items: Iterable[Mapping[str, Any]]) -> str:
     parts: list[str] = []
     for item in items:
@@ -87,3 +206,35 @@ def format_message_reactions(message: Any) -> str:
 
 def format_reactions_json(reactions_json: str | None) -> str:
     return format_reaction_counts(parse_reactions_json(reactions_json))
+
+
+def format_reaction_users(
+    items: Iterable[Mapping[str, Any]],
+    *,
+    unavailable: bool = False,
+    limited: bool = False,
+) -> str:
+    if unavailable:
+        return "пользователи реакций недоступны"
+
+    grouped: dict[str, list[str]] = {}
+    for item in items:
+        emoji = item.get("emoji")
+        display = item.get("display")
+        if not emoji or not display:
+            continue
+        grouped.setdefault(str(emoji), []).append(str(display))
+
+    parts = [f"{emoji} {', '.join(users)}" for emoji, users in grouped.items()]
+    text = "; ".join(parts)
+    if text and limited:
+        text += " ..."
+    return text
+
+
+def format_reaction_users_result(result: ReactionUsersResult) -> str:
+    return format_reaction_users(
+        result.items,
+        unavailable=bool(result.unavailable),
+        limited=result.limited,
+    )

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -846,6 +846,88 @@ class TestReadMessagesTool:
         assert "Popular post | реакции: 👍 5 ❤️ 2" in text
 
     @pytest.mark.anyio
+    async def test_with_reaction_users_flag(self, mock_db, mock_pool):
+        client = AsyncMock()
+        _setup_resolve_entity(mock_pool, client)
+
+        msg = SimpleNamespace(
+            id=1,
+            sender_id=42,
+            date=None,
+            text="Popular post",
+            reactions=SimpleNamespace(
+                results=[
+                    SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+                ]
+            ),
+        )
+
+        async def iter_msgs(*a, **kw):
+            yield msg
+
+        client.iter_messages = iter_msgs
+        client.return_value = SimpleNamespace(
+            count=1,
+            next_offset=None,
+            reactions=[
+                SimpleNamespace(
+                    peer_id=SimpleNamespace(user_id=55),
+                    reaction=SimpleNamespace(emoticon="👍"),
+                ),
+            ],
+            users=[SimpleNamespace(id=55, username="ivan", first_name="Ivan", last_name="Petrov")],
+            chats=[],
+        )
+
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["read_messages"]({
+            "phone": "+79001234567",
+            "chat_id": "@test",
+            "limit": 10,
+            "include_reaction_users": True,
+            "reaction_users_limit": 10,
+        })
+
+        text = _text(result)
+        assert "Popular post | реакции: 👍 5 | поставили: 👍 @ivan" in text
+        assert client.await_args.args[0].id == 1
+        assert client.await_args.args[0].limit == 10
+
+    @pytest.mark.anyio
+    async def test_reaction_users_unavailable_does_not_break_read(self, mock_db, mock_pool):
+        client = AsyncMock(side_effect=RuntimeError("forbidden"))
+        _setup_resolve_entity(mock_pool, client)
+
+        msg = SimpleNamespace(
+            id=1,
+            sender_id=42,
+            date=None,
+            text="Popular post",
+            reactions=SimpleNamespace(
+                results=[
+                    SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+                ]
+            ),
+        )
+
+        async def iter_msgs(*a, **kw):
+            yield msg
+
+        client.iter_messages = iter_msgs
+
+        handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+        result = await handlers["read_messages"]({
+            "phone": "+79001234567",
+            "chat_id": "@test",
+            "limit": 10,
+            "include_reaction_users": True,
+        })
+
+        text = _text(result)
+        assert "Popular post | реакции: 👍 5" in text
+        assert "пользователи реакций недоступны" in text
+
+    @pytest.mark.anyio
     async def test_none_phone_uses_available_connected_account(self, mock_db, mock_pool):
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -13,6 +13,7 @@ from src.telegram.backends import (
     NativeTelethonBackend,
     TelegramTransportSession,
     TelethonCliBackend,
+    fetch_message_reaction_users_raw,
 )
 from src.telegram.flood_wait import HandledFloodWaitError
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
@@ -114,6 +115,18 @@ async def test_send_reaction_invokes_raw_api_with_empty_vector_to_clear():
     assert request.peer == "chat"
     assert request.msg_id == 42
     assert request.reaction == []
+
+
+@pytest.mark.anyio
+async def test_fetch_message_reaction_users_raw_invokes_request():
+    client = FakeCliTelethonClient()
+
+    await fetch_message_reaction_users_raw(client, "chat", 42, limit=10)
+
+    request = client.invoke.await_args.args[0]
+    assert request.peer == "chat"
+    assert request.id == 42
+    assert request.limit == 10
 
 
 # --- Batch 2: Media (#187) ---

--- a/tests/test_cli_commands_edge_cases.py
+++ b/tests/test_cli_commands_edge_cases.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from src.cli.commands.filter import _build_deletion_service, _parse_pks, _print_result
 from src.cli.commands.messages import _print_live_messages, _print_messages
 from src.models import Account, Channel, Message, SearchQuery, SearchQueryDailyStat
-from tests.helpers import cli_ns
+from tests.helpers import AsyncIterMessages, cli_ns
 
 # ---------------------------------------------------------------------------
 # Helper: make runtime.init_db return an awaitable that yields (config, db)
@@ -228,6 +228,17 @@ class TestPrintLiveMessages:
         _print_live_messages(msgs)
         out = capsys.readouterr().out
         assert "reactions: 👍 5 ❤️ 2" in out
+
+    def test_with_reaction_users(self, capsys):
+        reactions = SimpleNamespace(
+            results=[
+                SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+            ]
+        )
+        msgs = [self._make_live_msg(reactions=reactions)]
+        _print_live_messages(msgs, reaction_users_by_message_id={10: "👍 @ivan, id=55"})
+        out = capsys.readouterr().out
+        assert "reaction users: 👍 @ivan, id=55" in out
 
 
 # ---------------------------------------------------------------------------
@@ -1478,6 +1489,32 @@ class TestSearchQueryStats:
 
 
 class TestMessagesReadDbMode:
+    def test_include_reaction_users_requires_live_mode(self, capsys):
+        from src.cli.commands.messages import run
+
+        db = MagicMock()
+        db.close = AsyncMock()
+
+        with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))):
+            run(cli_ns(
+                messages_action="read",
+                identifier="testch",
+                live=False,
+                query=None,
+                date_from=None,
+                date_to=None,
+                limit=10,
+                output_format="text",
+                topic_id=None,
+                offset_id=None,
+                include_reaction_users=True,
+                reaction_users_limit=20,
+            ))
+
+        out = capsys.readouterr().out
+        assert "--include-reaction-users works only with --live." in out
+        db.get_channels.assert_not_called()
+
     def test_channel_not_found(self, capsys):
         from src.cli.commands.messages import run
 
@@ -1621,3 +1658,71 @@ class TestMessagesReadDbMode:
 
         out = capsys.readouterr().out
         assert "msg by pk" in out
+
+
+class TestMessagesReadLiveMode:
+    def test_read_live_with_reaction_users(self, capsys):
+        from src.cli.commands.messages import run
+
+        reactions = SimpleNamespace(
+            results=[
+                SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=5),
+            ]
+        )
+        msg = SimpleNamespace(
+            id=10,
+            date=datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+            text="live reacted",
+            sender=None,
+            media=None,
+            reactions=reactions,
+        )
+
+        client = AsyncMock()
+        client.get_entity = AsyncMock(return_value="entity")
+        client.iter_messages = MagicMock(return_value=AsyncIterMessages([msg]))
+        client.return_value = SimpleNamespace(
+            count=1,
+            next_offset=None,
+            reactions=[
+                SimpleNamespace(
+                    peer_id=SimpleNamespace(user_id=55),
+                    reaction=SimpleNamespace(emoticon="👍"),
+                ),
+            ],
+            users=[SimpleNamespace(id=55, username="ivan")],
+            chats=[],
+        )
+
+        pool = MagicMock()
+        pool.clients = {"+79001234567": object()}
+        pool.get_native_client_by_phone = AsyncMock(return_value=(client, None))
+        pool.disconnect_all = AsyncMock()
+
+        db = MagicMock()
+        db.close = AsyncMock()
+
+        with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))), \
+             patch("src.cli.commands.messages.runtime.init_pool", side_effect=_make_coro((MagicMock(), pool))):
+            run(cli_ns(
+                messages_action="read",
+                identifier="@test",
+                live=True,
+                query=None,
+                date_from=None,
+                date_to=None,
+                limit=10,
+                output_format="text",
+                topic_id=None,
+                offset_id=None,
+                phone="+79001234567",
+                include_reaction_users=True,
+                reaction_users_limit=10,
+            ))
+
+        out = capsys.readouterr().out
+        assert "live reacted" in out
+        assert "reactions: 👍 5" in out
+        assert "reaction users: 👍 @ivan" in out
+        assert client.await_args.args[0].id == 10
+        assert client.await_args.args[0].limit == 10

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -81,11 +81,22 @@ class TestParser:
     def test_parser_messages_read(self):
         """messages read subcommand parses identifier and options."""
         parser = build_parser()
-        args = parser.parse_args(["messages", "read", "test_channel", "--limit", "10"])
+        args = parser.parse_args([
+            "messages",
+            "read",
+            "test_channel",
+            "--limit",
+            "10",
+            "--include-reaction-users",
+            "--reaction-users-limit",
+            "5",
+        ])
         assert args.command == "messages"
         assert args.messages_action == "read"
         assert args.identifier == "test_channel"
         assert args.limit == 10
+        assert args.include_reaction_users is True
+        assert args.reaction_users_limit == 5
 
     def test_parser_channel_list(self):
         """channel list subcommand."""

--- a/tests/test_telegram_reactions.py
+++ b/tests/test_telegram_reactions.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 from telethon.tl.types import ReactionPaid
 
 from src.telegram.reactions import (
     extract_message_reactions,
     extract_message_reactions_json,
+    extract_reaction_users,
+    fetch_message_reaction_users,
     format_message_reactions,
     format_reaction_counts,
+    format_reaction_users,
+    format_reaction_users_result,
     format_reactions_json,
+    normalize_reaction_users_limit,
     parse_reactions_json,
 )
 from tests.helpers import make_mock_reactions
@@ -66,3 +72,108 @@ def test_parse_reactions_json_invalid():
     assert parse_reactions_json("not json") == []
     assert parse_reactions_json(None) == []
     assert parse_reactions_json('{"emoji": "👍", "count": 1}') == []
+
+
+def test_extract_reaction_users_groups_users_chats_custom_and_paid():
+    result = SimpleNamespace(
+        reactions=[
+            SimpleNamespace(
+                peer_id=SimpleNamespace(user_id=10),
+                reaction=SimpleNamespace(emoticon="👍"),
+            ),
+            SimpleNamespace(
+                peer_id=SimpleNamespace(user_id=11),
+                reaction=SimpleNamespace(document_id=42),
+            ),
+            SimpleNamespace(
+                peer_id=SimpleNamespace(channel_id=12),
+                reaction=ReactionPaid(),
+            ),
+            SimpleNamespace(
+                peer_id=SimpleNamespace(user_id=13),
+                reaction=SimpleNamespace(),
+            ),
+        ],
+        users=[
+            SimpleNamespace(id=10, username="ivan", first_name="Ivan", last_name="Petrov"),
+            SimpleNamespace(id=11, username=None, first_name="Maria", last_name=""),
+        ],
+        chats=[SimpleNamespace(id=12, title="Channel Reactor")],
+    )
+
+    items = extract_reaction_users(result)
+
+    assert items == [
+        {"emoji": "👍", "display": "@ivan", "peer_id": 10},
+        {"emoji": "custom:42", "display": "Maria", "peer_id": 11},
+        {"emoji": "paid", "display": "Channel Reactor", "peer_id": 12},
+    ]
+    assert format_reaction_users(items) == "👍 @ivan; custom:42 Maria; paid Channel Reactor"
+
+
+def test_extract_reaction_users_falls_back_to_peer_id():
+    result = SimpleNamespace(
+        reactions=[
+            SimpleNamespace(peer_id=SimpleNamespace(user_id=55), reaction=SimpleNamespace(emoticon="❤️")),
+        ],
+        users=[],
+        chats=[],
+    )
+
+    assert extract_reaction_users(result) == [{"emoji": "❤️", "display": "id=55", "peer_id": 55}]
+
+
+def test_format_reaction_users_unavailable_and_limited():
+    assert format_reaction_users([], unavailable=True) == "пользователи реакций недоступны"
+    assert format_reaction_users([{"emoji": "👍", "display": "@ivan"}], limited=True) == "👍 @ivan ..."
+
+
+def test_normalize_reaction_users_limit():
+    assert normalize_reaction_users_limit(None) == 20
+    assert normalize_reaction_users_limit("3") == 3
+    assert normalize_reaction_users_limit(0) == 1
+    assert normalize_reaction_users_limit(999) == 100
+
+
+@pytest.mark.anyio
+async def test_fetch_message_reaction_users_invokes_telethon_request():
+    class FakeClient:
+        request = None
+
+        async def __call__(self, request):
+            self.request = request
+            return SimpleNamespace(
+                count=2,
+                next_offset="next",
+                reactions=[
+                    SimpleNamespace(
+                        peer_id=SimpleNamespace(user_id=10),
+                        reaction=SimpleNamespace(emoticon="👍"),
+                    ),
+                ],
+                users=[SimpleNamespace(id=10, username="ivan")],
+                chats=[],
+            )
+
+    client = FakeClient()
+    result = await fetch_message_reaction_users(client, "peer", 123, limit=500)
+
+    assert client.request.peer == "peer"
+    assert client.request.id == 123
+    assert client.request.limit == 100
+    assert result.items == [{"emoji": "👍", "display": "@ivan", "peer_id": 10}]
+    assert result.limited is True
+    assert format_reaction_users_result(result) == "👍 @ivan ..."
+
+
+@pytest.mark.anyio
+async def test_fetch_message_reaction_users_returns_unavailable_on_error():
+    class FakeClient:
+        async def __call__(self, request):
+            raise RuntimeError("forbidden")
+
+    result = await fetch_message_reaction_users(FakeClient(), "peer", 123)
+
+    assert result.items == []
+    assert result.unavailable == "forbidden"
+    assert format_reaction_users_result(result) == "пользователи реакций недоступны"


### PR DESCRIPTION
## Summary
- add live-only reaction user fetching for agent read_messages and CLI messages read --live
- show grouped reaction users with a capped per-message limit and graceful unavailable fallback
- keep raw Telethon reaction-user request in backend layer and cover parser/formatter paths

Closes #605

## Validation
- python3 -m ruff check src/ tests/ conftest.py
- python3 -m pytest tests/test_telegram_reactions.py tests/test_backends.py -v
- python3 -m pytest tests/test_agent_tools_messaging_errors.py::TestReadMessagesTool -v
- python3 -m pytest tests/test_cli_messages.py -v
- python3 -m pytest tests/test_cli_commands_edge_cases.py -v
- python3 -m pytest tests/ -v -m aiosqlite_serial
- python3 -m pytest tests/test_provider_runtime_integration.py -v -m "not aiosqlite_serial"

## Validation note
- The full parallel non-serial lane hit an xdist-only torch duplicate-registration failure in tests/test_provider_runtime_integration.py; that same file passed standalone.