### PR TITLE
fix(telegram): retry transient flood waits inline

### DIFF
--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -11,6 +11,12 @@ from inspect import isawaitable
 from typing import Any
 
 from src.agent.runtime_context import AgentRuntimeContext
+from src.telegram.flood_wait import (
+    flood_wait_remaining_seconds,
+    is_blocking_flood_wait_until,
+    is_transient_flood_wait_until,
+    sleep_for_flood_wait_seconds,
+)
 from src.utils.datetime import try_parse_utc_datetime
 
 logger = logging.getLogger(__name__)
@@ -211,6 +217,12 @@ def is_flood_wait_active(account: object, now: datetime | None = None) -> bool:
     now = now or datetime.now(timezone.utc)
     flood_until = normalize_flood_wait_until(getattr(account, "flood_wait_until", None))
     return flood_until is not None and flood_until > now
+
+
+def is_blocking_flood_wait_active(account: object, now: datetime | None = None) -> bool:
+    """True when a flood wait is too long for inline tool-level waiting."""
+    now = now or datetime.now(timezone.utc)
+    return is_blocking_flood_wait_until(getattr(account, "flood_wait_until", None), now=now)
 
 
 def connected_phones_from_pool(client_pool: object | None) -> set[str]:
@@ -417,6 +429,76 @@ async def resolve_live_read_phone(
     pool_available = available_phones_from_pool(client_pool)
     connected = pool_available or connected_all
     trust_connected = _pool_reports_connections(client_pool)
+
+    async def _wait_for_transient_flood_once() -> bool:
+        connected_filter = connected if trust_connected or connected else active_phones
+        if not phone:
+            immediate = [
+                account
+                for account in accounts
+                if getattr(account, "is_active", True)
+                and account_session_status(account) == "ok"
+                and str(getattr(account, "phone", "")) in connected_filter
+                and not is_flood_wait_active(account, now)
+            ]
+            if immediate:
+                return False
+        candidates: list[tuple[int, str]] = []
+        for account in accounts:
+            account_phone = str(getattr(account, "phone", ""))
+            if not account_phone:
+                continue
+            if phone and account_phone != phone:
+                continue
+            if not getattr(account, "is_active", True):
+                continue
+            if account_session_status(account) != "ok":
+                continue
+            if account_phone not in connected_filter:
+                continue
+            flood_until = getattr(account, "flood_wait_until", None)
+            if not is_transient_flood_wait_until(flood_until, now=now):
+                continue
+            remaining = flood_wait_remaining_seconds(flood_until, now=now)
+            if remaining is not None and remaining > 0:
+                candidates.append((remaining, account_phone))
+        if phone:
+            wait = next((remaining for remaining, _ in candidates), None)
+        else:
+            blocking = [
+                account
+                for account in accounts
+                if getattr(account, "is_active", True)
+                and account_session_status(account) == "ok"
+                and str(getattr(account, "phone", "")) in connected_filter
+                and is_blocking_flood_wait_active(account, now)
+            ]
+            wait = min((remaining for remaining, _ in candidates), default=None)
+            if blocking:
+                wait = None
+        if wait is None:
+            return False
+        await sleep_for_flood_wait_seconds(
+            wait,
+            operation=f"agent_{tool_name}_transient_flood_wait",
+            phone=phone or None,
+            logger_=logger,
+        )
+        return True
+
+    active_phones = {str(getattr(account, "phone", "")) for account in accounts if str(getattr(account, "phone", ""))}
+    if await _wait_for_transient_flood_once():
+        now = datetime.now(timezone.utc)
+        accounts = await get_accounts_with_flood_cleanup(db, active_only=True, now=now)
+        connected_all = connected_phones_from_pool(client_pool)
+        pool_available = available_phones_from_pool(client_pool)
+        connected = pool_available or connected_all
+        active_phones = {
+            str(getattr(account, "phone", ""))
+            for account in accounts
+            if str(getattr(account, "phone", ""))
+        }
+
     available = available_live_read_phones(
         accounts,
         connected,
@@ -427,10 +509,9 @@ async def resolve_live_read_phone(
     flood_waited = {
         str(getattr(account, "phone", ""))
         for account in accounts
-        if is_flood_wait_active(account, now)
+        if is_blocking_flood_wait_active(account, now)
     }
     flood_waited |= flood_waited_phones_from_pool(client_pool)
-    active_phones = {str(getattr(account, "phone", "")) for account in accounts if str(getattr(account, "phone", ""))}
     connected_for_errors = connected_all if trust_connected else active_phones
 
     if phone:

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -297,7 +297,11 @@ def register(db, client_pool, embedding_service, **kwargs):
                 state = avail["state"]
                 guidance = _AVAILABILITY_GUIDANCE.get(state, state)
                 extra = ""
-                if state == "flood":
+                if avail.get("transient_flood_wait"):
+                    remaining = _remaining_seconds(a)
+                    if remaining is not None:
+                        extra = f" (короткий flood-wait ~{remaining}s; tools wait inline)"
+                elif state == "flood":
                     remaining = _remaining_seconds(a)
                     if remaining is not None:
                         extra = f" (осталось ~{remaining}s)"

--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -25,7 +25,7 @@ from src.services.telegram_actions import (
     TelegramActionClientUnavailableError,
     TelegramActionService,
 )
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait_retry
 from src.telegram.identity import extract_message_sender_identity
 from src.telegram.reactions import (
     fetch_message_reaction_users,
@@ -307,8 +307,8 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
                         break
 
             try:
-                await run_with_flood_wait(
-                    _read_recent(),
+                await run_with_flood_wait_retry(
+                    _read_recent,
                     operation="agent_read_recent_messages",
                     phone=phone,
                     pool=client_pool,

--- a/src/services/account_availability.py
+++ b/src/services/account_availability.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from src.models import AccountSessionStatus
+from src.telegram.flood_wait import is_blocking_flood_wait_until
 
 # Ordered roughly by severity. Mirrors the states rendered by the Settings page.
 AVAILABILITY_STATES = (
@@ -52,6 +53,13 @@ def compute_account_availability(
             flood_until = flood_until.replace(tzinfo=timezone.utc)
         remaining_seconds = max(0, int((flood_until - now).total_seconds()))
         if remaining_seconds > 0:
+            if not is_blocking_flood_wait_until(flood_until, now=now):
+                return {
+                    "state": "available",
+                    "remaining_seconds": remaining_seconds,
+                    "remaining_minutes": max(1, remaining_seconds // 60),
+                    "transient_flood_wait": True,
+                }
             return {
                 "state": "flood",
                 "remaining_seconds": remaining_seconds,

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -34,7 +34,13 @@ from src.telegram.backends import (
     TelethonCliBackend,
     adapt_transport_session,
 )
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.telegram.flood_wait import (
+    HandledFloodWaitError,
+    is_blocking_flood_wait_until,
+    is_transient_flood_wait_seconds,
+    run_with_flood_wait,
+    run_with_flood_wait_retry,
+)
 from src.telegram.session_materializer import SessionMaterializer
 from src.telegram.utils import normalize_utc
 
@@ -159,8 +165,10 @@ class ClientPool:
             flood_waited = {
                 account.phone
                 for account in accounts
-                if normalize_utc(getattr(account, "flood_wait_until", None)) is not None
-                and normalize_utc(getattr(account, "flood_wait_until", None)) > now
+                if is_blocking_flood_wait_until(
+                    normalize_utc(getattr(account, "flood_wait_until", None)),
+                    now=now,
+                )
             }
         except Exception:
             logger.debug("warm_all_dialogs: failed to load flood-wait status", exc_info=True)
@@ -173,7 +181,14 @@ class ClientPool:
                 continue
             session, p = result
             try:
-                dialogs = await asyncio.wait_for(session.warm_dialog_cache(), timeout=60.0)
+                dialogs = await run_with_flood_wait_retry(
+                    lambda: session.warm_dialog_cache(),
+                    operation="telegram_warm_dialog_cache",
+                    phone=p,
+                    pool=self,
+                    logger_=logger,
+                    timeout=60.0,
+                )
                 self.mark_dialogs_fetched(p)
                 for dialog in dialogs or []:
                     entity = getattr(dialog, "entity", None)
@@ -582,7 +597,8 @@ class ClientPool:
         """Mark account as flood-waited."""
         until = datetime.now(timezone.utc) + timedelta(seconds=wait_seconds)
         await self._db.update_account_flood(phone, until)
-        logger.warning("Flood wait for %s: %d seconds (until %s)", phone, wait_seconds, until)
+        level = logging.INFO if is_transient_flood_wait_seconds(wait_seconds) else logging.WARNING
+        logger.log(level, "Flood wait for %s: %d seconds (until %s)", phone, wait_seconds, until)
 
     async def report_premium_flood(self, phone: str, wait_seconds: int) -> None:
         """Mark account as premium-search flood-waited without touching generic account state."""

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -40,7 +40,13 @@ from src.services.translation_service import TranslationService
 from src.settings_utils import parse_int_setting
 from src.telegram.backends import adapt_transport_session
 from src.telegram.client_pool import ClientPool
-from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.telegram.flood_wait import (
+    HandledFloodWaitError,
+    is_transient_flood_wait_seconds,
+    run_with_flood_wait,
+    run_with_flood_wait_retry,
+    sleep_for_flood_wait_seconds,
+)
 from src.telegram.identity import extract_message_sender_identity
 from src.telegram.notifier import Notifier
 from src.telegram.rate_limiter import ResolveRateLimiter
@@ -299,8 +305,22 @@ class Collector:
     def _reset_collection_unavailability_log(self) -> None:
         self._last_unavailability_log = None
 
-    async def _raise_collection_unavailability(self) -> None:
-        availability = await self.get_collection_availability()
+    async def _wait_for_transient_collection_flood(self, availability) -> bool:
+        retry_after_sec = getattr(availability, "retry_after_sec", None)
+        if getattr(availability, "state", None) != "all_flooded":
+            return False
+        if not is_transient_flood_wait_seconds(retry_after_sec):
+            return False
+        await sleep_for_flood_wait_seconds(
+            int(retry_after_sec),
+            operation="collect_channel_all_clients_transient_flood_wait",
+            logger_=logger,
+        )
+        self._reset_collection_unavailability_log()
+        return True
+
+    async def _raise_collection_unavailability(self, availability=None) -> None:
+        availability = availability or await self.get_collection_availability()
         self._log_collection_unavailability_once(
             state=availability.state,
             retry_after_sec=availability.retry_after_sec,
@@ -666,7 +686,10 @@ class Collector:
                 result = await self._pool.get_available_client()
 
             if result is None:
-                await self._raise_collection_unavailability()
+                availability = await self.get_collection_availability()
+                if await self._wait_for_transient_collection_flood(availability):
+                    continue
+                await self._raise_collection_unavailability(availability)
 
             session, phone = result
             self._reset_collection_unavailability_log()
@@ -677,8 +700,8 @@ class Collector:
             # the in-memory cache persists.
             if not channel.username and not self._pool.is_dialogs_fetched(phone):
                 try:
-                    await run_with_flood_wait(
-                        session.warm_dialog_cache(),
+                    await run_with_flood_wait_retry(
+                        lambda: session.warm_dialog_cache(),
                         operation="collect_channel_warm_dialog_cache",
                         phone=phone,
                         pool=self._pool,
@@ -1129,10 +1152,17 @@ class Collector:
             # Only skip the channel if the channel no longer exists in DB.
             if flood_wait_sec is not None:
                 if flood_wait_operation == RESOLVE_USERNAME_OPERATION:
+                    if is_transient_flood_wait_seconds(flood_wait_sec):
+                        await sleep_for_flood_wait_seconds(
+                            flood_wait_sec,
+                            operation=RESOLVE_USERNAME_OPERATION,
+                            phone=phone,
+                            logger_=logger,
+                        )
+                        continue
                     # Only a *long* resolve flood freezes live resolves for every
-                    # account (#552). A short flood is transient — skip just this
-                    # channel and let the run continue with other accounts so one
-                    # blip does not stall the whole pool.
+                    # account (#552). A medium resolve flood skips just this
+                    # channel so one blip does not stall the whole pool.
                     if flood_wait_sec <= GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC:
                         logger.warning(
                             "%s short FloodWait %ss on %s; skipping channel %d "

--- a/src/telegram/flood_wait.py
+++ b/src/telegram/flood_wait.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, TypeVar
 
 from pydantic import BaseModel
 from telethon.errors import FloodWaitError
 
+from src.utils.datetime import try_parse_utc_datetime
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+TRANSIENT_FLOOD_WAIT_MAX_SEC = 60
+TRANSIENT_FLOOD_WAIT_RETRY_BUDGET_SEC = 120
+FLOOD_WAIT_RETRY_BUFFER_SEC = 1.0
 
 
 class FloodWaitInfo(BaseModel):
@@ -25,6 +32,50 @@ class HandledFloodWaitError(RuntimeError):
     def __init__(self, info: FloodWaitInfo):
         super().__init__(info.detail)
         self.info = info
+
+
+def coerce_flood_wait_seconds(value: object) -> int:
+    return max(1, int(value or 0))
+
+
+def is_transient_flood_wait_seconds(
+    wait_seconds: int | None,
+    *,
+    max_seconds: int = TRANSIENT_FLOOD_WAIT_MAX_SEC,
+) -> bool:
+    if wait_seconds is None:
+        return False
+    return 0 < int(wait_seconds) <= max_seconds
+
+
+def flood_wait_remaining_seconds(value: object, *, now: datetime | None = None) -> int | None:
+    if value is not None and not isinstance(value, (str, datetime)):
+        return None
+    flood_until = try_parse_utc_datetime(value)
+    if flood_until is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    return max(0, int((flood_until - now).total_seconds()))
+
+
+def is_transient_flood_wait_until(
+    value: object,
+    *,
+    now: datetime | None = None,
+    max_seconds: int = TRANSIENT_FLOOD_WAIT_MAX_SEC,
+) -> bool:
+    remaining = flood_wait_remaining_seconds(value, now=now)
+    return is_transient_flood_wait_seconds(remaining, max_seconds=max_seconds)
+
+
+def is_blocking_flood_wait_until(
+    value: object,
+    *,
+    now: datetime | None = None,
+    max_seconds: int = TRANSIENT_FLOOD_WAIT_MAX_SEC,
+) -> bool:
+    remaining = flood_wait_remaining_seconds(value, now=now)
+    return remaining is not None and remaining > max_seconds
 
 
 def format_flood_wait_detail(
@@ -49,7 +100,7 @@ async def handle_flood_wait(
     pool: Any | None = None,
     logger_: logging.Logger | None = None,
 ) -> FloodWaitInfo:
-    wait_seconds = max(1, int(getattr(exc, "seconds", 0) or 0))
+    wait_seconds = coerce_flood_wait_seconds(getattr(exc, "seconds", 0))
     next_available_at_utc = datetime.now(timezone.utc) + timedelta(seconds=wait_seconds)
     detail = format_flood_wait_detail(
         wait_seconds=wait_seconds,
@@ -63,7 +114,10 @@ async def handle_flood_wait(
             await reporter(phone, wait_seconds)
 
     active_logger = logger_ or logger
-    active_logger.warning("%s: %s", operation, detail)
+    if is_transient_flood_wait_seconds(wait_seconds):
+        active_logger.info("%s: transient %s", operation, detail)
+    else:
+        active_logger.warning("%s: %s", operation, detail)
 
     return FloodWaitInfo(
         operation=operation,
@@ -71,6 +125,41 @@ async def handle_flood_wait(
         wait_seconds=wait_seconds,
         next_available_at_utc=next_available_at_utc,
         detail=detail,
+    )
+
+
+async def sleep_for_flood_wait_seconds(
+    wait_seconds: int,
+    *,
+    operation: str,
+    phone: str | None = None,
+    logger_: logging.Logger | None = None,
+    buffer_seconds: float = FLOOD_WAIT_RETRY_BUFFER_SEC,
+) -> None:
+    sleep_seconds = max(0.0, float(wait_seconds)) + max(0.0, buffer_seconds)
+    active_logger = logger_ or logger
+    phone_suffix = f" for {phone}" if phone else ""
+    active_logger.info(
+        "%s: waiting %.1fs for transient FloodWait%s",
+        operation,
+        sleep_seconds,
+        phone_suffix,
+    )
+    await asyncio.sleep(sleep_seconds)
+
+
+async def sleep_for_handled_flood_wait(
+    info: FloodWaitInfo,
+    *,
+    logger_: logging.Logger | None = None,
+    buffer_seconds: float = FLOOD_WAIT_RETRY_BUFFER_SEC,
+) -> None:
+    await sleep_for_flood_wait_seconds(
+        info.wait_seconds,
+        operation=info.operation,
+        phone=info.phone,
+        logger_=logger_,
+        buffer_seconds=buffer_seconds,
     )
 
 
@@ -96,3 +185,38 @@ async def run_with_flood_wait(
             logger_=logger_,
         )
         raise HandledFloodWaitError(info) from exc
+
+
+async def run_with_flood_wait_retry(
+    awaitable_factory: Callable[[], Awaitable[T]],
+    *,
+    operation: str,
+    phone: str | None = None,
+    pool: Any | None = None,
+    logger_: logging.Logger | None = None,
+    timeout: float | None = None,
+    transient_wait_max_sec: int = TRANSIENT_FLOOD_WAIT_MAX_SEC,
+    transient_wait_budget_sec: int = TRANSIENT_FLOOD_WAIT_RETRY_BUDGET_SEC,
+) -> T:
+    waited_seconds = 0
+    while True:
+        try:
+            return await run_with_flood_wait(
+                awaitable_factory(),
+                operation=operation,
+                phone=phone,
+                pool=pool,
+                logger_=logger_,
+                timeout=timeout,
+            )
+        except HandledFloodWaitError as exc:
+            wait_seconds = exc.info.wait_seconds
+            if not is_transient_flood_wait_seconds(
+                wait_seconds,
+                max_seconds=transient_wait_max_sec,
+            ):
+                raise
+            if waited_seconds + wait_seconds > transient_wait_budget_sec:
+                raise
+            await sleep_for_handled_flood_wait(exc.info, logger_=logger_)
+            waited_seconds += wait_seconds

--- a/src/web/routes/dashboard.py
+++ b/src/web/routes/dashboard.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
 from src.models import AccountSessionStatus
+from src.telegram.flood_wait import is_blocking_flood_wait_until
 from src.web import deps
 
 router = APIRouter()
@@ -50,7 +51,7 @@ async def dashboard(request: Request):
             until = a.flood_wait_until
             if until.tzinfo is None:
                 until = until.replace(tzinfo=timezone.utc)
-            if until > now:
+            if is_blocking_flood_wait_until(until, now=now):
                 flood_wait_count += 1
         if (
             a.is_active
@@ -63,7 +64,7 @@ async def dashboard(request: Request):
             else:
                 if until.tzinfo is None:
                     until = until.replace(tzinfo=timezone.utc)
-                if until <= now:
+                if not is_blocking_flood_wait_until(until, now=now):
                     all_connected_flooded = False
     if connected_count == 0:
         all_connected_flooded = False

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -21,6 +21,10 @@ from src.services.runtime_diagnostics import (
     WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
 )
 from src.services.runtime_diagnostics import evaluate_worker_heartbeat
+from src.telegram.flood_wait import (
+    is_blocking_flood_wait_until,
+    is_transient_flood_wait_seconds,
+)
 from src.web import deps
 
 logger = logging.getLogger(__name__)
@@ -241,7 +245,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
             continue
         if flood_until.tzinfo is None:
             flood_until = flood_until.replace(tzinfo=timezone.utc)
-        if flood_until <= now:
+        if flood_until <= now or not is_blocking_flood_wait_until(flood_until, now=now):
             continue
         flooded_accounts.append({"phone": acc.phone, "until": flood_until})
         if next_available_at is None or flood_until < next_available_at:
@@ -259,6 +263,9 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         availability_next = None
     if not isinstance(availability_retry_after, int):
         availability_retry_after = None
+    availability_all_flooded_blocking = availability_state == "all_flooded" and not (
+        is_transient_flood_wait_seconds(availability_retry_after)
+    )
     available_accounts_now = max(0, len(connected_active_accounts) - len(flooded_accounts))
     active_unfiltered_channels = len(await db.repos.channels.get_channels(active_only=True, include_filtered=False))
     recent_tasks = await db.get_collection_tasks(limit=200)
@@ -289,7 +296,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         state = "session_degraded"
     elif not connected_active_accounts:
         state = "no_clients"
-    elif availability_state == "all_flooded" or available_accounts_now == 0:
+    elif availability_all_flooded_blocking or available_accounts_now == 0:
         state = "all_flooded"
     elif flooded_accounts:
         state = "degraded"

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -48,6 +48,7 @@ from src.services.telegram_command_dispatcher import (
     REACTION_MIN_INTERVAL_SETTING,
 )
 from src.settings_utils import parse_float_setting, parse_int_setting
+from src.telegram.flood_wait import is_blocking_flood_wait_until
 from src.utils.datetime import parse_datetime
 from src.web import deps
 from src.web.settings.forms import (
@@ -502,7 +503,8 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
             flood_until = account.flood_wait_until
             if flood_until.tzinfo is None:
                 flood_until = flood_until.replace(tzinfo=UTC)
-            flooded_connected.append(flood_until)
+            if is_blocking_flood_wait_until(flood_until, now=now):
+                flooded_connected.append(flood_until)
         account_status[account.phone] = availability
     all_accounts_flooded = bool(flooded_connected) and len(flooded_connected) == len(
         [

--- a/tests/routes/test_dashboard_routes.py
+++ b/tests/routes/test_dashboard_routes.py
@@ -207,6 +207,21 @@ async def test_dashboard_all_connected_flooded(route_client, base_app):
 
 
 @pytest.mark.anyio
+async def test_dashboard_ignores_transient_flood_wait(route_client, base_app):
+    """Short flood waits are handled inline and should not trigger collector attention."""
+    _app, db, _pool = base_app
+    future_time = datetime.now(tz=timezone.utc) + timedelta(seconds=30)
+    accounts = await db.get_accounts(active_only=False)
+    for acc in accounts:
+        await db.update_account_flood(acc.phone, future_time)
+
+    resp = await route_client.get("/dashboard/")
+    assert resp.status_code == 200
+    assert "Коллектор ограничен" not in resp.text
+    assert "flood-wait" not in resp.text
+
+
+@pytest.mark.anyio
 async def test_dashboard_flood_wait_naive_datetime(route_client, base_app):
     """Dashboard handles flood_wait_until with naive datetime (no tzinfo)."""
     app, db, pool = base_app

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -944,6 +944,8 @@ async def test_scheduler_hides_countdown_if_too_short(client):
     assert resp.status_code == 200
     # Countdown should not appear for very short waits
     assert "(0 мин)" not in resp.text
+    assert "Все аккаунты во Flood Wait" not in resp.text
+    assert "Частичная деградация" not in resp.text
 
 
 @pytest.mark.anyio

--- a/tests/test_account_availability.py
+++ b/tests/test_account_availability.py
@@ -50,6 +50,14 @@ def test_flood_reports_remaining():
     assert avail["remaining_minutes"] >= 1
 
 
+def test_transient_flood_is_available_with_marker():
+    future = datetime.now(timezone.utc) + timedelta(seconds=30)
+    avail = compute_account_availability(_acc(flood_wait_until=future), connected=True)
+    assert avail["state"] == "available"
+    assert avail["transient_flood_wait"] is True
+    assert avail["remaining_seconds"] > 0
+
+
 def test_expired_flood_is_available():
     past = datetime.now(timezone.utc) - timedelta(minutes=10)
     avail = compute_account_availability(_acc(flood_wait_until=past), connected=True)

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -272,6 +272,24 @@ class TestResolveLiveReadPhone:
         assert account.flood_wait_until is None
         db.update_account_flood.assert_awaited_once_with("+111", None)
 
+    @pytest.mark.anyio
+    async def test_explicit_transient_flood_wait_is_waited_inline(self, monkeypatch):
+        future = datetime.now(timezone.utc) + timedelta(seconds=30)
+        account = SimpleNamespace(phone="+111", is_primary=True, is_active=True, flood_wait_until=future)
+        available_account = SimpleNamespace(phone="+111", is_primary=True, is_active=True, flood_wait_until=None)
+        db = MagicMock()
+        db.get_accounts = AsyncMock(side_effect=[[account], [available_account]])
+        pool = SimpleNamespace(clients={"+111": object()})
+        sleep = AsyncMock()
+        monkeypatch.setattr("src.agent.tools._registry.sleep_for_flood_wait_seconds", sleep)
+
+        phone, err = await resolve_live_read_phone(db, pool, "+111", tool_name="read_messages")
+
+        assert phone == "+111"
+        assert err is None
+        sleep.assert_awaited_once()
+        assert 1 <= sleep.await_args.args[0] <= 30
+
 
 # ── require_phone_permission ──────────────────────────────────────────────────
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1236,6 +1236,60 @@ async def test_collect_channel_retries_after_short_flood_wait(db):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_waits_when_all_clients_transient_flooded(db, monkeypatch):
+    ch = Channel(channel_id=-100174, title="TransientAllFlood", username="transientall", last_collected_id=5)
+    ch_id = await db.add_channel(ch)
+    await db.update_channel_last_id(ch.channel_id, 5)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("src.telegram.flood_wait.asyncio.sleep", fake_sleep)
+
+    client1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    client2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+
+    async def _flooding_generator():
+        yield _make_mock_message(6, text="msg 6")
+        raise FloodWaitError(request=None, capture=3)
+
+    client1.iter_messages = MagicMock(return_value=_flooding_generator())
+    client2.iter_messages = MagicMock(return_value=_AsyncIterMessages([_make_mock_message(7, text="msg 7")]))
+
+    pool = make_mock_pool(
+        get_available_client=AsyncMock(
+            side_effect=[
+                (client1, "+70001"),
+                None,
+                (client2, "+70002"),
+            ]
+        ),
+        get_stats_availability=AsyncMock(
+            return_value=SimpleNamespace(
+                state="all_flooded",
+                retry_after_sec=3,
+                next_available_at_utc=datetime.now(timezone.utc) + timedelta(seconds=3),
+            )
+        ),
+    )
+    collector = Collector(
+        pool,
+        db,
+        SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
+    )
+
+    count = await collector._collect_channel(stored)
+
+    assert count == 2
+    assert sleeps == [4.0]
+    pool.report_flood.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_collect_channel_rotates_on_long_flood_wait(db):
     """FloodWait > max_flood_wait_sec still rotates to the next available account."""
     ch = Channel(channel_id=-100172, title="LongFlood", username="longflood", last_collected_id=5)

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -9,7 +9,10 @@ from src.telegram.flood_wait import (
     HandledFloodWaitError,
     format_flood_wait_detail,
     handle_flood_wait,
+    is_blocking_flood_wait_until,
+    is_transient_flood_wait_seconds,
     run_with_flood_wait,
+    run_with_flood_wait_retry,
 )
 
 
@@ -191,3 +194,47 @@ async def test_run_with_flood_wait_with_timeout(monkeypatch):
 
     assert result == "ok"
     assert captured == {"timeout": 0.5}
+
+
+def test_transient_flood_wait_policy():
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    assert is_transient_flood_wait_seconds(30)
+    assert is_transient_flood_wait_seconds(60)
+    assert not is_transient_flood_wait_seconds(61)
+    assert not is_blocking_flood_wait_until(now + timedelta(seconds=60), now=now)
+    assert is_blocking_flood_wait_until(now + timedelta(seconds=61), now=now)
+
+
+@pytest.mark.anyio
+async def test_run_with_flood_wait_retry_waits_for_transient_flood(monkeypatch):
+    err = FloodWaitError(request=None, capture=0)
+    err.seconds = 3
+    calls = {"count": 0}
+    sleeps = []
+    pool = AsyncMock()
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr("src.telegram.flood_wait.asyncio.sleep", fake_sleep)
+
+    async def _call():
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise err
+        return "ok"
+
+    result = await run_with_flood_wait_retry(
+        _call,
+        operation="retry_op",
+        phone="+7000",
+        pool=pool,
+    )
+
+    assert result == "ok"
+    assert calls["count"] == 2
+    assert sleeps == [4.0]
+    pool.report_flood.assert_awaited_once_with("+7000", 3)


### PR DESCRIPTION
Fixes #694.

## Summary

- Treat short Telegram FloodWait responses as transient waits that can be retried inline.
- Keep long FloodWait values blocking in account availability, dashboard, scheduler, and agent phone selection.
- Add retry helpers and coverage for collector, agent tools, dashboard, scheduler health, and account availability behavior.

## Validation

- `python3 -m ruff check src/agent/tools/_registry.py src/agent/tools/accounts.py src/agent/tools/messaging_chat_state.py src/services/account_availability.py src/telegram/client_pool.py src/telegram/collector.py src/telegram/flood_wait.py src/web/routes/dashboard.py src/web/scheduler/context.py src/web/settings/handlers.py tests/routes/test_dashboard_routes.py tests/routes/test_scheduler_routes.py tests/test_account_availability.py tests/test_agent_tools_registry.py tests/test_collector.py tests/test_flood_wait.py`
- `python3 -m pytest tests/test_flood_wait.py tests/test_account_availability.py tests/test_agent_tools_registry.py tests/test_collector.py tests/routes/test_dashboard_routes.py::test_dashboard_ignores_transient_flood_wait tests/routes/test_scheduler_routes.py::test_scheduler_hides_countdown_if_too_short -q`