### PR TITLE
refactor(web): atomize image routes into forms/handlers/responses (#657)

### DIFF
--- a/src/web/images/forms.py
+++ b/src/web/images/forms.py
@@ -1,0 +1,34 @@
+"""Request/form parsing for the image-generation web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Request
+
+
+@dataclass(frozen=True)
+class GenerateImageForm:
+    prompt: str
+    model: str
+
+
+async def parse_generate_form(request: Request) -> GenerateImageForm:
+    form = await request.form()
+    return GenerateImageForm(
+        prompt=str(form.get("prompt", "")).strip(),
+        model=str(form.get("model", "")).strip(),
+    )
+
+
+@dataclass(frozen=True)
+class ModelsSearchQuery:
+    provider: str
+    query: str
+
+
+def parse_models_search(request: Request) -> ModelsSearchQuery:
+    return ModelsSearchQuery(
+        provider=request.query_params.get("provider", "").strip(),
+        query=request.query_params.get("q", "").strip(),
+    )

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -1,0 +1,88 @@
+"""Application orchestration for the image-generation web domain."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Request
+
+from src.services.image_generation_service import ImageGenerationService
+from src.web import deps
+from src.web.images.forms import parse_generate_form, parse_models_search
+from src.web.images.responses import ImagesJson, ImagesTemplate
+
+logger = logging.getLogger(__name__)
+
+
+async def _get_image_service(request: Request) -> ImageGenerationService:
+    """Build ImageGenerationService with DB-configured providers + env fallback."""
+    try:
+        from src.services.image_provider_service import ImageProviderService
+
+        db = deps.get_db(request)
+        config = request.app.state.config
+        svc = ImageProviderService(db, config)
+        configs = await svc.load_provider_configs()
+        adapters = svc.build_adapters(configs)
+        if adapters:
+            return ImageGenerationService(adapters=adapters)
+    except Exception:
+        logger.warning("Failed to load image providers from DB", exc_info=True)
+    return ImageGenerationService()
+
+
+async def _get_provider_api_key(request: Request, provider: str) -> str:
+    """Get API key for provider from DB config, falling back to env."""
+    import os
+
+    try:
+        from src.services.image_provider_service import IMAGE_PROVIDER_SPECS, ImageProviderService
+
+        db = deps.get_db(request)
+        config = request.app.state.config
+        svc = ImageProviderService(db, config)
+        configs = await svc.load_provider_configs()
+        for cfg in configs:
+            if cfg.provider == provider and cfg.api_key:
+                return cfg.api_key
+        spec = IMAGE_PROVIDER_SPECS.get(provider)
+        if spec:
+            for var in spec.env_vars:
+                val = os.environ.get(var, "").strip()
+                if val:
+                    return val
+    except Exception:
+        pass
+    return ""
+
+
+async def images_page(request: Request) -> ImagesTemplate:
+    svc = await _get_image_service(request)
+    return ImagesTemplate("images.html", {"providers": svc.adapter_names})
+
+
+async def generate_image(request: Request) -> ImagesJson:
+    form = await parse_generate_form(request)
+    if not form.prompt:
+        return ImagesJson({"ok": False, "error": "Prompt is required"}, status_code=400)
+
+    svc = await _get_image_service(request)
+    if not await svc.is_available():
+        return ImagesJson({"ok": False, "error": "No image providers configured"}, status_code=409)
+
+    result = await svc.generate(form.model or None, form.prompt)
+    if result is None:
+        return ImagesJson({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
+
+    return ImagesJson({"ok": True, "url": result, "model": form.model, "prompt": form.prompt})
+
+
+async def search_models(request: Request) -> ImagesJson:
+    q = parse_models_search(request)
+    if not q.provider:
+        return ImagesJson({"ok": False, "error": "provider is required"}, status_code=400)
+
+    api_key = await _get_provider_api_key(request, q.provider)
+    svc = ImageGenerationService()
+    models = await svc.search_models(q.provider, q.query, api_key=api_key)
+    return ImagesJson({"ok": True, "models": models, "provider": q.provider})

--- a/src/web/images/responses.py
+++ b/src/web/images/responses.py
@@ -1,0 +1,34 @@
+"""Response mapping for the image-generation web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from src.web import deps
+
+
+@dataclass(frozen=True)
+class ImagesTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ImagesJson:
+    content: Any
+    status_code: int = 200
+
+
+ImagesResult = ImagesTemplate | ImagesJson | Any
+
+
+def images_response(request: Request, result: ImagesResult):
+    if isinstance(result, ImagesTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    if isinstance(result, ImagesJson):
+        return JSONResponse(content=result.content, status_code=result.status_code)
+    return result

--- a/src/web/routes/images.py
+++ b/src/web/routes/images.py
@@ -5,96 +5,25 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse
 
-from src.services.image_generation_service import ImageGenerationService
-from src.web import deps
+from src.web.images import handlers
+from src.web.images.responses import images_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-async def _get_image_service(request: Request) -> ImageGenerationService:
-    """Build ImageGenerationService with DB-configured providers + env fallback."""
-    try:
-        from src.services.image_provider_service import ImageProviderService
-
-        db = deps.get_db(request)
-        config = request.app.state.config
-        svc = ImageProviderService(db, config)
-        configs = await svc.load_provider_configs()
-        adapters = svc.build_adapters(configs)
-        if adapters:
-            return ImageGenerationService(adapters=adapters)
-    except Exception:
-        logger.warning("Failed to load image providers from DB", exc_info=True)
-    return ImageGenerationService()
-
-
-async def _get_provider_api_key(request: Request, provider: str) -> str:
-    """Get API key for provider from DB config, falling back to env."""
-    import os
-
-    try:
-        from src.services.image_provider_service import IMAGE_PROVIDER_SPECS, ImageProviderService
-
-        db = deps.get_db(request)
-        config = request.app.state.config
-        svc = ImageProviderService(db, config)
-        configs = await svc.load_provider_configs()
-        for cfg in configs:
-            if cfg.provider == provider and cfg.api_key:
-                return cfg.api_key
-        spec = IMAGE_PROVIDER_SPECS.get(provider)
-        if spec:
-            for var in spec.env_vars:
-                val = os.environ.get(var, "").strip()
-                if val:
-                    return val
-    except Exception:
-        pass
-    return ""
-
-
 @router.get("/", response_class=HTMLResponse)
 async def images_page(request: Request):
-    svc = await _get_image_service(request)
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "images.html",
-        {
-            "providers": svc.adapter_names,
-        },
-    )
+    return images_response(request, await handlers.images_page(request))
 
 
 @router.post("/generate")
 async def generate_image(request: Request):
-    form = await request.form()
-    prompt = str(form.get("prompt", "")).strip()
-    model = str(form.get("model", "")).strip()
-    if not prompt:
-        return JSONResponse({"ok": False, "error": "Prompt is required"}, status_code=400)
-
-    svc = await _get_image_service(request)
-    if not await svc.is_available():
-        return JSONResponse({"ok": False, "error": "No image providers configured"}, status_code=409)
-
-    result = await svc.generate(model or None, prompt)
-    if result is None:
-        return JSONResponse({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
-
-    return JSONResponse({"ok": True, "url": result, "model": model, "prompt": prompt})
+    return images_response(request, await handlers.generate_image(request))
 
 
 @router.get("/models/search")
 async def search_models_route(request: Request):
-    provider = request.query_params.get("provider", "").strip()
-    query = request.query_params.get("q", "").strip()
-    if not provider:
-        return JSONResponse({"ok": False, "error": "provider is required"}, status_code=400)
-
-    api_key = await _get_provider_api_key(request, provider)
-    svc = ImageGenerationService()
-    models = await svc.search_models(provider, query, api_key=api_key)
-    return JSONResponse({"ok": True, "models": models, "provider": provider})
+    return images_response(request, await handlers.search_models(request))

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -12,7 +12,7 @@ async def test_images_page(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.adapter_names = ["test_provider"]
     monkeypatch.setattr(
-        "src.web.routes.images._get_image_service",
+        "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
     )
     resp = await route_client.get("/images/")
@@ -34,7 +34,7 @@ async def test_generate_no_providers(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=False)
     monkeypatch.setattr(
-        "src.web.routes.images._get_image_service",
+        "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
     )
     resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
@@ -49,7 +49,7 @@ async def test_generate_success(route_client, monkeypatch):
     mock_svc.is_available = AsyncMock(return_value=True)
     mock_svc.generate = AsyncMock(return_value="https://img.example.com/1.png")
     monkeypatch.setattr(
-        "src.web.routes.images._get_image_service",
+        "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
     )
     resp = await route_client.post("/images/generate", data={"prompt": "a cat", "model": "test:model"})
@@ -65,7 +65,7 @@ async def test_generate_failure(route_client, monkeypatch):
     mock_svc.is_available = AsyncMock(return_value=True)
     mock_svc.generate = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        "src.web.routes.images._get_image_service",
+        "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
     )
     resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
@@ -86,11 +86,11 @@ async def test_search_models_no_provider(route_client, monkeypatch):
 @pytest.mark.anyio
 async def test_search_models_success(route_client, monkeypatch):
     monkeypatch.setattr(
-        "src.web.routes.images._get_provider_api_key",
+        "src.web.images.handlers._get_provider_api_key",
         AsyncMock(return_value="fake-key"),
     )
     mock_models = [{"id": "model-1", "name": "Test Model"}]
-    with patch("src.web.routes.images.ImageGenerationService") as mock_cls:
+    with patch("src.web.images.handlers.ImageGenerationService") as mock_cls:
         instance = MagicMock()
         instance.search_models = AsyncMock(return_value=mock_models)
         mock_cls.return_value = instance
@@ -106,7 +106,7 @@ async def test_search_models_success(route_client, monkeypatch):
 async def test_search_models_no_api_key(route_client, monkeypatch):
     """Test search models when no API key is found."""
     monkeypatch.setattr(
-        "src.web.routes.images._get_provider_api_key",
+        "src.web.images.handlers._get_provider_api_key",
         AsyncMock(return_value=""),
     )
     resp = await route_client.get("/images/models/search?provider=unknown&q=test")
@@ -130,7 +130,7 @@ async def test_generate_with_model(route_client, monkeypatch):
     mock_svc.is_available = AsyncMock(return_value=True)
     mock_svc.generate = AsyncMock(return_value="https://img.example.com/2.png")
     monkeypatch.setattr(
-        "src.web.routes.images._get_image_service",
+        "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
     )
     resp = await route_client.post("/images/generate", data={"prompt": "a dog", "model": "test:model"})
@@ -147,7 +147,7 @@ async def test_get_provider_api_key_from_db_config(monkeypatch):
     mock_svc = MagicMock()
     mock_svc.load_provider_configs = AsyncMock(return_value=[mock_config])
 
-    from src.web.routes.images import _get_provider_api_key
+    from src.web.images.handlers import _get_provider_api_key
 
     with patch("src.services.image_provider_service.ImageProviderService", return_value=mock_svc):
         result = await _get_provider_api_key(MagicMock(), "together")
@@ -171,7 +171,7 @@ async def test_get_provider_api_key_env_fallback(monkeypatch):
     for var in spec.env_vars:
         monkeypatch.setenv(var, "env-key-456")
 
-    from src.web.routes.images import _get_provider_api_key
+    from src.web.images.handlers import _get_provider_api_key
 
     with patch("src.services.image_provider_service.ImageProviderService", return_value=mock_svc):
         result = await _get_provider_api_key(MagicMock(), first_provider)
@@ -181,7 +181,7 @@ async def test_get_provider_api_key_env_fallback(monkeypatch):
 @pytest.mark.anyio
 async def test_get_provider_api_key_exception_returns_empty():
     """Returns empty string on any exception."""
-    from src.web.routes.images import _get_provider_api_key
+    from src.web.images.handlers import _get_provider_api_key
 
     with patch("src.services.image_provider_service.ImageProviderService", side_effect=Exception("boom")):
         result = await _get_provider_api_key(MagicMock(), "anything")

--- a/tests/test_cli_image_scheduler_web_routes.py
+++ b/tests/test_cli_image_scheduler_web_routes.py
@@ -499,7 +499,7 @@ class TestWebImagesRoutes:
     @pytest.mark.anyio
     async def test_images_page_renders(self, route_client):
         """GET /images/ returns 200."""
-        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+        with patch("src.web.images.handlers._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
             svc = MagicMock()
             svc.adapter_names = []
             mock_svc_fn.return_value = svc
@@ -509,7 +509,7 @@ class TestWebImagesRoutes:
     @pytest.mark.anyio
     async def test_generate_no_prompt(self, route_client):
         """POST /images/generate without prompt returns 400."""
-        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+        with patch("src.web.images.handlers._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=True)
             mock_svc_fn.return_value = svc
@@ -521,7 +521,7 @@ class TestWebImagesRoutes:
     @pytest.mark.anyio
     async def test_generate_no_providers(self, route_client):
         """POST /images/generate when no providers returns 409."""
-        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+        with patch("src.web.images.handlers._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=False)
             mock_svc_fn.return_value = svc
@@ -531,7 +531,7 @@ class TestWebImagesRoutes:
     @pytest.mark.anyio
     async def test_generate_success(self, route_client):
         """POST /images/generate with valid prompt and provider returns 200 with url."""
-        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+        with patch("src.web.images.handlers._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=True)
             svc.generate = AsyncMock(return_value="https://example.com/img.png")
@@ -548,7 +548,7 @@ class TestWebImagesRoutes:
     @pytest.mark.anyio
     async def test_generate_provider_failure(self, route_client):
         """POST /images/generate when generation fails returns 500."""
-        with patch("src.web.routes.images._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
+        with patch("src.web.images.handlers._get_image_service", new_callable=AsyncMock) as mock_svc_fn:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=True)
             svc.generate = AsyncMock(return_value=None)
@@ -566,8 +566,8 @@ class TestWebImagesRoutes:
     async def test_models_search_with_provider(self, route_client):
         """GET /images/models/search with provider returns model list."""
         with (
-            patch("src.web.routes.images._get_provider_api_key", new_callable=AsyncMock, return_value="key"),
-            patch("src.web.routes.images.ImageGenerationService") as mock_svc_cls,
+            patch("src.web.images.handlers._get_provider_api_key", new_callable=AsyncMock, return_value="key"),
+            patch("src.web.images.handlers.ImageGenerationService") as mock_svc_cls,
         ):
             svc = MagicMock()
             svc.search_models = AsyncMock(return_value=[])


### PR DESCRIPTION
Часть #657 (модуль `images`). Часть epic #402.

## Проблема
`src/web/routes/images.py` совмещал parsing формы/квери (prompt/model/provider/q), оркестрацию (сборка `ImageGenerationService`/`ImageProviderService`, generate, search_models) и конструирование JSON/HTML ответов.

## Решение
- `src/web/images/forms.py` — `GenerateImageForm`/`parse_generate_form`, `ModelsSearchQuery`/`parse_models_search`.
- `src/web/images/handlers.py` — `_get_image_service`/`_get_provider_api_key` + оркестрация страницы/generate/search-models, возвращает DTO.
- `src/web/images/responses.py` — `ImagesTemplate`/`ImagesJson` + `images_response`.
- `src/web/routes/images.py` — тонкий router.

## Контракт
URL, JSON-формы, статус-коды (400/409/500), контекст шаблона — без изменений. Patch-таргеты `_get_image_service`/`_get_provider_api_key`/`ImageGenerationService` в тестах перенацелены на `src.web.images.handlers`.

## Тесты
`ruff` чисто. Зелёные: `tests/routes/test_images_routes.py` + `tests/test_cli_image_scheduler_web_routes.py` (64), image-тесты в `tests/test_cross_domain_regression_paths.py` (20). Дифф ~275 строк.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## #657 closeout

This PR is one component of #657 and intentionally does not use a closing keyword.

Keep #657 open until all component PRs are merged:
- #669 filter
- #670 images
- #671 channels
- #672 search_queries
- #673 agent

After all five PRs are merged, close #657 manually from the issue.