### PR TITLE
fix(db): keep pipeline source/target replace inside the write-lock (#633)

### DIFF
--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -117,8 +117,8 @@ class ContentPipelinesRepository:
                 ),
             )
             pipeline_id = cur.lastrowid or 0
-            await self._replace_sources_no_commit(pipeline_id, source_channel_ids)
-            await self._replace_targets_no_commit(pipeline_id, targets)
+            await self._replace_sources_no_commit(pipeline_id, source_channel_ids, conn=conn)
+            await self._replace_targets_no_commit(pipeline_id, targets, conn=conn)
             return pipeline_id
 
     async def get_all(self, active_only: bool = False) -> list[ContentPipeline]:
@@ -187,8 +187,8 @@ class ContentPipelinesRepository:
                 )
                 if not cur.rowcount:
                     raise _NotFoundError
-                await self._replace_sources_no_commit(pipeline_id, source_channel_ids)
-                await self._replace_targets_no_commit(pipeline_id, targets)
+                await self._replace_sources_no_commit(pipeline_id, source_channel_ids, conn=conn)
+                await self._replace_targets_no_commit(pipeline_id, targets, conn=conn)
         except _NotFoundError:
             return False
         return True
@@ -261,10 +261,15 @@ class ContentPipelinesRepository:
         self,
         pipeline_id: int,
         source_channel_ids: list[int],
+        conn=None,
     ) -> None:
-        await self._db.execute("DELETE FROM pipeline_sources WHERE pipeline_id = ?", (pipeline_id,))
+        # Must run on the caller's transaction connection so the DELETE+INSERT
+        # stay inside the write-lock; falling back to self._db would commit them
+        # autonomously and let another coroutine interleave (#633).
+        executor = conn or self._db
+        await executor.execute("DELETE FROM pipeline_sources WHERE pipeline_id = ?", (pipeline_id,))
         if source_channel_ids:
-            await self._db.executemany(
+            await executor.executemany(
                 "INSERT INTO pipeline_sources (pipeline_id, channel_id) VALUES (?, ?)",
                 [(pipeline_id, channel_id) for channel_id in source_channel_ids],
             )
@@ -273,10 +278,12 @@ class ContentPipelinesRepository:
         self,
         pipeline_id: int,
         targets: list[PipelineTarget],
+        conn=None,
     ) -> None:
-        await self._db.execute("DELETE FROM pipeline_targets WHERE pipeline_id = ?", (pipeline_id,))
+        executor = conn or self._db
+        await executor.execute("DELETE FROM pipeline_targets WHERE pipeline_id = ?", (pipeline_id,))
         if targets:
-            await self._db.executemany(
+            await executor.executemany(
                 """
                 INSERT INTO pipeline_targets (
                     pipeline_id, phone, target_dialog_id, target_title, target_type

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -1044,7 +1044,13 @@ class TestDeepagentsBackendInit:
         config = AppConfig()
         config.agent.fallback_model = ""
         backend = DeepagentsBackend(mock_db, config)
+
+        assert backend.configured is False
         backend.initialize()
+
+        # Early return must not flag preflight availability or record an error.
+        assert backend.preflight_available is None
+        assert backend.init_error is None
 
     def test_initialize_no_candidates_with_legacy_model(self, mock_db):
         """initialize() raises when legacy model format is wrong."""

--- a/tests/test_database_write_lock.py
+++ b/tests/test_database_write_lock.py
@@ -17,6 +17,7 @@ from src.models import (
     ContentPipeline,
     PipelineGenerationBackend,
     PipelinePublishMode,
+    PipelineTarget,
 )
 
 
@@ -215,6 +216,40 @@ async def test_delete_channel_serialized_with_pipeline_add(db: Database):
             f"iter={i}: channel survived but children gone: "
             f"alive={channel_alive} msgs={msgs} stats={stats}"
         )
+
+
+async def test_replace_helpers_honor_provided_conn(db: Database):
+    """_replace_*_no_commit must write through the caller's transaction conn,
+    not self._db — otherwise the DELETE+INSERT escape the write-lock (#633)."""
+    repo = db.repos.content_pipelines
+    captured: list[tuple[str, str]] = []
+
+    class _FakeConn:
+        async def execute(self, sql, params=()):
+            captured.append(("execute", sql))
+
+        async def executemany(self, sql, seq):
+            captured.append(("executemany", sql))
+
+    fake = _FakeConn()
+    await repo._replace_sources_no_commit(1, [10, 11], conn=fake)
+    await repo._replace_targets_no_commit(
+        1,
+        [PipelineTarget(pipeline_id=1, phone="+1", dialog_id=-100, title="t", dialog_type="channel")],
+        conn=fake,
+    )
+
+    statements = [sql for (_, sql) in captured]
+    assert any("DELETE FROM pipeline_sources" in s for s in statements)
+    assert any("INSERT INTO pipeline_sources" in s for s in statements)
+    assert any("DELETE FROM pipeline_targets" in s for s in statements)
+    assert any("INSERT INTO pipeline_targets" in s for s in statements)
+
+    # Everything went to the fake conn (a no-op), so self._db wrote nothing.
+    src_rows = await db.execute_fetchall("SELECT COUNT(*) AS n FROM pipeline_sources")
+    tgt_rows = await db.execute_fetchall("SELECT COUNT(*) AS n FROM pipeline_targets")
+    assert src_rows[0]["n"] == 0
+    assert tgt_rows[0]["n"] == 0
 
 
 async def test_read_does_not_acquire_lock(db: Database):


### PR DESCRIPTION
Закрывает оставшиеся **HIGH**-баги из bug-report #633. На момент работы #5 (CI), #6 (purge-тест), #8 (double-read) уже починены на main, а #3/#4 не были реальными — остались #2 и #7.

## #2 — write-lock bypass в `_replace_*_no_commit`
`src/database/repositories/content_pipelines.py`

`_replace_sources_no_commit` и `_replace_targets_no_commit` выполняли DELETE+INSERT через `self._db.execute`, хотя оба вызывающих метода (`add`/`update`) работают внутри `async with self._database.transaction() as conn`. Это выводило операции из-под connection-wide write-lock (#569) — другая корутина могла вклиниться между DELETE и INSERT.

Фикс: пробрасываем `conn` в оба helper'а (`executor = conn or self._db`) и передаём его из `add()`/`update()`. `executemany` тоже идёт через `executor`.

## #7 — тест без assert
`tests/test_agent_manager_runtime_paths.py`

`test_initialize_not_configured` вызывал `DeepagentsBackend.initialize()` без единой проверки — тест не мог упасть. Добавлены осмысленные assert'ы для ветки «не сконфигурирован»: `configured is False`, а после `initialize()` — `preflight_available is None` и `init_error is None`.

## Тесты
- `tests/test_database_write_lock.py::test_replace_helpers_honor_provided_conn` — регрессия #2: helper'ы пишут через переданный `conn`, а не через `self._db` (фейковый conn — no-op, поэтому в БД ничего не попадает). Существующий стресс-тест `test_delete_channel_serialized_with_pipeline_add` продолжает проходить.
- `test_initialize_not_configured` — теперь с проверками (#7).

## Верификация
- `ruff check src/ tests/ conftest.py` — чисто.
- `pytest -m "not aiosqlite_serial" -n auto` → 7236 passed, 104 skipped.
- `pytest -m aiosqlite_serial` → 838 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)