### PR TITLE
refactor(web): atomize dialogs routes and command response mapping (#655)

### DIFF
--- a/src/web/dialogs/handlers.py
+++ b/src/web/dialogs/handlers.py
@@ -1,0 +1,437 @@
+"""Application orchestration for the dialogs web domain."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from fastapi import Request
+
+from src.models import AccountSessionStatus
+from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
+from src.web import deps
+from src.web.dialogs.forms import (
+    CacheClearForm,
+    ChatActionForm,
+    CreateChannelForm,
+    DownloadMediaForm,
+    EditAdminForm,
+    EditMessageForm,
+    EditPermissionsForm,
+    ForwardMessagesForm,
+    KickParticipantForm,
+    LeaveDialogsForm,
+    MarkReadForm,
+    MessageIdsForm,
+    PinMessageForm,
+    ReactionForm,
+    RefreshDialogsForm,
+    SendMessageForm,
+    UnpinMessageForm,
+    parse_dialog_form,
+)
+from src.web.dialogs.responses import (
+    CommandRedirect,
+    DialogJson,
+    DialogRedirect,
+    DialogTemplate,
+    PathRedirect,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def _enqueue(
+    request: Request,
+    command_type: str,
+    *,
+    payload: dict,
+    phone: str | None = None,
+    target_path: str = "/dialogs/",
+) -> CommandRedirect:
+    command_service = deps.telegram_command_service(request)
+    command_id = await command_service.enqueue(
+        command_type,
+        payload=payload,
+        requested_by="web:dialogs",
+    )
+    return CommandRedirect(command_id=command_id, phone=phone or "", target_path=target_path)
+
+
+async def _get_command_state(request: Request, command_id: str | None):
+    if not command_id or not command_id.isdigit():
+        return None
+    return await deps.telegram_command_service(request).get(int(command_id))
+
+
+async def _ok_accounts(db) -> list[str]:
+    return sorted(
+        account.phone
+        for account in await db.get_account_summaries(active_only=False)
+        if account.session_status == AccountSessionStatus.OK
+    )
+
+
+async def dialogs_page(
+    request: Request,
+    phone: str | None = None,
+    left: int = 0,
+    failed: int = 0,
+) -> DialogTemplate:
+    started_at = time.perf_counter()
+    db = deps.get_db(request)
+    channel_service = deps.channel_service(request)
+    accounts = await _ok_accounts(db)
+    selected_phone = phone if phone in accounts else None
+    dialogs = []
+    dialogs_cached_at = None
+    command = await _get_command_state(request, request.query_params.get("command_id"))
+    if selected_phone:
+        dialogs = await channel_service.get_my_dialogs(selected_phone)
+        dialogs_cached_at = await db.repos.dialog_cache.get_cached_at(selected_phone)
+    elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+    logger.info(
+        "dialogs_page: phone=%s accounts=%d dialogs=%d duration_ms=%d",
+        selected_phone,
+        len(accounts),
+        len(dialogs),
+        elapsed_ms,
+    )
+    return DialogTemplate(
+        "dialogs.html",
+        {
+            "accounts": accounts,
+            "selected_phone": selected_phone,
+            "dialogs": dialogs,
+            "dialogs_cached_at": dialogs_cached_at,
+            "left": left,
+            "failed": failed,
+            "command": command,
+        },
+    )
+
+
+async def refresh_dialogs(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, RefreshDialogsForm)
+    if not form.phone:
+        return DialogRedirect(error="missing_fields")
+    return await _enqueue(request, "dialogs.refresh", payload={"phone": form.phone}, phone=form.phone)
+
+
+async def cache_status(request: Request) -> DialogJson:
+    db = deps.get_db(request)
+    phones = await db.repos.dialog_cache.get_all_phones()
+    result = []
+    for ph in sorted(phones):
+        count = await db.repos.dialog_cache.count_dialogs(ph)
+        cached_at = await db.repos.dialog_cache.get_cached_at(ph)
+        result.append({
+            "phone": ph,
+            "count": count,
+            "cached_at": cached_at.isoformat() if cached_at else None,
+        })
+    return DialogJson(result)
+
+
+async def cache_clear(request: Request) -> CommandRedirect:
+    form = await parse_dialog_form(request, CacheClearForm)
+    return await _enqueue(
+        request, "dialogs.cache_clear", payload={"phone": form.phone}, phone=form.phone or None
+    )
+
+
+async def leave_dialogs(request: Request) -> CommandRedirect:
+    form = await parse_dialog_form(request, LeaveDialogsForm)
+    return await _enqueue(
+        request,
+        "dialogs.leave",
+        payload={
+            "phone": form.phone,
+            "dialogs": [{"dialog_id": dialog_id, "title": title} for dialog_id, title in form.dialogs],
+        },
+        phone=form.phone or None,
+    )
+
+
+async def send_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, SendMessageForm)
+    if not form.phone or not form.recipient or not form.text:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.send",
+        payload={"phone": form.phone, "recipient": form.recipient, "text": form.text},
+        phone=form.phone,
+    )
+
+
+async def edit_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, EditMessageForm)
+    if not form.phone or not form.chat_id or not form.message_id or not form.text:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.edit_message",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id, "text": form.text},
+        phone=form.phone,
+    )
+
+
+async def delete_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, MessageIdsForm)
+    if not form.phone or not form.chat_id or not form.message_ids:
+        return DialogRedirect(form.phone, error="missing_fields")
+    if not form.ids:
+        return DialogRedirect(form.phone, error="invalid_ids")
+    return await _enqueue(
+        request,
+        "dialogs.delete_message",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_ids": form.ids},
+        phone=form.phone,
+    )
+
+
+async def forward_messages(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, ForwardMessagesForm)
+    if not form.phone or not form.from_chat or not form.to_chat or not form.message_ids:
+        return DialogRedirect(form.phone, error="missing_fields")
+    if not form.ids:
+        return DialogRedirect(form.phone, error="invalid_ids")
+    return await _enqueue(
+        request,
+        "dialogs.forward_messages",
+        payload={"phone": form.phone, "from_chat": form.from_chat, "to_chat": form.to_chat, "message_ids": form.ids},
+        phone=form.phone,
+    )
+
+
+async def pin_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, PinMessageForm)
+    if not form.phone or not form.chat_id or not form.message_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.pin_message",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id, "notify": form.notify},
+        phone=form.phone,
+    )
+
+
+async def react_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, ReactionForm)
+    if not form.phone or not form.chat_id or not form.message_id or not form.emoji:
+        return DialogRedirect(form.phone, error="missing_fields")
+    if not form.message_id.isdigit():
+        return DialogRedirect(form.phone, error="invalid_message_id")
+    try:
+        emoji = normalize_outgoing_reaction_emoji(form.emoji)
+    except TelegramReactionInvalidError:
+        return DialogRedirect(form.phone, error="invalid_reaction")
+    return await _enqueue(
+        request,
+        "dialogs.react",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": int(form.message_id), "emoji": emoji},
+        phone=form.phone,
+    )
+
+
+async def cancel_queue_command(request: Request, command_id: int) -> DialogRedirect:
+    """Cancel a pending Telegram command living in `telegram_commands` (issue #621)."""
+    form = await request.form()
+    phone = (form.get("phone") or "") if hasattr(form, "get") else ""
+    ok = await deps.telegram_command_service(request).cancel(command_id)
+    error = None if ok else "command_not_cancellable"
+    msg = "command_cancelled" if ok else None
+    return DialogRedirect(phone, msg=msg, error=error)
+
+
+async def clear_pending_queue_commands(request: Request) -> DialogRedirect:
+    """Bulk-cancel pending Telegram commands. Optional filters: command_type, phone."""
+    form = await request.form()
+    if hasattr(form, "get"):
+        phone = str(form.get("phone") or "").strip() or None
+        command_type = str(form.get("command_type") or "").strip() or None
+    else:
+        phone = None
+        command_type = None
+    cancelled = await deps.telegram_command_service(request).cancel_pending(
+        command_type=command_type, phone=phone
+    )
+    msg = "pending_commands_cancelled" if cancelled > 0 else "pending_commands_empty"
+    return DialogRedirect(phone or "", msg=msg)
+
+
+async def unpin_message(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, UnpinMessageForm)
+    if not form.phone or not form.chat_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.unpin_message",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.parsed_message_id},
+        phone=form.phone,
+    )
+
+
+async def download_media(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, DownloadMediaForm)
+    if not form.phone or not form.chat_id or not form.message_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.download_media",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id},
+        phone=form.phone,
+    )
+
+
+async def get_participants(request: Request) -> DialogJson:
+    db = deps.get_db(request)
+    command_service = deps.telegram_command_service(request)
+    phone = request.query_params.get("phone", "")
+    chat_id = request.query_params.get("chat_id", "")
+    limit_str = request.query_params.get("limit", "")
+    search = request.query_params.get("search", "")
+    limit = int(limit_str) if limit_str and limit_str.isdigit() else 200
+    if not phone or not chat_id:
+        return DialogJson({"error": "phone and chat_id required"}, status_code=400)
+    scope = f"dialogs_participants:{phone}:{chat_id}"
+    # The cached snapshot is keyed only by (phone, chat_id), so it does not
+    # reflect a specific search string. When the caller asks for a filtered
+    # search, bypass the cache and always enqueue a fresh command; otherwise
+    # an older search result would be returned silently.
+    if not search:
+        snapshot = await db.repos.runtime_snapshots.get_snapshot("dialogs_participants", scope)
+        if snapshot is not None:
+            return DialogJson(snapshot.payload)
+    command_id = await command_service.enqueue(
+        "dialogs.participants",
+        payload={"phone": phone, "chat_id": chat_id, "limit": limit, "search": search},
+        requested_by="web:dialogs",
+    )
+    return DialogJson({"status": "queued", "command_id": command_id}, status_code=202)
+
+
+async def edit_admin(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, EditAdminForm)
+    if not form.phone or not form.chat_id or not form.user_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.edit_admin",
+        payload={
+            "phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id,
+            "title": form.title, "is_admin": form.is_admin,
+        },
+        phone=form.phone,
+    )
+
+
+async def edit_permissions(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, EditPermissionsForm)
+    if form.send_messages is None and form.send_media is None:
+        return DialogRedirect(form.phone, error="no_permission_flags")
+    if not form.phone or not form.chat_id or not form.user_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    payload = {"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id}
+    if form.until_date:
+        payload["until_date"] = form.until_date
+    if form.send_messages is not None:
+        payload["send_messages"] = form.send_messages
+    if form.send_media is not None:
+        payload["send_media"] = form.send_media
+    return await _enqueue(request, "dialogs.edit_permissions", payload=payload, phone=form.phone)
+
+
+async def kick_participant(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, KickParticipantForm)
+    if not form.phone or not form.chat_id or not form.user_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.kick",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id},
+        phone=form.phone,
+    )
+
+
+async def broadcast_stats(request: Request) -> DialogJson:
+    db = deps.get_db(request)
+    command_service = deps.telegram_command_service(request)
+    phone = request.query_params.get("phone", "")
+    chat_id = request.query_params.get("chat_id", "")
+    if not phone or not chat_id:
+        return DialogJson({"error": "phone and chat_id required"}, status_code=400)
+    scope = f"dialogs_broadcast_stats:{phone}:{chat_id}"
+    snapshot = await db.repos.runtime_snapshots.get_snapshot("dialogs_broadcast_stats", scope)
+    if snapshot is not None:
+        return DialogJson(snapshot.payload)
+    command_id = await command_service.enqueue(
+        "dialogs.broadcast_stats",
+        payload={"phone": phone, "chat_id": chat_id},
+        requested_by="web:dialogs",
+    )
+    return DialogJson({"status": "queued", "command_id": command_id}, status_code=202)
+
+
+async def archive_dialog(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, ChatActionForm)
+    if not form.phone or not form.chat_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.archive",
+        payload={"phone": form.phone, "chat_id": form.chat_id},
+        phone=form.phone,
+    )
+
+
+async def unarchive_dialog(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, ChatActionForm)
+    if not form.phone or not form.chat_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.unarchive",
+        payload={"phone": form.phone, "chat_id": form.chat_id},
+        phone=form.phone,
+    )
+
+
+async def mark_read(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, MarkReadForm)
+    if not form.phone or not form.chat_id:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.mark_read",
+        payload={"phone": form.phone, "chat_id": form.chat_id, "max_id": form.parsed_max_id},
+        phone=form.phone,
+    )
+
+
+async def create_channel_page(request: Request) -> DialogTemplate:
+    db = deps.get_db(request)
+    accounts = await _ok_accounts(db)
+    command = await _get_command_state(request, request.query_params.get("command_id"))
+    return DialogTemplate(
+        "dialogs_create_channel.html",
+        {"accounts": accounts, "command": command},
+    )
+
+
+async def create_channel(request: Request) -> CommandRedirect | PathRedirect:
+    form = await parse_dialog_form(request, CreateChannelForm)
+    if not form.phone or not form.title:
+        return PathRedirect("/dialogs/create-channel", {"error": "missing_fields"})
+    return await _enqueue(
+        request,
+        "dialogs.create_channel",
+        payload={
+            "phone": form.phone,
+            "title": form.title,
+            "about": form.about,
+            "username": form.username,
+        },
+        target_path="/dialogs/create-channel",
+    )

--- a/src/web/dialogs/responses.py
+++ b/src/web/dialogs/responses.py
@@ -1,0 +1,70 @@
+"""Response mapping for the dialogs web domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from src.web import deps
+from src.web.redirects import dialogs_redirect, redirect_see_other
+
+
+@dataclass(frozen=True)
+class DialogTemplate:
+    name: str
+    context: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class DialogRedirect:
+    """Flash redirect back to the dialogs screen (msg/error query params)."""
+
+    phone: str = ""
+    msg: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandRedirect:
+    """Redirect after enqueueing a Telegram command, carrying its command_id."""
+
+    command_id: int
+    phone: str = ""
+    target_path: str = "/dialogs/"
+
+
+@dataclass(frozen=True)
+class PathRedirect:
+    """See-other redirect to an explicit path with arbitrary query params."""
+
+    path: str
+    params: dict[str, object | None] | None = None
+
+
+@dataclass(frozen=True)
+class DialogJson:
+    content: Any
+    status_code: int = 200
+
+
+DialogResult = DialogTemplate | DialogRedirect | CommandRedirect | PathRedirect | DialogJson | Any
+
+
+def dialog_response(request: Request, result: DialogResult):
+    if isinstance(result, DialogTemplate):
+        return deps.get_templates(request).TemplateResponse(request, result.name, result.context)
+    if isinstance(result, DialogRedirect):
+        return dialogs_redirect(result.phone, msg=result.msg, error=result.error)
+    if isinstance(result, CommandRedirect):
+        params = {"command_id": result.command_id}
+        if result.phone and "phone=" not in result.target_path:
+            params["phone"] = result.phone
+        return redirect_see_other(result.target_path, params)
+    if isinstance(result, PathRedirect):
+        return redirect_see_other(result.path, result.params)
+    if isinstance(result, DialogJson):
+        return JSONResponse(result.content, status_code=result.status_code)
+    return result

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -1,524 +1,139 @@
 from __future__ import annotations
 
-import logging
-import time
-from typing import Annotated
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
 
-from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
-
-from src.database import Database
-from src.models import AccountSessionStatus
-from src.services.channel_service import ChannelService
-from src.services.telegram_command_service import TelegramCommandService
-from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
-from src.web import deps
-from src.web.dialogs.forms import (
-    CacheClearForm,
-    ChatActionForm,
-    CreateChannelForm,
-    DownloadMediaForm,
-    EditAdminForm,
-    EditMessageForm,
-    EditPermissionsForm,
-    ForwardMessagesForm,
-    KickParticipantForm,
-    LeaveDialogsForm,
-    MarkReadForm,
-    MessageIdsForm,
-    PinMessageForm,
-    ReactionForm,
-    RefreshDialogsForm,
-    SendMessageForm,
-    UnpinMessageForm,
-    parse_dialog_form,
-)
-from src.web.redirects import dialogs_redirect, redirect_see_other
+from src.web.dialogs import handlers
+from src.web.dialogs.responses import dialog_response
 
 router = APIRouter()
-logger = logging.getLogger(__name__)
-
-
-def _db_dep(request: Request) -> Database:
-    return deps.get_db(request)
-
-
-def _channel_service_dep(request: Request) -> ChannelService:
-    return deps.channel_service(request)
-
-
-def _templates_dep(request: Request):
-    return deps.get_templates(request)
-
-
-def _telegram_command_service_dep(request: Request) -> TelegramCommandService:
-    return deps.telegram_command_service(request)
-
-
-DbDep = Annotated[Database, Depends(_db_dep)]
-ChannelServiceDep = Annotated[ChannelService, Depends(_channel_service_dep)]
-TemplatesDep = Annotated[object, Depends(_templates_dep)]
-TelegramCommandServiceDep = Annotated[TelegramCommandService, Depends(_telegram_command_service_dep)]
-
-
-async def _enqueue_dialog_command(
-    command_service: TelegramCommandService,
-    command_type: str,
-    *,
-    payload: dict,
-    phone: str | None = None,
-    target_path: str = "/dialogs/",
-) -> RedirectResponse:
-    command_id = await command_service.enqueue(
-        command_type,
-        payload=payload,
-        requested_by="web:dialogs",
-    )
-    params = {"command_id": command_id}
-    if phone and "phone=" not in target_path:
-        params["phone"] = phone
-    return redirect_see_other(target_path, params)
-
-
-async def _get_command_state(command_service: TelegramCommandService, command_id: str | None):
-    if not command_id or not command_id.isdigit():
-        return None
-    return await command_service.get(int(command_id))
 
 
 @router.get("/", response_class=HTMLResponse)
 async def dialogs_page(
     request: Request,
-    db: DbDep,
-    channel_service: ChannelServiceDep,
-    templates: TemplatesDep,
-    command_service: TelegramCommandServiceDep,
     phone: str | None = None,
     left: int = 0,
     failed: int = 0,
 ):
-    started_at = time.perf_counter()
-    accounts = sorted(
-        account.phone
-        for account in await db.get_account_summaries(active_only=False)
-        if account.session_status == AccountSessionStatus.OK
-    )
-    selected_phone = phone if phone in accounts else None
-    dialogs = []
-    dialogs_cached_at = None
-    command = await _get_command_state(command_service, request.query_params.get("command_id"))
-    if selected_phone:
-        dialogs = await channel_service.get_my_dialogs(selected_phone)
-        dialogs_cached_at = await db.repos.dialog_cache.get_cached_at(selected_phone)
-    elapsed_ms = int((time.perf_counter() - started_at) * 1000)
-    logger.info(
-        "dialogs_page: phone=%s accounts=%d dialogs=%d duration_ms=%d",
-        selected_phone,
-        len(accounts),
-        len(dialogs),
-        elapsed_ms,
-    )
-    return templates.TemplateResponse(
-        request,
-        "dialogs.html",
-        {
-            "accounts": accounts,
-            "selected_phone": selected_phone,
-            "dialogs": dialogs,
-            "dialogs_cached_at": dialogs_cached_at,
-            "left": left,
-            "failed": failed,
-            "command": command,
-        },
-    )
+    return dialog_response(request, await handlers.dialogs_page(request, phone, left, failed))
 
 
 @router.post("/refresh")
-async def refresh_dialogs(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, RefreshDialogsForm)
-    if not form.phone:
-        return dialogs_redirect(error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.refresh",
-        payload={"phone": form.phone},
-        phone=form.phone,
-    )
+async def refresh_dialogs(request: Request):
+    return dialog_response(request, await handlers.refresh_dialogs(request))
 
 
 @router.get("/cache-status")
-async def cache_status(db: DbDep):
-    phones = await db.repos.dialog_cache.get_all_phones()
-    result = []
-    for ph in sorted(phones):
-        count = await db.repos.dialog_cache.count_dialogs(ph)
-        cached_at = await db.repos.dialog_cache.get_cached_at(ph)
-        result.append({
-            "phone": ph,
-            "count": count,
-            "cached_at": cached_at.isoformat() if cached_at else None,
-        })
-    return JSONResponse(result)
+async def cache_status(request: Request):
+    return dialog_response(request, await handlers.cache_status(request))
 
 
 @router.post("/cache-clear")
-async def cache_clear(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, CacheClearForm)
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.cache_clear",
-        payload={"phone": form.phone},
-        phone=form.phone or None,
-    )
+async def cache_clear(request: Request):
+    return dialog_response(request, await handlers.cache_clear(request))
 
 
 @router.post("/leave")
-async def leave_dialogs(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, LeaveDialogsForm)
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.leave",
-        payload={
-            "phone": form.phone,
-            "dialogs": [{"dialog_id": dialog_id, "title": title} for dialog_id, title in form.dialogs],
-        },
-        phone=form.phone or None,
-    )
+async def leave_dialogs(request: Request):
+    return dialog_response(request, await handlers.leave_dialogs(request))
 
 
 @router.post("/send")
-async def send_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, SendMessageForm)
-    if not form.phone or not form.recipient or not form.text:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.send",
-        payload={"phone": form.phone, "recipient": form.recipient, "text": form.text},
-        phone=form.phone,
-    )
+async def send_message(request: Request):
+    return dialog_response(request, await handlers.send_message(request))
 
 
 @router.post("/edit-message")
-async def edit_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, EditMessageForm)
-    if not form.phone or not form.chat_id or not form.message_id or not form.text:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.edit_message",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id, "text": form.text},
-        phone=form.phone,
-    )
+async def edit_message(request: Request):
+    return dialog_response(request, await handlers.edit_message(request))
 
 
 @router.post("/delete-message")
-async def delete_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, MessageIdsForm)
-    if not form.phone or not form.chat_id or not form.message_ids:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    if not form.ids:
-        return dialogs_redirect(form.phone, error="invalid_ids")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.delete_message",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "message_ids": form.ids},
-        phone=form.phone,
-    )
+async def delete_message(request: Request):
+    return dialog_response(request, await handlers.delete_message(request))
 
 
 @router.post("/forward-messages")
-async def forward_messages(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, ForwardMessagesForm)
-    if not form.phone or not form.from_chat or not form.to_chat or not form.message_ids:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    if not form.ids:
-        return dialogs_redirect(form.phone, error="invalid_ids")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.forward_messages",
-        payload={"phone": form.phone, "from_chat": form.from_chat, "to_chat": form.to_chat, "message_ids": form.ids},
-        phone=form.phone,
-    )
+async def forward_messages(request: Request):
+    return dialog_response(request, await handlers.forward_messages(request))
 
 
 @router.post("/pin-message")
-async def pin_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, PinMessageForm)
-    if not form.phone or not form.chat_id or not form.message_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.pin_message",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id, "notify": form.notify},
-        phone=form.phone,
-    )
+async def pin_message(request: Request):
+    return dialog_response(request, await handlers.pin_message(request))
 
 
 @router.post("/react")
-async def react_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, ReactionForm)
-    if not form.phone or not form.chat_id or not form.message_id or not form.emoji:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    if not form.message_id.isdigit():
-        return dialogs_redirect(form.phone, error="invalid_message_id")
-    try:
-        emoji = normalize_outgoing_reaction_emoji(form.emoji)
-    except TelegramReactionInvalidError:
-        return dialogs_redirect(form.phone, error="invalid_reaction")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.react",
-        payload={
-            "phone": form.phone,
-            "chat_id": form.chat_id,
-            "message_id": int(form.message_id),
-            "emoji": emoji,
-        },
-        phone=form.phone,
-    )
+async def react_message(request: Request):
+    return dialog_response(request, await handlers.react_message(request))
 
 
 @router.post("/queue/{command_id}/cancel")
-async def cancel_queue_command(
-    request: Request, command_id: int, command_service: TelegramCommandServiceDep
-):
-    """Cancel a pending Telegram command (reaction, send, forward, etc.).
-
-    Reactions and other dialog actions live in `telegram_commands`, NOT in
-    `collection_tasks` — so the regular scheduler-cancel route does not touch
-    them. This endpoint plugs that gap (issue #621).
-    """
-    form = await request.form()
-    phone = (form.get("phone") or "") if hasattr(form, "get") else ""
-    ok = await command_service.cancel(command_id)
-    error = None if ok else "command_not_cancellable"
-    msg = "command_cancelled" if ok else None
-    return dialogs_redirect(phone, msg=msg, error=error)
+async def cancel_queue_command(request: Request, command_id: int):
+    return dialog_response(request, await handlers.cancel_queue_command(request, command_id))
 
 
 @router.post("/queue/clear-pending")
-async def clear_pending_queue_commands(
-    request: Request, command_service: TelegramCommandServiceDep
-):
-    """Bulk-cancel pending Telegram commands. Optional filters: command_type, phone."""
-    form = await request.form()
-    if hasattr(form, "get"):
-        phone = str(form.get("phone") or "").strip() or None
-        command_type = str(form.get("command_type") or "").strip() or None
-    else:
-        phone = None
-        command_type = None
-    cancelled = await command_service.cancel_pending(
-        command_type=command_type, phone=phone
-    )
-    msg = "pending_commands_cancelled" if cancelled > 0 else "pending_commands_empty"
-    return dialogs_redirect(phone or "", msg=msg)
+async def clear_pending_queue_commands(request: Request):
+    return dialog_response(request, await handlers.clear_pending_queue_commands(request))
 
 
 @router.post("/unpin-message")
-async def unpin_message(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, UnpinMessageForm)
-    if not form.phone or not form.chat_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.unpin_message",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.parsed_message_id},
-        phone=form.phone,
-    )
+async def unpin_message(request: Request):
+    return dialog_response(request, await handlers.unpin_message(request))
 
 
 @router.post("/download-media")
-async def download_media(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, DownloadMediaForm)
-    if not form.phone or not form.chat_id or not form.message_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.download_media",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "message_id": form.message_id},
-        phone=form.phone,
-    )
+async def download_media(request: Request):
+    return dialog_response(request, await handlers.download_media(request))
 
 
 @router.get("/participants")
-async def get_participants(
-    request: Request,
-    db: DbDep,
-    command_service: TelegramCommandServiceDep,
-):
-    phone = request.query_params.get("phone", "")
-    chat_id = request.query_params.get("chat_id", "")
-    limit_str = request.query_params.get("limit", "")
-    search = request.query_params.get("search", "")
-    limit = int(limit_str) if limit_str and limit_str.isdigit() else 200
-    if not phone or not chat_id:
-        return JSONResponse({"error": "phone and chat_id required"}, status_code=400)
-    scope = f"dialogs_participants:{phone}:{chat_id}"
-    # The cached snapshot is keyed only by (phone, chat_id), so it does not
-    # reflect a specific search string. When the caller asks for a filtered
-    # search, bypass the cache and always enqueue a fresh command; otherwise
-    # an older search result would be returned silently.
-    if not search:
-        snapshot = await db.repos.runtime_snapshots.get_snapshot("dialogs_participants", scope)
-        if snapshot is not None:
-            return JSONResponse(snapshot.payload)
-    command_id = await command_service.enqueue(
-        "dialogs.participants",
-        payload={"phone": phone, "chat_id": chat_id, "limit": limit, "search": search},
-        requested_by="web:dialogs",
-    )
-    return JSONResponse({"status": "queued", "command_id": command_id}, status_code=202)
+async def get_participants(request: Request):
+    return dialog_response(request, await handlers.get_participants(request))
 
 
 @router.post("/edit-admin")
-async def edit_admin(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, EditAdminForm)
-    if not form.phone or not form.chat_id or not form.user_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.edit_admin",
-        payload={
-            "phone": form.phone,
-            "chat_id": form.chat_id,
-            "user_id": form.user_id,
-            "title": form.title,
-            "is_admin": form.is_admin,
-        },
-        phone=form.phone,
-    )
+async def edit_admin(request: Request):
+    return dialog_response(request, await handlers.edit_admin(request))
 
 
 @router.post("/edit-permissions")
-async def edit_permissions(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, EditPermissionsForm)
-    if form.send_messages is None and form.send_media is None:
-        return dialogs_redirect(form.phone, error="no_permission_flags")
-    if not form.phone or not form.chat_id or not form.user_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    payload = {"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id}
-    if form.until_date:
-        payload["until_date"] = form.until_date
-    if form.send_messages is not None:
-        payload["send_messages"] = form.send_messages
-    if form.send_media is not None:
-        payload["send_media"] = form.send_media
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.edit_permissions",
-        payload=payload,
-        phone=form.phone,
-    )
+async def edit_permissions(request: Request):
+    return dialog_response(request, await handlers.edit_permissions(request))
 
 
 @router.post("/kick")
-async def kick_participant(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, KickParticipantForm)
-    if not form.phone or not form.chat_id or not form.user_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.kick",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id},
-        phone=form.phone,
-    )
+async def kick_participant(request: Request):
+    return dialog_response(request, await handlers.kick_participant(request))
 
 
 @router.get("/broadcast-stats")
-async def broadcast_stats(request: Request, db: DbDep, command_service: TelegramCommandServiceDep):
-    phone = request.query_params.get("phone", "")
-    chat_id = request.query_params.get("chat_id", "")
-    if not phone or not chat_id:
-        return JSONResponse({"error": "phone and chat_id required"}, status_code=400)
-    scope = f"dialogs_broadcast_stats:{phone}:{chat_id}"
-    snapshot = await db.repos.runtime_snapshots.get_snapshot("dialogs_broadcast_stats", scope)
-    if snapshot is not None:
-        return JSONResponse(snapshot.payload)
-    command_id = await command_service.enqueue(
-        "dialogs.broadcast_stats",
-        payload={"phone": phone, "chat_id": chat_id},
-        requested_by="web:dialogs",
-    )
-    return JSONResponse({"status": "queued", "command_id": command_id}, status_code=202)
+async def broadcast_stats(request: Request):
+    return dialog_response(request, await handlers.broadcast_stats(request))
 
 
 @router.post("/archive")
-async def archive_dialog(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, ChatActionForm)
-    if not form.phone or not form.chat_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.archive",
-        payload={"phone": form.phone, "chat_id": form.chat_id},
-        phone=form.phone,
-    )
+async def archive_dialog(request: Request):
+    return dialog_response(request, await handlers.archive_dialog(request))
 
 
 @router.post("/unarchive")
-async def unarchive_dialog(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, ChatActionForm)
-    if not form.phone or not form.chat_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.unarchive",
-        payload={"phone": form.phone, "chat_id": form.chat_id},
-        phone=form.phone,
-    )
+async def unarchive_dialog(request: Request):
+    return dialog_response(request, await handlers.unarchive_dialog(request))
 
 
 @router.post("/mark-read")
-async def mark_read(request: Request, command_service: TelegramCommandServiceDep):
-    form = await parse_dialog_form(request, MarkReadForm)
-    if not form.phone or not form.chat_id:
-        return dialogs_redirect(form.phone, error="missing_fields")
-    return await _enqueue_dialog_command(
-        command_service,
-        "dialogs.mark_read",
-        payload={"phone": form.phone, "chat_id": form.chat_id, "max_id": form.parsed_max_id},
-        phone=form.phone,
-    )
+async def mark_read(request: Request):
+    return dialog_response(request, await handlers.mark_read(request))
 
 
 @router.get("/create-channel", response_class=HTMLResponse)
-async def create_channel_page(
-    request: Request,
-    db: DbDep,
-    templates: TemplatesDep,
-    command_service: TelegramCommandServiceDep,
-):
-    accounts = sorted(
-        account.phone
-        for account in await db.get_account_summaries(active_only=False)
-        if account.session_status == AccountSessionStatus.OK
-    )
-    command = await _get_command_state(command_service, request.query_params.get("command_id"))
-    return templates.TemplateResponse(
-        request,
-        "dialogs_create_channel.html",
-        {"accounts": accounts, "command": command},
-    )
+async def create_channel_page(request: Request):
+    return dialog_response(request, await handlers.create_channel_page(request))
 
 
 @router.post("/create-channel")
-async def create_channel(
-    request: Request,
-    command_service: TelegramCommandServiceDep,
-):
-    form = await parse_dialog_form(request, CreateChannelForm)
-    if not form.phone or not form.title:
-        return redirect_see_other("/dialogs/create-channel", {"error": "missing_fields"})
-    command_id = await command_service.enqueue(
-        "dialogs.create_channel",
-        payload={
-            "phone": form.phone,
-            "title": form.title,
-            "about": form.about,
-            "username": form.username,
-        },
-        requested_by="web:dialogs",
-    )
-    return redirect_see_other("/dialogs/create-channel", {"command_id": command_id})
+async def create_channel(request: Request):
+    return dialog_response(request, await handlers.create_channel(request))

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -8,6 +8,17 @@ from src.web.dialogs.responses import dialog_response
 
 router = APIRouter()
 
+handle_send_message = handlers.send_message
+handle_edit_message = handlers.edit_message
+handle_forward_messages = handlers.forward_messages
+handle_pin_message = handlers.pin_message
+handle_unpin_message = handlers.unpin_message
+handle_download_media = handlers.download_media
+handle_get_participants = handlers.get_participants
+handle_edit_admin = handlers.edit_admin
+handle_edit_permissions = handlers.edit_permissions
+handle_kick_participant = handlers.kick_participant
+
 
 @router.get("/", response_class=HTMLResponse)
 async def dialogs_page(
@@ -41,12 +52,12 @@ async def leave_dialogs(request: Request):
 
 @router.post("/send")
 async def send_message(request: Request):
-    return dialog_response(request, await handlers.send_message(request))
+    return dialog_response(request, await handle_send_message(request))
 
 
 @router.post("/edit-message")
 async def edit_message(request: Request):
-    return dialog_response(request, await handlers.edit_message(request))
+    return dialog_response(request, await handle_edit_message(request))
 
 
 @router.post("/delete-message")
@@ -56,12 +67,12 @@ async def delete_message(request: Request):
 
 @router.post("/forward-messages")
 async def forward_messages(request: Request):
-    return dialog_response(request, await handlers.forward_messages(request))
+    return dialog_response(request, await handle_forward_messages(request))
 
 
 @router.post("/pin-message")
 async def pin_message(request: Request):
-    return dialog_response(request, await handlers.pin_message(request))
+    return dialog_response(request, await handle_pin_message(request))
 
 
 @router.post("/react")
@@ -81,32 +92,32 @@ async def clear_pending_queue_commands(request: Request):
 
 @router.post("/unpin-message")
 async def unpin_message(request: Request):
-    return dialog_response(request, await handlers.unpin_message(request))
+    return dialog_response(request, await handle_unpin_message(request))
 
 
 @router.post("/download-media")
 async def download_media(request: Request):
-    return dialog_response(request, await handlers.download_media(request))
+    return dialog_response(request, await handle_download_media(request))
 
 
 @router.get("/participants")
 async def get_participants(request: Request):
-    return dialog_response(request, await handlers.get_participants(request))
+    return dialog_response(request, await handle_get_participants(request))
 
 
 @router.post("/edit-admin")
 async def edit_admin(request: Request):
-    return dialog_response(request, await handlers.edit_admin(request))
+    return dialog_response(request, await handle_edit_admin(request))
 
 
 @router.post("/edit-permissions")
 async def edit_permissions(request: Request):
-    return dialog_response(request, await handlers.edit_permissions(request))
+    return dialog_response(request, await handle_edit_permissions(request))
 
 
 @router.post("/kick")
 async def kick_participant(request: Request):
-    return dialog_response(request, await handlers.kick_participant(request))
+    return dialog_response(request, await handle_kick_participant(request))
 
 
 @router.get("/broadcast-stats")


### PR DESCRIPTION
## Что

Атомизация `src/web/routes/dialogs.py` (524 строки) по конвенции route-layering — закрывает **#655** и дубль **#667** (подзадачи #402, AC1).

Форм-слой (`src/web/dialogs/forms.py`) уже существовал. Добавлено:
- `src/web/dialogs/handlers.py` — оркестрация: валидация, emoji-нормализация, сборка payload, `_enqueue` (постановка команды в очередь), чтение состояния команды; возвращает доменные DTO, без FastAPI-ответов
- `src/web/dialogs/responses.py` — `DialogTemplate / DialogRedirect / CommandRedirect / PathRedirect / DialogJson` + `dialog_response()` → `dialogs_redirect` / `redirect_see_other` / `JSONResponse` / `TemplateResponse`
- `src/web/routes/dialogs.py` — тонкий router (`request → handler → dialog_response`)

## Контракт

Без изменений: URL всех ~25 эндпоинтов, имена form-полей, redirect-коды (303) и цели (включая `/dialogs/create-channel`), JSON-формы, статусы 202/400, query-параметры `command_id`/`phone`.

## Тесты

`pytest tests/routes/test_dialogs_routes.py tests/routes/test_dialogs_routes_actions.py tests/test_dialogs_cli_and_web_actions.py tests/test_dialogs.py` — 278 passed. Lint чист. Дифф ровно 1000 строк.

🤖 Generated with [Claude Code](https://claude.com/claude-code)