### PR TITLE
test(cli): fix real agent cleanup command

### DIFF
--- a/tests/cli_real_tg_integration/safe_write/test_proc_agent_chat_oneshot.py
+++ b/tests/cli_real_tg_integration/safe_write/test_proc_agent_chat_oneshot.py
@@ -62,7 +62,7 @@ def test_proc_agent_chat_oneshot(run_cli, assert_cli_ok, cli_real_cli_env):
             for tid in new_ids:
                 try:
                     cleanup = cli_run_direct(
-                        cli_real_cli_env, "agent", "thread-delete", "--thread-id", tid
+                        cli_real_cli_env, "agent", "thread-delete", tid
                     )
                 except subprocess.TimeoutExpired:
                     leak_msg = f"agent thread {tid} leaked: thread-delete timed out"


### PR DESCRIPTION
Fixes #692.

Fixes the real CLI agent chat smoke cleanup command to match the actual CLI parser: `agent thread-delete <thread_id>` instead of the unsupported `--thread-id` flag.

Validation:
- `RUN_CLI_REAL_TG_LIVE=1 RUN_REAL_TELEGRAM_SAFE=1 CLI_REAL_TG_ROOT=/Users/axisrow/Projects/tg_content_factory python3 -m pytest tests/cli_real_tg_integration/safe_write/test_proc_agent_chat_oneshot.py -q -rs`
- `python3 -m pytest tests/test_cli_agent_commands.py::test_run_thread_delete -q`
- `python3 -m ruff check tests/cli_real_tg_integration/safe_write/test_proc_agent_chat_oneshot.py`

Full verification run performed before this branch fix:
- `RUN_CLI_REAL_TG_LIVE=1 RUN_REAL_TELEGRAM_SAFE=1 CLI_REAL_TG_ROOT=/Users/axisrow/Projects/tg_content_factory python3 -m pytest tests/cli_real_tg_integration -q -rs` -> `72 passed, 30 skipped`
