### PR TITLE
fix(web): repair scheduler collect-all redirect

### DIFF
--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -507,7 +507,7 @@ def _scheduler_redirect(
             if v is not None:
                 qp[k] = str(v)
     suffix = f"?{urlencode(qp)}" if qp else ""
-    return RedirectResponse(url=f"/scheduler{suffix}", status_code=303)
+    return RedirectResponse(url=f"/scheduler/{suffix}", status_code=303)
 
 
 async def _enqueue_scheduler_command(

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -576,10 +576,15 @@ async def test_trigger_then_get_scheduler_with_pending_tasks(client):
             channel_type="channel",
         ))
 
-    # Trigger collection (follow redirect to GET /scheduler/?msg=...)
-    resp = await client.post("/scheduler/trigger")
-    assert resp.status_code == 200
-    assert "Планировщик" in resp.text
+    resp = await client.post("/scheduler/trigger", follow_redirects=False)
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert location.startswith("/scheduler")
+    assert "msg=collect_all_queued" in location
+
+    redirected = await client.get(location)
+    assert redirected.status_code == 200
+    assert "Планировщик" in redirected.text
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from src.models import CollectionTaskStatus, SearchQuery
+from src.models import Channel, CollectionTaskStatus, SearchQuery
 
 
 @pytest.fixture
@@ -646,6 +646,35 @@ async def test_web_mode_scheduler_page_renders(web_mode_client):
     """/scheduler/ must render a 200 OK under the real web-mode wiring, no 500."""
     resp = await web_mode_client.get("/scheduler/", follow_redirects=True)
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_web_mode_trigger_then_get_scheduler_with_pending_tasks(web_mode_app, web_mode_client):
+    """/scheduler/ must render after collect-all queues DB tasks in web-mode."""
+    _, container = web_mode_app
+    await container.db.add_channel(Channel(channel_id=-100571, title="Issue 571 Channel"))
+
+    resp = await web_mode_client.post("/scheduler/trigger")
+    assert resp.status_code == 303
+    location = resp.headers.get("location", "")
+    assert location.startswith("/scheduler")
+    assert "msg=collect_all_queued" in location
+
+    tasks = await container.db.repos.tasks.get_pending_channel_tasks()
+    assert any(t.channel_id == -100571 for t in tasks)
+
+    redirected = await web_mode_client.get(location)
+    assert redirected.status_code == 200
+    assert "Планировщик" in redirected.text
+
+    noop = await web_mode_client.post("/scheduler/trigger")
+    assert noop.status_code == 303
+    noop_location = noop.headers.get("location", "")
+    assert "msg=collect_all_noop" in noop_location
+
+    noop_redirected = await web_mode_client.get(noop_location)
+    assert noop_redirected.status_code == 200
+    assert "Планировщик" in noop_redirected.text
 
 
 # ── web-mode fallback: collection_queue=None must not 500 (fix for #457 round 2) ─


### PR DESCRIPTION
## Summary
- Redirect scheduler POST actions to the canonical `/scheduler/` URL so collect-all no longer bounces through an extra slash redirect.
- Strengthen the collect-all regression coverage to verify `POST /scheduler/trigger` followed by `GET Location` renders the scheduler page.
- Add production-like web-mode coverage for queued DB tasks and repeat no-op collect-all behavior.

## Test plan
- `pytest tests/routes/test_scheduler_routes.py tests/routes/test_scheduler_routes_edge_cases.py -v -k "trigger or collect_all"`
- `ruff check src/ tests/ conftest.py`

Fixes #571

Made with [Cursor](https://cursor.com)