### PR TITLE
fix(633): CI serial-step gating, weak filter test, adapter double-read (#5/#6/#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,9 @@ jobs:
               sys.exit(1)
           PY
 
-      - name: Pytest
-        run: pytest tests -q -m "not aiosqlite_serial" -n auto && pytest tests -q -m aiosqlite_serial
+      - name: Pytest (parallel-safe)
+        run: pytest tests -q -m "not aiosqlite_serial" -n auto
+
+      - name: Pytest (aiosqlite serial)
+        if: ${{ !cancelled() }}
+        run: pytest tests -q -m aiosqlite_serial

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -106,8 +106,8 @@ def make_generic_http_adapter(
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(endpoint, json=payload, headers=headers) as resp:
-                    text = await resp.text()
                     if resp.status != 200:
+                        text = await resp.text()
                         raise RuntimeError(f"Provider error {resp.status}: {text}")
                     data = await resp.json()
                     return await _parse_json_for_text(data)

--- a/tests/routes/test_filter_routes.py
+++ b/tests/routes/test_filter_routes.py
@@ -69,10 +69,15 @@ async def test_purge_selected_removes_messages(route_client, db):
 
     with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.purge_channels_by_pks = AsyncMock()
-        await route_client.post(
+        resp = await route_client.post(
             "/channels/filter/purge-selected",
             data={"pks": [str(pk)]},
+            follow_redirects=False,
         )
+
+    assert resp.status_code == 303
+    assert "msg=purged_selected" in resp.headers["location"]
+    mock_svc.return_value.purge_channels_by_pks.assert_awaited_once_with([pk])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Три низкорисковых фикса из баг-репорта #633 (HIGH-секция, пункты #5, #6, #8).

## #5 — `ci.yml`: `&&` прячет падение serial-тестов
Шаг Pytest был `pytest ... -n auto && pytest ... -m aiosqlite_serial`. При падении параллельной части serial-сьют не запускался, и его результаты не было видно. Разбито на два шага; serial-шаг помечен `if: ${{ !cancelled() }}`, чтобы оба сьюта всегда репортились независимо (но не запускались при отмене воркфлоу).

## #6 — `test_purge_selected_removes_messages` без assert'ов
Тест дёргал эндпоинт и не проверял ничего — всегда зелёный. Добавлены проверки: 303-редирект, `msg=purged_selected`, и делегирование выбранного pk в `filter_deletion_service.purge_channels_by_pks([pk])`.

## #8 — `make_generic_http_adapter`: двойное чтение тела ответа
Тело читалось `resp.text()`, затем `resp.json()` на success-пути. aiohttp кэширует тело, так что краша не было, но `text()` нужен только для текста ошибки. Перенёс его в ветку `status != 200` — как во всех остальных адаптерах файла (together/openai/hf/replicate).

## Проверка
- `pytest tests/routes/test_filter_routes.py` — 45 passed.
- `pytest -k "provider_adapter or generic_http"` — 52 passed.
- `ruff check` — чисто.
- `ci.yml` — YAML валиден, два независимых pytest-шага.

🤖 Generated with [Claude Code](https://claude.com/claude-code)