### PR TITLE
fix(db): atomic task claiming via UPDATE...RETURNING (#450)

### DIFF
--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -558,45 +558,27 @@ class CollectionTasksRepository:
     ) -> CollectionTask | None:
         if not handled_types:
             return None
-        now_iso = now.astimezone(timezone.utc).isoformat()
-        placeholders = ", ".join("?" for _ in handled_types)
-
-        # Phase 1: lightweight read-only peek — no write lock
-        cur = await self._db.execute(
-            f"SELECT id FROM collection_tasks "
-            f"WHERE task_type IN ({placeholders}) "
-            "AND status = ? "
-            "AND (run_after IS NULL OR run_after <= ?) "
-            "ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1",
-            (*handled_types, CollectionTaskStatus.PENDING.value, now_iso),
-        )
-        peek = await cur.fetchone()
-        if peek is None:
-            return None
-
-        # Phase 2: acquire write lock only when there is work to claim
         assert self._database is not None, (
             "CollectionTasksRepository.claim requires a Database reference"
         )
-        claimed = None
-        async with self._database.transaction() as conn:
-            selected_id = peek["id"]
-            updated = await conn.execute(
-                "UPDATE collection_tasks "
-                "SET status = 'running', started_at = ?, completed_at = NULL "
-                "WHERE id = ? AND status = ?",
-                (now_iso, selected_id, CollectionTaskStatus.PENDING.value),
-            )
-            if (updated.rowcount or 0) == 0:
-                return None
-            cur = await conn.execute(
-                "SELECT * FROM collection_tasks WHERE id = ?",
-                (selected_id,),
-            )
-            claimed = await cur.fetchone()
-        if claimed is None:
+        now_iso = now.astimezone(timezone.utc).isoformat()
+        placeholders = ", ".join("?" for _ in handled_types)
+        cur = await self._database.execute_write(
+            f"UPDATE collection_tasks "
+            f"SET status = 'running', started_at = ?, completed_at = NULL "
+            f"WHERE id = ("
+            f"    SELECT id FROM collection_tasks "
+            f"    WHERE task_type IN ({placeholders}) "
+            f"    AND status = ? "
+            f"    AND (run_after IS NULL OR run_after <= ?) "
+            f"    ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1"
+            f") RETURNING *",
+            (now_iso, *handled_types, CollectionTaskStatus.PENDING.value, now_iso),
+        )
+        row = await cur.fetchone()
+        if row is None:
             return None
-        return self._to_task(claimed)
+        return self._to_task(row)
 
     async def requeue_running_generic_tasks_on_startup(
         self, now: datetime, handled_types: list[str]

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 
 from src.database.repositories.collection_tasks import CollectionTasksRepository
@@ -371,18 +372,20 @@ async def test_claim_next_due_stats_task_success(collection_tasks_repo):
     assert claimed.started_at is not None
 
 
-async def test_claim_next_due_stats_task_recovers_from_stale_transaction(collection_tasks_repo):
-    """A stale transaction on the shared connection must not break claim flow."""
+async def test_claim_next_due_stats_task_only_claimed_once(collection_tasks_repo):
+    """Two concurrent claim calls on the same task must result in exactly one winner."""
     payload = StatsAllTaskPayload(channel_ids=[1, 2])
     task_id = await collection_tasks_repo.create_stats_task(payload)
 
-    await collection_tasks_repo._db.execute("BEGIN")
     now = datetime.now(tz=timezone.utc)
-    claimed = await collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value])
-
-    assert claimed is not None
-    assert claimed.id == task_id
-    assert claimed.status == CollectionTaskStatus.RUNNING
+    results = await asyncio.gather(
+        collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value]),
+        collection_tasks_repo.claim_next_due_generic_task(now, [CollectionTaskType.STATS_ALL.value]),
+    )
+    claimed = [r for r in results if r is not None]
+    assert len(claimed) == 1
+    assert claimed[0].id == task_id
+    assert claimed[0].status == CollectionTaskStatus.RUNNING
 
 
 async def test_claim_next_due_stats_task_respects_run_after(collection_tasks_repo):


### PR DESCRIPTION
Closes #450.

## Problem

`claim_next_due_generic_task()` in `src/database/repositories/collection_tasks.py` used a two-phase strategy:

1. **Phase 1 (unlocked):** `SELECT id ... LIMIT 1` to find the next pending task.
2. **Race window** — another dispatcher loop could observe and claim the same id here.
3. **Phase 2 (locked):** `UPDATE ... WHERE id=? AND status='pending'` inside `transaction()`.

The `rowcount == 0` guard handled the case correctly for the current single-process embedded worker, but the window is a real hazard if:

- `UnifiedDispatcher` ever runs multiple parallel loops over overlapping `handled_types`.
- A CLI command (`python -m src.main`) runs alongside the server and shares the same SQLite file.

Consequences when triggered: duplicate task execution → duplicate Telegram posts, double image-generation billing, and (per #450) potential permanent task stall if a rollback degrades to a no-op.

## Fix

Replace the two-phase peek + claim with a single atomic `UPDATE … RETURNING`:

```sql
UPDATE collection_tasks
SET status = 'running', started_at = ?, completed_at = NULL
WHERE id = (
    SELECT id FROM collection_tasks
    WHERE task_type IN (...) AND status = 'pending'
    AND (run_after IS NULL OR run_after <= ?)
    ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1
)
RETURNING *
```

SQLite processes this as a single write — no explicit transaction needed, no peek window. Uses `Database.execute_write()` which acquires `_write_lock` and autocommits, consistent with the rest of the repository.

## Files Changed

### `src/database/repositories/collection_tasks.py`

- `claim_next_due_generic_task()` rewritten as one `execute_write()` call.
- Removes the unlocked Phase 1 `SELECT`, the `async with self._database.transaction()` block, and the redundant follow-up `SELECT * WHERE id=?`.

### `tests/repositories/test_collection_tasks_repository.py`

- Replaced `test_claim_next_due_stats_task_recovers_from_stale_transaction` (which exercised the now-removed `BEGIN IMMEDIATE` retry path) with `test_claim_next_due_stats_task_only_claimed_once`. The new test runs two concurrent `claim_next_due_generic_task` calls via `asyncio.gather` and asserts exactly one winner — documents the invariant the new SQL provides.

## What Does NOT Change

- `requeue_running_generic_tasks_on_startup` — unrelated.
- `CollectionTaskStatus` values — unchanged.
- `_to_task()` row mapper — `RETURNING *` returns the same columns as `SELECT *`.
- `UnifiedDispatcher._run_loop` — call site signature unchanged.
- All other repository methods.

## Test Plan

- [x] `ruff check src/ tests/` — passes.
- [x] `pytest tests/repositories/test_collection_tasks_repository.py -v` — 52 passed (incl. new concurrent-claim test).
- [x] All claim-related downstream suites pass (`tests/test_unified_dispatcher*.py`, `tests/test_database.py`, `tests/test_bundles.py`, `tests/test_agent_threads_moderation_runtime_paths.py`, `tests/test_cli_telegram_agent_dispatcher_paths.py`) — 1005 passed.
- [x] 4 pre-existing failures in `tests/test_cross_domain_regression_paths.py::TestCLIAnalyticsBatch3` (`AttributeError: module 'src.services' has no attribute 'trend_service'`) confirmed identical on `main` — unrelated to this PR.

