### PR TITLE
fix(web): repair analytics pipeline links

### DIFF
--- a/src/web/templates/analytics/content.html
+++ b/src/web/templates/analytics/content.html
@@ -71,7 +71,7 @@
                         {% for stat in pipeline_stats %}
                         <tr>
                             <td>
-                                <a href="/pipelines/{{ stat.pipeline_id }}">{{ stat.pipeline_name }}</a>
+                                <a href="/pipelines/{{ stat.pipeline_id }}/edit">{{ stat.pipeline_name }}</a>
                             </td>
                             <td>{{ stat.total_generations }}</td>
                             <td class="text-success">{{ stat.total_published }}</td>

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -51,6 +51,25 @@ async def test_content_analytics_page_renders(route_client):
 
 
 @pytest.mark.anyio
+async def test_content_analytics_pipeline_links_use_edit_route(route_client):
+    """Pipeline statistics links point to an existing pipeline page."""
+    db = route_client._transport_app.state.db
+    from src.models import ContentPipeline
+
+    pipeline_id = await db.repos.content_pipelines.add(
+        ContentPipeline(name="Linked Pipeline", prompt_template="Write"),
+        source_channel_ids=[],
+        targets=[],
+    )
+
+    resp = await route_client.get("/analytics/content")
+
+    assert resp.status_code == 200
+    assert f'href="/pipelines/{pipeline_id}/edit"' in resp.text
+    assert f'href="/pipelines/{pipeline_id}"' not in resp.text
+
+
+@pytest.mark.anyio
 async def test_api_content_summary_returns_json(route_client):
     """Test content summary API returns JSON."""
     resp = await route_client.get("/analytics/content/api/summary")


### PR DESCRIPTION
## 💪 What
- Fixes the Pipeline Statistics links on `/analytics/content` so each pipeline name opens the existing pipeline edit page instead of a missing `/pipelines/{id}` route.
- Adds route coverage that renders content analytics with a pipeline and verifies the HTML uses `/pipelines/{id}/edit`.
- Keeps the analytics API and pipeline statistics data flow unchanged.

## 🤔 Why
- The content analytics dashboard currently sends users to a 404 when they click a pipeline in Pipeline Statistics.
- Routing to the existing edit page gives users a working destination for inspecting or updating the pipeline behind the stats row.
- The test locks the template behavior so the broken bare pipeline URL does not come back.

## 👀 Usage
- Open `/analytics/content`.
- In the Pipeline Statistics table, click a pipeline name.
- The browser should open `/pipelines/{id}/edit` for that pipeline instead of showing `{"detail":"Not Found"}`.

## 👩‍🔬 How to validate
- Create or use an existing content pipeline that appears in Pipeline Statistics.
- Visit the content analytics page and confirm pipeline names are visible as links.
- Click a pipeline name and confirm the pipeline edit page loads for the selected pipeline.

## 🔗 Related links
- Fixes #574

Made with [Cursor](https://cursor.com)