### PR TITLE
refactor(providers): dedup runtime-options mapping into provider_registry (#658)

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -487,3 +487,43 @@ class ProviderRuntimeConfig:
         if ":" in self.selected_model:
             return self.selected_model
         return f"{self.provider}:{self.selected_model}"
+
+
+def runtime_options_for_config(cfg: ProviderRuntimeConfig) -> tuple[str, dict[str, object]]:
+    """Map a provider config to its LangChain runtime ``(model_provider, kwargs)``.
+
+    Single source of truth shared by the deepagents and runtime-registry stacks
+    (#658). Collects non-empty plain fields, folds in secret fields, and applies
+    the provider-specific base_url normalization (Ollama auth headers, Z.AI
+    canonical endpoint) plus the Z.AI legacy-Anthropic-proxy guard.
+    """
+    spec = provider_spec(cfg.provider)
+    if spec is None:
+        raise RuntimeError(f"Unknown provider: {cfg.provider}")
+
+    model_provider = spec.resolved_runtime_provider
+    extra: dict[str, object] = {
+        key: value for key, value in cfg.plain_fields.items() if value.strip()
+    }
+    if cfg.provider == "ollama":
+        api_key = cfg.secret_fields.get("api_key", "").strip()
+        extra["base_url"] = normalize_ollama_base_url(
+            str(extra.get("base_url", "")),
+            api_key,
+        )
+        if api_key:
+            extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
+        return model_provider, extra
+
+    extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
+    if cfg.provider == "zai":
+        raw_base_url = cfg.plain_fields.get("base_url", "")
+        if is_zai_legacy_anthropic_base_url(raw_base_url):
+            raise RuntimeError(
+                "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
+                "anthropic provider with this URL instead, or use the OpenAI-compatible "
+                f"endpoint {ZAI_GENERAL_BASE_URL}. Coding Plan users can explicitly set "
+                f"{ZAI_CODING_BASE_URL}."
+            )
+        extra["base_url"] = normalize_zai_base_url(raw_base_url)
+    return model_provider, extra

--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -28,6 +28,7 @@ from src.agent.provider_registry import (
     normalize_urlish,
     normalize_zai_base_url,
     provider_spec,
+    runtime_options_for_config,
 )
 from src.config import AppConfig, resolve_session_encryption_secret
 from src.database import Database
@@ -464,37 +465,8 @@ class ProviderConfigService:
         self,
         cfg: ProviderRuntimeConfig,
     ) -> tuple[str, dict[str, object]]:
-        spec = provider_spec(cfg.provider)
-        if spec is None:
-            raise RuntimeError(f"Unknown provider: {cfg.provider}")
-
-        model_provider = spec.resolved_runtime_provider
-        extra: dict[str, object] = {
-            key: value for key, value in cfg.plain_fields.items() if value.strip()
-        }
-        if cfg.provider == "ollama":
-            api_key = cfg.secret_fields.get("api_key", "").strip()
-            extra["base_url"] = self.normalize_ollama_base_url(
-                str(extra.get("base_url", "")),
-                api_key,
-            )
-            if api_key:
-                extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
-            return model_provider, extra
-
-        extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
-        if cfg.provider == "zai":
-            raw_base_url = cfg.plain_fields.get("base_url", "")
-            if is_zai_legacy_anthropic_base_url(raw_base_url):
-                raise RuntimeError(
-                    "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
-                    "anthropic provider with this URL instead, or use the OpenAI-compatible "
-                    f"endpoint {ZAI_GENERAL_BASE_URL}. Coding Plan users can explicitly set "
-                    f"{ZAI_CODING_BASE_URL}."
-                )
-            normalized_base_url = normalize_zai_base_url(raw_base_url)
-            extra["base_url"] = normalized_base_url
-        return model_provider, extra
+        # Single source of truth shared with the runtime-registry stack (#658).
+        return runtime_options_for_config(cfg)
 
     def config_fingerprint(
         self,

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -10,6 +10,7 @@ from src.agent.provider_registry import (
     normalize_ollama_base_url,
     normalize_zai_base_url,
     provider_spec,
+    runtime_options_for_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -290,35 +291,8 @@ class RuntimeProviderRegistry:
 
     @staticmethod
     def _runtime_options_for_config(cfg: Any) -> tuple[str, dict[str, object]]:
-        spec = provider_spec(cfg.provider)
-        if spec is None:
-            raise RuntimeError(f"Unknown provider: {cfg.provider}")
-
-        model_provider = spec.resolved_runtime_provider
-        extra: dict[str, object] = {
-            key: value for key, value in cfg.plain_fields.items() if value.strip()
-        }
-        if cfg.provider == "ollama":
-            api_key = cfg.secret_fields.get("api_key", "").strip()
-            extra["base_url"] = normalize_ollama_base_url(
-                str(extra.get("base_url", "")),
-                api_key,
-            )
-            if api_key:
-                extra["client_kwargs"] = {"headers": {"Authorization": f"Bearer {api_key}"}}
-            return model_provider, extra
-
-        extra.update({key: value for key, value in cfg.secret_fields.items() if value.strip()})
-        if cfg.provider == "zai":
-            raw_base_url = cfg.plain_fields.get("base_url", "")
-            if is_zai_legacy_anthropic_base_url(raw_base_url):
-                raise RuntimeError(
-                    "This URL is the Z.AI Anthropic-compatible proxy. Configure the "
-                    "anthropic provider with this URL instead, or use the OpenAI-compatible "
-                    "endpoint."
-                )
-            extra["base_url"] = normalize_zai_base_url(raw_base_url)
-        return model_provider, extra
+        # Single source of truth shared with the deepagents stack (#658).
+        return runtime_options_for_config(cfg)
 
     @staticmethod
     def _response_text(response: Any) -> str:


### PR DESCRIPTION
## Summary
First step of **#658** (split provider stack). The deepagents stack (`ProviderConfigService.deepagents_runtime_options`) and the runtime-registry stack (`RuntimeProviderRegistry._runtime_options_for_config`) each carried a ~95%-identical copy of the config → LangChain `(model_provider, kwargs)` mapping.

This extracts the single canonical mapper `runtime_options_for_config()` into `src/agent/provider_registry.py` — the canon module that already defines `ProviderRuntimeConfig`, `provider_spec`, and all the base_url helpers — and has both stacks delegate to it.

## Why provider_registry
`ProviderRuntimeConfig` and `normalize_ollama_base_url` / `normalize_zai_base_url` / `is_zai_legacy_anthropic_base_url` / the Z.AI URL constants all already live there, and the module imports nothing from `services/` — no circular-import risk.

## Behavior note
The two former copies disagreed only in the Z.AI legacy-proxy `RuntimeError` text. Standardized on the more informative variant (includes the OpenAI-compatible `ZAI_GENERAL_BASE_URL` + Coding Plan `ZAI_CODING_BASE_URL`). Both old/new texts contain the `"Anthropic-compatible proxy"` substring that the tests assert, so no contract change.

Storage format (`agent_deepagents_providers_v1`), provider names, runtime kwargs, and external behavior unchanged.

## Test plan
- `ruff check` — clean
- `pytest test_provider_service*.py test_agent_provider_service.py test_provider_runtime_integration.py test_deepagents_sync_provider_paths.py test_agent.py` — 383 passed, 1 skipped
- `pytest test_cli_provider.py test_settings_routes_provider_notifications.py` — 82 passed

Diff: +46 / −60 = 106 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)