### PR TITLE
fix(web): repair calendar filters and open links

### DIFF
--- a/src/web/routes/calendar.py
+++ b/src/web/routes/calendar.py
@@ -9,15 +9,29 @@ from src.web import deps
 router = APIRouter()
 
 
+def _parse_pipeline_id(value: str | None) -> int | None:
+    if value is None or value.strip() == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
 @router.get("/", response_class=HTMLResponse)
-async def calendar_page(request: Request, days: int = Query(default=7, ge=1, le=90), pipeline_id: int | None = None):
+async def calendar_page(
+    request: Request,
+    days: int = Query(default=7, ge=1, le=90),
+    pipeline_id: str | None = None,
+):
     """Render content calendar page."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
+    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
 
-    calendar_days = await calendar.get_calendar(days=days, pipeline_id=pipeline_id)
+    calendar_days = await calendar.get_calendar(days=days, pipeline_id=selected_pipeline_id)
     stats = await calendar.get_stats()
-    upcoming = await calendar.get_upcoming(limit=10, pipeline_id=pipeline_id)
+    upcoming = await calendar.get_upcoming(limit=10, pipeline_id=selected_pipeline_id)
 
     pipelines = await db.repos.content_pipelines.get_all()
 
@@ -29,19 +43,24 @@ async def calendar_page(request: Request, days: int = Query(default=7, ge=1, le=
             "stats": stats,
             "upcoming": upcoming,
             "pipelines": pipelines,
-            "selected_pipeline_id": pipeline_id,
+            "selected_pipeline_id": selected_pipeline_id,
             "days": days,
         },
     )
 
 
 @router.get("/api/calendar")
-async def api_calendar(request: Request, days: int = Query(default=7, ge=1, le=90), pipeline_id: int | None = None):
+async def api_calendar(
+    request: Request,
+    days: int = Query(default=7, ge=1, le=90),
+    pipeline_id: str | None = None,
+):
     """Get calendar data as JSON."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
+    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
 
-    calendar_days = await calendar.get_calendar(days=days, pipeline_id=pipeline_id)
+    calendar_days = await calendar.get_calendar(days=days, pipeline_id=selected_pipeline_id)
 
     return JSONResponse([
         {
@@ -64,12 +83,17 @@ async def api_calendar(request: Request, days: int = Query(default=7, ge=1, le=9
 
 
 @router.get("/api/upcoming")
-async def api_upcoming(request: Request, limit: int = Query(default=20, ge=1, le=200), pipeline_id: int | None = None):
+async def api_upcoming(
+    request: Request,
+    limit: int = Query(default=20, ge=1, le=200),
+    pipeline_id: str | None = None,
+):
     """Get upcoming events as JSON."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
+    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
 
-    events = await calendar.get_upcoming(limit=limit, pipeline_id=pipeline_id)
+    events = await calendar.get_upcoming(limit=limit, pipeline_id=selected_pipeline_id)
 
     return JSONResponse([
         {

--- a/src/web/templates/calendar.html
+++ b/src/web/templates/calendar.html
@@ -81,7 +81,7 @@
                     {% if event.preview %}
                     <div class="small text-truncate" title="{{ event.preview }}">{{ event.preview[:60] }}</div>
                     {% endif %}
-                    <a href="/pipelines/runs/{{ event.run_id }}" class="btn btn-sm btn-outline-primary mt-1" style="font-size:.7rem;padding:.1rem .3rem">Открыть</a>
+                    <a href="/moderation/{{ event.run_id }}/view" class="btn btn-sm btn-outline-primary mt-1" style="font-size:.7rem;padding:.1rem .3rem">Открыть</a>
                 </div>
                 {% else %}
                 <p class="text-muted small mb-0 text-center mt-3">—</p>
@@ -110,7 +110,7 @@
                             {{ event.moderation_status }}
                         </span>
                     </div>
-                    <a href="/pipelines/runs/{{ event.run_id }}" class="btn btn-sm btn-outline-primary mt-1" style="font-size:.7rem;padding:.1rem .3rem">Открыть</a>
+                    <a href="/moderation/{{ event.run_id }}/view" class="btn btn-sm btn-outline-primary mt-1" style="font-size:.7rem;padding:.1rem .3rem">Открыть</a>
                 </div>
                 {% else %}
                 <p class="text-muted small mb-0">—</p>
@@ -150,7 +150,7 @@
                             </span>
                         </td>
                         <td class="small text-muted">{{ event.preview[:80] }}</td>
-                        <td><a href="/pipelines/runs/{{ event.run_id }}" class="btn btn-sm btn-outline-primary">Открыть</a></td>
+                        <td><a href="/moderation/{{ event.run_id }}/view" class="btn btn-sm btn-outline-primary">Открыть</a></td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/tests/routes/test_calendar_routes.py
+++ b/tests/routes/test_calendar_routes.py
@@ -3,6 +3,21 @@ from __future__ import annotations
 
 import pytest
 
+from src.models import ContentPipeline
+
+
+async def _create_calendar_run(route_client) -> int:
+    app = route_client._transport_app
+    db = app.state.db
+    pipeline_id = await db.repos.content_pipelines.add(
+        ContentPipeline(name="Calendar Pipeline", prompt_template="prompt"),
+        source_channel_ids=[],
+        targets=[],
+    )
+    run_id = await db.repos.generation_runs.create_run(pipeline_id, "prompt")
+    await db.repos.generation_runs.save_result(run_id, "Generated calendar text", {})
+    return run_id
+
 
 @pytest.mark.anyio
 async def test_calendar_page_renders(route_client):
@@ -31,6 +46,26 @@ async def test_calendar_page_with_pipeline_filter(route_client):
 
 
 @pytest.mark.anyio
+async def test_calendar_page_accepts_empty_pipeline_filter(route_client):
+    """Calendar page treats the empty 'All pipelines' value as no filter."""
+    resp = await route_client.get("/calendar/?days=14&pipeline_id=")
+    assert resp.status_code == 200
+    assert "Календарь" in resp.text
+
+
+@pytest.mark.anyio
+async def test_calendar_open_links_use_moderation_view(route_client):
+    """Calendar cards link to the existing moderation run view route."""
+    run_id = await _create_calendar_run(route_client)
+
+    resp = await route_client.get("/calendar/")
+
+    assert resp.status_code == 200
+    assert f"/moderation/{run_id}/view" in resp.text
+    assert f"/pipelines/runs/{run_id}" not in resp.text
+
+
+@pytest.mark.anyio
 async def test_api_calendar_empty(route_client):
     """Calendar JSON API returns empty list when no data."""
     resp = await route_client.get("/calendar/api/calendar")
@@ -49,6 +84,15 @@ async def test_api_calendar_with_days(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_calendar_accepts_empty_pipeline_filter(route_client):
+    """Calendar JSON API treats empty pipeline_id as no filter."""
+    resp = await route_client.get("/calendar/api/calendar?days=14&pipeline_id=")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.anyio
 async def test_api_upcoming_empty(route_client):
     """Upcoming JSON API returns empty list."""
     resp = await route_client.get("/calendar/api/upcoming")
@@ -61,6 +105,15 @@ async def test_api_upcoming_empty(route_client):
 async def test_api_upcoming_with_limit(route_client):
     """Upcoming JSON API accepts limit parameter."""
     resp = await route_client.get("/calendar/api/upcoming?limit=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.anyio
+async def test_api_upcoming_accepts_empty_pipeline_filter(route_client):
+    """Upcoming JSON API treats empty pipeline_id as no filter."""
+    resp = await route_client.get("/calendar/api/upcoming?limit=5&pipeline_id=")
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)


### PR DESCRIPTION
## Summary
- Normalize empty calendar `pipeline_id` query values so the “Все” pipeline filter no longer triggers validation errors.
- Update calendar “Открыть” links to use the existing moderation run view route.
- Add route tests for empty pipeline filters and calendar run links.

## Test plan
- `pytest tests/routes/test_calendar_routes.py -v`
- `ruff check src/ tests/ conftest.py`

Fixes #573
Fixes #593

Made with [Cursor](https://cursor.com)