### PR TITLE
fix(telegram): cap + cache-only global resolve backoff (#552)

### DIFF
--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -49,6 +49,12 @@ logger = logging.getLogger(__name__)
 
 RESOLVE_USERNAME_OPERATION = "collect_channel_resolve_username"
 RESOLVE_USERNAME_BACKOFF_BUFFER_SEC = 5
+# Global cross-account resolve backoff (#552). Only a *long* resolve flood
+# (> threshold) freezes live resolves for every account; short floods are left
+# to the per-account #502 rotation. The freeze is capped so a single 15-18h
+# Telegram flood cannot brick all collection for hours.
+GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC = 300
+GLOBAL_RESOLVE_BACKOFF_CAP_SEC = 3600
 
 
 class NoActiveStatsClientsError(RuntimeError):
@@ -161,8 +167,13 @@ class Collector:
         return int(remaining)
 
     def _set_resolve_username_backoff(self, wait_seconds: int) -> datetime:
+        # Cap the freeze (#552): Telegram resolve floods can be 15-18h; honoring
+        # them literally would brick all collection. We block live resolves for
+        # at most GLOBAL_RESOLVE_BACKOFF_CAP_SEC and rely on cache-only resolves
+        # plus rescheduling in the meantime.
+        capped = min(int(wait_seconds), GLOBAL_RESOLVE_BACKOFF_CAP_SEC)
         self._resolve_username_backoff_until_utc = datetime.now(timezone.utc) + timedelta(
-            seconds=wait_seconds
+            seconds=capped
         )
         return self._resolve_username_backoff_until_utc
 
@@ -377,6 +388,7 @@ class Collector:
         channel_id: int,
         username: str,
         phone: str,
+        cache_only: bool = False,
     ):
         try:
             return await session.resolve_cached_input_entity(PeerChannel(channel_id))
@@ -389,6 +401,13 @@ class Collector:
             cached = None
         if cached is not None and getattr(cached, "channel_id", None) == channel_id:
             return cached
+
+        if cache_only:
+            # Global resolve backoff (#552): the cache missed and we must not hit
+            # the live API on any account. Defer this channel for the run.
+            raise UsernameResolveRateLimitedError(
+                phone, self._get_resolve_username_backoff_remaining_sec()
+            )
 
         raw_client = None
         if isinstance(getattr(type(session), "raw_client", None), property):
@@ -562,18 +581,24 @@ class Collector:
             channel_id = channel.channel_id
             min_id = channel.last_collected_id
 
+            # Global resolve backoff (#552): while a long flood is in effect we
+            # do NOT abort the whole run. Instead this channel runs in cache-only
+            # mode — if its InputPeer is cached the collection proceeds, otherwise
+            # it is deferred and the run continues to the next channel (which may
+            # well be cache-resolvable).
+            resolve_cache_only = False
             if channel.username:
                 backoff_remaining_sec = self._get_resolve_username_backoff_remaining_sec()
                 if backoff_remaining_sec > 0:
+                    resolve_cache_only = True
                     logger.warning(
-                        "Skipping username resolve for channel %d (%s): "
-                        "%s backoff active for %ss",
+                        "Channel %d (%s): %s global backoff active for %ss — "
+                        "cache-only resolve",
                         channel_id,
                         channel.username,
                         RESOLVE_USERNAME_OPERATION,
                         backoff_remaining_sec,
                     )
-                    self._raise_resolve_username_deferred()
 
             # For private groups (no username):
             #   1. preferred_phone from DB (persists across restarts)
@@ -697,6 +722,7 @@ class Collector:
                             channel_id=channel_id,
                             username=channel.username,
                             phone=phone,
+                            cache_only=resolve_cache_only,
                         )
                     except asyncio.TimeoutError:
                         logger.warning(
@@ -1050,9 +1076,23 @@ class Collector:
             # Only skip the channel if the channel no longer exists in DB.
             if flood_wait_sec is not None:
                 if flood_wait_operation == RESOLVE_USERNAME_OPERATION:
+                    # Only a *long* resolve flood freezes live resolves for every
+                    # account (#552). A short flood is transient — skip just this
+                    # channel and let the run continue with other accounts so one
+                    # blip does not stall the whole pool.
+                    if flood_wait_sec <= GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC:
+                        logger.warning(
+                            "%s short FloodWait %ss on %s; skipping channel %d "
+                            "(no global backoff)",
+                            RESOLVE_USERNAME_OPERATION,
+                            flood_wait_sec,
+                            phone,
+                            channel_id,
+                        )
+                        return total_collected + collected_count
                     next_available_at = self._set_resolve_username_backoff(flood_wait_sec)
                     logger.warning(
-                        "%s got FloodWait %ss on %s; pausing username resolves until %s",
+                        "%s got FloodWait %ss on %s; pausing ALL username resolves until %s",
                         RESOLVE_USERNAME_OPERATION,
                         flood_wait_sec,
                         phone,

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -509,12 +509,20 @@ class Collector:
                         stats["errors"] += 1
                         break
                     except UsernameResolveFloodWaitDeferredError as e:
+                        # The triggering channel set the global resolve backoff and
+                        # deferred itself. Do NOT abort the whole run (#552): the
+                        # backoff is now active, so every subsequent channel resolves
+                        # cache-only and never hits the live API. Continue so cached
+                        # channels keep collecting within the same run instead of
+                        # bricking the run that first hits the flood.
                         logger.warning(
-                            "Stopping collection until %s: username resolve flood wait",
+                            "Channel %s deferred until %s (resolve flood backoff active); "
+                            "continuing run cache-only",
+                            channel.channel_id,
                             e.next_available_at.isoformat(),
                         )
-                        stats["errors"] += 1
-                        break
+                        stats["deferred"] = stats.get("deferred", 0) + 1
+                        continue
                     except Exception as e:
                         logger.error("Error collecting channel %s: %s", channel.channel_id, e)
                         stats["errors"] += 1

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -250,8 +250,9 @@ async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_
     pool.report_flood.assert_not_awaited()
     pool.get_available_client.assert_awaited_once()
     raw_client2.get_input_entity.assert_not_awaited()
+    # #552: a 7200s flood is capped to the 3600s global backoff window.
     remaining = collector._get_resolve_username_backoff_remaining_sec()
-    assert 7100 < remaining <= 7200
+    assert 3500 < remaining <= 3600
 
 
 @pytest.mark.anyio
@@ -294,13 +295,16 @@ async def test_collect_channel_username_resolve_flood_does_not_rotate(db):
         SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
     )
 
-    with pytest.raises(UsernameResolveFloodWaitDeferredError):
-        await collector._collect_channel(stored)
+    # #552: a 120s flood is below the global-backoff threshold (300s) — the
+    # channel is skipped for this run without freezing all accounts and
+    # without rotating to a second account.
+    result = await collector._collect_channel(stored)
 
+    assert result == 0
     pool.report_flood.assert_not_awaited()
     assert pool.get_available_client.await_count == 1
     raw_client2.get_input_entity.assert_not_awaited()
-    assert 0 < collector._get_resolve_username_backoff_remaining_sec() <= 120
+    assert collector._get_resolve_username_backoff_remaining_sec() == 0
 
 
 @pytest.mark.anyio
@@ -345,7 +349,10 @@ async def test_collect_channel_defers_when_resolve_rate_limited(db):
 
 
 @pytest.mark.anyio
-async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
+async def test_collect_channel_cache_only_defers_on_backoff_miss(db):
+    """#552: while a global resolve backoff is active, a channel whose InputPeer
+    is not cached runs in cache-only mode — it is deferred (returns 0) without
+    ever calling the live resolve API."""
     ch = Channel(
         channel_id=1970788986,
         title="Backoff Active",
@@ -356,17 +363,27 @@ async def test_collect_channel_skips_username_resolve_when_backoff_active(db):
     stored = await db.get_channel_by_pk(ch_id)
     assert stored is not None
 
-    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(AsyncMock(), "+7001")))
+    raw_client = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool()
+    session = TelegramTransportSession(
+        raw_client, disconnect_on_close=False, phone="+7001", pool=pool
+    )
+    pool.get_available_client = AsyncMock(return_value=(session, "+7001"))
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
     collector._set_resolve_username_backoff(600)
 
-    with pytest.raises(UsernameResolveFloodWaitDeferredError):
-        await collector._collect_channel(stored)
-    pool.get_available_client.assert_not_awaited()
+    result = await collector._collect_channel(stored)
+
+    assert result == 0
+    raw_client.get_input_entity.assert_not_awaited()
+    pool.report_flood.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_collect_all_channels_stops_on_username_resolve_backoff(db):
+async def test_collect_all_channels_continues_cache_only_during_backoff(db):
+    """#552: a global resolve backoff no longer aborts the whole run. Channels
+    that miss the cache are deferred while the run continues — cache-resolvable
+    channels keep collecting on subsequent accounts."""
     await db.add_channel(
         Channel(channel_id=1970788987, title="Backoff Active 1", username="backoff_active_1")
     )
@@ -374,14 +391,22 @@ async def test_collect_all_channels_stops_on_username_resolve_backoff(db):
         Channel(channel_id=1970788988, title="Backoff Active 2", username="backoff_active_2")
     )
 
-    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(AsyncMock(), "+7001")))
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool()
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
+    pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
     collector._set_resolve_username_backoff(600)
 
     stats = await collector.collect_all_channels()
 
-    assert stats == {"channels": 0, "messages": 0, "errors": 1}
-    pool.get_available_client.assert_not_awaited()
+    # Run did NOT stop on the backoff; both channels were processed (deferred).
+    assert stats["errors"] == 0
+    assert stats["messages"] == 0
+    raw1.get_input_entity.assert_not_awaited()
+    raw2.get_input_entity.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -410,6 +410,50 @@ async def test_collect_all_channels_continues_cache_only_during_backoff(db):
 
 
 @pytest.mark.anyio
+async def test_collect_all_channels_continues_after_mid_run_resolve_flood(db):
+    """#552: when the FIRST channel of a run triggers a long resolve flood mid-run,
+    the run must NOT abort — the backoff it just set makes every subsequent channel
+    resolve cache-only, so the run continues instead of bricking on the triggering
+    channel. Regression guard for the break→continue fix (the pre-set-backoff test
+    never reaches this path)."""
+    await db.add_channel(
+        Channel(channel_id=1970788991, title="Trigger Flood", username="trigger_flood")
+    )
+    await db.add_channel(
+        Channel(channel_id=1970788992, title="After Flood", username="after_flood")
+    )
+
+    # Channel 1's live resolve raises a 7200s flood (> 300s threshold) → sets the
+    # global backoff and raises UsernameResolveFloodWaitDeferredError mid-run.
+    flood_err = FloodWaitError(request=None, capture=7200)
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
+    # Channel 2 would resolve fine live, but the active backoff routes it cache-only,
+    # so its live get_input_entity must never be awaited.
+    raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool()
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
+    pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
+    collector = Collector(
+        pool, db, SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10)
+    )
+
+    stats = await collector.collect_all_channels()
+
+    # The run reached channel 2 (get_available_client awaited twice) — it did NOT
+    # break on channel 1's flood.
+    assert pool.get_available_client.await_count == 2
+    # The triggering channel is counted as deferred, not as an error.
+    assert stats["errors"] == 0
+    assert stats.get("deferred", 0) >= 1
+    # Backoff is active and capped to the 3600s window.
+    remaining = collector._get_resolve_username_backoff_remaining_sec()
+    assert 3500 < remaining <= 3600
+    # Channel 2 was routed cache-only — no live resolve fired.
+    raw2.get_input_entity.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_no_username_channel_fetches_dialogs_once(db):
     """For no-username channels get_dialogs() is called once per process to warm entity cache."""
     ch = Channel(channel_id=123, title="No Username")


### PR DESCRIPTION
> Заменяет #648, который был автоматически закрыт GitHub при удалении его base-ветки `fix/551-resolve-rate-limiter` (после squash-мержа #647). Эта ветка ребейзнута на `main`; diff содержит только изменение #552.

## Проблема (#552, саб-issue #464)

PR #502 сделал resolve_username backoff процесс-локальным, но остались два провала (боевые логи 2026-05-03):

1. Backoff честно соблюдал сырую длительность flood'а — **66230s (~18ч)** заморозили весь сбор на 18 часов.
2. Во время активного backoff **весь прогон сбора прерывался**, даже каналы, резолвящиеся из InputPeer-кэша, переставали собираться.

## Исправление

- **Cap** глобального backoff на `GLOBAL_RESOLVE_BACKOFF_CAP_SEC` (3600s) — один длинный flood больше не «кирпичит» сбор на часы.
- **Порог**: только *длинный* resolve-flood (`> 300s`) замораживает живые резолвы для всех аккаунтов; короткий — пропускает лишь проблемный канал, прогон продолжается (per-account ротация #502 остаётся).
- **Cache-only режим** при активном backoff: кэшированные InputPeer-резолвы проходят, промахи кэша откладываются на прогон через `UsernameResolveRateLimitedError`, и прогон **продолжается** к следующему каналу, а не падает.

## Acceptance criteria
- [x] После длинного flood ни один аккаунт не делает живой resolve в окне backoff
- [x] Кэш-резолвы продолжают работать во время глобального backoff
- [x] Каналы откладываются с понятным логом
- [x] Тесты глобального backoff

## Тесты
- `test_collect_channel_cache_only_defers_on_backoff_miss` — cache-miss при backoff → канал отложен, живой API не вызван.
- `test_collect_all_channels_continues_cache_only_during_backoff` — прогон не падает, оба канала обработаны (отложены).
- Обновлены `..._long_username_resolve_flood...` (cap 7200→≤3600) и `..._does_not_rotate` (120s ниже порога → пропуск без заморозки).

```
ruff  →  All checks passed!
pytest collector  →  79 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)