### PR TITLE
fix: validate Telegram reaction emoji

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -16,3 +16,4 @@ forbidden_modules =
 allow_indirect_imports = True
 ignore_imports =
     src.services.pipeline_nodes.handlers -> telethon
+    src.services.telegram_command_dispatcher -> telethon

--- a/src/agent/tools/messaging_write.py
+++ b/src/agent/tools/messaging_write.py
@@ -25,6 +25,11 @@ from src.agent.tools.messaging_schemas import (
 )
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
 from src.services.telegram_command_service import TelegramCommandService
+from src.telegram.reactions import (
+    SUPPORTED_REACTION_EMOJIS_DISPLAY,
+    TelegramReactionInvalidError,
+    normalize_outgoing_reaction_emoji,
+)
 
 
 def _command_status_text(status: object) -> str:
@@ -230,12 +235,14 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await ctx.require_phone_permission(phone, "send_reaction")
-        if perm_gate:
-            return perm_gate
         try:
             chat_id = arg_str(args, "chat_id", required=True)
-            emoji = arg_str(args, "emoji", required=True)
+            emoji = normalize_outgoing_reaction_emoji(arg_str(args, "emoji", required=True))
+        except TelegramReactionInvalidError:
+            return _text_response(
+                "Ошибка: Telegram не принимает такую реакцию. "
+                f"Поддерживаемые реакции: {SUPPORTED_REACTION_EMOJIS_DISPLAY}"
+            )
         except ToolInputError:
             return _text_response("Ошибка: chat_id и emoji обязательны.")
         message_id = args.get("message_id")
@@ -245,6 +252,9 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
             message_id_int = int(message_id)
         except (TypeError, ValueError):
             return _text_response("Ошибка: message_id должен быть целым числом.")
+        perm_gate = await ctx.require_phone_permission(phone, "send_reaction")
+        if perm_gate:
+            return perm_gate
         gate = require_confirmation(
             f"поставит реакцию {emoji!r} на сообщение #{message_id_int} в чате {chat_id}",
             args,

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -13,6 +13,11 @@ from src.services.telegram_actions import (
     TelegramActionService,
 )
 from src.telegram.flood_wait import HandledFloodWaitError
+from src.telegram.reactions import (
+    SUPPORTED_REACTION_EMOJIS_DISPLAY,
+    TelegramReactionInvalidError,
+    normalize_outgoing_reaction_emoji,
+)
 from src.utils.datetime import parse_required_datetime
 
 
@@ -319,10 +324,18 @@ def run_with_dependencies(
                 if args.clear:
                     emoji = None
                 else:
-                    emoji = args.emoji
-                    if not emoji:
+                    raw_emoji = args.emoji
+                    if not raw_emoji:
                         print("Error: emoji is required unless --clear is used.")
                         raise SystemExit(2)
+                    try:
+                        emoji = normalize_outgoing_reaction_emoji(raw_emoji)
+                    except TelegramReactionInvalidError:
+                        print(
+                            "Error: Telegram does not support this reaction emoji. "
+                            f"Supported reactions: {SUPPORTED_REACTION_EMOJIS_DISPLAY}"
+                        )
+                        return
                 if not args.yes:
                     action = (
                         f"Clear reaction from message #{args.message_id} in {args.chat_id}"

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -346,10 +346,10 @@ class ReactHandler(BaseNodeHandler):
         except TelegramReactionInvalidError as exc:
             if random_emoji_list:
                 emoji = random_emoji_list[0]
-                context.record_error(
-                    node_id=node_id,
-                    code="reaction_invalid",
-                    detail=str(exc),
+                logger.info(
+                    "ReactHandler[%s]: primary emoji invalid (%s); falling back to random_emojis",
+                    node_id,
+                    exc,
                 )
             else:
                 context.record_error(

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -345,7 +345,6 @@ class ReactHandler(BaseNodeHandler):
             emoji = normalize_outgoing_reaction_emoji(node_config.get("emoji") or "👍")
         except TelegramReactionInvalidError as exc:
             if random_emoji_list:
-                emoji = random_emoji_list[0]
                 logger.info(
                     "ReactHandler[%s]: primary emoji invalid (%s); falling back to random_emojis",
                     node_id,

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -10,6 +10,7 @@ from src.services.pipeline_filters import filter_messages
 from src.services.pipeline_nodes.base import BaseNodeHandler, NodeContext
 from src.services.pipeline_result import increment_action_count
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
+from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
 
 try:  # telethon is an optional dependency at test-time
     from telethon.errors import (
@@ -328,8 +329,35 @@ class ReactHandler(BaseNodeHandler):
             raise RuntimeError("ReactHandler: client_pool not available")
 
         messages = context.get_global("context_messages", [])
-        emoji = node_config.get("emoji") or "👍"
-        random_emoji_list = node_config.get("random_emojis", [])
+        raw_random_emojis = node_config.get("random_emojis", [])
+        random_emoji_list: list[str] = []
+        if isinstance(raw_random_emojis, (list, tuple)):
+            for raw_emoji in raw_random_emojis:
+                try:
+                    random_emoji_list.append(normalize_outgoing_reaction_emoji(str(raw_emoji)))
+                except TelegramReactionInvalidError as exc:
+                    context.record_error(
+                        node_id=node_id,
+                        code="reaction_invalid",
+                        detail=str(exc),
+                    )
+        try:
+            emoji = normalize_outgoing_reaction_emoji(node_config.get("emoji") or "👍")
+        except TelegramReactionInvalidError as exc:
+            if random_emoji_list:
+                emoji = random_emoji_list[0]
+                context.record_error(
+                    node_id=node_id,
+                    code="reaction_invalid",
+                    detail=str(exc),
+                )
+            else:
+                context.record_error(
+                    node_id=node_id,
+                    code="reaction_invalid",
+                    detail=str(exc),
+                )
+                return
         resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
         action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
 

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -29,8 +29,15 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.flood_wait import HandledFloodWaitError
 from src.telegram.notifier import Notifier
+from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
 from src.telegram.utils import normalize_utc
 from src.utils.datetime import parse_required_datetime, parse_required_schedule_datetime
+
+try:  # telethon is an optional dependency at test-time
+    from telethon.errors import ReactionInvalidError
+except ImportError:  # pragma: no cover
+    class ReactionInvalidError(Exception):  # type: ignore[no-redef]
+        pass
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +153,23 @@ class TelegramCommandDispatcher:
                     },
                     payload=command.payload,
                     run_after=run_after,
+                )
+            except (TelegramReactionInvalidError, ReactionInvalidError) as exc:
+                logger.info(
+                    "Telegram command rejected invalid reaction: id=%s type=%s error=%s",
+                    command.id,
+                    command.command_type,
+                    str(exc),
+                )
+                await self._db.repos.telegram_commands.update_command(
+                    command.id,
+                    status=TelegramCommandStatus.FAILED,
+                    error=str(exc),
+                    result_payload={
+                        "state": "invalid_reaction",
+                        "emoji": command.payload.get("emoji"),
+                    },
+                    payload=command.payload,
                 )
             except Exception as exc:
                 duration_ms = int((time.monotonic() - started_at) * 1000)
@@ -435,11 +459,12 @@ class TelegramCommandDispatcher:
     async def _handle_dialogs_react(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])
         await self._ensure_reaction_can_run(phone)
+        emoji = normalize_outgoing_reaction_emoji(str(payload["emoji"]))
         result = await TelegramActionService(self._pool).send_reaction(
             phone=phone,
             chat_id=payload["chat_id"],
             message_id=int(payload["message_id"]),
-            emoji=str(payload["emoji"]),
+            emoji=emoji,
             native=True,
             resolve_entity=True,
         )

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -459,7 +459,7 @@ class TelegramCommandDispatcher:
     async def _handle_dialogs_react(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])
         await self._ensure_reaction_can_run(phone)
-        emoji = normalize_outgoing_reaction_emoji(str(payload["emoji"]))
+        emoji = normalize_outgoing_reaction_emoji(str(payload.get("emoji") or ""))
         result = await TelegramActionService(self._pool).send_reaction(
             phone=phone,
             chat_id=payload["chat_id"],

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -15,6 +15,7 @@ from telethon_cli.errors import CLIError
 from src.models import Account
 from src.telegram.auth import TelegramAuth
 from src.telegram.flood_wait import HandledFloodWaitError, handle_flood_wait
+from src.telegram.reactions import normalize_outgoing_reaction_emoji
 from src.telegram.session_materializer import SessionMaterializer
 
 logger = logging.getLogger(__name__)
@@ -248,7 +249,8 @@ class TelegramTransportSession:
             from telethon.tl.functions.messages import SendReactionRequest
             from telethon.tl.types import ReactionEmoji
 
-            reaction = [] if emoji is None else [ReactionEmoji(emoticon=emoji)]
+            normalized_emoji = normalize_outgoing_reaction_emoji(emoji, allow_clear=True)
+            reaction = [] if normalized_emoji is None else [ReactionEmoji(emoticon=normalized_emoji)]
             return await self._run(
                 "telegram_send_reaction",
                 self._client(

--- a/src/telegram/reactions.py
+++ b/src/telegram/reactions.py
@@ -9,6 +9,84 @@ ReactionItem = dict[str, str | int]
 ReactionUserItem = dict[str, str | int]
 DEFAULT_REACTION_USERS_LIMIT = 20
 MAX_REACTION_USERS_LIMIT = 100
+SUPPORTED_REACTION_EMOJIS: tuple[str, ...] = (
+    "👍",
+    "👎",
+    "❤",
+    "🔥",
+    "🥰",
+    "👏",
+    "😁",
+    "🤔",
+    "🤯",
+    "😱",
+    "🤬",
+    "😢",
+    "🎉",
+    "🤩",
+    "🤮",
+    "💩",
+    "🙏",
+    "👌",
+    "🕊",
+    "🤡",
+    "🥱",
+    "🥴",
+    "😍",
+    "🐳",
+    "❤‍🔥",
+    "🌚",
+    "🌭",
+    "💯",
+    "🤣",
+    "⚡",
+    "🍌",
+    "🏆",
+    "💔",
+    "🤨",
+    "😐",
+    "🍓",
+    "🍾",
+    "💋",
+    "🖕",
+    "😈",
+    "😴",
+    "😭",
+    "🤓",
+    "👻",
+    "👨‍💻",
+    "👀",
+    "🎃",
+    "🙈",
+    "😇",
+    "😨",
+    "🤝",
+    "✍",
+    "🤗",
+    "🫡",
+    "🎅",
+    "🎄",
+    "☃",
+    "💅",
+    "🤪",
+    "🗿",
+    "🆒",
+    "💘",
+    "🙉",
+    "🦄",
+    "😘",
+    "💊",
+    "🙊",
+    "😎",
+    "👾",
+    "🤷‍♂",
+    "🤷",
+    "🤷‍♀",
+    "😡",
+)
+SUPPORTED_REACTION_EMOJIS_SET = frozenset(SUPPORTED_REACTION_EMOJIS)
+SUPPORTED_REACTION_EMOJIS_DISPLAY = " ".join(SUPPORTED_REACTION_EMOJIS)
+_VARIATION_SELECTOR_16 = "\ufe0f"
 
 
 @dataclass(frozen=True)
@@ -16,6 +94,30 @@ class ReactionUsersResult:
     items: list[ReactionUserItem]
     unavailable: str | None = None
     limited: bool = False
+
+
+class TelegramReactionInvalidError(ValueError):
+    """Raised when an outgoing reaction is not supported by Telegram."""
+
+
+def normalize_outgoing_reaction_emoji(emoji: str | None, *, allow_clear: bool = False) -> str | None:
+    """Normalize and validate a Telegram built-in reaction emoji before sending."""
+    if emoji is None:
+        if allow_clear:
+            return None
+        raise TelegramReactionInvalidError(_invalid_reaction_message(emoji))
+
+    normalized = str(emoji).strip().replace(_VARIATION_SELECTOR_16, "")
+    if not normalized or normalized not in SUPPORTED_REACTION_EMOJIS_SET:
+        raise TelegramReactionInvalidError(_invalid_reaction_message(emoji))
+    return normalized
+
+
+def _invalid_reaction_message(emoji: object) -> str:
+    return (
+        f"Unsupported Telegram reaction emoji {emoji!r}. "
+        f"Supported reactions: {SUPPORTED_REACTION_EMOJIS_DISPLAY}"
+    )
 
 
 def _coerce_count(value: Any) -> int:

--- a/src/telegram/reactions.py
+++ b/src/telegram/reactions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, overload
 
 ReactionItem = dict[str, str | int]
 ReactionUserItem = dict[str, str | int]
@@ -100,6 +100,12 @@ class TelegramReactionInvalidError(ValueError):
     """Raised when an outgoing reaction is not supported by Telegram."""
 
 
+@overload
+def normalize_outgoing_reaction_emoji(emoji: str | None) -> str: ...
+@overload
+def normalize_outgoing_reaction_emoji(emoji: str | None, *, allow_clear: Literal[False]) -> str: ...
+@overload
+def normalize_outgoing_reaction_emoji(emoji: str | None, *, allow_clear: Literal[True]) -> str | None: ...
 def normalize_outgoing_reaction_emoji(emoji: str | None, *, allow_clear: bool = False) -> str | None:
     """Normalize and validate a Telegram built-in reaction emoji before sending."""
     if emoji is None:

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -11,6 +11,7 @@ from src.database import Database
 from src.models import AccountSessionStatus
 from src.services.channel_service import ChannelService
 from src.services.telegram_command_service import TelegramCommandService
+from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
 from src.web import deps
 from src.web.dialogs.forms import (
     CacheClearForm,
@@ -261,6 +262,10 @@ async def react_message(request: Request, command_service: TelegramCommandServic
         return dialogs_redirect(form.phone, error="missing_fields")
     if not form.message_id.isdigit():
         return dialogs_redirect(form.phone, error="invalid_message_id")
+    try:
+        emoji = normalize_outgoing_reaction_emoji(form.emoji)
+    except TelegramReactionInvalidError:
+        return dialogs_redirect(form.phone, error="invalid_reaction")
     return await _enqueue_dialog_command(
         command_service,
         "dialogs.react",
@@ -268,7 +273,7 @@ async def react_message(request: Request, command_service: TelegramCommandServic
             "phone": form.phone,
             "chat_id": form.chat_id,
             "message_id": int(form.message_id),
-            "emoji": form.emoji,
+            "emoji": emoji,
         },
         phone=form.phone,
     )

--- a/tests/routes/test_dialogs_routes_actions.py
+++ b/tests/routes/test_dialogs_routes_actions.py
@@ -121,6 +121,28 @@ async def test_edit_permissions_missing_fields(route_client):
     assert "missing_fields" in resp.headers.get("location", "")
 
 
+# === react ===
+
+
+@pytest.mark.anyio
+async def test_react_rejects_unsupported_emoji(route_client):
+    resp = await route_client.post(
+        "/dialogs/react",
+        data={
+            "phone": "+1234567890",
+            "chat_id": "-100123",
+            "message_id": "42",
+            "emoji": "✅",
+        },
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert "invalid_reaction" in location
+    assert "command_id=" not in location
+
+
 # === kick ===
 
 

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -49,6 +49,50 @@ def test_deepagents_send_reaction_signature_and_runtime_gate(mock_db):
 
 
 @pytest.mark.anyio
+async def test_deepagents_send_reaction_invalid_emoji_does_not_prompt_or_enqueue(mock_db):
+    from src.agent.permission_gate import AgentRequestContext, reset_request_context, set_request_context
+    from src.agent.runtime_context import AgentRuntimeContext
+    from src.agent.tools.deepagents_sync import build_deepagents_tools
+
+    mock_db.get_account_summaries = AsyncMock(return_value=[
+        SimpleNamespace(phone="+79001234567", is_primary=True, session_status="ok")
+    ])
+    command_repo = MagicMock()
+    command_repo.find_active_by_type = AsyncMock(return_value=None)
+    command_repo.create_command = AsyncMock(return_value=55)
+    mock_db.repos = MagicMock()
+    mock_db.repos.telegram_commands = command_repo
+    runtime_context = AgentRuntimeContext.build(
+        db=mock_db,
+        client_pool=MagicMock(),
+        runtime_kind="live",
+        owner_loop=asyncio.get_running_loop(),
+    )
+    tool_map = {
+        tool.__name__: tool
+        for tool in build_deepagents_tools(mock_db, client_pool=MagicMock(), runtime_context=runtime_context)
+    }
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    token = set_request_context(
+        AgentRequestContext(session_id="invalid-reaction", thread_id=1, queue=queue, permission_timeout=1)
+    )
+    try:
+        result = await asyncio.to_thread(
+            tool_map["send_reaction"],
+            chat_id="@chat",
+            message_id=1,
+            emoji="✅",
+            confirm=True,
+        )
+    finally:
+        reset_request_context(token)
+
+    assert "Telegram не принимает такую реакцию" in result
+    assert queue.empty()
+    command_repo.create_command.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_deepagents_send_reaction_missing_acl_requests_permission_once(mock_db):
     from src.agent.permission_gate import (
         AgentRequestContext,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@ from src.telegram.backends import (
     fetch_message_reaction_users_raw,
 )
 from src.telegram.flood_wait import HandledFloodWaitError
+from src.telegram.reactions import TelegramReactionInvalidError
 from tests.helpers import AsyncIterMessages, FakeCliTelethonClient
 
 
@@ -97,12 +98,12 @@ async def test_delete_messages():
 async def test_send_reaction_invokes_raw_api_with_emoji():
     session = _session()
 
-    await session.send_reaction("chat", 42, "🔥")
+    await session.send_reaction("chat", 42, "❤️")
 
     request = session.raw_client.invoke.await_args.args[0]
     assert request.peer == "chat"
     assert request.msg_id == 42
-    assert [reaction.emoticon for reaction in request.reaction] == ["🔥"]
+    assert [reaction.emoticon for reaction in request.reaction] == ["❤"]
 
 
 @pytest.mark.anyio
@@ -115,6 +116,16 @@ async def test_send_reaction_invokes_raw_api_with_empty_vector_to_clear():
     assert request.peer == "chat"
     assert request.msg_id == 42
     assert request.reaction == []
+
+
+@pytest.mark.anyio
+async def test_send_reaction_rejects_unsupported_emoji_before_raw_api():
+    session = _session()
+
+    with pytest.raises(TelegramReactionInvalidError):
+        await session.send_reaction("chat", 42, "✅")
+
+    session.raw_client.invoke.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -549,6 +549,27 @@ async def test_react_random_emojis():
     session.send_reaction.assert_awaited_once_with(-100, 1, "🎉")
 
 
+@pytest.mark.anyio
+async def test_react_skips_invalid_random_emojis():
+    ctx = NodeContext()
+    m = _msg(channel_id=-100, message_id=1)
+    ctx.set_global("context_messages", [m])
+    session = AsyncMock()
+    pool = AsyncMock()
+    pool.get_available_client = AsyncMock(return_value=(session, "p"))
+    pool.release_client = AsyncMock()
+    with patch("random.choice", return_value="🔥"):
+        await ReactHandler().execute(
+            {"emoji": "✅", "random_emojis": ["✅", "🔥"]},
+            ctx,
+            {"client_pool": pool, "_current_node_id": "react_1"},
+        )
+
+    session.send_reaction.assert_awaited_once_with(-100, 1, "🔥")
+    errors = ctx.get_errors()
+    assert [error["code"] for error in errors] == ["reaction_invalid", "reaction_invalid"]
+
+
 # ── Issue #463: ReactHandler records structured node errors ───────────────────
 
 

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -567,7 +567,7 @@ async def test_react_skips_invalid_random_emojis():
 
     session.send_reaction.assert_awaited_once_with(-100, 1, "🔥")
     errors = ctx.get_errors()
-    assert [error["code"] for error in errors] == ["reaction_invalid", "reaction_invalid"]
+    assert [error["code"] for error in errors] == ["reaction_invalid"]
 
 
 # ── Issue #463: ReactHandler records structured node errors ───────────────────

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -488,6 +488,31 @@ async def test_run_loop_requeues_handled_flood_wait():
     assert kwargs["result_payload"]["state"] == "waiting_flood_wait"
 
 
+async def test_run_loop_marks_invalid_reaction_failed_without_calling_telegram():
+    db = _mock_db()
+    command = TelegramCommand(
+        id=10,
+        command_type="dialogs.react",
+        payload={"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "✅"},
+    )
+    db.repos.telegram_commands.claim_next_command = AsyncMock(return_value=command)
+    pool = _mock_pool()
+    d = _dispatcher(db=db, pool=pool)
+
+    async def _update_and_stop(*args, **kwargs):
+        d._stop_event.set()
+
+    db.repos.telegram_commands.update_command = AsyncMock(side_effect=_update_and_stop)
+
+    await d._run_loop()
+
+    pool.get_native_client_by_phone.assert_not_awaited()
+    kwargs = db.repos.telegram_commands.update_command.await_args.kwargs
+    assert kwargs["status"] == TelegramCommandStatus.FAILED
+    assert kwargs["result_payload"]["state"] == "invalid_reaction"
+    assert kwargs["result_payload"]["emoji"] == "✅"
+
+
 async def test_dialogs_pin_unpin():
     pool = _mock_pool()
     c = _client_mock()

--- a/tests/test_telegram_reactions.py
+++ b/tests/test_telegram_reactions.py
@@ -6,6 +6,8 @@ import pytest
 from telethon.tl.types import ReactionPaid
 
 from src.telegram.reactions import (
+    SUPPORTED_REACTION_EMOJIS_DISPLAY,
+    TelegramReactionInvalidError,
     extract_message_reactions,
     extract_message_reactions_json,
     extract_reaction_users,
@@ -15,6 +17,7 @@ from src.telegram.reactions import (
     format_reaction_users,
     format_reaction_users_result,
     format_reactions_json,
+    normalize_outgoing_reaction_emoji,
     normalize_reaction_users_limit,
     parse_reactions_json,
 )
@@ -27,6 +30,21 @@ def test_extract_message_reactions_none():
     assert extract_message_reactions(msg) == []
     assert extract_message_reactions_json(msg) is None
     assert format_message_reactions(msg) == ""
+
+
+def test_normalize_outgoing_reaction_accepts_supported_and_strips_variation_selector():
+    assert normalize_outgoing_reaction_emoji(" ❤️ ") == "❤"
+    assert normalize_outgoing_reaction_emoji("✍️") == "✍"
+    assert normalize_outgoing_reaction_emoji(None, allow_clear=True) is None
+
+
+@pytest.mark.parametrize("emoji", ["✅", "ok", "👍 ✅", ""])
+def test_normalize_outgoing_reaction_rejects_unsupported(emoji):
+    with pytest.raises(TelegramReactionInvalidError) as exc_info:
+        normalize_outgoing_reaction_emoji(emoji)
+
+    assert repr(emoji) in str(exc_info.value)
+    assert SUPPORTED_REACTION_EMOJIS_DISPLAY in str(exc_info.value)
 
 
 def test_extract_message_reactions_multiple_emoji():


### PR DESCRIPTION
## Summary
- Validate outgoing Telegram reaction emoji against the built-in reactions Telegram accepts.
- Reject unsupported reactions before enqueueing web/agent jobs or calling CLI/backend sends.
- Classify remaining invalid reaction failures as `invalid_reaction` without noisy tracebacks.

## Test plan
- `ruff check src/ tests/ conftest.py`
- `pytest tests/test_telegram_reactions.py tests/test_backends.py::test_send_reaction_invokes_raw_api_with_emoji tests/test_backends.py::test_send_reaction_invokes_raw_api_with_empty_vector_to_clear tests/test_backends.py::test_send_reaction_rejects_unsupported_emoji_before_raw_api tests/test_telegram_command_dispatcher.py::test_run_loop_marks_invalid_reaction_failed_without_calling_telegram tests/test_pipeline_nodes_handlers.py::test_react_skips_invalid_random_emojis tests/routes/test_dialogs_routes_actions.py::test_react_rejects_unsupported_emoji tests/test_agent_tools_deepagents_sync.py::test_deepagents_send_reaction_invalid_emoji_does_not_prompt_or_enqueue -v`
- `pytest tests/test_backends.py tests/test_telegram_command_dispatcher.py tests/test_pipeline_nodes_handlers.py tests/routes/test_dialogs_routes_actions.py tests/test_agent_tools_deepagents_sync.py -v`

Closes #613

Made with [Cursor](https://cursor.com)