### PR TITLE
refactor(web): atomize channels routes into forms/handlers/responses (#657)

### DIFF
--- a/src/web/channels/forms.py
+++ b/src/web/channels/forms.py
@@ -1,0 +1,15 @@
+"""Request/form parsing for the channels web domain."""
+
+from __future__ import annotations
+
+from starlette.datastructures import FormData
+
+
+def parse_channel_ids(form: FormData) -> list[str]:
+    """Extract the multi-value ``channel_ids`` field from a bulk-add form."""
+    return form.getlist("channel_ids")
+
+
+def parse_tags(raw: object) -> list[str]:
+    """Split a comma-separated ``tags`` field into a clean list."""
+    return [t.strip() for t in str(raw or "").split(",") if t.strip()]

--- a/src/web/channels/handlers.py
+++ b/src/web/channels/handlers.py
@@ -1,0 +1,119 @@
+"""Application orchestration for the channels web domain."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+from fastapi import Request
+
+from src.web import deps
+from src.web.channels.forms import parse_channel_ids, parse_tags
+from src.web.channels.responses import ChannelsJson, ChannelsRedirect, ChannelsTemplate
+
+logger = logging.getLogger(__name__)
+
+
+async def _enqueue_channel_command(request: Request, command_type: str, payload: dict) -> ChannelsRedirect:
+    command_id = await deps.telegram_command_service(request).enqueue(
+        command_type,
+        payload=payload,
+        requested_by="web:channels",
+    )
+    return ChannelsRedirect(extra={"command_id": command_id})
+
+
+async def channels_list(request: Request) -> ChannelsTemplate:
+    service = deps.channel_service(request)
+    show_all = request.query_params.get("view") == "all"
+    channels, latest_stats, prev_subscriber_counts = await service.list_for_page(
+        include_filtered=show_all
+    )
+    return ChannelsTemplate(
+        "channels.html",
+        {
+            "channels": channels,
+            "latest_stats": latest_stats,
+            "prev_subscriber_counts": prev_subscriber_counts,
+            "error": request.query_params.get("error"),
+            "msg": request.query_params.get("msg"),
+            "show_all": show_all,
+        },
+    )
+
+
+async def add_channel(request: Request, identifier: str) -> ChannelsRedirect:
+    if not identifier.strip():
+        return ChannelsRedirect(error="resolve")
+    return await _enqueue_channel_command(
+        request,
+        "channels.add_identifier",
+        {"identifier": identifier.strip()},
+    )
+
+
+async def get_dialogs(request: Request) -> ChannelsJson:
+    service = deps.channel_service(request)
+    dialogs = await service.get_dialogs_with_added_flags()
+    return ChannelsJson(dialogs)
+
+
+async def add_bulk(request: Request) -> ChannelsRedirect:
+    form = await request.form()
+    service = deps.channel_service(request)
+    await service.add_bulk_by_dialog_ids(parse_channel_ids(form))
+    return ChannelsRedirect(msg="channels_added")
+
+
+async def toggle_channel(request: Request, pk: int) -> ChannelsRedirect:
+    await deps.channel_service(request).toggle(pk)
+    return ChannelsRedirect(msg="channel_toggled")
+
+
+async def delete_channel(request: Request, pk: int) -> ChannelsRedirect:
+    try:
+        await deps.channel_service(request).delete(pk)
+    except sqlite3.IntegrityError:
+        return ChannelsRedirect(error="channel_in_pipeline")
+    return ChannelsRedirect(msg="channel_deleted")
+
+
+async def refresh_channel_types(request: Request) -> ChannelsRedirect:
+    return await _enqueue_channel_command(request, "channels.refresh_types", {})
+
+
+async def refresh_channel_meta(request: Request) -> ChannelsRedirect:
+    return await _enqueue_channel_command(request, "channels.refresh_meta", {})
+
+
+async def list_tags(request: Request) -> ChannelsJson:
+    db = deps.get_db(request)
+    tags = await db.repos.channels.list_all_tags()
+    return ChannelsJson({"tags": tags})
+
+
+async def create_tag(request: Request, name: str) -> ChannelsRedirect:
+    if not name.strip():
+        return ChannelsRedirect(error="missing_fields")
+    db = deps.get_db(request)
+    await db.repos.channels.create_tag(name.strip())
+    return ChannelsRedirect(msg="tag_created")
+
+
+async def delete_tag(request: Request, name: str) -> ChannelsJson:
+    db = deps.get_db(request)
+    await db.repos.channels.delete_tag(name)
+    return ChannelsJson({"ok": True})
+
+
+async def get_channel_tags(request: Request, pk: int) -> ChannelsJson:
+    db = deps.get_db(request)
+    tags = await db.repos.channels.get_channel_tags(pk)
+    return ChannelsJson({"tags": tags})
+
+
+async def set_channel_tags(request: Request, pk: int) -> ChannelsRedirect:
+    db = deps.get_db(request)
+    form = await request.form()
+    await db.repos.channels.set_channel_tags(pk, parse_tags(form.get("tags", "")))
+    return ChannelsRedirect(msg="tags_updated")

--- a/src/web/channels/responses.py
+++ b/src/web/channels/responses.py
@@ -1,0 +1,45 @@
+"""Response mapping for the channels web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from src.web import deps
+from src.web.responses import flash_redirect
+
+CHANNELS_PATH = "/channels"
+
+
+@dataclass(frozen=True)
+class ChannelsRedirect:
+    msg: str | None = None
+    error: str | None = None
+    extra: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class ChannelsTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ChannelsJson:
+    content: Any
+
+
+ChannelsResult = ChannelsRedirect | ChannelsTemplate | ChannelsJson | Any
+
+
+def channels_response(request: Request, result: ChannelsResult):
+    if isinstance(result, ChannelsRedirect):
+        return flash_redirect(CHANNELS_PATH, msg=result.msg, error=result.error, extra=result.extra)
+    if isinstance(result, ChannelsTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    if isinstance(result, ChannelsJson):
+        return JSONResponse(content=result.content)
+    return result

--- a/src/web/routes/channels.py
+++ b/src/web/routes/channels.py
@@ -1,136 +1,78 @@
 import logging
-import sqlite3
 
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 
-from src.web import deps
+from src.web.channels import handlers
+from src.web.channels.responses import channels_response
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
-async def _enqueue_channel_command(request: Request, command_type: str, payload: dict) -> RedirectResponse:
-    command_id = await deps.telegram_command_service(request).enqueue(
-        command_type,
-        payload=payload,
-        requested_by="web:channels",
-    )
-    return RedirectResponse(url=f"/channels?command_id={command_id}", status_code=303)
-
-
 @router.get("/", response_class=HTMLResponse)
 async def channels_list(request: Request):
-    service = deps.channel_service(request)
-    show_all = request.query_params.get("view") == "all"
-    channels, latest_stats, prev_subscriber_counts = await service.list_for_page(
-        include_filtered=show_all
-    )
-    error = request.query_params.get("error")
-    msg = request.query_params.get("msg")
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "channels.html",
-        {
-            "channels": channels,
-            "latest_stats": latest_stats,
-            "prev_subscriber_counts": prev_subscriber_counts,
-            "error": error,
-            "msg": msg,
-            "show_all": show_all,
-        },
-    )
+    return channels_response(request, await handlers.channels_list(request))
 
 
 @router.post("/add")
 async def add_channel(request: Request, identifier: str = Form("")):
-    if not identifier.strip():
-        return RedirectResponse(url="/channels?error=resolve", status_code=303)
-    return await _enqueue_channel_command(
-        request,
-        "channels.add_identifier",
-        {"identifier": identifier.strip()},
-    )
+    return channels_response(request, await handlers.add_channel(request, identifier))
 
 
 @router.get("/dialogs")
 async def get_dialogs(request: Request):
-    service = deps.channel_service(request)
-    dialogs = await service.get_dialogs_with_added_flags()
-    return JSONResponse(content=dialogs)
+    return channels_response(request, await handlers.get_dialogs(request))
 
 
 @router.post("/add-bulk")
 async def add_bulk(request: Request):
-    form = await request.form()
-    service = deps.channel_service(request)
-    await service.add_bulk_by_dialog_ids(form.getlist("channel_ids"))
-    return RedirectResponse(url="/channels?msg=channels_added", status_code=303)
+    return channels_response(request, await handlers.add_bulk(request))
 
 
 @router.post("/{pk}/toggle")
 async def toggle_channel(request: Request, pk: int):
-    await deps.channel_service(request).toggle(pk)
-    return RedirectResponse(url="/channels?msg=channel_toggled", status_code=303)
+    return channels_response(request, await handlers.toggle_channel(request, pk))
 
 
 @router.post("/{pk}/delete")
 async def delete_channel(request: Request, pk: int):
-    try:
-        await deps.channel_service(request).delete(pk)
-    except sqlite3.IntegrityError:
-        return RedirectResponse(url="/channels?error=channel_in_pipeline", status_code=303)
-    return RedirectResponse(url="/channels?msg=channel_deleted", status_code=303)
+    return channels_response(request, await handlers.delete_channel(request, pk))
 
 
 @router.post("/refresh-types")
 async def refresh_channel_types(request: Request):
-    return await _enqueue_channel_command(request, "channels.refresh_types", {})
+    return channels_response(request, await handlers.refresh_channel_types(request))
 
 
 @router.post("/refresh-meta")
 async def refresh_channel_meta(request: Request):
-    return await _enqueue_channel_command(request, "channels.refresh_meta", {})
+    return channels_response(request, await handlers.refresh_channel_meta(request))
 
 
 # ── Tag endpoints ────────────────────────────────────────────────────────────
 
 @router.get("/tags")
 async def list_tags(request: Request):
-    db = deps.get_db(request)
-    tags = await db.repos.channels.list_all_tags()
-    return JSONResponse(content={"tags": tags})
+    return channels_response(request, await handlers.list_tags(request))
 
 
 @router.post("/tags")
 async def create_tag(request: Request, name: str = Form("")):
-    if not name.strip():
-        return RedirectResponse(url="/channels?error=missing_fields", status_code=303)
-    db = deps.get_db(request)
-    await db.repos.channels.create_tag(name.strip())
-    return RedirectResponse(url="/channels?msg=tag_created", status_code=303)
+    return channels_response(request, await handlers.create_tag(request, name))
 
 
 @router.delete("/tags/{name}")
 async def delete_tag(request: Request, name: str):
-    db = deps.get_db(request)
-    await db.repos.channels.delete_tag(name)
-    return JSONResponse(content={"ok": True})
+    return channels_response(request, await handlers.delete_tag(request, name))
 
 
 @router.get("/{pk}/tags")
 async def get_channel_tags(request: Request, pk: int):
-    db = deps.get_db(request)
-    tags = await db.repos.channels.get_channel_tags(pk)
-    return JSONResponse(content={"tags": tags})
+    return channels_response(request, await handlers.get_channel_tags(request, pk))
 
 
 @router.post("/{pk}/tags")
 async def set_channel_tags(request: Request, pk: int):
-    db = deps.get_db(request)
-    form = await request.form()
-    raw = form.get("tags", "")
-    tag_names = [t.strip() for t in str(raw).split(",") if t.strip()]
-    await db.repos.channels.set_channel_tags(pk, tag_names)
-    return RedirectResponse(url="/channels?msg=tags_updated", status_code=303)
+    return channels_response(request, await handlers.set_channel_tags(request, pk))

--- a/tests/routes/test_agent_channels_routes_regression.py
+++ b/tests/routes/test_agent_channels_routes_regression.py
@@ -147,7 +147,7 @@ async def test_channels_set_channel_tags(client, db):
 @pytest.mark.anyio
 async def test_channels_refresh_types(client, db):
     """Covers POST /channels/refresh-types."""
-    with patch("src.web.routes.channels.deps.telegram_command_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.telegram_command_service") as mock_svc:
         mock_telegram_svc = MagicMock()
         mock_telegram_svc.enqueue = AsyncMock(return_value=42)
         mock_svc.return_value = mock_telegram_svc
@@ -160,7 +160,7 @@ async def test_channels_refresh_types(client, db):
 @pytest.mark.anyio
 async def test_channels_refresh_meta(client, db):
     """Covers POST /channels/refresh-meta."""
-    with patch("src.web.routes.channels.deps.telegram_command_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.telegram_command_service") as mock_svc:
         mock_telegram_svc = MagicMock()
         mock_telegram_svc.enqueue = AsyncMock(return_value=43)
         mock_svc.return_value = mock_telegram_svc

--- a/tests/routes/test_channels_routes.py
+++ b/tests/routes/test_channels_routes.py
@@ -88,7 +88,7 @@ async def test_get_dialogs_json(route_client, db):
         [{"channel_id": 200, "title": "Test Dialog", "channel_type": "channel"}],
     )
 
-    with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.channel_service") as mock_svc:
         mock_svc.return_value.get_dialogs_with_added_flags = AsyncMock(
             return_value=[{"channel_id": 200, "title": "Test Dialog"}]
         )
@@ -102,7 +102,7 @@ async def test_get_dialogs_json(route_client, db):
 @pytest.mark.anyio
 async def test_add_bulk_channels(route_client):
     """Test add bulk channels."""
-    with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.channel_service") as mock_svc:
         mock_svc.return_value.add_bulk_by_dialog_ids = AsyncMock()
         resp = await route_client.post(
             "/channels/add-bulk",
@@ -116,7 +116,7 @@ async def test_add_bulk_channels(route_client):
 @pytest.mark.anyio
 async def test_toggle_channel(route_client):
     """Test toggle channel."""
-    with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.channel_service") as mock_svc:
         mock_svc.return_value.toggle = AsyncMock()
         resp = await route_client.post("/channels/1/toggle", follow_redirects=False)
         assert resp.status_code == 303
@@ -126,7 +126,7 @@ async def test_toggle_channel(route_client):
 @pytest.mark.anyio
 async def test_delete_channel(route_client):
     """Test delete channel."""
-    with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.channel_service") as mock_svc:
         mock_svc.return_value.delete = AsyncMock()
         resp = await route_client.post("/channels/1/delete", follow_redirects=False)
         assert resp.status_code == 303
@@ -136,7 +136,7 @@ async def test_delete_channel(route_client):
 @pytest.mark.anyio
 async def test_delete_channel_in_pipeline(route_client):
     """Test delete channel that is in pipeline."""
-    with patch("src.web.routes.channels.deps.channel_service") as mock_svc:
+    with patch("src.web.channels.handlers.deps.channel_service") as mock_svc:
         import sqlite3
 
         mock_svc.return_value.delete = AsyncMock(


### PR DESCRIPTION
Часть #657 (модуль `channels`). Часть epic #402.

## Проблема
`src/web/routes/channels.py` совмещал Form-parsing, оркестрацию (`channel_service`, enqueue telegram-команд, tag-repo) и Redirect/JSON/Template-ответы.

## Решение
- `src/web/channels/forms.py` — `parse_channel_ids` / `parse_tags`.
- `src/web/channels/handlers.py` — оркестрация + `_enqueue_channel_command`, возвращает DTO.
- `src/web/channels/responses.py` — `ChannelsRedirect/ChannelsTemplate/ChannelsJson` + `channels_response` (поверх `flash_redirect`).
- `src/web/routes/channels.py` — тонкий router (одиночные `Form()`-поля остаются на границе router).

## Контракт
URL, redirect-коды (`resolve/channels_added/channel_toggled/channel_deleted/channel_in_pipeline/tag_created/tags_updated/missing_fields`), `command_id`-redirect и JSON-формы — без изменений. Patch-таргеты `deps.*` в тестах перенацелены на `src.web.channels.handlers`.

## Тесты
`ruff` чисто. Зелёные: `tests/routes/test_channels_routes.py` + `test_agent_channels_routes_regression.py` (33); channel/tag/dialog-тесты в `test_web.py`+`test_cross_domain_regression_paths.py` (80). Дифф ~283 строки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## #657 closeout

This PR is one component of #657 and intentionally does not use a closing keyword.

Keep #657 open until all component PRs are merged:
- #669 filter
- #670 images
- #671 channels
- #672 search_queries
- #673 agent

After all five PRs are merged, close #657 manually from the issue.