### PR TITLE
test(cli): manifest scheduler queue-pause/queue-resume (fix red main from #663)

### DIFF
--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -239,6 +239,8 @@ CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS: dict[tuple[str, ...], str] = {
     ("provider", "test-all"): "external provider network calls",
     ("scheduler", "clear-pending"): "unsafe standalone live smoke; deletes all pending channel collection tasks",
     ("scheduler", "job-toggle"): "local scheduler setting mutation",
+    ("scheduler", "queue-pause"): "local scheduler setting mutation",
+    ("scheduler", "queue-resume"): "local scheduler setting mutation",
     ("scheduler", "set-interval"): "local scheduler setting mutation",
     ("scheduler", "stop"): "local scheduler setting mutation",
     ("scheduler", "task-cancel"): "local task mutation",


### PR DESCRIPTION
## Проблема

PR #663 (пауза очереди) добавил CLI-команды `scheduler queue-pause` / `queue-resume`, но не внёс их в `CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS`. Тест `test_cli_real_tg_parser_leaf_commands_are_covered_or_manifested` требует, чтобы каждая CLI-leaf была либо покрыта real-TG тестом, либо внесена в манифест. После мержа #663 main стал красным.

## Фикс

Добавил обе команды в манифест как `"local scheduler setting mutation"` — по аналогии с уже исключёнными `scheduler stop` / `job-toggle` / `set-interval` (локальная мутация настройки, без живого Telegram).

## Тесты

`pytest tests/test_real_telegram_policy.py` — 39 passed. Lint чист.

🤖 Generated with [Claude Code](https://claude.com/claude-code)