### PR TITLE
refactor(web): atomize agent routes into forms/handlers/responses (#657)

### DIFF
--- a/src/web/agent/forms.py
+++ b/src/web/agent/forms.py
@@ -1,0 +1,18 @@
+"""Request body parsing for the agent web domain."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from src.agent.models import CLAUDE_MODEL_IDS
+
+
+class ChatRequest(BaseModel):
+    message: str
+    model: str | None = None
+
+
+def select_model(raw_model: object) -> str | None:
+    """Return the requested model id only if it is a known Claude model, else None."""
+    model = (str(raw_model) if raw_model is not None else "").strip()
+    return model if model in CLAUDE_MODEL_IDS else None

--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -1,0 +1,314 @@
+"""Application orchestration for the agent web domain."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+from fastapi import HTTPException, Request
+
+from src.agent.models import CLAUDE_MODELS
+from src.web import deps
+from src.web.agent.forms import select_model
+from src.web.agent.responses import AgentJson, AgentRedirect, AgentStream, AgentTemplate
+
+logger = logging.getLogger(__name__)
+
+
+def _agent_unavailable_copy(runtime_state: deps.AgentRuntimeState) -> tuple[str, str]:
+    if runtime_state.state == "starting":
+        return (
+            "Агент запускается.",
+            "Рабочий процесс запускает чат. Обновите страницу через несколько секунд.",
+        )
+    if runtime_state.state == "failed":
+        return (
+            "Агент не запустился.",
+            runtime_state.error or "Рабочий процесс не запустился. Проверьте логи сервера.",
+        )
+    return (
+        "Чат недоступен в web-процессе.",
+        "Чат работает только в рабочем процессе. "
+        "Запустите рядом с web-сервером команду `python -m src.main worker`.",
+    )
+
+
+def _agent_unavailable_result(runtime_state: deps.AgentRuntimeState) -> AgentJson:
+    _, detail = _agent_unavailable_copy(runtime_state)
+    headers = {"Retry-After": "3"} if runtime_state.state == "starting" else None
+    return AgentJson(
+        {"detail": detail, "runtime_state": runtime_state.state},
+        status_code=503,
+        headers=headers,
+    )
+
+
+async def agent_page(request: Request, thread_id: int | None = None):
+    db = deps.get_db(request)
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
+    threads = await db.get_agent_threads()
+    agent_status = None
+    agent_disabled_title = None
+    agent_disabled_reason = None
+    if agent_manager is not None:
+        runtime_status = await agent_manager.get_runtime_status()
+        agent_status = {
+            "claude_available": runtime_status.claude_available,
+            "deepagents_available": runtime_status.deepagents_available,
+            "dev_mode_enabled": runtime_status.dev_mode_enabled,
+            "backend_override": runtime_status.backend_override,
+            "selected_backend": runtime_status.selected_backend,
+            "fallback_model": runtime_status.fallback_model,
+            "fallback_provider": runtime_status.fallback_provider,
+            "using_override": runtime_status.using_override,
+            "error": runtime_status.error,
+        }
+    else:
+        agent_disabled_title, agent_disabled_reason = _agent_unavailable_copy(agent_runtime_state)
+
+    messages = []
+    active_thread = None
+
+    if thread_id is not None:
+        active_thread = await db.get_agent_thread(thread_id)
+        if active_thread is None and threads:
+            logger.debug("Thread %s not found, redirect to first thread", thread_id)
+            return AgentRedirect(f"/agent?thread_id={threads[0]['id']}")
+        if active_thread is not None:
+            messages = await db.get_agent_messages(thread_id)
+    elif threads:
+        logger.debug("No thread_id param, redirect to first thread %s", threads[0]["id"])
+        return AgentRedirect(f"/agent?thread_id={threads[0]['id']}")
+    else:
+        thread_id = await db.create_agent_thread("Новый тред")
+        logger.debug("No threads exist, auto-created thread %s", thread_id)
+        return AgentRedirect(f"/agent?thread_id={thread_id}")
+
+    return AgentTemplate(
+        "agent.html",
+        {
+            "threads": threads,
+            "active_thread": active_thread,
+            "messages": messages,
+            "agent_status": agent_status,
+            "agent_runtime_state": agent_runtime_state.state,
+            "agent_disabled_title": agent_disabled_title,
+            "agent_disabled_reason": agent_disabled_reason,
+            "model_options": CLAUDE_MODELS,
+        },
+    )
+
+
+async def create_thread(request: Request) -> AgentRedirect:
+    db = deps.get_db(request)
+    thread_id = await db.create_agent_thread("Новый тред")
+    return AgentRedirect(f"/agent?thread_id={thread_id}")
+
+
+async def delete_thread(request: Request, thread_id: int) -> AgentJson:
+    db = deps.get_db(request)
+    agent_manager = deps.get_agent_manager(request)
+    cancelled = False
+    if agent_manager is not None:
+        cancelled = await agent_manager.cancel_stream(thread_id, wait_timeout=5.0)
+    await db.delete_agent_thread(thread_id)
+    if agent_manager is not None and agent_manager.permission_gate is not None:
+        session_id = request.cookies.get("session", "web")
+        agent_manager.permission_gate.clear_thread(session_id, thread_id)
+        agent_manager.permission_gate.clear_session(session_id)
+    return AgentJson({"ok": True, "cancelled": cancelled})
+
+
+async def rename_thread(request: Request, thread_id: int) -> AgentJson:
+    body = await request.json()
+    title = (body.get("title") or "").strip()
+    if not title:
+        raise HTTPException(status_code=400, detail="Title cannot be empty")
+    db = deps.get_db(request)
+    await db.rename_agent_thread(thread_id, title[:100])
+    return AgentJson({"ok": True})
+
+
+async def get_channels_json(request: Request) -> AgentJson:
+    db = deps.get_db(request)
+    channels = await db.get_channels(active_only=True, include_filtered=False)
+    return AgentJson(
+        [
+            {
+                "id": ch.channel_id,
+                "title": ch.title or str(ch.channel_id),
+                "channel_type": ch.channel_type,
+            }
+            for ch in channels
+        ]
+    )
+
+
+async def get_forum_topics(request: Request, channel_id: int) -> AgentJson:
+    db = deps.get_db(request)
+    cached = await db.get_forum_topics(channel_id)
+    if cached:
+        return AgentJson(cached)
+    command_id = await deps.telegram_command_service(request).enqueue(
+        "agent.forum_topics_refresh",
+        payload={"channel_id": channel_id},
+        requested_by="web:agent",
+    )
+    return AgentJson({"status": "queued", "command_id": command_id}, status_code=202)
+
+
+async def inject_context(request: Request, thread_id: int) -> AgentJson:
+    data = await request.json()
+    channel_id_raw = data.get("channel_id")
+    if not channel_id_raw:
+        raise HTTPException(status_code=400, detail="channel_id is required")
+    channel_id = int(channel_id_raw)
+    raw_limit = int(data.get("limit", 0))
+    limit = min(raw_limit, 10_000) if raw_limit > 0 else 10_000
+    topic_id = data.get("topic_id")
+    if topic_id is not None:
+        topic_id = int(topic_id) if str(topic_id).strip() else None
+
+    db = deps.get_db(request)
+    thread = await db.get_agent_thread(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    messages, _ = await db.search_messages(
+        query="",
+        channel_id=channel_id,
+        limit=limit,
+        topic_id=topic_id,
+    )
+    ch = await db.get_channel_by_channel_id(channel_id)
+    title = ch.title if ch else str(channel_id)
+
+    topics = await db.get_forum_topics(channel_id)
+    topics_map = {t["id"]: t["title"] for t in topics}
+
+    from src.agent.context import format_context
+
+    content = format_context(messages, title, topic_id, topics_map)
+
+    await db.save_agent_message(thread_id=thread_id, role="user", content=content)
+    logger.info(
+        "Context loaded for thread %d: %d messages, %d chars",
+        thread_id,
+        len(messages),
+        len(content),
+    )
+    if len(content) > 200_000:
+        logger.warning(
+            "Large context for thread %d: %d chars (>200K) — may cause prompt overflow",
+            thread_id,
+            len(content),
+        )
+    return AgentJson({"content": content})
+
+
+async def resolve_permission(request: Request, thread_id: int, request_id: str):
+    body = await request.json()
+    choice = body.get("choice", "deny")
+    if choice not in ("once", "session", "deny"):
+        raise HTTPException(status_code=400, detail="Invalid choice")
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
+    if agent_manager is None:
+        return _agent_unavailable_result(agent_runtime_state)
+    ok = agent_manager.permission_gate.resolve(request_id, choice)
+    logger.info(
+        "Permission resolve from web: thread_id=%s request_id=%s choice=%s ok=%s",
+        thread_id,
+        request_id,
+        choice,
+        ok,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Permission request not found or already resolved")
+    return AgentJson({"ok": True})
+
+
+async def stop_chat(request: Request, thread_id: int) -> AgentJson:
+    db = deps.get_db(request)
+    agent_manager = deps.get_agent_manager(request)
+    cancelled = False
+    if agent_manager is not None:
+        cancelled = await agent_manager.cancel_stream(thread_id)
+    await db.delete_last_agent_exchange(thread_id)
+    return AgentJson({"ok": True, "cancelled": cancelled})
+
+
+async def chat(request: Request, thread_id: int):
+    body = await request.json()
+    message = (body.get("message") or "").strip()
+    if not message:
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
+
+    model = select_model(body.get("model"))
+
+    db = deps.get_db(request)
+    agent_runtime_state = deps.get_agent_runtime_state(request)
+    agent_manager = agent_runtime_state.manager
+    if agent_manager is None:
+        return _agent_unavailable_result(agent_runtime_state)
+    runtime_status = await agent_manager.get_runtime_status()
+    if runtime_status.selected_backend is None:
+        raise HTTPException(
+            status_code=503, detail=runtime_status.error or "Agent backend unavailable"
+        )
+    if runtime_status.using_override and runtime_status.error:
+        raise HTTPException(status_code=503, detail=runtime_status.error)
+
+    # Verify thread exists
+    thread = await db.get_agent_thread(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    # Check prompt size before saving
+    estimated = await agent_manager.estimate_prompt_tokens(thread_id, message)
+    if estimated > 100_000:
+        raise HTTPException(
+            status_code=400,
+            detail="Контекст слишком длинный. Создайте новый тред.",
+        )
+
+    # Save user message
+    await db.save_agent_message(thread_id, "user", message)
+
+    # Auto-rename thread from first message
+    if thread["title"] == "Новый тред":
+        await db.rename_agent_thread(thread_id, message[:60])
+
+    # Use HTTP session cookie as session_id so per-user overrides are isolated
+    session_id = request.cookies.get("session", "web")
+
+    async def generate():
+        async for chunk in agent_manager.chat_stream(
+            thread_id,
+            message,
+            model=model,
+            session_id=session_id,
+            interactive_permissions=True,
+        ):
+            try:
+                data_str = chunk.removeprefix("data: ").strip()
+                data = json.loads(data_str)
+                if data.get("done") and data.get("full_text"):
+                    try:
+                        await db.save_agent_message(thread_id, "assistant", data["full_text"])
+                    except sqlite3.IntegrityError:
+                        logger.debug("Thread %d deleted during response — skipping save", thread_id)
+                elif data.get("error"):
+                    try:
+                        await db.delete_last_agent_exchange(thread_id)
+                    except sqlite3.IntegrityError:
+                        pass
+            except json.JSONDecodeError:
+                pass
+            except Exception:
+                logger.exception("Failed to process agent message for thread %d", thread_id)
+            yield chunk
+
+    return AgentStream(generate())

--- a/src/web/agent/responses.py
+++ b/src/web/agent/responses.py
@@ -1,0 +1,51 @@
+"""Response mapping for the agent web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
+
+from src.web import deps
+
+
+@dataclass(frozen=True)
+class AgentTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class AgentJson:
+    content: Any
+    status_code: int = 200
+    headers: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class AgentRedirect:
+    url: str
+    status_code: int = 303
+
+
+@dataclass(frozen=True)
+class AgentStream:
+    iterator: Any
+    media_type: str = "text/event-stream"
+
+
+AgentResult = AgentTemplate | AgentJson | AgentRedirect | AgentStream | Any
+
+
+def agent_response(request: Request, result: AgentResult):
+    if isinstance(result, AgentTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    if isinstance(result, AgentJson):
+        return JSONResponse(result.content, status_code=result.status_code, headers=result.headers)
+    if isinstance(result, AgentRedirect):
+        return RedirectResponse(url=result.url, status_code=result.status_code)
+    if isinstance(result, AgentStream):
+        return StreamingResponse(result.iterator, media_type=result.media_type)
+    return result

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -1,338 +1,62 @@
 from __future__ import annotations
 
-import json
 import logging
-import sqlite3
 
-from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
-from pydantic import BaseModel
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
 
-from src.agent.models import CLAUDE_MODEL_IDS, CLAUDE_MODELS
-from src.web import deps
+from src.web.agent import handlers
+from src.web.agent.responses import agent_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-class ChatRequest(BaseModel):
-    message: str
-    model: str | None = None
-
-
-def _agent_unavailable_copy(runtime_state: deps.AgentRuntimeState) -> tuple[str, str]:
-    if runtime_state.state == "starting":
-        return (
-            "Агент запускается.",
-            "Рабочий процесс запускает чат. Обновите страницу через несколько секунд.",
-        )
-    if runtime_state.state == "failed":
-        return (
-            "Агент не запустился.",
-            runtime_state.error or "Рабочий процесс не запустился. Проверьте логи сервера.",
-        )
-    return (
-        "Чат недоступен в web-процессе.",
-        "Чат работает только в рабочем процессе. "
-        "Запустите рядом с web-сервером команду `python -m src.main worker`.",
-    )
-
-
-def _agent_unavailable_response(runtime_state: deps.AgentRuntimeState) -> JSONResponse:
-    _, detail = _agent_unavailable_copy(runtime_state)
-    headers = {"Retry-After": "3"} if runtime_state.state == "starting" else None
-    return JSONResponse(
-        {
-            "detail": detail,
-            "runtime_state": runtime_state.state,
-        },
-        status_code=503,
-        headers=headers,
-    )
-
-
 @router.get("", response_class=HTMLResponse)
 async def agent_page(request: Request, thread_id: int | None = None):
-    db = deps.get_db(request)
-    agent_runtime_state = deps.get_agent_runtime_state(request)
-    agent_manager = agent_runtime_state.manager
-    threads = await db.get_agent_threads()
-    agent_status = None
-    agent_disabled_title = None
-    agent_disabled_reason = None
-    if agent_manager is not None:
-        runtime_status = await agent_manager.get_runtime_status()
-        agent_status = {
-            "claude_available": runtime_status.claude_available,
-            "deepagents_available": runtime_status.deepagents_available,
-            "dev_mode_enabled": runtime_status.dev_mode_enabled,
-            "backend_override": runtime_status.backend_override,
-            "selected_backend": runtime_status.selected_backend,
-            "fallback_model": runtime_status.fallback_model,
-            "fallback_provider": runtime_status.fallback_provider,
-            "using_override": runtime_status.using_override,
-            "error": runtime_status.error,
-        }
-    else:
-        agent_disabled_title, agent_disabled_reason = _agent_unavailable_copy(agent_runtime_state)
-
-    messages = []
-    active_thread = None
-
-    if thread_id is not None:
-        active_thread = await db.get_agent_thread(thread_id)
-        if active_thread is None and threads:
-            logger.debug("Thread %s not found, redirect to first thread", thread_id)
-            return RedirectResponse(url=f"/agent?thread_id={threads[0]['id']}", status_code=303)
-        if active_thread is not None:
-            messages = await db.get_agent_messages(thread_id)
-    elif threads:
-        logger.debug("No thread_id param, redirect to first thread %s", threads[0]["id"])
-        return RedirectResponse(url=f"/agent?thread_id={threads[0]['id']}", status_code=303)
-    else:
-        thread_id = await db.create_agent_thread("Новый тред")
-        logger.debug("No threads exist, auto-created thread %s", thread_id)
-        return RedirectResponse(url=f"/agent?thread_id={thread_id}", status_code=303)
-
-    return deps.get_templates(request).TemplateResponse(
-        request,
-        "agent.html",
-        {
-            "threads": threads,
-            "active_thread": active_thread,
-            "messages": messages,
-            "agent_status": agent_status,
-            "agent_runtime_state": agent_runtime_state.state,
-            "agent_disabled_title": agent_disabled_title,
-            "agent_disabled_reason": agent_disabled_reason,
-            "model_options": CLAUDE_MODELS,
-        },
-    )
+    return agent_response(request, await handlers.agent_page(request, thread_id))
 
 
 @router.post("/threads", response_class=HTMLResponse)
 async def create_thread(request: Request):
-    db = deps.get_db(request)
-    thread_id = await db.create_agent_thread("Новый тред")
-    return RedirectResponse(url=f"/agent?thread_id={thread_id}", status_code=303)
+    return agent_response(request, await handlers.create_thread(request))
 
 
 @router.delete("/threads/{thread_id}")
 async def delete_thread(request: Request, thread_id: int):
-    db = deps.get_db(request)
-    agent_manager = deps.get_agent_manager(request)
-    cancelled = False
-    if agent_manager is not None:
-        cancelled = await agent_manager.cancel_stream(thread_id, wait_timeout=5.0)
-    await db.delete_agent_thread(thread_id)
-    if agent_manager is not None and agent_manager.permission_gate is not None:
-        session_id = request.cookies.get("session", "web")
-        agent_manager.permission_gate.clear_thread(session_id, thread_id)
-        agent_manager.permission_gate.clear_session(session_id)
-    return {"ok": True, "cancelled": cancelled}
+    return agent_response(request, await handlers.delete_thread(request, thread_id))
 
 
 @router.post("/threads/{thread_id}/rename")
 async def rename_thread(request: Request, thread_id: int):
-    body = await request.json()
-    title = (body.get("title") or "").strip()
-    if not title:
-        raise HTTPException(status_code=400, detail="Title cannot be empty")
-    db = deps.get_db(request)
-    await db.rename_agent_thread(thread_id, title[:100])
-    return {"ok": True}
+    return agent_response(request, await handlers.rename_thread(request, thread_id))
 
 
 @router.get("/channels-json")
 async def get_channels_json(request: Request):
-    db = deps.get_db(request)
-    channels = await db.get_channels(active_only=True, include_filtered=False)
-    return JSONResponse(
-        [
-            {
-                "id": ch.channel_id,
-                "title": ch.title or str(ch.channel_id),
-                "channel_type": ch.channel_type,
-            }
-            for ch in channels
-        ]
-    )
+    return agent_response(request, await handlers.get_channels_json(request))
 
 
 @router.get("/forum-topics")
 async def get_forum_topics(request: Request, channel_id: int):
-    db = deps.get_db(request)
-    cached = await db.get_forum_topics(channel_id)
-    if cached:
-        return JSONResponse(cached)
-    command_id = await deps.telegram_command_service(request).enqueue(
-        "agent.forum_topics_refresh",
-        payload={"channel_id": channel_id},
-        requested_by="web:agent",
-    )
-    return JSONResponse({"status": "queued", "command_id": command_id}, status_code=202)
+    return agent_response(request, await handlers.get_forum_topics(request, channel_id))
 
 
 @router.post("/threads/{thread_id}/context")
 async def inject_context(request: Request, thread_id: int):
-    data = await request.json()
-    channel_id_raw = data.get("channel_id")
-    if not channel_id_raw:
-        raise HTTPException(status_code=400, detail="channel_id is required")
-    channel_id = int(channel_id_raw)
-    raw_limit = int(data.get("limit", 0))
-    limit = min(raw_limit, 10_000) if raw_limit > 0 else 10_000
-    topic_id = data.get("topic_id")
-    if topic_id is not None:
-        topic_id = int(topic_id) if str(topic_id).strip() else None
-
-    db = deps.get_db(request)
-    thread = await db.get_agent_thread(thread_id)
-    if thread is None:
-        raise HTTPException(status_code=404, detail="Thread not found")
-
-    messages, _ = await db.search_messages(
-        query="",
-        channel_id=channel_id,
-        limit=limit,
-        topic_id=topic_id,
-    )
-    ch = await db.get_channel_by_channel_id(channel_id)
-    title = ch.title if ch else str(channel_id)
-
-    topics = await db.get_forum_topics(channel_id)
-    topics_map = {t["id"]: t["title"] for t in topics}
-
-    from src.agent.context import format_context
-
-    content = format_context(messages, title, topic_id, topics_map)
-
-    await db.save_agent_message(thread_id=thread_id, role="user", content=content)
-    logger.info(
-        "Context loaded for thread %d: %d messages, %d chars",
-        thread_id,
-        len(messages),
-        len(content),
-    )
-    if len(content) > 200_000:
-        logger.warning(
-            "Large context for thread %d: %d chars (>200K) — may cause prompt overflow",
-            thread_id,
-            len(content),
-        )
-    return JSONResponse({"content": content})
+    return agent_response(request, await handlers.inject_context(request, thread_id))
 
 
 @router.post("/threads/{thread_id}/permission/{request_id}")
 async def resolve_permission(request: Request, thread_id: int, request_id: str):
-    """Resolve a pending permission request from the agent.
-
-    Called by the browser after the user picks a choice in the permission dialog.
-    Body: {"choice": "once"|"session"|"deny"}
-    """
-    body = await request.json()
-    choice = body.get("choice", "deny")
-    if choice not in ("once", "session", "deny"):
-        raise HTTPException(status_code=400, detail="Invalid choice")
-    agent_runtime_state = deps.get_agent_runtime_state(request)
-    agent_manager = agent_runtime_state.manager
-    if agent_manager is None:
-        return _agent_unavailable_response(agent_runtime_state)
-    ok = agent_manager.permission_gate.resolve(request_id, choice)
-    logger.info(
-        "Permission resolve from web: thread_id=%s request_id=%s choice=%s ok=%s",
-        thread_id,
-        request_id,
-        choice,
-        ok,
-    )
-    if not ok:
-        raise HTTPException(status_code=404, detail="Permission request not found or already resolved")
-    return JSONResponse({"ok": True})
+    return agent_response(request, await handlers.resolve_permission(request, thread_id, request_id))
 
 
 @router.post("/threads/{thread_id}/stop")
 async def stop_chat(request: Request, thread_id: int):
-    db = deps.get_db(request)
-    agent_manager = deps.get_agent_manager(request)
-    cancelled = False
-    if agent_manager is not None:
-        cancelled = await agent_manager.cancel_stream(thread_id)
-    await db.delete_last_agent_exchange(thread_id)
-    return JSONResponse({"ok": True, "cancelled": cancelled})
+    return agent_response(request, await handlers.stop_chat(request, thread_id))
 
 
 @router.post("/threads/{thread_id}/chat")
 async def chat(request: Request, thread_id: int):
-    body = await request.json()
-    message = (body.get("message") or "").strip()
-    if not message:
-        raise HTTPException(status_code=400, detail="Message cannot be empty")
-
-    raw_model = (body.get("model") or "").strip()
-    model = raw_model if raw_model in CLAUDE_MODEL_IDS else None
-
-    db = deps.get_db(request)
-    agent_runtime_state = deps.get_agent_runtime_state(request)
-    agent_manager = agent_runtime_state.manager
-    if agent_manager is None:
-        return _agent_unavailable_response(agent_runtime_state)
-    runtime_status = await agent_manager.get_runtime_status()
-    if runtime_status.selected_backend is None:
-        raise HTTPException(
-            status_code=503, detail=runtime_status.error or "Agent backend unavailable"
-        )
-    if runtime_status.using_override and runtime_status.error:
-        raise HTTPException(status_code=503, detail=runtime_status.error)
-
-    # Verify thread exists
-    thread = await db.get_agent_thread(thread_id)
-    if thread is None:
-        raise HTTPException(status_code=404, detail="Thread not found")
-
-    # Check prompt size before saving
-    estimated = await agent_manager.estimate_prompt_tokens(thread_id, message)
-    if estimated > 100_000:
-        raise HTTPException(
-            status_code=400,
-            detail="Контекст слишком длинный. Создайте новый тред.",
-        )
-
-    # Save user message
-    await db.save_agent_message(thread_id, "user", message)
-
-    # Auto-rename thread from first message
-    if thread["title"] == "Новый тред":
-        await db.rename_agent_thread(thread_id, message[:60])
-
-    # Use HTTP session cookie as session_id so per-user overrides are isolated
-    session_id = request.cookies.get("session", "web")
-
-    async def generate():
-        async for chunk in agent_manager.chat_stream(
-            thread_id,
-            message,
-            model=model,
-            session_id=session_id,
-            interactive_permissions=True,
-        ):
-            try:
-                data_str = chunk.removeprefix("data: ").strip()
-                data = json.loads(data_str)
-                if data.get("done") and data.get("full_text"):
-                    try:
-                        await db.save_agent_message(thread_id, "assistant", data["full_text"])
-                    except sqlite3.IntegrityError:
-                        logger.debug("Thread %d deleted during response — skipping save", thread_id)
-                elif data.get("error"):
-                    try:
-                        await db.delete_last_agent_exchange(thread_id)
-                    except sqlite3.IntegrityError:
-                        pass
-            except json.JSONDecodeError:
-                pass
-            except Exception:
-                logger.exception("Failed to process agent message for thread %d", thread_id)
-            yield chunk
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
+    return agent_response(request, await handlers.chat(request, thread_id))


### PR DESCRIPTION
Часть #657 (модуль `agent`, последний из medium-routes). Часть epic #402.

## Проблема
`src/web/routes/agent.py` совмещал JSON-parsing, оркестрацию (threads/runtime/permission), SSE-генератор чата и конструирование Redirect/JSON/Template/Stream ответов.

## Решение
- `src/web/agent/forms.py` — `ChatRequest` + `select_model`.
- `src/web/agent/handlers.py` — оркестрация страницы/тредов/контекста/permission/чата, включая SSE-генератор; возвращает DTO, для API-ошибок сохранён контракт `HTTPException` (400/404/503 c `{"detail": ...}`).
- `src/web/agent/responses.py` — `AgentTemplate/AgentJson/AgentRedirect/AgentStream` + `agent_response`.
- `src/web/routes/agent.py` — тонкий router.

## Контракт
URL, семантика SSE-стрима, гард 100K токенов, авто-rename, 503-payload «агент недоступен» (с `Retry-After`), JSON-формы и редиректы — без изменений. Завершает список medium-модулей #657.

## Тесты
`ruff` чисто. Зелёные: agent route/streaming/threads + regression + runtime (`test_agent_routes*.py`, `test_agent_channels_routes_regression.py`, `test_agent_threads_moderation_runtime_paths.py`, `test_accounts_agent_web_mode.py`) — 242 теста.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## #657 closeout

This PR is one component of #657 and intentionally does not use a closing keyword.

Keep #657 open until all component PRs are merged:
- #669 filter
- #670 images
- #671 channels
- #672 search_queries
- #673 agent

After all five PRs are merged, close #657 manually from the issue.