### PR TITLE
fix(telegram): bound first-run memory + PeerChat for legacy groups (#633)

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -18,7 +18,7 @@ from telethon.errors import (
     UsernameNotOccupiedError,
 )
 from telethon.tl.types import Channel as TLChannel
-from telethon.tl.types import ChannelForbidden, Chat, PeerChannel, PeerUser
+from telethon.tl.types import ChannelForbidden, Chat, PeerChannel, PeerChat, PeerUser
 
 from src.config import TelegramRuntimeConfig
 from src.database import Database
@@ -330,9 +330,15 @@ class ClientPool:
         if target_type is None:
             dialog = await self._get_cached_dialog(phone, dialog_id)
             cached_type = str(dialog.get("channel_type") or "") if dialog else ""
-            if cached_type in {"dm", "bot", "saved"}:
+            if cached_type in {"dm", "bot", "saved", "group"}:
                 target_type = cached_type
-        peer = PeerUser(dialog_id) if target_type in ("dm", "bot", "saved") else PeerChannel(abs(dialog_id))
+        if target_type in ("dm", "bot", "saved"):
+            peer = PeerUser(dialog_id)
+        elif target_type == "group":
+            # Legacy small groups are PeerChat, not PeerChannel.
+            peer = PeerChat(abs(dialog_id))
+        else:
+            peer = PeerChannel(abs(dialog_id))
         try:
             return await run_with_flood_wait(
                 session.resolve_input_entity(peer),
@@ -1363,7 +1369,13 @@ class ClientPool:
         try:
             for cid, ctype in dialogs:
                 try:
-                    peer = PeerUser(cid) if ctype in ("dm", "bot", "saved") else PeerChannel(abs(cid))
+                    if ctype in ("dm", "bot", "saved"):
+                        peer = PeerUser(cid)
+                    elif ctype == "group":
+                        # Legacy small groups are PeerChat, not PeerChannel.
+                        peer = PeerChat(abs(cid))
+                    else:
+                        peer = PeerChannel(abs(cid))
                     async def _remove_dialog() -> None:
                         entity = await session.resolve_entity(peer)
                         await session.remove_dialog(entity)

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -595,7 +595,12 @@ class Collector:
                 except Exception as e:
                     logger.warning("Failed to prefetch dialogs for %s: %s", phone, e)
             messages_batch: list[Message] = []
+            # `all_messages` only retains message objects when notifications are
+            # enabled (incremental runs, bounded by min_id). On first-run for huge
+            # channels we keep just a count to avoid unbounded growth / OOM (#633).
             all_messages: list[Message] = []
+            collected_count = 0
+            saw_topic_message = False
             persisted_max_msg_id = min_id
             flood_wait_sec: int | None = None
             flood_wait_operation: str | None = None
@@ -614,7 +619,7 @@ class Collector:
             )
 
             async def _flush_batch(batch: list[Message]) -> bool:
-                nonlocal persisted_max_msg_id
+                nonlocal persisted_max_msg_id, collected_count, saw_topic_message
                 if not batch:
                     return True
 
@@ -641,15 +646,20 @@ class Collector:
                     return False
 
                 persisted_max_msg_id = max(persisted_max_msg_id, max(expected_ids))
-                all_messages.extend(batch)
+                collected_count += len(batch)
+                if not saw_topic_message and any(m.topic_id is not None for m in batch):
+                    saw_topic_message = True
+                # Only retain objects when they are needed downstream (notifications).
+                if should_notify:
+                    all_messages.extend(batch)
                 logger.info(
                     "Channel %d: persisted %d messages, total %d",
                     channel_id,
                     len(batch),
-                    len(all_messages),
+                    collected_count,
                 )
                 if progress_callback:
-                    await progress_callback(total_collected + len(all_messages))
+                    await progress_callback(total_collected + collected_count)
                 return True
 
             try:
@@ -989,7 +999,7 @@ class Collector:
                 await self._pool.release_client(phone)
 
             if stop_due_to_persistence_error:
-                return total_collected + len(all_messages)
+                return total_collected + collected_count
 
             # Handle FloodWait AFTER finally has flushed progress.
             # Rotate regular collection FloodWaits to another account
@@ -1032,11 +1042,11 @@ class Collector:
                 if channel.id is not None:
                     updated = await self._db.get_channel_by_pk(channel.id)
                 if updated:
-                    total_collected += len(all_messages)
-                    progress_offset += len(all_messages)
+                    total_collected += collected_count
+                    progress_offset += collected_count
                     channel = updated
                     continue
-                return total_collected + len(all_messages)
+                return total_collected + collected_count
 
             if should_notify and all_messages:
                 for m in all_messages:
@@ -1045,7 +1055,7 @@ class Collector:
 
             # Update forum topics in DB if messages with topic_id
             # were collected
-            if all_messages and any(m.topic_id is not None for m in all_messages):
+            if saw_topic_message:
                 cached = await self._db.get_forum_topics(channel_id)
                 if not cached:
                     try:
@@ -1059,7 +1069,7 @@ class Collector:
                             e,
                         )
 
-            if is_first_run and not force and len(all_messages) >= 50:
+            if is_first_run and not force and collected_count >= 50:
                 cur = await self._db.execute(
                     "SELECT COUNT(*) as total,"
                     " COUNT(DISTINCT substr(text,1,100)) as uniq"
@@ -1080,7 +1090,7 @@ class Collector:
                         # Not auto-deleting here: messages were just collected,
                         # channel will be deleted on the next collection run.
 
-            return total_collected + len(all_messages)
+            return total_collected + collected_count
 
     async def _discover_phone_for_channel(
         self, channel_id: int, exclude: str

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -907,6 +907,59 @@ async def test_incremental_collection_sends_notification_queries(db):
 
 
 @pytest.mark.anyio
+async def test_first_run_detects_topics_without_retaining_messages(db):
+    """First-run forum-topic detection runs via the saw_topic_message flag (#633).
+
+    On first-run we no longer accumulate every Message object in memory, so topic
+    detection must rely on the running flag rather than scanning a retained list.
+    """
+    ch = Channel(channel_id=-100199, title="Forum", username="forum199", last_collected_id=0)
+    await db.add_channel(ch)
+
+    topic_msg = make_mock_message(1, text="topic msg")
+    topic_msg.reply_to = SimpleNamespace(forum_topic=True, reply_to_top_id=42, reply_to_msg_id=None)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(side_effect=lambda *a, **kw: _AsyncIterMessages([topic_msg]))
+
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(return_value=(mock_client, "+7000")),
+        get_forum_topics=AsyncMock(return_value=[]),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+    count = await collector._collect_channel(ch)
+
+    assert count == 1
+    pool.get_forum_topics.assert_awaited_once_with(-100199)
+
+
+@pytest.mark.anyio
+async def test_first_run_skips_topic_lookup_without_topic_messages(db):
+    """No topic messages → no forum-topic lookup (saw_topic_message stays False) (#633)."""
+    ch = Channel(channel_id=-100200, title="Plain", username="plain200", last_collected_id=0)
+    await db.add_channel(ch)
+
+    mock_msgs = [make_mock_message(i, text=f"msg {i}") for i in range(1, 4)]
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(side_effect=lambda *a, **kw: _AsyncIterMessages(mock_msgs))
+
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(return_value=(mock_client, "+7000")),
+        get_forum_topics=AsyncMock(return_value=[]),
+    )
+
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+    count = await collector._collect_channel(ch)
+
+    assert count == 3
+    pool.get_forum_topics.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_channel_retries_after_short_flood_wait(db):
     ch = Channel(channel_id=-100171, title="Retry", username="retry", last_collected_id=5)
     ch_id = await db.add_channel(ch)

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -29,6 +29,8 @@ from telethon.tl.types import (
     MessageMediaGeo,
     MessageMediaGeoLive,
     MessageMediaWebPage,
+    PeerChannel,
+    PeerChat,
     PeerUser,
 )
 
@@ -109,6 +111,49 @@ async def test_resolve_dialog_entity_uses_cached_dm_type_before_warm(pool, mock_
     peer = client.get_input_entity.await_args.args[0]
     assert isinstance(peer, PeerUser)
     client.get_dialogs.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_resolve_dialog_entity_legacy_group_uses_peerchat(pool, mock_db):
+    """Legacy small groups (channel_type == 'group') must resolve via PeerChat (#633)."""
+    client = AsyncMock()
+    client.get_input_entity = AsyncMock(return_value="chat-entity")
+    client.get_dialogs = AsyncMock(return_value=[])
+    mock_db.repos.dialog_cache.get_dialog.return_value = {
+        "channel_id": -1234567,
+        "title": "Legacy Group",
+        "username": None,
+        "channel_type": "group",
+    }
+
+    result = await pool.resolve_dialog_entity(client, "+1", -1234567)
+
+    assert result == "chat-entity"
+    peer = client.get_input_entity.await_args.args[0]
+    assert isinstance(peer, PeerChat)
+    assert peer.chat_id == 1234567
+    client.get_dialogs.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_resolve_dialog_entity_channel_uses_peerchannel(pool, mock_db):
+    """Regular channels still resolve via PeerChannel (#633 regression guard)."""
+    client = AsyncMock()
+    client.get_input_entity = AsyncMock(return_value="channel-entity")
+    client.get_dialogs = AsyncMock(return_value=[])
+    mock_db.repos.dialog_cache.get_dialog.return_value = {
+        "channel_id": -1001234567,
+        "title": "Some Channel",
+        "username": "somechannel",
+        "channel_type": "channel",
+    }
+
+    result = await pool.resolve_dialog_entity(client, "+1", -1001234567)
+
+    assert result == "channel-entity"
+    peer = client.get_input_entity.await_args.args[0]
+    assert isinstance(peer, PeerChannel)
+    assert peer.channel_id == 1001234567
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Часть bug-report **#633** — MEDIUM-кластер «Telegram collector/pool» (#13/#14/#15).

## #14 — неограниченный рост памяти при first-run (`src/telegram/collector.py`)
На первичном сборе (`is_first_run`, без `min_id`) per-channel коллектор копил **все**
персистнутые `Message` в `all_messages` → для каналов с миллионами сообщений список рос
без ограничений и грозил OOM.

Исправление:
- Введён счётчик `collected_count` (заменяет `len(all_messages)` во всех подсчётах/прогрессе/возврате).
- Введён флаг `saw_topic_message`, обновляемый в `_flush_batch` (заменяет `any(m.topic_id ...)` для определения forum-топиков).
- Объекты `Message` накапливаются в `all_messages` **только когда уведомления активны**
  (`should_notify` — инкрементальный прогон, объём ограничен `min_id`). На first-run
  `should_notify == False`, поэтому список остаётся пустым.

Возвращаемое значение, прогресс-колбэки, поведение уведомлений и топиков сохранены.

## #15 — PeerChat для legacy small groups (`src/telegram/client_pool.py`)
`resolve_dialog_entity` (и `leave_channels`) всегда строили `PeerChannel(abs(dialog_id))`.
Для legacy-групп (Telegram `channel_type == "group"`) корректен `PeerChat`, а не
`PeerChannel`. Добавлен импорт `PeerChat` и ветвление по типу; каналы и пользователи не затронуты.

## #13 — verified already resolved (no-op)
`_discover_phone_for_channel` уже имеет выделенный `except FloodWaitError` →
`report_flood`, а основной путь сбора оборачивает `warm_dialog_cache()` в
`run_with_flood_wait`. Пул узнаёт о flood. Изменений не требуется — отмечено для полноты.

## Тесты
- `test_first_run_detects_topics_without_retaining_messages` / `..._skips_topic_lookup_without_topic_messages` — detection топиков через флаг на first-run.
- `test_resolve_dialog_entity_legacy_group_uses_peerchat` / `..._channel_uses_peerchannel` — маршрутизация PeerChat vs PeerChannel vs PeerUser.

## Верификация
- `ruff check src/ tests/ conftest.py` — чисто.
- `pytest -m "not aiosqlite_serial" -n auto` → 7211 passed, 104 skipped.
- `pytest -m aiosqlite_serial` → 833 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)