### PR TITLE
refactor(web): atomize search-queries routes into forms/handlers/responses (#657)

### DIFF
--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,20 +1,16 @@
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
-from pydantic import ValidationError
 
-from src.web import deps
-from src.web.responses import flash_redirect
+from src.web.search_queries import handlers
+from src.web.search_queries.forms import SearchQueryForm
+from src.web.search_queries.responses import search_query_response
 
 router = APIRouter()
 
 
 @router.get("/", response_class=HTMLResponse)
 async def search_queries_page(request: Request):
-    svc = deps.search_query_service(request)
-    items = await svc.get_with_stats()
-    return deps.get_templates(request).TemplateResponse(
-        request, "search_queries.html", {"items": items}
-    )
+    return search_query_response(request, await handlers.search_queries_page(request))
 
 
 @router.post("/add")
@@ -30,42 +26,23 @@ async def add_search_query(
     max_length: int | None = Form(None),
     chat_filter: str = Form(""),
 ):
-    if not query.strip():
-        return flash_redirect("/search-queries", error="invalid_value")
-    svc = deps.search_query_service(request)
-    try:
-        await svc.add(
-            query,
-            interval_minutes,
-            is_regex=is_regex,
-            is_fts=is_fts,
-            notify_on_collect=notify_on_collect,
-            track_stats=track_stats,
-            exclude_patterns=exclude_patterns,
-            max_length=max_length,
-            chat_filter=chat_filter,
-        )
-    except ValidationError:
-        return flash_redirect("/search-queries", error="invalid_value")
-    chat_validation = await svc.validate_chat_filter(chat_filter)
-    scheduler = deps.get_scheduler(request)
-    if scheduler.is_running:
-        await scheduler.sync_search_query_jobs()
-    return flash_redirect(
-        "/search-queries",
-        msg="sq_added",
-        extra={"warning": chat_validation.warning_text() or None},
+    form = SearchQueryForm(
+        query=query,
+        interval_minutes=interval_minutes,
+        is_regex=is_regex,
+        is_fts=is_fts,
+        notify_on_collect=notify_on_collect,
+        track_stats=track_stats,
+        exclude_patterns=exclude_patterns,
+        max_length=max_length,
+        chat_filter=chat_filter,
     )
+    return search_query_response(request, await handlers.add_search_query(request, form))
 
 
 @router.post("/{sq_id}/toggle")
 async def toggle_search_query(request: Request, sq_id: int):
-    svc = deps.search_query_service(request)
-    await svc.toggle(sq_id)
-    scheduler = deps.get_scheduler(request)
-    if scheduler.is_running:
-        await scheduler.sync_search_query_jobs()
-    return flash_redirect("/search-queries", msg="sq_toggled")
+    return search_query_response(request, await handlers.toggle_search_query(request, sq_id))
 
 
 @router.post("/{sq_id}/edit")
@@ -82,47 +59,25 @@ async def edit_search_query(
     max_length: int | None = Form(None),
     chat_filter: str = Form(""),
 ):
-    if not query.strip():
-        return flash_redirect("/search-queries", error="invalid_value")
-    svc = deps.search_query_service(request)
-    try:
-        await svc.update(
-            sq_id,
-            query,
-            interval_minutes,
-            is_regex=is_regex,
-            is_fts=is_fts,
-            notify_on_collect=notify_on_collect,
-            track_stats=track_stats,
-            exclude_patterns=exclude_patterns,
-            max_length=max_length,
-            chat_filter=chat_filter,
-        )
-    except ValidationError:
-        return flash_redirect("/search-queries", error="invalid_value")
-    chat_validation = await svc.validate_chat_filter(chat_filter)
-    scheduler = deps.get_scheduler(request)
-    if scheduler.is_running:
-        await scheduler.sync_search_query_jobs()
-    return flash_redirect(
-        "/search-queries",
-        msg="sq_edited",
-        extra={"warning": chat_validation.warning_text() or None},
+    form = SearchQueryForm(
+        query=query,
+        interval_minutes=interval_minutes,
+        is_regex=is_regex,
+        is_fts=is_fts,
+        notify_on_collect=notify_on_collect,
+        track_stats=track_stats,
+        exclude_patterns=exclude_patterns,
+        max_length=max_length,
+        chat_filter=chat_filter,
     )
+    return search_query_response(request, await handlers.edit_search_query(request, sq_id, form))
 
 
 @router.post("/{sq_id}/delete")
 async def delete_search_query(request: Request, sq_id: int):
-    svc = deps.search_query_service(request)
-    await svc.delete(sq_id)
-    scheduler = deps.get_scheduler(request)
-    if scheduler.is_running:
-        await scheduler.sync_search_query_jobs()
-    return flash_redirect("/search-queries", msg="sq_deleted")
+    return search_query_response(request, await handlers.delete_search_query(request, sq_id))
 
 
 @router.post("/{sq_id}/run")
 async def run_search_query(request: Request, sq_id: int):
-    svc = deps.search_query_service(request)
-    await svc.run_once(sq_id)
-    return flash_redirect("/search-queries", msg="sq_run")
+    return search_query_response(request, await handlers.run_search_query(request, sq_id))

--- a/src/web/search_queries/forms.py
+++ b/src/web/search_queries/forms.py
@@ -1,0 +1,18 @@
+"""Form DTO for the search-queries web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchQueryForm:
+    query: str = ""
+    interval_minutes: int = 60
+    is_regex: bool = False
+    is_fts: bool = False
+    notify_on_collect: bool = False
+    track_stats: bool = False
+    exclude_patterns: str = ""
+    max_length: int | None = None
+    chat_filter: str = ""

--- a/src/web/search_queries/handlers.py
+++ b/src/web/search_queries/handlers.py
@@ -1,0 +1,86 @@
+"""Application orchestration for the search-queries web domain."""
+
+from __future__ import annotations
+
+from fastapi import Request
+from pydantic import ValidationError
+
+from src.web import deps
+from src.web.search_queries.forms import SearchQueryForm
+from src.web.search_queries.responses import SearchQueryRedirect, SearchQueryTemplate
+
+
+async def _sync_scheduler(request: Request) -> None:
+    scheduler = deps.get_scheduler(request)
+    if scheduler.is_running:
+        await scheduler.sync_search_query_jobs()
+
+
+async def search_queries_page(request: Request) -> SearchQueryTemplate:
+    svc = deps.search_query_service(request)
+    items = await svc.get_with_stats()
+    return SearchQueryTemplate("search_queries.html", {"items": items})
+
+
+async def add_search_query(request: Request, form: SearchQueryForm) -> SearchQueryRedirect:
+    if not form.query.strip():
+        return SearchQueryRedirect(error="invalid_value")
+    svc = deps.search_query_service(request)
+    try:
+        await svc.add(
+            form.query,
+            form.interval_minutes,
+            is_regex=form.is_regex,
+            is_fts=form.is_fts,
+            notify_on_collect=form.notify_on_collect,
+            track_stats=form.track_stats,
+            exclude_patterns=form.exclude_patterns,
+            max_length=form.max_length,
+            chat_filter=form.chat_filter,
+        )
+    except ValidationError:
+        return SearchQueryRedirect(error="invalid_value")
+    chat_validation = await svc.validate_chat_filter(form.chat_filter)
+    await _sync_scheduler(request)
+    return SearchQueryRedirect(msg="sq_added", extra={"warning": chat_validation.warning_text() or None})
+
+
+async def toggle_search_query(request: Request, sq_id: int) -> SearchQueryRedirect:
+    await deps.search_query_service(request).toggle(sq_id)
+    await _sync_scheduler(request)
+    return SearchQueryRedirect(msg="sq_toggled")
+
+
+async def edit_search_query(request: Request, sq_id: int, form: SearchQueryForm) -> SearchQueryRedirect:
+    if not form.query.strip():
+        return SearchQueryRedirect(error="invalid_value")
+    svc = deps.search_query_service(request)
+    try:
+        await svc.update(
+            sq_id,
+            form.query,
+            form.interval_minutes,
+            is_regex=form.is_regex,
+            is_fts=form.is_fts,
+            notify_on_collect=form.notify_on_collect,
+            track_stats=form.track_stats,
+            exclude_patterns=form.exclude_patterns,
+            max_length=form.max_length,
+            chat_filter=form.chat_filter,
+        )
+    except ValidationError:
+        return SearchQueryRedirect(error="invalid_value")
+    chat_validation = await svc.validate_chat_filter(form.chat_filter)
+    await _sync_scheduler(request)
+    return SearchQueryRedirect(msg="sq_edited", extra={"warning": chat_validation.warning_text() or None})
+
+
+async def delete_search_query(request: Request, sq_id: int) -> SearchQueryRedirect:
+    await deps.search_query_service(request).delete(sq_id)
+    await _sync_scheduler(request)
+    return SearchQueryRedirect(msg="sq_deleted")
+
+
+async def run_search_query(request: Request, sq_id: int) -> SearchQueryRedirect:
+    await deps.search_query_service(request).run_once(sq_id)
+    return SearchQueryRedirect(msg="sq_run")

--- a/src/web/search_queries/responses.py
+++ b/src/web/search_queries/responses.py
@@ -1,0 +1,37 @@
+"""Response mapping for the search-queries web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+
+from src.web import deps
+from src.web.responses import flash_redirect
+
+SEARCH_QUERIES_PATH = "/search-queries"
+
+
+@dataclass(frozen=True)
+class SearchQueryRedirect:
+    msg: str | None = None
+    error: str | None = None
+    extra: dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class SearchQueryTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+SearchQueryResult = SearchQueryRedirect | SearchQueryTemplate | Any
+
+
+def search_query_response(request: Request, result: SearchQueryResult):
+    if isinstance(result, SearchQueryRedirect):
+        return flash_redirect(SEARCH_QUERIES_PATH, msg=result.msg, error=result.error, extra=result.extra)
+    if isinstance(result, SearchQueryTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    return result

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -130,7 +130,7 @@ async def test_run_search_query(route_client):
         data={"query": "run test", "interval_minutes": "60"},
     )
 
-    with patch("src.web.routes.search_queries.deps.search_query_service") as mock_svc:
+    with patch("src.web.search_queries.handlers.deps.search_query_service") as mock_svc:
         mock_svc.return_value.run_once = AsyncMock()
         resp = await route_client.post("/search-queries/1/run", follow_redirects=False)
         assert resp.status_code == 303
@@ -143,7 +143,7 @@ async def test_scheduler_synced_after_add(route_client):
     route_client._transport_app.state.scheduler._running = True
 
     with patch(
-        "src.web.routes.search_queries.deps.get_scheduler"
+        "src.web.search_queries.handlers.deps.get_scheduler"
     ) as mock_get_scheduler:
         mock_scheduler = MagicMock()
         mock_scheduler.is_running = True
@@ -168,7 +168,7 @@ async def test_scheduler_synced_after_toggle(route_client):
     )
 
     with patch(
-        "src.web.routes.search_queries.deps.get_scheduler"
+        "src.web.search_queries.handlers.deps.get_scheduler"
     ) as mock_get_scheduler:
         mock_scheduler = MagicMock()
         mock_scheduler.is_running = True


### PR DESCRIPTION
Часть #657 (модуль `search_queries`). Часть epic #402.

## Проблема
`src/web/routes/search_queries.py` совмещал Form-parsing, оркестрацию (svc + scheduler sync + chat-validation) и redirect/template-маппинг; add/edit дублировали форму из 9 полей.

## Решение
- `src/web/search_queries/forms.py` — DTO `SearchQueryForm` (общий для add/edit).
- `src/web/search_queries/handlers.py` — оркестрация + хелпер `_sync_scheduler`, возвращает DTO.
- `src/web/search_queries/responses.py` — `SearchQueryRedirect/SearchQueryTemplate` + `search_query_response` (поверх `flash_redirect`).
- `src/web/routes/search_queries.py` — тонкий router (декларативный Form → DTO).

## Контракт
URL, redirect-коды (`invalid_value/sq_added/sq_toggled/sq_edited/sq_deleted/sq_run`), параметр `warning`, контекст шаблона — без изменений. Patch-таргеты `deps.*` перенацелены на handlers.

## Тесты
`ruff` чисто. Зелёные: `tests/routes/test_search_queries_routes.py` (14); sq-тесты в `test_web.py`+`test_cross_domain_regression_paths.py` (16). Дифф ~250 строк.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## #657 closeout

This PR is one component of #657 and intentionally does not use a closing keyword.

Keep #657 open until all component PRs are merged:
- #669 filter
- #670 images
- #671 channels
- #672 search_queries
- #673 agent

After all five PRs are merged, close #657 manually from the issue.