### PR TITLE
fix(agent): report account availability from the Settings source of truth (#529)

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -98,6 +98,7 @@
 | `toggle_account` | WRITE | Вкл/выкл |
 | `delete_account` | DELETE | Удалить |
 | `get_flood_status` | READ | Статус flood wait |
+| `get_account_availability` | READ | Доступность аккаунта (как в Settings UI): available/flood/disconnected/inactive/session_unavailable |
 | `clear_flood_status` | WRITE | Сбросить flood wait |
 | `get_account_info` | READ | Информация об аккаунте (имя, username, premium) |
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -148,6 +148,7 @@
 | Flood статус | `account flood-status` | `GET /settings/flood-status` | `get_flood_status` |
 | Сбросить flood | `account flood-clear` | `POST /settings/{id}/flood-clear` | `clear_flood_status` |
 | Инфо | `account info` | — | `get_account_info` |
+| Доступность | `account list` | `GET /settings/` | `get_account_availability` |
 | Добавить аккаунт | `account add` | `POST /auth/send-code`, `POST /auth/verify-code` | — |
 | Отправить код авторизации | `account send-code` | `POST /auth/send-code` | — |
 | Подтвердить код авторизации | `account verify-code` | `POST /auth/verify-code` | — |

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -21,8 +21,25 @@ from src.agent.tools._registry import (
     require_confirmation,
     resolve_phone,
 )
+from src.services.account_availability import compute_account_availability
 
 _NO_LIVE_RUNTIME = "live Telegram runtime unavailable"
+
+# Human guidance per availability state (#529). Critically distinguishes a
+# saved-session reconnect (no SMS/2FA) from interactive Telegram login.
+_AVAILABILITY_GUIDANCE = {
+    "available": "OK — аккаунт доступен и пригоден к использованию.",
+    "flood": "временный flood-wait (ограничение Telegram); дождитесь окончания.",
+    "disconnected": (
+        "сессия сохранена, но live-клиент не подключён — можно переподключить "
+        "СОХРАНЁННУЮ сессию (reconnect); повторный вход по SMS/2FA НЕ требуется."
+    ),
+    "inactive": "выключен в БД (is_active=false); включите через toggle_account.",
+    "session_unavailable": (
+        "сохранённая сессия отсутствует или невалидна — требуется ИНТЕРАКТИВНЫЙ "
+        "вход в Telegram (через /auth/login?phone=..., с кодом из SMS и 2FA)."
+    ),
+}
 
 
 def _runtime(kwargs: dict, db, client_pool) -> AgentRuntimeContext:
@@ -253,6 +270,46 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка получения flood-статуса: {e}")
 
     tools.append(get_flood_status)
+
+    @tool(
+        "get_account_availability",
+        "Report each Telegram account's availability using the SAME source of truth as the "
+        "Settings UI (states: available / flood / disconnected / inactive / session_unavailable). "
+        "ALWAYS call this BEFORE claiming an account is unavailable or needs re-authorization. "
+        "It distinguishes a saved-session reconnect (no SMS/2FA) from interactive Telegram login.",
+        {"phone": Annotated[str, "Опционально: телефон или префикс (например +8613... или +861*)"]},
+    )
+    async def get_account_availability(args):
+        try:
+            accounts = await get_accounts_with_flood_cleanup(db)
+            if not accounts:
+                return _text_response("Аккаунты не найдены.")
+            phone_filter = normalize_phone(args.get("phone", ""))
+            connected = connected_phones_from_pool(client_pool)
+            rows = []
+            for a in accounts:
+                phone = str(getattr(a, "phone", "") or "")
+                if not phone or (phone_filter and not _matches_phone(phone, phone_filter)):
+                    continue
+                avail = compute_account_availability(a, connected=phone in connected)
+                state = avail["state"]
+                guidance = _AVAILABILITY_GUIDANCE.get(state, state)
+                extra = ""
+                if state == "flood":
+                    remaining = _remaining_seconds(a)
+                    if remaining is not None:
+                        extra = f" (осталось ~{remaining}s)"
+                elif state == "session_unavailable":
+                    extra = f" (session_status={account_session_status(a)})"
+                rows.append(f"- {phone}: {state}{extra} — {guidance}")
+            if not rows:
+                return _text_response(f"Аккаунты по фильтру '{phone_filter}' не найдены.")
+            header = "Доступность аккаунтов (тот же источник истины, что и Settings UI):"
+            return _text_response("\n".join([header, *rows]))
+        except Exception as e:
+            return _text_response(f"Ошибка получения доступности аккаунтов: {e}")
+
+    tools.append(get_account_availability)
 
     @tool(
         "clear_flood_status",

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -161,6 +161,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "toggle_account": ToolCategory.WRITE,
     "delete_account": ToolCategory.DELETE,
     "get_flood_status": ToolCategory.READ,
+    "get_account_availability": ToolCategory.READ,
     "clear_flood_status": ToolCategory.WRITE,
     "get_account_info": ToolCategory.READ,
     # Filters
@@ -303,7 +304,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ]),
     ("Аккаунты", [
         "list_accounts", "toggle_account", "delete_account", "get_flood_status",
-        "clear_flood_status", "get_account_info",
+        "get_account_availability", "clear_flood_status", "get_account_info",
     ]),
     ("Фильтры", [
         "analyze_filters", "apply_filters", "reset_filters", "toggle_channel_filter",

--- a/src/services/account_availability.py
+++ b/src/services/account_availability.py
@@ -1,0 +1,64 @@
+"""Single source of truth for per-account availability state (#529).
+
+The Settings UI and the agent tools must agree on whether an account is
+"available", "disconnected", needs interactive re-auth, etc. Previously the
+Settings page computed this inline while the agent had no equivalent and would
+wrongly tell the user an account was unavailable / needed re-auth even when
+Settings showed "Availability: OK". This helper is the one place that decides,
+so both surfaces stay in lock-step.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.models import AccountSessionStatus
+
+# Ordered roughly by severity. Mirrors the states rendered by the Settings page.
+AVAILABILITY_STATES = (
+    "available",
+    "flood",
+    "disconnected",
+    "inactive",
+    "session_unavailable",
+)
+
+
+def compute_account_availability(
+    account: object,
+    *,
+    connected: bool,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    """Return ``{"state", "remaining_seconds", "remaining_minutes"}`` for one account.
+
+    ``connected`` is whether the account's phone is currently in the live/worker
+    client pool. The precedence — session validity, then active flag, then
+    connection, then flood — matches ``handle_settings_page`` exactly.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    session_status = getattr(account, "session_status", AccountSessionStatus.OK)
+    if session_status != AccountSessionStatus.OK:
+        return _state("session_unavailable")
+    if not getattr(account, "is_active", False):
+        return _state("inactive")
+    if not connected:
+        return _state("disconnected")
+
+    flood_until = getattr(account, "flood_wait_until", None)
+    if flood_until is not None:
+        if flood_until.tzinfo is None:
+            flood_until = flood_until.replace(tzinfo=timezone.utc)
+        remaining_seconds = max(0, int((flood_until - now).total_seconds()))
+        if remaining_seconds > 0:
+            return {
+                "state": "flood",
+                "remaining_seconds": remaining_seconds,
+                "remaining_minutes": max(1, remaining_seconds // 60),
+            }
+    return _state("available")
+
+
+def _state(state: str) -> dict[str, object]:
+    return {"state": state, "remaining_seconds": 0, "remaining_minutes": 0}

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -19,6 +19,7 @@ from src.agent.prompt_template import (
 from src.agent.provider_registry import PROVIDER_ORDER, ProviderRuntimeConfig
 from src.agent.provider_registry import provider_spec as deepagents_provider_spec
 from src.models import AccountSessionStatus
+from src.services.account_availability import compute_account_availability
 from src.services.agent_provider_service import (
     ProviderConfigService,
     ProviderModelCacheEntry,
@@ -494,34 +495,15 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
     account_status: dict[str, dict[str, object]] = {}
     flooded_connected = []
     for account in accounts:
-        connected = account.phone in connected_phones
-        if account.session_status != AccountSessionStatus.OK:
-            state = "session_unavailable"
-            remaining_seconds = 0
-        elif not account.is_active:
-            state = "inactive"
-            remaining_seconds = 0
-        elif not connected:
-            state = "disconnected"
-            remaining_seconds = 0
-        elif account.flood_wait_until is not None:
+        availability = compute_account_availability(
+            account, connected=account.phone in connected_phones, now=now
+        )
+        if availability["state"] == "flood" and account.flood_wait_until is not None:
             flood_until = account.flood_wait_until
             if flood_until.tzinfo is None:
                 flood_until = flood_until.replace(tzinfo=UTC)
-            remaining_seconds = max(0, int((flood_until - now).total_seconds()))
-            if remaining_seconds > 0:
-                state = "flood"
-                flooded_connected.append(flood_until)
-            else:
-                state = "available"
-        else:
-            state = "available"
-            remaining_seconds = 0
-        account_status[account.phone] = {
-            "state": state,
-            "remaining_seconds": remaining_seconds,
-            "remaining_minutes": max(1, remaining_seconds // 60) if remaining_seconds else 0,
-        }
+            flooded_connected.append(flood_until)
+        account_status[account.phone] = availability
     all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
         [
             acc

--- a/tests/test_account_availability.py
+++ b/tests/test_account_availability.py
@@ -1,0 +1,62 @@
+"""Unit tests for the shared account-availability source of truth (#529)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from src.models import AccountSessionStatus
+from src.services.account_availability import compute_account_availability
+
+
+def _acc(**kw):
+    base = {
+        "phone": "+8613000000000",
+        "is_active": True,
+        "flood_wait_until": None,
+        "session_status": AccountSessionStatus.OK,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_available_when_active_connected_ok_session():
+    avail = compute_account_availability(_acc(), connected=True)
+    assert avail["state"] == "available"
+
+
+def test_session_unavailable_takes_precedence():
+    # Even active + connected, a bad session means re-auth is required.
+    avail = compute_account_availability(
+        _acc(session_status=AccountSessionStatus.DECRYPT_FAILED), connected=True
+    )
+    assert avail["state"] == "session_unavailable"
+
+
+def test_inactive_when_toggled_off():
+    avail = compute_account_availability(_acc(is_active=False), connected=True)
+    assert avail["state"] == "inactive"
+
+
+def test_disconnected_when_session_ok_but_not_in_pool():
+    avail = compute_account_availability(_acc(), connected=False)
+    assert avail["state"] == "disconnected"
+
+
+def test_flood_reports_remaining():
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    avail = compute_account_availability(_acc(flood_wait_until=future), connected=True)
+    assert avail["state"] == "flood"
+    assert avail["remaining_seconds"] > 0
+    assert avail["remaining_minutes"] >= 1
+
+
+def test_expired_flood_is_available():
+    past = datetime.now(timezone.utc) - timedelta(minutes=10)
+    avail = compute_account_availability(_acc(flood_wait_until=past), connected=True)
+    assert avail["state"] == "available"
+
+
+def test_naive_flood_timestamp_treated_as_utc():
+    future_naive = (datetime.now(timezone.utc) + timedelta(minutes=5)).replace(tzinfo=None)
+    avail = compute_account_availability(_acc(flood_wait_until=future_naive), connected=True)
+    assert avail["state"] == "flood"

--- a/tests/test_agent_tools_accounts.py
+++ b/tests/test_agent_tools_accounts.py
@@ -302,3 +302,79 @@ class TestClearFloodStatusTool:
         assert "Отклонено" in text
         assert "Telegram" in text
         mock_db.update_account_flood.assert_not_awaited()
+
+
+def _avail_account(phone, *, is_active=True, flood_wait_until=None, session_status=None):
+    from src.models import AccountSessionStatus
+
+    return SimpleNamespace(
+        phone=phone,
+        is_active=is_active,
+        flood_wait_until=flood_wait_until,
+        session_status=session_status or AccountSessionStatus.OK,
+        is_primary=False,
+        id=1,
+    )
+
+
+def _pool_with(*connected_phones):
+    return SimpleNamespace(clients={p: object() for p in connected_phones})
+
+
+class TestGetAccountAvailabilityTool:
+    """#529: agent availability must match the Settings UI and distinguish a
+    saved-session reconnect from interactive Telegram login."""
+
+    @pytest.mark.anyio
+    async def test_available_account_reports_ok(self, mock_db):
+        acc = _avail_account("+8613000000000")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=_pool_with("+8613000000000"))
+        text = _text(await handlers["get_account_availability"]({"phone": "+8613000000000"}))
+        assert "available" in text
+        assert "OK" in text
+        # An available account must NOT be described as unavailable / needing re-auth.
+        assert "session_unavailable" not in text
+        assert "SMS" not in text
+
+    @pytest.mark.anyio
+    async def test_session_unavailable_reports_interactive_login(self, mock_db):
+        from src.models import AccountSessionStatus
+
+        acc = _avail_account(
+            "+8613000000000", session_status=AccountSessionStatus.DECRYPT_FAILED
+        )
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=_pool_with("+8613000000000"))
+        text = _text(await handlers["get_account_availability"]({}))
+        assert "session_unavailable" in text
+        assert "decrypt_failed" in text
+        assert "SMS" in text and "/auth/login" in text
+
+    @pytest.mark.anyio
+    async def test_disconnected_saved_session_is_reconnect_not_reauth(self, mock_db):
+        # session ok, active, but not in the pool → reconnect saved session.
+        acc = _avail_account("+8613000000000")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=_pool_with())  # nothing connected
+        text = _text(await handlers["get_account_availability"]({}))
+        assert "disconnected" in text
+        assert "reconnect" in text.lower()
+        # The guidance must explicitly state SMS/2FA is NOT required for a
+        # saved-session reconnect (the bug was conflating it with re-auth).
+        assert "НЕ требуется" in text
+        assert "/auth/login" not in text
+
+    @pytest.mark.anyio
+    async def test_flood_reports_actual_reason(self, mock_db):
+        future = datetime.now(timezone.utc) + timedelta(minutes=10)
+        acc = _avail_account("+8613000000000", flood_wait_until=future)
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=_pool_with("+8613000000000"))
+        text = _text(await handlers["get_account_availability"]({}))
+        assert "flood" in text
+        assert "осталось" in text


### PR DESCRIPTION
## Проблема (#529)

Агент сообщал, что аккаунт недоступен / требует повторной авторизации, **даже когда Settings UI показывал «Availability: OK»**. Причина: Settings вычислял доступность инлайн, а у агента **не было аналога** и он путал два разных случая — переподключение сохранённой сессии и интерактивный вход в Telegram (SMS/2FA).

## Исправление

**1. Единый источник истины** — `src/services/account_availability.py::compute_account_availability` (состояния `available / flood / disconnected / inactive / session_unavailable`, тот же приоритет, что в `handle_settings_page`). Settings-страница теперь вызывает его вместо инлайн-копии → surfaces не разъедутся.

**2. Новый read-only agent-tool `get_account_availability(phone="")`** — отдаёт те же состояния с явными подсказками, критически разделяя:
- `disconnected` (сессия сохранена) → **reconnect, SMS/2FA НЕ нужны**;
- `session_unavailable` → интерактивный `/auth/login` (SMS + 2FA).

Инструмент классифицирован `READ` в `permissions.py` и добавлен в группу «Аккаунты».

## Acceptance criteria
- [x] Ответы агента о статусе совпадают с состоянием Settings UI (общий хелпер)
- [x] Для `Availability: OK` агент не говорит, что аккаунт не OK
- [x] Агент различает reconnect сохранённой сессии и интерактивный вход/2FA
- [x] Тесты: available→OK; flood/unavailable→реальная причина; saved-session reconnect не описывается как SMS/2FA

## Тесты
- `tests/test_account_availability.py` — 7 кейсов state-машины (precedence, expired flood, naive-tz).
- `TestGetAccountAvailabilityTool` — available/session_unavailable/disconnected/flood пути инструмента.
- `tests/routes/test_settings_routes.py` — без регрессий после рефактора Settings.

```
ruff  →  All checks passed!
pytest availability + accounts + settings routes + permissions  →  129 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)