### PR TITLE
refactor(web): extract scheduler page context construction (#654, part 1)

### DIFF
--- a/src/web/routes/scheduler.py
+++ b/src/web/routes/scheduler.py
@@ -1,360 +1,60 @@
 import asyncio
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import timezone
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from src.models import AccountSessionStatus
-from src.services.pipeline_result import result_kind_label
-from src.services.runtime_diagnostics import (
-    WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
-)
-from src.services.runtime_diagnostics import evaluate_worker_heartbeat
 from src.web import deps
 from src.web.routes.channel_collection import bulk_enqueue_msg
 
+# Heavy context construction lives in src/web/scheduler/context.py (#654). The
+# helpers below are re-exported here for backward compatibility: src/web/search
+# imports `_is_worker_alive` from this module, and several test modules import
+# the pure presentation helpers + monkeypatch `_is_worker_alive` via this path.
+from src.web.scheduler.context import (
+    JOB_LABELS,
+    WORKER_HEARTBEAT_STALE_AFTER_SEC,
+    _build_collector_health_context,
+    _build_jobs_context,
+    _collector_health_border_severity,
+    _collector_health_recommendations,
+    _compute_load_level,
+    _dedupe_recent_unavailability_events,
+    _format_retry_hint,
+    _is_worker_alive,
+    _job_label,
+    _load_pipeline_run_result_meta,
+    _notification_snapshot_payload,
+    _worker_status,
+)
+
 logger = logging.getLogger(__name__)
-_PIPELINE_RUN_NOTE_RE = re.compile(r"Pipeline run id=(\d+)")
 
 router = APIRouter()
 
-JOB_LABELS = {
-    "collect_all": "Сбор всех каналов",
-    "photo_due": "Фото по расписанию",
-    "photo_auto": "Автозагрузка фото",
-    "warm_all_dialogs": "Прогрев кэша диалогов",
-}
-
-# Worker publishes `worker_heartbeat` every ~5s (src/runtime/worker.py:_publish_snapshots).
-# 60s gives us 12 missed publishes before we conclude the worker is down. The
-# staleness window + classification now live in src.services.runtime_diagnostics
-# so the agent's get_runtime_diagnostics tool stays in lock-step with this banner.
-WORKER_HEARTBEAT_STALE_AFTER_SEC = WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC
-
-
-def _job_label(job_id: str) -> str:
-    if job_id in JOB_LABELS:
-        return JOB_LABELS[job_id]
-    if job_id.startswith("sq_"):
-        return f"Стат. запроса #{job_id.removeprefix('sq_')}"
-    if job_id.startswith("pipeline_run_"):
-        return f"Пайплайн #{job_id.removeprefix('pipeline_run_')}"
-    if job_id.startswith("content_generate_"):
-        return f"Генерация #{job_id.removeprefix('content_generate_')}"
-    return job_id
-
-
-def _format_retry_hint(run_after) -> str:
-    if run_after is None:
-        return ""
-    return run_after.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-
-
-def _compute_load_level(
-    *,
-    interval_minutes: int,
-    active_unfiltered_channels: int,
-    available_accounts_now: int,
-    state: str,
-) -> str:
-    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
-        return "overload"
-    capacity_accounts = max(1, available_accounts_now)
-    pressure = active_unfiltered_channels / capacity_accounts
-    if interval_minutes <= 15 and pressure >= 60:
-        return "overload"
-    if interval_minutes <= 30 and pressure >= 40:
-        return "high"
-    if pressure >= 75:
-        return "high"
-    return "ok"
-
-
-def _current_status_presentation(state: str, *, is_running: bool) -> tuple[str, str, str]:
-    if state == "worker_down":
-        return "Telegram-воркер не запущен", "Задачи копятся в БД, но воркер их не исполняет.", "danger"
-    if state == "all_flooded":
-        return "Все аккаунты во Flood Wait", "Сбор заблокирован до ближайшего окна доступности.", "danger"
-    if state == "no_clients":
-        return "Нет доступных клиентов", "Нет подключенного активного Telegram-аккаунта для сбора.", "danger"
-    if state == "session_degraded":
-        return "SESSION_ENCRYPTION_KEY не подходит", "Активные сессии не расшифровываются текущим ключом.", "danger"
-    if state == "degraded":
-        return "Частичная деградация", "Часть аккаунтов временно ограничена, но сбор может продолжаться.", "warning"
-    if is_running:
-        return "Сбор идёт", "Коллектор выполняет текущую задачу.", "success"
-    return "Коллектор ждёт", "Блокеров сбора сейчас нет.", "success"
-
-
-def _load_presentation(load_level: str) -> tuple[str, str]:
-    if load_level == "overload":
-        return "Риск перегрузки", "warning"
-    if load_level == "high":
-        return "Высокая нагрузка", "warning"
-    return "Нагрузка в норме", "success"
-
-
-def _collector_health_border_severity(*, state: str, load_level: str) -> str:
-    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
-        return "danger"
-    if state == "degraded" or load_level in {"high", "overload"}:
-        return "warning"
-    return "success"
-
-
-def _collector_health_recommendations(
-    *,
-    state: str,
-    load_level: str,
-    interval_minutes: int,
-    active_unfiltered_channels: int,
-    available_accounts_now: int,
-    is_running: bool = False,
-    pending_count: int = 0,
-) -> list[str]:
-    recommendations: list[str] = []
-    if state == "worker_down":
-        recommendations.append(
-            "Telegram-воркер не запущен. Если используете `serve` — перезапустите его; "
-            "если `serve --no-worker` — запустите воркер отдельно: `python -m src.main worker`. "
-            "Без воркера задачи сбора копятся в БД, но не исполняются."
-        )
-    if state == "all_flooded":
-        recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
-    if state == "no_clients":
-        recommendations.append("Проверить активность аккаунтов и переподключить хотя бы один рабочий клиент.")
-    if state == "session_degraded":
-        recommendations.append(
-            "Восстановить прежний SESSION_ENCRYPTION_KEY или повторно войти в Telegram-аккаунты."
-        )
-    if load_level in {"high", "overload"}:
-        recommendations.append(
-            f"Поднять интервал автосбора выше текущих {interval_minutes} мин, чтобы снизить частоту обращений."
-        )
-        recommendations.append(
-            "Сократить число активных отслеживаемых каналов: "
-            f"сейчас активных неотфильтрованных {active_unfiltered_channels}."
-        )
-    if available_accounts_now <= 1:
-        recommendations.append("Добавить ещё Telegram-аккаунты, чтобы распределить нагрузку по чтению.")
-    if is_running and pending_count > 0:
-        recommendations.append(
-            "Дождаться завершения текущего первичного сбора; "
-            "не запускать collect-all вручную, пока очередь не разгребётся."
-        )
-    return recommendations
-
-
-def _dedupe_recent_unavailability_events(recent_tasks) -> list[dict[str, object]]:
-    events: dict[str, dict[str, object]] = {}
-    for task in recent_tasks:
-        message = ""
-        if task.note and "Flood Wait" in task.note:
-            message = task.note
-        elif task.note and "нет подключённых активных аккаунтов" in task.note:
-            message = task.note
-        elif task.error and "No active connected clients" in task.error:
-            message = task.error
-        if not message:
-            continue
-        item = events.setdefault(message, {"message": message, "count": 0, "latest_at": None})
-        item["count"] = int(item["count"]) + 1
-        occurred_at = _as_utc_datetime(task.completed_at or task.started_at or task.created_at)
-        if occurred_at is not None:
-            latest_at = item["latest_at"]
-            if latest_at is None or occurred_at > latest_at:
-                item["latest_at"] = occurred_at
-    return sorted(
-        events.values(),
-        key=lambda item: item["latest_at"] or datetime.min.replace(tzinfo=timezone.utc),
-        reverse=True,
-    )[:5]
-
-
-def _as_utc_datetime(value) -> datetime | None:
-    if not isinstance(value, datetime):
-        return None
-    if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc)
-
-
-async def _worker_status(db) -> tuple[bool, str]:
-    """Return True when the worker-process heartbeat snapshot is fresh.
-
-    The worker publishes `worker_heartbeat` every ~5s
-    (`src/runtime/worker.py:_publish_snapshots`). We treat anything older than
-    `WORKER_HEARTBEAT_STALE_AFTER_SEC` as the worker being down — that turns the
-    silent failure from #444 (serve running alone, collection tasks piling up
-    with no executor) into an explicit banner.
-    """
-    try:
-        snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
-    except Exception as exc:  # noqa: BLE001
-        # Fail closed (#530): a snapshot read failure means we cannot prove the
-        # worker is alive, so report it as down — matching the agent tool's
-        # get_runtime_diagnostics, which passes snapshot=None to
-        # evaluate_worker_heartbeat and gets status="missing". Returning True
-        # here (fail-open) would let the two surfaces drift: the banner would say
-        # "alive" while the agent says "missing" from the same DB error, defeating
-        # the single-source-of-truth goal and suppressing the very #444 banner.
-        logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
-        return False, ""
-    health = evaluate_worker_heartbeat(snapshot, stale_after_sec=WORKER_HEARTBEAT_STALE_AFTER_SEC)
-    return health.alive, health.reason
-
-
-async def _is_worker_alive(db) -> bool:
-    alive, _ = await _worker_status(db)
-    return alive
-
-
-async def _build_collector_health_context(request: Request) -> dict[str, object]:
-    db = deps.get_db(request)
-    pool = deps.get_pool(request)
-    collector = deps.get_collector(request)
-    accounts = await db.get_account_summaries(active_only=False)
-    connected_phones = set(pool.clients.keys())
-    degraded_session_accounts = [
-        acc for acc in accounts if acc.is_active and acc.session_status != AccountSessionStatus.OK
-    ]
-    active_accounts = [
-        acc for acc in accounts if acc.is_active and acc.session_status == AccountSessionStatus.OK
-    ]
-    connected_active_accounts = [acc for acc in active_accounts if acc.phone in connected_phones]
-    now = datetime.now(timezone.utc)
-    worker_alive, worker_reason = await _worker_status(db)
-
-    flooded_accounts = []
-    next_available_at = None
-    for acc in connected_active_accounts:
-        flood_until = acc.flood_wait_until
-        if flood_until is None:
-            continue
-        if flood_until.tzinfo is None:
-            flood_until = flood_until.replace(tzinfo=timezone.utc)
-        if flood_until <= now:
-            continue
-        flooded_accounts.append({"phone": acc.phone, "until": flood_until})
-        if next_available_at is None or flood_until < next_available_at:
-            next_available_at = flood_until
-
-    try:
-        availability = await asyncio.wait_for(collector.get_collection_availability(), timeout=1.0)
-    except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001
-        logger.warning("get_collection_availability timed out or failed: %s", exc)
-        availability = None
-    availability_state = getattr(availability, "state", "no_connected_active")
-    availability_retry_after = getattr(availability, "retry_after_sec", None)
-    availability_next = getattr(availability, "next_available_at_utc", None)
-    if not isinstance(availability_next, datetime):
-        availability_next = None
-    if not isinstance(availability_retry_after, int):
-        availability_retry_after = None
-    available_accounts_now = max(0, len(connected_active_accounts) - len(flooded_accounts))
-    active_unfiltered_channels = len(await db.get_channels(active_only=True, include_filtered=False))
-    recent_tasks = await db.get_collection_tasks(limit=200)
-    recent_zero_collect_count = sum(
-        1
-        for task in recent_tasks
-        if task.task_type.value == "channel_collect"
-        and task.status == "completed"
-        and task.messages_collected == 0
-    )
-    recent_unavailability_events = _dedupe_recent_unavailability_events(recent_tasks)
-    pending_channel_tasks = await db.get_pending_channel_tasks()
-    running_task = next(
-        (
-            task
-            for task in recent_tasks
-            if task.task_type.value == "channel_collect" and task.status.value == "running"
-        ),
-        None,
-    )
-
-    state = "healthy"
-    if not worker_alive:
-        # Worker-process absent dominates: without it `no_clients` /
-        # `all_flooded` are symptoms, not the root cause.
-        state = "worker_down"
-    elif degraded_session_accounts and not active_accounts:
-        state = "session_degraded"
-    elif not connected_active_accounts:
-        state = "no_clients"
-    elif availability_state == "all_flooded" or available_accounts_now == 0:
-        state = "all_flooded"
-    elif flooded_accounts:
-        state = "degraded"
-
-    interval_minutes = max(1, getattr(deps.get_scheduler(request), "interval_minutes", 60))
-    load_level = _compute_load_level(
-        interval_minutes=interval_minutes,
-        active_unfiltered_channels=active_unfiltered_channels,
-        available_accounts_now=available_accounts_now,
-        state=state,
-    )
-    current_status_label, current_status_detail, current_status_severity = _current_status_presentation(
-        state, is_running=collector.is_running
-    )
-    load_label, load_severity = _load_presentation(load_level)
-    capacity_accounts = max(1, available_accounts_now)
-    channels_per_account = active_unfiltered_channels // capacity_accounts
-    capacity_label = (
-        f"{active_unfiltered_channels} каналов на {capacity_accounts} "
-        f"{'аккаунт' if capacity_accounts == 1 else 'аккаунта'}, интервал {interval_minutes} мин"
-    )
-    capacity_detail = (
-        f"Около {channels_per_account} каналов на доступный аккаунт; "
-        f"в очереди {len(pending_channel_tasks)} задач."
-    )
-    # Compute retry_after_sec from next_available_at if available
-    computed_retry_after_sec = availability_retry_after
-    if computed_retry_after_sec is None and (next_available_at or availability_next):
-        effective_next = next_available_at or availability_next
-        delta = effective_next - now
-        computed_retry_after_sec = max(0, int(delta.total_seconds()))
-    return {
-        "state": state,
-        "connected_accounts": len(connected_phones),
-        "active_accounts": len(active_accounts),
-        "session_degraded_accounts": len(degraded_session_accounts),
-        "worker_reason": worker_reason,
-        "available_accounts_now": available_accounts_now,
-        "flooded_accounts": flooded_accounts,
-        "flooded_accounts_count": len(flooded_accounts),
-        "next_available_at": next_available_at or availability_next,
-        "retry_after_sec": computed_retry_after_sec,
-        "active_unfiltered_channels": active_unfiltered_channels,
-        "collect_interval_minutes": interval_minutes,
-        "load_level": load_level,
-        "recommendations": _collector_health_recommendations(
-            state=state,
-            load_level=load_level,
-            interval_minutes=interval_minutes,
-            active_unfiltered_channels=active_unfiltered_channels,
-            available_accounts_now=available_accounts_now,
-            is_running=collector.is_running,
-            pending_count=len(pending_channel_tasks),
-        ),
-        "current_status_label": current_status_label,
-        "current_status_detail": current_status_detail,
-        "current_status_severity": current_status_severity,
-        "health_border_severity": _collector_health_border_severity(state=state, load_level=load_level),
-        "load_label": load_label,
-        "load_severity": load_severity,
-        "capacity_label": capacity_label,
-        "capacity_detail": capacity_detail,
-        "queue_pending_count": len(pending_channel_tasks),
-        "running_task_title": running_task.channel_title if running_task else "",
-        "running_task_messages_collected": running_task.messages_collected if running_task else 0,
-        "recent_zero_collect_count": recent_zero_collect_count,
-        "recent_unavailability_events": recent_unavailability_events,
-        "is_running": collector.is_running,
-        "next_available_label": _format_retry_hint(next_available_at or availability_next),
-    }
+# Re-exported for backward compatibility (importers/tests reach these via
+# src.web.routes.scheduler). Listed here so the imports above are not flagged
+# as unused.
+__all__ = [
+    "router",
+    "WORKER_HEARTBEAT_STALE_AFTER_SEC",
+    "JOB_LABELS",
+    "_build_collector_health_context",
+    "_build_jobs_context",
+    "_collector_health_border_severity",
+    "_collector_health_recommendations",
+    "_compute_load_level",
+    "_dedupe_recent_unavailability_events",
+    "_format_retry_hint",
+    "_is_worker_alive",
+    "_job_label",
+    "_load_pipeline_run_result_meta",
+    "_notification_snapshot_payload",
+    "_worker_status",
+]
 
 
 @router.post("/tasks/{task_id}/cancel")
@@ -383,94 +83,6 @@ VALID_STATUS_FILTERS = {"all", "active", "completed"}
 _VALID_JOB_ID_RE = re.compile(
     r"^(collect_all|photo_due|photo_auto|sq_\d+|pipeline_run_\d+|content_generate_\d+)$"
 )
-
-
-async def _build_jobs_context(sched, db) -> list[dict]:
-    """Build a list of job dicts for the scheduler page template."""
-    # Always fetch potential jobs to get DB-sourced interval_minutes
-    potential = await sched.get_potential_jobs()
-    potential_map = {j["job_id"]: j for j in potential}
-
-    if sched.is_running:
-        raw = sched.get_all_jobs_next_run()
-        jobs = []
-        for job_id, next_run in raw.items():
-            db_interval = potential_map.get(job_id, {}).get("interval_minutes")
-            jobs.append({
-                "job_id": job_id,
-                "label": _job_label(job_id),
-                "next_run": next_run,
-                "interval_minutes": db_interval,
-            })
-        # Also include disabled jobs (not in APScheduler but exist in potential_map)
-        running_ids = set(raw.keys())
-        for j in potential:
-            if j["job_id"] not in running_ids:
-                jobs.append({
-                    "job_id": j["job_id"],
-                    "label": _job_label(j["job_id"]),
-                    "next_run": None,
-                    "interval_minutes": j["interval_minutes"],
-                })
-    else:
-        jobs = [
-            {
-                "job_id": j["job_id"],
-                "label": _job_label(j["job_id"]),
-                "next_run": None,
-                "interval_minutes": j["interval_minutes"],
-            }
-            for j in potential
-        ]
-
-    disabled_map = await db.repos.settings.get_settings_by_prefix("scheduler_job_disabled:")
-    for j in jobs:
-        val = disabled_map.get(f"scheduler_job_disabled:{j['job_id']}")
-        j["enabled"] = val != "1"
-        j["interval_editable"] = j["job_id"] not in ("photo_due", "photo_auto")
-    return jobs
-
-
-async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
-    snapshot = await deps.get_db(request).repos.runtime_snapshots.get_snapshot("notification_target_status")
-    payload = snapshot.payload if snapshot is not None else {}
-    return payload if isinstance(payload, dict) else {}
-
-
-async def _load_pipeline_run_result_meta(db, tasks) -> dict[int, dict[str, object]]:
-    run_ids_by_task_id: dict[int, int] = {}
-    for task in tasks:
-        if task.id is None or task.task_type.value != "pipeline_run" or not task.note:
-            continue
-        match = _PIPELINE_RUN_NOTE_RE.search(task.note)
-        if match is None:
-            continue
-        run_ids_by_task_id[task.id] = int(match.group(1))
-    if not run_ids_by_task_id:
-        return {}
-
-    runs = await asyncio.gather(*(db.repos.generation_runs.get(run_id) for run_id in run_ids_by_task_id.values()))
-    result: dict[int, dict[str, object]] = {}
-    for task_id, run in zip(run_ids_by_task_id.keys(), runs, strict=False):
-        if run is None:
-            continue
-        metadata = run.metadata if isinstance(run.metadata, dict) else {}
-        raw_errors = metadata.get("node_errors")
-        node_errors = raw_errors if isinstance(raw_errors, list) else []
-        errors_count = len(node_errors)
-        first_error_detail: str | None = None
-        if node_errors and isinstance(node_errors[0], dict):
-            detail = node_errors[0].get("detail")
-            if isinstance(detail, str):
-                first_error_detail = detail
-        result[task_id] = {
-            "kind": run.result_kind,
-            "count": run.result_count,
-            "label": result_kind_label(run.result_kind),
-            "errors_count": errors_count,
-            "first_error_detail": first_error_detail,
-        }
-    return result
 
 
 _PRESERVED_SCHEDULER_QUERY_KEYS = ("status", "page", "limit")

--- a/src/web/scheduler/__init__.py
+++ b/src/web/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""Scheduler web domain: context builders, handlers, responses."""

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -1,0 +1,450 @@
+"""Context construction for the scheduler web page.
+
+Pure presentation helpers, worker-health probing, and the heavy collector-health /
+jobs / pipeline-result context builders that the scheduler page renders. Extracted
+from ``src/web/routes/scheduler.py`` so route functions no longer own heavy context
+construction (#654).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+
+from fastapi import Request
+
+from src.models import AccountSessionStatus
+from src.services.pipeline_result import result_kind_label
+from src.services.runtime_diagnostics import (
+    WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
+)
+from src.services.runtime_diagnostics import evaluate_worker_heartbeat
+from src.web import deps
+
+logger = logging.getLogger(__name__)
+_PIPELINE_RUN_NOTE_RE = re.compile(r"Pipeline run id=(\d+)")
+
+JOB_LABELS = {
+    "collect_all": "Сбор всех каналов",
+    "photo_due": "Фото по расписанию",
+    "photo_auto": "Автозагрузка фото",
+    "warm_all_dialogs": "Прогрев кэша диалогов",
+}
+
+# Worker publishes `worker_heartbeat` every ~5s (src/runtime/worker.py:_publish_snapshots).
+# 60s gives us 12 missed publishes before we conclude the worker is down. The
+# staleness window + classification now live in src.services.runtime_diagnostics
+# so the agent's get_runtime_diagnostics tool stays in lock-step with this banner.
+WORKER_HEARTBEAT_STALE_AFTER_SEC = WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC
+
+
+def _job_label(job_id: str) -> str:
+    if job_id in JOB_LABELS:
+        return JOB_LABELS[job_id]
+    if job_id.startswith("sq_"):
+        return f"Стат. запроса #{job_id.removeprefix('sq_')}"
+    if job_id.startswith("pipeline_run_"):
+        return f"Пайплайн #{job_id.removeprefix('pipeline_run_')}"
+    if job_id.startswith("content_generate_"):
+        return f"Генерация #{job_id.removeprefix('content_generate_')}"
+    return job_id
+
+
+def _format_retry_hint(run_after) -> str:
+    if run_after is None:
+        return ""
+    return run_after.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _compute_load_level(
+    *,
+    interval_minutes: int,
+    active_unfiltered_channels: int,
+    available_accounts_now: int,
+    state: str,
+) -> str:
+    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
+        return "overload"
+    capacity_accounts = max(1, available_accounts_now)
+    pressure = active_unfiltered_channels / capacity_accounts
+    if interval_minutes <= 15 and pressure >= 60:
+        return "overload"
+    if interval_minutes <= 30 and pressure >= 40:
+        return "high"
+    if pressure >= 75:
+        return "high"
+    return "ok"
+
+
+def _current_status_presentation(state: str, *, is_running: bool) -> tuple[str, str, str]:
+    if state == "worker_down":
+        return "Telegram-воркер не запущен", "Задачи копятся в БД, но воркер их не исполняет.", "danger"
+    if state == "all_flooded":
+        return "Все аккаунты во Flood Wait", "Сбор заблокирован до ближайшего окна доступности.", "danger"
+    if state == "no_clients":
+        return "Нет доступных клиентов", "Нет подключенного активного Telegram-аккаунта для сбора.", "danger"
+    if state == "session_degraded":
+        return "SESSION_ENCRYPTION_KEY не подходит", "Активные сессии не расшифровываются текущим ключом.", "danger"
+    if state == "degraded":
+        return "Частичная деградация", "Часть аккаунтов временно ограничена, но сбор может продолжаться.", "warning"
+    if is_running:
+        return "Сбор идёт", "Коллектор выполняет текущую задачу.", "success"
+    return "Коллектор ждёт", "Блокеров сбора сейчас нет.", "success"
+
+
+def _load_presentation(load_level: str) -> tuple[str, str]:
+    if load_level == "overload":
+        return "Риск перегрузки", "warning"
+    if load_level == "high":
+        return "Высокая нагрузка", "warning"
+    return "Нагрузка в норме", "success"
+
+
+def _collector_health_border_severity(*, state: str, load_level: str) -> str:
+    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
+        return "danger"
+    if state == "degraded" or load_level in {"high", "overload"}:
+        return "warning"
+    return "success"
+
+
+def _collector_health_recommendations(
+    *,
+    state: str,
+    load_level: str,
+    interval_minutes: int,
+    active_unfiltered_channels: int,
+    available_accounts_now: int,
+    is_running: bool = False,
+    pending_count: int = 0,
+) -> list[str]:
+    recommendations: list[str] = []
+    if state == "worker_down":
+        recommendations.append(
+            "Telegram-воркер не запущен. Если используете `serve` — перезапустите его; "
+            "если `serve --no-worker` — запустите воркер отдельно: `python -m src.main worker`. "
+            "Без воркера задачи сбора копятся в БД, но не исполняются."
+        )
+    if state == "all_flooded":
+        recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
+    if state == "no_clients":
+        recommendations.append("Проверить активность аккаунтов и переподключить хотя бы один рабочий клиент.")
+    if state == "session_degraded":
+        recommendations.append(
+            "Восстановить прежний SESSION_ENCRYPTION_KEY или повторно войти в Telegram-аккаунты."
+        )
+    if load_level in {"high", "overload"}:
+        recommendations.append(
+            f"Поднять интервал автосбора выше текущих {interval_minutes} мин, чтобы снизить частоту обращений."
+        )
+        recommendations.append(
+            "Сократить число активных отслеживаемых каналов: "
+            f"сейчас активных неотфильтрованных {active_unfiltered_channels}."
+        )
+    if available_accounts_now <= 1:
+        recommendations.append("Добавить ещё Telegram-аккаунты, чтобы распределить нагрузку по чтению.")
+    if is_running and pending_count > 0:
+        recommendations.append(
+            "Дождаться завершения текущего первичного сбора; "
+            "не запускать collect-all вручную, пока очередь не разгребётся."
+        )
+    return recommendations
+
+
+def _dedupe_recent_unavailability_events(recent_tasks) -> list[dict[str, object]]:
+    events: dict[str, dict[str, object]] = {}
+    for task in recent_tasks:
+        message = ""
+        if task.note and "Flood Wait" in task.note:
+            message = task.note
+        elif task.note and "нет подключённых активных аккаунтов" in task.note:
+            message = task.note
+        elif task.error and "No active connected clients" in task.error:
+            message = task.error
+        if not message:
+            continue
+        item = events.setdefault(message, {"message": message, "count": 0, "latest_at": None})
+        item["count"] = int(item["count"]) + 1
+        occurred_at = _as_utc_datetime(task.completed_at or task.started_at or task.created_at)
+        if occurred_at is not None:
+            latest_at = item["latest_at"]
+            if latest_at is None or occurred_at > latest_at:
+                item["latest_at"] = occurred_at
+    return sorted(
+        events.values(),
+        key=lambda item: item["latest_at"] or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )[:5]
+
+
+def _as_utc_datetime(value) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+async def _worker_status(db) -> tuple[bool, str]:
+    """Return True when the worker-process heartbeat snapshot is fresh.
+
+    The worker publishes `worker_heartbeat` every ~5s
+    (`src/runtime/worker.py:_publish_snapshots`). We treat anything older than
+    `WORKER_HEARTBEAT_STALE_AFTER_SEC` as the worker being down — that turns the
+    silent failure from #444 (serve running alone, collection tasks piling up
+    with no executor) into an explicit banner.
+    """
+    try:
+        snapshot = await db.repos.runtime_snapshots.get_snapshot("worker_heartbeat")
+    except Exception as exc:  # noqa: BLE001
+        # Fail closed (#530): a snapshot read failure means we cannot prove the
+        # worker is alive, so report it as down — matching the agent tool's
+        # get_runtime_diagnostics, which passes snapshot=None to
+        # evaluate_worker_heartbeat and gets status="missing". Returning True
+        # here (fail-open) would let the two surfaces drift: the banner would say
+        # "alive" while the agent says "missing" from the same DB error, defeating
+        # the single-source-of-truth goal and suppressing the very #444 banner.
+        logger.warning("Failed to read worker_heartbeat snapshot: %s", exc)
+        return False, ""
+    health = evaluate_worker_heartbeat(snapshot, stale_after_sec=WORKER_HEARTBEAT_STALE_AFTER_SEC)
+    return health.alive, health.reason
+
+
+async def _is_worker_alive(db) -> bool:
+    alive, _ = await _worker_status(db)
+    return alive
+
+
+async def _build_collector_health_context(request: Request) -> dict[str, object]:
+    db = deps.get_db(request)
+    pool = deps.get_pool(request)
+    collector = deps.get_collector(request)
+    accounts = await db.get_account_summaries(active_only=False)
+    connected_phones = set(pool.clients.keys())
+    degraded_session_accounts = [
+        acc for acc in accounts if acc.is_active and acc.session_status != AccountSessionStatus.OK
+    ]
+    active_accounts = [
+        acc for acc in accounts if acc.is_active and acc.session_status == AccountSessionStatus.OK
+    ]
+    connected_active_accounts = [acc for acc in active_accounts if acc.phone in connected_phones]
+    now = datetime.now(timezone.utc)
+    worker_alive, worker_reason = await _worker_status(db)
+
+    flooded_accounts = []
+    next_available_at = None
+    for acc in connected_active_accounts:
+        flood_until = acc.flood_wait_until
+        if flood_until is None:
+            continue
+        if flood_until.tzinfo is None:
+            flood_until = flood_until.replace(tzinfo=timezone.utc)
+        if flood_until <= now:
+            continue
+        flooded_accounts.append({"phone": acc.phone, "until": flood_until})
+        if next_available_at is None or flood_until < next_available_at:
+            next_available_at = flood_until
+
+    try:
+        availability = await asyncio.wait_for(collector.get_collection_availability(), timeout=1.0)
+    except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001
+        logger.warning("get_collection_availability timed out or failed: %s", exc)
+        availability = None
+    availability_state = getattr(availability, "state", "no_connected_active")
+    availability_retry_after = getattr(availability, "retry_after_sec", None)
+    availability_next = getattr(availability, "next_available_at_utc", None)
+    if not isinstance(availability_next, datetime):
+        availability_next = None
+    if not isinstance(availability_retry_after, int):
+        availability_retry_after = None
+    available_accounts_now = max(0, len(connected_active_accounts) - len(flooded_accounts))
+    active_unfiltered_channels = len(await db.get_channels(active_only=True, include_filtered=False))
+    recent_tasks = await db.get_collection_tasks(limit=200)
+    recent_zero_collect_count = sum(
+        1
+        for task in recent_tasks
+        if task.task_type.value == "channel_collect"
+        and task.status == "completed"
+        and task.messages_collected == 0
+    )
+    recent_unavailability_events = _dedupe_recent_unavailability_events(recent_tasks)
+    pending_channel_tasks = await db.get_pending_channel_tasks()
+    running_task = next(
+        (
+            task
+            for task in recent_tasks
+            if task.task_type.value == "channel_collect" and task.status.value == "running"
+        ),
+        None,
+    )
+
+    state = "healthy"
+    if not worker_alive:
+        # Worker-process absent dominates: without it `no_clients` /
+        # `all_flooded` are symptoms, not the root cause.
+        state = "worker_down"
+    elif degraded_session_accounts and not active_accounts:
+        state = "session_degraded"
+    elif not connected_active_accounts:
+        state = "no_clients"
+    elif availability_state == "all_flooded" or available_accounts_now == 0:
+        state = "all_flooded"
+    elif flooded_accounts:
+        state = "degraded"
+
+    interval_minutes = max(1, getattr(deps.get_scheduler(request), "interval_minutes", 60))
+    load_level = _compute_load_level(
+        interval_minutes=interval_minutes,
+        active_unfiltered_channels=active_unfiltered_channels,
+        available_accounts_now=available_accounts_now,
+        state=state,
+    )
+    current_status_label, current_status_detail, current_status_severity = _current_status_presentation(
+        state, is_running=collector.is_running
+    )
+    load_label, load_severity = _load_presentation(load_level)
+    capacity_accounts = max(1, available_accounts_now)
+    channels_per_account = active_unfiltered_channels // capacity_accounts
+    capacity_label = (
+        f"{active_unfiltered_channels} каналов на {capacity_accounts} "
+        f"{'аккаунт' if capacity_accounts == 1 else 'аккаунта'}, интервал {interval_minutes} мин"
+    )
+    capacity_detail = (
+        f"Около {channels_per_account} каналов на доступный аккаунт; "
+        f"в очереди {len(pending_channel_tasks)} задач."
+    )
+    # Compute retry_after_sec from next_available_at if available
+    computed_retry_after_sec = availability_retry_after
+    if computed_retry_after_sec is None and (next_available_at or availability_next):
+        effective_next = next_available_at or availability_next
+        delta = effective_next - now
+        computed_retry_after_sec = max(0, int(delta.total_seconds()))
+    return {
+        "state": state,
+        "connected_accounts": len(connected_phones),
+        "active_accounts": len(active_accounts),
+        "session_degraded_accounts": len(degraded_session_accounts),
+        "worker_reason": worker_reason,
+        "available_accounts_now": available_accounts_now,
+        "flooded_accounts": flooded_accounts,
+        "flooded_accounts_count": len(flooded_accounts),
+        "next_available_at": next_available_at or availability_next,
+        "retry_after_sec": computed_retry_after_sec,
+        "active_unfiltered_channels": active_unfiltered_channels,
+        "collect_interval_minutes": interval_minutes,
+        "load_level": load_level,
+        "recommendations": _collector_health_recommendations(
+            state=state,
+            load_level=load_level,
+            interval_minutes=interval_minutes,
+            active_unfiltered_channels=active_unfiltered_channels,
+            available_accounts_now=available_accounts_now,
+            is_running=collector.is_running,
+            pending_count=len(pending_channel_tasks),
+        ),
+        "current_status_label": current_status_label,
+        "current_status_detail": current_status_detail,
+        "current_status_severity": current_status_severity,
+        "health_border_severity": _collector_health_border_severity(state=state, load_level=load_level),
+        "load_label": load_label,
+        "load_severity": load_severity,
+        "capacity_label": capacity_label,
+        "capacity_detail": capacity_detail,
+        "queue_pending_count": len(pending_channel_tasks),
+        "running_task_title": running_task.channel_title if running_task else "",
+        "running_task_messages_collected": running_task.messages_collected if running_task else 0,
+        "recent_zero_collect_count": recent_zero_collect_count,
+        "recent_unavailability_events": recent_unavailability_events,
+        "is_running": collector.is_running,
+        "next_available_label": _format_retry_hint(next_available_at or availability_next),
+    }
+
+
+async def _build_jobs_context(sched, db) -> list[dict]:
+    """Build a list of job dicts for the scheduler page template."""
+    # Always fetch potential jobs to get DB-sourced interval_minutes
+    potential = await sched.get_potential_jobs()
+    potential_map = {j["job_id"]: j for j in potential}
+
+    if sched.is_running:
+        raw = sched.get_all_jobs_next_run()
+        jobs = []
+        for job_id, next_run in raw.items():
+            db_interval = potential_map.get(job_id, {}).get("interval_minutes")
+            jobs.append({
+                "job_id": job_id,
+                "label": _job_label(job_id),
+                "next_run": next_run,
+                "interval_minutes": db_interval,
+            })
+        # Also include disabled jobs (not in APScheduler but exist in potential_map)
+        running_ids = set(raw.keys())
+        for j in potential:
+            if j["job_id"] not in running_ids:
+                jobs.append({
+                    "job_id": j["job_id"],
+                    "label": _job_label(j["job_id"]),
+                    "next_run": None,
+                    "interval_minutes": j["interval_minutes"],
+                })
+    else:
+        jobs = [
+            {
+                "job_id": j["job_id"],
+                "label": _job_label(j["job_id"]),
+                "next_run": None,
+                "interval_minutes": j["interval_minutes"],
+            }
+            for j in potential
+        ]
+
+    disabled_map = await db.repos.settings.get_settings_by_prefix("scheduler_job_disabled:")
+    for j in jobs:
+        val = disabled_map.get(f"scheduler_job_disabled:{j['job_id']}")
+        j["enabled"] = val != "1"
+        j["interval_editable"] = j["job_id"] not in ("photo_due", "photo_auto")
+    return jobs
+
+
+async def _notification_snapshot_payload(request: Request) -> dict[str, object]:
+    snapshot = await deps.get_db(request).repos.runtime_snapshots.get_snapshot("notification_target_status")
+    payload = snapshot.payload if snapshot is not None else {}
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _load_pipeline_run_result_meta(db, tasks) -> dict[int, dict[str, object]]:
+    run_ids_by_task_id: dict[int, int] = {}
+    for task in tasks:
+        if task.id is None or task.task_type.value != "pipeline_run" or not task.note:
+            continue
+        match = _PIPELINE_RUN_NOTE_RE.search(task.note)
+        if match is None:
+            continue
+        run_ids_by_task_id[task.id] = int(match.group(1))
+    if not run_ids_by_task_id:
+        return {}
+
+    runs = await asyncio.gather(*(db.repos.generation_runs.get(run_id) for run_id in run_ids_by_task_id.values()))
+    result: dict[int, dict[str, object]] = {}
+    for task_id, run in zip(run_ids_by_task_id.keys(), runs, strict=False):
+        if run is None:
+            continue
+        metadata = run.metadata if isinstance(run.metadata, dict) else {}
+        raw_errors = metadata.get("node_errors")
+        node_errors = raw_errors if isinstance(raw_errors, list) else []
+        errors_count = len(node_errors)
+        first_error_detail: str | None = None
+        if node_errors and isinstance(node_errors[0], dict):
+            detail = node_errors[0].get("detail")
+            if isinstance(detail, str):
+                first_error_detail = detail
+        result[task_id] = {
+            "kind": run.result_kind,
+            "count": run.result_count,
+            "label": result_kind_label(run.result_kind),
+            "errors_count": errors_count,
+            "first_error_detail": first_error_detail,
+        }
+    return result


### PR DESCRIPTION
## Что

Первый срез атомизации `src/web/routes/scheduler.py` (#654, подзадача #402 AC1). Тяжёлая сборка контекста вынесена в новый `src/web/scheduler/context.py`:
- `_build_collector_health_context` + presentation-хелперы (`_compute_load_level`, `_current_status_presentation`, `_load_presentation`, `_collector_health_border_severity`, `_collector_health_recommendations`, `_dedupe_recent_unavailability_events`, `_as_utc_datetime`, `_format_retry_hint`, `_job_label`)
- `_build_jobs_context`, `_load_pipeline_run_result_meta`, `_notification_snapshot_payload`
- `_worker_status` / `_is_worker_alive`
- константы `JOB_LABELS`, `WORKER_HEARTBEAT_STALE_AFTER_SEC`, `_PIPELINE_RUN_NOTE_RE`

`routes/scheduler.py` **ре-экспортирует** перенесённые имена (через `__all__`), поэтому:
- `src/web/search/handlers.py` (`from src.web.routes.scheduler import _is_worker_alive`) работает без правок;
- тесты, импортирующие хелперы и monkeypatch-ящие `src.web.routes.scheduler._is_worker_alive`, не трогаются.

Эндпоинты, redirect-хелперы и рендер страницы остаются в router — их атомизация в follow-up (part 2).

## Контракт

Без изменений: `/scheduler/*` маршруты, ключи контекста шаблона, worker-health banner, pause/resume (#663).

## Тесты

`pytest tests/routes/test_scheduler_routes.py tests/routes/test_scheduler_routes_edge_cases.py tests/test_web_scheduler_helpers.py tests/test_scheduler_ui.py tests/routes/test_search_routes.py` — 174 passed; `tests/test_web.py tests/test_cross_domain_regression_paths.py tests/test_settings_scheduler_pipeline_search_paths.py tests/test_real_telegram_policy.py` — 832 passed. Lint чист. Дифф 923 строки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)