### PR TITLE
[codex] Polish TG Agent responsive layout

### DIFF
--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -24,17 +24,17 @@ def _agent_unavailable_copy(runtime_state: deps.AgentRuntimeState) -> tuple[str,
     if runtime_state.state == "starting":
         return (
             "Агент запускается.",
-            "Embedded worker поднимает live runtime. Обновите страницу через несколько секунд.",
+            "Рабочий процесс запускает чат. Обновите страницу через несколько секунд.",
         )
     if runtime_state.state == "failed":
         return (
             "Агент не запустился.",
-            runtime_state.error or "Embedded worker failed to start. Check server logs for details.",
+            runtime_state.error or "Рабочий процесс не запустился. Проверьте логи сервера.",
         )
     return (
         "Чат недоступен в web-процессе.",
-        "Agent chat is only available in the worker process. "
-        "Run `python -m src.main worker` alongside the web server to enable it.",
+        "Чат работает только в рабочем процессе. "
+        "Запустите рядом с web-сервером команду `python -m src.main worker`.",
     )
 
 

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -86,7 +86,52 @@
     }
 
     var path = window.location.pathname;
-    var links = document.querySelectorAll("#mainNav .nav-link");
+    var sidebar = document.getElementById("app-sidebar");
+    var sidebarStorageKey = "tg-agent-sidebar-collapsed";
+    var sidebarToggles = document.querySelectorAll("[data-sidebar-toggle]");
+    var sidebarBackdrop = document.querySelector("[data-sidebar-backdrop]");
+    var topbarTitle = document.getElementById("app-topbar-title");
+    var settingsBtn = document.querySelector(".app-settings-btn");
+
+    function isDesktopSidebar() {
+        return window.matchMedia("(min-width: 992px)").matches;
+    }
+
+    function applySidebarState() {
+        if (!sidebar) return;
+        document.body.classList.toggle("sidebar-collapsed", localStorage.getItem(sidebarStorageKey) === "1");
+        if (isDesktopSidebar()) {
+            document.body.classList.remove("sidebar-open");
+        }
+    }
+
+    function toggleSidebar() {
+        if (!sidebar) return;
+        if (isDesktopSidebar()) {
+            var collapsed = !document.body.classList.contains("sidebar-collapsed");
+            document.body.classList.toggle("sidebar-collapsed", collapsed);
+            if (collapsed) {
+                localStorage.setItem(sidebarStorageKey, "1");
+            } else {
+                localStorage.removeItem(sidebarStorageKey);
+            }
+            return;
+        }
+        document.body.classList.toggle("sidebar-open");
+    }
+
+    applySidebarState();
+    sidebarToggles.forEach(function(btn) {
+        btn.addEventListener("click", toggleSidebar);
+    });
+    if (sidebarBackdrop) {
+        sidebarBackdrop.addEventListener("click", function() {
+            document.body.classList.remove("sidebar-open");
+        });
+    }
+    window.addEventListener("resize", applySidebarState);
+
+    var links = document.querySelectorAll("#mainNav .app-sidebar-link");
     function isActiveLink(path, href) {
         if (href === "/") {
             return path === "/";
@@ -96,11 +141,34 @@
         }
         return path.startsWith(href + "/");
     }
+    var activeLink = null;
     links.forEach(function(a) {
         var href = a.getAttribute("href");
         if (isActiveLink(path, href)) {
-            a.classList.add("active");
+            if (!activeLink || href.length > activeLink.getAttribute("href").length) {
+                activeLink = a;
+            }
         }
+    });
+    if (activeLink) {
+        activeLink.classList.add("active");
+        if (topbarTitle) {
+            var label = activeLink.querySelector("span");
+            topbarTitle.textContent = label ? label.textContent.trim() : document.title.split("—")[0].trim();
+        }
+    } else if (topbarTitle) {
+        topbarTitle.textContent = document.title.split("—")[0].trim() || "TG Agent";
+    }
+    if (settingsBtn && isActiveLink(path, "/settings")) {
+        settingsBtn.classList.add("active");
+        settingsBtn.setAttribute("aria-current", "page");
+    }
+    links.forEach(function(a) {
+        a.addEventListener("click", function() {
+            if (!isDesktopSidebar()) {
+                document.body.classList.remove("sidebar-open");
+            }
+        });
     });
 
     function convertLocalDates(root) {

--- a/src/web/static/settings.js
+++ b/src/web/static/settings.js
@@ -360,6 +360,10 @@ function activateSettingsTab(tabId) {
     if (btn) {
         var tab = new bootstrap.Tab(btn);
         tab.show();
+        var select = document.getElementById('settings-section-select');
+        if (select && select.value !== tabId) {
+            select.value = tabId;
+        }
     }
 }
 
@@ -393,9 +397,24 @@ function initSettingsTabs() {
     document.querySelectorAll('#settings-tabs button[data-bs-toggle="pill"]').forEach(function(btn) {
         btn.addEventListener('shown.bs.tab', function() {
             var id = btn.getAttribute('data-bs-target').replace('#pane-', '');
+            var select = document.getElementById('settings-section-select');
+            if (select && select.value !== id) {
+                select.value = id;
+            }
             history.replaceState(null, '', '#' + id);
         });
     });
+
+    var sectionSelect = document.getElementById('settings-section-select');
+    if (sectionSelect) {
+        var active = document.querySelector('#settings-tabs .nav-link.active');
+        if (active) {
+            sectionSelect.value = active.getAttribute('data-bs-target').replace('#pane-', '');
+        }
+        sectionSelect.addEventListener('change', function() {
+            activateSettingsTab(sectionSelect.value);
+        });
+    }
 
     window.addEventListener('hashchange', function() {
         var tabId = settingsTabIdFromHash(window.location.hash);

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -1,6 +1,197 @@
 /* TG Agent — Custom styles (Bootstrap 5) */
 
 html { font-size: 14px; }
+body { overflow-x: hidden; }
+
+/* App shell */
+:root {
+    --app-sidebar-width: 244px;
+    --app-topbar-height: 56px;
+}
+
+.app-sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 1040;
+    width: var(--app-sidebar-width);
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--bs-border-color);
+    background: var(--bs-body-bg);
+    transition: transform 0.18s ease;
+}
+
+.app-sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: var(--app-topbar-height);
+    padding: 0.75rem 0.9rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.app-sidebar-brand {
+    color: var(--bs-emphasis-color);
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-decoration: none;
+}
+
+.app-sidebar-brand:hover { color: var(--bs-emphasis-color); }
+
+.app-sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0.6rem;
+}
+
+.app-sidebar-link {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 36px;
+    padding: 0.45rem 0.6rem;
+    border-radius: 0.45rem;
+    color: var(--bs-body-color);
+    text-decoration: none;
+    line-height: 1.2;
+}
+
+.app-sidebar-link i {
+    width: 1.15rem;
+    color: var(--bs-secondary-color);
+    text-align: center;
+}
+
+.app-sidebar-link:hover {
+    background: var(--bs-tertiary-bg);
+    color: var(--bs-emphasis-color);
+}
+
+.app-sidebar-link.active {
+    background: var(--bs-primary-bg-subtle);
+    color: var(--bs-primary-text-emphasis);
+    font-weight: 600;
+}
+
+.app-sidebar-link.active i { color: var(--bs-primary-text-emphasis); }
+
+.app-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 1030;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-height: var(--app-topbar-height);
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--bs-border-color);
+    background: color-mix(in srgb, var(--bs-body-bg) 94%, transparent);
+    backdrop-filter: blur(8px);
+}
+
+.app-menu-btn {
+    width: 2.25rem;
+    height: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.app-topbar-title {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+}
+
+.app-topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.app-topbar-actions .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 2rem;
+}
+
+.app-topbar-actions .btn.active {
+    color: var(--bs-primary-text-emphasis);
+    background: var(--bs-primary-bg-subtle);
+    border-color: var(--bs-primary-border-subtle);
+}
+
+.server-clock {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    white-space: nowrap;
+}
+
+.app-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1035;
+    display: none;
+    background: rgba(0, 0, 0, 0.35);
+}
+
+@media (min-width: 992px) {
+    .app-body:has(.app-sidebar):not(.sidebar-collapsed) .app-topbar,
+    .app-body:has(.app-sidebar):not(.sidebar-collapsed) .app-container,
+    .app-body:has(.app-sidebar):not(.sidebar-collapsed) footer {
+        margin-left: var(--app-sidebar-width);
+        width: calc(100% - var(--app-sidebar-width));
+    }
+
+    .app-body:has(.app-sidebar).sidebar-collapsed .app-sidebar {
+        transform: translateX(-100%);
+    }
+
+    .app-topbar,
+    .app-container,
+    footer {
+        transition: margin-left 0.18s ease;
+    }
+}
+
+@media (max-width: 991.98px) {
+    .app-sidebar {
+        transform: translateX(-100%);
+        box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.18);
+    }
+
+    .app-body.sidebar-open .app-sidebar {
+        transform: translateX(0);
+    }
+
+    .app-body.sidebar-open .app-sidebar-backdrop {
+        display: block;
+    }
+
+    .app-topbar {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
+
+    .emoji-btn {
+        min-width: 44px;
+        min-height: 44px;
+        font-size: 1.15rem;
+        justify-content: center;
+    }
+}
 
 /* Utility class for flex text truncation */
 .min-w-0 { min-width: 0; }
@@ -53,28 +244,46 @@ html { font-size: 14px; }
 .channels-table {
     table-layout: fixed;
     width: 100%;
-    min-width: 1250px;
+    min-width: 0;
 }
 .channels-table th { white-space: nowrap; }
-.channels-table th:nth-child(1), .channels-table td:nth-child(1) { width: 100px; }
-.channels-table th:nth-child(2), .channels-table td:nth-child(2) { width: 135px; }
-.channels-table th:nth-child(3), .channels-table td:nth-child(3) { width: 110px; }
-.channels-table th:nth-child(4), .channels-table td:nth-child(4) { width: 85px; }
-.channels-table th:nth-child(5), .channels-table td:nth-child(5) { width: 55px; }
-.channels-table th:nth-child(6), .channels-table td:nth-child(6) { width: 80px; }
-.channels-table th:nth-child(7), .channels-table td:nth-child(7) { width: 100px; }
-.channels-table th:nth-child(8), .channels-table td:nth-child(8) { width: 75px; }
-.channels-table th:nth-child(9), .channels-table td:nth-child(9) { width: 70px; }
-.channels-table th:nth-child(10), .channels-table td:nth-child(10) { width: 70px; }
-.channels-table th:nth-child(11), .channels-table td:nth-child(11) { width: 65px; }
-.channels-table th:nth-child(12), .channels-table td:nth-child(12) { width: 175px; }
-.channels-table td:nth-child(12) { white-space: nowrap; }
+.channels-table th,
+.channels-table td { font-size: 0.86rem; }
+.channels-table th:nth-child(1), .channels-table td:nth-child(1) { width: 4.8rem; }
+.channels-table th:nth-child(2), .channels-table td:nth-child(2) { width: 6.8rem; }
+.channels-table th:nth-child(3), .channels-table td:nth-child(3) { width: 6.8rem; }
+.channels-table th:nth-child(4), .channels-table td:nth-child(4) { width: auto; min-width: 6rem; }
+.channels-table th:nth-child(5), .channels-table td:nth-child(5) { width: 4.4rem; }
+.channels-table th:nth-child(6), .channels-table td:nth-child(6) { width: 4rem; }
+.channels-table th:nth-child(7), .channels-table td:nth-child(7) { width: 5.6rem; }
+.channels-table th:nth-child(8), .channels-table td:nth-child(8) { width: 5.8rem; }
+.channels-table th:nth-child(9), .channels-table td:nth-child(9) { width: 5.5rem; }
+.channels-table th:nth-child(10), .channels-table td:nth-child(10) { width: 4.4rem; }
+.channels-table th:nth-child(11), .channels-table td:nth-child(11) { width: 4.3rem; }
+.channels-table th:nth-child(12), .channels-table td:nth-child(12) { width: 3.5rem; }
+.channels-table th:nth-child(13), .channels-table td:nth-child(13) { width: 11.8rem; }
+.channels-table td:nth-child(13) { white-space: nowrap; }
 .channels-table td:nth-child(1),
 .channels-table td:nth-child(2),
 .channels-table td:nth-child(3) {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+.channels-table td:nth-child(4) {
+    white-space: normal;
+    word-break: break-word;
+}
+.channels-table td:nth-child(3) a {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+}
+.channels-table td:nth-child(n+5):nth-child(-n+12) {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Emoji action buttons (used in channels, search queries) */
@@ -113,6 +322,34 @@ html { font-size: 14px; }
     font-size: 0.9rem;
     display: inline-flex;
     align-items: center;
+}
+
+.search-options .form-check {
+    margin-bottom: 0;
+    padding-top: 0.45rem;
+    padding-bottom: 0.45rem;
+}
+
+.search-options .form-check-input:disabled + .form-check-label {
+    opacity: 0.68;
+}
+
+.scheduler-filter-group {
+    gap: 0.25rem;
+}
+
+.scheduler-filter-group .btn {
+    border-radius: var(--bs-btn-border-radius) !important;
+}
+
+.scheduler-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.scheduler-actions .btn {
+    min-width: 8.5rem;
 }
 
 /* Search queries table */
@@ -255,24 +492,15 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
     }
 }
 
-/* ── Responsive: Tablet (<768px) ── */
-@media (max-width: 767.98px) {
+/* ── Responsive: Tablet and phone (<992px) ── */
+@media (max-width: 991.98px) {
     .channels-table,
     .sq-table {
         min-width: 0;
     }
 
-    .emoji-btn {
-        min-width: 44px;
-        min-height: 44px;
-        font-size: 1.15rem;
-        justify-content: center;
-    }
-
     #settings-tabs {
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
+        display: none;
     }
     #settings-tabs .nav-link {
         white-space: nowrap;
@@ -280,6 +508,19 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
 }
 
 /* ── Responsive: Phone (<576px) ── */
+@media (max-width: 767.98px) {
+    .scheduler-actions {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.5rem;
+    }
+
+    .scheduler-actions .btn {
+        width: 100%;
+        min-width: 0;
+    }
+}
+
 @media (max-width: 575.98px) {
     html { font-size: 13px; }
 

--- a/src/web/templates/_macros.html
+++ b/src/web/templates/_macros.html
@@ -35,7 +35,7 @@
 <span id="collect-btn-{{ prefix }}{{ ch.id }}">
     <form action="/channels/{{ ch.id }}/collect" method="post"
           hx-post="/channels/{{ ch.id }}/collect"
-          hx-target="#collect-btn-{{ ch.id }}"
+          hx-target="#collect-btn-{{ prefix }}{{ ch.id }}"
           hx-swap="outerHTML"
           hx-disabled-elt="find button"
           class="d-inline">

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -21,9 +21,9 @@
     overflow-y: auto;
     padding: 0.85rem;
     border: 1px solid var(--bs-border-color);
-    border-radius: 18px;
+    border-radius: 8px;
     background: var(--bs-body-bg);
-    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.04);
+    box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.04);
 }
 .thread-item {
     display: flex;
@@ -80,11 +80,11 @@
     gap: 0.7rem;
     padding: 1rem 1.1rem;
     border: 1px solid var(--bs-border-color);
-    border-radius: 18px;
+    border-radius: 8px;
     background:
         linear-gradient(135deg, var(--bs-primary-bg-subtle), transparent 55%),
         var(--bs-body-bg);
-    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.05);
+    box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.05);
 }
 .chat-header {
     display: flex;
@@ -148,9 +148,9 @@
     display: flex;
     flex-direction: column;
     border: 1px solid var(--bs-border-color);
-    border-radius: 22px;
+    border-radius: 8px;
     background: var(--bs-body-bg);
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.05);
+    box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.05);
     overflow: hidden;
 }
 .chat-messages {
@@ -293,7 +293,7 @@
     max-height: 180px;
     font-size: 0.9rem;
     padding: 0.9rem 1rem;
-    border-radius: 16px;
+    border-radius: 8px;
 }
 .composer-actions {
     width: 230px;
@@ -311,12 +311,12 @@
 }
 .chat-send-btn {
     min-height: 46px;
-    border-radius: 14px;
+    border-radius: 8px;
     font-weight: 600;
 }
 .composer-hint {
     padding: 0.5rem 0.65rem;
-    border-radius: 14px;
+    border-radius: 8px;
     border: 1px solid var(--bs-border-color);
     background: var(--bs-tertiary-bg);
     color: var(--bs-secondary-color);
@@ -349,9 +349,9 @@
     padding: 0.85rem;
     font-size: 0.8rem;
     border: 1px solid var(--bs-border-color);
-    border-radius: 18px;
+    border-radius: 8px;
     background: var(--bs-body-bg);
-    box-shadow: 0 14px 36px rgba(15, 23, 42, 0.04);
+    box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.04);
 }
 .agent-context h3 {
     margin: 0 0 0.25rem 0;
@@ -402,40 +402,68 @@
 }
 @media (max-width: 767.98px) {
     .agent-layout {
-        height: calc(100vh - 160px);
+        height: auto;
+        min-height: 0;
+        gap: 0.6rem;
     }
     .chat-header {
         flex-direction: column;
         align-items: flex-start;
+        gap: 0.45rem;
+        padding-bottom: 0.45rem;
+    }
+    .chat-header-title {
+        font-size: 1.25rem;
     }
     .chat-header-badges {
         justify-content: flex-start;
     }
     .chat-status-panel {
-        padding: 0.9rem;
-        border-radius: 16px;
+        padding: 0.65rem 0.8rem;
+        border-radius: 8px;
     }
     .chat-stage {
-        border-radius: 18px;
+        border-radius: 8px;
+    }
+    .chat-messages {
+        flex: 0 1 auto;
+        min-height: 185px;
+        max-height: 28vh;
+        padding: 0.8rem 0.75rem;
+    }
+    .empty-state {
+        min-height: 150px;
+    }
+    .chat-composer {
+        padding: 0.75rem;
+        gap: 0.55rem;
     }
     .chat-input-area {
         flex-wrap: wrap;
         align-items: stretch;
+        gap: 0.55rem;
     }
     .chat-input-area textarea {
         width: 100%;
         flex: 1 1 100%;
-        min-height: 72px;
+        min-height: 64px;
+        max-height: 110px;
+        padding: 0.7rem 0.8rem;
     }
     .composer-actions {
         width: 100%;
+        gap: 0.45rem;
     }
     .chat-composer-meta {
         align-items: flex-start;
+        gap: 0.35rem;
     }
     .composer-subtle {
         width: 100%;
         text-align: left;
+    }
+    .chat-send-btn {
+        min-height: 42px;
     }
 }
 

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -7,66 +7,72 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔍</text></svg>">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous">
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="/static/style.css?v={{ app_version }}-layout">
     <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
     <script src="/static/_theme_init.js"></script>
     {% block head_scripts %}{% endblock %}
 </head>
-<body class="d-flex flex-column min-vh-100">
+<body class="app-body d-flex flex-column min-vh-100">
     {% block nav %}
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <div class="container">
-            <a class="navbar-brand fw-bold" href="/">TG Agent</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mainNav" aria-controls="mainNav" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
+    {% set nav_items = [
+        ("/agent", "Агент", "robot"),
+        ("/search", "Поиск", "search"),
+        ("/analytics", "Аналитика", "bar-chart"),
+        ("/analytics/trends", "Тренды", "graph-up"),
+        ("/dashboard", "Панель", "speedometer2"),
+        ("/channels", "Каналы", "broadcast"),
+        ("/channels/filter/manage", "Очистка", "funnel"),
+        ("/channels/renames", "Переименования", "type"),
+        ("/search-queries", "Запросы", "list-check"),
+        ("/pipelines", "Пайплайны", "diagram-3"),
+        ("/moderation", "Модерация", "shield-check"),
+        ("/images", "Картинки", "image"),
+        ("/calendar", "Календарь", "calendar-event"),
+        ("/dialogs", "Диалоги", "chat-dots"),
+        ("/scheduler", "Планировщик", "clock-history"),
+        ("/debug", "Дебаг", "bug")
+    ] %}
+    <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>
+    <aside class="app-sidebar" id="app-sidebar" aria-label="Главное меню">
+        <div class="app-sidebar-header">
+            <a class="app-sidebar-brand" href="/">TG Agent</a>
+            <button class="btn btn-sm btn-outline-secondary app-sidebar-close" type="button" data-sidebar-toggle aria-label="Скрыть меню">
+                <i class="bi bi-layout-sidebar-inset"></i>
             </button>
-            <div class="offcanvas offcanvas-end text-bg-dark" tabindex="-1" id="mainNav">
-                <div class="offcanvas-header">
-                    <h5 class="offcanvas-title">TG Agent</h5>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-                </div>
-                <div class="offcanvas-body">
-                <ul class="navbar-nav ms-auto">
-                    {% if agent_available(request) %}<li class="nav-item"><a class="nav-link" href="/agent">Чат</a></li>{% endif %}
-                    <li class="nav-item"><a class="nav-link" href="/search">Поиск</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/analytics">Аналитика</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/analytics/trends">Тренды</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/dashboard">Панель</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/channels">Каналы</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/channels/filter/manage">Очистка</a></li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/channels/renames">
-                            Переименования<span
-                                id="rename-badge"
-                                hx-get="/channels/renames/count"
-                                hx-trigger="load, every 60s"
-                                hx-swap="innerHTML"></span>
-                        </a>
-                    </li>
-                    <li class="nav-item"><a class="nav-link" href="/search-queries">Запросы</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/pipelines">Пайплайны</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/moderation">Модерация</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/images">Картинки</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/calendar">Календарь</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/dialogs">Диалоги</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/scheduler">Планировщик</a></li>
-                    <li class="nav-item"><a class="nav-link" href="/debug">Дебаг</a></li>
-                    <li class="nav-item ms-lg-2 mt-2 mt-lg-0 d-flex align-items-center gap-2">
-                        <span class="navbar-text text-light small me-2 server-clock" data-utc="{{ server_now().isoformat() }}" title="Время сервера (UTC)"><i class="bi bi-clock"></i> <span class="server-clock-value">--:--:-- UTC</span></span>
-                        <a class="btn btn-sm btn-outline-light" href="/settings" title="Настройки"><i class="bi bi-gear"></i></a>
-                        <button class="btn btn-sm btn-outline-light" id="theme-toggle" type="button" title="Тема: авто"></button>
-                        <form method="post" action="/logout" class="d-inline m-0">
-                            <button type="submit" class="btn btn-sm btn-outline-light" title="Выйти"><i class="bi bi-box-arrow-right"></i></button>
-                        </form>
-                    </li>
-                </ul>
-                </div>
-            </div>
         </div>
-    </nav>
+        <nav class="app-sidebar-nav" id="mainNav">
+            {% for href, label, icon_name in nav_items %}
+            <a class="app-sidebar-link" href="{{ href }}">
+                <i class="bi bi-{{ icon_name }}"></i><span>{{ label }}</span>
+                {% if href == "/channels/renames" %}
+                <span
+                    id="rename-badge"
+                    class="ms-auto"
+                    hx-get="/channels/renames/count"
+                    hx-trigger="load, every 60s"
+                    hx-swap="innerHTML"></span>
+                {% endif %}
+            </a>
+            {% endfor %}
+        </nav>
+    </aside>
+    <header class="app-topbar">
+        <button class="btn btn-outline-secondary app-menu-btn" type="button" data-sidebar-toggle aria-label="Открыть меню">
+            <i class="bi bi-list"></i>
+        </button>
+        <div class="app-topbar-title" id="app-topbar-title">TG Agent</div>
+        <div class="app-topbar-actions">
+            <span class="server-clock text-muted small" data-utc="{{ server_now().isoformat() }}" title="Время сервера (UTC)"><i class="bi bi-clock"></i> <span class="server-clock-value">--:--:-- UTC</span></span>
+            <a class="btn btn-sm btn-outline-secondary app-settings-btn" href="/settings" title="Настройки" aria-label="Настройки"><i class="bi bi-gear"></i></a>
+            <button class="btn btn-sm btn-outline-secondary" id="theme-toggle" type="button" title="Тема: авто" aria-label="Тема"></button>
+            <form method="post" action="/logout" class="d-inline m-0">
+                <button type="submit" class="btn btn-sm btn-outline-secondary" title="Выйти" aria-label="Выйти"><i class="bi bi-box-arrow-right"></i></button>
+            </form>
+        </div>
+    </header>
     {% endblock %}
-    <div id="flash-container" class="container mt-3"></div>
-    <main class="container py-3 flex-grow-1">
+    <div id="flash-container" class="container-fluid app-container mt-3"></div>
+    <main class="container-fluid app-container py-3 flex-grow-1">
         {% block content %}{% endblock %}
     </main>
     <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index:1090">
@@ -86,6 +92,6 @@
     window.__flashMessages = {{ flash_messages | tojson }};
     window.__flashErrors = {{ flash_errors | tojson }};
 </script>
-<script src="/static/js/app.js"></script>
+<script src="/static/js/app.js?v={{ app_version }}-layout"></script>
 </body>
 </html>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -42,6 +42,7 @@
         </div>
         <nav class="app-sidebar-nav" id="mainNav">
             {% for href, label, icon_name in nav_items %}
+            {% if href != "/agent" or agent_available(request) %}
             <a class="app-sidebar-link" href="{{ href }}">
                 <i class="bi bi-{{ icon_name }}"></i><span>{{ label }}</span>
                 {% if href == "/channels/renames" %}
@@ -53,6 +54,7 @@
                     hx-swap="innerHTML"></span>
                 {% endif %}
             </a>
+            {% endif %}
             {% endfor %}
         </nav>
     </aside>

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -42,7 +42,7 @@
     </span>
 </div>
 <!-- Desktop: table -->
-<div class="table-responsive d-none d-md-block">
+<div class="table-responsive d-none d-lg-block">
 <table class="tga-table-striped-hover channels-table">
     <thead>
         <tr>
@@ -110,7 +110,7 @@
 </div>
 
 <!-- Mobile: cards -->
-<div class="d-md-none mobile-cards">
+<div class="d-lg-none mobile-cards">
     {% for ch in channels %}
     {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
     <div class="card mb-2{% if ch.is_filtered %} opacity-50{% endif %}">

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -37,7 +37,7 @@
         <small class="text-muted d-block mb-2">Автоматическое создание задач: сбор каждые {{ interval_minutes }} мин.</small>
         <p>Статус: <strong>{{ "Запущен" if is_running else "Остановлен" }}</strong></p>
 
-        <div class="d-flex flex-wrap gap-2">
+        <div class="scheduler-actions">
             {% if not is_running %}
             <form method="post" action="/scheduler/start{{ filter_qs }}" data-busy>
                 <button type="submit" class="btn btn-primary">{{ icon("run") }} Запустить</button>
@@ -240,7 +240,7 @@
     </div>
     <div class="card-body p-0">
         <!-- Desktop -->
-        <div class="table-responsive d-none d-md-block">
+        <div class="table-responsive d-none d-lg-block">
         <table class="tga-table-striped mb-0">
             <thead>
                 <tr>
@@ -263,7 +263,7 @@
         </table>
         </div>
         <!-- Mobile -->
-        <div class="d-md-none mobile-cards p-2">
+        <div class="d-lg-none mobile-cards p-2">
             {% for entry in search_log %}
             <div class="card mb-2">
                 <div class="card-body">
@@ -288,7 +288,7 @@
 
         <!-- Filter tabs -->
         <div class="px-3 pb-2">
-            <div class="btn-group" role="tablist">
+            <div class="btn-group flex-wrap scheduler-filter-group" role="tablist">
                 <a href="/scheduler?status=all&page=1&limit={{ limit }}" class="btn btn-sm {% if status_filter == 'all' %}btn-primary{% else %}btn-outline-primary{% endif %}">
                     Все ({{ all_count }})
                 </a>
@@ -303,7 +303,7 @@
 
         {% if tasks %}
         <!-- Desktop -->
-        <div class="table-responsive d-none d-md-block">
+        <div class="table-responsive d-none d-lg-block">
         <table class="tga-table-striped mb-0">
             <thead>
                 <tr>
@@ -363,7 +363,7 @@
         </table>
         </div>
         <!-- Mobile -->
-        <div class="d-md-none mobile-cards p-2">
+        <div class="d-lg-none mobile-cards p-2">
             {% for t in tasks %}
             <div class="card mb-2">
                 <div class="card-body">

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -32,47 +32,51 @@
         </div>
     </div>
 
-    <div class="d-flex align-items-center gap-3 flex-wrap mb-3">
-        <div class="form-check form-check-inline" title="Поиск по ранее собранным сообщениям в локальной базе данных">
+    <div class="row g-2 align-items-end mb-3 search-options">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="Поиск по ранее собранным сообщениям в локальной базе данных">
             <input class="form-check-input" type="radio" name="mode" id="mode-local" value="local" {{ 'checked' if mode == 'local' else '' }}>
             <label class="form-check-label" for="mode-local">Локальная база</label>
         </div>
-        <div class="form-check form-check-inline" title="{{ 'Недоступно: не установлен numpy / sqlite-vec' if not semantic_available else 'Семантический поиск по локальной базе через embeddings и semantic backend' }}">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="{{ 'Недоступно: не установлен numpy / sqlite-vec' if not semantic_available else 'Семантический поиск по локальной базе через embeddings и semantic backend' }}">
             <input class="form-check-input" type="radio" name="mode" id="mode-semantic" value="semantic" {{ 'checked' if mode == 'semantic' else '' }} {{ 'disabled' if not semantic_available else '' }}>
             <label class="form-check-label {{ 'text-muted' if not semantic_available else '' }}" for="mode-semantic">Семантический</label>
         </div>
-        <div class="form-check form-check-inline" title="{{ 'Недоступно: не установлен numpy / sqlite-vec' if not semantic_available else 'Гибридный поиск: объединяет FTS5 и semantic retrieval' }}">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="{{ 'Недоступно: не установлен numpy / sqlite-vec' if not semantic_available else 'Гибридный поиск: объединяет FTS5 и semantic retrieval' }}">
             <input class="form-check-input" type="radio" name="mode" id="mode-hybrid" value="hybrid" {{ 'checked' if mode == 'hybrid' else '' }} {{ 'disabled' if not semantic_available else '' }}>
             <label class="form-check-label {{ 'text-muted' if not semantic_available else '' }}" for="mode-hybrid">Гибридный</label>
         </div>
-        <div class="form-check form-check-inline" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Поиск по всем чатам и каналам подключённого аккаунта через Telegram API' }}">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Поиск по всем чатам и каналам подключённого аккаунта через Telegram API' }}">
             <input class="form-check-input" type="radio" name="mode" id="mode-my-chats" value="my_chats" {{ 'checked' if mode == 'my_chats' else '' }} {{ 'disabled' if not telegram_available else '' }}>
             <label class="form-check-label {{ 'text-muted' if not telegram_available else '' }}" for="mode-my-chats">Мои чаты</label>
         </div>
-        <div class="form-check form-check-inline" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Поиск внутри выбранного канала через Telegram API' }}">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Поиск внутри выбранного канала через Telegram API' }}">
             <input class="form-check-input" type="radio" name="mode" id="mode-channel" value="channel" {{ 'checked' if mode == 'channel' else '' }} {{ 'disabled' if not telegram_available else '' }}>
             <label class="form-check-label {{ 'text-muted' if not telegram_available else '' }}" for="mode-channel">В канале</label>
         </div>
-        <div class="form-check form-check-inline" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Глобальный поиск по публичным каналам (требуется Telegram Premium)' }}">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="{{ 'Недоступно: нет подключённого Telegram-аккаунта' if not telegram_available else 'Глобальный поиск по публичным каналам (требуется Telegram Premium)' }}">
             <input class="form-check-input" type="radio" name="mode" id="mode-telegram" value="telegram" {{ 'checked' if mode == 'telegram' else '' }} {{ 'disabled' if not telegram_available else '' }}>
             <label class="form-check-label {{ 'text-muted' if not telegram_available else '' }}" for="mode-telegram">Публичные (Premium)</label>
         </div>
         {% if search_quota and search_quota.remains is not none %}
-        <small id="quota-info" class="text-muted">
-            Premium-поиск: осталось {{ search_quota.remains }}{% if search_quota.total_daily %} из {{ search_quota.total_daily }}{% endif %} сегодня
-        </small>
+        <div class="col-12 col-lg-auto">
+            <small id="quota-info" class="text-muted">
+                Premium-поиск: осталось {{ search_quota.remains }}{% if search_quota.total_daily %} из {{ search_quota.total_daily }}{% endif %} сегодня
+            </small>
+        </div>
         {% endif %}
         {% if ai_enabled %}
-        <div class="form-check form-check-inline" title="Семантический поиск с помощью LLM по локальной базе">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" title="Семантический поиск с помощью LLM по локальной базе">
             <input class="form-check-input" type="radio" name="mode" id="mode-ai" value="ai" {{ 'checked' if mode == 'ai' else '' }}>
             <label class="form-check-label" for="mode-ai">AI-поиск</label>
         </div>
         {% endif %}
-        <div class="form-check form-check-inline" id="fts-label" title="Полнотекстовый поиск FTS5 (поддерживает операторы AND, OR, NOT, фразы в кавычках)">
+        <div class="col-12 col-sm-6 col-lg-auto form-check" id="fts-label" title="Полнотекстовый поиск FTS5 (поддерживает операторы AND, OR, NOT, фразы в кавычках)">
             <input class="form-check-input" type="checkbox" name="is_fts" value="1" id="fts-checkbox" {{ 'checked' if is_fts else '' }}>
             <label class="form-check-label" for="fts-checkbox">FTS5 <span class="hint" data-tooltip="Полнотекстовый поиск с поддержкой операторов: OR, AND, NOT, префикс*, «точная фраза», len&lt;400, len&gt;100">?</span></label>
         </div>
-        <button type="submit" class="btn btn-primary ms-auto">Найти</button>
+        <div class="col-12 col-sm-auto ms-sm-auto">
+            <button type="submit" class="btn btn-primary w-100">Найти</button>
+        </div>
     </div>
 </form>
 

--- a/src/web/templates/settings.html
+++ b/src/web/templates/settings.html
@@ -2,6 +2,18 @@
 {% block title %}Настройки — TG Agent{% endblock %}
 {% block content %}
 <h1 class="mb-4">Настройки</h1>
+{% set settings_tabs = [
+    ("accounts", "Аккаунты", "phone", "Telegram-аккаунты", "settings/_accounts.html"),
+    ("credentials", "API", "key", "Telegram API credentials", "settings/_credentials.html"),
+    ("scheduler", "Планировщик", "clock", "Планировщик", "settings/_scheduler.html"),
+    ("semantic", "Semantic Search", "search-heart", "Semantic Search & Embeddings", "settings/_semantic.html"),
+    ("image", "Изображения", "image", "Image Generation Providers", "settings/_image_providers.html"),
+    ("devmode", "Разработчик", "code-slash", "Режим разработчика", "settings/_devmode.html"),
+    ("filters", "Фильтры", "funnel", "Фильтры каналов", "settings/_filters.html"),
+    ("notifications", "Уведомления", "bell", "Уведомления", "settings/_notifications.html"),
+    ("translation", "Перевод", "translate", "Перевод и определение языка", "settings/_translation.html"),
+    ("tool-permissions", "Разрешения агента", "shield-lock", "Разрешения инструментов агента", "settings/_tool_permissions.html")
+] %}
 
 {% set failed_agent_providers = agent_provider_views|selectattr("requires_secret_reentry")|list %}
 {% set failed_img_providers = img_provider_views|selectattr("requires_secret_reentry")|list %}
@@ -10,191 +22,58 @@
     <ul class="mb-0">
         {% if telegram_session_warning %}
         <li>
-            Saved Telegram logins are unavailable.
-            Restore <code>SESSION_ENCRYPTION_KEY</code> if it changed, upgrade the app if needed, or re-login accounts.
+            Сохранённые входы Telegram сейчас недоступны.
+            Восстановите прежний <code>SESSION_ENCRYPTION_KEY</code> или войдите в аккаунты заново.
         </li>
         {% endif %}
         {% if failed_agent_providers %}
         <li>
-            Agent provider API keys cannot be decrypted:{% for item in failed_agent_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
-            Re-enter the provider API key or restore the old <code>SESSION_ENCRYPTION_KEY</code>.
+            Ключи провайдеров агента не расшифровываются:{% for item in failed_agent_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
+            Введите ключ заново или восстановите прежний <code>SESSION_ENCRYPTION_KEY</code>.
         </li>
         {% endif %}
         {% if failed_img_providers %}
         <li>
-            Image provider API keys cannot be decrypted:{% for item in failed_img_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
-            Re-enter the provider API key or restore the old <code>SESSION_ENCRYPTION_KEY</code>.
+            Ключи генерации изображений не расшифровываются:{% for item in failed_img_providers %}{% if loop.first %} {% endif %}{{ item.display_name or item.provider }}{% if not loop.last %}, {% endif %}{% endfor %}.
+            Введите ключ заново или восстановите прежний <code>SESSION_ENCRYPTION_KEY</code>.
         </li>
         {% endif %}
     </ul>
 </div>
 {% endif %}
 
-<ul class="nav nav-pills mb-4" id="settings-tabs" role="tablist">
+<label for="settings-section-select" class="form-label d-lg-none">Раздел настроек</label>
+<select class="form-select mb-3 d-lg-none" id="settings-section-select">
+    {% for tab_id, label, icon_name, title, include_name in settings_tabs %}
+    <option value="{{ tab_id }}">{{ label }}</option>
+    {% endfor %}
+</select>
+
+<ul class="nav nav-pills mb-4 d-none d-lg-flex" id="settings-tabs" role="tablist">
+    {% for tab_id, label, icon_name, title, include_name in settings_tabs %}
     <li class="nav-item" role="presentation">
-        <button class="nav-link active" id="tab-accounts" data-bs-toggle="pill"
-                data-bs-target="#pane-accounts" type="button" role="tab"
-                aria-controls="pane-accounts" aria-selected="true">
-            <i class="bi bi-phone me-1"></i>Аккаунты
+        <button class="nav-link {{ 'active' if loop.first else '' }}" id="tab-{{ tab_id }}" data-bs-toggle="pill"
+                data-bs-target="#pane-{{ tab_id }}" type="button" role="tab"
+                aria-controls="pane-{{ tab_id }}" aria-selected="{{ 'true' if loop.first else 'false' }}">
+            <i class="bi bi-{{ icon_name }} me-1"></i>{{ label }}
         </button>
     </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-credentials" data-bs-toggle="pill"
-                data-bs-target="#pane-credentials" type="button" role="tab"
-                aria-controls="pane-credentials" aria-selected="false">
-            <i class="bi bi-key me-1"></i>API
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-scheduler" data-bs-toggle="pill"
-                data-bs-target="#pane-scheduler" type="button" role="tab"
-                aria-controls="pane-scheduler" aria-selected="false">
-            <i class="bi bi-clock me-1"></i>Планировщик
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-semantic" data-bs-toggle="pill"
-                data-bs-target="#pane-semantic" type="button" role="tab"
-                aria-controls="pane-semantic" aria-selected="false">
-            <i class="bi bi-search-heart me-1"></i>Semantic Search
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-image" data-bs-toggle="pill"
-                data-bs-target="#pane-image" type="button" role="tab"
-                aria-controls="pane-image" aria-selected="false">
-            <i class="bi bi-image me-1"></i>Изображения
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-devmode" data-bs-toggle="pill"
-                data-bs-target="#pane-devmode" type="button" role="tab"
-                aria-controls="pane-devmode" aria-selected="false">
-            <i class="bi bi-code-slash me-1"></i>Разработчик
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-filters" data-bs-toggle="pill"
-                data-bs-target="#pane-filters" type="button" role="tab"
-                aria-controls="pane-filters" aria-selected="false">
-            <i class="bi bi-funnel me-1"></i>Фильтры
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-notifications" data-bs-toggle="pill"
-                data-bs-target="#pane-notifications" type="button" role="tab"
-                aria-controls="pane-notifications" aria-selected="false">
-            <i class="bi bi-bell me-1"></i>Уведомления
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-translation" data-bs-toggle="pill"
-                data-bs-target="#pane-translation" type="button" role="tab"
-                aria-controls="pane-translation" aria-selected="false">
-            <i class="bi bi-translate me-1"></i>Перевод
-        </button>
-    </li>
-    <li class="nav-item" role="presentation">
-        <button class="nav-link" id="tab-tool-permissions" data-bs-toggle="pill"
-                data-bs-target="#pane-tool-permissions" type="button" role="tab"
-                aria-controls="pane-tool-permissions" aria-selected="false">
-            <i class="bi bi-shield-lock me-1"></i>Разрешения агента
-        </button>
-    </li>
+    {% endfor %}
 </ul>
 
 <div class="tab-content" id="settings-tab-content">
-    <div class="tab-pane fade show active" id="pane-accounts" role="tabpanel" aria-labelledby="tab-accounts">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Telegram-аккаунты</div>
-            <div class="card-body">
-                {% include "settings/_accounts.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-credentials" role="tabpanel" aria-labelledby="tab-credentials">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Telegram API credentials</div>
-            <div class="card-body">
-                {% include "settings/_credentials.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-scheduler" role="tabpanel" aria-labelledby="tab-scheduler">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Планировщик</div>
-            <div class="card-body">
-                {% include "settings/_scheduler.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-semantic" role="tabpanel" aria-labelledby="tab-semantic">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Semantic Search & Embeddings</div>
-            <div class="card-body">
-                {% include "settings/_semantic.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-image" role="tabpanel" aria-labelledby="tab-image">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Image Generation Providers</div>
-            <div class="card-body">
-                {% include "settings/_image_providers.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-devmode" role="tabpanel" aria-labelledby="tab-devmode">
+    {% for tab_id, label, icon_name, title, include_name in settings_tabs %}
+    <div class="tab-pane fade {{ 'show active' if loop.first else '' }}" id="pane-{{ tab_id }}" role="tabpanel" aria-labelledby="tab-{{ tab_id }}">
         <div class="card shadow-sm">
             <div class="card-header bg-body-secondary fw-semibold">
-                Режим разработчика{% if agent_dev_mode_enabled %} & AI Agent{% endif %}
+                {{ title|safe }}{% if tab_id == "devmode" and agent_dev_mode_enabled %} & AI Agent{% endif %}
             </div>
             <div class="card-body">
-                {% include "settings/_devmode.html" %}
+                {% include include_name %}
             </div>
         </div>
     </div>
-
-    <div class="tab-pane fade" id="pane-filters" role="tabpanel" aria-labelledby="tab-filters">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Фильтры каналов</div>
-            <div class="card-body">
-                {% include "settings/_filters.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-notifications" role="tabpanel" aria-labelledby="tab-notifications">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Уведомления</div>
-            <div class="card-body">
-                {% include "settings/_notifications.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-translation" role="tabpanel" aria-labelledby="tab-translation">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Перевод и определение языка</div>
-            <div class="card-body">
-                {% include "settings/_translation.html" %}
-            </div>
-        </div>
-    </div>
-
-    <div class="tab-pane fade" id="pane-tool-permissions" role="tabpanel" aria-labelledby="tab-tool-permissions">
-        <div class="card shadow-sm">
-            <div class="card-header bg-body-secondary fw-semibold">Разрешения инструментов агента</div>
-            <div class="card-body">
-                {% include "settings/_tool_permissions.html" %}
-            </div>
-        </div>
-    </div>
+    {% endfor %}
 </div>
 
 {% endblock %}

--- a/src/web/templates/settings/_devmode.html
+++ b/src/web/templates/settings/_devmode.html
@@ -159,7 +159,7 @@
 
             {% if item.requires_secret_reentry %}
             <div class="alert alert-warning py-2 mb-3">
-                Saved provider secrets cannot be decrypted. Re-enter the secret or restore <code>SESSION_ENCRYPTION_KEY</code>.
+                Сохранённые ключи провайдера не расшифровываются. Введите ключ заново или восстановите <code>SESSION_ENCRYPTION_KEY</code>.
             </div>
             {% endif %}
 

--- a/src/web/templates/settings/_image_providers.html
+++ b/src/web/templates/settings/_image_providers.html
@@ -49,7 +49,7 @@
 
             {% if item.requires_secret_reentry %}
             <div class="alert alert-warning py-2 mb-3">
-                Saved image provider secret cannot be decrypted. Re-enter the API key or restore <code>SESSION_ENCRYPTION_KEY</code>.
+                Сохранённый ключ провайдера изображений не расшифровывается. Введите ключ заново или восстановите <code>SESSION_ENCRYPTION_KEY</code>.
             </div>
             {% endif %}
 

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -41,6 +41,30 @@ async def test_search_page_renders(route_client):
 
 
 @pytest.mark.anyio
+async def test_sidebar_hides_agent_link_when_unavailable(route_client):
+    """The sidebar should preserve the existing agent availability gate."""
+    resp = await route_client.get("/search")
+
+    assert resp.status_code == 200
+    assert 'href="/agent"' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_sidebar_shows_agent_link_when_available(route_client):
+    """Available agent backends should still get an active-capable sidebar link."""
+    from src.agent.manager import AgentManager
+
+    agent_manager_mock = MagicMock(spec=AgentManager)
+    agent_manager_mock.available = True
+    route_client._transport_app.state.agent_manager = agent_manager_mock
+
+    resp = await route_client.get("/search")
+
+    assert resp.status_code == 200
+    assert 'href="/agent"' in resp.text
+
+
+@pytest.mark.anyio
 async def test_search_page_with_message(route_client):
     """Test search page with message param."""
     resp = await route_client.get("/search?msg=test_message")

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -78,8 +78,8 @@ async def test_settings_degrades_when_account_session_key_is_wrong(route_client,
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Saved Telegram logins are unavailable" in resp.text
-    assert "provider API keys cannot be decrypted" not in resp.text
+    assert "Сохранённые входы Telegram сейчас недоступны" in resp.text
+    assert "Ключи провайдеров агента не расшифровываются" not in resp.text
     # Human-readable label is shown (issue #550); raw enum stays as the tooltip.
     assert "Ошибка расшифровки" in resp.text
     assert 'title="decrypt_failed"' in resp.text
@@ -101,8 +101,8 @@ async def test_settings_degrades_for_image_provider_only_key_failure(route_clien
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
-    assert "Saved Telegram logins are unavailable" not in resp.text
+    assert "Ключи генерации изображений не расшифровываются: Replicate" in resp.text
+    assert "Сохранённые входы Telegram сейчас недоступны" not in resp.text
     assert "Saved Telegram logins and provider API keys cannot be decrypted" not in resp.text
 
 
@@ -127,8 +127,8 @@ async def test_settings_degrades_with_separate_telegram_and_image_warnings(route
         resp = await route_client.get("/settings/")
 
     assert resp.status_code == 200
-    assert "Saved Telegram logins are unavailable" in resp.text
-    assert "Image provider API keys cannot be decrypted: Replicate" in resp.text
+    assert "Сохранённые входы Telegram сейчас недоступны" in resp.text
+    assert "Ключи генерации изображений не расшифровываются: Replicate" in resp.text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- move TG Agent navigation into the reusable left app shell and add Agent active-state coverage
- tighten desktop channels table sizing so action buttons remain visible with the sidebar open
- improve tablet/mobile settings, scheduler, search, channels, and agent layouts without changing backend behavior

## Why

The repeated visual pass found a few remaining layout issues after the sidebar migration: the channels table still pushed wide on desktop, settings tabs were too dense on tablet, scheduler actions were uneven on mobile, and the agent page kept too much empty vertical space on phones.

## Validation

- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/routes -q`
- `python3 -m pytest tests/ -v -m "not aiosqlite_serial" -n auto`
- `python3 -m pytest tests/ -v -m aiosqlite_serial`
- browser screenshots at `1440x900`, `768x1024`, and `390x844` for `/search`, `/channels`, `/settings`, `/scheduler`, and `/agent`
- extra browser checks for desktop collapsed `/search` and mobile open menu `/channels`

## Notes

No new libraries, routes, APIs, database schema, or config changes.