### PR TITLE
feat(agent): grounded runtime diagnostics tool (#530)

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -99,6 +99,7 @@
 | `delete_account` | DELETE | Удалить |
 | `get_flood_status` | READ | Статус flood wait |
 | `get_account_availability` | READ | Доступность аккаунта (как в Settings UI): available/flood/disconnected/inactive/session_unavailable |
+| `get_runtime_diagnostics` | READ | Диагностика рантайма: runtime_kind (live/snapshot/none), live-пул отдельно от DB-флагов, свежесть снапшота воркера |
 | `clear_flood_status` | WRITE | Сбросить flood wait |
 | `get_account_info` | READ | Информация об аккаунте (имя, username, premium) |
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -149,6 +149,7 @@
 | Сбросить flood | `account flood-clear` | `POST /settings/{id}/flood-clear` | `clear_flood_status` |
 | Инфо | `account info` | — | `get_account_info` |
 | Доступность | `account list` | `GET /settings/` | `get_account_availability` |
+| Диагностика рантайма | `scheduler status` | `GET /settings/` | `get_runtime_diagnostics` |
 | Добавить аккаунт | `account add` | `POST /auth/send-code`, `POST /auth/verify-code` | — |
 | Отправить код авторизации | `account send-code` | `POST /auth/send-code` | — |
 | Подтвердить код авторизации | `account verify-code` | `POST /auth/verify-code` | — |

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -22,6 +22,7 @@ from src.agent.tools._registry import (
     resolve_phone,
 )
 from src.services.account_availability import compute_account_availability
+from src.services.runtime_diagnostics import evaluate_worker_heartbeat
 
 _NO_LIVE_RUNTIME = "live Telegram runtime unavailable"
 
@@ -310,6 +311,70 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка получения доступности аккаунтов: {e}")
 
     tools.append(get_account_availability)
+
+    @tool(
+        "get_runtime_diagnostics",
+        "Grounded diagnostics for the agent's Telegram runtime. Labels runtime_kind "
+        "(live/snapshot/none), shows live ClientPool connectivity SEPARATELY from DB "
+        "active/flood flags, and reports worker-snapshot freshness as snapshot HEALTH "
+        "only — never as proof that an account is reachable. Call this before making "
+        "claims about whether Telegram/the runtime is available.",
+        {},
+    )
+    async def get_runtime_diagnostics(args):
+        try:
+            kind = runtime.runtime_kind
+            kind_expl = {
+                "live": "live — этот backend держит реальный ClientPool и может звать Telegram напрямую.",
+                "snapshot": (
+                    "snapshot — web-backend без live Telegram; видит снимок воркера, "
+                    "это НЕ доказательство связи с аккаунтом."
+                ),
+                "none": "none — Telegram runtime не подключён к этому backend.",
+            }.get(kind, kind)
+            lines = [f"runtime_kind: {kind_expl}"]
+
+            # Live pool connectivity — kept strictly separate from DB flags.
+            connected = connected_phones_from_pool(client_pool)
+            lines.append(f"Live ClientPool подключённые телефоны: {_format_phones(connected)}.")
+
+            accounts = await get_accounts_with_flood_cleanup(db)
+            active = [str(a.phone) for a in accounts if getattr(a, "is_active", False)]
+            flooded = [str(a.phone) for a in accounts if is_flood_wait_active(a)]
+            lines.append(f"DB активные аккаунты: {_format_phone_list(active)}.")
+            lines.append(f"DB flood-waited аккаунты: {_format_phone_list(flooded)}.")
+
+            # Snapshot health is only meaningful when this backend is NOT live.
+            if kind != "live":
+                snapshot = None
+                try:
+                    snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
+                except Exception:
+                    snapshot = None
+                health = evaluate_worker_heartbeat(snapshot)
+                if health.alive:
+                    age = int(health.age_sec) if health.age_sec is not None else "?"
+                    lines.append(
+                        f"Здоровье снапшота воркера: свежий (heartbeat ~{age}s назад). "
+                        "Это здоровье СНАПШОТА, а не доказательство связи аккаунта."
+                    )
+                else:
+                    detail = f" ({health.reason})" if health.reason else ""
+                    state = "устаревший" if health.stale else "отсутствует/недоступен"
+                    lines.append(
+                        f"Здоровье снапшота воркера: {state}{detail}. "
+                        "Не делайте выводов о доступности аккаунтов из устаревшего снапшота."
+                    )
+
+            lines.append(
+                "Для статуса конкретного аккаунта используйте get_account_availability/"
+                "get_account_info, а не вывод из снапшота."
+            )
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка диагностики рантайма: {e}")
+
+    tools.append(get_runtime_diagnostics)
 
     @tool(
         "clear_flood_status",

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -162,6 +162,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "delete_account": ToolCategory.DELETE,
     "get_flood_status": ToolCategory.READ,
     "get_account_availability": ToolCategory.READ,
+    "get_runtime_diagnostics": ToolCategory.READ,
     "clear_flood_status": ToolCategory.WRITE,
     "get_account_info": ToolCategory.READ,
     # Filters
@@ -304,7 +305,8 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ]),
     ("Аккаунты", [
         "list_accounts", "toggle_account", "delete_account", "get_flood_status",
-        "get_account_availability", "clear_flood_status", "get_account_info",
+        "get_account_availability", "get_runtime_diagnostics", "clear_flood_status",
+        "get_account_info",
     ]),
     ("Фильтры", [
         "analyze_filters", "apply_filters", "reset_filters", "toggle_channel_filter",

--- a/src/services/runtime_diagnostics.py
+++ b/src/services/runtime_diagnostics.py
@@ -1,0 +1,60 @@
+"""Grounded runtime diagnostics shared by the web worker banner and agent tools
+(#530).
+
+The recurring failure mode is treating a *snapshot* of the worker (or a stale
+heartbeat) as proof that a Telegram account is reachable. This module is the one
+place that evaluates worker-heartbeat freshness, so the Settings banner and the
+agent's `get_runtime_diagnostics` tool report the same thing and cannot drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+# The worker publishes `worker_heartbeat` every ~5s
+# (src/runtime/worker.py:_publish_snapshots). Anything older than this means the
+# worker process is effectively down.
+WORKER_HEARTBEAT_STALE_AFTER_SEC = 60.0
+
+
+@dataclass(frozen=True)
+class WorkerHeartbeatHealth:
+    alive: bool
+    status: str  # "alive"/"ok"/"missing"/<worker-reported status>
+    reason: str  # explicit worker-reported failure detail, else ""
+    age_sec: float | None  # seconds since last heartbeat, None if unknown
+    stale: bool  # heartbeat present but older than the staleness window
+
+
+def evaluate_worker_heartbeat(
+    snapshot: object,
+    *,
+    now: datetime | None = None,
+    stale_after_sec: float = WORKER_HEARTBEAT_STALE_AFTER_SEC,
+) -> WorkerHeartbeatHealth:
+    """Classify a ``worker_heartbeat`` runtime snapshot into health state.
+
+    ``reason`` is only populated for an explicit worker-reported failure status
+    (so callers that surface a banner reason keep their prior behaviour); a
+    missing or merely stale heartbeat carries its signal in ``status``/``stale``.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    updated_at = getattr(snapshot, "updated_at", None)
+    if snapshot is None or updated_at is None:
+        return WorkerHeartbeatHealth(False, "missing", "", None, False)
+
+    payload = getattr(snapshot, "payload", None)
+    payload = payload if isinstance(payload, dict) else {}
+    status = str(payload.get("status", "alive"))
+    if status not in {"alive", "ok"}:
+        reason = str(payload.get("detail", "") or payload.get("reason", ""))
+        return WorkerHeartbeatHealth(False, status, reason, None, False)
+
+    if updated_at.tzinfo is None:
+        updated_at = updated_at.replace(tzinfo=timezone.utc)
+    age = (now - updated_at).total_seconds()
+    if age > stale_after_sec:
+        return WorkerHeartbeatHealth(False, status, "", age, True)
+    return WorkerHeartbeatHealth(True, status, "", age, False)

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -194,8 +194,15 @@ async def _worker_status(db) -> tuple[bool, str]:
     try:
         snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
     except Exception as exc:  # noqa: BLE001
+        # Fail closed (#530): a snapshot read failure means we cannot prove the
+        # worker is alive, so report it as down — matching the agent tool's
+        # get_runtime_diagnostics, which passes snapshot=None to
+        # evaluate_worker_heartbeat and gets status="missing". Returning True
+        # here (fail-open) would let the two surfaces drift: the banner would say
+        # "alive" while the agent says "missing" from the same DB error, defeating
+        # the single-source-of-truth goal and suppressing the very #444 banner.
         logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
-        return True, ""
+        return False, ""
     health = evaluate_worker_heartbeat(snapshot, stale_after_sec=WORKER_HEARTBEAT_STALE_AFTER_SEC)
     return health.alive, health.reason
 

--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -9,6 +9,10 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.models import AccountSessionStatus
 from src.services.pipeline_result import result_kind_label
+from src.services.runtime_diagnostics import (
+    WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
+)
+from src.services.runtime_diagnostics import evaluate_worker_heartbeat
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
 
@@ -25,8 +29,10 @@ JOB_LABELS = {
 }
 
 # Worker publishes `worker_heartbeat` every ~5s (src/runtime/worker.py:_publish_snapshots).
-# 60s gives us 12 missed publishes before we conclude the worker is down.
-WORKER_HEARTBEAT_STALE_AFTER_SEC = 60
+# 60s gives us 12 missed publishes before we conclude the worker is down. The
+# staleness window + classification now live in src.services.runtime_diagnostics
+# so the agent's get_runtime_diagnostics tool stays in lock-step with this banner.
+WORKER_HEARTBEAT_STALE_AFTER_SEC = WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC
 
 
 def _job_label(job_id: str) -> str:
@@ -190,20 +196,8 @@ async def _worker_status(db) -> tuple[bool, str]:
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
         return True, ""
-    if snapshot is None or snapshot.updated_at is None:
-        return False, ""
-    payload = snapshot.payload if isinstance(snapshot.payload, dict) else {}
-    status = str(payload.get("status", "alive"))
-    if status not in {"alive", "ok"}:
-        reason = str(payload.get("detail", "") or payload.get("reason", ""))
-        return False, reason
-    updated_at = snapshot.updated_at
-    if updated_at.tzinfo is None:
-        updated_at = updated_at.replace(tzinfo=timezone.utc)
-    age = (datetime.now(timezone.utc) - updated_at).total_seconds()
-    if age > WORKER_HEARTBEAT_STALE_AFTER_SEC:
-        return False, ""
-    return True, ""
+    health = evaluate_worker_heartbeat(snapshot, stale_after_sec=WORKER_HEARTBEAT_STALE_AFTER_SEC)
+    return health.alive, health.reason
 
 
 async def _is_worker_alive(db) -> bool:

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -580,6 +580,21 @@ async def test_is_worker_alive_naive_datetime(base_app):
 
 
 @pytest.mark.anyio
+async def test_is_worker_alive_db_error_fails_closed(base_app):
+    """#530: a snapshot READ failure must be treated as worker-down (fail-closed),
+    matching the agent tool get_runtime_diagnostics — not silently reported as
+    'alive'. Returning True on a DB error would let the web banner and the agent
+    tool drift from the same failure, defeating the single-source-of-truth goal."""
+    from unittest.mock import AsyncMock
+
+    from src.web.routes.scheduler import _is_worker_alive
+
+    _, db, _ = base_app
+    db.repos.runtime_snapshots.get_snapshot = AsyncMock(side_effect=Exception("table missing"))
+    assert await _is_worker_alive(db) is False
+
+
+@pytest.mark.anyio
 async def test_scheduler_page_renders_worker_down_banner(client, base_app):
     """/scheduler/ surfaces the `worker_down` banner when the heartbeat is stale.
 

--- a/tests/test_agent_tools_accounts.py
+++ b/tests/test_agent_tools_accounts.py
@@ -378,3 +378,54 @@ class TestGetAccountAvailabilityTool:
         text = _text(await handlers["get_account_availability"]({}))
         assert "flood" in text
         assert "осталось" in text
+
+
+class SnapshotClientPool:  # noqa: N801 — exact name drives detect_runtime_kind
+    """Stand-in whose class name triggers runtime_kind == 'snapshot'."""
+
+    __test__ = False
+
+    def __init__(self, *connected):
+        self.clients = {p: object() for p in connected}
+
+
+class TestGetRuntimeDiagnosticsTool:
+    """#530: grounded runtime diagnostics — live pool kept separate from DB flags,
+    snapshot freshness reported only as snapshot health."""
+
+    @pytest.mark.anyio
+    async def test_live_runtime_omits_snapshot_health(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[_avail_account("+8613000000000")])
+        mock_db.update_account_flood = AsyncMock()
+        handlers = _get_tool_handlers(mock_db, client_pool=_pool_with("+8613000000000"))
+        text = _text(await handlers["get_runtime_diagnostics"]({}))
+        assert "runtime_kind: live" in text
+        assert "+8613000000000" in text
+        # Live runtime proves connectivity directly — no snapshot-health line.
+        assert "снапшота воркера" not in text
+        assert "get_account_availability" in text
+
+    @pytest.mark.anyio
+    async def test_snapshot_runtime_warns_on_stale_heartbeat(self, mock_db):
+        stale = SimpleNamespace(
+            updated_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+            payload={"status": "alive"},
+        )
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        mock_db.update_account_flood = AsyncMock()
+        mock_db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=stale)
+        handlers = _get_tool_handlers(mock_db, client_pool=SnapshotClientPool())
+        text = _text(await handlers["get_runtime_diagnostics"]({}))
+        assert "snapshot" in text
+        assert "устаревший" in text
+        assert "Не делайте выводов" in text
+
+    @pytest.mark.anyio
+    async def test_none_runtime_reported(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        mock_db.update_account_flood = AsyncMock()
+        mock_db.repos.runtime_snapshots.get_snapshot = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, client_pool=None)
+        text = _text(await handlers["get_runtime_diagnostics"]({}))
+        assert "runtime_kind: none" in text
+        assert "get_account_availability" in text

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -1,0 +1,58 @@
+"""Unit tests for the shared worker-heartbeat health evaluator (#530)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from src.services.runtime_diagnostics import (
+    WORKER_HEARTBEAT_STALE_AFTER_SEC,
+    evaluate_worker_heartbeat,
+)
+
+
+def _snapshot(*, updated_at, payload=None):
+    return SimpleNamespace(updated_at=updated_at, payload=payload or {"status": "alive"})
+
+
+def test_missing_snapshot_is_not_alive():
+    health = evaluate_worker_heartbeat(None)
+    assert health.alive is False
+    assert health.status == "missing"
+    assert health.age_sec is None
+
+
+def test_fresh_heartbeat_is_alive():
+    now = datetime.now(timezone.utc)
+    health = evaluate_worker_heartbeat(_snapshot(updated_at=now - timedelta(seconds=5)), now=now)
+    assert health.alive is True
+    assert health.stale is False
+    assert 0 <= health.age_sec < WORKER_HEARTBEAT_STALE_AFTER_SEC
+
+
+def test_stale_heartbeat_not_alive_with_age():
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(seconds=WORKER_HEARTBEAT_STALE_AFTER_SEC + 30)
+    health = evaluate_worker_heartbeat(_snapshot(updated_at=old), now=now)
+    assert health.alive is False
+    assert health.stale is True
+    assert health.reason == ""  # stale carries its signal via .stale, not .reason
+    assert health.age_sec is not None
+
+
+def test_explicit_failure_status_carries_reason():
+    now = datetime.now(timezone.utc)
+    snap = _snapshot(
+        updated_at=now,
+        payload={"status": "degraded", "detail": "session decrypt failed"},
+    )
+    health = evaluate_worker_heartbeat(snap, now=now)
+    assert health.alive is False
+    assert health.status == "degraded"
+    assert health.reason == "session decrypt failed"
+
+
+def test_naive_updated_at_treated_as_utc():
+    now = datetime.now(timezone.utc)
+    naive = (now - timedelta(seconds=5)).replace(tzinfo=None)
+    health = evaluate_worker_heartbeat(_snapshot(updated_at=naive), now=now)
+    assert health.alive is True


### PR DESCRIPTION
> **Стек поверх #650 (#529).** База — ветка `fix/529-agent-account-availability` (общий `accounts.py`/`permissions`/доки). После мержа #650 базу можно переключить на `main`.

## Цель (#530)

Follow-up #529. Явная заземлённая диагностика, чтобы агент **перестал выводить доступность Telegram-аккаунта из устаревшего снапшота воркера**.

## Изменения

**1. `src/services/runtime_diagnostics.py::evaluate_worker_heartbeat`** — единый классификатор свежести `worker_heartbeat` (`alive / stale / missing / explicit-failure`). `scheduler._worker_status` теперь делегирует ему → баннер Settings и agent-tool не разъедутся (тот же приём single-source, что в #529).

**2. Новый read-only agent-tool `get_runtime_diagnostics`:**
- маркирует `runtime_kind` (live / snapshot / none) с пояснением;
- показывает подключённость live `ClientPool` **отдельно** от DB active/flood-флагов;
- свежесть снапшота воркера — строго как **здоровье СНАПШОТА**, не доказательство связи аккаунта;
- завершает заземляющей подсказкой: статус аккаунта — через `get_account_availability`/`get_account_info`, а не вывод из снапшота.

**3.** Классифицирован `READ`, добавлен в группу «Аккаунты» и в reference + parity доки.

## Suggested scope (из issue) — покрытие
- [x] runtime diagnostics tool помечает runtime_kind live/snapshot/none
- [x] live ClientPool availability отдельно от DB active/flood
- [x] snapshot freshness только как snapshot health, не доказательство связи
- [x] регресс-покрытие: тесты на live/snapshot-stale/none + заземляющая подсказка

## Тесты
- `tests/test_runtime_diagnostics.py` — 5 кейсов классификатора (missing/fresh/stale/explicit-failure/naive-tz).
- `TestGetRuntimeDiagnosticsTool` — live (без snapshot health), snapshot+устаревший heartbeat (предупреждение), none.

```
ruff  →  All checks passed!
pytest runtime_diagnostics + accounts + doc-contract + parity  →  46 passed
pytest -k "scheduler or worker or permission"  →  878 passed, 3 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)