### PR TITLE
docs(database): establish db.repos as canonical + ratchet pass-through surface (#660)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,12 +47,32 @@
 
 ## Database Access Pattern
 
+`db.repos.<repo>.<method>()` — **канонический** низкоуровневый доступ к БД. Новый код
+обращается к репозиториям напрямую через `db.repos`, а не через pass-through-методы
+фасада/бандлов.
+
 ```python
-# Репозитории через db.repos
-db.repos.channels.get_all()
+# Репозитории через db.repos (канон)
+db.repos.channels.get_channels(active_only=True, include_filtered=False)
 db.repos.generation_runs.list_pending_moderation(pipeline_id=1)
-db.repos.settings.get("key")
+db.repos.settings.get_setting("key")
 ```
+
+### Bundles и facade — compat-шимы
+
+- `src/database/facade.py` (`Database`) исторически экспонирует ~90 методов вида
+  `self._require(); return await self._<repo>.<method>(...)` — это механические
+  pass-through к репозиториям. Они сохраняются как **compat-шимы** на время окна
+  совместимости; новый код их не наращивает (`db.get_setting(k)` → `db.repos.settings.get_setting(k)`,
+  `db.get_channels(...)` → `db.repos.channels.get_channels(...)`).
+- `src/database/bundles.py` (`AccountBundle`, `ChannelBundle`, …) группирует несколько
+  репозиториев под сервисную границу (`ChannelBundle` агрегирует `channels` + `channel_stats`
+  + `tasks`). Бандлы остаются там, где дают осмысленную агрегацию; чисто
+  переименовывающие 1:1-методы — тоже compat-шимы.
+
+Структурный guard `tests/test_db_access_conventions.py` фиксирует текущее число
+pass-through-методов (ratchet «только вниз») — добавление новых pass-through падает в CI,
+вынуждая использовать `db.repos`.
 
 ## Web App Wiring
 

--- a/tests/test_db_access_conventions.py
+++ b/tests/test_db_access_conventions.py
@@ -1,0 +1,50 @@
+"""Structural guards for the database access boundary (#660).
+
+`db.repos.<repo>.<method>()` is the canonical low-level DB access path. The
+facade (`src/database/facade.py`) and bundles (`src/database/bundles.py`) expose
+many mechanical pass-throughs that are kept as compatibility shims — but they
+must not grow. These ratchet tests fail when the pass-through surface increases,
+nudging new code toward `db.repos` (and focused services) instead.
+
+The baselines are deliberately downward-only: when you delete a shim and migrate
+its callers, lower the matching baseline so the ratchet keeps tightening.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+FACADE = SRC_DIR / "database" / "facade.py"
+BUNDLES = SRC_DIR / "database" / "bundles.py"
+
+# Current size of the pass-through surface. These are CAPS, not exact counts:
+# the guard prevents growth. Lower them whenever shims are removed.
+FACADE_PASSTHROUGH_BASELINE = 88
+BUNDLE_METHOD_BASELINE = 135
+
+# Every facade pass-through opens with `self._require()`; counting it is a
+# robust, signature-shape-independent proxy for the pass-through surface.
+_REQUIRE_RE = re.compile(r"self\._require\(\)")
+# Bundle delegating methods, excluding the `from_database` constructors and dunders.
+_BUNDLE_METHOD_RE = re.compile(r"^    (?:async )?def (?!from_database\b|__)\w+", re.MULTILINE)
+
+
+def test_facade_passthrough_surface_does_not_grow():
+    count = len(_REQUIRE_RE.findall(FACADE.read_text()))
+    assert count <= FACADE_PASSTHROUGH_BASELINE, (
+        f"facade.py pass-through count grew to {count} (baseline "
+        f"{FACADE_PASSTHROUGH_BASELINE}).\n"
+        "Do not add new `self._require(); return await self._<repo>...` pass-throughs — "
+        "call db.repos.<repo>.<method>() directly. If you removed shims, lower the baseline."
+    )
+
+
+def test_bundle_method_surface_does_not_grow():
+    count = len(_BUNDLE_METHOD_RE.findall(BUNDLES.read_text()))
+    assert count <= BUNDLE_METHOD_BASELINE, (
+        f"bundles.py method count grew to {count} (baseline {BUNDLE_METHOD_BASELINE}).\n"
+        "Prefer db.repos or a focused service over a new bundle pass-through. "
+        "If you removed methods, lower the baseline."
+    )


### PR DESCRIPTION
## Summary
Conservative first step of **#660**. Establishes `db.repos.<repo>.<method>()` as the canonical low-level DB access path and locks the bundle/facade pass-through surface so it can only shrink.

- **`docs/architecture.md`** — `db.repos` documented as canonical; `facade.py` (~90 `self._require()` pass-throughs) and `bundles.py` documented as compatibility shims that new code must not grow. Fixed the stale example (`get_all()`/`get("key")` → the real `get_channels(...)`/`get_setting(...)`).
- **`tests/test_db_access_conventions.py`** (new) — downward-only ratchet guards (model: `tests/test_sql_conventions.py`). Fail CI when the facade pass-through count (>88) or bundle method count (>135) grows. Baselines are caps; removing shims should lower them.

## Why conservative
Per the agreed scope (#402), bundles/facade pass-throughs stay as compat shims during the compatibility window — no public methods deleted. The guard enforces AC bullet 2 ("new code paths prefer db.repos") structurally without touching production code.

## Test plan
- `ruff check` — clean
- `pytest tests/test_db_access_conventions.py` — 2 passed
- `pytest tests/test_bundles.py tests/repositories/` — 376 passed

No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)