### PR TITLE
refactor(web): atomize filter routes into forms/handlers/responses (#657)

### DIFF
--- a/src/web/filter/forms.py
+++ b/src/web/filter/forms.py
@@ -1,0 +1,79 @@
+"""Request/form parsing and validation for the filter web domain."""
+
+from __future__ import annotations
+
+from starlette.datastructures import FormData
+
+from src.filters.criteria import VALID_FLAGS
+from src.filters.models import ChannelFilterResult
+
+# Confirmation phrase required by the hard-delete-all flow; defeats blind direct POSTs.
+HARD_DELETE_ALL_CONFIRM_PHRASE = "DELETE_ALL_FILTERED"
+
+
+def parse_snapshot(values: list[str]) -> list[ChannelFilterResult]:
+    """Parse the apply-filters snapshot of ``<channel_id>|<flags_csv>`` tokens."""
+    deduped: dict[int, list[str]] = {}
+    for value in values:
+        channel_id_str, sep, flags_csv = value.partition("|")
+        if not sep:
+            continue
+        try:
+            channel_id = int(channel_id_str)
+        except ValueError:
+            continue
+        flags = [f for f in (f.strip() for f in flags_csv.split(",")) if f in VALID_FLAGS]
+        if not flags:
+            continue
+        deduped[channel_id] = flags
+    return [
+        ChannelFilterResult(channel_id=channel_id, flags=flags, is_filtered=True)
+        for channel_id, flags in deduped.items()
+    ]
+
+
+def parse_pks(form: FormData, field: str = "pks") -> list[int]:
+    """Extract integer primary keys from a multi-value form field."""
+    pks: list[int] = []
+    for v in form.getlist(field):
+        try:
+            pks.append(int(v))
+        except (ValueError, TypeError):
+            continue
+    return pks
+
+
+def parse_confirm_pairs(raw: str) -> list[tuple[int, int]] | None:
+    """Parse the hard-delete-all snapshot as ``pk:channel_id`` pairs.
+
+    Each token must be ``<pk>:<channel_id>`` where both are integers.
+    Duplicate ``pk`` values (or duplicate ``channel_id`` values) are rejected
+    so a crafted ``"1:1001,1:1001"`` cannot smuggle a delete past the set
+    comparison. Empty/whitespace input is treated as an empty snapshot so
+    the no_filtered_channels branch stays reachable through the normal form
+    flow. Returns ``None`` when any token is malformed.
+
+    Binding to ``channel_id`` (the Telegram-assigned identifier, not the
+    SQLite rowid) guards against PK reuse: if the rendered row is deleted
+    and a new row is inserted between render and submit, the new row will
+    likely have a different ``channel_id`` and the comparison will reject.
+    """
+    tokens = [tok.strip() for tok in (raw or "").split(",") if tok.strip()]
+    pairs: list[tuple[int, int]] = []
+    seen_pks: set[int] = set()
+    seen_chids: set[int] = set()
+    for tok in tokens:
+        parts = tok.split(":")
+        if len(parts) != 2:
+            return None
+        try:
+            pk = int(parts[0])
+            chid = int(parts[1])
+        except ValueError:
+            return None
+        if pk in seen_pks or chid in seen_chids:
+            return None
+        seen_pks.add(pk)
+        seen_chids.add(chid)
+        pairs.append((pk, chid))
+    return pairs

--- a/src/web/filter/handlers.py
+++ b/src/web/filter/handlers.py
@@ -1,0 +1,235 @@
+"""Application orchestration for the filter web domain."""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from src.filters.analyzer import ChannelAnalyzer
+from src.filters.models import FilterReport
+from src.web import deps
+from src.web.filter.forms import (
+    HARD_DELETE_ALL_CONFIRM_PHRASE,
+    parse_confirm_pairs,
+    parse_pks,
+    parse_snapshot,
+)
+from src.web.filter.responses import (
+    FilterRedirect,
+    FilterTemplate,
+    channels_redirect,
+    manage_redirect,
+)
+
+
+async def _dev_mode_enabled(request: Request) -> bool:
+    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
+
+
+async def filter_manage(request: Request) -> FilterTemplate:
+    db = deps.get_db(request)
+    channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
+    filtered = [ch for ch in channels if ch.is_filtered]
+    dev_mode = await _dev_mode_enabled(request)
+    pending_rename_count = await db.count_pending_rename_events()
+    return FilterTemplate(
+        "filter_manage.html",
+        {
+            "channels": filtered,
+            "total": len(filtered),
+            "dev_mode": dev_mode,
+            "pending_rename_count": pending_rename_count,
+        },
+    )
+
+
+async def purge_selected_filtered(request: Request) -> FilterRedirect:
+    form = await request.form()
+    pks = parse_pks(form)
+    if not pks:
+        return manage_redirect(error="no_filtered_channels")
+    svc = deps.filter_deletion_service(request)
+    await svc.purge_channels_by_pks(pks)
+    return manage_redirect(msg="purged_selected")
+
+
+async def purge_all_filtered(request: Request) -> FilterRedirect:
+    svc = deps.filter_deletion_service(request)
+    result = await svc.purge_all_filtered()
+    if result.purged_count == 0:
+        return manage_redirect(error="no_filtered_channels")
+    return manage_redirect(msg="purged_all_filtered", count=result.purged_count)
+
+
+async def hard_delete_selected(request: Request) -> FilterRedirect:
+    if not await _dev_mode_enabled(request):
+        return manage_redirect(error="dev_mode_required_for_hard_delete")
+    form = await request.form()
+    pks = parse_pks(form)
+    if not pks:
+        return manage_redirect(error="no_filtered_channels")
+    svc = deps.filter_deletion_service(request)
+    result = await svc.hard_delete_channels_by_pks(pks)
+    # Codex round 9 follow-up: surface partial failures on the selected path
+    # too. hard_delete_channels_by_pks catches per-channel exceptions into
+    # skipped_count, and child-data rollback (introduced in the round-9
+    # atomicity fix on delete_channel) means a "skipped" row keeps its data
+    # — but only when the FK violation lets us roll back. Either way the
+    # admin needs to see the exact count breakdown.
+    if result.skipped_count or result.purged_count != len(pks):
+        return manage_redirect(
+            error="hard_delete_partial",
+            purged=result.purged_count,
+            skipped=result.skipped_count,
+            expected=len(pks),
+        )
+    return manage_redirect(msg="deleted_filtered", count=result.purged_count)
+
+
+async def hard_delete_all(request: Request) -> FilterRedirect:
+    if not await _dev_mode_enabled(request):
+        return manage_redirect(error="dev_mode_required_for_hard_delete")
+    form = await request.form()
+    # Server-side confirmation defends against direct POSTs, stale pages,
+    # resubmits, and same-count stale swaps. Two interlocking checks:
+    #   1. confirm phrase — defeats blind direct POSTs.
+    #   2. confirm_pks snapshot of (pk, channel_id) pairs — exact rendered
+    #      set with stable identities (Codex round 7). channel_id is the
+    #      Telegram-assigned ID, not the SQLite rowid, so a PK reused after
+    #      a delete+insert race resolves to a different channel_id and the
+    #      comparison rejects. Duplicates are rejected at parse time.
+    #      Delete then runs on the unique PK list extracted from the
+    #      validated snapshot.
+    confirm = (form.get("confirm") or "").strip()
+    if confirm != HARD_DELETE_ALL_CONFIRM_PHRASE:
+        return manage_redirect(error="hard_delete_confirm_required")
+    confirm_pks_raw = form.get("confirm_pks")
+    if confirm_pks_raw is None:
+        return manage_redirect(error="hard_delete_confirm_required")
+    confirmed_pairs = parse_confirm_pairs(str(confirm_pks_raw))
+    if confirmed_pairs is None:
+        return manage_redirect(error="hard_delete_confirm_required")
+    db = deps.get_db(request)
+    channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
+    current_pairs = {
+        (ch.id, ch.channel_id)
+        for ch in channels
+        if ch.is_filtered and ch.id is not None and ch.channel_id is not None
+    }
+    if not current_pairs:
+        return manage_redirect(error="no_filtered_channels")
+    if set(confirmed_pairs) != current_pairs:
+        return manage_redirect(error="hard_delete_set_changed")
+    svc = deps.filter_deletion_service(request)
+    # Pass only the unique PKs from the validated snapshot to the service.
+    # The set comparison above already proved each (pk, channel_id) pair
+    # matches the current filtered row, so the PK list is canonical.
+    confirmed_pks = [pk for pk, _ in confirmed_pairs]
+    result = await svc.hard_delete_channels_by_pks(confirmed_pks)
+    # Partial-failure surfacing (Codex round 8): the deletion service catches
+    # per-channel exceptions and increments skipped_count, but commits are
+    # per-channel. A partial result means rows are already gone irreversibly
+    # while others remain — admin needs to see the discrepancy instead of a
+    # blanket "deleted" message.
+    if result.skipped_count or result.purged_count != len(confirmed_pks):
+        return manage_redirect(
+            error="hard_delete_partial",
+            purged=result.purged_count,
+            skipped=result.skipped_count,
+            expected=len(confirmed_pks),
+        )
+    return manage_redirect(msg="deleted_filtered", count=result.purged_count)
+
+
+async def analyze_channels(request: Request) -> FilterRedirect:
+    db = deps.get_db(request)
+    analyzer = ChannelAnalyzer(db)
+    report = await analyzer.analyze_all()
+    await analyzer.apply_filters(report)
+
+    purged_count = 0
+    auto_delete = await db.get_setting("auto_delete_filtered")
+    if auto_delete == "1" and report.filtered_count > 0:
+        channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
+        pk_map = {ch.channel_id: ch.id for ch in channels if ch.id is not None}
+        filtered_pks = [
+            pk_map[r.channel_id] for r in report.results if r.is_filtered and r.channel_id in pk_map
+        ]
+        if filtered_pks:
+            svc = deps.filter_deletion_service(request)
+            result = await svc.purge_channels_by_pks(filtered_pks)
+            purged_count = result.purged_count
+
+    msg = "purged_all_filtered" if purged_count else "filter_applied"
+    return manage_redirect(msg=msg)
+
+
+async def apply_filters(request: Request) -> FilterRedirect:
+    db = deps.get_db(request)
+    analyzer = ChannelAnalyzer(db)
+
+    form = await request.form()
+    if form.get("snapshot") != "1":
+        return channels_redirect(error="filter_snapshot_required")
+    snapshot_results = parse_snapshot(form.getlist("selected"))
+    report = FilterReport(
+        results=snapshot_results,
+        total_channels=len(snapshot_results),
+        filtered_count=len(snapshot_results),
+    )
+    count = await analyzer.apply_filters(report)
+    return channels_redirect(msg="filter_applied", count=count)
+
+
+async def has_stats(request: Request) -> dict:
+    db = deps.get_db(request)
+    channels = await db.get_channels(active_only=True, include_filtered=False)
+    if not channels:
+        return {"has_stats": True}
+    stats_map = await db.get_latest_stats_for_all()
+    for ch in channels:
+        if ch.channel_id not in stats_map:
+            return {"has_stats": False}
+    return {"has_stats": True}
+
+
+async def precheck_subscriber_ratio(request: Request) -> FilterRedirect:
+    db = deps.get_db(request)
+    analyzer = ChannelAnalyzer(db)
+    count = await analyzer.precheck_subscriber_ratio()
+    return manage_redirect(msg="precheck_done", count=count)
+
+
+async def reset_filters(request: Request) -> FilterRedirect:
+    db = deps.get_db(request)
+    analyzer = ChannelAnalyzer(db)
+    await analyzer.reset_filters()
+    return manage_redirect(msg="filter_reset")
+
+
+async def reset_filters_selected(request: Request) -> FilterRedirect:
+    db = deps.get_db(request)
+    form = await request.form()
+    pks = parse_pks(form)
+    if not pks:
+        return manage_redirect(error="no_filtered_channels")
+    analyzer = ChannelAnalyzer(db)
+    count = await analyzer.reset_filters_for_pks(pks)
+    return manage_redirect(msg="filter_reset_selected", count=count)
+
+
+async def purge_channel_messages(request: Request, channel_id: int) -> FilterRedirect:
+    db = deps.get_db(request)
+    channel = await db.get_channel_by_channel_id(channel_id)
+    if not channel or not channel.is_filtered:
+        return channels_redirect(error="not_filtered")
+    deleted = await db.delete_messages_for_channel(channel_id)
+    return channels_redirect(msg="purged", count=deleted)
+
+
+async def toggle_channel_filter(request: Request, pk: int) -> FilterRedirect:
+    db = deps.get_db(request)
+    channel = await db.get_channel_by_pk(pk)
+    if not channel:
+        return channels_redirect(msg="channel_not_found")
+    await db.set_channel_filtered(pk, not channel.is_filtered)
+    return channels_redirect(msg="filter_toggled")

--- a/src/web/filter/responses.py
+++ b/src/web/filter/responses.py
@@ -1,0 +1,48 @@
+"""Response mapping for the filter web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+
+from src.web import deps
+from src.web.responses import flash_redirect
+
+# Redirect targets used by the filter routes.
+MANAGE_PATH = "/channels/filter/manage"
+CHANNELS_PATH = "/channels"
+
+
+@dataclass(frozen=True)
+class FilterRedirect:
+    path: str
+    msg: str | None = None
+    error: str | None = None
+    extra: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class FilterTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+def manage_redirect(*, msg: str | None = None, error: str | None = None, **extra: object) -> FilterRedirect:
+    return FilterRedirect(MANAGE_PATH, msg=msg, error=error, extra=extra or None)
+
+
+def channels_redirect(*, msg: str | None = None, error: str | None = None, **extra: object) -> FilterRedirect:
+    return FilterRedirect(CHANNELS_PATH, msg=msg, error=error, extra=extra or None)
+
+
+FilterResult = FilterRedirect | FilterTemplate | Any
+
+
+def filter_response(request: Request, result: FilterResult):
+    if isinstance(result, FilterRedirect):
+        return flash_redirect(result.path, msg=result.msg, error=result.error, extra=result.extra)
+    if isinstance(result, FilterTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    return result

--- a/src/web/routes/filter.py
+++ b/src/web/routes/filter.py
@@ -1,375 +1,76 @@
 import logging
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 
-from src.filters.analyzer import ChannelAnalyzer
-from src.filters.criteria import VALID_FLAGS
-from src.filters.models import ChannelFilterResult, FilterReport
-from src.web import deps
+from src.web.filter import handlers
+from src.web.filter.responses import filter_response
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
-async def _dev_mode_enabled(request: Request) -> bool:
-    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
-
-
-def _parse_snapshot(values: list[str]) -> list[ChannelFilterResult]:
-    deduped: dict[int, list[str]] = {}
-    for value in values:
-        channel_id_str, sep, flags_csv = value.partition("|")
-        if not sep:
-            continue
-        try:
-            channel_id = int(channel_id_str)
-        except ValueError:
-            continue
-        flags = [f for f in (f.strip() for f in flags_csv.split(",")) if f in VALID_FLAGS]
-        if not flags:
-            continue
-        deduped[channel_id] = flags
-    return [
-        ChannelFilterResult(channel_id=channel_id, flags=flags, is_filtered=True)
-        for channel_id, flags in deduped.items()
-    ]
-
-
-def _parse_pks(form, field: str = "pks") -> list[int]:
-    pks = []
-    for v in form.getlist(field):
-        try:
-            pks.append(int(v))
-        except (ValueError, TypeError):
-            continue
-    return pks
-
-
 @router.get("/filter/manage", response_class=HTMLResponse)
 async def filter_manage(request: Request):
-    db = deps.get_db(request)
-    channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
-    filtered = [ch for ch in channels if ch.is_filtered]
-    dev_mode = await _dev_mode_enabled(request)
-    pending_rename_count = await db.count_pending_rename_events()
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "filter_manage.html",
-        {
-            "channels": filtered,
-            "total": len(filtered),
-            "dev_mode": dev_mode,
-            "pending_rename_count": pending_rename_count,
-        },
-    )
+    return filter_response(request, await handlers.filter_manage(request))
 
 
 @router.post("/filter/purge-selected")
 async def purge_selected_filtered(request: Request):
-    form = await request.form()
-    pks = _parse_pks(form)
-    if not pks:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=no_filtered_channels",
-            status_code=303,
-        )
-    svc = deps.filter_deletion_service(request)
-    await svc.purge_channels_by_pks(pks)
-    return RedirectResponse(
-        url="/channels/filter/manage?msg=purged_selected",
-        status_code=303,
-    )
+    return filter_response(request, await handlers.purge_selected_filtered(request))
 
 
 @router.post("/filter/purge-all")
 async def purge_all_filtered(request: Request):
-    svc = deps.filter_deletion_service(request)
-    result = await svc.purge_all_filtered()
-    if result.purged_count == 0:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=no_filtered_channels",
-            status_code=303,
-        )
-    return RedirectResponse(
-        url=(f"/channels/filter/manage?msg=purged_all_filtered" f"&count={result.purged_count}"),
-        status_code=303,
-    )
+    return filter_response(request, await handlers.purge_all_filtered(request))
 
 
 @router.post("/filter/hard-delete-selected")
 async def hard_delete_selected(request: Request):
-    if not await _dev_mode_enabled(request):
-        return RedirectResponse(
-            url="/channels/filter/manage?error=dev_mode_required_for_hard_delete",
-            status_code=303,
-        )
-    form = await request.form()
-    pks = _parse_pks(form)
-    if not pks:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=no_filtered_channels",
-            status_code=303,
-        )
-    svc = deps.filter_deletion_service(request)
-    result = await svc.hard_delete_channels_by_pks(pks)
-    # Codex round 9 follow-up: surface partial failures on the selected path
-    # too. hard_delete_channels_by_pks catches per-channel exceptions into
-    # skipped_count, and child-data rollback (introduced in the round-9
-    # atomicity fix on delete_channel) means a "skipped" row keeps its data
-    # — but only when the FK violation lets us roll back. Either way the
-    # admin needs to see the exact count breakdown.
-    if result.skipped_count or result.purged_count != len(pks):
-        return RedirectResponse(
-            url=(
-                "/channels/filter/manage?error=hard_delete_partial"
-                f"&purged={result.purged_count}"
-                f"&skipped={result.skipped_count}"
-                f"&expected={len(pks)}"
-            ),
-            status_code=303,
-        )
-    return RedirectResponse(
-        url=(f"/channels/filter/manage?msg=deleted_filtered" f"&count={result.purged_count}"),
-        status_code=303,
-    )
-
-
-HARD_DELETE_ALL_CONFIRM_PHRASE = "DELETE_ALL_FILTERED"
-
-
-def _parse_confirm_pairs(raw: str) -> list[tuple[int, int]] | None:
-    """Parse the hard-delete-all snapshot as ``pk:channel_id`` pairs.
-
-    Each token must be ``<pk>:<channel_id>`` where both are integers.
-    Duplicate ``pk`` values (or duplicate ``channel_id`` values) are rejected
-    so a crafted ``"1:1001,1:1001"`` cannot smuggle a delete past the set
-    comparison. Empty/whitespace input is treated as an empty snapshot so
-    the no_filtered_channels branch stays reachable through the normal form
-    flow. Returns ``None`` when any token is malformed.
-
-    Binding to ``channel_id`` (the Telegram-assigned identifier, not the
-    SQLite rowid) guards against PK reuse: if the rendered row is deleted
-    and a new row is inserted between render and submit, the new row will
-    likely have a different ``channel_id`` and the comparison will reject.
-    """
-    tokens = [tok.strip() for tok in (raw or "").split(",") if tok.strip()]
-    pairs: list[tuple[int, int]] = []
-    seen_pks: set[int] = set()
-    seen_chids: set[int] = set()
-    for tok in tokens:
-        parts = tok.split(":")
-        if len(parts) != 2:
-            return None
-        try:
-            pk = int(parts[0])
-            chid = int(parts[1])
-        except ValueError:
-            return None
-        if pk in seen_pks or chid in seen_chids:
-            return None
-        seen_pks.add(pk)
-        seen_chids.add(chid)
-        pairs.append((pk, chid))
-    return pairs
+    return filter_response(request, await handlers.hard_delete_selected(request))
 
 
 @router.post("/filter/hard-delete-all")
 async def hard_delete_all(request: Request):
-    if not await _dev_mode_enabled(request):
-        return RedirectResponse(
-            url="/channels/filter/manage?error=dev_mode_required_for_hard_delete",
-            status_code=303,
-        )
-    form = await request.form()
-    # Server-side confirmation defends against direct POSTs, stale pages,
-    # resubmits, and same-count stale swaps. Two interlocking checks:
-    #   1. confirm phrase — defeats blind direct POSTs.
-    #   2. confirm_pks snapshot of (pk, channel_id) pairs — exact rendered
-    #      set with stable identities (Codex round 7). channel_id is the
-    #      Telegram-assigned ID, not the SQLite rowid, so a PK reused after
-    #      a delete+insert race resolves to a different channel_id and the
-    #      comparison rejects. Duplicates are rejected at parse time.
-    #      Delete then runs on the unique PK list extracted from the
-    #      validated snapshot.
-    confirm = (form.get("confirm") or "").strip()
-    if confirm != HARD_DELETE_ALL_CONFIRM_PHRASE:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=hard_delete_confirm_required",
-            status_code=303,
-        )
-    confirm_pks_raw = form.get("confirm_pks")
-    if confirm_pks_raw is None:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=hard_delete_confirm_required",
-            status_code=303,
-        )
-    confirmed_pairs = _parse_confirm_pairs(str(confirm_pks_raw))
-    if confirmed_pairs is None:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=hard_delete_confirm_required",
-            status_code=303,
-        )
-    db = deps.get_db(request)
-    channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
-    current_pairs = {
-        (ch.id, ch.channel_id)
-        for ch in channels
-        if ch.is_filtered and ch.id is not None and ch.channel_id is not None
-    }
-    if not current_pairs:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=no_filtered_channels",
-            status_code=303,
-        )
-    if set(confirmed_pairs) != current_pairs:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=hard_delete_set_changed",
-            status_code=303,
-        )
-    svc = deps.filter_deletion_service(request)
-    # Pass only the unique PKs from the validated snapshot to the service.
-    # The set comparison above already proved each (pk, channel_id) pair
-    # matches the current filtered row, so the PK list is canonical.
-    confirmed_pks = [pk for pk, _ in confirmed_pairs]
-    result = await svc.hard_delete_channels_by_pks(confirmed_pks)
-    # Partial-failure surfacing (Codex round 8): the deletion service catches
-    # per-channel exceptions and increments skipped_count, but commits are
-    # per-channel. A partial result means rows are already gone irreversibly
-    # while others remain — admin needs to see the discrepancy instead of a
-    # blanket "deleted" message.
-    if result.skipped_count or result.purged_count != len(confirmed_pks):
-        return RedirectResponse(
-            url=(
-                "/channels/filter/manage?error=hard_delete_partial"
-                f"&purged={result.purged_count}"
-                f"&skipped={result.skipped_count}"
-                f"&expected={len(confirmed_pks)}"
-            ),
-            status_code=303,
-        )
-    return RedirectResponse(
-        url=(f"/channels/filter/manage?msg=deleted_filtered" f"&count={result.purged_count}"),
-        status_code=303,
-    )
+    return filter_response(request, await handlers.hard_delete_all(request))
 
 
 @router.post("/filter/analyze")
 async def analyze_channels(request: Request):
-    db = deps.get_db(request)
-    analyzer = ChannelAnalyzer(db)
-    report = await analyzer.analyze_all()
-    await analyzer.apply_filters(report)
-
-    purged_count = 0
-    auto_delete = await db.get_setting("auto_delete_filtered")
-    if auto_delete == "1" and report.filtered_count > 0:
-        channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
-        pk_map = {ch.channel_id: ch.id for ch in channels if ch.id is not None}
-        filtered_pks = [
-            pk_map[r.channel_id] for r in report.results if r.is_filtered and r.channel_id in pk_map
-        ]
-        if filtered_pks:
-            svc = deps.filter_deletion_service(request)
-            result = await svc.purge_channels_by_pks(filtered_pks)
-            purged_count = result.purged_count
-
-    msg = "filter_applied"
-    if purged_count:
-        msg = "purged_all_filtered"
-    return RedirectResponse(
-        url=f"/channels/filter/manage?msg={msg}",
-        status_code=303,
-    )
+    return filter_response(request, await handlers.analyze_channels(request))
 
 
 @router.post("/filter/apply")
 async def apply_filters(request: Request):
-    db = deps.get_db(request)
-    analyzer = ChannelAnalyzer(db)
-
-    form = await request.form()
-    if form.get("snapshot") != "1":
-        return RedirectResponse(url="/channels?error=filter_snapshot_required", status_code=303)
-    snapshot_results = _parse_snapshot(form.getlist("selected"))
-    report = FilterReport(
-        results=snapshot_results,
-        total_channels=len(snapshot_results),
-        filtered_count=len(snapshot_results),
-    )
-
-    count = await analyzer.apply_filters(report)
-    return RedirectResponse(url=f"/channels?msg=filter_applied&count={count}", status_code=303)
+    return filter_response(request, await handlers.apply_filters(request))
 
 
 @router.get("/filter/has-stats")
 async def has_stats(request: Request):
-    db = deps.get_db(request)
-    channels = await db.get_channels(active_only=True, include_filtered=False)
-    if not channels:
-        return {"has_stats": True}
-
-    stats_map = await db.get_latest_stats_for_all()
-    for ch in channels:
-        if ch.channel_id not in stats_map:
-            return {"has_stats": False}
-
-    return {"has_stats": True}
+    return filter_response(request, await handlers.has_stats(request))
 
 
 @router.post("/filter/precheck")
 async def precheck_subscriber_ratio(request: Request):
-    db = deps.get_db(request)
-    analyzer = ChannelAnalyzer(db)
-    count = await analyzer.precheck_subscriber_ratio()
-    return RedirectResponse(
-        url=f"/channels/filter/manage?msg=precheck_done&count={count}",
-        status_code=303,
-    )
+    return filter_response(request, await handlers.precheck_subscriber_ratio(request))
 
 
 @router.post("/filter/reset")
 async def reset_filters(request: Request):
-    db = deps.get_db(request)
-    analyzer = ChannelAnalyzer(db)
-    await analyzer.reset_filters()
-    return RedirectResponse(url="/channels/filter/manage?msg=filter_reset", status_code=303)
+    return filter_response(request, await handlers.reset_filters(request))
 
 
 @router.post("/filter/reset-selected")
 async def reset_filters_selected(request: Request):
-    db = deps.get_db(request)
-    form = await request.form()
-    pks = _parse_pks(form)
-    if not pks:
-        return RedirectResponse(
-            url="/channels/filter/manage?error=no_filtered_channels",
-            status_code=303,
-        )
-    analyzer = ChannelAnalyzer(db)
-    count = await analyzer.reset_filters_for_pks(pks)
-    return RedirectResponse(
-        url=f"/channels/filter/manage?msg=filter_reset_selected&count={count}",
-        status_code=303,
-    )
+    return filter_response(request, await handlers.reset_filters_selected(request))
 
 
 @router.post("/{channel_id}/purge-messages")
 async def purge_channel_messages(request: Request, channel_id: int):
-    db = deps.get_db(request)
-    channel = await db.get_channel_by_channel_id(channel_id)
-    if not channel or not channel.is_filtered:
-        return RedirectResponse(url="/channels?error=not_filtered", status_code=303)
-    deleted = await db.delete_messages_for_channel(channel_id)
-    return RedirectResponse(url=f"/channels?msg=purged&count={deleted}", status_code=303)
+    return filter_response(request, await handlers.purge_channel_messages(request, channel_id))
 
 
 @router.post("/{pk}/filter-toggle")
 async def toggle_channel_filter(request: Request, pk: int):
-    db = deps.get_db(request)
-    channel = await db.get_channel_by_pk(pk)
-    if not channel:
-        return RedirectResponse(url="/channels?msg=channel_not_found", status_code=303)
-    await db.set_channel_filtered(pk, not channel.is_filtered)
-    return RedirectResponse(url="/channels?msg=filter_toggled", status_code=303)
+    return filter_response(request, await handlers.toggle_channel_filter(request, pk))

--- a/tests/routes/test_filter_routes.py
+++ b/tests/routes/test_filter_routes.py
@@ -51,7 +51,7 @@ async def test_purge_selected_success(route_client, db):
     """Test purge selected channels."""
     pk = await _add_filtered_channel(db, channel_id=400, title="To Purge")
 
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.purge_channels_by_pks = AsyncMock()
         resp = await route_client.post(
             "/channels/filter/purge-selected",
@@ -67,7 +67,7 @@ async def test_purge_selected_removes_messages(route_client, db):
     """Test purge selected removes messages from DB."""
     pk = await _add_filtered_channel(db, channel_id=500, title="Purge Messages")
 
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.purge_channels_by_pks = AsyncMock()
         resp = await route_client.post(
             "/channels/filter/purge-selected",
@@ -83,7 +83,7 @@ async def test_purge_selected_removes_messages(route_client, db):
 @pytest.mark.anyio
 async def test_purge_all_no_filtered(route_client):
     """Test purge all with no filtered channels."""
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         from src.services.filter_deletion_service import PurgeResult
         mock_svc.return_value.purge_all_filtered = AsyncMock(
             return_value=PurgeResult(purged_count=0)
@@ -98,7 +98,7 @@ async def test_purge_all_success(route_client, db):
     """Test purge all filtered channels."""
     await _add_filtered_channel(db, channel_id=600, title="Purge All")
 
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         from src.services.filter_deletion_service import PurgeResult
         mock_svc.return_value.purge_all_filtered = AsyncMock(
             return_value=PurgeResult(purged_count=1)
@@ -140,7 +140,7 @@ async def test_hard_delete_selected_partial_failure_reports_error(route_client, 
     pk1 = await _add_filtered_channel(db, channel_id=810, title="Sel OK")
     pk2 = await _add_filtered_channel(db, channel_id=811, title="Sel Skip")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1, skipped_count=1)
         )
@@ -163,7 +163,7 @@ async def test_hard_delete_success(route_client, db):
     pk = await _add_filtered_channel(db, channel_id=800, title="Hard Delete OK")
     await _enable_dev_mode(db)
 
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         from src.services.filter_deletion_service import PurgeResult
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
@@ -196,7 +196,7 @@ async def test_hard_delete_all_rejects_without_confirm_phrase(route_client, db):
     when dev mode is on — a direct POST without it must NOT delete."""
     pk = await _add_filtered_channel(db, channel_id=901, title="No Confirm")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -217,7 +217,7 @@ async def test_hard_delete_all_rejects_wrong_confirm_phrase(route_client, db):
     """A non-matching confirm value must be rejected (no fuzzy match)."""
     pk = await _add_filtered_channel(db, channel_id=902, title="Wrong Confirm")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -236,7 +236,7 @@ async def test_hard_delete_all_rejects_missing_confirm_pks(route_client, db):
     """confirm_pks is required: a request without it cannot reach the delete."""
     await _add_filtered_channel(db, channel_id=903, title="No PKs")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -264,7 +264,7 @@ async def test_hard_delete_all_rejects_malformed_confirm_pks(route_client, db):
         ":1",            # empty pk
     ]
     for raw in cases:
-        with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+        with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
             mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
                 return_value=PurgeResult(purged_count=1)
             )
@@ -291,7 +291,7 @@ async def test_hard_delete_all_rejects_duplicate_confirm_pks(route_client, db):
         f"{pk}:970,99:970",     # duplicate chid, different pk
     ]
     for raw in cases:
-        with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+        with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
             mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
                 return_value=PurgeResult(purged_count=1)
             )
@@ -319,7 +319,7 @@ async def test_hard_delete_all_rejects_pk_with_wrong_channel_id(route_client, db
     """
     pk = await _add_filtered_channel(db, channel_id=975, title="Stable")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -341,7 +341,7 @@ async def test_hard_delete_all_rejects_set_mismatch(route_client, db):
     """Stale page snapshots a different filtered set — bounce."""
     pk = await _add_filtered_channel(db, channel_id=920, title="OnlyMe")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -372,7 +372,7 @@ async def test_hard_delete_all_rejects_same_count_stale_swap(route_client, db):
     await db.set_channel_filtered(a_pk, False)
     b_pk = await _add_filtered_channel(db, channel_id=941, title="ChB")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -397,7 +397,7 @@ async def test_hard_delete_all_success_with_matching_snapshot(route_client, db):
     the delete, and the service is called with exactly the confirmed PKs."""
     pk = await _add_filtered_channel(db, channel_id=950, title="Will Delete")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1)
         )
@@ -424,7 +424,7 @@ async def test_hard_delete_all_rejects_empty_confirm(route_client, db):
     await _enable_dev_mode(db)
     cases = ["", "   ", "\t", "\n"]
     for raw in cases:
-        with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+        with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
             mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
                 return_value=PurgeResult(purged_count=1)
             )
@@ -450,7 +450,7 @@ async def test_hard_delete_all_partial_failure_reports_error(route_client, db):
     pk1 = await _add_filtered_channel(db, channel_id=981, title="ChDelOK")
     pk2 = await _add_filtered_channel(db, channel_id=982, title="ChDelFail")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         # Service deleted pk1 but skipped pk2.
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=1, skipped_count=1)
@@ -478,7 +478,7 @@ async def test_hard_delete_all_purge_count_mismatch_reports_error(route_client, 
     the route still surfaces it as an error rather than a silent partial."""
     pk = await _add_filtered_channel(db, channel_id=983, title="Mismatch")
     await _enable_dev_mode(db)
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         # purged=0, skipped=0 — count mismatches expected (1).
         mock_svc.return_value.hard_delete_channels_by_pks = AsyncMock(
             return_value=PurgeResult(purged_count=0, skipped_count=0)
@@ -510,7 +510,7 @@ async def test_hard_delete_all_no_filtered_channels(route_client, db):
 @pytest.mark.anyio
 async def test_analyze_redirects(route_client):
     """Test analyze channels redirects."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         from src.filters.models import FilterReport
         mock_instance = mock_analyzer.return_value
         mock_instance.analyze_all = AsyncMock(
@@ -525,14 +525,14 @@ async def test_analyze_redirects(route_client):
 @pytest.mark.anyio
 async def test_analyze_ignores_with_stats_query(route_client):
     """Test analyze route no longer runs stats collection inline."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         from src.filters.models import FilterReport
         mock_instance = mock_analyzer.return_value
         mock_instance.analyze_all = AsyncMock(
             return_value=FilterReport(results=[], total_channels=0, filtered_count=0)
         )
         mock_instance.apply_filters = AsyncMock(return_value=0)
-        with patch("src.web.routes.filter.deps.collection_service") as mock_collection:
+        with patch("src.web.filter.handlers.deps.collection_service") as mock_collection:
             resp = await route_client.post("/channels/filter/analyze?with_stats=1", follow_redirects=False)
 
         assert resp.status_code == 303
@@ -586,7 +586,7 @@ async def test_apply_missing_snapshot(route_client):
 @pytest.mark.anyio
 async def test_apply_with_snapshot(route_client):
     """Test apply filters with snapshot."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=1)
         resp = await route_client.post(
@@ -601,7 +601,7 @@ async def test_apply_with_snapshot(route_client):
 @pytest.mark.anyio
 async def test_precheck_redirects(route_client):
     """Test precheck subscriber ratio redirects."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.precheck_subscriber_ratio = AsyncMock(return_value=5)
         resp = await route_client.post("/channels/filter/precheck", follow_redirects=False)
@@ -612,7 +612,7 @@ async def test_precheck_redirects(route_client):
 @pytest.mark.anyio
 async def test_reset_redirects(route_client):
     """Test reset filters redirects."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.reset_filters = AsyncMock()
         resp = await route_client.post("/channels/filter/reset", follow_redirects=False)
@@ -666,7 +666,7 @@ async def test_filter_toggle_success(route_client, db):
 @pytest.mark.anyio
 async def test_parse_snapshot_valid(route_client, db):
     """Test apply filters with valid snapshot parsing."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=2)
         resp = await route_client.post(
@@ -684,7 +684,7 @@ async def test_parse_snapshot_valid(route_client, db):
 @pytest.mark.anyio
 async def test_parse_snapshot_dedupes_by_channel_id(route_client, db):
     """Test snapshot parsing dedupes by channel_id."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=1)
         resp = await route_client.post(
@@ -701,7 +701,7 @@ async def test_parse_snapshot_dedupes_by_channel_id(route_client, db):
 @pytest.mark.anyio
 async def test_parse_snapshot_invalid_channel_id(route_client, db):
     """Test snapshot parsing with invalid channel_id."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=0)
         resp = await route_client.post(
@@ -718,7 +718,7 @@ async def test_parse_snapshot_invalid_channel_id(route_client, db):
 @pytest.mark.anyio
 async def test_parse_snapshot_no_separator(route_client, db):
     """Test snapshot parsing without separator."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=0)
         resp = await route_client.post(
@@ -735,7 +735,7 @@ async def test_parse_snapshot_no_separator(route_client, db):
 @pytest.mark.anyio
 async def test_parse_snapshot_invalid_flag(route_client, db):
     """Test snapshot parsing with invalid flag."""
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer:
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer:
         mock_instance = mock_analyzer.return_value
         mock_instance.apply_filters = AsyncMock(return_value=0)
         resp = await route_client.post(
@@ -755,8 +755,8 @@ async def test_analyze_with_auto_delete(route_client, db):
     await _add_filtered_channel(db, channel_id=3100, title="Auto Delete")
     await db.set_setting("auto_delete_filtered", "1")
 
-    with patch("src.web.routes.filter.ChannelAnalyzer") as mock_analyzer, patch(
-        "src.web.routes.filter.deps.filter_deletion_service"
+    with patch("src.web.filter.handlers.ChannelAnalyzer") as mock_analyzer, patch(
+        "src.web.filter.handlers.deps.filter_deletion_service"
     ) as mock_svc:
         from src.filters.models import ChannelFilterResult, FilterReport
 
@@ -788,7 +788,7 @@ async def test_purge_selected_with_multiple_pks(route_client, db):
     pk1 = await _add_filtered_channel(db, channel_id=3200, title="Purge 1")
     pk2 = await _add_filtered_channel(db, channel_id=3201, title="Purge 2")
 
-    with patch("src.web.routes.filter.deps.filter_deletion_service") as mock_svc:
+    with patch("src.web.filter.handlers.deps.filter_deletion_service") as mock_svc:
         mock_svc.return_value.purge_channels_by_pks = AsyncMock()
         resp = await route_client.post(
             "/channels/filter/purge-selected",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2487,7 +2487,7 @@ async def test_filter_apply_with_snapshot_skips_reanalyze(client, monkeypatch):
     async def _boom(self):
         raise AssertionError("analyze_all should not be called for snapshot apply")
 
-    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _boom)
+    monkeypatch.setattr("src.web.filter.handlers.ChannelAnalyzer.analyze_all", _boom)
 
     resp = await client.post(
         "/channels/filter/apply",
@@ -2518,7 +2518,7 @@ async def test_filter_apply_without_snapshot_returns_error(client, monkeypatch):
     async def _boom(self):
         raise AssertionError("analyze_all should not be called without snapshot")
 
-    monkeypatch.setattr("src.web.routes.filter.ChannelAnalyzer.analyze_all", _boom)
+    monkeypatch.setattr("src.web.filter.handlers.ChannelAnalyzer.analyze_all", _boom)
 
     resp = await client.post("/channels/filter/apply", data={}, follow_redirects=False)
     assert resp.status_code == 303


### PR DESCRIPTION
Часть #657 (модуль `filter`). Часть epic #402.

## Проблема
`src/web/routes/filter.py` совмещал form-parsing (`_parse_snapshot/_parse_pks/_parse_confirm_pairs`), оркестрацию (analyzer, deletion-service, dev-mode gate, set-comparison в `hard_delete_all`) и response/redirect-маппинг в одном модуле.

## Решение
Разбито по принятой конвенции:
- `src/web/filter/forms.py` — парсинг/валидация + `HARD_DELETE_ALL_CONFIRM_PHRASE`.
- `src/web/filter/handlers.py` — оркестрация, возвращает domain-DTO (`FilterRedirect`/`FilterTemplate`).
- `src/web/filter/responses.py` — DTO + маппер `filter_response()` поверх общего `flash_redirect`.
- `src/web/routes/filter.py` — тонкий router.

## Контракт
URL, redirect-коды и параметры (`error/msg/count/purged/skipped/expected`), контексты шаблонов — без изменений. Patch-таргеты в тестах перенацелены на новый модуль `handlers` (туда переехали `deps`/`ChannelAnalyzer`); сами ассерты не тронуты.

## Тесты
`ruff check src/ tests/ conftest.py` чисто. Зелёные: `tests/routes/test_filter_routes.py` (45), `tests/test_filter_flash_messages.py` + `tests/test_web_route_helpers.py` (19), filter-related в `tests/test_web.py` (12).

Дифф ~760 строк (≤1000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## #657 closeout

This PR is one component of #657 and intentionally does not use a closing keyword.

Keep #657 open until all component PRs are merged:
- #669 filter
- #670 images
- #671 channels
- #672 search_queries
- #673 agent

After all five PRs are merged, close #657 manually from the issue.