### PR TITLE
refactor(agent): route remaining tool modules through AgentToolContext (#659)

### DIFF
--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -77,6 +77,9 @@ class AgentToolContext:
     async def require_phone_permission(self, phone: str, tool_name: str) -> dict | None:
         return await require_phone_permission(self.db, phone, tool_name)
 
+    async def resolve_live_read_phone(self, raw_phone: object, *, tool_name: str) -> tuple[str, dict | None]:
+        return await resolve_live_read_phone(self.db, self.client_pool, raw_phone, tool_name=tool_name)
+
     def channel_service(self):
         from src.services.channel_service import ChannelService
 

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -15,11 +15,11 @@ from src.agent.tools._registry import (
     available_live_read_phones,
     connected_phones_from_pool,
     get_accounts_with_flood_cleanup,
+    get_tool_context,
     is_flood_wait_active,
     normalize_flood_wait_until,
     normalize_phone,
     require_confirmation,
-    resolve_phone,
 )
 from src.services.account_availability import compute_account_availability
 from src.services.runtime_diagnostics import evaluate_worker_heartbeat
@@ -168,6 +168,7 @@ async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: object
 
 def register(db, client_pool, embedding_service, **kwargs):
     runtime = _runtime(kwargs, db, client_pool)
+    ctx = get_tool_context(kwargs, db=db, client_pool=client_pool, embedding_service=embedding_service)
     tools = []
 
     @tool(
@@ -387,7 +388,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def clear_flood_status(args):
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
         gate = require_confirmation(f"сбросит flood-wait для аккаунта {phone}", args)

--- a/src/agent/tools/dialogs.py
+++ b/src/agent/tools/dialogs.py
@@ -15,10 +15,6 @@ from src.agent.tools._registry import (
     get_tool_context,
     normalize_phone,
     require_confirmation,
-    require_phone_permission,
-    require_pool,
-    resolve_live_read_phone,
-    resolve_phone,
 )
 from src.parsers import normalize_identifier
 from src.services.telegram_actions import TelegramActionClientUnavailableError, TelegramActionService
@@ -53,18 +49,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         },
     )
     async def search_dialogs(args):
-        pool_gate = require_pool(client_pool, "Поиск диалогов")
+        pool_gate = ctx.require_pool("Поиск диалогов")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_live_read_phone(
-            db,
-            client_pool,
-            args.get("phone", ""),
-            tool_name="search_dialogs",
-        )
+        phone, err = await ctx.resolve_live_read_phone(args.get("phone", ""), tool_name="search_dialogs")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "search_dialogs")
+        perm_gate = await ctx.require_phone_permission(phone, "search_dialogs")
         if perm_gate:
             return perm_gate
         try:
@@ -160,10 +151,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         live_gate = ctx.require_live_runtime("Обновление диалогов", tool_name="refresh_dialogs")
         if live_gate:
             return live_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "refresh_dialogs")
+        perm_gate = await ctx.require_phone_permission(phone,"refresh_dialogs")
         if perm_gate:
             return perm_gate
         try:
@@ -197,13 +188,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         live_gate = ctx.require_live_runtime("Выход из диалогов", tool_name="leave_dialogs")
         if live_gate:
             return live_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
         dialog_ids_str = args.get("dialog_ids", "")
         if not dialog_ids_str:
             return _text_response("Ошибка: dialog_ids обязателен.")
-        perm_gate = await require_phone_permission(db, phone, "leave_dialogs")
+        perm_gate = await ctx.require_phone_permission(phone,"leave_dialogs")
         if perm_gate:
             return perm_gate
         gate = require_confirmation(
@@ -241,13 +232,13 @@ def register(db, client_pool, embedding_service, **kwargs):
         live_gate = ctx.require_live_runtime("Создание канала", tool_name="create_telegram_channel")
         if live_gate:
             return live_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
         title = args.get("title", "")
         if not title:
             return _text_response("Ошибка: title обязателен.")
-        perm_gate = await require_phone_permission(db, phone, "create_telegram_channel")
+        perm_gate = await ctx.require_phone_permission(phone,"create_telegram_channel")
         if perm_gate:
             return perm_gate
         gate = require_confirmation(f"создаст новый Telegram-канал '{title}'", args)
@@ -312,7 +303,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     async def clear_dialog_cache(args):
         phone = normalize_phone(args.get("phone", ""))
         if phone:
-            perm_gate = await require_phone_permission(db, phone, "clear_dialog_cache")
+            perm_gate = await ctx.require_phone_permission(phone,"clear_dialog_cache")
             if perm_gate:
                 return perm_gate
         else:
@@ -381,15 +372,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         identifier = (args.get("identifier") or "").strip()
         if not identifier:
             return _text_response("Ошибка: identifier обязателен.")
-        phone, err = await resolve_live_read_phone(
-            db,
-            client_pool,
-            args.get("phone", ""),
-            tool_name="resolve_entity",
-        )
+        phone, err = await ctx.resolve_live_read_phone(args.get("phone", ""), tool_name="resolve_entity")
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "resolve_entity")
+        perm_gate = await ctx.require_phone_permission(phone,"resolve_entity")
         if perm_gate:
             return perm_gate
         try:

--- a/src/agent/tools/messaging.py
+++ b/src/agent/tools/messaging.py
@@ -22,5 +22,5 @@ def register(db, client_pool, embedding_service, **kwargs):
     tools.extend(register_pin_media_tools(ctx, client_pool))
     tools.extend(register_admin_moderation_tools(ctx, client_pool))
     tools.extend(register_chat_state_read_tools(db, ctx, client_pool))
-    tools.extend(register_queue_status_tools(db))
+    tools.extend(register_queue_status_tools(db, ctx))
     return tools

--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -11,7 +11,6 @@ from src.agent.tools._registry import (
     arg_bool,
     require_confirmation,
     resolve_entity,
-    resolve_live_read_phone,
 )
 from src.agent.tools._telegram_runtime import find_single_dialog_id_by_title
 from src.agent.tools.messaging_schemas import (
@@ -212,7 +211,7 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         live_gate = ctx.require_live_runtime("Чтение сообщений", tool_name="read_messages")
         if live_gate:
             return live_gate
-        phone, err = await resolve_live_read_phone(db, client_pool, args.get("phone", ""), tool_name="read_messages")
+        phone, err = await ctx.resolve_live_read_phone(args.get("phone", ""), tool_name="read_messages")
         if err:
             return err
         perm_gate = await ctx.require_phone_permission(phone, "read_messages")

--- a/src/agent/tools/photo_loader.py
+++ b/src/agent/tools/photo_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from src.agent.tools._registry import get_tool_context
 from src.agent.tools.photo_loader_read import (
     register_auto_read_tools,
     register_batch_read_tools,
@@ -15,14 +16,14 @@ from src.agent.tools.photo_loader_write import (
 
 
 def register(db, client_pool, embedding_service, **kwargs):
-    del embedding_service, kwargs
+    ctx = get_tool_context(kwargs, db=db, client_pool=client_pool, embedding_service=embedding_service)
     tools = []
     tools.extend(register_batch_read_tools(db, client_pool))
-    tools.extend(register_send_tools(db, client_pool))
+    tools.extend(register_send_tools(db, ctx, client_pool))
     tools.extend(register_auto_read_tools(db, client_pool))
-    auto_write_tools = register_auto_write_tools(db, client_pool)
+    auto_write_tools = register_auto_write_tools(db, ctx, client_pool)
     tools.extend(auto_write_tools[:2])
-    tools.extend(register_batch_write_tools(db, client_pool))
+    tools.extend(register_batch_write_tools(db, ctx, client_pool))
     tools.extend(auto_write_tools[2:])
-    tools.extend(register_dialog_tools(db, client_pool))
+    tools.extend(register_dialog_tools(db, ctx, client_pool))
     return tools

--- a/src/agent/tools/photo_loader_read.py
+++ b/src/agent/tools/photo_loader_read.py
@@ -5,7 +5,7 @@ from typing import Any
 from claude_agent_sdk import tool
 
 from src.agent.tools._photo_loader_runtime import photo_auto_upload_service, photo_task_service
-from src.agent.tools._registry import _text_response, require_phone_permission, require_pool, resolve_phone
+from src.agent.tools._registry import _text_response
 from src.agent.tools.photo_loader_schemas import (
     LIST_AUTO_UPLOADS_SCHEMA,
     LIST_PHOTO_BATCHES_SCHEMA,
@@ -99,7 +99,7 @@ def register_auto_read_tools(db: Any, client_pool: Any) -> list[Any]:
     return tools
 
 
-def register_dialog_tools(db: Any, client_pool: Any) -> list[Any]:
+def register_dialog_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
     tools: list[Any] = []
 
     @tool(
@@ -108,13 +108,13 @@ def register_dialog_tools(db: Any, client_pool: Any) -> list[Any]:
         LIST_PHOTO_DIALOGS_SCHEMA,
     )
     async def list_photo_dialogs(args):
-        pool_gate = require_pool(client_pool, "Список диалогов для фото")
+        pool_gate = ctx.require_pool("Список диалогов для фото")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "list_photo_dialogs")
+        perm_gate = await ctx.require_phone_permission(phone, "list_photo_dialogs")
         if perm_gate:
             return perm_gate
         try:
@@ -143,13 +143,13 @@ def register_dialog_tools(db: Any, client_pool: Any) -> list[Any]:
         REFRESH_PHOTO_DIALOGS_SCHEMA,
     )
     async def refresh_photo_dialogs(args):
-        pool_gate = require_pool(client_pool, "Обновление кэша диалогов")
+        pool_gate = ctx.require_pool("Обновление кэша диалогов")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "refresh_photo_dialogs")
+        perm_gate = await ctx.require_phone_permission(phone, "refresh_photo_dialogs")
         if perm_gate:
             return perm_gate
         from src.agent.tools._registry import require_confirmation

--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -14,9 +14,6 @@ from src.agent.tools._photo_loader_runtime import (
 from src.agent.tools._registry import (
     _text_response,
     require_confirmation,
-    require_phone_permission,
-    require_pool,
-    resolve_phone,
 )
 from src.agent.tools.photo_loader_schemas import (
     CANCEL_PHOTO_ITEM_SCHEMA,
@@ -34,7 +31,7 @@ from src.services import photo_task_service as photo_task_module
 from src.utils.datetime import parse_required_schedule_datetime
 
 
-def register_send_tools(db: Any, client_pool: Any) -> list[Any]:
+def register_send_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
     tools: list[Any] = []
 
     @tool(
@@ -46,13 +43,13 @@ def register_send_tools(db: Any, client_pool: Any) -> list[Any]:
         SEND_PHOTOS_NOW_SCHEMA,
     )
     async def send_photos_now(args):
-        pool_gate = require_pool(client_pool, "Отправка фото")
+        pool_gate = ctx.require_pool("Отправка фото")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "send_photos_now")
+        perm_gate = await ctx.require_phone_permission(phone, "send_photos_now")
         if perm_gate:
             return perm_gate
         gate = require_confirmation("отправит фото в Telegram-диалог", args)
@@ -89,13 +86,13 @@ def register_send_tools(db: Any, client_pool: Any) -> list[Any]:
         SCHEDULE_PHOTOS_SCHEMA,
     )
     async def schedule_photos(args):
-        pool_gate = require_pool(client_pool, "Планирование фото")
+        pool_gate = ctx.require_pool("Планирование фото")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "schedule_photos")
+        perm_gate = await ctx.require_phone_permission(phone, "schedule_photos")
         if perm_gate:
             return perm_gate
         gate = require_confirmation("запланирует отправку фото", args)
@@ -150,7 +147,7 @@ def register_send_tools(db: Any, client_pool: Any) -> list[Any]:
     return tools
 
 
-def register_batch_write_tools(db: Any, client_pool: Any) -> list[Any]:
+def register_batch_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
     tools: list[Any] = []
 
     @tool(
@@ -161,13 +158,13 @@ def register_batch_write_tools(db: Any, client_pool: Any) -> list[Any]:
         CREATE_PHOTO_BATCH_SCHEMA,
     )
     async def create_photo_batch(args):
-        pool_gate = require_pool(client_pool, "Создание батча фото")
+        pool_gate = ctx.require_pool("Создание батча фото")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "create_photo_batch")
+        perm_gate = await ctx.require_phone_permission(phone, "create_photo_batch")
         if perm_gate:
             return perm_gate
         target = args.get("target", "")
@@ -202,7 +199,7 @@ def register_batch_write_tools(db: Any, client_pool: Any) -> list[Any]:
         RUN_PHOTO_DUE_SCHEMA,
     )
     async def run_photo_due(args):
-        pool_gate = require_pool(client_pool, "Обработка фото")
+        pool_gate = ctx.require_pool("Обработка фото")
         if pool_gate:
             return pool_gate
         gate = require_confirmation("отправит все запланированные фото в Telegram", args)
@@ -221,7 +218,7 @@ def register_batch_write_tools(db: Any, client_pool: Any) -> list[Any]:
     return tools
 
 
-def register_auto_write_tools(db: Any, client_pool: Any) -> list[Any]:
+def register_auto_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
     tools: list[Any] = []
 
     @tool(
@@ -276,13 +273,13 @@ def register_auto_write_tools(db: Any, client_pool: Any) -> list[Any]:
         CREATE_AUTO_UPLOAD_SCHEMA,
     )
     async def create_auto_upload(args):
-        pool_gate = require_pool(client_pool, "Создание автозагрузки")
+        pool_gate = ctx.require_pool("Создание автозагрузки")
         if pool_gate:
             return pool_gate
-        phone, err = await resolve_phone(db, args.get("phone", ""))
+        phone, err = await ctx.resolve_phone(args.get("phone", ""))
         if err:
             return err
-        perm_gate = await require_phone_permission(db, phone, "create_auto_upload")
+        perm_gate = await ctx.require_phone_permission(phone, "create_auto_upload")
         if perm_gate:
             return perm_gate
         folder_path = args.get("folder_path", "")

--- a/src/agent/tools/telegram_queue.py
+++ b/src/agent/tools/telegram_queue.py
@@ -14,7 +14,6 @@ from src.agent.tools._registry import (
     arg_str,
     normalize_phone,
     require_confirmation,
-    require_phone_permission,
 )
 from src.models import TelegramCommand, TelegramCommandStatus
 from src.services.telegram_command_service import TelegramCommandService
@@ -138,7 +137,7 @@ def _reaction_wait_line(state_counts: dict[str, int]) -> str | None:
     return "Ожидание реакций: " + ", ".join(parts) + "."
 
 
-def register_queue_status_tools(db: Any) -> list[Any]:
+def register_queue_status_tools(db: Any, ctx: Any) -> list[Any]:
     tools: list[Any] = []
 
     @tool(
@@ -156,7 +155,7 @@ def register_queue_status_tools(db: Any) -> list[Any]:
         except ToolInputError as exc:
             return exc.to_response()
 
-        perm_gate = await require_phone_permission(db, phone, "get_telegram_queue_status")
+        perm_gate = await ctx.require_phone_permission(phone, "get_telegram_queue_status")
         if perm_gate:
             return perm_gate
 
@@ -239,7 +238,7 @@ def register_queue_status_tools(db: Any) -> list[Any]:
                 f"Задание #{command_id} не найдено или не в статусе 'ждёт' (отменять можно только PENDING)."
             )
         command_phone = str(command.payload.get("phone") or "")
-        perm_gate = await require_phone_permission(db, command_phone, "cancel_telegram_command")
+        perm_gate = await ctx.require_phone_permission(command_phone, "cancel_telegram_command")
         if perm_gate:
             return perm_gate
         gate = require_confirmation(f"отменит задание очереди id={command_id}", args)
@@ -278,7 +277,7 @@ def register_queue_status_tools(db: Any) -> list[Any]:
         # PHONE_BINDED_TOOLS, so a phone-restricted agent calling it with no phone (which would
         # bulk-cancel across ALL accounts) must still be gated. require_phone_permission returns
         # None when no ACL is configured, so this stays a no-op for single-admin deployments.
-        perm_gate = await require_phone_permission(db, phone, "clear_pending_telegram_commands")
+        perm_gate = await ctx.require_phone_permission(phone, "clear_pending_telegram_commands")
         if perm_gate:
             return perm_gate
         scope_parts = []


### PR DESCRIPTION
## Что

Закрывает **#659** (подзадача #402). Tool-модули, которые ещё звали модульные хелперы `resolve_phone`/`require_phone_permission`/`resolve_live_read_phone`/`require_pool` напрямую, переведены на общий `AgentToolContext`:

- `_registry`: добавлен метод-обёртка `AgentToolContext.resolve_live_read_phone()`
- `dialogs.py`, `messaging_chat_state.py`, `accounts.py` → `ctx.*` (в `accounts.register` добавлен `get_tool_context`)
- `photo_loader_read/_write.py`, `telegram_queue.py`: `ctx` протянут параметром в sub-регистраторы (`db, ctx, client_pool`) по образцу `register_chat_state_read_tools`; агрегаторы (`photo_loader.register`, `messaging.register`) передают общий `ctx`

## Контракт

Без изменений: имена tools, схемы, output-формы, permission/`confirm=true` семантика, live/snapshot runtime-ошибки. Модульные хелперы (используются тестами напрямую) сохранены — инструменты теперь доходят до них через контекст.

## Тесты

`pytest tests/test_agent_tools_registry.py tests/test_tool_permissions.py tests/test_agent_tool_smoke_contract.py` — 145 passed. Широкий прогон `-k "agent_tool or tool_permission or photo or dialog or messaging or telegram_queue or accounts"` — 2034 passed, 20 skipped. Lint чист. Дифф 122 строки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)