### PR TITLE
fix(web): repair search translations and post stats

### DIFF
--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -223,6 +223,14 @@ class MessagesRepository:
         ]
         try:
             existing_keys = await self._existing_message_keys(messages)
+        except Exception as exc:
+            logger.warning(
+                "Could not pre-fetch existing message keys for refresh, proceeding without: %s",
+                exc,
+            )
+            existing_keys = set()
+
+        try:
             cur = await self._database.executemany_write(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
@@ -236,13 +244,14 @@ class MessagesRepository:
                 data,
             )
             count = cur.rowcount if cur.rowcount >= 0 else len(messages)
-            if existing_keys:
-                duplicates = [m for m in messages if (m.channel_id, m.message_id) in existing_keys]
-                if duplicates:
-                    await self._refresh_existing_messages(duplicates)
         except Exception as exc:
             logger.error("Failed to insert batch of %d messages: %s", len(messages), exc)
             return 0
+
+        if existing_keys:
+            duplicates = [m for m in messages if (m.channel_id, m.message_id) in existing_keys]
+            if duplicates:
+                await self._refresh_existing_messages(duplicates)
 
         reactions_data = [
             (m.channel_id, m.message_id, r["emoji"], r.get("count", 0))

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -157,6 +157,8 @@ class MessagesRepository:
                 ),
             )
             inserted = cur.rowcount > 0
+            if not inserted:
+                await self._refresh_existing_messages([msg])
             if msg.reactions_json:
                 await self._upsert_reactions(msg.channel_id, msg.message_id, msg.reactions_json)
             return inserted
@@ -233,6 +235,7 @@ class MessagesRepository:
                 data,
             )
             count = cur.rowcount if cur.rowcount >= 0 else len(messages)
+            await self._refresh_existing_messages(messages)
         except Exception as exc:
             logger.error("Failed to insert batch of %d messages: %s", len(messages), exc)
             return 0
@@ -254,6 +257,41 @@ class MessagesRepository:
                 logger.error("Failed to upsert reactions for batch: %s", exc)
 
         return count
+
+    async def _refresh_existing_messages(self, messages: list[Message]) -> None:
+        """Refresh mutable fields for already-known Telegram messages."""
+        if not messages:
+            return
+        data = [
+            (
+                m.views,
+                m.views,
+                m.forwards,
+                m.forwards,
+                m.reply_count,
+                m.reply_count,
+                m.reactions_json,
+                m.reactions_json,
+                m.detected_lang,
+                m.detected_lang,
+                m.channel_id,
+                m.message_id,
+            )
+            for m in messages
+        ]
+        try:
+            await self._database.executemany_write(
+                """UPDATE messages
+                   SET views = CASE WHEN ? IS NOT NULL THEN ? ELSE views END,
+                       forwards = CASE WHEN ? IS NOT NULL THEN ? ELSE forwards END,
+                       reply_count = CASE WHEN ? IS NOT NULL THEN ? ELSE reply_count END,
+                       reactions_json = CASE WHEN ? IS NOT NULL THEN ? ELSE reactions_json END,
+                       detected_lang = CASE WHEN ? IS NOT NULL THEN ? ELSE detected_lang END
+                   WHERE channel_id = ? AND message_id = ?""",
+                data,
+            )
+        except Exception as exc:
+            logger.error("Failed to refresh %d existing messages: %s", len(messages), exc)
 
     async def ensure_embeddings_table(self, dimensions: int) -> None:
         if dimensions < 1:
@@ -1220,6 +1258,24 @@ class MessagesRepository:
             return None
         msgs = self._rows_to_messages([row])
         return msgs[0] if msgs else None
+
+    async def get_messages_by_channel_message_ids(self, keys: list[tuple[int, int]]) -> list[Message]:
+        """Load messages by Telegram identity, preserving the requested order."""
+        if not keys:
+            return []
+        unique_keys = list(dict.fromkeys(keys))
+        predicates = " OR ".join("(m.channel_id = ? AND m.message_id = ?)" for _ in unique_keys)
+        params = [value for key in unique_keys for value in key]
+        cur = await self._db.execute(
+            f"""SELECT m.*, c.title AS channel_title, c.username AS channel_username
+                FROM messages m
+                LEFT JOIN channels c ON m.channel_id = c.channel_id
+                WHERE {predicates}""",
+            params,
+        )
+        rows = await cur.fetchall()
+        by_key = {(msg.channel_id, msg.message_id): msg for msg in self._rows_to_messages(rows)}
+        return [by_key[key] for key in keys if key in by_key]
 
     async def update_detected_lang(self, message_db_id: int, lang: str) -> None:
         """Update detected_lang for a message."""

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -222,6 +222,7 @@ class MessagesRepository:
             for m in messages
         ]
         try:
+            existing_keys = await self._existing_message_keys(messages)
             cur = await self._database.executemany_write(
                 """INSERT OR IGNORE INTO messages
                    (channel_id, message_id, sender_id, sender_name,
@@ -235,7 +236,10 @@ class MessagesRepository:
                 data,
             )
             count = cur.rowcount if cur.rowcount >= 0 else len(messages)
-            await self._refresh_existing_messages(messages)
+            if existing_keys:
+                duplicates = [m for m in messages if (m.channel_id, m.message_id) in existing_keys]
+                if duplicates:
+                    await self._refresh_existing_messages(duplicates)
         except Exception as exc:
             logger.error("Failed to insert batch of %d messages: %s", len(messages), exc)
             return 0
@@ -257,6 +261,25 @@ class MessagesRepository:
                 logger.error("Failed to upsert reactions for batch: %s", exc)
 
         return count
+
+    async def _existing_message_keys(self, messages: list[Message]) -> set[tuple[int, int]]:
+        """Return the subset of (channel_id, message_id) pairs already present in the DB."""
+        if not messages:
+            return set()
+        unique_keys = list({(m.channel_id, m.message_id) for m in messages})
+        existing: set[tuple[int, int]] = set()
+        chunk_size = 400
+        for start in range(0, len(unique_keys), chunk_size):
+            chunk = unique_keys[start : start + chunk_size]
+            predicates = " OR ".join("(channel_id = ? AND message_id = ?)" for _ in chunk)
+            params = [value for key in chunk for value in key]
+            cur = await self._db.execute(
+                f"SELECT channel_id, message_id FROM messages WHERE {predicates}",
+                params,
+            )
+            rows = await cur.fetchall()
+            existing.update((row["channel_id"], row["message_id"]) for row in rows)
+        return existing
 
     async def _refresh_existing_messages(self, messages: list[Message]) -> None:
         """Refresh mutable fields for already-known Telegram messages."""

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -43,16 +43,17 @@ class SearchPersistence:
         if not messages:
             return []
         keys = [(msg.channel_id, msg.message_id) for msg in messages]
+        unique_keys = set(keys)
         try:
             persisted = await self._search.messages.get_messages_by_channel_message_ids(keys)
         except Exception:
             logger.exception("Failed to load persisted messages; returning originals")
             return messages
         by_key = {(msg.channel_id, msg.message_id): msg for msg in persisted}
-        if len(by_key) < len(keys):
+        if len(by_key) < len(unique_keys):
             logger.warning(
                 "Partial persistence load: %d of %d messages found; falling back to originals for the rest",
                 len(by_key),
-                len(keys),
+                len(unique_keys),
             )
         return [by_key.get((msg.channel_id, msg.message_id), msg) for msg in messages]

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 from src.database.bundles import SearchBundle
 from src.models import Channel, Message
+
+logger = logging.getLogger(__name__)
 
 
 class SearchPersistence:
@@ -39,5 +43,16 @@ class SearchPersistence:
         if not messages:
             return []
         keys = [(msg.channel_id, msg.message_id) for msg in messages]
-        persisted = await self._search.messages.get_messages_by_channel_message_ids(keys)
-        return persisted or messages
+        try:
+            persisted = await self._search.messages.get_messages_by_channel_message_ids(keys)
+        except Exception:
+            logger.exception("Failed to load persisted messages; returning originals")
+            return messages
+        by_key = {(msg.channel_id, msg.message_id): msg for msg in persisted}
+        if len(by_key) < len(keys):
+            logger.warning(
+                "Partial persistence load: %d of %d messages found; falling back to originals for the rest",
+                len(by_key),
+                len(keys),
+            )
+        return [by_key.get((msg.channel_id, msg.message_id), msg) for msg in messages]

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -14,7 +14,7 @@ class SearchPersistence:
         messages: list[Message],
         phone: str,
         query: str,
-    ) -> None:
+    ) -> list[Message]:
         for ch in channels.values():
             await self._search.add_channel(ch)
 
@@ -22,13 +22,22 @@ class SearchPersistence:
             await self._search.insert_messages_batch(messages)
 
         await self._search.log_search(phone, query, len(messages))
+        return await self._load_persisted_messages(messages)
 
     async def cache_messages_and_channels(
         self,
         channels: dict[int, Channel],
         messages: list[Message],
-    ) -> None:
+    ) -> list[Message]:
         for ch in channels.values():
             await self._search.add_channel(ch)
         if messages:
             await self._search.insert_messages_batch(messages)
+        return await self._load_persisted_messages(messages)
+
+    async def _load_persisted_messages(self, messages: list[Message]) -> list[Message]:
+        if not messages:
+            return []
+        keys = [(msg.channel_id, msg.message_id) for msg in messages]
+        persisted = await self._search.messages.get_messages_by_channel_message_ids(keys)
+        return persisted or messages

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -172,7 +172,7 @@ class TelegramSearch:
                 result = clearer(phone)
                 if inspect.isawaitable(result):
                     await result
-            await self._persistence.cache_search_results(seen_channels, messages, phone, query)
+            messages = await self._persistence.cache_search_results(seen_channels, messages, phone, query)
             return SearchResult(messages=messages, total=len(messages), query=query)
         except HandledFloodWaitError as exc:
             reporter = getattr(self._pool, "report_premium_flood", None)
@@ -268,6 +268,7 @@ class TelegramSearch:
                         ),
                         channel_title=chat_title,
                         channel_username=chat_username,
+                        **TelegramMessageTransformer.engagement_fields_from_message(msg),
                     )
                 )
 
@@ -341,7 +342,7 @@ class TelegramSearch:
                 timeout=90.0,
             )
 
-            await self._persistence.cache_messages_and_channels(seen_channels, messages)
+            messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
             return SearchResult(messages=messages, total=len(messages), query=query)
         except HandledFloodWaitError as exc:
             return SearchResult(
@@ -477,7 +478,7 @@ class TelegramSearch:
                 timeout=90.0,
             )
 
-            await self._persistence.cache_messages_and_channels(seen_channels, messages)
+            messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
             return SearchResult(messages=messages, total=len(messages), query=query)
         except HandledFloodWaitError as exc:
             return SearchResult(

--- a/src/search/transformers.py
+++ b/src/search/transformers.py
@@ -3,10 +3,33 @@ from __future__ import annotations
 from datetime import timezone
 
 from src.models import Message
+from src.services.translation_service import TranslationService
 from src.telegram.identity import SenderIdentity, extract_message_sender_identity, extract_sender_identity
+from src.telegram.reactions import extract_message_reactions_json
 
 
 class TelegramMessageTransformer:
+    @staticmethod
+    def _optional_int(value) -> int | None:
+        if isinstance(value, bool) or value is None:
+            return None
+        return value if isinstance(value, int) else None
+
+    @staticmethod
+    def engagement_fields_from_message(msg) -> dict:
+        """Extract mutable post stats from a Telethon-like message."""
+        return {
+            "reactions_json": extract_message_reactions_json(msg),
+            "views": TelegramMessageTransformer._optional_int(getattr(msg, "views", None)),
+            "forwards": TelegramMessageTransformer._optional_int(getattr(msg, "forwards", None)),
+            "reply_count": TelegramMessageTransformer._optional_int(
+                getattr(getattr(msg, "replies", None), "replies", None)
+            ),
+            "detected_lang": TranslationService.detect_language(
+                getattr(msg, "message", None) or getattr(msg, "text", None)
+            ),
+        }
+
     @staticmethod
     def media_type_from_message(msg) -> str | None:
         from telethon.tl.types import (
@@ -88,6 +111,7 @@ class TelegramMessageTransformer:
             date=date,
             channel_title=chat_title,
             channel_username=chat_username,
+            **TelegramMessageTransformer.engagement_fields_from_message(msg),
         )
 
     @staticmethod

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -127,7 +127,7 @@
                 <span>{{ msg.text[:300] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 300 else "" }}</span>
                 {% if msg.translation_en %}
                 <div class="text-muted mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:300] }}{{ "..." if msg.translation_en|length > 300 else "" }}</div>
-                {% elif msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
+                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
                 <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
                 <div class="translation-result text-muted mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></div>
                 {% endif %}
@@ -160,7 +160,7 @@
                 {{ msg.text[:200] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 200 else "" }}
                 {% if msg.translation_en %}
                 <span class="text-muted d-block mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:200] }}{{ "..." if msg.translation_en|length > 200 else "" }}</span>
-                {% elif msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
+                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
                 <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
                 <span class="translation-result text-muted d-block mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></span>
                 {% endif %}
@@ -230,6 +230,14 @@ document.addEventListener('click', function(e) {
     if (!btn) return;
     e.preventDefault();
     var msgId = btn.dataset.msgId;
+    if (!/^\d+$/.test(msgId || '')) return;
+    function showTranslationStatus(text, isError) {
+        var container = btn.parentElement.querySelector('[data-target="translation-' + msgId + '"]');
+        if (!container) return;
+        container.textContent = text;
+        container.classList.toggle('text-danger', !!isError);
+        container.style.display = '';
+    }
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     btn.disabled = true;
     fetch('/search/translate/' + msgId, {
@@ -245,6 +253,7 @@ document.addEventListener('click', function(e) {
                 var icon = document.createElement('i');
                 icon.className = 'bi bi-translate me-1';
                 container.innerHTML = '';
+                container.classList.remove('text-danger');
                 container.appendChild(icon);
                 container.appendChild(document.createTextNode(data.translation));
                 container.style.display = '';
@@ -253,11 +262,15 @@ document.addEventListener('click', function(e) {
         } else if (data.same_lang) {
             btn.innerHTML = '<i class="bi bi-check"></i>';
         } else {
+            showTranslationStatus(data.error || 'Не удалось перевести сообщение', true);
             btn.innerHTML = '<i class="bi bi-x text-danger"></i>';
+            btn.disabled = false;
         }
     })
     .catch(function() {
+        showTranslationStatus('Ошибка запроса перевода', true);
         btn.innerHTML = '<i class="bi bi-x text-danger"></i>';
+        btn.disabled = false;
     });
 });
 </script>

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -172,6 +172,62 @@ async def test_insert_messages_batch_with_duplicates(messages_repo):
     assert "New" in texts
 
 
+async def test_insert_messages_batch_refreshes_duplicate_stats(messages_repo):
+    await messages_repo.insert_messages_batch(
+        [
+            make_message(
+                1,
+                100,
+                "Original",
+                views=10,
+                forwards=1,
+                reply_count=2,
+                reactions_json='[{"emoji": "👍", "count": 1}]',
+                detected_lang="ru",
+            )
+        ]
+    )
+    rows = await messages_repo._db.execute(
+        "SELECT id FROM messages WHERE channel_id = ? AND message_id = ?",
+        (1, 100),
+    )
+    message_db_id = (await rows.fetchone())["id"]
+    await messages_repo.update_translation(message_db_id, "en", "Cached translation")
+
+    count = await messages_repo.insert_messages_batch(
+        [
+            make_message(
+                1,
+                100,
+                "Duplicate text should not replace original",
+                views=25,
+                forwards=3,
+                reply_count=4,
+                reactions_json='[{"emoji": "👍", "count": 9}]',
+                detected_lang="uk",
+            )
+        ]
+    )
+
+    assert count == 0
+    messages, total = await messages_repo.search_messages()
+    assert total == 1
+    stored = messages[0]
+    assert stored.text == "Original"
+    assert stored.views == 25
+    assert stored.forwards == 3
+    assert stored.reply_count == 4
+    assert stored.reactions_json == '[{"emoji": "👍", "count": 9}]'
+    assert stored.detected_lang == "uk"
+    assert stored.translation_en == "Cached translation"
+    cur = await messages_repo._db.execute(
+        "SELECT count FROM message_reactions WHERE channel_id = ? AND message_id = ? AND emoji = ?",
+        (1, 100, "👍"),
+    )
+    reaction = await cur.fetchone()
+    assert reaction["count"] == 9
+
+
 async def test_insert_messages_batch_sender_identity_round_trips(messages_repo):
     messages = [
         make_message(

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import SearchResult
+from src.models import Message, SearchResult
 
 
 @pytest.mark.anyio
@@ -61,6 +62,69 @@ async def test_search_with_query(route_client, monkeypatch):
     resp = await route_client.get("/search?q=test")
     assert resp.status_code == 200
     mock_svc.search.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_search_result_does_not_render_translate_button_without_db_id(route_client, monkeypatch):
+    """Live/transient search results without DB id must not call /translate/None."""
+    mock_result = SearchResult(
+        messages=[
+            Message(
+                id=None,
+                channel_id=100,
+                message_id=1,
+                text="Привет, это достаточно длинный текст",
+                detected_lang="ru",
+                date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            )
+        ],
+        total=1,
+        query="привет",
+    )
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=mock_result)
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "src.web.routes.search.deps.search_service",
+        lambda r: mock_svc,
+    )
+
+    resp = await route_client.get("/search?q=привет")
+
+    assert resp.status_code == 200
+    assert 'data-msg-id="None"' not in resp.text
+    assert 'data-target="translation-None"' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_search_result_renders_translate_button_with_db_id(route_client, monkeypatch):
+    mock_result = SearchResult(
+        messages=[
+            Message(
+                id=123,
+                channel_id=100,
+                message_id=1,
+                text="Привет, это достаточно длинный текст",
+                detected_lang="ru",
+                date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            )
+        ],
+        total=1,
+        query="привет",
+    )
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=mock_result)
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "src.web.routes.search.deps.search_service",
+        lambda r: mock_svc,
+    )
+
+    resp = await route_client.get("/search?q=привет")
+
+    assert resp.status_code == 200
+    assert 'data-msg-id="123"' in resp.text
+    assert 'data-target="translation-123"' in resp.text
 
 
 @pytest.mark.anyio

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -142,6 +142,10 @@ def _make_mock_api_message(channel_id=100123, msg_id=42, text="Test message abou
     msg.message = text
     msg.date = datetime.now(timezone.utc)
     msg.media = None
+    msg.views = 123
+    msg.forwards = 4
+    msg.replies = SimpleNamespace(replies=5)
+    msg.reactions = None
     return msg
 
 
@@ -183,6 +187,10 @@ def _make_resolved_message(
     msg.text = text
     msg.date = datetime.now(timezone.utc)
     msg.media = None
+    msg.views = 123
+    msg.forwards = 4
+    msg.replies = SimpleNamespace(replies=5)
+    msg.reactions = None
     return msg
 
 
@@ -233,6 +241,10 @@ async def test_search_telegram_returns_results(db, real_pool_harness_factory):
     assert result.messages[0].message_id == 42
     assert result.messages[0].text == "Test message about AI"
     assert result.messages[0].channel_title == "Test Channel"
+    assert result.messages[0].id is not None
+    assert result.messages[0].views == 123
+    assert result.messages[0].forwards == 4
+    assert result.messages[0].reply_count == 5
 
 
 @pytest.mark.anyio

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from telethon.tl.types import (
@@ -108,6 +109,34 @@ def test_convert_telethon_message_basic():
     assert res.sender_last_name == "Doe"
     assert res.sender_username == "jdoe"
     assert res.date.tzinfo == timezone.utc
+
+
+def test_convert_telethon_message_includes_engagement_fields():
+    msg = SimpleNamespace(
+        id=124,
+        chat=SimpleNamespace(id=456, title="Chat", username="user"),
+        sender=SimpleNamespace(id=789, first_name="John", last_name="Doe", username="jdoe"),
+        date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        message="Это достаточно длинный русский текст для определения языка",
+        text="Это достаточно длинный русский текст для определения языка",
+        media=None,
+        views=123,
+        forwards=4,
+        replies=SimpleNamespace(replies=5),
+        reactions=SimpleNamespace(
+            results=[
+                SimpleNamespace(reaction=SimpleNamespace(emoticon="👍"), count=7),
+            ]
+        ),
+    )
+
+    res = TelegramMessageTransformer.convert_telethon_message(msg)
+
+    assert res.views == 123
+    assert res.forwards == 4
+    assert res.reply_count == 5
+    assert res.reactions_json == '[{"emoji": "👍", "count": 7}]'
+    assert res.detected_lang == "ru"
 
 
 def test_convert_telethon_message_no_chat():


### PR DESCRIPTION
## Summary
- Fix live search results so translated posts have DB-backed message IDs and usable translate buttons.
- Refresh mutable post engagement fields on duplicate message saves so search stats stay current.
- Add regression coverage for translation rendering, Telegram search metadata, and duplicate stats refresh.

## Test plan
- `pytest tests/test_transformers.py tests/test_search.py tests/routes/test_search_routes.py tests/repositories/test_messages_repository.py -v`
- `ruff check src/ tests/ conftest.py`

Fixes #603

Made with [Cursor](https://cursor.com)