### PR TITLE
[codex] Collect channel metadata and stats on add

### DIFF
--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -9,6 +9,12 @@ from src.cli import runtime
 from src.cli.commands.common import resolve_channel
 from src.models import Channel, CollectionTaskStatus
 from src.parsers import deduplicate_identifiers, parse_file, parse_identifiers
+from src.services.channel_onboarding import (
+    channel_from_resolved_info,
+    channel_with_meta,
+    enqueue_stats_for_new_channels,
+    fetch_channel_meta,
+)
 from src.services.channel_service import ChannelService
 from src.telegram.backends import adapt_transport_session
 from src.telegram.collector import Collector
@@ -128,22 +134,17 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Could not resolve channel: {args.identifier}")
                     return
 
-                # Fetch full metadata
-                meta = await pool.fetch_channel_meta(info["channel_id"], info.get("channel_type"))
+                existing = await db.get_channel_by_channel_id(int(info["channel_id"]))
+                meta = await fetch_channel_meta(pool, int(info["channel_id"]), info.get("channel_type"))
                 deactivate = info.get("deactivate", False)
-                await db.add_channel(
-                    Channel(
-                        channel_id=info["channel_id"],
-                        title=info["title"],
-                        username=info["username"],
-                        channel_type=info.get("channel_type"),
-                        is_active=not deactivate,
-                        about=meta.get("about") if meta else None,
-                        linked_chat_id=meta.get("linked_chat_id") if meta else None,
-                        has_comments=meta.get("has_comments", False) if meta else False,
-                        created_at=info.get("created_at"),
+                channel = channel_from_resolved_info(info, meta)
+                await db.add_channel(channel)
+                if existing is None and channel.is_active:
+                    await enqueue_stats_for_new_channels(
+                        db.create_stats_task,
+                        [channel.channel_id],
+                        context="cli channel add",
                     )
-                )
                 msg = f"Added channel: {info['title']} ({info['channel_id']})"
                 if deactivate:
                     msg += f" [WARN: deactivated, type={info['channel_type']}]"
@@ -190,6 +191,7 @@ def run(args: argparse.Namespace) -> None:
                 existing_ids = {ch.channel_id for ch in existing}
 
                 added = skipped = failed = 0
+                stats_channel_ids: list[int] = []
                 for ident in identifiers:
                     try:
                         info = await pool.resolve_channel(ident.strip())
@@ -213,21 +215,23 @@ def run(args: argparse.Namespace) -> None:
                         continue
 
                     deactivate = info.get("deactivate", False)
-                    await db.add_channel(
-                        Channel(
-                            channel_id=info["channel_id"],
-                            title=info["title"],
-                            username=info["username"],
-                            channel_type=info.get("channel_type"),
-                            is_active=not deactivate,
-                            created_at=info.get("created_at"),
-                        )
+                    meta = await fetch_channel_meta(
+                        pool, int(info["channel_id"]), info.get("channel_type")
                     )
+                    channel = channel_from_resolved_info(info, meta)
+                    await db.add_channel(channel)
                     existing_ids.add(info["channel_id"])
+                    if channel.is_active:
+                        stats_channel_ids.append(channel.channel_id)
                     status = f"WARN ({info['channel_type']})" if deactivate else "OK"
                     print(f"{status}: {ident} — {info.get('title', '')} ({info['channel_id']})")
                     added += 1
 
+                await enqueue_stats_for_new_channels(
+                    db.create_stats_task,
+                    stats_channel_ids,
+                    context="cli channel import",
+                )
                 print(
                     f"\nTotal: {len(identifiers)}, Added: {added}, "
                     f"Skipped: {skipped}, Failed: {failed}"
@@ -392,6 +396,7 @@ def run(args: argparse.Namespace) -> None:
                 existing = await db.get_channels()
                 existing_ids = {ch.channel_id for ch in existing}
                 added = skipped = failed = 0
+                stats_channel_ids: list[int] = []
                 for did in dialog_ids:
                     info = info_map.get(did)
                     if not info:
@@ -402,19 +407,28 @@ def run(args: argparse.Namespace) -> None:
                         print(f"SKIP: {did} — already exists ({info.get('title', '')})")
                         skipped += 1
                         continue
-                    await db.add_channel(
-                        Channel(
-                            channel_id=info["channel_id"],
-                            title=info["title"],
-                            username=info.get("username"),
-                            channel_type=info.get("channel_type"),
-                            is_active=True,
-                            created_at=info.get("created_at"),
-                        )
+                    meta = await fetch_channel_meta(
+                        pool, int(info["channel_id"]), info.get("channel_type")
                     )
+                    channel = Channel(
+                        channel_id=int(info["channel_id"]),
+                        title=info["title"],
+                        username=info.get("username"),
+                        channel_type=info.get("channel_type"),
+                        is_active=True,
+                        created_at=info.get("created_at"),
+                    )
+                    channel = channel_with_meta(channel, meta)
+                    await db.add_channel(channel)
                     existing_ids.add(info["channel_id"])
+                    stats_channel_ids.append(channel.channel_id)
                     print(f"OK: {info.get('title', did)} ({info['channel_id']})")
                     added += 1
+                await enqueue_stats_for_new_channels(
+                    db.create_stats_task,
+                    stats_channel_ids,
+                    context="cli channel add-bulk",
+                )
                 print(f"\nAdded: {added}, Skipped: {skipped}, Failed: {failed}")
 
             elif args.channel_action == "tag":

--- a/src/config.py
+++ b/src/config.py
@@ -27,6 +27,7 @@ class SchedulerConfig(BaseModel):
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1
     max_flood_wait_sec: int = 300
+    stats_worker_count: int = 3
 
 
 class NotificationsConfig(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -165,6 +165,7 @@ class StatsAllTaskPayload(BaseModel):
     next_index: int = 0
     channels_ok: int = 0
     channels_err: int = 0
+    remaining_channel_ids: list[int] | None = None
 
 
 class SqStatsTaskPayload(BaseModel):

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -25,12 +25,18 @@ class SearchEngine:
         *,
         config=None,
     ):
+        create_stats_task = None
         if isinstance(search, Database):
+            create_stats_task = search.create_stats_task
             search = SearchBundle.from_database(search)
+        fetch_channel_meta = getattr(pool, "fetch_channel_meta", None) if pool else None
         self._search_bundle = search
         embedding_service = EmbeddingService(search, config=config)
         self._local = LocalSearch(search, embedding_service=embedding_service)
-        self._telegram = TelegramSearch(pool, SearchPersistence(search))
+        self._telegram = TelegramSearch(
+            pool,
+            SearchPersistence(search, create_stats_task, fetch_channel_meta),
+        )
 
     @property
     def semantic_available(self) -> bool:

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable, Iterable
 
 from src.database.bundles import SearchBundle
-from src.models import Channel, Message
+from src.models import Channel, Message, StatsAllTaskPayload
+from src.services.channel_onboarding import channel_with_meta, enqueue_stats_for_new_channels
 
 logger = logging.getLogger(__name__)
 
 
 class SearchPersistence:
-    def __init__(self, search: SearchBundle):
+    def __init__(
+        self,
+        search: SearchBundle,
+        create_stats_task: Callable[[StatsAllTaskPayload], Awaitable[int]] | None = None,
+        fetch_channel_meta: Callable[[int, str | None], Awaitable[dict | None]] | None = None,
+    ):
         self._search = search
+        self._create_stats_task = create_stats_task
+        self._fetch_channel_meta = fetch_channel_meta
 
     async def cache_search_results(
         self,
@@ -19,8 +28,12 @@ class SearchPersistence:
         phone: str,
         query: str,
     ) -> list[Message]:
-        for ch in channels.values():
-            await self._search.add_channel(ch)
+        new_channel_ids = await self._cache_channels(channels.values())
+        await enqueue_stats_for_new_channels(
+            self._create_stats_task,
+            new_channel_ids,
+            context="telegram search cache",
+        )
 
         if messages:
             await self._search.insert_messages_batch(messages)
@@ -33,11 +46,36 @@ class SearchPersistence:
         channels: dict[int, Channel],
         messages: list[Message],
     ) -> list[Message]:
-        for ch in channels.values():
-            await self._search.add_channel(ch)
+        new_channel_ids = await self._cache_channels(channels.values())
+        await enqueue_stats_for_new_channels(
+            self._create_stats_task,
+            new_channel_ids,
+            context="telegram chat search cache",
+        )
         if messages:
             await self._search.insert_messages_batch(messages)
         return await self._load_persisted_messages(messages)
+
+    async def _cache_channels(self, channels: Iterable[Channel]) -> list[int]:
+        new_channel_ids: list[int] = []
+        for ch in channels:
+            existing = await self._search.channels.get_channel_by_channel_id(ch.channel_id)
+            channel = ch
+            if existing is None and ch.is_active:
+                channel = channel_with_meta(ch, await self._fetch_meta(ch))
+            await self._search.add_channel(channel)
+            if existing is None and channel.is_active:
+                new_channel_ids.append(channel.channel_id)
+        return new_channel_ids
+
+    async def _fetch_meta(self, channel: Channel) -> dict | None:
+        if self._fetch_channel_meta is None:
+            return None
+        try:
+            return await self._fetch_channel_meta(channel.channel_id, channel.channel_type)
+        except Exception as exc:
+            logger.warning("Failed to fetch search channel metadata for %s: %s", channel.channel_id, exc)
+            return None
 
     async def _load_persisted_messages(self, messages: list[Message]) -> list[Message]:
         if not messages:

--- a/src/services/channel_onboarding.py
+++ b/src/services/channel_onboarding.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+from src.models import Channel, StatsAllTaskPayload
+
+logger = logging.getLogger(__name__)
+
+CreateStatsTask = Callable[[StatsAllTaskPayload], Awaitable[int]]
+
+
+def clean_channel_meta(meta: dict | None) -> dict:
+    if not meta:
+        return {"about": None, "linked_chat_id": None, "has_comments": False}
+    about = meta.get("about")
+    linked_chat_id = meta.get("linked_chat_id")
+    if not isinstance(about, str):
+        about = None
+    if isinstance(linked_chat_id, bool) or not isinstance(linked_chat_id, int):
+        linked_chat_id = None
+    has_comments = meta.get("has_comments")
+    if not isinstance(has_comments, bool):
+        has_comments = linked_chat_id is not None
+    return {
+        "about": about,
+        "linked_chat_id": linked_chat_id,
+        "has_comments": has_comments,
+    }
+
+
+async def fetch_channel_meta(pool: Any, channel_id: int, channel_type: str | None) -> dict | None:
+    fetcher = getattr(pool, "fetch_channel_meta", None)
+    if not callable(fetcher):
+        return None
+    try:
+        return await fetcher(channel_id, channel_type)
+    except Exception as exc:
+        logger.warning("Failed to fetch channel metadata for %s: %s", channel_id, exc)
+        return None
+
+
+def channel_from_resolved_info(info: dict[str, Any], meta: dict | None = None) -> Channel:
+    clean_meta = clean_channel_meta(meta)
+    return Channel(
+        channel_id=int(info["channel_id"]),
+        title=info.get("title"),
+        username=info.get("username"),
+        channel_type=info.get("channel_type"),
+        is_active=not info.get("deactivate", False),
+        about=clean_meta["about"],
+        linked_chat_id=clean_meta["linked_chat_id"],
+        has_comments=clean_meta["has_comments"],
+        created_at=info.get("created_at"),
+    )
+
+
+def channel_with_meta(channel: Channel, meta: dict | None = None) -> Channel:
+    clean_meta = clean_channel_meta(meta)
+    if clean_meta["about"] is None and clean_meta["linked_chat_id"] is None and not clean_meta["has_comments"]:
+        return channel
+    return channel.model_copy(
+        update={
+            "about": clean_meta["about"],
+            "linked_chat_id": clean_meta["linked_chat_id"],
+            "has_comments": clean_meta["has_comments"],
+        }
+    )
+
+
+async def get_existing_channel(store: Any, channel_id: int) -> Channel | None:
+    for name in ("get_by_channel_id", "get_channel_by_channel_id"):
+        getter = getattr(store, name, None)
+        if not callable(getter):
+            continue
+        try:
+            result = getter(channel_id)
+            if inspect.isawaitable(result):
+                return await result
+        except (AttributeError, TypeError):
+            continue
+    return None
+
+
+async def enqueue_stats_for_new_channels(
+    create_stats_task: CreateStatsTask | None,
+    channel_ids: Iterable[int],
+    *,
+    context: str,
+) -> int | None:
+    if create_stats_task is None:
+        return None
+    unique_ids = list(dict.fromkeys(int(channel_id) for channel_id in channel_ids))
+    if not unique_ids:
+        return None
+    try:
+        return await create_stats_task(StatsAllTaskPayload(channel_ids=unique_ids))
+    except Exception as exc:
+        logger.warning("Failed to enqueue stats task after %s: %s", context, exc)
+        return None

--- a/src/services/channel_onboarding.py
+++ b/src/services/channel_onboarding.py
@@ -79,6 +79,8 @@ async def get_existing_channel(store: Any, channel_id: int) -> Channel | None:
             result = getter(channel_id)
             if inspect.isawaitable(result):
                 return await result
+            if result is None or isinstance(result, Channel):
+                return result
         except (AttributeError, TypeError):
             continue
     return None

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -7,6 +7,13 @@ from typing import TYPE_CHECKING
 from src.database import Database
 from src.database.bundles import ChannelBundle
 from src.models import Channel
+from src.services.channel_onboarding import (
+    channel_from_resolved_info,
+    channel_with_meta,
+    enqueue_stats_for_new_channels,
+    fetch_channel_meta,
+    get_existing_channel,
+)
 from src.telegram.client_pool import ClientPool
 
 if TYPE_CHECKING:
@@ -40,21 +47,16 @@ class ChannelService:
         info = await self._pool.resolve_channel(identifier.strip())
         if not info:
             return False
-        meta = await self._pool.fetch_channel_meta(
-            info["channel_id"], info.get("channel_type")
-        )
-        channel = Channel(
-            channel_id=info["channel_id"],
-            title=info["title"],
-            username=info["username"],
-            channel_type=info.get("channel_type"),
-            is_active=not info.get("deactivate", False),
-            about=meta.get("about") if meta else None,
-            linked_chat_id=meta.get("linked_chat_id") if meta else None,
-            has_comments=meta.get("has_comments", False) if meta else False,
-            created_at=info.get("created_at"),
-        )
+        existing = await get_existing_channel(self._channels, int(info["channel_id"]))
+        meta = await fetch_channel_meta(self._pool, int(info["channel_id"]), info.get("channel_type"))
+        channel = channel_from_resolved_info(info, meta)
         await self._channels.add_channel(channel)
+        if existing is None and channel.is_active:
+            await enqueue_stats_for_new_channels(
+                self._channels.create_stats_task,
+                [channel.channel_id],
+                context="channel add",
+            )
         return True
 
     async def get_dialogs_with_added_flags(self) -> list[dict]:
@@ -78,20 +80,33 @@ class ChannelService:
         else:
             dialogs = await self._pool.get_dialogs()
         dialogs_map = {str(d["channel_id"]): d for d in dialogs}
+        stats_channel_ids: list[int] = []
         for cid in channel_ids:
             if cid not in dialogs_map:
                 continue
             dialog = dialogs_map[cid]
-            await self._channels.add_channel(
-                Channel(
-                    channel_id=dialog["channel_id"],
-                    title=dialog["title"],
-                    username=dialog["username"],
-                    channel_type=dialog.get("channel_type"),
-                    is_active=not dialog.get("deactivate", False),
-                    created_at=dialog.get("created_at"),
-                )
+            channel_id = int(dialog["channel_id"])
+            existing = await get_existing_channel(self._channels, channel_id)
+            meta = await fetch_channel_meta(
+                self._pool, channel_id, dialog.get("channel_type")
             )
+            channel = Channel(
+                channel_id=channel_id,
+                title=dialog["title"],
+                username=dialog["username"],
+                channel_type=dialog.get("channel_type"),
+                is_active=not dialog.get("deactivate", False),
+                created_at=dialog.get("created_at"),
+            )
+            channel = channel_with_meta(channel, meta)
+            await self._channels.add_channel(channel)
+            if existing is None and channel.is_active:
+                stats_channel_ids.append(channel.channel_id)
+        await enqueue_stats_for_new_channels(
+            self._channels.create_stats_task,
+            stats_channel_ids,
+            context="bulk dialog add",
+        )
 
     async def get_my_dialogs(self, phone: str, refresh: bool = False) -> list[dict]:
         """Get all dialogs for a specific account, enriched with already_added flag."""

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 from datetime import date, datetime, timezone
 
 from src.models import (
@@ -47,10 +48,10 @@ class StatsTaskHandler:
         channel_ids = payload.channel_ids
         channels_ok = payload.channels_ok or 0
         channels_err = payload.channels_err or 0
-        remaining_ids = (
-            list(payload.remaining_channel_ids)
+        remaining_ids = deque(
+            payload.remaining_channel_ids
             if payload.remaining_channel_ids is not None
-            else list(channel_ids[payload.next_index:])
+            else channel_ids[payload.next_index:]
         )
         next_index = len(channel_ids) - len(remaining_ids)
 
@@ -91,7 +92,7 @@ class StatsTaskHandler:
                 next_index=len(channel_ids) - len(remaining_ids),
                 channels_ok=channels_ok,
                 channels_err=channels_err,
-                remaining_channel_ids=remaining_ids,
+                remaining_channel_ids=list(remaining_ids),
             )
             await ctx.tasks.reschedule_stats_task(
                 task.id,
@@ -107,7 +108,7 @@ class StatsTaskHandler:
         cancelled = False
         reschedule_at: datetime | None = None
         fail_error: str | None = None
-        deferred_front: list[int] = []
+        deferred_front: deque[int] = deque()
 
         type_collect_unlocked = getattr(type(ctx.collector), "collect_channel_stats_unlocked", None)
         collect_stats = (
@@ -142,7 +143,7 @@ class StatsTaskHandler:
                 stop_workers = True
                 if channel_id in in_flight:
                     in_flight.remove(channel_id)
-                deferred_front.insert(0, channel_id)
+                deferred_front.appendleft(channel_id)
                 if run_after is not None:
                     reschedule_at = run_after
                 if error is not None:
@@ -172,7 +173,7 @@ class StatsTaskHandler:
                 async with state_lock:
                     if stop_workers or not remaining_ids:
                         return
-                    channel_id = remaining_ids.pop(0)
+                    channel_id = remaining_ids.popleft()
                     in_flight.append(channel_id)
 
                 channel = await ctx.channel_bundle.get_by_channel_id(channel_id)
@@ -231,9 +232,13 @@ class StatsTaskHandler:
                 if has_more:
                     await asyncio.sleep(ctx.collector.delay_between_channels_sec)
 
-        worker_count = self._stats_worker_count(len(remaining_ids))
-        workers = [asyncio.create_task(_worker()) for _ in range(worker_count)]
-        await asyncio.gather(*workers)
+        self._set_stats_all_running(True)
+        try:
+            worker_count = await self._stats_worker_count(len(remaining_ids))
+            workers = [asyncio.create_task(_worker()) for _ in range(worker_count)]
+            await asyncio.gather(*workers)
+        finally:
+            self._set_stats_all_running(False)
 
         if cancelled:
             return
@@ -264,23 +269,38 @@ class StatsTaskHandler:
             messages_collected=channels_ok + channels_err,
         )
 
-    def _stats_worker_count(self, remaining_count: int) -> int:
+    def _set_stats_all_running(self, running: bool) -> None:
+        setter = getattr(self._context.collector, "set_stats_all_running", None)
+        if callable(setter):
+            setter(running)
+        elif hasattr(self._context.collector, "_stats_all_running"):
+            setattr(self._context.collector, "_stats_all_running", running)
+
+    async def _stats_worker_count(self, remaining_count: int) -> int:
         ctx = self._context
         configured = 3
         config = ctx.config
         scheduler_config = getattr(config, "scheduler", config)
         if scheduler_config is not None:
             configured = int(getattr(scheduler_config, "stats_worker_count", configured) or configured)
-        collector_counter = getattr(ctx.collector, "stats_worker_count", None)
-        type_counter = getattr(type(ctx.collector), "stats_worker_count", None)
+        collector_counter = getattr(ctx.collector, "available_stats_worker_count", None)
+        type_counter = getattr(type(ctx.collector), "available_stats_worker_count", None)
         if callable(collector_counter) and callable(type_counter):
             try:
-                configured = int(collector_counter())
+                counter_result = collector_counter()
+                if asyncio.iscoroutine(counter_result):
+                    counter_result = await counter_result
+                configured = int(counter_result)
             except Exception:
                 logger.debug("Failed to read collector stats worker count", exc_info=True)
-        connected_count = len(getattr(ctx.client_pool, "clients", {}) or {})
-        if connected_count > 0:
-            configured = min(configured, connected_count)
+        else:
+            collector_counter = getattr(ctx.collector, "stats_worker_count", None)
+            type_counter = getattr(type(ctx.collector), "stats_worker_count", None)
+            if callable(collector_counter) and callable(type_counter):
+                try:
+                    configured = int(collector_counter())
+                except Exception:
+                    logger.debug("Failed to read collector stats worker count", exc_info=True)
         return max(1, min(configured, max(1, remaining_count)))
 
     async def handle_sq_stats(self, task: CollectionTask) -> None:

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -12,6 +12,7 @@ from src.models import (
     StatsAllTaskPayload,
 )
 from src.services.task_handlers.base import TaskHandlerContext
+from src.telegram.collector import AllStatsClientsFloodedError, NoActiveStatsClientsError
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +45,14 @@ class StatsTaskHandler:
             return
 
         channel_ids = payload.channel_ids
-        next_index = payload.next_index
         channels_ok = payload.channels_ok or 0
         channels_err = payload.channels_err or 0
+        remaining_ids = (
+            list(payload.remaining_channel_ids)
+            if payload.remaining_channel_ids is not None
+            else list(channel_ids[payload.next_index:])
+        )
+        next_index = len(channel_ids) - len(remaining_ids)
 
         logger.info(
             "Running stats task #%s: next_index=%d total=%d",
@@ -55,7 +61,7 @@ class StatsTaskHandler:
             len(channel_ids),
         )
 
-        if next_index >= len(channel_ids):
+        if not remaining_ids:
             await ctx.tasks.update_collection_task(
                 task.id,
                 CollectionTaskStatus.COMPLETED,
@@ -63,16 +69,8 @@ class StatsTaskHandler:
             )
             return
 
-        cursor = next_index
         collector_wait_sec = 0.0
-        while cursor < len(channel_ids):
-            if ctx.stop_event.is_set():
-                break
-
-            fresh = await ctx.tasks.get_collection_task(task.id)
-            if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
-                return
-
+        while not ctx.stop_event.is_set():
             if ctx.collector.is_running:
                 await asyncio.sleep(ctx.poll_interval_sec)
                 collector_wait_sec += ctx.poll_interval_sec
@@ -85,94 +83,15 @@ class StatsTaskHandler:
                     )
                     return
                 continue
-            collector_wait_sec = 0.0
+            break
 
-            channel_id = channel_ids[cursor]
-            channel = await ctx.channel_bundle.get_by_channel_id(channel_id)
-            if channel is None:
-                channels_err += 1
-                cursor += 1
-                progress_payload = StatsAllTaskPayload(
-                    channel_ids=channel_ids,
-                    next_index=cursor,
-                    channels_ok=channels_ok,
-                    channels_err=channels_err,
-                )
-                await ctx.tasks.persist_stats_progress(
-                    task.id,
-                    payload=progress_payload,
-                    messages_collected=channels_ok + channels_err,
-                )
-                continue
-
-            try:
-                result = await asyncio.wait_for(
-                    ctx.collector.collect_channel_stats(channel),
-                    timeout=ctx.channel_timeout_sec,
-                )
-            except asyncio.TimeoutError:
-                channels_err += 1
-                cursor += 1
-            except Exception as exc:
-                logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
-                channels_err += 1
-                cursor += 1
-            else:
-                fresh = await ctx.tasks.get_collection_task(task.id)
-                if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
-                    return
-                if result is None:
-                    availability = await ctx.collector.get_stats_availability()
-                    if (
-                        availability.state == "all_flooded"
-                        and availability.next_available_at_utc is not None
-                    ):
-                        reschedule_payload = StatsAllTaskPayload(
-                            channel_ids=channel_ids,
-                            next_index=cursor,
-                            channels_ok=channels_ok,
-                            channels_err=channels_err,
-                        )
-                        await ctx.tasks.reschedule_stats_task(
-                            task.id,
-                            payload=reschedule_payload,
-                            run_after=availability.next_available_at_utc,
-                            messages_collected=channels_ok + channels_err,
-                        )
-                        return
-
-                    await ctx.tasks.update_collection_task(
-                        task.id,
-                        CollectionTaskStatus.FAILED,
-                        messages_collected=channels_ok + channels_err,
-                        error="No active connected Telegram accounts",
-                    )
-                    return
-
-                channels_ok += 1
-                cursor += 1
-
-            progress_payload = StatsAllTaskPayload(
-                channel_ids=channel_ids,
-                next_index=cursor,
-                channels_ok=channels_ok,
-                channels_err=channels_err,
-            )
-            await ctx.tasks.persist_stats_progress(
-                task.id,
-                payload=progress_payload,
-                messages_collected=channels_ok + channels_err,
-            )
-
-            if cursor < len(channel_ids):
-                await asyncio.sleep(ctx.collector.delay_between_channels_sec)
-
-        if cursor < len(channel_ids):
+        if ctx.stop_event.is_set():
             reschedule_payload = StatsAllTaskPayload(
                 channel_ids=channel_ids,
-                next_index=cursor,
+                next_index=len(channel_ids) - len(remaining_ids),
                 channels_ok=channels_ok,
                 channels_err=channels_err,
+                remaining_channel_ids=remaining_ids,
             )
             await ctx.tasks.reschedule_stats_task(
                 task.id,
@@ -182,11 +101,187 @@ class StatsTaskHandler:
             )
             return
 
+        state_lock = asyncio.Lock()
+        in_flight: list[int] = []
+        stop_workers = False
+        cancelled = False
+        reschedule_at: datetime | None = None
+        fail_error: str | None = None
+        deferred_front: list[int] = []
+
+        type_collect_unlocked = getattr(type(ctx.collector), "collect_channel_stats_unlocked", None)
+        collect_stats = (
+            ctx.collector.collect_channel_stats_unlocked
+            if callable(type_collect_unlocked)
+            else ctx.collector.collect_channel_stats
+        )
+
+        async def _snapshot_payload() -> StatsAllTaskPayload:
+            async with state_lock:
+                remaining_snapshot = list(dict.fromkeys([*deferred_front, *in_flight, *remaining_ids]))
+                processed = len(channel_ids) - len(remaining_snapshot)
+                return StatsAllTaskPayload(
+                    channel_ids=channel_ids,
+                    next_index=processed,
+                    channels_ok=channels_ok,
+                    channels_err=channels_err,
+                    remaining_channel_ids=remaining_snapshot,
+                )
+
+        async def _persist_progress() -> None:
+            progress_payload = await _snapshot_payload()
+            await ctx.tasks.persist_stats_progress(
+                task.id,
+                payload=progress_payload,
+                messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
+            )
+
+        async def _defer_remaining(channel_id: int, run_after: datetime | None, error: str | None = None) -> None:
+            nonlocal stop_workers, reschedule_at, fail_error
+            async with state_lock:
+                stop_workers = True
+                if channel_id in in_flight:
+                    in_flight.remove(channel_id)
+                deferred_front.insert(0, channel_id)
+                if run_after is not None:
+                    reschedule_at = run_after
+                if error is not None:
+                    fail_error = error
+
+        async def _record_processed(channel_id: int, ok: bool) -> None:
+            nonlocal channels_ok, channels_err
+            async with state_lock:
+                if channel_id in in_flight:
+                    in_flight.remove(channel_id)
+                if ok:
+                    channels_ok += 1
+                else:
+                    channels_err += 1
+            await _persist_progress()
+
+        async def _worker() -> None:
+            nonlocal cancelled, stop_workers
+            while not ctx.stop_event.is_set():
+                fresh = await ctx.tasks.get_collection_task(task.id)
+                if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
+                    async with state_lock:
+                        cancelled = True
+                        stop_workers = True
+                    return
+
+                async with state_lock:
+                    if stop_workers or not remaining_ids:
+                        return
+                    channel_id = remaining_ids.pop(0)
+                    in_flight.append(channel_id)
+
+                channel = await ctx.channel_bundle.get_by_channel_id(channel_id)
+                if channel is None:
+                    await _record_processed(channel_id, ok=False)
+                    continue
+
+                try:
+                    result = await asyncio.wait_for(
+                        collect_stats(channel),
+                        timeout=ctx.channel_timeout_sec,
+                    )
+                except asyncio.TimeoutError:
+                    await _record_processed(channel_id, ok=False)
+                except AllStatsClientsFloodedError as exc:
+                    await _defer_remaining(channel_id, exc.next_available_at)
+                    return
+                except NoActiveStatsClientsError:
+                    await _defer_remaining(
+                        channel_id,
+                        None,
+                        error="No active connected Telegram accounts",
+                    )
+                    return
+                except Exception as exc:
+                    logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
+                    await _record_processed(channel_id, ok=False)
+                else:
+                    fresh = await ctx.tasks.get_collection_task(task.id)
+                    if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
+                        async with state_lock:
+                            cancelled = True
+                            stop_workers = True
+                        return
+                    if result is None:
+                        availability = await ctx.collector.get_stats_availability()
+                        if (
+                            availability.state == "all_flooded"
+                            and availability.next_available_at_utc is not None
+                        ):
+                            await _defer_remaining(channel_id, availability.next_available_at_utc)
+                            return
+                        if availability.state != "available":
+                            await _defer_remaining(
+                                channel_id,
+                                None,
+                                error="No active connected Telegram accounts",
+                            )
+                            return
+                        await _record_processed(channel_id, ok=False)
+                    else:
+                        await _record_processed(channel_id, ok=True)
+
+                async with state_lock:
+                    has_more = bool(remaining_ids) and not stop_workers
+                if has_more:
+                    await asyncio.sleep(ctx.collector.delay_between_channels_sec)
+
+        worker_count = self._stats_worker_count(len(remaining_ids))
+        workers = [asyncio.create_task(_worker()) for _ in range(worker_count)]
+        await asyncio.gather(*workers)
+
+        if cancelled:
+            return
+
+        if fail_error is not None:
+            progress_payload = await _snapshot_payload()
+            await ctx.tasks.update_collection_task(
+                task.id,
+                CollectionTaskStatus.FAILED,
+                messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
+                error=fail_error,
+            )
+            return
+
+        progress_payload = await _snapshot_payload()
+        if reschedule_at is not None or progress_payload.remaining_channel_ids:
+            await ctx.tasks.reschedule_stats_task(
+                task.id,
+                payload=progress_payload,
+                run_after=reschedule_at or datetime.now(timezone.utc),
+                messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
+            )
+            return
+
         await ctx.tasks.update_collection_task(
             task.id,
             CollectionTaskStatus.COMPLETED,
             messages_collected=channels_ok + channels_err,
         )
+
+    def _stats_worker_count(self, remaining_count: int) -> int:
+        ctx = self._context
+        configured = 3
+        config = ctx.config
+        scheduler_config = getattr(config, "scheduler", config)
+        if scheduler_config is not None:
+            configured = int(getattr(scheduler_config, "stats_worker_count", configured) or configured)
+        collector_counter = getattr(ctx.collector, "stats_worker_count", None)
+        type_counter = getattr(type(ctx.collector), "stats_worker_count", None)
+        if callable(collector_counter) and callable(type_counter):
+            try:
+                configured = int(collector_counter())
+            except Exception:
+                logger.debug("Failed to read collector stats worker count", exc_info=True)
+        connected_count = len(getattr(ctx.client_pool, "clients", {}) or {})
+        if connected_count > 0:
+            configured = min(configured, connected_count)
+        return max(1, min(configured, max(1, remaining_count)))
 
     async def handle_sq_stats(self, task: CollectionTask) -> None:
         ctx = self._context

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -14,6 +14,12 @@ from src.database import Database
 from src.database.live_accounts import load_live_usable_accounts
 from src.models import Account, RuntimeSnapshot, TelegramCommandStatus
 from src.scheduler.service import SchedulerManager
+from src.services.channel_onboarding import (
+    channel_from_resolved_info,
+    enqueue_stats_for_new_channels,
+    fetch_channel_meta,
+    get_existing_channel,
+)
 from src.services.notification_service import NotificationService
 from src.services.notification_target_service import NotificationTargetService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
@@ -701,23 +707,20 @@ class TelegramCommandDispatcher:
         info = await self._pool.resolve_channel(identifier)
         if not info:
             raise RuntimeError("resolve failed")
-        meta = await self._pool.fetch_channel_meta(info["channel_id"], info.get("channel_type"))
-        from src.models import Channel
-
-        await self._db.add_channel(
-            Channel(
-                channel_id=info["channel_id"],
-                title=info["title"],
-                username=info["username"],
-                channel_type=info.get("channel_type"),
-                is_active=not info.get("deactivate", False),
-                about=meta.get("about") if meta else None,
-                linked_chat_id=meta.get("linked_chat_id") if meta else None,
-                has_comments=meta.get("has_comments", False) if meta else False,
-                created_at=info.get("created_at"),
-            )
+        existing = await get_existing_channel(self._db, int(info["channel_id"]))
+        meta = await fetch_channel_meta(
+            self._pool, int(info["channel_id"]), info.get("channel_type")
         )
-        return {"channel_id": info["channel_id"]}
+        channel = channel_from_resolved_info(info, meta)
+        await self._db.add_channel(channel)
+        stats_task_id = None
+        if existing is None and channel.is_active:
+            stats_task_id = await enqueue_stats_for_new_channels(
+                self._db.create_stats_task,
+                [channel.channel_id],
+                context="channels.add_identifier",
+            )
+        return {"channel_id": info["channel_id"], "stats_task_id": stats_task_id}
 
     async def _handle_channels_collect_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
         if self._collector is None:
@@ -773,14 +776,13 @@ class TelegramCommandDispatcher:
         return {"updated": updated, "failed": failed}
 
     async def _handle_channels_import_batch(self, payload: dict[str, Any]) -> dict[str, Any]:
-        from src.models import Channel
-
         identifiers = [str(item).strip() for item in payload.get("identifiers", []) if str(item).strip()]
         existing = await self._db.get_channels()
         existing_ids = {channel.channel_id for channel in existing}
         added = 0
         skipped = 0
         failed = 0
+        stats_channel_ids: list[int] = []
         details: list[dict[str, Any]] = []
         for ident in identifiers:
             try:
@@ -795,20 +797,28 @@ class TelegramCommandDispatcher:
                 skipped += 1
                 details.append({"identifier": ident, "status": "skipped"})
                 continue
-            await self._db.add_channel(
-                Channel(
-                    channel_id=info["channel_id"],
-                    title=info["title"],
-                    username=info["username"],
-                    channel_type=info.get("channel_type"),
-                    is_active=not info.get("deactivate", False),
-                    created_at=info.get("created_at"),
-                )
+            meta = await fetch_channel_meta(
+                self._pool, int(info["channel_id"]), info.get("channel_type")
             )
+            channel = channel_from_resolved_info(info, meta)
+            await self._db.add_channel(channel)
             existing_ids.add(info["channel_id"])
+            if channel.is_active:
+                stats_channel_ids.append(channel.channel_id)
             added += 1
             details.append({"identifier": ident, "status": "added"})
-        return {"added": added, "skipped": skipped, "failed": failed, "details": details}
+        stats_task_id = await enqueue_stats_for_new_channels(
+            self._db.create_stats_task,
+            stats_channel_ids,
+            context="channels.import_batch",
+        )
+        return {
+            "added": added,
+            "skipped": skipped,
+            "failed": failed,
+            "details": details,
+            "stats_task_id": stats_task_id,
+        }
 
     async def _handle_dialogs_download_media(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])

--- a/src/telegram/account_lease_pool.py
+++ b/src/telegram/account_lease_pool.py
@@ -62,6 +62,26 @@ class AccountLeasePool:
 
             return None
 
+    async def available_exclusive_count(self, connected_phones: set[str]) -> int:
+        async with self._lock:
+            now = datetime.now(timezone.utc)
+            accounts = await load_live_usable_accounts(self._db, active_only=True)
+            count = 0
+            for account in accounts:
+                flood_until = normalize_utc(account.flood_wait_until)
+                if flood_until is not None and flood_until <= now:
+                    await self._db.update_account_flood(account.phone, None)
+                    account.flood_wait_until = None
+                    flood_until = None
+                if account.phone not in connected_phones:
+                    continue
+                if account.phone in self._in_use:
+                    continue
+                if flood_until is not None and flood_until > now:
+                    continue
+                count += 1
+            return count
+
     async def acquire_by_phone(self, phone: str, connected_phones: set[str]) -> AccountLease | None:
         async with self._lock:
             account = await self._get_account(phone)

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -457,6 +457,9 @@ class ClientPool:
                 return result
         return None
 
+    async def available_stats_client_count(self) -> int:
+        return await self._lease_pool.available_exclusive_count(self._connected_phones())
+
     async def get_client_by_phone(
         self,
         phone: str,

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -217,6 +217,13 @@ class Collector:
     def delay_between_channels_sec(self) -> int:
         return self._config.delay_between_channels_sec
 
+    def stats_worker_count(self) -> int:
+        configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
+        connected = len(getattr(self._pool, "clients", {}) or {})
+        if connected <= 0:
+            return configured
+        return max(1, min(configured, connected))
+
     async def get_stats_availability(self):
         return await self.get_collection_availability()
 
@@ -1353,6 +1360,9 @@ class Collector:
             finally:
                 self._stats_running = False
 
+    async def collect_channel_stats_unlocked(self, channel: Channel) -> ChannelStats | None:
+        return await self._collect_channel_stats(channel)
+
     async def _collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
         while True:
             result = await self._pool.get_available_client()
@@ -1517,30 +1527,55 @@ class Collector:
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
                 stats = {"channels": 0, "errors": 0}
-                for idx, channel in enumerate(channels):
-                    while True:
-                        try:
-                            async with self._stats_lock:
-                                await self._collect_channel_stats(channel)
-                            stats["channels"] += 1
-                            break
-                        except AllStatsClientsFloodedError as e:
-                            logger.warning(
-                                "All clients are flood-waited for stats. " "Waiting %ds until %s",
-                                e.retry_after_sec,
-                                e.next_available_at.isoformat(),
-                            )
-                            await asyncio.sleep(e.retry_after_sec)
-                        except NoActiveStatsClientsError:
-                            logger.error("No active connected clients for stats collection")
-                            stats["errors"] += len(channels) - idx
-                            return stats
-                        except Exception as e:
-                            logger.error("Stats error for %s: %s", channel.channel_id, e)
-                            stats["errors"] += 1
-                            break
-                    if idx < len(channels) - 1:
-                        await asyncio.sleep(self._config.delay_between_channels_sec)
+                if not channels:
+                    return stats
+
+                queue = list(channels)
+                state_lock = asyncio.Lock()
+
+                async def _worker() -> None:
+                    while not self._cancel_event.is_set():
+                        async with state_lock:
+                            if not queue:
+                                return
+                            channel = queue.pop(0)
+                        while True:
+                            try:
+                                result = await self._collect_channel_stats(channel)
+                                async with state_lock:
+                                    if result is None:
+                                        stats["errors"] += 1
+                                    else:
+                                        stats["channels"] += 1
+                                break
+                            except AllStatsClientsFloodedError as e:
+                                logger.warning(
+                                    "All clients are flood-waited for stats. Waiting %ds until %s",
+                                    e.retry_after_sec,
+                                    e.next_available_at.isoformat(),
+                                )
+                                await asyncio.sleep(e.retry_after_sec)
+                            except NoActiveStatsClientsError:
+                                logger.error("No active connected clients for stats collection")
+                                async with state_lock:
+                                    stats["errors"] += 1 + len(queue)
+                                    queue.clear()
+                                return
+                            except Exception as e:
+                                logger.error("Stats error for %s: %s", channel.channel_id, e)
+                                async with state_lock:
+                                    stats["errors"] += 1
+                                break
+                        async with state_lock:
+                            has_more = bool(queue)
+                        if has_more:
+                            await asyncio.sleep(self._config.delay_between_channels_sec)
+
+                workers = [
+                    asyncio.create_task(_worker())
+                    for _ in range(min(self.stats_worker_count(), len(channels)))
+                ]
+                await asyncio.gather(*workers)
                 return stats
             finally:
                 self._stats_all_running = False

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import date, datetime, timedelta, timezone
 
@@ -223,6 +224,25 @@ class Collector:
         if connected <= 0:
             return configured
         return max(1, min(configured, connected))
+
+    async def available_stats_worker_count(self) -> int:
+        configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
+        counter = getattr(self._pool, "available_stats_client_count", None)
+        if callable(counter):
+            try:
+                count = counter()
+                if asyncio.iscoroutine(count):
+                    count = await count
+                available = int(count)
+                if available > 0:
+                    return max(1, min(configured, available))
+                return 1
+            except Exception:
+                logger.debug("Failed to read available stats client count", exc_info=True)
+        return self.stats_worker_count()
+
+    def set_stats_all_running(self, running: bool) -> None:
+        self._stats_all_running = running
 
     async def get_stats_availability(self):
         return await self.get_collection_availability()
@@ -1530,7 +1550,7 @@ class Collector:
                 if not channels:
                     return stats
 
-                queue = list(channels)
+                queue = deque(channels)
                 state_lock = asyncio.Lock()
 
                 async def _worker() -> None:
@@ -1538,7 +1558,7 @@ class Collector:
                         async with state_lock:
                             if not queue:
                                 return
-                            channel = queue.pop(0)
+                            channel = queue.popleft()
                         while True:
                             try:
                                 result = await self._collect_channel_stats(channel)
@@ -1573,7 +1593,7 @@ class Collector:
 
                 workers = [
                     asyncio.create_task(_worker())
-                    for _ in range(min(self.stats_worker_count(), len(channels)))
+                    for _ in range(min(await self.available_stats_worker_count(), len(channels)))
                 ]
                 await asyncio.gather(*workers)
                 return stats

--- a/tests/test_account_lease_pool.py
+++ b/tests/test_account_lease_pool.py
@@ -60,6 +60,20 @@ async def test_acquire_available_returns_non_flooded_when_one_flooded(db):
 
 
 @pytest.mark.anyio
+async def test_available_exclusive_count_skips_flooded_disconnected_and_in_use(db):
+    phones = ["+70031", "+70032", "+70033", "+70034"]
+    for phone in phones:
+        await db.add_account(Account(phone=phone, session_string=phone, is_active=True))
+    await db.update_account_flood("+70032", datetime.now(timezone.utc) + timedelta(hours=1))
+
+    pool = AccountLeasePool(db, {"+70033"})
+
+    count = await pool.available_exclusive_count({"+70031", "+70032", "+70033"})
+
+    assert count == 1
+
+
+@pytest.mark.anyio
 async def test_is_flood_waited_returns_false_for_expired(db):
     """_is_flood_waited correctly ignores expired timestamps."""
     past = datetime.now(timezone.utc) - timedelta(seconds=1)

--- a/tests/test_channel_onboarding.py
+++ b/tests/test_channel_onboarding.py
@@ -1,0 +1,34 @@
+"""Tests for channel onboarding helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models import Channel
+from src.services.channel_onboarding import get_existing_channel
+
+
+class SyncChannelStore:
+    def __init__(self, channel: Channel | None):
+        self.channel = channel
+
+    def get_by_channel_id(self, channel_id: int) -> Channel | None:
+        if self.channel and self.channel.channel_id == channel_id:
+            return self.channel
+        return None
+
+
+@pytest.mark.anyio
+async def test_get_existing_channel_accepts_sync_store_result():
+    channel = Channel(channel_id=100, title="Existing")
+
+    result = await get_existing_channel(SyncChannelStore(channel), 100)
+
+    assert result == channel
+
+
+@pytest.mark.anyio
+async def test_get_existing_channel_accepts_sync_store_none():
+    result = await get_existing_channel(SyncChannelStore(None), 100)
+
+    assert result is None

--- a/tests/test_channel_service.py
+++ b/tests/test_channel_service.py
@@ -34,6 +34,8 @@ def _make_bundle() -> MagicMock:
     bundle.list_channels_with_counts = AsyncMock(return_value=[])
     bundle.get_latest_and_previous_stats = AsyncMock(return_value=({}, {}))
     bundle.add_channel = AsyncMock(return_value=1)
+    bundle.get_by_channel_id = AsyncMock(return_value=None)
+    bundle.create_stats_task = AsyncMock(return_value=10)
     bundle.get_by_pk = AsyncMock(return_value=None)
     bundle.set_active = AsyncMock(return_value=None)
     bundle.delete_channel = AsyncMock(return_value=None)

--- a/tests/test_channel_service_new.py
+++ b/tests/test_channel_service_new.py
@@ -34,6 +34,8 @@ async def test_list_for_page():
 async def test_add_by_identifier_success():
     channels = MagicMock()
     channels.add_channel = AsyncMock(return_value=1)
+    channels.get_by_channel_id = AsyncMock(return_value=None)
+    channels.create_stats_task = AsyncMock(return_value=10)
     pool = MagicMock()
     pool.resolve_channel = AsyncMock(return_value={
         "channel_id": -100123,
@@ -59,6 +61,7 @@ async def test_add_by_identifier_success():
     assert added.username == "testch"
     assert added.channel_type == "channel"
     assert added.about == "Test about"
+    channels.create_stats_task.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -94,7 +97,14 @@ async def test_get_dialogs_with_added_flags():
 async def test_add_bulk_by_dialog_ids():
     channels = MagicMock()
     channels.add_channel = AsyncMock(return_value=1)
+    channels.get_by_channel_id = AsyncMock(return_value=None)
+    channels.create_stats_task = AsyncMock(return_value=10)
     pool = MagicMock()
+    pool.fetch_channel_meta = AsyncMock(return_value={
+        "about": "Bulk about",
+        "linked_chat_id": None,
+        "has_comments": False,
+    })
     pool.get_dialogs = AsyncMock(return_value=[
         {"channel_id": 100, "title": "Test", "username": "testch", "channel_type": "channel"},
         {"channel_id": 200, "title": "Other", "username": "other", "channel_type": "channel"},
@@ -106,6 +116,8 @@ async def test_add_bulk_by_dialog_ids():
     # Should only add the requested channel
     added = channels.add_channel.call_args[0][0]
     assert added.channel_id == 100
+    assert added.about == "Bulk about"
+    channels.create_stats_task.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/test_search_persistence.py
+++ b/tests/test_search_persistence.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models import Channel
+from src.search.persistence import SearchPersistence
+
+
+@pytest.mark.anyio
+async def test_cache_search_results_enqueues_stats_for_new_channels():
+    bundle = MagicMock()
+    bundle.channels.get_channel_by_channel_id = AsyncMock(return_value=None)
+    bundle.add_channel = AsyncMock(return_value=1)
+    bundle.log_search = AsyncMock()
+    create_stats_task = AsyncMock(return_value=7)
+    fetch_channel_meta = AsyncMock(
+        return_value={"about": "about text", "linked_chat_id": 123, "has_comments": True}
+    )
+
+    persistence = SearchPersistence(bundle, create_stats_task, fetch_channel_meta)
+
+    await persistence.cache_search_results(
+        {
+            100: Channel(channel_id=100, title="A"),
+            200: Channel(channel_id=200, title="B"),
+        },
+        [],
+        "+1",
+        "query",
+    )
+
+    create_stats_task.assert_awaited_once()
+    payload = create_stats_task.await_args.args[0]
+    assert payload.channel_ids == [100, 200]
+    added_channels = [call.args[0] for call in bundle.add_channel.await_args_list]
+    assert [channel.about for channel in added_channels] == ["about text", "about text"]
+    assert [channel.linked_chat_id for channel in added_channels] == [123, 123]
+
+
+@pytest.mark.anyio
+async def test_cache_search_results_skips_stats_for_existing_channels():
+    bundle = MagicMock()
+    bundle.channels.get_channel_by_channel_id = AsyncMock(
+        return_value=Channel(channel_id=100, title="Existing")
+    )
+    bundle.add_channel = AsyncMock(return_value=1)
+    bundle.log_search = AsyncMock()
+    create_stats_task = AsyncMock(return_value=7)
+    fetch_channel_meta = AsyncMock()
+
+    persistence = SearchPersistence(bundle, create_stats_task, fetch_channel_meta)
+
+    await persistence.cache_search_results(
+        {100: Channel(channel_id=100, title="Existing")},
+        [],
+        "+1",
+        "query",
+    )
+
+    create_stats_task.assert_not_awaited()
+    fetch_channel_meta.assert_not_awaited()

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1473,6 +1473,33 @@ async def test_is_running_initially_false():
 
 
 @pytest.mark.anyio
+async def test_set_stats_all_running_updates_running_properties():
+    pool = make_mock_pool()
+    collector = Collector(pool, MagicMock(), SchedulerConfig())
+
+    collector.set_stats_all_running(True)
+
+    assert collector.is_running is True
+    assert collector.is_stats_running is True
+
+    collector.set_stats_all_running(False)
+
+    assert collector.is_running is False
+    assert collector.is_stats_running is False
+
+
+@pytest.mark.anyio
+async def test_available_stats_worker_count_uses_available_stats_clients():
+    pool = make_mock_pool(
+        clients={"+7001": object(), "+7002": object(), "+7003": object()},
+        available_stats_client_count=AsyncMock(return_value=1),
+    )
+    collector = Collector(pool, MagicMock(), SchedulerConfig(stats_worker_count=3))
+
+    assert await collector.available_stats_worker_count() == 1
+
+
+@pytest.mark.anyio
 async def test_delay_between_channels_sec():
     pool = make_mock_pool()
     config = SchedulerConfig(delay_between_channels_sec=5)

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -191,8 +191,10 @@ def _mock_db():
     db.delete_account = AsyncMock()
     db.update_account_premium = AsyncMock()
     db.get_channel_by_pk = AsyncMock(return_value=None)
+    db.get_channel_by_channel_id = AsyncMock(return_value=None)
     db.get_channels = AsyncMock(return_value=[])
     db.add_channel = AsyncMock()
+    db.create_stats_task = AsyncMock(return_value=123)
     db.set_channel_active = AsyncMock()
     db.set_channel_type = AsyncMock()
     db.update_channel_full_meta = AsyncMock()
@@ -657,6 +659,9 @@ async def test_channels_add_identifier():
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_channels_add_identifier({"identifier": "@t"})
     assert r["channel_id"] == -100
+    added = db.add_channel.await_args.args[0]
+    assert added.about == "a"
+    db.create_stats_task.assert_awaited_once()
 
 
 async def test_channels_add_identifier_fail():
@@ -705,10 +710,15 @@ async def test_channels_refresh_meta():
 
 async def test_channels_import_batch():
     pool = _mock_pool()
+    db = _mock_db()
     pool.resolve_channel.return_value = {"channel_id": -100, "title": "T", "username": "t", "channel_type": "channel"}
-    d = _dispatcher(pool=pool)
+    pool.fetch_channel_meta.return_value = {"about": "a", "linked_chat_id": None, "has_comments": False}
+    d = _dispatcher(db=db, pool=pool)
     r = await d._handle_channels_import_batch({"identifiers": ["@t"]})
     assert r["added"] == 1
+    added = db.add_channel.await_args.args[0]
+    assert added.about == "a"
+    db.create_stats_task.assert_awaited_once()
 
 
 async def test_channels_import_batch_existing():

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -207,6 +208,7 @@ async def test_handle_stats_all_stops_after_cancelled_result(
 
     mock_collector.collect_channel_stats.assert_awaited_once()
     mock_tasks_repo.persist_stats_progress.assert_not_called()
+    mock_tasks_repo.reschedule_stats_task.assert_not_called()
     mock_tasks_repo.update_collection_task.assert_not_called()
 
 
@@ -320,6 +322,44 @@ async def test_handle_stats_all_processes_batch(
 
     # Should process all 3 channels, no continuation
     assert mock_collector.collect_channel_stats.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_handle_stats_all_respects_worker_count(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """_handle_stats_all processes stats with bounded concurrency."""
+    active = 0
+    max_active = 0
+    mock_collector.delay_between_channels_sec = 0
+
+    async def collect(_channel):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return MagicMock(subscriber_count=100)
+
+    mock_collector.collect_channel_stats = AsyncMock(side_effect=collect)
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[100, 101, 102, 103]),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+        config=SimpleNamespace(scheduler=SimpleNamespace(stats_worker_count=2)),
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    assert max_active == 2
 
 
 @pytest.mark.anyio

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -363,6 +363,89 @@ async def test_handle_stats_all_respects_worker_count(
 
 
 @pytest.mark.anyio
+async def test_handle_stats_all_uses_available_stats_worker_count(
+    mock_channel_bundle, mock_tasks_repo
+):
+    """Stats-all concurrency follows non-flooded available stats account count."""
+    active = 0
+    max_active = 0
+
+    class Collector:
+        is_running = False
+        delay_between_channels_sec = 0
+
+        async def available_stats_worker_count(self):
+            return 1
+
+        async def collect_channel_stats(self, _channel):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return MagicMock(subscriber_count=100)
+
+        async def get_stats_availability(self):
+            return MagicMock(state="available", next_available_at_utc=None)
+
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[100, 101, 102]),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        Collector(),
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+        config=SimpleNamespace(scheduler=SimpleNamespace(stats_worker_count=3)),
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    assert max_active == 1
+
+
+@pytest.mark.anyio
+async def test_handle_stats_all_marks_collector_stats_running(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """Stats-all keeps collector status true while unlocked per-channel stats run."""
+    seen_running: list[bool] = []
+    mock_collector.delay_between_channels_sec = 0
+    mock_collector._stats_all_running = False
+    mock_collector.set_stats_all_running.side_effect = (
+        lambda running: setattr(mock_collector, "_stats_all_running", running)
+    )
+
+    async def collect(_channel):
+        seen_running.append(mock_collector._stats_all_running)
+        return MagicMock(subscriber_count=100)
+
+    mock_collector.collect_channel_stats = AsyncMock(side_effect=collect)
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[100]),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+    )
+
+    await dispatcher._handle_stats_all(task)
+
+    assert seen_running == [True]
+    assert mock_collector._stats_all_running is False
+
+
+@pytest.mark.anyio
 async def test_handle_stats_all_channel_not_found(
     mock_collector, mock_channel_bundle, mock_tasks_repo
 ):


### PR DESCRIPTION
## Summary

Closes #687.

- Fetch and persist channel metadata during CLI/service/dispatcher channel onboarding.
- Enqueue stats collection automatically for newly added active channels, including channels first cached from Telegram search.
- Run stats-all collection with bounded worker concurrency and resumable remaining-channel payloads.

## Validation

- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_channel_service.py tests/test_channel_service_new.py tests/test_telegram_command_dispatcher.py tests/test_unified_dispatcher.py tests/test_search_persistence.py tests/test_cli_channel_pipeline_route_paths.py tests/test_web.py tests/test_search.py -q`
- Before rebase: `python3 -m pytest tests/ -q -m "not aiosqlite_serial" -n auto`
- Before rebase: `python3 -m pytest tests/ -q -m aiosqlite_serial`