### PR TITLE
refactor(web): migrate request-handler DB calls to db.repos (#660)

### DIFF
--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -162,7 +162,7 @@ async def rename_thread(request: Request, thread_id: int) -> AgentJson:
 
 async def get_channels_json(request: Request) -> AgentJson:
     db = deps.get_db(request)
-    channels = await db.get_channels(active_only=True, include_filtered=False)
+    channels = await db.repos.channels.get_channels(active_only=True, include_filtered=False)
     return AgentJson(
         [
             {

--- a/src/web/filter/handlers.py
+++ b/src/web/filter/handlers.py
@@ -22,7 +22,7 @@ from src.web.filter.responses import (
 
 
 async def _dev_mode_enabled(request: Request) -> bool:
-    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
+    return (await deps.get_db(request).repos.settings.get_setting("agent_dev_mode_enabled") or "0") == "1"
 
 
 async def filter_manage(request: Request) -> FilterTemplate:
@@ -147,7 +147,7 @@ async def analyze_channels(request: Request) -> FilterRedirect:
     await analyzer.apply_filters(report)
 
     purged_count = 0
-    auto_delete = await db.get_setting("auto_delete_filtered")
+    auto_delete = await db.repos.settings.get_setting("auto_delete_filtered")
     if auto_delete == "1" and report.filtered_count > 0:
         channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
         pk_map = {ch.channel_id: ch.id for ch in channels if ch.id is not None}
@@ -182,7 +182,7 @@ async def apply_filters(request: Request) -> FilterRedirect:
 
 async def has_stats(request: Request) -> dict:
     db = deps.get_db(request)
-    channels = await db.get_channels(active_only=True, include_filtered=False)
+    channels = await db.repos.channels.get_channels(active_only=True, include_filtered=False)
     if not channels:
         return {"has_stats": True}
     stats_map = await db.get_latest_stats_for_all()

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -133,8 +133,8 @@ async def save_credentials(
     db = request.app.state.db
     auth = request.app.state.auth
 
-    await db.set_setting("tg_api_id", str(api_id))
-    await db.set_setting("tg_api_hash", api_hash)
+    await db.repos.settings.set_setting("tg_api_id", str(api_id))
+    await db.repos.settings.set_setting("tg_api_hash", api_hash)
     auth.update_credentials(api_id, api_hash)
 
     return RedirectResponse(url="/auth/login", status_code=303)

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -160,7 +160,7 @@ async def collect_all_stats(request: Request):
     if existing:
         return RedirectResponse(url="/channels?error=stats_running", status_code=303)
 
-    channels = await db.get_channels(active_only=True, include_filtered=False)
+    channels = await db.repos.channels.get_channels(active_only=True, include_filtered=False)
     latest_stats = await db.get_latest_stats_for_all()
     channels_without_stats = [ch for ch in channels if ch.channel_id not in latest_stats]
     channels_with_stats = [ch for ch in channels if ch.channel_id in latest_stats]

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -260,7 +260,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     if not isinstance(availability_retry_after, int):
         availability_retry_after = None
     available_accounts_now = max(0, len(connected_active_accounts) - len(flooded_accounts))
-    active_unfiltered_channels = len(await db.get_channels(active_only=True, include_filtered=False))
+    active_unfiltered_channels = len(await db.repos.channels.get_channels(active_only=True, include_filtered=False))
     recent_tasks = await db.get_collection_tasks(limit=200)
     recent_zero_collect_count = sum(
         1

--- a/src/web/scheduler/handlers.py
+++ b/src/web/scheduler/handlers.py
@@ -207,7 +207,7 @@ async def set_job_interval(request: Request, job_id: str) -> SchedulerRedirect:
 async def start_scheduler(request: Request) -> SchedulerRedirect:
     if _shutting_down(request):
         return SchedulerRedirect(error="shutting_down")
-    await deps.get_db(request).set_setting("scheduler_autostart", "1")
+    await deps.get_db(request).repos.settings.set_setting("scheduler_autostart", "1")
     return await enqueue_scheduler_command(
         request,
         "scheduler.reconcile",
@@ -216,7 +216,7 @@ async def start_scheduler(request: Request) -> SchedulerRedirect:
 
 
 async def stop_scheduler(request: Request) -> SchedulerRedirect:
-    await deps.get_db(request).set_setting("scheduler_autostart", "0")
+    await deps.get_db(request).repos.settings.set_setting("scheduler_autostart", "0")
     return await enqueue_scheduler_command(
         request,
         "scheduler.reconcile",
@@ -227,7 +227,7 @@ async def stop_scheduler(request: Request) -> SchedulerRedirect:
 async def pause_collection_queue(request: Request) -> SchedulerRedirect:
     if _shutting_down(request):
         return SchedulerRedirect(error="shutting_down")
-    await deps.get_db(request).set_setting("collection_queue_paused", "1")
+    await deps.get_db(request).repos.settings.set_setting("collection_queue_paused", "1")
     return await enqueue_scheduler_command(
         request,
         "collection.pause",
@@ -238,7 +238,7 @@ async def pause_collection_queue(request: Request) -> SchedulerRedirect:
 async def resume_collection_queue(request: Request) -> SchedulerRedirect:
     if _shutting_down(request):
         return SchedulerRedirect(error="shutting_down")
-    await deps.get_db(request).set_setting("collection_queue_paused", "0")
+    await deps.get_db(request).repos.settings.set_setting("collection_queue_paused", "0")
     return await enqueue_scheduler_command(
         request,
         "collection.resume",

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -116,7 +116,7 @@ async def render_search_page(
         min_length, max_length = None, None
 
     service = deps.search_service(request)
-    channels = await db.get_channels()
+    channels = await db.repos.channels.get_channels()
     runtime_mode = getattr(request.app.state, "runtime_mode", "web")
 
     # Browse mode: channel_id without query shows latest messages from that channel
@@ -260,8 +260,8 @@ async def translate_message(request: Request, message_db_id: int) -> SearchJson:
 
     translated = await translation_service.translate_message(
         msg.text, detected, target_lang,
-        provider_name=await db.get_setting("translation_provider"),
-        model=await db.get_setting("translation_model"),
+        provider_name=await db.repos.settings.get_setting("translation_provider"),
+        model=await db.repos.settings.get_setting("translation_model"),
     )
     if translated:
         target = "en" if target_lang == "en" else "custom"

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -135,13 +135,13 @@ async def _reload_llm_providers(request: Request) -> None:
 async def _semantic_settings_context(request: Request) -> dict[str, object]:
     db = deps.get_db(request)
     last_embedded_id = parse_int_setting(
-        await db.get_setting(LAST_EMBEDDED_ID_SETTING),
+        await db.repos.settings.get_setting(LAST_EMBEDDED_ID_SETTING),
         setting_name=LAST_EMBEDDED_ID_SETTING,
         default=0,
         logger=logger,
     )
     batch_size = parse_int_setting(
-        await db.get_setting(EMBEDDINGS_BATCH_SIZE_SETTING),
+        await db.repos.settings.get_setting(EMBEDDINGS_BATCH_SIZE_SETTING),
         setting_name=EMBEDDINGS_BATCH_SIZE_SETTING,
         default=DEFAULT_EMBEDDINGS_BATCH_SIZE,
         logger=logger,
@@ -150,15 +150,15 @@ async def _semantic_settings_context(request: Request) -> dict[str, object]:
     embeddings_count = await db.repos.messages.count_embeddings()
     return {
         "semantic_embeddings_provider": (
-            await db.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
+            await db.repos.settings.get_setting(EMBEDDINGS_PROVIDER_SETTING) or DEFAULT_EMBEDDINGS_PROVIDER
         ),
         "semantic_embeddings_model": (
-            await db.get_setting(EMBEDDINGS_MODEL_SETTING) or DEFAULT_EMBEDDINGS_MODEL
+            await db.repos.settings.get_setting(EMBEDDINGS_MODEL_SETTING) or DEFAULT_EMBEDDINGS_MODEL
         ),
         "semantic_embeddings_api_key": (
-            CREDENTIALS_MASK if await db.get_setting(EMBEDDINGS_API_KEY_SETTING) else ""
+            CREDENTIALS_MASK if await db.repos.settings.get_setting(EMBEDDINGS_API_KEY_SETTING) else ""
         ),
-        "semantic_embeddings_base_url": await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
+        "semantic_embeddings_base_url": await db.repos.settings.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
         "semantic_embeddings_batch_size": batch_size,
         "semantic_last_embedded_id": last_embedded_id,
         "semantic_embedding_dimensions": embedding_dimensions,
@@ -175,7 +175,7 @@ def _settings_agent_manager(request: Request) -> tuple[AgentManager, bool]:
 
 
 async def _dev_mode_enabled(request: Request) -> bool:
-    return (await deps.get_db(request).get_setting("agent_dev_mode_enabled") or "0") == "1"
+    return (await deps.get_db(request).repos.settings.get_setting("agent_dev_mode_enabled") or "0") == "1"
 
 
 async def _require_agent_dev_mode(
@@ -432,21 +432,21 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
     auth = deps.get_auth(request)
     db = deps.get_db(request)
     pool = deps.get_pool(request)
-    api_id_raw = await db.get_setting("tg_api_id") or ""
-    api_hash_raw = await db.get_setting("tg_api_hash") or ""
+    api_id_raw = await db.repos.settings.get_setting("tg_api_id") or ""
+    api_hash_raw = await db.repos.settings.get_setting("tg_api_hash") or ""
     min_subscribers_filter = parse_int_setting(
-        await db.get_setting("min_subscribers_filter"),
+        await db.repos.settings.get_setting("min_subscribers_filter"),
         setting_name="min_subscribers_filter",
         default=0,
         logger=logger,
     )
-    auto_delete_filtered = (await db.get_setting("auto_delete_filtered") or "0") == "1"
-    auto_delete_on_collect = (await db.get_setting("auto_delete_on_collect") or "0") == "1"
-    saved_interval = await db.get_setting("collect_interval_minutes")
-    agent_dev_mode_enabled = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
-    agent_backend_override = await db.get_setting("agent_backend_override") or "auto"
+    auto_delete_filtered = (await db.repos.settings.get_setting("auto_delete_filtered") or "0") == "1"
+    auto_delete_on_collect = (await db.repos.settings.get_setting("auto_delete_on_collect") or "0") == "1"
+    saved_interval = await db.repos.settings.get_setting("collect_interval_minutes")
+    agent_dev_mode_enabled = (await db.repos.settings.get_setting("agent_dev_mode_enabled") or "0") == "1"
+    agent_backend_override = await db.repos.settings.get_setting("agent_backend_override") or "auto"
     agent_prompt_template = (
-        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
+        await db.repos.settings.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
     )
     if agent_backend_override not in {"auto", "claude", "deepagents"}:
         agent_backend_override = "auto"
@@ -468,7 +468,7 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
     # it is enforced rather than silently shown as the default. Render as int when
     # the value is whole (the typed CLI/web write paths only ever emit integers).
     reaction_min_interval_value = parse_float_setting(
-        await db.get_setting(REACTION_MIN_INTERVAL_SETTING),
+        await db.repos.settings.get_setting(REACTION_MIN_INTERVAL_SETTING),
         setting_name=REACTION_MIN_INTERVAL_SETTING,
         default=DEFAULT_REACTION_MIN_INTERVAL_SEC,
         logger=logger,
@@ -535,11 +535,11 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
     ]
     semantic_context = await _semantic_settings_context(request)
 
-    translation_provider = await db.get_setting("translation_provider") or ""
-    translation_model = await db.get_setting("translation_model") or ""
-    translation_target_lang = await db.get_setting("translation_target_lang") or ""
-    translation_source_filter = await db.get_setting("translation_source_filter") or ""
-    translation_auto_on_collect = await db.get_setting("translation_auto_on_collect") or "0"
+    translation_provider = await db.repos.settings.get_setting("translation_provider") or ""
+    translation_model = await db.repos.settings.get_setting("translation_model") or ""
+    translation_target_lang = await db.repos.settings.get_setting("translation_target_lang") or ""
+    translation_source_filter = await db.repos.settings.get_setting("translation_source_filter") or ""
+    translation_auto_on_collect = await db.repos.settings.get_setting("translation_auto_on_collect") or "0"
     language_stats = await db.repos.messages.get_language_stats()
 
     from src.agent.tools.permissions import (
@@ -585,7 +585,7 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
         "img_provider_writes_enabled": img_provider_service.writes_enabled,
         "img_provider_views": img_provider_views,
         "img_provider_options": available_img_options,
-        "default_image_model": await db.get_setting("default_image_model") or "",
+        "default_image_model": await db.repos.settings.get_setting("default_image_model") or "",
         **semantic_context,
         "phone_perm_contexts": phone_perm_contexts,
         "translation_provider": translation_provider,
@@ -603,8 +603,8 @@ async def handle_save_scheduler_settings(
     form: SchedulerSettingsForm,
 ) -> SettingsFlash:
     db = deps.get_db(request)
-    await db.set_setting("collect_interval_minutes", str(form.interval_minutes))
-    await db.set_setting(REACTION_MIN_INTERVAL_SETTING, str(form.reaction_min_interval_sec))
+    await db.repos.settings.set_setting("collect_interval_minutes", str(form.interval_minutes))
+    await db.repos.settings.set_setting(REACTION_MIN_INTERVAL_SETTING, str(form.reaction_min_interval_sec))
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler:
         scheduler.update_interval(form.interval_minutes)
@@ -617,24 +617,24 @@ async def handle_save_semantic_search_settings(
 ) -> SettingsFlash:
     db = deps.get_db(request)
     current_values = {
-        EMBEDDINGS_PROVIDER_SETTING: await db.get_setting(EMBEDDINGS_PROVIDER_SETTING)
+        EMBEDDINGS_PROVIDER_SETTING: await db.repos.settings.get_setting(EMBEDDINGS_PROVIDER_SETTING)
         or DEFAULT_EMBEDDINGS_PROVIDER,
-        EMBEDDINGS_MODEL_SETTING: await db.get_setting(EMBEDDINGS_MODEL_SETTING)
+        EMBEDDINGS_MODEL_SETTING: await db.repos.settings.get_setting(EMBEDDINGS_MODEL_SETTING)
         or DEFAULT_EMBEDDINGS_MODEL,
-        EMBEDDINGS_BASE_URL_SETTING: await db.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
-        EMBEDDINGS_API_KEY_SETTING: await db.get_setting(EMBEDDINGS_API_KEY_SETTING) or "",
+        EMBEDDINGS_BASE_URL_SETTING: await db.repos.settings.get_setting(EMBEDDINGS_BASE_URL_SETTING) or "",
+        EMBEDDINGS_API_KEY_SETTING: await db.repos.settings.get_setting(EMBEDDINGS_API_KEY_SETTING) or "",
     }
     changed = (
         current_values[EMBEDDINGS_PROVIDER_SETTING] != form.provider
         or current_values[EMBEDDINGS_MODEL_SETTING] != form.model
         or current_values[EMBEDDINGS_BASE_URL_SETTING] != form.base_url
     )
-    await db.set_setting(EMBEDDINGS_PROVIDER_SETTING, form.provider)
-    await db.set_setting(EMBEDDINGS_MODEL_SETTING, form.model)
-    await db.set_setting(EMBEDDINGS_BASE_URL_SETTING, form.base_url)
-    await db.set_setting(EMBEDDINGS_BATCH_SIZE_SETTING, str(form.batch_size))
+    await db.repos.settings.set_setting(EMBEDDINGS_PROVIDER_SETTING, form.provider)
+    await db.repos.settings.set_setting(EMBEDDINGS_MODEL_SETTING, form.model)
+    await db.repos.settings.set_setting(EMBEDDINGS_BASE_URL_SETTING, form.base_url)
+    await db.repos.settings.set_setting(EMBEDDINGS_BATCH_SIZE_SETTING, str(form.batch_size))
     if form.api_key is not None and form.api_key != CREDENTIALS_MASK:
-        await db.set_setting(EMBEDDINGS_API_KEY_SETTING, form.api_key)
+        await db.repos.settings.set_setting(EMBEDDINGS_API_KEY_SETTING, form.api_key)
     if changed or form.reset_index:
         await db.repos.messages.reset_embeddings_index()
         deps.get_search_engine(request).invalidate_numpy_index()
@@ -668,10 +668,10 @@ async def handle_save_agent_settings(request: Request, form: AgentSettingsForm) 
         )
         return SettingsFlash(msg="tool_permissions_saved", fragment="pane-tool-permissions")
 
-    current_dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
-    current_backend_override = await db.get_setting("agent_backend_override") or "auto"
+    current_dev_mode = (await db.repos.settings.get_setting("agent_dev_mode_enabled") or "0") == "1"
+    current_backend_override = await db.repos.settings.get_setting("agent_backend_override") or "auto"
     current_prompt_template = (
-        await db.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
+        await db.repos.settings.get_setting(AGENT_PROMPT_TEMPLATE_SETTING) or DEFAULT_AGENT_PROMPT_TEMPLATE
     )
 
     if form.backend_override is None:
@@ -727,9 +727,9 @@ async def handle_save_agent_settings(request: Request, form: AgentSettingsForm) 
                 )
                 return SettingsFlash(error="agent_backend_claude_unavailable")
 
-    await db.set_setting("agent_dev_mode_enabled", "1" if dev_mode_enabled else "0")
-    await db.set_setting("agent_backend_override", backend_override)
-    await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
+    await db.repos.settings.set_setting("agent_dev_mode_enabled", "1" if dev_mode_enabled else "0")
+    await db.repos.settings.set_setting("agent_backend_override", backend_override)
+    await db.repos.settings.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
     agent_manager = deps.get_agent_manager(request)
     if agent_manager is not None:
         await agent_manager.refresh_settings_cache(preflight=True)
@@ -1023,12 +1023,12 @@ async def handle_test_all_agent_provider_models_status(request: Request) -> Sett
 
 async def handle_save_filters(request: Request, form: FiltersForm) -> SettingsFlash:
     db = deps.get_db(request)
-    await db.set_setting("min_subscribers_filter", form.min_subscribers)
-    await db.set_setting(
+    await db.repos.settings.set_setting("min_subscribers_filter", form.min_subscribers)
+    await db.repos.settings.set_setting(
         "auto_delete_filtered",
         "1" if form.auto_delete_filtered else "0",
     )
-    await db.set_setting(
+    await db.repos.settings.set_setting(
         "auto_delete_on_collect",
         "1" if form.auto_delete_on_collect else "0",
     )
@@ -1071,13 +1071,13 @@ async def handle_save_credentials(request: Request, form: CredentialsForm) -> Se
         return SettingsFlash(error="invalid_api_id")
 
     if id_changed:
-        await db.set_setting("tg_api_id", form.api_id)
+        await db.repos.settings.set_setting("tg_api_id", form.api_id)
     if hash_changed:
-        await db.set_setting("tg_api_hash", form.api_hash)
+        await db.repos.settings.set_setting("tg_api_hash", form.api_hash)
 
     if id_changed or hash_changed:
-        actual_id = form.api_id if id_changed else (await db.get_setting("tg_api_id") or "")
-        actual_hash = form.api_hash if hash_changed else (await db.get_setting("tg_api_hash") or "")
+        actual_id = form.api_id if id_changed else (await db.repos.settings.get_setting("tg_api_id") or "")
+        actual_hash = form.api_hash if hash_changed else (await db.repos.settings.get_setting("tg_api_hash") or "")
         if actual_id and actual_hash:
             if not actual_id.isdigit():
                 return SettingsFlash(error="invalid_api_id")
@@ -1172,7 +1172,7 @@ async def handle_save_image_providers(
         if not has_key and not has_env:
             return SettingsFlash(error="image_provider_missing_key")
     await service.save_provider_configs(configs)
-    await deps.get_db(request).set_setting("default_image_model", form.default_model)
+    await deps.get_db(request).repos.settings.set_setting("default_image_model", form.default_model)
     return SettingsFlash(msg="image_saved")
 
 
@@ -1191,11 +1191,11 @@ async def handle_save_translation_settings(
     form: TranslationSettingsForm,
 ) -> SettingsFlash:
     db = deps.get_db(request)
-    await db.set_setting("translation_provider", form.provider)
-    await db.set_setting("translation_model", form.model)
-    await db.set_setting("translation_target_lang", form.target_lang)
-    await db.set_setting("translation_source_filter", form.source_filter)
-    await db.set_setting("translation_auto_on_collect", "1" if form.auto_on_collect else "0")
+    await db.repos.settings.set_setting("translation_provider", form.provider)
+    await db.repos.settings.set_setting("translation_model", form.model)
+    await db.repos.settings.set_setting("translation_target_lang", form.target_lang)
+    await db.repos.settings.set_setting("translation_source_filter", form.source_filter)
+    await db.repos.settings.set_setting("translation_auto_on_collect", "1" if form.auto_on_collect else "0")
     return SettingsFlash(msg="translation_saved", fragment="pane-translation")
 
 
@@ -1214,7 +1214,7 @@ async def handle_translation_run_batch(
     form: TranslationRunForm,
 ) -> SettingsFlash:
     db = deps.get_db(request)
-    source_filter_raw = await db.get_setting("translation_source_filter") or ""
+    source_filter_raw = await db.repos.settings.get_setting("translation_source_filter") or ""
     source_filter = [source.strip() for source in source_filter_raw.split(",") if source.strip()]
 
     from src.models import CollectionTaskType, TranslateBatchTaskPayload


### PR DESCRIPTION
## Summary
Second step of **#660** (after #685 established `db.repos` as canonical + the ratchet guard). Migrates the high-traffic web request-handler slice off the mechanical facade pass-throughs onto `db.repos`:

- `db.get_setting(k)` → `db.repos.settings.get_setting(k)`
- `db.set_setting(k, v)` → `db.repos.settings.set_setting(k, v)`
- `db.get_channels(...)` → `db.repos.channels.get_channels(...)`

Across `settings`/`search`/`scheduler`/`filter`/`agent` handlers plus `auth` and `channel_collection` routes (69 call sites, 8 files).

## Safety
- `db.repos.settings`/`channels` and the facade's `self._settings`/`self._channels` are the **same** repository objects (built together in `Database.connect`), so behavior is identical — pure path rename.
- Facade shims kept intact (compatibility window; ratchet baseline unchanged).
- `bootstrap.py` startup path intentionally **left on the facade** so its `self._require()` guard still applies before the connection is fully wired.

## Test plan
- `ruff check src/` — clean
- `pytest tests/routes/ tests/test_web.py tests/test_db_access_conventions.py` — **1055 passed**

Diff: +69 / −69 = 138 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)