### PR TITLE
fix(publish): avoid duplicate sends on multi-target publish retry (#633)

### DIFF
--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -92,6 +92,17 @@ class GenerationRunsRepository:
             (run_id,),
         )
 
+    async def set_metadata(self, run_id: int, metadata: dict) -> None:
+        """Persist the run metadata JSON without touching status or published_at.
+
+        Used to record incremental publish progress (per-target delivery) so a
+        retry does not re-send to targets already published.
+        """
+        await self._database.execute_write(
+            "UPDATE generation_runs SET metadata = ?, updated_at = datetime('now') WHERE id = ?",
+            (safe_json_dumps(metadata, ensure_ascii=False), run_id),
+        )
+
     async def set_quality_score(
         self, run_id: int, score: float, issues: list[str] | None = None
     ) -> None:

--- a/src/services/publish_service.py
+++ b/src/services/publish_service.py
@@ -18,6 +18,11 @@ class PublishResult:
     error: str | None = None
 
 
+def _target_key(target: PipelineTarget) -> str:
+    """Stable identity for a publish target — (phone, dialog_id) pair."""
+    return f"{target.phone}:{target.dialog_id}"
+
+
 class PublishService:
     """Service for publishing generated content to Telegram targets.
 
@@ -64,10 +69,30 @@ class PublishService:
             logger.warning("Pipeline %s has no targets", pipeline.id)
             return [PublishResult(success=False, error="No targets configured")]
 
+        # Track per-target delivery across attempts: on a partial failure the run
+        # stays eligible for retry, so without this a re-publish would re-send to
+        # targets that already succeeded, duplicating messages (issue #633).
+        metadata = dict(run.metadata or {})
+        delivered: set[str] = set(metadata.get("published_targets") or [])
+
         results: list[PublishResult] = []
+        newly_delivered: list[str] = []
         for target in targets:
+            key = _target_key(target)
+            if key in delivered:
+                # Already published on a previous attempt — skip to avoid a duplicate.
+                results.append(PublishResult(success=True))
+                continue
             result = await self._publish_to_target(run, target)
             results.append(result)
+            if result.success:
+                newly_delivered.append(key)
+
+        # Persist incremental progress so a later retry resumes only the failed targets.
+        if newly_delivered:
+            delivered.update(newly_delivered)
+            metadata["published_targets"] = sorted(delivered)
+            await self._db.repos.generation_runs.set_metadata(run.id, metadata)
 
         if all(r.success for r in results):
             await self._db.repos.generation_runs.set_published_at(run.id)

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -95,3 +95,20 @@ async def test_generation_runs_repo_hydrates_variant_fields(db):
     rows = await repo.list_by_pipeline(42)
     assert rows[0].variants == ["base", "variant 2"]
     assert rows[0].selected_variant == 1
+
+
+@pytest.mark.anyio
+async def test_set_metadata_persists_without_changing_status(db):
+    """set_metadata writes the metadata JSON but leaves status/published_at intact (issue #633)."""
+    repo = db.repos.generation_runs
+    run_id = await repo.create_run(42, "prompt-template")
+    await repo.set_moderation_status(run_id, "approved")
+
+    await repo.set_metadata(run_id, {"published_targets": ["+1:-1001"]})
+
+    run = await repo.get(run_id)
+    assert run is not None
+    assert run.metadata["published_targets"] == ["+1:-1001"]
+    # Status and publication state are untouched.
+    assert run.moderation_status == "approved"
+    assert run.published_at is None

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -37,19 +37,24 @@ class FakePipelinesRepo:
 class FakeGenerationRunsRepo:
     def __init__(self):
         self.published_ids = []
+        self.metadata_by_id = {}
 
     async def set_published_at(self, run_id):
         self.published_ids.append(run_id)
 
+    async def set_metadata(self, run_id, metadata):
+        self.metadata_by_id[run_id] = metadata
+
 
 class FakeClientPool:
-    def __init__(self, should_succeed=True):
+    def __init__(self, should_succeed=True, fail_phones=None):
         self._should_succeed = should_succeed
+        self._fail_phones = set(fail_phones or [])
         self._clients = {}
         self.released = []
 
     async def get_client_by_phone(self, phone):
-        if not self._should_succeed:
+        if not self._should_succeed or phone in self._fail_phones:
             return None
         client = self._clients.setdefault(phone, FakeClient())
         return (client, phone)
@@ -186,6 +191,75 @@ async def test_publish_service_success():
     assert results[0].message_id == 12345
     assert 1 in db.repos.generation_runs.published_ids
     assert pool.released == ["+1234567890"]
+
+
+@pytest.mark.anyio
+async def test_publish_service_partial_failure_records_delivered():
+    """Partial multi-target failure records delivered targets and does NOT mark published (issue #633)."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [
+            PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+            PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+        ]
+    )
+    # Second target has no available client → fails.
+    pool = FakeClientPool(fail_phones={"+2222222222"})
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert [r.success for r in results] == [True, False]
+    # Not fully published → run stays eligible for retry.
+    assert 1 not in db.repos.generation_runs.published_ids
+    # The delivered target is persisted so a retry can skip it.
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == ["+1111111111:-1001"]
+
+
+@pytest.mark.anyio
+async def test_publish_service_retry_skips_delivered_targets():
+    """A retry skips already-delivered targets (no duplicate) and completes the run (issue #633)."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [
+            PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+            PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+        ]
+    )
+    # On retry every client is available again.
+    pool = FakeClientPool()
+    service = PublishService(db, pool)
+
+    # Simulate a prior attempt that already delivered to the first target.
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        metadata={"published_targets": ["+1111111111:-1001"]},
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert [r.success for r in results] == [True, True]
+    # First target was skipped — never acquired a client, so no duplicate send.
+    assert "+1111111111" not in pool._clients
+    # Second target was actually sent.
+    assert "+2222222222" in pool._clients
+    assert len(pool._clients["+2222222222"].sent_messages) == 1
+    # All targets delivered → run is now marked published.
+    assert 1 in db.repos.generation_runs.published_ids
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
+        "+1111111111:-1001",
+        "+2222222222:-1002",
+    ]
 
 
 @pytest.mark.anyio

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -263,6 +263,40 @@ async def test_publish_service_retry_skips_delivered_targets():
 
 
 @pytest.mark.anyio
+async def test_publish_service_all_targets_already_delivered():
+    """All targets already delivered: no new sends, set_metadata NOT called, run marked published (issue #633)."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [
+            PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+            PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+        ]
+    )
+    pool = FakeClientPool()
+    service = PublishService(db, pool)
+
+    # A prior attempt already delivered to every target.
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        metadata={"published_targets": ["+1111111111:-1001", "+2222222222:-1002"]},
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    # Every target was skipped — reported success, no client acquired, no send.
+    assert [r.success for r in results] == [True, True]
+    assert pool._clients == {}
+    assert pool.released == []
+    # newly_delivered is empty → set_metadata must NOT be called (no clobber, no redundant write).
+    assert 1 not in db.repos.generation_runs.metadata_by_id
+    # All results succeeded → idempotent re-publish still closes the run.
+    assert 1 in db.repos.generation_runs.published_ids
+
+
+@pytest.mark.anyio
 async def test_publish_service_allows_auto_pipeline_without_approval():
     db = FakeDB()
     db.repos.content_pipelines.set_targets(


### PR DESCRIPTION
Адресует HIGH-баг #4 из баг-репорта #633.

## Проблема
`PublishService.publish_run` вызывал `set_published_at` только если **все** таргеты успешны (`if all(r.success ...)`). При частичном провале (часть таргетов ок, часть упала) `published_at`/`moderation_status='published'` не выставлялись → run оставался eligible. На retry сообщение слалось повторно **во все** таргеты, включая уже опубликованные — дубли.

> Замечу для контекста: при триаже #633 я также перепроверил HIGH-баги #2 (write-lock bypass в `content_pipelines._replace_*_no_commit`) и #3 (блокирующий I/O в `react_agent`) — **оба ложные**: `conn` и `self._db` это один и тот же объект соединения под удерживаемым write-lock; а `OllamaReActAgent` везде вызывается через `asyncio.to_thread`. Их не трогаю.

## Решение
Учёт доставки по таргетам в `run.metadata["published_targets"]` (ключ `phone:dialog_id`):
- таргеты, доставленные на прошлой попытке, **пропускаются** (без повторной отправки);
- вновь доставленные сохраняются новым `GenerationRunsRepository.set_metadata` (пишет только metadata, не трогая status/published_at);
- run помечается published, когда доставлены **все** таргеты (накопительно по попыткам), поэтому retry до-отправляет только упавшие.

Это лучше «глобального `any()`», который пометил бы run опубликованным при потере части таргетов (тихая потеря данных).

## Тесты
- `test_publish_service_partial_failure_records_delivered` — частичный провал: фиксирует доставленный таргет, не помечает published.
- `test_publish_service_retry_skips_delivered_targets` — retry пропускает доставленный таргет (нет дубля), добивает упавший, помечает published.
- `test_set_metadata_persists_without_changing_status` — repo-метод пишет metadata, не трогая status/published_at.

## Проверка
- `pytest tests/test_publish_service.py tests/test_generation_runs_repo.py` — 24 passed.
- `pytest tests/test_unified_dispatcher*.py tests/test_photo_publish_runtime.py` — 70 passed.
- `ruff check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)