### PR TITLE
refactor(web): finish response DTO layering for pipelines handlers (#656)

### DIFF
--- a/src/web/photo_loader/handlers.py
+++ b/src/web/photo_loader/handlers.py
@@ -19,7 +19,7 @@ from src.web.photo_loader.forms import (
     PhotoScheduleForm,
     PhotoSendForm,
 )
-from src.web.photo_loader.responses import PhotoLoaderRedirect
+from src.web.photo_loader.responses import PhotoLoaderRedirect, PhotoLoaderTemplate
 
 logger = logging.getLogger("src.web.routes.photo_loader")
 
@@ -155,7 +155,7 @@ def build_feedback(
     return None
 
 
-async def handle_photo_loader_page(request: Request, phone: str | None = None) -> dict:
+async def handle_photo_loader_page(request: Request, phone: str | None = None) -> PhotoLoaderTemplate:
     pool = deps.get_pool(request)
     accounts = sorted(pool.clients.keys())
     selected_phone = phone if phone in pool.clients else (accounts[0] if accounts else None)
@@ -176,7 +176,7 @@ async def handle_photo_loader_page(request: Request, phone: str | None = None) -
         items=items,
         auto_jobs=auto_jobs,
     )
-    return {
+    context = {
         "accounts": accounts,
         "selected_phone": selected_phone,
         "dialogs": dialogs,
@@ -186,6 +186,7 @@ async def handle_photo_loader_page(request: Request, phone: str | None = None) -
         "auto_jobs": auto_jobs,
         "photo_feedback": photo_feedback,
     }
+    return PhotoLoaderTemplate("photo_loader.html", context)
 
 
 async def _validate_target(
@@ -438,8 +439,10 @@ async def handle_photo_toggle_auto(request: Request, job_id: int, form: PhotoPho
 async def handle_photo_update_auto(
     request: Request,
     job_id: int,
-    form: PhotoAutoUpdateForm,
+    form: PhotoAutoUpdateForm | None = None,
 ) -> PhotoLoaderRedirect:
+    if form is None:
+        form = forms.parse_auto_update_form(await request.form())
     service = deps.get_photo_auto_upload_service(request)
     job = await service.get_job(job_id)
     if job is None:
@@ -451,4 +454,3 @@ async def handle_photo_update_auto(
 async def handle_photo_delete_auto(request: Request, job_id: int, form: PhotoPhoneForm) -> PhotoLoaderRedirect:
     await deps.get_photo_auto_upload_service(request).delete_job(job_id)
     return PhotoLoaderRedirect(form.phone, "photo_auto_deleted")
-

--- a/src/web/photo_loader/responses.py
+++ b/src/web/photo_loader/responses.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote
 
-from fastapi.responses import RedirectResponse
+from fastapi import Request
+from fastapi.responses import RedirectResponse, Response
+
+from src.web import deps
 
 
 @dataclass(frozen=True)
@@ -14,6 +18,12 @@ class PhotoLoaderRedirect:
     command_id: int | None = None
 
 
+@dataclass(frozen=True)
+class PhotoLoaderTemplate:
+    name: str
+    context: dict[str, Any]
+
+
 def photo_loader_redirect_response(result: PhotoLoaderRedirect) -> RedirectResponse:
     key = "error" if result.error else "msg"
     suffix = f"&command_id={result.command_id}" if result.command_id is not None else ""
@@ -22,3 +32,11 @@ def photo_loader_redirect_response(result: PhotoLoaderRedirect) -> RedirectRespo
         status_code=303,
     )
 
+
+PhotoLoaderResult = PhotoLoaderRedirect | PhotoLoaderTemplate
+
+
+def photo_loader_response(request: Request, result: PhotoLoaderResult) -> Response:
+    if isinstance(result, PhotoLoaderTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    return photo_loader_redirect_response(result)

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 from fastapi import Request
-from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 
 from src.agent.prompt_template import ALLOWED_TEMPLATE_VARIABLES
 from src.models import PipelineGenerationBackend, PipelinePublishMode
@@ -37,7 +36,14 @@ from src.web.pipelines.forms import (
     get_filter_config,
     parse_target_refs,
 )
-from src.web.pipelines.responses import PipelineRedirect
+from src.web.pipelines.responses import (
+    PipelineFile,
+    PipelineJson,
+    PipelineRedirect,
+    PipelineStream,
+    PipelineTemplate,
+    PipelineUrlRedirect,
+)
 
 logger = logging.getLogger("src.web.routes.pipelines")
 
@@ -179,11 +185,7 @@ async def _page_context(request: Request) -> dict:
 
 
 async def pipelines_page(request: Request):
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "pipelines.html",
-        await _page_context(request),
-    )
+    return PipelineTemplate("pipelines.html", await _page_context(request))
 
 
 async def create_wizard_page(request: Request):
@@ -192,8 +194,7 @@ async def create_wizard_page(request: Request):
     cached_dialogs = await svc.list_cached_dialogs_by_phone()
     llm_provider_svc = deps.get_llm_provider_service(request)
     llm_configured = llm_provider_svc.has_providers()
-    return deps.get_templates(request).TemplateResponse(
-        request,
+    return PipelineTemplate(
         "pipelines/create.html",
         {
             "accounts": accounts,
@@ -425,8 +426,7 @@ async def edit_page(request: Request, pipeline_id: int):
     targets = await db.repos.content_pipelines.list_targets(pipeline_id)
     source_ids = [s.channel_id for s in sources]
     target_refs = [f"{t.phone}|{t.dialog_id}" for t in targets]
-    return deps.get_templates(request).TemplateResponse(
-        request,
+    return PipelineTemplate(
         "pipelines/edit.html",
         {
             "pipeline": pipeline,
@@ -455,8 +455,7 @@ async def generate_page(request: Request, pipeline_id: int):
         return _pipeline_redirect("pipeline_invalid", error=True)
     db = deps.get_db(request)
     runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
-    return deps.get_templates(request).TemplateResponse(
-        request,
+    return PipelineTemplate(
         "pipelines/generate.html",
         {"pipeline": pipeline, "runs": runs, "request": request},
     )
@@ -528,7 +527,7 @@ async def generate_stream(
             await db.repos.generation_runs.set_status(run_id, "failed")
             raise
 
-    return StreamingResponse(event_gen(), media_type="text/event-stream")
+    return PipelineStream(event_gen())
 
 
 async def generate_pipeline(
@@ -572,13 +571,11 @@ async def generate_pipeline(
     except Exception:
         logger.exception("Generation failed for pipeline_id=%d", pipeline_id)
         runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
-        return deps.get_templates(request).TemplateResponse(
-            request,
+        return PipelineTemplate(
             "pipelines/generate.html",
             {"pipeline": pipeline, "runs": runs, "error": "Generation failed", "request": request},
         )
-    return deps.get_templates(request).TemplateResponse(
-        request,
+    return PipelineTemplate(
         "pipelines/generate.html",
         {"pipeline": pipeline, "run": run, "request": request},
     )
@@ -607,7 +604,7 @@ async def get_refinement_steps(request: Request, pipeline_id: int):
     pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
     if pipeline is None:
         return _pipeline_redirect("pipeline_not_found", error=True)
-    return JSONResponse(content={"steps": pipeline.refinement_steps})
+    return PipelineJson({"steps": pipeline.refinement_steps})
 
 
 # ------------------------------------------------------------------
@@ -644,7 +641,7 @@ async def dry_run_count(request: Request, pipeline_id: int,
     svc = deps.pipeline_service(request)
     pipeline = await svc.get(pipeline_id)
     if pipeline is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
+        return PipelineJson({"error": "not found"}, status_code=404)
     db = deps.get_db(request)
     if pipeline.pipeline_json:
         ids = get_dag_source_channel_ids(pipeline) or []
@@ -668,8 +665,7 @@ async def templates_page(request: Request):
     accounts = await deps.get_account_bundle(request).list_account_summaries()
     cached_dialogs = await svc.list_cached_dialogs_by_phone()
     llm_configured = deps.get_llm_provider_service(request).has_providers()
-    return deps.get_templates(request).TemplateResponse(
-        request,
+    return PipelineTemplate(
         "pipelines/templates.html",
         {
             "templates": templates,
@@ -694,7 +690,7 @@ async def templates_json(request: Request):
             "category": tpl.category,
             "template_json": _json.loads(tpl.template_json.to_json()),
         })
-    return JSONResponse(content=result)
+    return PipelineJson(result)
 
 
 async def create_from_template(
@@ -723,7 +719,7 @@ async def create_from_template(
         await scheduler.sync_pipeline_jobs()
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
-    return RedirectResponse(url=f"/pipelines/{pipeline_id}/edit", status_code=303)
+    return PipelineUrlRedirect(f"/pipelines/{pipeline_id}/edit")
 
 
 # ------------------------------------------------------------------
@@ -736,13 +732,7 @@ async def export_pipeline(request: Request, pipeline_id: int):
     data = await svc.export_json(pipeline_id)
     if data is None:
         return _pipeline_redirect("pipeline_invalid", error=True)
-    filename = f"pipeline_{pipeline_id}.json"
-    content = safe_json_dumps(data, ensure_ascii=False, indent=2)
-    return Response(
-        content=content,
-        media_type="application/json",
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
+    return PipelineFile(content=data, filename=f"pipeline_{pipeline_id}.json")
 
 
 async def import_pipeline(
@@ -775,24 +765,24 @@ async def import_pipeline(
         await scheduler.sync_pipeline_jobs()
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
-    return RedirectResponse(url=f"/pipelines/{pipeline_id}/generate", status_code=303)
+    return PipelineUrlRedirect(f"/pipelines/{pipeline_id}/generate")
 
 
 async def ai_edit_pipeline(request: Request, pipeline_id: int):
     """Accept JSON body: {"instruction": "..."}. Returns updated pipeline_json."""
     if not deps.get_llm_provider_service(request).has_providers():
-        return JSONResponse(content={"ok": False, "error": "LLM not configured"}, status_code=400)
+        return PipelineJson({"ok": False, "error": "LLM not configured"}, status_code=400)
     svc: PipelineService = deps.pipeline_service(request)
     db = deps.get_db(request)
     try:
         body = await request.json()
         instruction = body.get("instruction", "").strip()
         if not instruction:
-            return JSONResponse(content={"ok": False, "error": "instruction is required"}, status_code=400)
+            return PipelineJson({"ok": False, "error": "instruction is required"}, status_code=400)
         result = await svc.edit_via_llm(pipeline_id, instruction, db, config=request.app.state.config)
-        return JSONResponse(content=result)
+        return PipelineJson(result)
     except Exception as exc:
-        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=500)
+        return PipelineJson({"ok": False, "error": str(exc)}, status_code=500)
 
 
 async def set_refinement_steps(request: Request, pipeline_id: int):
@@ -812,6 +802,6 @@ async def set_refinement_steps(request: Request, pipeline_id: int):
             if isinstance(s, dict) and s.get("prompt", "").strip()
         ]
     except Exception as exc:
-        return JSONResponse(content={"ok": False, "error": str(exc)}, status_code=400)
+        return PipelineJson({"ok": False, "error": str(exc)}, status_code=400)
     await db.repos.content_pipelines.set_refinement_steps(pipeline_id, validated)
-    return JSONResponse(content={"ok": True, "steps": validated})
+    return PipelineJson({"ok": True, "steps": validated})

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -97,7 +97,7 @@ async def api_channels_search(request: Request, q: str = ""):
             "SELECT channel_id, title, username FROM channels ORDER BY id DESC LIMIT 50",
         )
         rows = await cur.fetchall()
-        return [
+        items = [
             {
                 "value": row["channel_id"],
                 "title": row["title"] or str(row["channel_id"]),
@@ -106,6 +106,7 @@ async def api_channels_search(request: Request, q: str = ""):
             }
             for row in rows
         ]
+        return PipelineJson(items)
     cur = await db.execute(
         """SELECT channel_id, title, username FROM channels
            WHERE (LOWER(title) LIKE ? OR LOWER(username) LIKE ? OR CAST(channel_id AS TEXT) LIKE ?)
@@ -113,7 +114,7 @@ async def api_channels_search(request: Request, q: str = ""):
         (f"%{query.lower()}%", f"%{query.lower()}%", f"%{query}%"),
     )
     rows = await cur.fetchall()
-    return [
+    items = [
         {
             "value": row["channel_id"],
             "title": row["title"] or str(row["channel_id"]),
@@ -122,6 +123,7 @@ async def api_channels_search(request: Request, q: str = ""):
         }
         for row in rows
     ]
+    return PipelineJson(items)
 
 
 async def _page_context(request: Request) -> dict:
@@ -632,7 +634,7 @@ async def dry_run_count_new(request: Request, source_ids: str = "",
     ids = [int(x) for x in source_ids.split(",") if x.strip().isdigit()]
     db = deps.get_db(request)
     messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
-    return {"total": len(messages), "after_filter": len(messages)}
+    return PipelineJson({"total": len(messages), "after_filter": len(messages)})
 
 
 async def dry_run_count(request: Request, pipeline_id: int,
@@ -650,7 +652,7 @@ async def dry_run_count(request: Request, pipeline_id: int,
         ids = [s.channel_id for s in sources]
     messages = await db.repos.messages.get_recent_for_channels(ids, since_hours)
     after_filter = _apply_pipeline_filter(pipeline, messages)
-    return {"total": len(messages), "after_filter": after_filter}
+    return PipelineJson({"total": len(messages), "after_filter": after_filter})
 
 
 # ------------------------------------------------------------------

--- a/src/web/pipelines/responses.py
+++ b/src/web/pipelines/responses.py
@@ -58,8 +58,6 @@ PipelineResult = (
     | PipelineJson
     | PipelineStream
     | PipelineFile
-    | Response
-    | Any
 )
 
 
@@ -68,7 +66,7 @@ def pipeline_redirect_response(result: PipelineRedirect) -> RedirectResponse:
     return redirect_see_other("/pipelines", {key: result.code, "phone": result.phone})
 
 
-def pipeline_response(request: Request, result: PipelineResult):
+def pipeline_response(request: Request, result: PipelineResult) -> Response:
     if isinstance(result, PipelineRedirect):
         return pipeline_redirect_response(result)
     if isinstance(result, PipelineUrlRedirect):
@@ -85,4 +83,3 @@ def pipeline_response(request: Request, result: PipelineResult):
             media_type=result.media_type,
             headers={"Content-Disposition": f'attachment; filename="{result.filename}"'},
         )
-    return result

--- a/src/web/pipelines/responses.py
+++ b/src/web/pipelines/responses.py
@@ -19,6 +19,14 @@ class PipelineRedirect:
 
 
 @dataclass(frozen=True)
+class PipelineUrlRedirect:
+    """Redirect to an explicit URL (e.g. /pipelines/{id}/edit), not the flash list page."""
+
+    url: str
+    status_code: int = 303
+
+
+@dataclass(frozen=True)
 class PipelineTemplate:
     name: str
     context: dict[str, Any]
@@ -43,7 +51,16 @@ class PipelineFile:
     media_type: str = "application/json"
 
 
-PipelineResult = PipelineRedirect | PipelineTemplate | PipelineJson | PipelineStream | PipelineFile | Response | Any
+PipelineResult = (
+    PipelineRedirect
+    | PipelineUrlRedirect
+    | PipelineTemplate
+    | PipelineJson
+    | PipelineStream
+    | PipelineFile
+    | Response
+    | Any
+)
 
 
 def pipeline_redirect_response(result: PipelineRedirect) -> RedirectResponse:
@@ -54,6 +71,8 @@ def pipeline_redirect_response(result: PipelineRedirect) -> RedirectResponse:
 def pipeline_response(request: Request, result: PipelineResult):
     if isinstance(result, PipelineRedirect):
         return pipeline_redirect_response(result)
+    if isinstance(result, PipelineUrlRedirect):
+        return RedirectResponse(url=result.url, status_code=result.status_code)
     if isinstance(result, PipelineTemplate):
         return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
     if isinstance(result, PipelineJson):

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, File, Form, Request, UploadFile
 from fastapi.responses import HTMLResponse
 
 from src.models import PhotoSendMode
-from src.web import deps
 from src.web.photo_loader.forms import (
     PhotoAutoCreateForm,
     PhotoBatchForm,
@@ -12,7 +11,6 @@ from src.web.photo_loader.forms import (
     PhotoRefreshForm,
     PhotoScheduleForm,
     PhotoSendForm,
-    parse_auto_update_form,
 )
 from src.web.photo_loader.handlers import (
     handle_photo_auto_create,
@@ -27,21 +25,20 @@ from src.web.photo_loader.handlers import (
     handle_photo_toggle_auto,
     handle_photo_update_auto,
 )
-from src.web.photo_loader.responses import photo_loader_redirect_response
+from src.web.photo_loader.responses import photo_loader_response
 
 router = APIRouter()
 
 
 @router.get("", response_class=HTMLResponse)
 async def photo_loader_page(request: Request, phone: str | None = None):
-    context = await handle_photo_loader_page(request, phone)
-    return deps.get_templates(request).TemplateResponse(request, "photo_loader.html", context)
+    return photo_loader_response(request, await handle_photo_loader_page(request, phone))
 
 
 @router.post("/refresh")
 async def photo_loader_refresh(request: Request, phone: str = Form("")):
     result = await handle_photo_loader_refresh(request, PhotoRefreshForm(phone=phone))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/send")
@@ -67,7 +64,7 @@ async def photo_send(
             photos=photos,
         ),
     )
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/schedule")
@@ -95,7 +92,7 @@ async def photo_schedule(
             photos=photos,
         ),
     )
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/batch")
@@ -119,7 +116,7 @@ async def photo_batch(
             manifest_text=manifest_text,
         ),
     )
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/auto")
@@ -147,34 +144,33 @@ async def photo_auto_create(
             interval_minutes=interval_minutes,
         ),
     )
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/run-due")
 async def photo_run_due(request: Request, phone: str = Form("")):
     result = await handle_photo_run_due(request, PhotoPhoneForm(phone=phone))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/items/{item_id}/cancel")
 async def photo_cancel_item(request: Request, item_id: int, phone: str = Form("")):
     result = await handle_photo_cancel_item(request, item_id, PhotoPhoneForm(phone=phone))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/auto/{job_id}/toggle")
 async def photo_toggle_auto(request: Request, job_id: int, phone: str = Form("")):
     result = await handle_photo_toggle_auto(request, job_id, PhotoPhoneForm(phone=phone))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)
 
 
 @router.post("/auto/{job_id}/update")
 async def photo_update_auto(request: Request, job_id: int):
-    result = await handle_photo_update_auto(request, job_id, parse_auto_update_form(await request.form()))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, await handle_photo_update_auto(request, job_id))
 
 
 @router.post("/auto/{job_id}/delete")
 async def photo_delete_auto(request: Request, job_id: int, phone: str = Form("")):
     result = await handle_photo_delete_auto(request, job_id, PhotoPhoneForm(phone=phone))
-    return photo_loader_redirect_response(result)
+    return photo_loader_response(request, result)

--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -5,7 +5,6 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
 
-from src.web import deps
 from src.web.settings.forms import (
     AgentSettingsForm,
     CredentialsForm,
@@ -127,8 +126,7 @@ def _form_error_response(form: object):
 
 @router.get("/", response_class=HTMLResponse)
 async def settings_page(request: Request):
-    context = await handle_settings_page(request)
-    return deps.get_templates(request).TemplateResponse(request, "settings.html", context)
+    return settings_result_response(request, await handle_settings_page(request))
 
 
 @router.post("/save-scheduler")
@@ -234,7 +232,7 @@ async def save_credentials(request: Request, form: CredentialsFormDep):
 
 @router.post("/notifications/setup")
 async def setup_notification_bot(request: Request):
-    return settings_result_response(await handle_setup_notification_bot(request))
+    return settings_result_response(request, await handle_setup_notification_bot(request))
 
 
 @router.get("/notifications/status")
@@ -244,12 +242,12 @@ async def notification_bot_status(request: Request):
 
 @router.post("/notifications/delete")
 async def delete_notification_bot(request: Request):
-    return settings_result_response(await handle_delete_notification_bot(request))
+    return settings_result_response(request, await handle_delete_notification_bot(request))
 
 
 @router.post("/notifications/test")
 async def test_notification(request: Request):
-    return settings_result_response(await handle_test_notification(request))
+    return settings_result_response(request, await handle_test_notification(request))
 
 
 @router.post("/image-providers/add")

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -65,7 +65,7 @@ from src.web.settings.forms import (
     TranslationRunForm,
     TranslationSettingsForm,
 )
-from src.web.settings.responses import SettingsFlash, SettingsJson
+from src.web.settings.responses import SettingsFlash, SettingsJson, SettingsTemplate
 
 logger = logging.getLogger("src.web.routes.settings")
 
@@ -428,7 +428,7 @@ async def _run_bulk_test_job(
         status["current_model"] = ""
 
 
-async def handle_settings_page(request: Request) -> dict[str, object]:
+async def handle_settings_page(request: Request) -> SettingsTemplate:
     auth = deps.get_auth(request)
     db = deps.get_db(request)
     pool = deps.get_pool(request)
@@ -553,7 +553,7 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
         for phone, perms in phone_permissions.items()
     }
 
-    return {
+    context = {
         "is_configured": auth.is_configured,
         "telegram_credentials_from_env": telegram_credentials_from_env,
         "api_id": CREDENTIALS_MASK if api_id_raw else "",
@@ -595,6 +595,7 @@ async def handle_settings_page(request: Request) -> dict[str, object]:
         "translation_auto_on_collect": translation_auto_on_collect,
         "language_stats": language_stats,
     }
+    return SettingsTemplate("settings.html", context)
 
 
 async def handle_save_scheduler_settings(

--- a/src/web/settings/responses.py
+++ b/src/web/settings/responses.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi import Request
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 
+from src.web import deps
 from src.web.responses import flash_redirect, json_response
 
 
@@ -22,6 +24,12 @@ class SettingsJson:
     status_code: int = 200
 
 
+@dataclass(frozen=True)
+class SettingsTemplate:
+    name: str
+    context: dict[str, Any]
+
+
 def settings_flash_response(result: SettingsFlash) -> RedirectResponse:
     return flash_redirect(
         "/settings",
@@ -36,8 +44,15 @@ def settings_json_response(result: SettingsJson) -> JSONResponse:
     return json_response(result.payload, status_code=result.status_code)
 
 
-def settings_result_response(result: SettingsFlash | SettingsJson) -> RedirectResponse | JSONResponse:
+SettingsResult = SettingsFlash | SettingsJson | SettingsTemplate
+
+
+def settings_result_response(
+    request: Request,
+    result: SettingsResult,
+) -> Response:
+    if isinstance(result, SettingsTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
     if isinstance(result, SettingsJson):
         return settings_json_response(result)
     return settings_flash_response(result)
-

--- a/tests/routes/test_settings_routes.py
+++ b/tests/routes/test_settings_routes.py
@@ -321,9 +321,9 @@ async def test_save_agent_backend(route_client, db):
 async def test_save_notification_account(route_client, db):
     """Test save notification account."""
     with patch(
-        "src.web.routes.settings.deps.get_notification_target_service"
+        "src.web.settings.handlers.deps.get_notification_target_service"
     ) as mock_svc, patch(
-        "src.web.routes.settings.deps.get_notifier"
+        "src.web.settings.handlers.deps.get_notifier"
     ) as mock_notifier:
         mock_svc.return_value.set_configured_phone = AsyncMock()
         mock_notifier.return_value = None

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -95,7 +95,7 @@ async def test_settings_page_notification_bot_error(route_client, db):
         "src.web.settings.handlers.ProviderConfigService.load_model_cache",
         AsyncMock(return_value={}),
     ), patch(
-        "src.web.routes.settings.deps.get_notification_target_service"
+        "src.web.settings.handlers.deps.get_notification_target_service"
     ) as mock_target_svc:
         mock_target_svc.return_value.describe_target = AsyncMock(
             return_value=MagicMock(state="available", configured_phone="+1234567890")
@@ -201,9 +201,7 @@ async def test_save_semantic_search_no_api_key_field(route_client, db):
 @pytest.mark.anyio
 async def test_run_semantic_index_unavailable(route_client, db):
     """Test running semantic index when not available (line 624)."""
-    with patch(
-        "src.web.routes.settings.deps.get_search_engine"
-    ) as mock_se:
+    with patch("src.web.settings.handlers.deps.get_search_engine") as mock_se:
         mock_se.return_value.semantic_available = False
         resp = await route_client.post(
             "/settings/semantic-index",
@@ -221,7 +219,7 @@ async def test_run_semantic_index_with_reset_flag(route_client, db):
         "src.web.settings.handlers.EmbeddingService.index_pending_messages",
         AsyncMock(return_value=0),
     ), patch(
-        "src.web.routes.settings.deps.get_search_engine"
+        "src.web.settings.handlers.deps.get_search_engine"
     ) as mock_se:
         se = mock_se.return_value
         se.semantic_available = True
@@ -510,7 +508,7 @@ async def test_save_agent_providers_probes_enabled(route_client, db):
     with patch(
         "src.web.settings.handlers.ProviderConfigService"
     ) as mock_service_cls, patch(
-        "src.web.routes.settings.deps.get_agent_manager"
+        "src.web.settings.handlers.deps.get_agent_manager"
     ) as mock_get_mgr, patch(
         "src.web.settings.handlers._probe_provider_config",
         AsyncMock(return_value=MagicMock()),
@@ -775,9 +773,9 @@ async def test_save_notification_account_with_notifier(route_client, db):
     mock_notifier.invalidate_me_cache = MagicMock()
 
     with patch(
-        "src.web.routes.settings.deps.get_notification_target_service"
+        "src.web.settings.handlers.deps.get_notification_target_service"
     ) as mock_svc, patch(
-        "src.web.routes.settings.deps.get_notifier"
+        "src.web.settings.handlers.deps.get_notifier"
     ) as mock_get_notifier:
         mock_svc.return_value.set_configured_phone = AsyncMock()
         mock_get_notifier.return_value = mock_notifier
@@ -796,9 +794,9 @@ async def test_save_notification_account_with_notifier(route_client, db):
 async def test_save_notification_account_empty_phone(route_client, db):
     """Test save notification account with empty phone clears setting."""
     with patch(
-        "src.web.routes.settings.deps.get_notification_target_service"
+        "src.web.settings.handlers.deps.get_notification_target_service"
     ) as mock_svc, patch(
-        "src.web.routes.settings.deps.get_notifier"
+        "src.web.settings.handlers.deps.get_notifier"
     ) as mock_get_notifier:
         mock_svc.return_value.set_configured_phone = AsyncMock()
         mock_get_notifier.return_value = None

--- a/tests/test_cli_channel_pipeline_route_paths.py
+++ b/tests/test_cli_channel_pipeline_route_paths.py
@@ -1171,8 +1171,8 @@ async def test_settings_save_notification_account_empty_b3(_route_client_b3):
     """Saving empty notification phone clears it."""
     client = _route_client_b3
     with patch(
-        "src.web.routes.settings.deps.get_notification_target_service"
-    ) as mock_svc, patch("src.web.routes.settings.deps.get_notifier") as mock_notifier:
+        "src.web.settings.handlers.deps.get_notification_target_service"
+    ) as mock_svc, patch("src.web.settings.handlers.deps.get_notifier") as mock_notifier:
         mock_svc.return_value.set_configured_phone = AsyncMock()
         mock_notifier.return_value = None
         resp = await client.post(


### PR DESCRIPTION
Closes #656. Часть epic #402.

## Проблема
Issue #656 требует завершить response DTO split во всех уже разделённых доменах: `settings`, `pipelines`, `photo_loader`. После первого прохода pipelines handlers уже не создавали FastAPI response classes напрямую, но оставались неполные места:
- route-facing pipeline handlers возвращали raw `list`/`dict` для JSON endpoints;
- settings/photo_loader page routes всё ещё строили `TemplateResponse` напрямую;
- photo_loader route вручную делал `request.form()` для auto-update;
- tests продолжали патчить старый route-layer `deps`.

## Решение
- `src/web/pipelines/handlers.py` теперь возвращает `PipelineJson` для route-facing JSON endpoints; `pipeline_response()` больше не имеет `Response | Any` passthrough fallback.
- `src/web/settings/responses.py` получил `SettingsTemplate`; `handle_settings_page()` возвращает DTO, а route вызывает общий `settings_result_response(request, result)`.
- `src/web/photo_loader/responses.py` получил `PhotoLoaderTemplate` и общий `photo_loader_response()`; page template construction и redirect mapping теперь живут в responses layer.
- `/dialogs/photos/auto/{job_id}/update` больше не парсит `request.form()` в route; parsing moved into the photo_loader handler boundary.
- Patch targets в tests перенесены с `src.web.routes.settings.deps` на `src.web.settings.handlers.deps`.

## Контракт
URL, redirect/query params, JSON payloads, status codes, streaming, file download behavior and template contexts are unchanged.

## Проверки
Static guards:
- `rg -n "TemplateResponse|JSONResponse|RedirectResponse|StreamingResponse|Response\\(" src/web/settings src/web/pipelines src/web/photo_loader -g 'handlers.py'` — no matches
- `rg -n "return (\\{|\\[)" src/web/pipelines/handlers.py` — no matches
- `rg -n "TemplateResponse|request\\.form\\(" src/web/routes/settings.py src/web/routes/photo_loader.py` — no matches

Tests:
- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/routes/test_settings_routes.py tests/routes/test_pipelines_routes.py tests/routes/test_photo_loader_routes.py -q` — 103 passed
- `python3 -m pytest tests/routes/test_pipelines_routes_dag_and_templates.py tests/routes/test_pipeline_run_cross_layer.py tests/routes/test_settings_routes_provider_notifications.py -q` — 132 passed

🤖 Generated with Codex