### PR TITLE
fix(search): proxy web premium/telegram search to the worker (#643)

### DIFF
--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.config import AppConfig
 from src.database import Database
@@ -40,6 +40,9 @@ except ImportError:  # pragma: no cover
     class ReactionInvalidError(Exception):  # type: ignore[no-redef]
         pass
 
+if TYPE_CHECKING:
+    from src.search.engine import SearchEngine
+
 logger = logging.getLogger(__name__)
 
 # Minimum spacing between reactions on the same phone. Configurable live via the
@@ -71,6 +74,7 @@ class TelegramCommandDispatcher:
         *,
         scheduler: SchedulerManager | None = None,
         auth: TelegramAuth | None = None,
+        search_engine: "SearchEngine | None" = None,
     ):
         self._db = db
         self._pool = pool
@@ -78,6 +82,7 @@ class TelegramCommandDispatcher:
         self._collector = collector
         self._scheduler = scheduler
         self._auth = auth
+        self._search_engine = search_engine
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
         self._last_reaction_at_monotonic: dict[str, float] = {}
@@ -644,6 +649,29 @@ class TelegramCommandDispatcher:
             "channel_username": result.channel_username,
             "invite_link": result.invite_link,
         }
+
+    async def _handle_search_telegram(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Run a live Telegram-backed search on the worker's real pool.
+
+        The web container has no live ClientPool (runtime_mode="web"), so it
+        proxies premium/my_chats/in-channel search here and reads the serialized
+        SearchResult back from ``result_payload`` (#643).
+        """
+        if self._search_engine is None:
+            raise RuntimeError("Search engine unavailable in worker")
+        query = str(payload.get("query", ""))
+        mode = str(payload.get("mode", "telegram"))
+        limit = int(payload.get("limit", 50))
+        if mode == "my_chats":
+            result = await self._search_engine.search_my_chats(query, limit=limit)
+        elif mode == "channel":
+            channel_id = payload.get("channel_id")
+            result = await self._search_engine.search_in_channel(
+                int(channel_id) if channel_id is not None else None, query, limit=limit
+            )
+        else:
+            result = await self._search_engine.search_telegram(query, limit=limit)
+        return {"result": result.model_dump(mode="json")}
 
     async def _handle_agent_forum_topics_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
         channel_id = int(payload["channel_id"])

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -297,6 +297,7 @@ async def build_container_with_templates(
             collector,
             scheduler=scheduler,
             auth=auth,
+            search_engine=search_engine,
         )
         agent_manager = AgentManager(db, config, client_pool=pool, scheduler_manager=scheduler)
     else:

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -1,10 +1,13 @@
+import asyncio
 import logging
 import re
+import time
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from pydantic import ValidationError
 
-from src.models import SearchResult
+from src.models import SearchResult, TelegramCommandStatus
 from src.web import deps
 from src.web.template_globals import _agent_available_for_request
 
@@ -12,6 +15,70 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _LEN_RE = re.compile(r"\blen\s*(<|>)\s*(\d+)[,;]?")
+
+# Telegram-backed search modes need a live ClientPool. The web container has
+# none (runtime_mode="web"), so these are proxied to the worker process (#643).
+_TELEGRAM_SEARCH_MODES = {"telegram", "my_chats", "channel"}
+_WORKER_SEARCH_TIMEOUT_SEC = 45.0
+_WORKER_SEARCH_POLL_SEC = 0.4
+
+
+async def _telegram_search_via_worker(
+    request: Request,
+    *,
+    mode: str,
+    query: str,
+    limit: int,
+    channel_id: int | None,
+) -> SearchResult:
+    """Proxy a live Telegram search to the worker and await its result (#643).
+
+    The web container cannot open Telegram connections, so it enqueues a
+    ``search.telegram`` command and polls ``telegram_commands.result_payload``
+    until the worker (embedded or standalone) finishes it.
+    """
+    from src.web.routes.scheduler import _is_worker_alive
+
+    db = deps.get_db(request)
+    if not await _is_worker_alive(db):
+        return SearchResult(
+            messages=[],
+            total=0,
+            query=query,
+            error="Telegram-worker не запущен — premium-поиск недоступен. Запустите worker.",
+        )
+    cmd_service = deps.telegram_command_service(request)
+    payload: dict = {"mode": mode, "query": query, "limit": limit}
+    if channel_id is not None:
+        payload["channel_id"] = channel_id
+    command_id = await cmd_service.enqueue(
+        "search.telegram", payload=payload, requested_by="web:search"
+    )
+    deadline = time.monotonic() + _WORKER_SEARCH_TIMEOUT_SEC
+    while time.monotonic() < deadline:
+        command = await cmd_service.get(command_id)
+        if command is None:
+            break
+        if command.status == TelegramCommandStatus.SUCCEEDED:
+            try:
+                return SearchResult.model_validate(command.result_payload or {})
+            except ValidationError:
+                logger.warning("Malformed worker search result for command %s", command_id)
+                return SearchResult(messages=[], total=0, query=query, error="Некорректный ответ worker.")
+        if command.status == TelegramCommandStatus.FAILED:
+            return SearchResult(
+                messages=[], total=0, query=query,
+                error=command.error or "Ошибка поиска в worker.",
+            )
+        if command.status == TelegramCommandStatus.CANCELLED:
+            return SearchResult(messages=[], total=0, query=query, error="Поиск отменён.")
+        await asyncio.sleep(_WORKER_SEARCH_POLL_SEC)
+    return SearchResult(
+        messages=[],
+        total=0,
+        query=query,
+        error="Worker не ответил вовремя. Проверьте, что Telegram-worker запущен.",
+    )
 
 
 def _extract_length(q: str) -> tuple[str, int | None, int | None]:
@@ -70,6 +137,7 @@ async def _render_search_page(
 
     service = deps.search_service(request)
     channels = await db.get_channels()
+    runtime_mode = getattr(request.app.state, "runtime_mode", "web")
 
     # Browse mode: channel_id without query shows latest messages from that channel
     if not q and channel_id_int and mode in {"local", "semantic", "hybrid"}:
@@ -95,6 +163,15 @@ async def _render_search_page(
     elif q:
         if channel_id_error and mode in {"local", "semantic", "hybrid", "channel"}:
             result = SearchResult(messages=[], total=0, query=q, error=channel_id_error)
+        elif mode in _TELEGRAM_SEARCH_MODES and runtime_mode == "web":
+            # Web container has no live ClientPool — run it on the worker (#643).
+            try:
+                result = await _telegram_search_via_worker(
+                    request, mode=mode, query=fts_query, limit=limit, channel_id=channel_id_int
+                )
+            except Exception as exc:
+                logger.exception("Worker search proxy failed: mode=%s query=%r", mode, q)
+                result = SearchResult(messages=[], total=0, query=q, error=f"Ошибка поиска: {exc}")
         else:
             try:
                 result = await service.search(

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -2002,3 +2002,47 @@ async def test_dialogs_edit_permissions_with_until_date():
     })
     kwargs = c.edit_permissions.call_args[1]
     assert "until_date" in kwargs
+
+
+# --- _handle_search_telegram: proxies live Telegram search to the worker (#643) ---
+
+
+async def test_search_telegram_handler_routes_premium():
+    from src.models import Message, SearchResult
+
+    engine = MagicMock()
+    msg = Message(
+        channel_id=-100, message_id=1, text="hit",
+        date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    engine.search_telegram = AsyncMock(return_value=SearchResult(messages=[msg], total=1, query="q"))
+    d = _dispatcher(search_engine=engine)
+
+    out = await d._handle_search_telegram({"mode": "telegram", "query": "q", "limit": 25})
+
+    engine.search_telegram.assert_awaited_once_with("q", limit=25)
+    assert out["result"]["total"] == 1
+    assert out["result"]["messages"][0]["text"] == "hit"
+    # result_payload must round-trip back into a SearchResult
+    assert SearchResult.model_validate(out["result"]).messages[0].message_id == 1
+
+
+async def test_search_telegram_handler_routes_my_chats_and_channel():
+    from src.models import SearchResult
+
+    engine = MagicMock()
+    engine.search_my_chats = AsyncMock(return_value=SearchResult(messages=[], total=0, query="q"))
+    engine.search_in_channel = AsyncMock(return_value=SearchResult(messages=[], total=0, query="q"))
+    d = _dispatcher(search_engine=engine)
+
+    await d._handle_search_telegram({"mode": "my_chats", "query": "q", "limit": 10})
+    engine.search_my_chats.assert_awaited_once_with("q", limit=10)
+
+    await d._handle_search_telegram({"mode": "channel", "query": "q", "limit": 10, "channel_id": -100500})
+    engine.search_in_channel.assert_awaited_once_with(-100500, "q", limit=10)
+
+
+async def test_search_telegram_handler_without_engine_raises():
+    d = _dispatcher(search_engine=None)
+    with pytest.raises(RuntimeError, match="Search engine unavailable"):
+        await d._handle_search_telegram({"mode": "telegram", "query": "q"})

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1594,10 +1594,56 @@ async def test_search_runtime_error_is_rendered(client, monkeypatch):
 
     monkeypatch.setattr(deps, "search_service", lambda request: BrokenSearchService())
 
-    resp = await client.get("/search?q=test&mode=telegram")
+    # mode=local goes through service.search directly (telegram modes are now
+    # proxied to the worker in web runtime, see #643).
+    resp = await client.get("/search?q=test&mode=local")
 
     assert resp.status_code == 200
     assert "Ошибка поиска: boom" in resp.text
+
+
+@pytest.mark.anyio
+async def test_search_telegram_proxy_when_worker_down(client, monkeypatch):
+    """Telegram-mode search in web runtime fails fast when no worker is alive (#643)."""
+    monkeypatch.setattr("src.web.routes.scheduler._is_worker_alive", AsyncMock(return_value=False))
+
+    resp = await client.get("/search?q=test&mode=telegram")
+
+    assert resp.status_code == 200
+    assert "Telegram-worker не запущен" in resp.text
+
+
+@pytest.mark.anyio
+async def test_search_telegram_proxy_renders_worker_result(client, monkeypatch):
+    """Web proxies premium search to the worker and renders its result (#643)."""
+    from src.models import Message, SearchResult, TelegramCommand, TelegramCommandStatus
+    from src.web import deps
+
+    monkeypatch.setattr("src.web.routes.scheduler._is_worker_alive", AsyncMock(return_value=True))
+
+    msg = Message(
+        channel_id=-100, message_id=7, text="proxied premium hit",
+        date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    payload = SearchResult(messages=[msg], total=1, query="test").model_dump(mode="json")
+    command = TelegramCommand(
+        id=99,
+        command_type="search.telegram",
+        status=TelegramCommandStatus.SUCCEEDED,
+        result_payload=payload,
+    )
+    fake_cmd_service = SimpleNamespace(
+        enqueue=AsyncMock(return_value=99),
+        get=AsyncMock(return_value=command),
+    )
+    monkeypatch.setattr(deps, "telegram_command_service", lambda request: fake_cmd_service)
+
+    resp = await client.get("/search?q=test&mode=telegram")
+
+    assert resp.status_code == 200
+    assert "proxied premium hit" in resp.text
+    fake_cmd_service.enqueue.assert_awaited_once()
+    assert fake_cmd_service.enqueue.await_args.args[0] == "search.telegram"
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #643.

## Симптом
Режим **«Публичные (Premium)»** (а также «Мои чаты» и «В канале») в веб-интерфейсе падает с `Ошибка: Нет подключённых Telegram-аккаунтов.` — даже когда Premium-аккаунт подключён. Заголовок issue («не основной аккаунт») — ошибочная догадка.

## Корень (регрессия после #452)
Разделение web/worker runtime (#452) перевело web-контейнер в `runtime_mode="web"` с `search_pool = None` (`src/web/bootstrap.py`). Поэтому `TelegramSearch.search_telegram` сразу возвращает «нет аккаунтов» — независимо от того, какой аккаунт держит Premium. CLI (`search --mode telegram`) работает, т.к. строит реальный `ClientPool`. До #452 web владел пулом и premium-поиск в вебе работал.

## Решение
Проксируем live-поиск на worker (он владеет реальным пулом) — тем же механизмом `telegram_commands`, что и другие live-действия:

- **`TelegramCommandDispatcher`**: новый опциональный `search_engine` и обработчик `_handle_search_telegram`, который вызывает `search_telegram` / `search_my_chats` / `search_in_channel` и кладёт сериализованный `SearchResult` в `result_payload`.
- **Worker bootstrap**: пробрасывает worker-side `search_engine` в диспетчер.
- **Web-роут `/search`**: для режимов `telegram`/`my_chats`/`channel` в web-runtime ставит команду `search.telegram` и опрашивает `result_payload` до завершения. Быстрый fail-fast с понятным сообщением, если heartbeat worker устарел (переиспользуется `_is_worker_alive`) — отсутствие worker больше не вешает запрос на таймаут.

Гейтинг радио-кнопок (`telegram_available` по подключённым телефонам из snapshot, #624) не меняется: режимы предлагаются только когда у worker есть аккаунты.

## Тесты
- `tests/test_telegram_command_dispatcher.py`: маршрутизация обработчика (telegram/my_chats/channel), round-trip `result_payload` → `SearchResult`, ошибка без движка.
- `tests/test_web.py`: прокси рендерит результат worker; fail-fast при недоступном worker. Обновлён `test_search_runtime_error_is_rendered` (telegram теперь проксируется → проверка generic-ошибки через `mode=local`).

## Верификация
- `ruff check src/ tests/ conftest.py` — чисто.
- `pytest -m "not aiosqlite_serial" -n auto` → 7216 passed, 104 skipped.
- `pytest -m aiosqlite_serial` → 833 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)