### PR TITLE
fix(agent): stop reaction flood-wait bypass + retryable cancellation (#597)

### DIFF
--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Awaitable, Callable
+from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
 from typing import Literal, TypeVar
@@ -139,6 +140,16 @@ class AgentRuntimeContext:
 
                 try:
                     return future.result(timeout=poll_timeout)
+                except FutureCancelledError as exc:
+                    # The live operation was cancelled (e.g. a parallel flood-wait
+                    # batch tore down sibling futures). Surface it as a retryable
+                    # tool error instead of a raw CancelledError so the model can
+                    # retry/report it as a transient condition rather than a crash (#597).
+                    raise AgentToolRuntimeError(
+                        f"Agent tool '{tool_name}' was cancelled while running on the live "
+                        "Telegram runtime; retry shortly.",
+                        retryable=True,
+                    ) from exc
                 except FutureTimeoutError as exc:
                     permission_waiting = (
                         permission_wait_tracker is not None

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -256,7 +256,9 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "clear_flood_status",
-        "Clear flood wait restriction for a specific account. Ask user for confirmation first.",
+        "Clear a STALE/expired flood-wait entry for an account. Refuses to clear an "
+        "ACTIVE flood wait — that is a Telegram-mandated pause and must not be bypassed. "
+        "Ask user for confirmation first.",
         {
             "phone": Annotated[str, "Номер телефона аккаунта (например +79001234567)"],
             "confirm": Annotated[bool, "Установите true для подтверждения действия"],
@@ -274,6 +276,20 @@ def register(db, client_pool, embedding_service, **kwargs):
             acc = next((a for a in accounts if a.phone == phone), None)
             if acc is None:
                 return _text_response(f"Аккаунт {phone} не найден.")
+            # Do not let the agent defeat a live Telegram flood wait by clearing
+            # it as a retry hack (#597). An active wait is server-mandated; only
+            # stale/expired entries may be cleared here. Manual stale-state repair
+            # stays available via CLI `account flood-clear`.
+            if is_flood_wait_active(acc):
+                remaining = _remaining_seconds(acc)
+                suffix = f" (осталось ~{remaining}s)" if remaining is not None else ""
+                return _text_response(
+                    f"Отклонено: у {phone} активен flood-wait до {acc.flood_wait_until}{suffix}. "
+                    "Это пауза, предписанная Telegram, — её нельзя обойти сбросом, "
+                    "иначе аккаунт получит ещё более длинную блокировку. Дождитесь "
+                    "окончания. Для ручного восстановления зависшего состояния есть "
+                    "CLI `account flood-clear`."
+                )
             await db.update_account_flood(phone, None)
             return _text_response(f"Flood-wait для {phone} сброшен.")
         except Exception as e:

--- a/tests/test_agent_tools_accounts.py
+++ b/tests/test_agent_tools_accounts.py
@@ -278,7 +278,8 @@ class TestClearFloodStatusTool:
         assert "не найден" in _text(result)
 
     @pytest.mark.anyio
-    async def test_with_confirm_clears_flood(self, mock_db):
+    async def test_with_confirm_clears_stale_flood(self, mock_db):
+        # Past timestamp → flood already expired → safe to clear.
         acc = _make_account(phone="+71111111111", flood_wait_until="2025-01-01")
         mock_db.get_accounts = AsyncMock(return_value=[acc])
         mock_db.update_account_flood = AsyncMock()
@@ -286,3 +287,18 @@ class TestClearFloodStatusTool:
         result = await handlers["clear_flood_status"]({"phone": "+71111111111", "confirm": True})
         assert "сброшен" in _text(result)
         mock_db.update_account_flood.assert_awaited_once_with("+71111111111", None)
+
+    @pytest.mark.anyio
+    async def test_refuses_to_clear_active_flood(self, mock_db):
+        # #597: an active (future) flood wait is Telegram-mandated — the agent
+        # must NOT be able to clear it as a retry hack.
+        future = datetime.now(timezone.utc) + timedelta(hours=2)
+        acc = _make_account(phone="+71111111111", flood_wait_until=future)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["clear_flood_status"]({"phone": "+71111111111", "confirm": True})
+        text = _text(result)
+        assert "Отклонено" in text
+        assert "Telegram" in text
+        mock_db.update_account_flood.assert_not_awaited()

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -372,6 +372,31 @@ async def test_live_runtime_sync_bridge_uses_owner_loop_not_asyncio_run(mock_db,
     run_mock.assert_not_called()
 
 
+@pytest.mark.anyio
+async def test_live_runtime_sync_bridge_converts_cancellation_to_retryable(mock_db):
+    """#597: a cancelled live operation (e.g. a sibling reaction future torn down
+    on flood) must surface as a retryable AgentToolRuntimeError, not a raw
+    concurrent.futures.CancelledError that the model misreports as a crash."""
+    from src.agent.runtime_context import AgentRuntimeContext, AgentToolRuntimeError
+
+    owner_loop = asyncio.get_running_loop()
+    ctx = AgentRuntimeContext.build(
+        db=mock_db,
+        client_pool=object(),
+        runtime_kind="live",
+        owner_loop=owner_loop,
+    )
+
+    async def _operation():
+        raise asyncio.CancelledError
+
+    with pytest.raises(AgentToolRuntimeError) as exc_info:
+        await asyncio.to_thread(ctx.run_sync, "send_reaction", _operation)
+
+    assert exc_info.value.retryable is True
+    assert "cancel" in str(exc_info.value).lower()
+
+
 class TestDeepagentsSyncSearchMessages:
     def test_results_include_channel_label(self, mock_db):
         from src.agent.tools.deepagents_sync import build_deepagents_tools


### PR DESCRIPTION
## Контекст (#597)

Ядро governor'а для реакций (per-phone min-interval, ожидание warm-up, defer при flood) уже приехало в **#641** на уровне `TelegramCommandDispatcher`. Из плана #597 оставались два **guardrail'а** — оба позволяли агенту/рантайму обойти Telegram-предписанную паузу.

## Исправление

**1. `clear_flood_status` (agent-tool) больше не сбрасывает активный flood.**
Раньше агент мог одним вызовом снять живой flood-wait и сразу повторить зафлуженную реакцию → ещё более длинный бан. Теперь активный (будущий) flood **отклоняется** с объяснением, что это серверная пауза. Протухшие/истёкшие записи по-прежнему чистятся; CLI `account flood-clear` остаётся админ-override для ручного восстановления зависшего состояния.

**2. `AgentRuntimeContext.run_sync()` конвертирует `concurrent.futures.CancelledError` в retryable `AgentToolRuntimeError`.**
При отмене соседнего live-future (например, при flood в параллельной пачке реакций) сырой `CancelledError` пробрасывался наружу, и модель рапортовала это как краш. Теперь — retryable-ошибка, как и соседние timeout/cancel-ветки.

## Что НЕ входит (уже сделано в #641)
Per-phone min-interval, live-настройка `reaction_min_interval_sec`, warm-up/flood defer с reschedule — `_ensure_reaction_can_run` в диспетчере.

## Тесты
- `test_refuses_to_clear_active_flood` — активный flood → «Отклонено», `update_account_flood` не вызывается; `test_with_confirm_clears_stale_flood` — истёкший flood чистится.
- `test_live_runtime_sync_bridge_converts_cancellation_to_retryable` — отменённая live-операция → retryable `AgentToolRuntimeError`.

```
ruff  →  All checks passed!
pytest test_agent_tools_accounts + test_agent_tools_deepagents_sync  →  73 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)