### PR TITLE
feat(notifications): custom test-notification text in web (#563)

### DIFF
--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -855,7 +855,8 @@ class TelegramCommandDispatcher:
 
         target_service = self._notification_target_service()
         notifier = Notifier(target_service, None, NotificationBundle.from_database(self._db))
-        ok = await notifier.notify("✅ Тест уведомлений: соединение установлено")
+        text = str(payload.get("text") or "").strip() or "✅ Тест уведомлений: соединение установлено"
+        ok = await notifier.notify(text)
         if not ok:
             raise RuntimeError("notification_test_failed")
         return {"sent": True}

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -1121,11 +1121,14 @@ async def handle_delete_notification_bot(request: Request) -> SettingsFlash | Se
 
 
 async def handle_test_notification(request: Request) -> SettingsFlash | SettingsJson:
+    form = await request.form()
+    text = str(form.get("text", "")).strip()
     return await _enqueue_notification_command(
         request,
         "notifications.test",
         requested_by="web:settings.notifications.test",
         redirect_code="notification_test_queued",
+        payload={"text": text} if text else None,
     )
 
 

--- a/src/web/templates/settings/_notifications.html
+++ b/src/web/templates/settings/_notifications.html
@@ -35,7 +35,9 @@
         <button type="submit" class="btn btn-outline-danger btn-sm"><i class="bi bi-trash me-1"></i>Удалить bot</button>
     </form>
     {% if notification_target.state == "available" %}
-    <form method="post" action="/settings/notifications/test" data-busy>
+    <form method="post" action="/settings/notifications/test" class="d-flex gap-2" data-busy>
+        <input type="text" name="text" class="form-control form-control-sm" style="max-width:20rem"
+               placeholder="Текст теста (необязательно)">
         <button type="submit" class="btn btn-outline-secondary btn-sm"><i class="bi bi-send me-1"></i>Тест</button>
     </form>
     {% endif %}

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -965,6 +965,49 @@ async def test_test_notification_notify_fails(route_client, db):
     assert "command_id=" in resp.headers["location"]
 
 
+@pytest.mark.anyio
+async def test_test_notification_custom_text_in_payload(route_client, db):
+    """Custom text from the form is forwarded to the queued command (#563)."""
+    with patch(
+        "src.web.settings.handlers.deps.telegram_command_service"
+    ) as mock_svc_factory:
+        svc = MagicMock()
+        svc.enqueue = AsyncMock(return_value=123)
+        mock_svc_factory.return_value = svc
+
+        resp = await route_client.post(
+            "/settings/notifications/test",
+            data={"text": "Custom alert"},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    svc.enqueue.assert_awaited_once()
+    _, kwargs = svc.enqueue.call_args
+    assert kwargs["payload"] == {"text": "Custom alert"}
+
+
+@pytest.mark.anyio
+async def test_test_notification_blank_text_omits_payload(route_client, db):
+    """Blank text yields an empty payload so the dispatcher uses its default (#563)."""
+    with patch(
+        "src.web.settings.handlers.deps.telegram_command_service"
+    ) as mock_svc_factory:
+        svc = MagicMock()
+        svc.enqueue = AsyncMock(return_value=123)
+        mock_svc_factory.return_value = svc
+
+        resp = await route_client.post(
+            "/settings/notifications/test",
+            data={"text": "   "},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    _, kwargs = svc.enqueue.call_args
+    assert kwargs["payload"] == {}
+
+
 # ── Image Providers: lines 1202-1262 ───────────────────────────────────
 
 

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -865,6 +865,22 @@ async def test_notifications_test():
         mock_notifier.return_value = mock_instance
         r = await d._handle_notifications_test({})
     assert r["sent"] is True
+    mock_instance.notify.assert_awaited_once_with("✅ Тест уведомлений: соединение установлено")
+
+
+async def test_notifications_test_custom_text():
+    db = _mock_db()
+    pool = _mock_pool()
+    d = _dispatcher(db=db, pool=pool)
+    with patch.object(mod, "Notifier") as mock_notifier, \
+         patch("src.database.bundles.NotificationBundle") as mock_bundle:
+        mock_bundle.from_database.return_value = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.notify = AsyncMock(return_value=True)
+        mock_notifier.return_value = mock_instance
+        r = await d._handle_notifications_test({"text": "hello world"})
+    assert r["sent"] is True
+    mock_instance.notify.assert_awaited_once_with("hello world")
 
 
 async def test_notifications_test_failed():


### PR DESCRIPTION
Addresses the «Тест уведомлений» parity gap from #563.

## Проблема
Одно и то же действие вело себя по-разному: CLI `notification test --message "..."` позволяет задать свой текст, а кнопка «Тест» в вебе всегда слала фиксированную строку.

## Решение
- **dispatcher** `_handle_notifications_test`: использует `payload["text"]`, если задан и непустой; иначе — дефолтное сообщение.
- **web** `handle_test_notification`: читает необязательное поле формы `text` и прокидывает его в payload только если оно непустое (пустое → дефолт диспетчера).
- **шаблон** `settings/_notifications.html`: добавлено необязательное текстовое поле рядом с кнопкой «Тест».

CLI уже поддерживал `--message`, поэтому правок там не требуется — теперь поведение совпадает.

> Примечание: остальные пункты #563 (collect через слой-посредник, интерактивный agent chat, context rebuild, окно dry-run) — отдельные расхождения уровня архитектуры; этот PR закрывает изолированный и безопасный пункт про тест уведомлений.

## Проверка
- `ruff` чисто; dispatcher + web notifications + CLI notification тесты — 191 passed (включая новые: кастомный текст в payload, пустой текст → пустой payload, дефолт диспетчера).

🤖 Generated with [Claude Code](https://claude.com/claude-code)