### PR TITLE
fix(cli): persist account before pool warm-up in verify-code (#449)

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -101,8 +101,6 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Auth failed: {exc}")
                     return
 
-                await db.set_setting(_pending_key(phone), "")
-
                 existing = await db.get_account_summaries(active_only=False)
                 is_primary = len(existing) == 0
 
@@ -119,6 +117,15 @@ def run(args: argparse.Namespace) -> None:
                     is_premium=False,
                 )
                 await db.add_account(account)
+
+                # Clear the pending-auth key only AFTER the account is durably
+                # persisted (#449). Clearing it before add_account opened a data-loss
+                # window: a crash between the two autocommit writes would leave no
+                # pending key AND no account, so a verify-code retry would hit the
+                # "No pending auth" guard above with the session gone. add_account is
+                # an idempotent ON CONFLICT(phone) upsert, so a retry after a crash
+                # between sign-in and this point safely re-persists the same session.
+                await db.set_setting(_pending_key(phone), "")
 
                 is_premium = False
                 try:

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -106,28 +106,42 @@ def run(args: argparse.Namespace) -> None:
                 existing = await db.get_account_summaries(active_only=False)
                 is_primary = len(existing) == 0
 
-                _, pool = await runtime.init_pool(config, db)
-                await pool.add_client(phone, session_string)
-
-                is_premium = False
-                acquired = await pool.get_client_by_phone(phone)
-                if acquired:
-                    session, acquired_phone = acquired
-                    try:
-                        me = await session.fetch_me()
-                        is_premium = bool(getattr(me, "premium", False))
-                    except Exception:
-                        pass
-                    finally:
-                        await pool.release_client(acquired_phone)
-
+                # Persist the freshly authenticated session to the DB FIRST, before
+                # warming the in-memory pool (#449). The inverse order — pool first,
+                # DB second — loses the session string permanently if anything between
+                # the two calls fails (network, process kill): the pool is rebuilt from
+                # the DB on restart, so an unpersisted client vanishes. Premium status
+                # is a best-effort enrichment updated afterwards.
                 account = Account(
                     phone=phone,
                     session_string=session_string,
                     is_primary=is_primary,
-                    is_premium=is_premium,
+                    is_premium=False,
                 )
                 await db.add_account(account)
+
+                is_premium = False
+                try:
+                    _, pool = await runtime.init_pool(config, db)
+                    await pool.add_client(phone, session_string)
+                    acquired = await pool.get_client_by_phone(phone)
+                    if acquired:
+                        session, acquired_phone = acquired
+                        try:
+                            me = await session.fetch_me()
+                            is_premium = bool(getattr(me, "premium", False))
+                        except Exception:
+                            pass
+                        finally:
+                            await pool.release_client(acquired_phone)
+                    if is_premium:
+                        await db.update_account_premium(phone, is_premium)
+                except Exception as exc:
+                    print(
+                        f"Account {phone} saved, but pool warm-up failed "
+                        f"(premium unknown): {exc}"
+                    )
+
                 print(f"Account {phone} added successfully (primary={is_primary}).")
                 return
 

--- a/tests/test_auth_flow_cli.py
+++ b/tests/test_auth_flow_cli.py
@@ -1,6 +1,8 @@
 """CLI auth flow tests — pure unit tests covering two-step send-code/verify-code flow."""
 from __future__ import annotations
 
+import argparse
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -115,6 +117,79 @@ async def test_sign_in_fresh_2fa_with_password():
         session = await auth.sign_in_fresh("+1234567890", "54321", "hash_abc", password_2fa="mypass")
 
     assert session == "session_2fa_ok"
+
+
+@pytest.mark.telegram_unit
+def test_cli_verify_code_persists_account_before_pool_warmup(tmp_path, capsys):
+    """Regression #449: `account verify-code` must persist the authenticated session
+    to the DB BEFORE warming the in-memory pool. If the pool warm-up fails afterwards,
+    the session string is already safe; the inverse order would lose it permanently on
+    the next restart (the pool is rebuilt from the DB)."""
+    from src.cli.commands import account as account_cmd
+
+    order: list[str] = []
+
+    config = MagicMock()
+    config.telegram.api_id = 123
+    config.telegram.api_hash = "abc"
+
+    captured: dict = {}
+
+    async def fake_init_db(_config_path):
+        from src.database import Database
+
+        db = Database(str(tmp_path / "verify.db"))
+        await db.initialize()
+        await db.set_setting("auth_pending:+1", json.dumps({"phone_code_hash": "h"}))
+        original_add = db.add_account
+
+        async def traced_add_account(account):
+            order.append("add_account")
+            captured["account"] = account
+            return await original_add(account)
+
+        db.add_account = traced_add_account  # type: ignore[method-assign]
+        captured["db"] = db
+        return config, db
+
+    async def fake_init_pool(_config, _db):
+        pool = MagicMock()
+
+        async def add_client(_phone, _session):
+            order.append("add_client")
+            raise RuntimeError("pool boom")
+
+        pool.add_client = add_client
+        pool.disconnect_all = AsyncMock()
+        return None, pool
+
+    auth = MagicMock()
+    auth.sign_in_fresh = AsyncMock(return_value="SESSION_XYZ")
+
+    args = argparse.Namespace(
+        account_action="verify-code",
+        phone="+1",
+        code="55555",
+        password=None,
+        config=None,
+        api_id=None,
+        api_hash=None,
+    )
+
+    with patch.object(account_cmd.runtime, "init_db", fake_init_db), \
+         patch.object(account_cmd.runtime, "init_pool", fake_init_pool), \
+         patch.object(account_cmd, "TelegramAuth", return_value=auth):
+        account_cmd.run(args)
+
+    # DB write happened, and it happened BEFORE the (failing) pool warm-up.
+    assert order == ["add_account", "add_client"], order
+    assert captured["account"].phone == "+1"
+    assert captured["account"].session_string == "SESSION_XYZ"
+    assert captured["account"].is_primary is True
+
+    out = capsys.readouterr().out
+    assert "added successfully" in out
+    assert "pool warm-up failed" in out
 
 
 @pytest.mark.telegram_unit

--- a/tests/test_auth_flow_cli.py
+++ b/tests/test_auth_flow_cli.py
@@ -149,6 +149,17 @@ def test_cli_verify_code_persists_account_before_pool_warmup(tmp_path, capsys):
             return await original_add(account)
 
         db.add_account = traced_add_account  # type: ignore[method-assign]
+
+        original_set_setting = db.set_setting
+
+        async def traced_set_setting(key, value):
+            # Trace only the pending-auth clear (value == "") so the order list
+            # captures when the pending key is wiped relative to add_account (#449).
+            if key == "auth_pending:+1" and value == "":
+                order.append("clear_pending")
+            return await original_set_setting(key, value)
+
+        db.set_setting = traced_set_setting  # type: ignore[method-assign]
         captured["db"] = db
         return config, db
 
@@ -182,7 +193,9 @@ def test_cli_verify_code_persists_account_before_pool_warmup(tmp_path, capsys):
         account_cmd.run(args)
 
     # DB write happened, and it happened BEFORE the (failing) pool warm-up.
-    assert order == ["add_account", "add_client"], order
+    # The pending-auth key is cleared AFTER the account is persisted (#449), so a
+    # crash between sign-in and persist leaves the pending key intact for retry.
+    assert order == ["add_account", "clear_pending", "add_client"], order
     assert captured["account"].phone == "+1"
     assert captured["account"].session_string == "SESSION_XYZ"
     assert captured["account"].is_primary is True


### PR DESCRIPTION
## Проблема (#449)

`account verify-code` (CLI) добавлял свежеаутентифицированный клиент в **in-memory пул** (`pool.add_client`) **до** записи session-строки в **БД** (`db.add_account`). При любом сбое между этими вызовами (сеть, блокировка БД, SIGKILL) клиент оставался в пуле, но не в БД. Поскольку пул при рестарте перестраивается из БД, **аутентифицированная session-строка терялась навсегда** — без какой-либо ошибки для пользователя.

## Где был баг

- **Web-путь — уже исправлен** ранее: регистрация переехала в `TelegramCommandDispatcher._handle_auth_verify_code`, где `db.add_account()` идёт **до** прогрева пула (`_handle_accounts_connect`).
- **CLI-путь (`src/cli/commands/account.py`) — оставался последним экземпляром исходного порядка** из тела issue (`pool.add_client()` → … → `db.add_account()`).

## Исправление

Порядок изменён на **DB-first**, зеркально диспетчеру:
1. Сохраняем `Account(..., is_premium=False)` в БД сразу после успешной аутентификации.
2. Затем best-effort прогрев пула + `fetch_me()` → `update_account_premium(phone, is_premium)`.
3. Сбой прогрева пула больше **не теряет** session и не прерывает persist — он логируется в вывод, аккаунт остаётся сохранённым.

Инверсный отказ (пул ✅ / БД ❌) был невосстановим; новый порядок (БД ✅ / пул ❌) восстанавливается при следующем рестарте.

## Тесты

`tests/test_auth_flow_cli.py::test_cli_verify_code_persists_account_before_pool_warmup` — мокает падающий `pool.add_client` и проверяет порядок вызовов `["add_account", "add_client"]`, факт сохранённого аккаунта с корректным session-string/`is_primary`, и сообщение «pool warm-up failed».

```
ruff check src/ tests/ conftest.py  →  All checks passed!
pytest tests/test_auth_flow_cli.py  →  6 passed
pytest -m "not aiosqlite_serial" -n auto  →  7232 passed, 104 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)