### PR TITLE
fix(telegram): per-account rate limiter for resolve_username (#551)

### DIFF
--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -42,6 +42,7 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.identity import extract_message_sender_identity
 from src.telegram.notifier import Notifier
+from src.telegram.rate_limiter import ResolveRateLimiter
 from src.telegram.reactions import extract_message_reactions_json
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,20 @@ class UsernameResolveFloodWaitDeferredError(RuntimeError):
         self.next_available_at = next_available_at
 
 
+class UsernameResolveRateLimitedError(RuntimeError):
+    """Raised when a live username resolve is throttled by the per-account
+    rate limiter (#551) *before* hitting Telegram. Unlike a flood-wait deferral
+    this is a short, preventive reschedule — the channel is skipped this run and
+    retried shortly, not paused for hours."""
+
+    def __init__(self, phone: str, retry_after_sec: float):
+        super().__init__(
+            f"resolve_username rate-limited for {phone}; retry in {int(retry_after_sec)}s"
+        )
+        self.phone = phone
+        self.retry_after_sec = retry_after_sec
+
+
 class Collector:
     _SERVICE_ACTION_SEMANTICS = {
         "MessageActionChatAddUser": "join",
@@ -130,6 +145,9 @@ class Collector:
         self._stats_all_lock = asyncio.Lock()
         self._last_unavailability_log: tuple[str, str | int | None, datetime | None] | None = None
         self._resolve_username_backoff_until_utc: datetime | None = None
+        # Preventive per-account throttle for live resolve_username calls (#551):
+        # caps the burst that the reactive backoff above can only react to.
+        self._resolve_rate_limiter = ResolveRateLimiter()
 
     def _get_resolve_username_backoff_remaining_sec(self) -> int:
         if self._resolve_username_backoff_until_utc is None:
@@ -387,6 +405,15 @@ class Collector:
             live_input_resolver = _session_resolver("resolve_input_entity")
         if live_input_resolver is None:
             live_input_resolver = session.get_entity
+
+        # Only the live API fallback is rate-limited (#551) — the cached
+        # resolves above are free and must stay free. If the account has
+        # burned its window, defer the channel rather than firing the call
+        # that would trigger a multi-hour flood wait.
+        retry_after = self._resolve_rate_limiter.try_acquire(phone)
+        if retry_after > 0:
+            raise UsernameResolveRateLimitedError(phone, retry_after)
+
         return await run_with_flood_wait(
             live_input_resolver(username),
             operation=RESOLVE_USERNAME_OPERATION,
@@ -675,6 +702,19 @@ class Collector:
                         logger.warning(
                             "get_input_entity timed out for channel %d, skipping",
                             channel_id,
+                        )
+                        return total_collected
+                    except UsernameResolveRateLimitedError as exc:
+                        # Preventive throttle (#551): defer this channel briefly
+                        # rather than firing a resolve that would flood the
+                        # account. The next scheduler tick picks it up again.
+                        logger.warning(
+                            "Channel %d (%s): resolve_username rate-limited on %s, "
+                            "deferring ~%ss",
+                            channel_id,
+                            channel.username,
+                            exc.phone,
+                            int(exc.retry_after_sec),
                         )
                         return total_collected
                     except HandledFloodWaitError as exc:

--- a/src/telegram/rate_limiter.py
+++ b/src/telegram/rate_limiter.py
@@ -1,0 +1,86 @@
+"""Per-account sliding-window rate limiter for live ``auth.resolveUsername``
+calls (#551).
+
+The reactive backoff added in #502 only kicks in *after* Telegram has already
+returned a multi-hour ``FLOOD_WAIT_X``. By then the damage is done: production
+logs show a single fresh session firing 160+ ``resolve_username`` calls in
+seconds, escalating to 15–18 hour flood waits.
+
+This limiter caps the *burst* before it happens. It is a pure in-memory,
+per-account sliding window — no DB, no locks — so it is cheap to consult on the
+hot resolve path. When an account exceeds its window the caller defers the
+channel (short reschedule) instead of issuing the live API call.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections import defaultdict, deque
+
+# Telegram does not publish the ``auth.resolveUsername`` limit; production
+# evidence (#464/#551) points at roughly 30 calls / account / minute before
+# escalation begins, so we stay just under that.
+DEFAULT_MAX_CALLS = 30
+DEFAULT_WINDOW_SEC = 60.0
+DEFAULT_JITTER_SEC = 5.0
+
+
+class ResolveRateLimiter:
+    """Sliding-window limiter keyed by account phone.
+
+    ``try_acquire`` is the only method that mutates state: it prunes the
+    window, and either records the call and returns ``0.0`` (allowed) or
+    returns a positive number of seconds the caller should defer for. The
+    deferral includes a small ``±jitter`` so that many accounts unblocking at
+    the same instant do not re-burst in lockstep.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_calls: int = DEFAULT_MAX_CALLS,
+        window_sec: float = DEFAULT_WINDOW_SEC,
+        jitter_sec: float = DEFAULT_JITTER_SEC,
+        time_func=time.monotonic,
+        jitter_func=random.uniform,
+    ) -> None:
+        self._max_calls = max(1, int(max_calls))
+        self._window_sec = float(window_sec)
+        self._jitter_sec = max(0.0, float(jitter_sec))
+        self._time = time_func
+        self._jitter = jitter_func
+        self._calls: dict[str, deque[float]] = defaultdict(deque)
+
+    def _prune(self, phone: str, now: float) -> deque[float]:
+        window = self._calls[phone]
+        cutoff = now - self._window_sec
+        while window and window[0] <= cutoff:
+            window.popleft()
+        return window
+
+    def try_acquire(self, phone: str) -> float:
+        """Reserve one resolve slot for ``phone``.
+
+        Returns ``0.0`` when the call is allowed (and records it). Otherwise
+        returns the number of seconds to defer before retrying — the window is
+        full and no slot is consumed.
+        """
+        now = self._time()
+        window = self._prune(phone, now)
+        if len(window) < self._max_calls:
+            window.append(now)
+            return 0.0
+        # Window full: the oldest call falls out of the window at
+        # ``oldest + window_sec``. Defer until then, plus jitter.
+        retry_after = (window[0] + self._window_sec) - now
+        if self._jitter_sec:
+            retry_after += self._jitter(0.0, self._jitter_sec)
+        return max(retry_after, 0.0)
+
+    def reset(self, phone: str | None = None) -> None:
+        """Drop recorded history for ``phone`` (or all accounts)."""
+        if phone is None:
+            self._calls.clear()
+        else:
+            self._calls.pop(phone, None)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -304,6 +304,47 @@ async def test_collect_channel_username_resolve_flood_does_not_rotate(db):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_defers_when_resolve_rate_limited(db):
+    """#551: when the per-account resolve limiter is exhausted, the live
+    get_input_entity call must not fire — the channel is deferred (returns 0),
+    not flooded."""
+    from src.telegram.rate_limiter import ResolveRateLimiter
+
+    ch = Channel(
+        channel_id=1970788990,
+        title="Rate Limited",
+        username="rate_limited",
+        last_collected_id=5,
+    )
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    raw_client = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool()
+    session = TelegramTransportSession(
+        raw_client,
+        disconnect_on_close=False,
+        phone="+7001",
+        pool=pool,
+    )
+    pool.get_available_client = AsyncMock(return_value=(session, "+7001"))
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+
+    # Exhaust the limiter for +7001 before collection runs.
+    collector._resolve_rate_limiter = ResolveRateLimiter(
+        max_calls=1, window_sec=60.0, jitter_sec=0.0
+    )
+    assert collector._resolve_rate_limiter.try_acquire("+7001") == 0.0
+
+    result = await collector._collect_channel(stored)
+
+    assert result == 0
+    raw_client.get_input_entity.assert_not_awaited()
+    pool.report_flood.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
     ch = Channel(
         channel_id=1970788986,

--- a/tests/test_resolve_rate_limiter.py
+++ b/tests/test_resolve_rate_limiter.py
@@ -1,0 +1,92 @@
+"""Unit tests for the per-account resolve_username rate limiter (#551)."""
+from __future__ import annotations
+
+from src.telegram.rate_limiter import ResolveRateLimiter
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _limiter(clock: _FakeClock, *, max_calls: int = 3, window: float = 60.0, jitter: float = 0.0):
+    return ResolveRateLimiter(
+        max_calls=max_calls,
+        window_sec=window,
+        jitter_sec=jitter,
+        time_func=clock,
+        jitter_func=lambda _a, _b: 0.0,
+    )
+
+
+def test_allows_up_to_max_then_defers():
+    clock = _FakeClock()
+    limiter = _limiter(clock, max_calls=3, window=60.0)
+
+    assert limiter.try_acquire("+1") == 0.0
+    assert limiter.try_acquire("+1") == 0.0
+    assert limiter.try_acquire("+1") == 0.0
+    # Fourth call within the window is throttled.
+    retry = limiter.try_acquire("+1")
+    assert retry > 0.0
+    # Defer until the oldest call (t=1000) exits the 60s window.
+    assert retry == 60.0
+
+
+def test_window_slides_and_frees_slots():
+    clock = _FakeClock()
+    limiter = _limiter(clock, max_calls=2, window=60.0)
+
+    assert limiter.try_acquire("+1") == 0.0  # t=1000
+    clock.advance(30)
+    assert limiter.try_acquire("+1") == 0.0  # t=1030
+    # Window full now.
+    assert limiter.try_acquire("+1") > 0.0
+    # Advance past the first call's expiry (1000 + 60 = 1060).
+    clock.advance(31)  # t=1061
+    assert limiter.try_acquire("+1") == 0.0
+
+
+def test_limit_is_per_account():
+    clock = _FakeClock()
+    limiter = _limiter(clock, max_calls=1, window=60.0)
+
+    assert limiter.try_acquire("+1") == 0.0
+    assert limiter.try_acquire("+1") > 0.0  # +1 throttled
+    # A different account has its own independent window.
+    assert limiter.try_acquire("+2") == 0.0
+
+
+def test_jitter_added_to_retry():
+    clock = _FakeClock()
+    limiter = ResolveRateLimiter(
+        max_calls=1,
+        window_sec=60.0,
+        jitter_sec=5.0,
+        time_func=clock,
+        jitter_func=lambda _a, b: b,  # always max jitter
+    )
+    assert limiter.try_acquire("+1") == 0.0
+    retry = limiter.try_acquire("+1")
+    assert retry == 65.0  # 60s window + 5s jitter
+
+
+def test_reset_clears_history():
+    clock = _FakeClock()
+    limiter = _limiter(clock, max_calls=1, window=60.0)
+
+    assert limiter.try_acquire("+1") == 0.0
+    assert limiter.try_acquire("+1") > 0.0
+    limiter.reset("+1")
+    assert limiter.try_acquire("+1") == 0.0
+
+    # reset() with no arg clears all accounts.
+    limiter.try_acquire("+2")
+    limiter.reset()
+    assert limiter.try_acquire("+2") == 0.0


### PR DESCRIPTION
## Проблема (#551, саб-issue #464)

Реактивный backoff из #502 включается только **после** того, как Telegram уже вернул многочасовой `FLOOD_WAIT_X`. Боевые логи (2026-05-03): свежая сессия выпускает 160+ `auth.resolveUsername` за секунды, эскалация 3s → 26s → **66230s**. Backoff не успевает предотвратить сам всплеск, который и вызывает flood.

## Исправление

Новый `src/telegram/rate_limiter.py` — `ResolveRateLimiter`: чистое in-memory скользящее окно **на аккаунт** (по умолчанию 30 вызовов / 60с, джиттер ±5с, без БД и блокировок).

- Проверяется в `_resolve_channel_input_entity()` **прямо перед** живым API-fallback — кэш-резолвы остаются бесплатными.
- При исчерпании окна аккаунта поднимается новый `UsernameResolveRateLimitedError`, и канал **откладывается** (пропуск в этом прогоне, повтор на следующем тике планировщика), а не падает.

## Acceptance criteria
- [x] Не более N resolve_username на аккаунт в минуту
- [x] Лишние каналы откладываются, не фейлятся
- [x] Нет регрессии throughput при нормальной работе (лимит выше штатного темпа; кэш-путь не затронут)
- [x] Тесты поведения лимитера

## Тесты
- `tests/test_resolve_rate_limiter.py` — окно/слайдинг/изоляция по аккаунту/джиттер/reset (инъекция часов).
- `tests/test_collector.py::test_collect_channel_defers_when_resolve_rate_limited` — при исчерпанном лимитере живой `get_input_entity` не вызывается, канал возвращает 0.

```
ruff  →  All checks passed!
pytest tests/test_resolve_rate_limiter.py tests/test_collector.py  →  84 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)