### PR TITLE
test(agent): lock web chat multi-turn + tool-event parity with CLI (#635)

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -247,12 +247,18 @@
 | Удалить тред | `agent thread-delete` | `DELETE /agent/threads/{id}` | `delete_agent_thread` |
 | Переименовать | `agent thread-rename` | `POST /agent/threads/{id}/rename` | `rename_agent_thread` |
 | Сообщения треда | `agent messages` | — | `get_thread_messages` |
-| Чат | `agent chat` | `POST /agent/threads/{id}/chat` | — |
+| Чат (многоходовой) | `agent chat` | `POST /agent/threads/{id}/chat` | — |
 | Статус Telegram-очереди | `dialogs queue status` | `POST /agent/threads/{id}/chat` | `get_telegram_queue_status` |
 | Отменить задание очереди | `dialogs queue cancel` | `POST /dialogs/queue/{id}/cancel` | `cancel_telegram_command` |
 | Очистить ожидающие в очереди | `dialogs queue clear-pending` | `POST /dialogs/queue/clear-pending` | `clear_pending_telegram_commands` |
 | Контекст | `agent context` | `POST /agent/threads/{id}/context` | — |
 | Остановить | — | `POST /agent/threads/{id}/stop` | — |
+
+> **Многоходовой чат (паритет CLI ↔ Web).** Обе стороны идут через единый
+> `AgentManager.chat_stream`, который на каждом ходе загружает полную историю треда
+> (`get_agent_messages`). В web многоходовость реализована как повторные `POST` в один и тот же
+> `thread_id`: контекст между ходами и события `tool_start`/`tool_end` в SSE на паритете с
+> интерактивным циклом CLI `agent chat`.
 
 ## Настройки
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3294,6 +3294,91 @@ class TestWebAgent:
         assert resp_stop.status_code == 200
         agent_manager.cancel_stream.assert_called_once_with(thread_id)
 
+    @staticmethod
+    def _ready_agent_manager() -> AsyncMock:
+        """AgentManager mock that reports a ready Claude backend (parity with CLI)."""
+        agent_manager = AsyncMock()
+        agent_manager.estimate_prompt_tokens = AsyncMock(return_value=10)
+        agent_manager.get_runtime_status = AsyncMock(
+            return_value=SimpleNamespace(
+                claude_available=True,
+                deepagents_available=False,
+                dev_mode_enabled=False,
+                backend_override="auto",
+                selected_backend="claude",
+                fallback_model="",
+                fallback_provider="",
+                using_override=False,
+                error=None,
+            )
+        )
+        return agent_manager
+
+    @pytest.mark.anyio
+    async def test_chat_multiturn_preserves_thread_context(self, client):
+        """Web drives the same thread across separate POSTs, so history accumulates (#635).
+
+        Parity with the CLI ``agent chat`` loop: both go through the same
+        ``AgentManager.chat_stream`` which loads the full thread history each turn.
+        """
+        db = client._transport.app.state.db
+        thread_id = await db.create_agent_thread("Новый тред")
+
+        calls: list[tuple[int, str]] = []
+
+        async def mock_stream(t_id, message, *args, **kwargs):
+            calls.append((t_id, message))
+            yield f'data: {{"done": true, "full_text": "A{len(calls)}"}}\n\n'
+
+        agent_manager = self._ready_agent_manager()
+        agent_manager.chat_stream = mock_stream
+        client._transport.app.state.agent_manager = agent_manager
+
+        resp1 = await client.post(
+            f"/agent/threads/{thread_id}/chat", json={"message": "Q1"}
+        )
+        assert resp1.status_code == 200
+        resp2 = await client.post(
+            f"/agent/threads/{thread_id}/chat", json={"message": "Q2"}
+        )
+        assert resp2.status_code == 200
+
+        # Both turns hit the same thread via the shared chat_stream entrypoint.
+        assert calls == [(thread_id, "Q1"), (thread_id, "Q2")]
+
+        # History accumulates in the thread: user/assistant/user/assistant.
+        messages = await db.get_agent_messages(thread_id)
+        assert [(m["role"], m["content"]) for m in messages] == [
+            ("user", "Q1"),
+            ("assistant", "A1"),
+            ("user", "Q2"),
+            ("assistant", "A2"),
+        ]
+
+    @pytest.mark.anyio
+    async def test_chat_stream_relays_tool_events(self, client):
+        """tool_start/tool_end events reach the web SSE client verbatim (#635 parity)."""
+        db = client._transport.app.state.db
+        thread_id = await db.create_agent_thread("Новый тред")
+
+        async def mock_stream(*args, **kwargs):
+            yield 'data: {"type": "tool_start", "tool": "list_channels"}\n\n'
+            yield 'data: {"type": "tool_end", "tool": "list_channels", "duration": 0.5, "is_error": false}\n\n'
+            yield 'data: {"text": "done thinking"}\n\n'
+            yield 'data: {"done": true, "full_text": "ok"}\n\n'
+
+        agent_manager = self._ready_agent_manager()
+        agent_manager.chat_stream = mock_stream
+        client._transport.app.state.agent_manager = agent_manager
+
+        resp = await client.post(
+            f"/agent/threads/{thread_id}/chat", json={"message": "list my channels"}
+        )
+        assert resp.status_code == 200
+        assert "tool_start" in resp.text
+        assert "tool_end" in resp.text
+        assert "list_channels" in resp.text
+
 
 @pytest.mark.anyio
 async def test_test_notification_no_bot(client):


### PR DESCRIPTION
Closes #635 — последний открытый пункт аудита #563 («Болтать с агентом»).

## Контекст
Исследование (CLI `agent chat` vs web `POST /agent/threads/{id}/chat`) показало, что **паритет уже достигнут де-факто**: обе стороны идут через единый `AgentManager.chat_stream`, который на каждом ходе грузит полную историю треда (`get_agent_messages`), и обе эмитят одинаковые SSE-события `tool_start`/`tool_end`. Многоходовость в web — это повторные `POST` в один и тот же `thread_id`; фронтенд (`agent.html`, `sendMessage()`) держит постоянный `threadId`.

Поэтому работа сведена к сценарию №3 из issue: **зафиксировать паритет тестами и задокументировать** — без изменений рантайма.

## Изменения
- **`tests/test_web.py`** — два регресс-теста в `TestWebAgent`:
  - `test_chat_multiturn_preserves_thread_context` — два POST в один тред, история накапливается user/assistant×2 через общий `chat_stream`.
  - `test_chat_stream_relays_tool_events` — `tool_start`/`tool_end` доходят до SSE-клиента дословно.
- **`docs/reference/parity.md`** — строка чата помечена как «многоходовой» + сноска про паритет web↔CLI.

Рантайм-код не меняется.

## Критерии приёмки #635
- [x] Многоходовой диалог в web сохраняет контекст треда между запросами.
- [x] События `tool_start`/`tool_end` доступны в web-стриме на паритете с CLI.
- [x] `docs/reference/parity.md` отражает фактическое состояние.
- [x] Parity/manifest-инварианты проходят.

## Проверка
- `pytest tests/test_web.py -k TestWebAgent tests/test_cli_agent_parity.py` — 9 passed.
- `pytest -k "parity or manifest"` — 4 passed.
- `ruff check src/ tests/` — чисто.

> После мёрджа #563 закрыт целиком → можно мёрджить #630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)