### PR TITLE
fix(db): repair get_preferred_phone crash via execute+fetchone (#633)

### DIFF
--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -269,10 +269,11 @@ class ChannelsRepository:
 
     async def get_preferred_phone(self, channel_id: int) -> str | None:
         """Return the preferred phone for a channel, or None if not set."""
-        row = await self._db.fetchone(
+        cur = await self._db.execute(
             "SELECT preferred_phone FROM channels WHERE channel_id = ?",
             (channel_id,),
         )
+        row = await cur.fetchone()
         return row["preferred_phone"] if row else None
 
     async def update_channel_created_at(self, channel_id: int, created_at) -> None:

--- a/tests/repositories/test_channels_repository.py
+++ b/tests/repositories/test_channels_repository.py
@@ -624,3 +624,32 @@ async def test_set_channel_type(channels_repo):
 
     channel = await channels_repo.get_channel_by_channel_id(1)
     assert channel.channel_type == "supergroup"
+
+
+# preferred_phone tests
+
+
+async def test_get_preferred_phone_default_none(channels_repo):
+    """A freshly added channel has no preferred phone."""
+    await channels_repo.add_channel(make_channel(1))
+    assert await channels_repo.get_preferred_phone(1) is None
+
+
+async def test_get_preferred_phone_roundtrip(channels_repo):
+    """update_channel_preferred_phone is readable back via get_preferred_phone.
+
+    Regression for #633 (#1): get_preferred_phone used a non-existent
+    Database.fetchone() and crashed with AttributeError on every call.
+    """
+    await channels_repo.add_channel(make_channel(1))
+    await channels_repo.update_channel_preferred_phone(1, "+1234567890")
+    assert await channels_repo.get_preferred_phone(1) == "+1234567890"
+
+    # Clearing resets it back to None.
+    await channels_repo.update_channel_preferred_phone(1, None)
+    assert await channels_repo.get_preferred_phone(1) is None
+
+
+async def test_get_preferred_phone_unknown_channel(channels_repo):
+    """Unknown channel_id yields None, not an error."""
+    assert await channels_repo.get_preferred_phone(999) is None


### PR DESCRIPTION
Адресует CRITICAL-баг #1 из баг-репорта #633.

## Проблема
`ChannelsRepository.get_preferred_phone` (`src/database/repositories/channels.py:272`) вызывал `self._db.fetchone(...)`, но ни `Database` (facade), ни `DBConnection` (connection) не имеют метода `fetchone()` — каждый вызов падал с `AttributeError`.

Баг не ловился, потому что единственный реальный вызывающий (`ClientPool`, `client_pool.py:190`) во всех тестах замокан (`tests/test_telegram_client_pool_collector.py:73`).

## Решение
Тот же идиом `execute()` + курсорный `fetchone()`, что и у соседних lookup-методов репозитория (`get_channel_by_pk`, `get_channel_by_channel_id`).

## Тесты
Добавлены тесты репозитория, прогоняющие **реальный** метод (до фикса упали бы с `AttributeError`):
- дефолт `None` у свежего канала;
- round-trip set/clear через `update_channel_preferred_phone`;
- неизвестный `channel_id` → `None`.

## Проверка
- `pytest tests/repositories/test_channels_repository.py -k preferred_phone` — 3 passed.
- `pytest tests/test_telegram_client_pool_collector.py` — 137 passed.
- `ruff check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)