### PR TITLE
fix(633): harden web against CSRF logout and XSS (#16/#21/#22/#23)

### DIFF
--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -130,8 +130,9 @@ def register_builtin_endpoints(app: FastAPI) -> None:
             status_code=401,  # RFC 7235 / Starlette convention for failed auth
         )
 
-    @app.get("/logout")
+    @app.post("/logout")
     async def logout():
+        # POST-only: a GET logout is CSRF-able via <img src="/logout"> (issue #633).
         response = RedirectResponse(url="/login", status_code=303)
         response.delete_cookie(COOKIE_NAME)
         return response

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -4,6 +4,7 @@
 
 {% block head_scripts %}
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <style>
 .agent-layout {
     display: flex;
@@ -738,7 +739,11 @@
     marked.setOptions({breaks: true, gfm: true});
 
     function renderMd(text) {
-        return marked.parse(text || '');
+        var raw = marked.parse(text || '');
+        // Markdown may contain raw HTML; sanitize before innerHTML to block XSS (issue #633).
+        if (window.DOMPurify) return DOMPurify.sanitize(raw);
+        // Fail closed: if the sanitizer is unavailable, render escaped plain text.
+        return escapeHtml(text || '');
     }
 
     // Permission request dialog — menu style with keyboard shortcuts (1/2/3 + Enter)

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -3,8 +3,8 @@
 {% block title %}Агент — TG Agent{% endblock %}
 
 {% block head_scripts %}
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js" integrity="sha384-eEu5CTj3qGvu9PdJuS+YlkNi7d2XxQROAFYOr59zgObtlcux1ae1Il3u7jvdCSWu" crossorigin="anonymous"></script>
 <style>
 .agent-layout {
     display: flex;

--- a/src/web/templates/analytics/channels.html
+++ b/src/web/templates/analytics/channels.html
@@ -281,7 +281,17 @@
       crossCite.forEach(function(row) {
         var name = row.source_title || row.source_username || row.source_channel_id;
         var tr = document.createElement('tr');
-        tr.innerHTML = '<td>' + name + '</td><td>' + row.citation_count + '</td><td>' + (row.latest_date || '').slice(0, 10) + '</td>';
+        // textContent (not innerHTML): channel titles are attacker-controlled and
+        // would otherwise allow stored XSS, e.g. a title of "<img onerror=...>" (issue #633).
+        var nameTd = document.createElement('td');
+        nameTd.textContent = name;
+        var countTd = document.createElement('td');
+        countTd.textContent = row.citation_count;
+        var dateTd = document.createElement('td');
+        dateTd.textContent = (row.latest_date || '').slice(0, 10);
+        tr.appendChild(nameTd);
+        tr.appendChild(countTd);
+        tr.appendChild(dateTd);
         tbody.appendChild(tr);
       });
     } else {

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -55,7 +55,9 @@
                         <span class="navbar-text text-light small me-2 server-clock" data-utc="{{ server_now().isoformat() }}" title="Время сервера (UTC)"><i class="bi bi-clock"></i> <span class="server-clock-value">--:--:-- UTC</span></span>
                         <a class="btn btn-sm btn-outline-light" href="/settings" title="Настройки"><i class="bi bi-gear"></i></a>
                         <button class="btn btn-sm btn-outline-light" id="theme-toggle" type="button" title="Тема: авто"></button>
-                        <a class="btn btn-sm btn-outline-light" href="/logout" title="Выйти"><i class="bi bi-box-arrow-right"></i></a>
+                        <form method="post" action="/logout" class="d-inline m-0">
+                            <button type="submit" class="btn btn-sm btn-outline-light" title="Выйти"><i class="bi bi-box-arrow-right"></i></button>
+                        </form>
                     </li>
                 </ul>
                 </div>

--- a/src/web/templates/settings/_image_providers.html
+++ b/src/web/templates/settings/_image_providers.html
@@ -205,7 +205,11 @@ document.addEventListener('DOMContentLoaded', function() {
             resultsDiv.innerHTML = '';
             resultsDiv.appendChild(list);
         } catch (err) {
-            resultsDiv.innerHTML = '<p class="text-danger small">' + err.message + '</p>';
+            resultsDiv.innerHTML = '';
+            var errP = document.createElement('p');
+            errP.className = 'text-danger small';
+            errP.textContent = err.message;  // textContent, not innerHTML (issue #633)
+            resultsDiv.appendChild(errP);
         } finally {
             spinner.classList.add('d-none');
         }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1772,12 +1772,19 @@ async def test_web_login_redirects_authenticated_user_to_next(client):
 
 @pytest.mark.anyio
 async def test_logout_clears_cookie_and_redirects_to_login(client):
-    resp = await client.get("/logout", follow_redirects=False)
+    resp = await client.post("/logout", follow_redirects=False)
     assert resp.status_code == 303
     assert resp.headers["location"] == "/login"
     assert COOKIE_NAME in resp.headers.get("set-cookie", "")
     cookie_header = resp.headers.get("set-cookie", "")
     assert "Max-Age=0" in cookie_header or "max-age=0" in cookie_header
+
+
+@pytest.mark.anyio
+async def test_logout_rejects_get(client):
+    """GET /logout must not log out — prevents CSRF via <img src="/logout"> (issue #633)."""
+    resp = await client.get("/logout", follow_redirects=False)
+    assert resp.status_code == 405
 
 
 @pytest.mark.anyio
@@ -1816,7 +1823,7 @@ async def test_invalid_cookie_falls_back(unauth_client):
 
 @pytest.mark.anyio
 async def test_logout_no_auth_required(unauth_client):
-    resp = await unauth_client.get("/logout", follow_redirects=False)
+    resp = await unauth_client.post("/logout", follow_redirects=False)
     assert resp.status_code == 303
     assert resp.headers["location"] == "/login"
 


### PR DESCRIPTION
Security-фиксы из баг-репорта #633 (MEDIUM-секция). Все четыре пункта проверены по коду.

## #16 — CSRF-logout (GET → POST)
`/logout` был GET, удаляющим session-cookie → `<img src="/logout">` на чужом сайте разлогинивал пользователя. Маршрут сделан `@app.post("/logout")`, в навбаре ссылка заменена на маленькую POST-форму. GET теперь возвращает 405.

## #21 — stored XSS в `analytics/channels.html`
Строки cross-citations вставляли **заголовок канала** (произвольный, контролируемый источником) в `tr.innerHTML`. Канал с заголовком `<img src=x onerror=...>` исполнял бы скрипт. Ячейки строятся через `createElement` + `textContent`.

## #22 — XSS в `agent.html` (marked без санитайзера)
Markdown чата рендерился `marked.parse` → `innerHTML` без санитайзера, сырой HTML в сообщении исполнялся. Подключён DOMPurify (CDN), `renderMd` санитизирует вывод; fail-closed на экранированный текст, если DOMPurify не загрузился.

## #23 — XSS в `settings/_image_providers.html`
`err.message` конкатенировался в `innerHTML`. Заменено на `textContent`.

## Проверка
- `pytest tests/test_web.py tests/test_panel_auth.py tests/test_web_route_helpers.py` — 200 passed (logout: POST=303, GET=405; страницы analytics/agent/image-providers рендерятся).
- `ruff check` — чисто.

> Контекст триажа: пункты #21/#22 — реальные stored XSS через данные из Telegram/чата; #16 — реальный CSRF; #23 — низкий риск, но `textContent` строго безопаснее и тривиален.

🤖 Generated with [Claude Code](https://claude.com/claude-code)