### PR TITLE
[codex] Queue agent permission prompts

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -2219,7 +2219,7 @@ class AgentManager:
             with suppress(asyncio.CancelledError):
                 await task
 
-    async def cancel_stream(self, thread_id: int) -> bool:
+    async def cancel_stream(self, thread_id: int, *, wait_timeout: float | None = None) -> bool:
         task = self._active_tasks.pop(thread_id, None)
         if task is None:
             return False
@@ -2230,8 +2230,26 @@ class AgentManager:
         if session_id is not None:
             self._permission_gate.clear_thread(session_id, thread_id)
         task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
+        if wait_timeout is None:
+            with suppress(asyncio.CancelledError):
+                await task
+        else:
+            done, pending = await asyncio.wait({task}, timeout=wait_timeout)
+            for done_task in done:
+                with suppress(asyncio.CancelledError):
+                    exc = done_task.exception()
+                    if exc is not None:
+                        logger.debug(
+                            "Cancelled agent stream %d finished with error",
+                            thread_id,
+                            exc_info=(type(exc), exc, exc.__traceback__),
+                        )
+            if pending:
+                logger.warning(
+                    "Agent stream %d did not stop within %.1fs; continuing cleanup",
+                    thread_id,
+                    wait_timeout,
+                )
         return True
 
     async def close_all(self) -> None:

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -2221,3 +2221,4 @@ class AgentManager:
             _, pending = await asyncio.wait(tasks, timeout=5.0)
             for task in pending:
                 logger.debug("Agent task did not finish within timeout: %s", task.get_name())
+        self._permission_gate.cancel_all()

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -2103,12 +2103,14 @@ class AgentManager:
         # so the actual set/reset happens inside _run_backend (not in the generator).
         from src.agent.permission_gate import (
             AgentRequestContext,
+            PermissionWaitTracker,
             reset_request_context,
             set_request_context,
         )
 
         _req_ctx: AgentRequestContext | None = None
         cancel_event = threading.Event()
+        permission_wait_tracker = PermissionWaitTracker()
         if interactive_permissions:
             from src.agent.tools.permissions import load_tool_access_policy
 
@@ -2121,6 +2123,7 @@ class AgentManager:
                 permission_gate=self._permission_gate,
                 permission_timeout=self._config.agent.permission_timeout,
                 cancel_event=cancel_event,
+                permission_wait_tracker=permission_wait_tracker,
             )
 
         async def _run_backend(

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import threading
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import suppress
@@ -1852,6 +1853,8 @@ class AgentManager:
             db, self._config, client_pool=client_pool, scheduler_manager=scheduler_manager,
         )
         self._active_tasks: dict[int, asyncio.Task] = {}
+        self._active_task_sessions: dict[int, str] = {}
+        self._active_task_cancel_events: dict[int, threading.Event] = {}
         self._settings_cache = _SettingsCache()
         self._cached_allowed_tools: list[str] | None = None
         self._cached_filtered_tools: tuple[list[str], dict[str, bool]] | None = None
@@ -2105,6 +2108,7 @@ class AgentManager:
         )
 
         _req_ctx: AgentRequestContext | None = None
+        cancel_event = threading.Event()
         if interactive_permissions:
             from src.agent.tools.permissions import load_tool_access_policy
 
@@ -2116,6 +2120,7 @@ class AgentManager:
                 tool_access_policy=_access_policy,
                 permission_gate=self._permission_gate,
                 permission_timeout=self._config.agent.permission_timeout,
+                cancel_event=cancel_event,
             )
 
         async def _run_backend(
@@ -2165,6 +2170,8 @@ class AgentManager:
                 )
                 await queue.put(f"data: {err_payload}\n\n")
             finally:
+                cancel_event.set()
+                self._permission_gate.clear_thread(session_id, thread_id)
                 if _token is not None:
                     reset_request_context(_token)
             await queue.put(None)
@@ -2178,10 +2185,14 @@ class AgentManager:
             _run_backend(backend, lambda text: f"Ошибка агента ({backend_name}): {text}")
         )
         self._active_tasks[thread_id] = task
+        self._active_task_sessions[thread_id] = session_id
+        self._active_task_cancel_events[thread_id] = cancel_event
 
         def _cleanup(t: asyncio.Task) -> None:
             if self._active_tasks.get(thread_id) is t:
                 del self._active_tasks[thread_id]
+                self._active_task_sessions.pop(thread_id, None)
+                self._active_task_cancel_events.pop(thread_id, None)
 
         task.add_done_callback(_cleanup)
 
@@ -2199,6 +2210,8 @@ class AgentManager:
                     break
                 yield item
         finally:
+            cancel_event.set()
+            self._permission_gate.clear_thread(session_id, thread_id)
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
@@ -2207,6 +2220,12 @@ class AgentManager:
         task = self._active_tasks.pop(thread_id, None)
         if task is None:
             return False
+        session_id = self._active_task_sessions.pop(thread_id, None)
+        cancel_event = self._active_task_cancel_events.pop(thread_id, None)
+        if cancel_event is not None:
+            cancel_event.set()
+        if session_id is not None:
+            self._permission_gate.clear_thread(session_id, thread_id)
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
@@ -2215,6 +2234,10 @@ class AgentManager:
     async def close_all(self) -> None:
         tasks = list(self._active_tasks.values())
         self._active_tasks.clear()
+        for cancel_event in self._active_task_cancel_events.values():
+            cancel_event.set()
+        self._active_task_sessions.clear()
+        self._active_task_cancel_events.clear()
         for task in tasks:
             task.cancel()
         if tasks:

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -43,6 +44,7 @@ class AgentRequestContext:
     tool_access_policy: dict[str, object] | None = None
     permission_gate: PermissionGate | None = None
     permission_timeout: int | None = None  # legacy config field; prompts no longer time out
+    cancel_event: threading.Event | None = None
 
 
 _request_ctx: ContextVar[AgentRequestContext | None] = ContextVar(

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -10,6 +10,11 @@ Flow:
 5. choice "once"  → allow this single call (no override stored)
    choice "session" → store in _session_overrides[session_id], allow
    choice "deny"  → return _text_response error to the LLM
+
+Permission prompts are serialized per agent session.  This prevents parallel
+tool calls from opening a burst of dialogs before the user answers the first
+one.  There is intentionally no timeout: the agent pauses until the user
+chooses once/session/deny, or until the agent task is cancelled.
 """
 
 from __future__ import annotations
@@ -37,7 +42,7 @@ class AgentRequestContext:
     db_permissions: dict[str, bool] | None = None  # legacy boolean view
     tool_access_policy: dict[str, object] | None = None
     permission_gate: PermissionGate | None = None
-    permission_timeout: int = 120     # seconds to wait for user response
+    permission_timeout: int | None = None  # legacy config field; prompts no longer time out
 
 
 _request_ctx: ContextVar[AgentRequestContext | None] = ContextVar(
@@ -101,10 +106,24 @@ class PermissionGate:
     _session_overrides: dict[str, set[tuple[str, str]]] = field(default_factory=dict)
     # request_id (UUID str) → Future that resolves with "once"|"session"|"deny"
     _pending: dict[str, asyncio.Future] = field(default_factory=dict)
+    # request_id → session_id, so clear_session/cancel_all can unblock visible prompts
+    _pending_sessions: dict[str, str] = field(default_factory=dict)
+    # (session_id, event_loop_id) → lock.  A lock is loop-bound once contended,
+    # so tests and embedded runtimes that create fresh loops need separate locks.
+    _session_prompt_locks: dict[tuple[str, int], asyncio.Lock] = field(default_factory=dict)
 
     def is_session_approved(self, tool_name: str, session_id: str, phone: str = "") -> bool:
         """True if (tool, phone) was previously approved for this session_id."""
         return (tool_name, phone) in self._session_overrides.get(session_id, set())
+
+    def _prompt_lock(self, session_id: str) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        key = (session_id, id(loop))
+        lock = self._session_prompt_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._session_prompt_locks[key] = lock
+        return lock
 
     async def check(self, tool_name: str, phone: str) -> dict | None:
         """Check if tool/phone is allowed; show permission dialog if not.
@@ -125,48 +144,51 @@ class PermissionGate:
         if self.is_session_approved(tool_name, ctx.session_id, phone):
             return None
 
-        # Ask user
+        lock = self._prompt_lock(ctx.session_id)
+        async with lock:
+            # Another request may have received "session" while we were queued.
+            if self.is_session_approved(tool_name, ctx.session_id, phone):
+                return None
+            return await self._ask_user(ctx, tool_name, phone)
+
+    async def _ask_user(self, ctx: AgentRequestContext, tool_name: str, phone: str) -> dict | None:
+        """Emit one permission prompt and wait indefinitely for the user's choice."""
         request_id = str(uuid.uuid4())
         future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
+        self._pending_sessions[request_id] = ctx.session_id
 
-        timeout = ctx.permission_timeout
         event = json.dumps(
             {
                 "type": "permission_request",
                 "request_id": request_id,
                 "tool": tool_name,
                 "phone": phone,
-                "timeout": timeout,
+                "timeout": None,
             },
             ensure_ascii=False,
         )
         await ctx.queue.put(f"data: {event}\n\n")
         logger.info(
-            "Permission request emitted: request_id=%s tool=%s phone=%s thread=%d session=%s timeout=%ds",
+            "Permission request emitted: request_id=%s tool=%s phone=%s thread=%d session=%s timeout=none",
             request_id,
             tool_name,
             phone or "(none)",
             ctx.thread_id,
             ctx.session_id,
-            timeout,
         )
 
         try:
-            choice: str = await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
-            self._pending.pop(request_id, None)
-            logger.warning(
-                "Permission timeout %ds fired for request_id=%s tool '%s' (thread %d, session %s)",
-                timeout, request_id, tool_name, ctx.thread_id, ctx.session_id,
-            )
-            mins = timeout // 60
-            return _text_response(f"❌ Таймаут запроса разрешения для '{tool_name}' ({mins} мин).")
+            choice: str = await future
         except asyncio.CancelledError:
             self._pending.pop(request_id, None)
+            self._pending_sessions.pop(request_id, None)
+            if not future.done():
+                future.cancel()
             raise
         finally:
             self._pending.pop(request_id, None)
+            self._pending_sessions.pop(request_id, None)
 
         if choice == "session":
             self._session_overrides.setdefault(ctx.session_id, set()).add((tool_name, phone))
@@ -203,6 +225,27 @@ class PermissionGate:
     def clear_session(self, session_id: str) -> None:
         """Clear session overrides for a specific session_id."""
         self._session_overrides.pop(session_id, None)
+        for request_id, pending_session_id in list(self._pending_sessions.items()):
+            if pending_session_id != session_id:
+                continue
+            future = self._pending.get(request_id)
+            if future is not None and not future.done():
+                future.cancel()
+            self._pending.pop(request_id, None)
+            self._pending_sessions.pop(request_id, None)
+        for key, lock in list(self._session_prompt_locks.items()):
+            if key[0] == session_id and not lock.locked():
+                self._session_prompt_locks.pop(key, None)
+
+    def cancel_all(self) -> None:
+        """Cancel all pending permission prompts and clear in-memory grants."""
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+        self._pending_sessions.clear()
+        self._session_overrides.clear()
+        self._session_prompt_locks.clear()
 
 
 def _text_response(text: str) -> dict:

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -106,8 +106,10 @@ class PermissionGate:
     _session_overrides: dict[str, set[tuple[str, str]]] = field(default_factory=dict)
     # request_id (UUID str) → Future that resolves with "once"|"session"|"deny"
     _pending: dict[str, asyncio.Future] = field(default_factory=dict)
-    # request_id → session_id, so clear_session/cancel_all can unblock visible prompts
+    # request_id → session_id, so clear_thread/cancel_all can unblock visible prompts
     _pending_sessions: dict[str, str] = field(default_factory=dict)
+    # request_id → thread_id, so thread deletion cancels only its own visible prompt
+    _pending_threads: dict[str, int] = field(default_factory=dict)
     # (session_id, event_loop_id) → lock.  A lock is loop-bound once contended,
     # so tests and embedded runtimes that create fresh loops need separate locks.
     _session_prompt_locks: dict[tuple[str, int], asyncio.Lock] = field(default_factory=dict)
@@ -157,6 +159,7 @@ class PermissionGate:
         future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
         self._pending_sessions[request_id] = ctx.session_id
+        self._pending_threads[request_id] = ctx.thread_id
 
         event = json.dumps(
             {
@@ -183,12 +186,14 @@ class PermissionGate:
         except asyncio.CancelledError:
             self._pending.pop(request_id, None)
             self._pending_sessions.pop(request_id, None)
+            self._pending_threads.pop(request_id, None)
             if not future.done():
                 future.cancel()
             raise
         finally:
             self._pending.pop(request_id, None)
             self._pending_sessions.pop(request_id, None)
+            self._pending_threads.pop(request_id, None)
 
         if choice == "session":
             self._session_overrides.setdefault(ctx.session_id, set()).add((tool_name, phone))
@@ -225,14 +230,23 @@ class PermissionGate:
     def clear_session(self, session_id: str) -> None:
         """Clear session overrides for a specific session_id."""
         self._session_overrides.pop(session_id, None)
+        for key, lock in list(self._session_prompt_locks.items()):
+            if key[0] == session_id and not lock.locked():
+                self._session_prompt_locks.pop(key, None)
+
+    def clear_thread(self, session_id: str, thread_id: int) -> None:
+        """Cancel pending permission prompts for one thread in one session."""
         for request_id, pending_session_id in list(self._pending_sessions.items()):
             if pending_session_id != session_id:
+                continue
+            if self._pending_threads.get(request_id) != thread_id:
                 continue
             future = self._pending.get(request_id)
             if future is not None and not future.done():
                 future.cancel()
             self._pending.pop(request_id, None)
             self._pending_sessions.pop(request_id, None)
+            self._pending_threads.pop(request_id, None)
         for key, lock in list(self._session_prompt_locks.items()):
             if key[0] == session_id and not lock.locked():
                 self._session_prompt_locks.pop(key, None)
@@ -244,6 +258,7 @@ class PermissionGate:
                 future.cancel()
         self._pending.clear()
         self._pending_sessions.clear()
+        self._pending_threads.clear()
         self._session_overrides.clear()
         self._session_prompt_locks.clear()
 

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -36,6 +36,29 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class PermissionWaitTracker:
+    """Thread-safe marker for sync bridges blocked on interactive permissions."""
+
+    _event: threading.Event = field(default_factory=threading.Event)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _count: int = 0
+
+    def begin(self) -> None:
+        with self._lock:
+            self._count += 1
+            self._event.set()
+
+    def end(self) -> None:
+        with self._lock:
+            self._count = max(0, self._count - 1)
+            if self._count == 0:
+                self._event.clear()
+
+    def is_waiting(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass
 class AgentRequestContext:
     session_id: str                   # UUID — unique per TUI launch / web session
     thread_id: int
@@ -45,6 +68,7 @@ class AgentRequestContext:
     permission_gate: PermissionGate | None = None
     permission_timeout: int | None = None  # legacy config field; prompts no longer time out
     cancel_event: threading.Event | None = None
+    permission_wait_tracker: PermissionWaitTracker | None = None
 
 
 _request_ctx: ContextVar[AgentRequestContext | None] = ContextVar(
@@ -149,11 +173,18 @@ class PermissionGate:
             return None
 
         lock = self._prompt_lock(ctx.session_id)
-        async with lock:
-            # Another request may have received "session" while we were queued.
-            if self.is_session_approved(tool_name, ctx.session_id, phone):
-                return None
-            return await self._ask_user(ctx, tool_name, phone)
+        tracker = ctx.permission_wait_tracker
+        if tracker is not None:
+            tracker.begin()
+        try:
+            async with lock:
+                # Another request may have received "session" while we were queued.
+                if self.is_session_approved(tool_name, ctx.session_id, phone):
+                    return None
+                return await self._ask_user(ctx, tool_name, phone)
+        finally:
+            if tracker is not None:
+                tracker.end()
 
     async def _ask_user(self, ctx: AgentRequestContext, tool_name: str, phone: str) -> dict | None:
         """Emit one permission prompt and wait indefinitely for the user's choice."""

--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -39,7 +39,7 @@ class AgentRuntimeContext:
     scheduler_manager: object | None = None
     runtime_kind: RuntimeKind = "none"
     owner_loop: asyncio.AbstractEventLoop | None = None
-    sync_timeout_sec: float = 120.0
+    sync_timeout_sec: float | None = None
 
     @classmethod
     def build(
@@ -57,11 +57,6 @@ class AgentRuntimeContext:
                 owner_loop = asyncio.get_running_loop()
             except RuntimeError:
                 owner_loop = None
-        sync_timeout_sec = 120.0
-        agent_config = getattr(config, "agent", None)
-        permission_timeout = getattr(agent_config, "permission_timeout", None)
-        if isinstance(permission_timeout, (int, float)):
-            sync_timeout_sec = max(sync_timeout_sec, float(permission_timeout) + 5.0)
         return cls(
             db=db,
             config=config,
@@ -69,7 +64,6 @@ class AgentRuntimeContext:
             scheduler_manager=scheduler_manager,
             runtime_kind=runtime_kind or detect_runtime_kind(client_pool),
             owner_loop=owner_loop,
-            sync_timeout_sec=sync_timeout_sec,
         )
 
     @property
@@ -99,6 +93,8 @@ class AgentRuntimeContext:
                     retryable=True,
                 )
             future = asyncio.run_coroutine_threadsafe(operation(), self.owner_loop)
+            if self.sync_timeout_sec is None:
+                return future.result()
             try:
                 return future.result(timeout=self.sync_timeout_sec)
             except FutureTimeoutError as exc:

--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -94,7 +94,25 @@ class AgentRuntimeContext:
                 )
             future = asyncio.run_coroutine_threadsafe(operation(), self.owner_loop)
             if self.sync_timeout_sec is None:
-                return future.result()
+                cancel_event = None
+                try:
+                    from src.agent.permission_gate import get_request_context
+
+                    request_context = get_request_context()
+                    cancel_event = request_context.cancel_event if request_context is not None else None
+                except (AttributeError, LookupError):
+                    cancel_event = None
+                while True:
+                    if cancel_event is not None and cancel_event.is_set():
+                        future.cancel()
+                        raise AgentToolRuntimeError(
+                            f"Agent tool '{tool_name}' was cancelled while waiting for the live Telegram runtime.",
+                            retryable=True,
+                        )
+                    try:
+                        return future.result(timeout=0.5)
+                    except FutureTimeoutError:
+                        continue
             try:
                 return future.result(timeout=self.sync_timeout_sec)
             except FutureTimeoutError as exc:

--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from typing import Literal, TypeVar
 
 _T = TypeVar("_T")
 RuntimeKind = Literal["live", "snapshot", "none"]
+DEFAULT_SYNC_TIMEOUT_SEC = 120.0
 
 
 class AgentToolRuntimeError(RuntimeError):
@@ -39,7 +41,7 @@ class AgentRuntimeContext:
     scheduler_manager: object | None = None
     runtime_kind: RuntimeKind = "none"
     owner_loop: asyncio.AbstractEventLoop | None = None
-    sync_timeout_sec: float | None = None
+    sync_timeout_sec: float | None = DEFAULT_SYNC_TIMEOUT_SEC
 
     @classmethod
     def build(
@@ -93,34 +95,63 @@ class AgentRuntimeContext:
                     retryable=True,
                 )
             future = asyncio.run_coroutine_threadsafe(operation(), self.owner_loop)
-            if self.sync_timeout_sec is None:
-                cancel_event = None
-                try:
-                    from src.agent.permission_gate import get_request_context
+            cancel_event = None
+            permission_wait_tracker = None
+            try:
+                from src.agent.permission_gate import get_request_context
 
-                    request_context = get_request_context()
-                    cancel_event = request_context.cancel_event if request_context is not None else None
-                except (AttributeError, LookupError):
-                    cancel_event = None
-                while True:
-                    if cancel_event is not None and cancel_event.is_set():
+                request_context = get_request_context()
+                if request_context is not None:
+                    cancel_event = request_context.cancel_event
+                    permission_wait_tracker = request_context.permission_wait_tracker
+            except (AttributeError, LookupError):
+                cancel_event = None
+                permission_wait_tracker = None
+
+            deadline = (
+                time.monotonic() + self.sync_timeout_sec
+                if self.sync_timeout_sec is not None
+                else None
+            )
+            while True:
+                if cancel_event is not None and cancel_event.is_set():
+                    future.cancel()
+                    raise AgentToolRuntimeError(
+                        f"Agent tool '{tool_name}' was cancelled while waiting for the live Telegram runtime.",
+                        retryable=True,
+                    )
+
+                permission_waiting = (
+                    permission_wait_tracker is not None
+                    and permission_wait_tracker.is_waiting()
+                )
+                poll_timeout = 0.5
+                started_at = time.monotonic()
+                if deadline is not None and not permission_waiting:
+                    remaining = deadline - started_at
+                    if remaining <= 0:
                         future.cancel()
                         raise AgentToolRuntimeError(
-                            f"Agent tool '{tool_name}' was cancelled while waiting for the live Telegram runtime.",
+                            f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime.",
                             retryable=True,
                         )
-                    try:
-                        return future.result(timeout=0.5)
-                    except FutureTimeoutError:
-                        continue
-            try:
-                return future.result(timeout=self.sync_timeout_sec)
-            except FutureTimeoutError as exc:
-                future.cancel()
-                raise AgentToolRuntimeError(
-                    f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime.",
-                    retryable=True,
-                ) from exc
+                    poll_timeout = min(poll_timeout, remaining)
+
+                try:
+                    return future.result(timeout=poll_timeout)
+                except FutureTimeoutError as exc:
+                    permission_waiting = (
+                        permission_wait_tracker is not None
+                        and permission_wait_tracker.is_waiting()
+                    )
+                    if deadline is not None and permission_waiting:
+                        deadline += time.monotonic() - started_at
+                    elif deadline is not None and deadline <= time.monotonic():
+                        future.cancel()
+                        raise AgentToolRuntimeError(
+                            f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime.",
+                            retryable=True,
+                        ) from exc
 
         if current_loop is None:
             return asyncio.run(operation())

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -579,7 +579,7 @@ class AgentTuiApp(App):
                     dialog = PermissionDialog(payload["tool"], payload.get("phone", ""))
                     choice = await self.push_screen_wait(dialog)
                     if not self.agent_manager.permission_gate.resolve(payload["request_id"], choice):
-                        widget._append_log("  ⚠️ Запрос разрешения уже истёк или был обработан.")
+                        widget._append_log("  ⚠️ Запрос разрешения уже обработан или был отменён.")
                     continue
                 if event_type == "thinking":
                     widget.set_pending_status("Думает...")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -127,6 +127,7 @@ async def delete_thread(request: Request, thread_id: int):
     await db.delete_agent_thread(thread_id)
     if agent_manager is not None and agent_manager.permission_gate is not None:
         session_id = request.cookies.get("session", "web")
+        agent_manager.permission_gate.clear_thread(session_id, thread_id)
         agent_manager.permission_gate.clear_session(session_id)
     return {"ok": True, "cancelled": cancelled}
 

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -120,12 +120,15 @@ async def create_thread(request: Request):
 @router.delete("/threads/{thread_id}")
 async def delete_thread(request: Request, thread_id: int):
     db = deps.get_db(request)
-    await db.delete_agent_thread(thread_id)
     agent_manager = deps.get_agent_manager(request)
+    cancelled = False
+    if agent_manager is not None:
+        cancelled = await agent_manager.cancel_stream(thread_id)
+    await db.delete_agent_thread(thread_id)
     if agent_manager is not None and agent_manager.permission_gate is not None:
         session_id = request.cookies.get("session", "web")
         agent_manager.permission_gate.clear_session(session_id)
-    return {"ok": True}
+    return {"ok": True, "cancelled": cancelled}
 
 
 @router.post("/threads/{thread_id}/rename")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -123,7 +123,7 @@ async def delete_thread(request: Request, thread_id: int):
     agent_manager = deps.get_agent_manager(request)
     cancelled = False
     if agent_manager is not None:
-        cancelled = await agent_manager.cancel_stream(thread_id)
+        cancelled = await agent_manager.cancel_stream(thread_id, wait_timeout=5.0)
     await db.delete_agent_thread(thread_id)
     if agent_manager is not None and agent_manager.permission_gate is not None:
         session_id = request.cookies.get("session", "web")

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -468,6 +468,12 @@
 }
 .perm-item.perm-selected { color: var(--bs-primary); }
 .perm-hint { margin-top: 0.75rem; color: var(--bs-secondary-color); font-size: 0.8rem; }
+.perm-error {
+    margin-top: 0.75rem;
+    color: var(--bs-danger-text-emphasis);
+    font-size: 0.8rem;
+    white-space: normal;
+}
 
 /* Tool call visibility */
 .tool-status-line {
@@ -742,12 +748,15 @@
         return d.innerHTML;
     }
 
-    function showPermissionDialog(toolName, phone) {
+    function showPermissionDialog(toolName, phone, errorMessage) {
         return new Promise(function(resolve) {
             document.querySelectorAll('#permission-modal').forEach(function(el) {
                 if (el.parentNode) el.parentNode.removeChild(el);
             });
             var phoneStr = phone ? ' (' + escapeHtml(phone) + ')' : '';
+            var errorHtml = errorMessage
+                ? '<div class="perm-error">' + escapeHtml(errorMessage) + '</div>'
+                : '';
             var modal = document.createElement('div');
             modal.id = 'permission-modal';
             modal.innerHTML =
@@ -759,6 +768,7 @@
                 '<div class="perm-item" data-choice="session" tabindex="0"><span class="perm-cursor"> </span> 2. Разрешить в этой сессии</div>' +
                 '<div class="perm-item" data-choice="deny" tabindex="0"><span class="perm-cursor"> </span> 3. Запретить</div>' +
                 '</div>' +
+                errorHtml +
                 '<div class="perm-hint">↑↓ навигация &nbsp;·&nbsp; Enter выбор &nbsp;·&nbsp; Esc = Запретить</div>' +
                 '</div>';
             document.body.appendChild(modal);
@@ -835,7 +845,9 @@
         });
         var permissionResult = await permissionResp.json().catch(function() { return {}; });
         if (!permissionResp.ok || !permissionResult.ok) {
-            throw new Error(permissionResult.detail || ('Permission resolve failed: HTTP ' + permissionResp.status));
+            var err = new Error(permissionResult.detail || ('Permission resolve failed: HTTP ' + permissionResp.status));
+            err.status = permissionResp.status;
+            throw err;
         }
     }
 
@@ -1124,14 +1136,23 @@
                     try {
                         var data = JSON.parse(jsonStr);
                         if (data.type === 'permission_request') {
-                            var choice = await showPermissionDialog(data.tool, data.phone || '');
-                            try {
-                                await resolvePermissionRequest(data.request_id, choice);
-                            } catch (fetchErr) {
-                                console.error('Permission POST failed:', fetchErr);
-                                statusTracker.onWarning(
-                                    'Запрос разрешения уже обработан или был отменён. Повторите действие, если нужно.'
-                                );
+                            var permissionError = '';
+                            while (true) {
+                                var choice = await showPermissionDialog(data.tool, data.phone || '', permissionError);
+                                try {
+                                    await resolvePermissionRequest(data.request_id, choice);
+                                    break;
+                                } catch (fetchErr) {
+                                    console.error('Permission POST failed:', fetchErr);
+                                    if (fetchErr.status && fetchErr.status < 500) {
+                                        statusTracker.onWarning(
+                                            'Запрос разрешения уже обработан или был отменён. Повторите действие, если нужно.'
+                                        );
+                                        break;
+                                    }
+                                    permissionError = 'Не удалось отправить выбор. Проверьте соединение и выберите ещё раз.';
+                                    statusTracker.onWarning(permissionError);
+                                }
                             }
                         } else if (data.type === 'thinking') {
                             statusTracker.onThinking();

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -1130,7 +1130,7 @@
                             } catch (fetchErr) {
                                 console.error('Permission POST failed:', fetchErr);
                                 statusTracker.onWarning(
-                                    'Не удалось отправить выбор разрешения. Запрос разрешения истечёт по таймауту.'
+                                    'Запрос разрешения уже обработан или был отменён. Повторите действие, если нужно.'
                                 );
                             }
                         } else if (data.type === 'thinking') {

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -434,7 +434,7 @@ def test_permission_dialog_keyboard_and_post_contract():
     assert "resolvePermissionRequest(data.request_id, choice)" in template
     assert "!permissionResp.ok || !permissionResult.ok" in template
     assert "body: JSON.stringify({choice: 'deny'})" not in template
-    assert "sending deny" not in template
+    assert "истечёт по таймауту" not in template
 
 
 # ── delete_thread: lines 86-88 (permission gate clearing) ──────────────

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -433,6 +433,9 @@ def test_permission_dialog_keyboard_and_post_contract():
     assert "pick('session')" in template
     assert "resolvePermissionRequest(data.request_id, choice)" in template
     assert "!permissionResp.ok || !permissionResult.ok" in template
+    assert "while (true)" in template
+    assert "showPermissionDialog(data.tool, data.phone || '', permissionError)" in template
+    assert "Не удалось отправить выбор. Проверьте соединение и выберите ещё раз." in template
     assert "body: JSON.stringify({choice: 'deny'})" not in template
     assert "истечёт по таймауту" not in template
 

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -448,13 +448,19 @@ async def test_delete_thread_clears_permission_gate(client, db):
     """Test delete thread clears permission gate for session (lines 86-88)."""
     thread_id = await db.create_agent_thread("Perm")
 
+    mock_mgr = MagicMock()
+    mock_mgr.cancel_stream = AsyncMock(return_value=True)
     mock_gate = MagicMock()
     mock_gate.clear_thread = MagicMock()
     mock_gate.clear_session = MagicMock()
-    client._transport_app.state.agent_manager.permission_gate = mock_gate
+    mock_mgr.permission_gate = mock_gate
+    client._transport_app.state.agent_manager = mock_mgr
 
     resp = await client.delete(f"/agent/threads/{thread_id}")
     assert resp.status_code == 200
+    data = json.loads(resp.text)
+    assert data["cancelled"] is True
+    mock_mgr.cancel_stream.assert_called_once_with(thread_id, wait_timeout=5.0)
     mock_gate.clear_thread.assert_called_once_with("web", thread_id)
     mock_gate.clear_session.assert_called_once_with("web")
 

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -446,12 +446,14 @@ async def test_delete_thread_clears_permission_gate(client, db):
     thread_id = await db.create_agent_thread("Perm")
 
     mock_gate = MagicMock()
+    mock_gate.clear_thread = MagicMock()
     mock_gate.clear_session = MagicMock()
     client._transport_app.state.agent_manager.permission_gate = mock_gate
 
     resp = await client.delete(f"/agent/threads/{thread_id}")
     assert resp.status_code == 200
-    mock_gate.clear_session.assert_called_once()
+    mock_gate.clear_thread.assert_called_once_with("web", thread_id)
+    mock_gate.clear_session.assert_called_once_with("web")
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1890,6 +1891,27 @@ class TestAgentManagerChatStreamErrors:
         mgr.initialize()
         result = await mgr.cancel_stream(999)
         assert result is False
+
+    @pytest.mark.anyio
+    async def test_cancel_stream_sets_runtime_cancel_event_and_clears_thread(self, db):
+        """cancel_stream unblocks sync tool waits tied to the cancelled thread."""
+        mgr = AgentManager(db)
+        cancel_event = threading.Event()
+        task = asyncio.create_task(asyncio.sleep(100))
+        mgr._active_tasks[123] = task
+        mgr._active_task_sessions[123] = "session-123"
+        mgr._active_task_cancel_events[123] = cancel_event
+        mgr.permission_gate.clear_thread = MagicMock()
+
+        result = await mgr.cancel_stream(123)
+
+        assert result is True
+        assert cancel_event.is_set()
+        mgr.permission_gate.clear_thread.assert_called_once_with("session-123", 123)
+        assert 123 not in mgr._active_tasks
+        assert 123 not in mgr._active_task_sessions
+        assert 123 not in mgr._active_task_cancel_events
+        assert task.cancelled() or task.done()
 
     @pytest.mark.anyio
     async def test_chat_stream_with_invalid_model_for_claude(self, db):

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -7,6 +7,7 @@ import json
 import os
 import threading
 import time
+from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1912,6 +1913,41 @@ class TestAgentManagerChatStreamErrors:
         assert 123 not in mgr._active_task_sessions
         assert 123 not in mgr._active_task_cancel_events
         assert task.cancelled() or task.done()
+
+    @pytest.mark.anyio
+    async def test_cancel_stream_timeout_does_not_wait_forever(self, db):
+        """cancel_stream can bound the wait for tasks that ignore cancellation."""
+        mgr = AgentManager(db)
+        stop = False
+        started = asyncio.Event()
+
+        async def _stubborn_task():
+            nonlocal stop
+            started.set()
+            while not stop:
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    if stop:
+                        raise
+                    continue
+
+        task = asyncio.create_task(_stubborn_task())
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        mgr._active_tasks[123] = task
+
+        started_at = time.monotonic()
+        result = await mgr.cancel_stream(123, wait_timeout=0.01)
+
+        assert result is True
+        assert time.monotonic() - started_at < 0.5
+        assert 123 not in mgr._active_tasks
+        assert not task.done()
+
+        stop = True
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     @pytest.mark.anyio
     async def test_chat_stream_with_invalid_model_for_claude(self, db):

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -180,6 +180,80 @@ async def test_deepagents_send_reaction_permission_allow_reaches_action_service(
 
 
 @pytest.mark.anyio
+async def test_deepagents_parallel_send_reaction_session_allow_prompts_once(mock_db):
+    from src.agent.permission_gate import (
+        AgentRequestContext,
+        PermissionGate,
+        reset_request_context,
+        set_gate,
+        set_request_context,
+    )
+    from src.agent.runtime_context import AgentRuntimeContext
+    from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+    mock_db.get_setting = AsyncMock(return_value=json.dumps({"+79001234567": {"pin_message": True}}))
+    mock_db.get_account_summaries = AsyncMock(return_value=[
+        SimpleNamespace(phone="+79001234567", is_primary=True, session_status="ok")
+    ])
+    command_repo = MagicMock()
+    command_repo.find_active_by_type = AsyncMock(return_value=None)
+    command_repo.create_command = AsyncMock(return_value=55)
+    command_repo.get_command = AsyncMock(return_value=SimpleNamespace(id=55, status="pending"))
+    mock_db.repos = MagicMock()
+    mock_db.repos.telegram_commands = command_repo
+    runtime_context = AgentRuntimeContext.build(
+        db=mock_db,
+        client_pool=MagicMock(),
+        runtime_kind="live",
+        owner_loop=asyncio.get_running_loop(),
+    )
+    tool_map = {
+        tool.__name__: tool
+        for tool in build_deepagents_tools(mock_db, client_pool=MagicMock(), runtime_context=runtime_context)
+    }
+    gate = PermissionGate()
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    ctx = AgentRequestContext(
+        session_id="deepagents-parallel-session",
+        thread_id=1,
+        queue=queue,
+        permission_timeout=5,
+    )
+    set_gate(gate)
+    token = set_request_context(ctx)
+    try:
+        tasks = [
+            asyncio.create_task(
+                asyncio.to_thread(
+                    tool_map["send_reaction"],
+                    chat_id="@chat",
+                    message_id=message_id,
+                    emoji="👍",
+                    confirm=True,
+                )
+            )
+            for message_id in (1, 2)
+        ]
+
+        event = await asyncio.wait_for(queue.get(), timeout=2)
+        payload = json.loads(event.removeprefix("data: ").strip())
+        assert payload["tool"] == "send_reaction"
+        assert payload["phone"] == "+79001234567"
+        await asyncio.sleep(0.05)
+        assert queue.empty()
+
+        gate.resolve(payload["request_id"], "session")
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+
+        assert all("Реакция '👍' принята в очередь" in result for result in results)
+        assert command_repo.create_command.await_count == 2
+        assert queue.empty()
+    finally:
+        reset_request_context(token)
+        set_gate(None)
+
+
+@pytest.mark.anyio
 async def test_deepagents_send_reaction_explicit_false_does_not_prompt(mock_db):
     from src.agent.permission_gate import (
         AgentRequestContext,

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -1087,20 +1087,20 @@ class TestAgentRuntimeContextRunSync:
         result = AgentRuntimeContext.build(db=MagicMock()).run_sync("test_tool", _op)
         assert result == 42
 
-    def test_sync_bridge_has_no_default_permission_timeout_ceiling(self):
-        from src.agent.runtime_context import AgentRuntimeContext
+    def test_sync_bridge_keeps_runtime_timeout_independent_from_permission_timeout(self):
+        from src.agent.runtime_context import DEFAULT_SYNC_TIMEOUT_SEC, AgentRuntimeContext
 
         config = MagicMock()
         config.agent.permission_timeout = 77
 
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
-        assert ctx.sync_timeout_sec is None
+        assert ctx.sync_timeout_sec == DEFAULT_SYNC_TIMEOUT_SEC
 
         config.agent.permission_timeout = 130
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
-        assert ctx.sync_timeout_sec is None
+        assert ctx.sync_timeout_sec == DEFAULT_SYNC_TIMEOUT_SEC
 
     @pytest.mark.anyio
     async def test_inside_event_loop_raises(self):
@@ -1151,6 +1151,86 @@ class TestAgentRuntimeContextRunSync:
             with pytest.raises(AgentToolRuntimeError, match="cancelled"):
                 await asyncio.wait_for(task, timeout=2.0)
             await asyncio.wait_for(cancelled.wait(), timeout=2.0)
+        finally:
+            reset_request_context(token)
+
+    @pytest.mark.anyio
+    async def test_sync_bridge_times_out_non_permission_waits(self):
+        from src.agent.runtime_context import AgentRuntimeContext, AgentToolRuntimeError
+
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        ctx = AgentRuntimeContext.build(
+            db=MagicMock(),
+            client_pool=MagicMock(),
+            runtime_kind="live",
+            owner_loop=asyncio.get_running_loop(),
+        )
+        ctx.sync_timeout_sec = 0.05
+
+        async def _op():
+            started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        task = asyncio.create_task(asyncio.to_thread(ctx.run_sync, "test_tool", _op))
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        with pytest.raises(AgentToolRuntimeError, match="timed out"):
+            await asyncio.wait_for(task, timeout=2.0)
+        await asyncio.wait_for(cancelled.wait(), timeout=2.0)
+
+    @pytest.mark.anyio
+    async def test_sync_bridge_excludes_permission_waits_from_runtime_timeout(self):
+        from src.agent.permission_gate import (
+            AgentRequestContext,
+            PermissionWaitTracker,
+            reset_request_context,
+            set_request_context,
+        )
+        from src.agent.runtime_context import AgentRuntimeContext
+
+        tracker = PermissionWaitTracker()
+        cancel_event = threading.Event()
+        started = asyncio.Event()
+        release = asyncio.Event()
+        ctx = AgentRuntimeContext.build(
+            db=MagicMock(),
+            client_pool=MagicMock(),
+            runtime_kind="live",
+            owner_loop=asyncio.get_running_loop(),
+        )
+        ctx.sync_timeout_sec = 0.05
+        request_ctx = AgentRequestContext(
+            session_id="sync-permission-wait",
+            thread_id=1,
+            queue=asyncio.Queue(),
+            cancel_event=cancel_event,
+            permission_wait_tracker=tracker,
+        )
+
+        async def _op():
+            tracker.begin()
+            started.set()
+            try:
+                await release.wait()
+            finally:
+                tracker.end()
+            return "ok"
+
+        token = set_request_context(request_ctx)
+        try:
+            task = asyncio.create_task(asyncio.to_thread(ctx.run_sync, "test_tool", _op))
+            await asyncio.wait_for(started.wait(), timeout=2.0)
+            await asyncio.sleep(0.12)
+            assert not task.done()
+
+            release.set()
+
+            assert await asyncio.wait_for(task, timeout=2.0) == "ok"
         finally:
             reset_request_context(token)
 

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -14,6 +14,7 @@ Targets:
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -1110,6 +1111,48 @@ class TestAgentRuntimeContextRunSync:
 
         with pytest.raises(RuntimeError, match="cannot run inside"):
             AgentRuntimeContext.build(db=MagicMock()).run_sync("test_tool", _op)
+
+    @pytest.mark.anyio
+    async def test_sync_bridge_unbounded_wait_stops_on_request_cancel(self):
+        from src.agent.permission_gate import AgentRequestContext, reset_request_context, set_request_context
+        from src.agent.runtime_context import AgentRuntimeContext, AgentToolRuntimeError
+
+        cancel_event = threading.Event()
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        ctx = AgentRuntimeContext.build(
+            db=MagicMock(),
+            client_pool=MagicMock(),
+            runtime_kind="live",
+            owner_loop=asyncio.get_running_loop(),
+        )
+        request_ctx = AgentRequestContext(
+            session_id="sync-cancel",
+            thread_id=1,
+            queue=asyncio.Queue(),
+            cancel_event=cancel_event,
+        )
+
+        async def _op():
+            started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        token = set_request_context(request_ctx)
+        try:
+            task = asyncio.create_task(asyncio.to_thread(ctx.run_sync, "test_tool", _op))
+            await asyncio.wait_for(started.wait(), timeout=2.0)
+
+            cancel_event.set()
+
+            with pytest.raises(AgentToolRuntimeError, match="cancelled"):
+                await asyncio.wait_for(task, timeout=2.0)
+            await asyncio.wait_for(cancelled.wait(), timeout=2.0)
+        finally:
+            reset_request_context(token)
 
 
 class TestDeepagentsSyncTools:

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -1086,7 +1086,7 @@ class TestAgentRuntimeContextRunSync:
         result = AgentRuntimeContext.build(db=MagicMock()).run_sync("test_tool", _op)
         assert result == 42
 
-    def test_sync_timeout_exceeds_permission_timeout(self):
+    def test_sync_bridge_has_no_default_permission_timeout_ceiling(self):
         from src.agent.runtime_context import AgentRuntimeContext
 
         config = MagicMock()
@@ -1094,12 +1094,12 @@ class TestAgentRuntimeContextRunSync:
 
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
-        assert ctx.sync_timeout_sec == 120.0
+        assert ctx.sync_timeout_sec is None
 
         config.agent.permission_timeout = 130
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
-        assert ctx.sync_timeout_sec == 135.0
+        assert ctx.sync_timeout_sec is None
 
     @pytest.mark.anyio
     async def test_inside_event_loop_raises(self):

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -107,9 +107,70 @@ def test_clear_session():
     assert "session-1" not in gate._session_overrides
 
 
+@pytest.mark.anyio
+async def test_clear_session_does_not_cancel_pending_prompts():
+    gate = PermissionGate()
+    future = asyncio.get_running_loop().create_future()
+    gate._session_overrides["session-1"] = {("tool_a", "+1")}
+    gate._pending["request-1"] = future
+    gate._pending_sessions["request-1"] = "session-1"
+    gate._pending_threads["request-1"] = 10
+
+    gate.clear_session("session-1")
+
+    assert "session-1" not in gate._session_overrides
+    assert not future.cancelled()
+    assert gate._pending["request-1"] is future
+    assert gate._pending_sessions["request-1"] == "session-1"
+    assert gate._pending_threads["request-1"] == 10
+
+
 def test_clear_session_nonexistent():
     gate = PermissionGate()
     gate.clear_session("nonexistent")  # should not raise
+
+
+# ── clear_thread() ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_clear_thread_cancels_only_matching_thread():
+    gate = PermissionGate()
+    matching = asyncio.get_running_loop().create_future()
+    other_thread = asyncio.get_running_loop().create_future()
+    other_session = asyncio.get_running_loop().create_future()
+    gate._pending.update(
+        {
+            "matching": matching,
+            "other-thread": other_thread,
+            "other-session": other_session,
+        }
+    )
+    gate._pending_sessions.update(
+        {
+            "matching": "session-1",
+            "other-thread": "session-1",
+            "other-session": "session-2",
+        }
+    )
+    gate._pending_threads.update(
+        {
+            "matching": 10,
+            "other-thread": 11,
+            "other-session": 10,
+        }
+    )
+
+    gate.clear_thread("session-1", 10)
+
+    assert matching.cancelled()
+    assert not other_thread.cancelled()
+    assert not other_session.cancelled()
+    assert "matching" not in gate._pending
+    assert "other-thread" in gate._pending
+    assert "other-session" in gate._pending
+    assert gate._pending_threads["other-thread"] == 11
+    assert gate._pending_threads["other-session"] == 10
 
 
 # ── check() with no context ────────────────────────────────────────

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -246,24 +246,31 @@ async def test_check_user_denies():
         reset_request_context(token)
 
 
-# ── check() — timeout ──────────────────────────────────────────────
+# ── check() — no timeout ───────────────────────────────────────────
 
 
 @pytest.mark.anyio
-async def test_check_timeout():
+async def test_check_waits_without_permission_timeout():
     gate = PermissionGate()
     ctx = AgentRequestContext(
         session_id="session-5",
         thread_id=5,
         queue=asyncio.Queue(),
         db_permissions={},
-        permission_timeout=1,  # 1 second timeout
+        permission_timeout=0,
     )
     token = set_request_context(ctx)
     try:
-        result = await gate.check("my_tool", "")
-        assert result is not None
-        assert "Таймаут" in result["content"][0]["text"]
+        task = asyncio.create_task(gate.check("my_tool", ""))
+        event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        event_data = json.loads(event.removeprefix("data: ").strip())
+        assert event_data["timeout"] is None
+
+        done, _pending = await asyncio.wait({task}, timeout=0.05)
+        assert not done
+
+        gate.resolve(event_data["request_id"], "once")
+        assert await asyncio.wait_for(task, timeout=2.0) is None
     finally:
         reset_request_context(token)
 
@@ -293,6 +300,114 @@ async def test_check_cancelled_error_propagates():
 
         with pytest.raises(asyncio.CancelledError):
             await task
+    finally:
+        reset_request_context(token)
+
+
+# ── check() — serialized prompts ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_concurrent_session_grant_serializes_prompts_and_releases_all():
+    gate = PermissionGate()
+    ctx = AgentRequestContext(
+        session_id="session-queue-session",
+        thread_id=7,
+        queue=asyncio.Queue(),
+        db_permissions={},
+    )
+    token = set_request_context(ctx)
+    try:
+        tasks = [
+            asyncio.create_task(gate.check("send_reaction", "+1234567890"))
+            for _ in range(10)
+        ]
+
+        event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        event_data = json.loads(event.removeprefix("data: ").strip())
+        assert event_data["tool"] == "send_reaction"
+        assert event_data["phone"] == "+1234567890"
+        await asyncio.sleep(0.05)
+        assert ctx.queue.empty()
+
+        gate.resolve(event_data["request_id"], "session")
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2.0)
+
+        assert results == [None] * 10
+        assert ctx.queue.empty()
+        assert gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.anyio
+async def test_concurrent_once_grant_keeps_following_requests_queued():
+    gate = PermissionGate()
+    ctx = AgentRequestContext(
+        session_id="session-queue-once",
+        thread_id=8,
+        queue=asyncio.Queue(),
+        db_permissions={},
+    )
+    token = set_request_context(ctx)
+    try:
+        tasks = [
+            asyncio.create_task(gate.check("send_reaction", "+1234567890"))
+            for _ in range(3)
+        ]
+
+        first_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        first_data = json.loads(first_event.removeprefix("data: ").strip())
+        await asyncio.sleep(0.05)
+        assert ctx.queue.empty()
+
+        gate.resolve(first_data["request_id"], "once")
+        second_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        second_data = json.loads(second_event.removeprefix("data: ").strip())
+
+        assert second_data["request_id"] != first_data["request_id"]
+        assert not gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
+
+        gate.resolve(second_data["request_id"], "session")
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2.0)
+
+        assert results == [None] * 3
+        assert ctx.queue.empty()
+        assert gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.anyio
+async def test_concurrent_deny_does_not_store_session_grant():
+    gate = PermissionGate()
+    ctx = AgentRequestContext(
+        session_id="session-queue-deny",
+        thread_id=9,
+        queue=asyncio.Queue(),
+        db_permissions={},
+    )
+    token = set_request_context(ctx)
+    try:
+        tasks = [
+            asyncio.create_task(gate.check("send_reaction", "+1234567890"))
+            for _ in range(2)
+        ]
+
+        first_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        first_data = json.loads(first_event.removeprefix("data: ").strip())
+        gate.resolve(first_data["request_id"], "deny")
+
+        second_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        second_data = json.loads(second_event.removeprefix("data: ").strip())
+        assert not gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
+
+        gate.resolve(second_data["request_id"], "session")
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2.0)
+
+        assert any(result is not None for result in results)
+        assert any(result is None for result in results)
+        assert gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
     finally:
         reset_request_context(token)
 

--- a/tests/test_permission_gate.py
+++ b/tests/test_permission_gate.py
@@ -10,6 +10,7 @@ import pytest
 from src.agent.permission_gate import (
     AgentRequestContext,
     PermissionGate,
+    PermissionWaitTracker,
     _text_response,
     get_gate,
     get_request_context,
@@ -435,6 +436,43 @@ async def test_concurrent_once_grant_keeps_following_requests_queued():
         assert results == [None] * 3
         assert ctx.queue.empty()
         assert gate.is_session_approved("send_reaction", ctx.session_id, "+1234567890")
+    finally:
+        reset_request_context(token)
+
+
+@pytest.mark.anyio
+async def test_permission_wait_tracker_stays_active_for_queued_prompts():
+    gate = PermissionGate()
+    tracker = PermissionWaitTracker()
+    ctx = AgentRequestContext(
+        session_id="session-queue-tracker",
+        thread_id=10,
+        queue=asyncio.Queue(),
+        db_permissions={},
+        permission_wait_tracker=tracker,
+    )
+    token = set_request_context(ctx)
+    try:
+        tasks = [
+            asyncio.create_task(gate.check("send_reaction", "+1234567890"))
+            for _ in range(2)
+        ]
+
+        first_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        first_data = json.loads(first_event.removeprefix("data: ").strip())
+        await asyncio.sleep(0.05)
+        assert tracker.is_waiting()
+
+        gate.resolve(first_data["request_id"], "once")
+        second_event = await asyncio.wait_for(ctx.queue.get(), timeout=2.0)
+        second_data = json.loads(second_event.removeprefix("data: ").strip())
+        assert tracker.is_waiting()
+
+        gate.resolve(second_data["request_id"], "once")
+        results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2.0)
+
+        assert results == [None, None]
+        assert not tracker.is_waiting()
     finally:
         reset_request_context(token)
 


### PR DESCRIPTION
## Summary
- Serialize interactive agent permission prompts per session so parallel tool calls wait behind the visible request.
- Remove the permission timeout path and keep the agent paused until the user chooses once, session, or deny.
- Cancel and clean pending permission prompts when streams, threads, or the manager are stopped, and update Web/TUI timeout wording.

## Root Cause
Parallel `send_reaction` calls could all emit permission requests before the first user choice was processed, so the UI showed many dialogs and later requests could fail by timeout instead of respecting the session decision.

## Validation
- `ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto` — 7128 passed, 103 skipped
- `python3 -m pytest tests/ -v -m aiosqlite_serial` — 833 passed, 7231 deselected

Fixes #610