### PR TITLE
feat(pipeline): deduplicate react/forward/delete across runs (#471)

### DIFF
--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -16,6 +16,7 @@ from src.database.repositories.generation_runs import GenerationRunsRepository
 from src.database.repositories.messages import MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.database.repositories.photo_loader import PhotoLoaderRepository
+from src.database.repositories.pipeline_action_log import PipelineActionLogRepository
 from src.database.repositories.pipeline_templates import PipelineTemplatesRepository
 from src.database.repositories.runtime_snapshots import RuntimeSnapshotsRepository
 from src.database.repositories.search_log import SearchLogRepository
@@ -68,6 +69,7 @@ class DatabaseRepositories:
     pipeline_templates: PipelineTemplatesRepository
     telegram_commands: TelegramCommandsRepository
     runtime_snapshots: RuntimeSnapshotsRepository
+    pipeline_action_log: PipelineActionLogRepository
 
 
 @dataclass(frozen=True)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -26,6 +26,7 @@ from src.database.repositories.generation_runs import GenerationRunsRepository
 from src.database.repositories.messages import MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.database.repositories.photo_loader import PhotoLoaderRepository
+from src.database.repositories.pipeline_action_log import PipelineActionLogRepository
 from src.database.repositories.pipeline_templates import PipelineTemplatesRepository
 from src.database.repositories.runtime_snapshots import RuntimeSnapshotsRepository
 from src.database.repositories.search_log import SearchLogRepository
@@ -99,6 +100,7 @@ class Database:
         self._content_pipelines: ContentPipelinesRepository | None = None
         self._telegram_commands: TelegramCommandsRepository | None = None
         self._runtime_snapshots: RuntimeSnapshotsRepository | None = None
+        self._pipeline_action_log: PipelineActionLogRepository | None = None
         self._repos: DatabaseRepositories | None = None
 
     async def _has_encrypted_sessions(self) -> bool:
@@ -151,6 +153,7 @@ class Database:
         self._generation_runs = GenerationRunsRepository(self._db, database=self)
         self._generated_images = GeneratedImagesRepository(self._db, database=self)
         self._pipeline_templates = PipelineTemplatesRepository(self._db, database=self)
+        self._pipeline_action_log = PipelineActionLogRepository(self._db, database=self)
         self._repos = DatabaseRepositories(
             accounts=self._accounts,
             channels=self._channels,
@@ -170,6 +173,7 @@ class Database:
             pipeline_templates=self._pipeline_templates,
             telegram_commands=self._telegram_commands,
             runtime_snapshots=self._runtime_snapshots,
+            pipeline_action_log=self._pipeline_action_log,
         )
 
         await self._accounts.migrate_sessions()

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -161,6 +161,10 @@ SCHEMA_REPAIR_INDEXES: Sequence[str] = (
     CREATE INDEX IF NOT EXISTS idx_generation_runs_moderation
     ON generation_runs(moderation_status, pipeline_id)
     """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_pipeline_action_log_lookup
+    ON pipeline_action_log(pipeline_id, node_id, action)
+    """,
 )
 
 

--- a/src/database/repositories/pipeline_action_log.py
+++ b/src/database/repositories/pipeline_action_log.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiosqlite
+
+if TYPE_CHECKING:
+    from src.database.facade import Database
+
+
+class PipelineActionLogRepository:
+    """Tracks which messages a pipeline node already acted on, so re-runs over
+    the same time window do not re-react/re-forward/re-delete them (issue #471)."""
+
+    def __init__(
+        self,
+        db: aiosqlite.Connection,
+        *,
+        database: "Database | None" = None,
+    ):
+        self._db = db
+        self._database = database
+
+    async def processed_message_ids(
+        self,
+        pipeline_id: int,
+        node_id: str,
+        action: str,
+    ) -> set[int]:
+        """Return the set of already-processed message_ids for this pipeline+node+action."""
+        cur = await self._db.execute(
+            "SELECT message_id FROM pipeline_action_log "
+            "WHERE pipeline_id = ? AND node_id = ? AND action = ?",
+            (pipeline_id, node_id, action),
+        )
+        rows = await cur.fetchall()
+        return {int(r["message_id"]) for r in rows}
+
+    async def log_action(
+        self,
+        pipeline_id: int,
+        node_id: str,
+        action: str,
+        channel_id: int,
+        message_id: int,
+    ) -> None:
+        """Record that (pipeline, node, action) acted on a message. Idempotent."""
+        await self._database.execute_write(
+            "INSERT OR IGNORE INTO pipeline_action_log "
+            "(pipeline_id, node_id, action, channel_id, message_id) VALUES (?, ?, ?, ?, ?)",
+            (pipeline_id, node_id, action, channel_id, message_id),
+        )

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -446,4 +446,15 @@ CREATE TABLE IF NOT EXISTS agent_messages (
     content    TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE TABLE IF NOT EXISTS pipeline_action_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    pipeline_id INTEGER NOT NULL,
+    node_id     TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    channel_id  INTEGER NOT NULL,
+    message_id  INTEGER NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(pipeline_id, node_id, action, channel_id, message_id)
+);
 """

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -243,6 +243,7 @@ class ContentGenerationService:
             "generation_query": scope.query,
             "channel_id": scope.channel_id,
             "account_phone": pipeline.account_phone,
+            "pipeline_id": pipeline.id,
         }
 
         # Inject read-only agent tools for AgentLoopHandler

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -43,6 +43,28 @@ def _current_node_id(services: dict, default: str = "?") -> str:
     return str(value) if value else default
 
 
+async def _dedup_context(services: dict, node_id: str, action: str, node_config: dict):
+    """Return (repo, processed_message_ids) when action dedup is active (issue #471).
+
+    Dedup is opt-out via node_config["deduplicate"]=false and only engages when a
+    pipeline_id and a db with the pipeline_action_log repo are available — so unit
+    tests and ad-hoc executions without those keys keep the previous behaviour.
+    The processed-id set is a snapshot of *prior* runs; callers must not mutate it
+    mid-run so that multi-target forwards still reach every target in one run.
+    """
+    if not node_config.get("deduplicate", True):
+        return None, set()
+    db = services.get("db")
+    pipeline_id = services.get("pipeline_id")
+    if db is None or pipeline_id is None:
+        return None, set()
+    repo = getattr(getattr(db, "repos", None), "pipeline_action_log", None)
+    if repo is None:
+        return None, set()
+    processed = await repo.processed_message_ids(pipeline_id, node_id, action)
+    return repo, processed
+
+
 def _resolve_account_phone(account_phone: str | None, services: dict, context: NodeContext) -> str | None:
     """Return explicit account_phone, or discover one from source channel access map."""
     if account_phone:
@@ -415,8 +437,14 @@ class ReactHandler(BaseNodeHandler):
                 return
         resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
         action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
+        dedup_repo, processed_ids = await _dedup_context(services, node_id, "react", node_config)
+        pipeline_id = services.get("pipeline_id")
+        skipped = 0
 
         for message in messages:
+            if message.message_id in processed_ids:
+                skipped += 1
+                continue
             try:
                 chosen_emoji = random.choice(random_emoji_list) if random_emoji_list else emoji
                 await action_service.send_reaction(
@@ -429,6 +457,10 @@ class ReactHandler(BaseNodeHandler):
                     resolve_entity=False,
                 )
                 increment_action_count(context, "react")
+                if dedup_repo is not None:
+                    await dedup_repo.log_action(
+                        pipeline_id, node_id, "react", message.channel_id, message.message_id
+                    )
                 logger.info(
                     "ReactHandler[%s]: reacted %s to message_id=%s channel_id=%s phone=%s",
                     node_id,
@@ -481,6 +513,8 @@ class ReactHandler(BaseNodeHandler):
                     message.message_id,
                     exc_info=True,
                 )
+        if skipped:
+            logger.info("ReactHandler[%s]: skipped %d already-reacted message(s)", node_id, skipped)
 
 
 class ForwardHandler(BaseNodeHandler):
@@ -501,6 +535,8 @@ class ForwardHandler(BaseNodeHandler):
         messages = context.get_global("context_messages", [])
         targets = node_config.get("targets", [])
         action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
+        dedup_repo, processed_ids = await _dedup_context(services, node_id, "forward", node_config)
+        pipeline_id = services.get("pipeline_id")
 
         for target in targets:
             phone = target.get("phone", "")
@@ -512,6 +548,10 @@ class ForwardHandler(BaseNodeHandler):
                     await action_service.ensure_client(phone=phone, native=False)
                     continue
                 for message in messages:
+                    # processed_ids is a prior-run snapshot; not mutated mid-run so
+                    # every target still receives the message within this run.
+                    if message.message_id in processed_ids:
+                        continue
                     await action_service.forward_messages(
                         phone=phone,
                         from_chat=message.channel_id,
@@ -522,6 +562,10 @@ class ForwardHandler(BaseNodeHandler):
                         collapse_single_message_id=True,
                     )
                     increment_action_count(context, "forward")
+                    if dedup_repo is not None:
+                        await dedup_repo.log_action(
+                            pipeline_id, node_id, "forward", message.channel_id, message.message_id
+                        )
                     logger.info(
                         "ForwardHandler[%s]: forwarded message_id=%s channel_id=%s to dialog_id=%s phone=%s",
                         node_id,
@@ -582,8 +626,14 @@ class DeleteMessageHandler(BaseNodeHandler):
         messages = context.get_global("context_messages", [])
         resolved_phone = _resolve_account_phone(services.get("account_phone"), services, context)
         action_service = services.get("telegram_actions") or TelegramActionService(client_pool)
+        dedup_repo, processed_ids = await _dedup_context(services, node_id, "delete_message", node_config)
+        pipeline_id = services.get("pipeline_id")
+        skipped = 0
 
         for message in messages:
+            if message.message_id in processed_ids:
+                skipped += 1
+                continue
             try:
                 await action_service.delete_messages(
                     phone=resolved_phone,
@@ -594,6 +644,10 @@ class DeleteMessageHandler(BaseNodeHandler):
                     resolve_entity=False,
                 )
                 increment_action_count(context, "delete_message")
+                if dedup_repo is not None:
+                    await dedup_repo.log_action(
+                        pipeline_id, node_id, "delete_message", message.channel_id, message.message_id
+                    )
                 logger.info(
                     "DeleteMessageHandler[%s]: deleted message_id=%s channel_id=%s phone=%s",
                     node_id,
@@ -639,6 +693,10 @@ class DeleteMessageHandler(BaseNodeHandler):
                     message.message_id,
                     exc_info=True,
                 )
+        if skipped:
+            logger.info(
+                "DeleteMessageHandler[%s]: skipped %d already-deleted message(s)", node_id, skipped
+            )
 
 
 class ConditionHandler(BaseNodeHandler):

--- a/tests/repositories/test_pipeline_action_log_repository.py
+++ b/tests/repositories/test_pipeline_action_log_repository.py
@@ -1,0 +1,40 @@
+"""Tests for PipelineActionLogRepository (issue #471)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.database.repositories.pipeline_action_log import PipelineActionLogRepository
+
+
+@pytest.fixture
+async def action_log_repo(db):
+    return PipelineActionLogRepository(db.db, database=db)
+
+
+async def test_empty_returns_no_processed_ids(action_log_repo):
+    assert await action_log_repo.processed_message_ids(1, "react", "react") == set()
+
+
+async def test_log_and_read_back(action_log_repo):
+    await action_log_repo.log_action(1, "react", "react", -100, 5)
+    await action_log_repo.log_action(1, "react", "react", -100, 6)
+    assert await action_log_repo.processed_message_ids(1, "react", "react") == {5, 6}
+
+
+async def test_log_action_is_idempotent(action_log_repo):
+    await action_log_repo.log_action(1, "react", "react", -100, 5)
+    await action_log_repo.log_action(1, "react", "react", -100, 5)
+    assert await action_log_repo.processed_message_ids(1, "react", "react") == {5}
+
+
+async def test_scoped_by_pipeline_node_and_action(action_log_repo):
+    await action_log_repo.log_action(1, "react", "react", -100, 5)
+    await action_log_repo.log_action(2, "react", "react", -100, 5)
+    await action_log_repo.log_action(1, "forward", "forward", -100, 5)
+    await action_log_repo.log_action(1, "react", "delete_message", -100, 5)
+
+    assert await action_log_repo.processed_message_ids(1, "react", "react") == {5}
+    assert await action_log_repo.processed_message_ids(2, "react", "react") == {5}
+    assert await action_log_repo.processed_message_ids(1, "forward", "forward") == {5}
+    assert await action_log_repo.processed_message_ids(99, "react", "react") == set()

--- a/tests/test_pipeline_nodes_handlers.py
+++ b/tests/test_pipeline_nodes_handlers.py
@@ -1175,3 +1175,123 @@ async def test_agent_loop_with_tools_in_graph_execution():
     result = await executor.execute(pipeline, graph, services)
 
     assert result.get("generated_text") == "Final answer from agent"
+
+
+# ---------------------------------------------------------------------------
+# Action dedup (issue #471) — skip already-processed messages across runs
+# ---------------------------------------------------------------------------
+
+
+def _dedup_db(processed_ids):
+    db = MagicMock()
+    db.repos.pipeline_action_log.processed_message_ids = AsyncMock(return_value=set(processed_ids))
+    db.repos.pipeline_action_log.log_action = AsyncMock()
+    return db
+
+
+@pytest.mark.anyio
+async def test_react_skips_already_processed_message():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=7)])
+    action_service = AsyncMock()
+    db = _dedup_db({7})
+    await ReactHandler().execute(
+        {"emoji": "🔥"},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 42},
+    )
+    action_service.send_reaction.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_react_processes_and_logs_new_message():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=8)])
+    action_service = AsyncMock()
+    db = _dedup_db(set())
+    await ReactHandler().execute(
+        {"emoji": "🔥"},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 42},
+    )
+    action_service.send_reaction.assert_awaited_once()
+    db.repos.pipeline_action_log.log_action.assert_awaited_once_with(42, "react", "react", -100, 8)
+
+
+@pytest.mark.anyio
+async def test_react_dedup_disabled_via_config():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=7)])
+    action_service = AsyncMock()
+    db = _dedup_db({7})
+    await ReactHandler().execute(
+        {"emoji": "🔥", "deduplicate": False},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 42},
+    )
+    # Dedup turned off → never consults the log, acts on the message.
+    db.repos.pipeline_action_log.processed_message_ids.assert_not_awaited()
+    action_service.send_reaction.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_react_dedup_inactive_without_pipeline_id():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=7)])
+    action_service = AsyncMock()
+    db = _dedup_db({7})
+    # No pipeline_id → dedup stays off (back-compat), message is acted on.
+    await ReactHandler().execute(
+        {"emoji": "🔥"},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db},
+    )
+    action_service.send_reaction.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_delete_skips_already_processed_message():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=5)])
+    action_service = AsyncMock()
+    db = _dedup_db({5})
+    await DeleteMessageHandler().execute(
+        {},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 1},
+    )
+    action_service.delete_messages.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_forward_reaches_all_targets_within_run():
+    """A new message must be forwarded to every target in one run, even though
+    it is logged after the first target (snapshot is not mutated mid-run)."""
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=9)])
+    action_service = AsyncMock()
+    db = _dedup_db(set())
+    targets = [
+        {"phone": "+1", "dialog_id": 111},
+        {"phone": "+1", "dialog_id": 222},
+    ]
+    await ForwardHandler().execute(
+        {"targets": targets},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 3},
+    )
+    assert action_service.forward_messages.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_forward_skips_message_processed_in_prior_run():
+    ctx = NodeContext()
+    ctx.set_global("context_messages", [_msg(channel_id=-100, message_id=9)])
+    action_service = AsyncMock()
+    db = _dedup_db({9})
+    await ForwardHandler().execute(
+        {"targets": [{"phone": "+1", "dialog_id": 111}]},
+        ctx,
+        {"client_pool": MagicMock(), "telegram_actions": action_service, "db": db, "pipeline_id": 3},
+    )
+    action_service.forward_messages.assert_not_awaited()


### PR DESCRIPTION
Closes #471

> ⚠️ Base — ветка PR #631 (#468), т.к. изменения handlers.py лежат поверх structured-logging. После мёржа #468 GitHub переориентирует base на `main`.

## Проблема
Обработчики действий не помнили обработанные сообщения, поэтому каждый прогон в окне `since_hours` повторно реагировал/пересылал/удалял те же сообщения (react-пайплайн с интервалом 5 мин ре-реагировал на те же вступления ~288 раз/день — лишние API-вызовы и FloodWait).

## Решение
- **Таблица `pipeline_action_log`** (schema + индекс в migrations): `(pipeline_id, node_id, action, channel_id, message_id)` с `UNIQUE`.
- **`PipelineActionLogRepository`**: `processed_message_ids()` (снимок) + идемпотентный `log_action()` (`INSERT OR IGNORE`); зарегистрирован в `db.repos`.
- **`ContentGenerationService`** прокидывает `pipeline_id` в services узлов.
- **React/Forward/Delete** пропускают сообщения, обработанные в прошлых прогонах, и логируют новые. Отключается через конфиг узла `deduplicate: false`.

### Безопасность изменения
- Dedup включается только когда в services есть и `pipeline_id`, и репозиторий — поэтому юнит-тесты/ad-hoc запуски без них работают как раньше.
- Снимок processed-id не мутируется в течение прогона, поэтому **multi-target forward** доставляет сообщение всем таргетам за один прогон, а дубли отсекаются только между прогонами.

## Acceptance criteria
- [x] React/Forward/Delete пропускают уже обработанные сообщения.
- [x] Повторный прогон по тому же окну → новых действий нет (result_count=0 для уже обработанных).
- [x] Дедуп конфигурируем (`deduplicate: false`).

## Проверка
- `ruff` чисто; новые тесты обработчиков (skip/log/multi-target/back-compat) + репозитория; широкая регрессия pipeline/migration/schema/facade/repositories — 1329 passed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)