### PR TITLE
fix(telegram): bound bulk stats batches

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,9 @@ scheduler:
   delay_between_channels_sec: 2
   delay_between_requests_sec: 1
   max_flood_wait_sec: 300
+  stats_all_max_channels_per_run: 10
+  stats_all_cooldown_sec: 600
+  stats_all_worker_count: 1
 
 notifications:
   admin_chat_id: null

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -245,7 +245,11 @@ def run(args: argparse.Namespace) -> None:
                 collector = Collector(pool, db, config.scheduler)
 
                 if args.all:
-                    result = await collector.collect_all_stats()
+                    max_channels = getattr(args, "max_channels", None)
+                    if max_channels is not None and max_channels <= 0:
+                        print("--max-channels must be a positive integer")
+                        return
+                    result = await collector.collect_all_stats(max_channels=max_channels)
                     print(f"Stats collected: {result}")
                 elif not args.identifier:
                     print("Specify a channel identifier or use --all")

--- a/src/cli/parser_domains/channel.py
+++ b/src/cli/parser_domains/channel.py
@@ -37,6 +37,12 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         action="store_true",
         help="Collect stats for all active channels",
     )
+    ch_stats.add_argument(
+        "--max-channels",
+        type=int,
+        default=None,
+        help="Maximum active channels to process in this bounded stats-all run",
+    )
 
     ch_sub.add_parser("refresh-types", help="Fill missing channel_type for existing channels")
 

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,9 @@ class SchedulerConfig(BaseModel):
     delay_between_requests_sec: int = 1
     max_flood_wait_sec: int = 300
     stats_worker_count: int = 3
+    stats_all_max_channels_per_run: int = 10
+    stats_all_cooldown_sec: int = 600
+    stats_all_worker_count: int = 1
 
 
 class NotificationsConfig(BaseModel):

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from src.models import (
     CollectionTask,
@@ -102,6 +102,11 @@ class StatsTaskHandler:
             )
             return
 
+        batch_limit = self._stats_batch_limit()
+        batch_queue: deque[int] = deque()
+        while remaining_ids and len(batch_queue) < batch_limit:
+            batch_queue.append(remaining_ids.popleft())
+
         state_lock = asyncio.Lock()
         in_flight: list[int] = []
         stop_workers = False
@@ -119,7 +124,9 @@ class StatsTaskHandler:
 
         async def _snapshot_payload() -> StatsAllTaskPayload:
             async with state_lock:
-                remaining_snapshot = list(dict.fromkeys([*deferred_front, *in_flight, *remaining_ids]))
+                remaining_snapshot = list(
+                    dict.fromkeys([*deferred_front, *in_flight, *batch_queue, *remaining_ids])
+                )
                 processed = len(channel_ids) - len(remaining_snapshot)
                 return StatsAllTaskPayload(
                     channel_ids=channel_ids,
@@ -171,9 +178,9 @@ class StatsTaskHandler:
                     return
 
                 async with state_lock:
-                    if stop_workers or not remaining_ids:
+                    if stop_workers or not batch_queue:
                         return
-                    channel_id = remaining_ids.popleft()
+                    channel_id = batch_queue.popleft()
                     in_flight.append(channel_id)
 
                 channel = await ctx.channel_bundle.get_by_channel_id(channel_id)
@@ -228,13 +235,13 @@ class StatsTaskHandler:
                         await _record_processed(channel_id, ok=True)
 
                 async with state_lock:
-                    has_more = bool(remaining_ids) and not stop_workers
+                    has_more = bool(batch_queue) and not stop_workers
                 if has_more:
                     await asyncio.sleep(ctx.collector.delay_between_channels_sec)
 
         self._set_stats_all_running(True)
         try:
-            worker_count = await self._stats_worker_count(len(remaining_ids))
+            worker_count = await self._stats_worker_count(len(batch_queue))
             workers = [asyncio.create_task(_worker()) for _ in range(worker_count)]
             await asyncio.gather(*workers)
         finally:
@@ -255,10 +262,11 @@ class StatsTaskHandler:
 
         progress_payload = await _snapshot_payload()
         if reschedule_at is not None or progress_payload.remaining_channel_ids:
+            cooldown_at = datetime.now(timezone.utc) + timedelta(seconds=self._stats_cooldown_sec())
             await ctx.tasks.reschedule_stats_task(
                 task.id,
                 payload=progress_payload,
-                run_after=reschedule_at or datetime.now(timezone.utc),
+                run_after=reschedule_at or cooldown_at,
                 messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
             )
             return
@@ -276,15 +284,31 @@ class StatsTaskHandler:
         elif hasattr(self._context.collector, "_stats_all_running"):
             setattr(self._context.collector, "_stats_all_running", running)
 
+    def _stats_batch_limit(self) -> int:
+        config = self._context.config
+        scheduler_config = getattr(config, "scheduler", config)
+        configured = 10
+        if scheduler_config is not None:
+            configured = int(getattr(scheduler_config, "stats_all_max_channels_per_run", configured) or configured)
+        return max(1, configured)
+
+    def _stats_cooldown_sec(self) -> int:
+        config = self._context.config
+        scheduler_config = getattr(config, "scheduler", config)
+        configured = 600
+        if scheduler_config is not None:
+            configured = int(getattr(scheduler_config, "stats_all_cooldown_sec", configured) or configured)
+        return max(0, configured)
+
     async def _stats_worker_count(self, remaining_count: int) -> int:
         ctx = self._context
-        configured = 3
+        configured = 1
         config = ctx.config
         scheduler_config = getattr(config, "scheduler", config)
         if scheduler_config is not None:
-            configured = int(getattr(scheduler_config, "stats_worker_count", configured) or configured)
-        collector_counter = getattr(ctx.collector, "available_stats_worker_count", None)
-        type_counter = getattr(type(ctx.collector), "available_stats_worker_count", None)
+            configured = int(getattr(scheduler_config, "stats_all_worker_count", configured) or configured)
+        collector_counter = getattr(ctx.collector, "available_stats_all_worker_count", None)
+        type_counter = getattr(type(ctx.collector), "available_stats_all_worker_count", None)
         if callable(collector_counter) and callable(type_counter):
             try:
                 counter_result = collector_counter()
@@ -292,15 +316,7 @@ class StatsTaskHandler:
                     counter_result = await counter_result
                 configured = int(counter_result)
             except Exception:
-                logger.debug("Failed to read collector stats worker count", exc_info=True)
-        else:
-            collector_counter = getattr(ctx.collector, "stats_worker_count", None)
-            type_counter = getattr(type(ctx.collector), "stats_worker_count", None)
-            if callable(collector_counter) and callable(type_counter):
-                try:
-                    configured = int(collector_counter())
-                except Exception:
-                    logger.debug("Failed to read collector stats worker count", exc_info=True)
+                logger.debug("Failed to read collector stats-all worker count", exc_info=True)
         return max(1, min(configured, max(1, remaining_count)))
 
     async def handle_sq_stats(self, task: CollectionTask) -> None:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1600,11 +1600,31 @@ class Collector:
             configured = int(getattr(self._config, "stats_all_max_channels_per_run", 10) or 10)
         return max(1, int(configured))
 
+    async def _order_stats_all_channels(self, channels: list[Channel]) -> list[Channel]:
+        try:
+            latest_stats = await self._db.get_latest_stats_for_all()
+        except Exception:
+            logger.debug("Failed to load latest channel stats for stats-all ordering", exc_info=True)
+            return channels
+
+        def _sort_key(item: tuple[int, Channel]) -> tuple[int, datetime, int]:
+            index, channel = item
+            latest = latest_stats.get(channel.channel_id)
+            if latest is None:
+                return (0, datetime.min.replace(tzinfo=timezone.utc), index)
+            collected_at = latest.collected_at or datetime.min.replace(tzinfo=timezone.utc)
+            if collected_at.tzinfo is None:
+                collected_at = collected_at.replace(tzinfo=timezone.utc)
+            return (1, collected_at, index)
+
+        return [channel for _index, channel in sorted(enumerate(channels), key=_sort_key)]
+
     async def collect_all_stats(self, *, max_channels: int | None = None) -> dict:
         async with self._stats_all_lock:
             self._stats_all_running = True
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
+                channels = await self._order_stats_all_channels(channels)
                 channel_limit = self._stats_all_channel_limit(max_channels)
                 total_channels = len(channels)
                 selected_channels = channels[:channel_limit]

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -231,6 +231,13 @@ class Collector:
             return configured
         return max(1, min(configured, connected))
 
+    def stats_all_worker_count(self) -> int:
+        configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
+        connected = len(getattr(self._pool, "clients", {}) or {})
+        if connected <= 0:
+            return configured
+        return max(1, min(configured, connected))
+
     async def available_stats_worker_count(self) -> int:
         configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
         counter = getattr(self._pool, "available_stats_client_count", None)
@@ -246,6 +253,22 @@ class Collector:
             except Exception:
                 logger.debug("Failed to read available stats client count", exc_info=True)
         return self.stats_worker_count()
+
+    async def available_stats_all_worker_count(self) -> int:
+        configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
+        counter = getattr(self._pool, "available_stats_client_count", None)
+        if callable(counter):
+            try:
+                count = counter()
+                if asyncio.iscoroutine(count):
+                    count = await count
+                available = int(count)
+                if available > 0:
+                    return max(1, min(configured, available))
+                return 1
+            except Exception:
+                logger.debug("Failed to read available stats-all client count", exc_info=True)
+        return self.stats_all_worker_count()
 
     def set_stats_all_running(self, running: bool) -> None:
         self._stats_all_running = running
@@ -1571,61 +1594,115 @@ class Collector:
             finally:
                 await self._pool.release_client(phone)
 
-    async def collect_all_stats(self) -> dict:
+    def _stats_all_channel_limit(self, max_channels: int | None = None) -> int:
+        configured = max_channels
+        if configured is None:
+            configured = int(getattr(self._config, "stats_all_max_channels_per_run", 10) or 10)
+        return max(1, int(configured))
+
+    async def collect_all_stats(self, *, max_channels: int | None = None) -> dict:
         async with self._stats_all_lock:
             self._stats_all_running = True
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
-                stats = {"channels": 0, "errors": 0}
+                channel_limit = self._stats_all_channel_limit(max_channels)
+                total_channels = len(channels)
+                selected_channels = channels[:channel_limit]
+                initial_remaining = max(0, total_channels - len(selected_channels))
+                stats = {
+                    "channels": 0,
+                    "errors": 0,
+                    "remaining": initial_remaining,
+                    "limited": initial_remaining > 0,
+                    "total": total_channels,
+                    "max_channels": channel_limit,
+                }
                 if not channels:
                     return stats
 
-                queue = deque(channels)
+                queue = deque(selected_channels)
+                in_flight: list[Channel] = []
+                deferred_front: deque[Channel] = deque()
                 state_lock = asyncio.Lock()
+                stop_workers = False
+
+                def _remaining_count_unlocked() -> int:
+                    seen: set[int] = set()
+                    remaining = 0
+                    for channel in [*deferred_front, *in_flight, *queue]:
+                        if channel.channel_id in seen:
+                            continue
+                        seen.add(channel.channel_id)
+                        remaining += 1
+                    return remaining
+
+                async def _defer_batch(channel: Channel, exc: AllStatsClientsFloodedError) -> None:
+                    nonlocal stop_workers
+                    async with state_lock:
+                        stop_workers = True
+                        if channel in in_flight:
+                            in_flight.remove(channel)
+                        deferred_front.appendleft(channel)
+                        stats["flood_wait_until"] = exc.next_available_at.isoformat()
+                        stats["flood_wait_retry_after_sec"] = exc.retry_after_sec
+                        stats["limited"] = True
 
                 async def _worker() -> None:
+                    nonlocal stop_workers
                     while not self._cancel_event.is_set():
                         async with state_lock:
-                            if not queue:
+                            if stop_workers or not queue:
                                 return
                             channel = queue.popleft()
-                        while True:
-                            try:
-                                result = await self._collect_channel_stats(channel)
-                                async with state_lock:
-                                    if result is None:
-                                        stats["errors"] += 1
-                                    else:
-                                        stats["channels"] += 1
-                                break
-                            except AllStatsClientsFloodedError as e:
-                                logger.warning(
-                                    "All clients are flood-waited for stats. Waiting %ds until %s",
-                                    e.retry_after_sec,
-                                    e.next_available_at.isoformat(),
-                                )
-                                await asyncio.sleep(e.retry_after_sec)
-                            except NoActiveStatsClientsError:
-                                logger.error("No active connected clients for stats collection")
-                                async with state_lock:
-                                    stats["errors"] += 1 + len(queue)
-                                    queue.clear()
-                                return
-                            except Exception as e:
-                                logger.error("Stats error for %s: %s", channel.channel_id, e)
-                                async with state_lock:
+                            in_flight.append(channel)
+                        try:
+                            result = await self._collect_channel_stats(channel)
+                            async with state_lock:
+                                if channel in in_flight:
+                                    in_flight.remove(channel)
+                                if result is None:
                                     stats["errors"] += 1
-                                break
+                                else:
+                                    stats["channels"] += 1
+                        except AllStatsClientsFloodedError as e:
+                            logger.warning(
+                                "All clients are flood-waited for stats. Deferring %d queued channels until %s",
+                                1 + len(queue),
+                                e.next_available_at.isoformat(),
+                            )
+                            await _defer_batch(channel, e)
+                            return
+                        except NoActiveStatsClientsError:
+                            logger.error("No active connected clients for stats collection")
+                            async with state_lock:
+                                if channel in in_flight:
+                                    in_flight.remove(channel)
+                                stats["errors"] += 1 + len(queue)
+                                queue.clear()
+                                stop_workers = True
+                            return
+                        except Exception as e:
+                            logger.error("Stats error for %s: %s", channel.channel_id, e)
+                            async with state_lock:
+                                if channel in in_flight:
+                                    in_flight.remove(channel)
+                                stats["errors"] += 1
                         async with state_lock:
-                            has_more = bool(queue)
+                            has_more = bool(queue) and not stop_workers
                         if has_more:
                             await asyncio.sleep(self._config.delay_between_channels_sec)
 
                 workers = [
                     asyncio.create_task(_worker())
-                    for _ in range(min(await self.available_stats_worker_count(), len(channels)))
+                    for _ in range(
+                        min(await self.available_stats_all_worker_count(), len(selected_channels))
+                    )
                 ]
-                await asyncio.gather(*workers)
+                if workers:
+                    await asyncio.gather(*workers)
+                async with state_lock:
+                    stats["remaining"] = initial_remaining + _remaining_count_unlocked()
+                    stats["limited"] = bool(stats["remaining"])
                 return stats
             finally:
                 self._stats_all_running = False

--- a/tests/cli_real_tg_integration/heavy/test_channel_stats_all.py
+++ b/tests/cli_real_tg_integration/heavy/test_channel_stats_all.py
@@ -1,11 +1,40 @@
+from datetime import datetime, timezone
+
 import pytest
+
+from src.telegram.flood_wait import is_blocking_flood_wait_until
 
 pytestmark = pytest.mark.real_tg_safe
 
 
 @pytest.mark.timeout(960)
-def test_channel_stats_all(run_cli, assert_cli_ok):
+def test_channel_stats_all(run_cli, assert_cli_ok, cli_real_cli_env):
     """N-channel stats — foreach activeChannels, риск FLOOD_WAIT."""
+    before = _blocking_flood_state(cli_real_cli_env.db_path)
     result = run_cli("channel", "stats", "--all", timeout=900)
     assert_cli_ok(result)
     assert result.stdout.strip() or result.stderr.strip()
+    assert "remaining" in result.stdout
+    after = _blocking_flood_state(cli_real_cli_env.db_path)
+    assert set(after) <= set(before)
+    for phone, flood_until in after.items():
+        assert flood_until <= before[phone]
+
+
+def _blocking_flood_state(db_path):
+    import sqlite3
+
+    now = datetime.now(timezone.utc)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT phone, flood_wait_until FROM accounts WHERE flood_wait_until IS NOT NULL"
+        ).fetchall()
+    state = {}
+    for phone, flood_until in rows:
+        if not is_blocking_flood_wait_until(flood_until, now=now):
+            continue
+        parsed = datetime.fromisoformat(str(flood_until))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        state[str(phone)] = parsed
+    return state

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -202,6 +202,25 @@ class TestCLIChannelExtended:
         out = capsys.readouterr().out
         assert "Stats collected: {'channels': 5, 'errors': 0}" in out
 
+    def test_stats_all_passes_max_channels(self, cli_env_with_mock_pool, capsys):
+        db, pool = cli_env_with_mock_pool
+        with patch(
+            "src.cli.commands.channel.Collector",
+        ) as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_all_stats = AsyncMock(
+                return_value={"channels": 3, "errors": 0, "remaining": 7, "limited": True},
+            )
+
+            from src.cli.commands.channel import run
+
+            run(_ns(channel_action="stats", identifier=None, all=True, max_channels=3))
+
+        inst.collect_all_stats.assert_awaited_once_with(max_channels=3)
+        out = capsys.readouterr().out
+        assert "'remaining': 7" in out
+        assert "'limited': True" in out
+
     def test_refresh_types_success(self, cli_env_with_mock_pool, capsys):
         db, pool = cli_env_with_mock_pool
         asyncio.run(

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1795,7 +1795,7 @@ async def test_collect_stats_updates_channel_type():
 
 
 @pytest.mark.anyio
-async def test_collect_all_stats_waits_on_flood():
+async def test_collect_all_stats_defers_on_flood_without_sleep(monkeypatch):
     pool = make_mock_pool()
     db = MagicMock()
     db.get_channels = AsyncMock(return_value=[Channel(channel_id=1, title="Ch")])
@@ -1803,21 +1803,58 @@ async def test_collect_all_stats_waits_on_flood():
     config = SchedulerConfig()
     collector = Collector(pool, db, config)
 
-    next_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+    sleep = AsyncMock()
+    monkeypatch.setattr("src.telegram.collector.asyncio.sleep", sleep)
+
+    next_at = datetime.now(timezone.utc) + timedelta(hours=1)
 
     call_count = {"n": 0}
 
     async def _collect_stats(channel):
         call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise AllStatsClientsFloodedError(retry_after_sec=0, next_available_at=next_at)
-        return ChannelStats(channel_id=1, subscriber_count=10)
+        raise AllStatsClientsFloodedError(retry_after_sec=3600, next_available_at=next_at)
 
     collector._collect_channel_stats = _collect_stats
 
     stats = await collector.collect_all_stats()
-    assert stats["channels"] == 1
+    assert call_count["n"] == 1
+    assert stats["channels"] == 0
     assert stats["errors"] == 0
+    assert stats["remaining"] == 1
+    assert stats["limited"] is True
+    assert stats["flood_wait_until"] == next_at.isoformat()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_collect_all_stats_respects_max_channels():
+    pool = make_mock_pool()
+    db = MagicMock()
+    db.get_channels = AsyncMock(
+        return_value=[
+            Channel(channel_id=1, title="Ch1"),
+            Channel(channel_id=2, title="Ch2"),
+            Channel(channel_id=3, title="Ch3"),
+        ]
+    )
+
+    collector = Collector(pool, db, SchedulerConfig(stats_all_worker_count=1))
+    seen: list[int] = []
+
+    async def _collect_stats(channel):
+        seen.append(channel.channel_id)
+        return ChannelStats(channel_id=channel.channel_id, subscriber_count=10)
+
+    collector._collect_channel_stats = _collect_stats
+
+    stats = await collector.collect_all_stats(max_channels=2)
+    assert seen == [1, 2]
+    assert stats["channels"] == 2
+    assert stats["errors"] == 0
+    assert stats["remaining"] == 1
+    assert stats["limited"] is True
+    assert stats["total"] == 3
+    assert stats["max_channels"] == 2
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1799,6 +1799,7 @@ async def test_collect_all_stats_defers_on_flood_without_sleep(monkeypatch):
     pool = make_mock_pool()
     db = MagicMock()
     db.get_channels = AsyncMock(return_value=[Channel(channel_id=1, title="Ch")])
+    db.get_latest_stats_for_all = AsyncMock(return_value={})
 
     config = SchedulerConfig()
     collector = Collector(pool, db, config)
@@ -1837,6 +1838,7 @@ async def test_collect_all_stats_respects_max_channels():
             Channel(channel_id=3, title="Ch3"),
         ]
     )
+    db.get_latest_stats_for_all = AsyncMock(return_value={})
 
     collector = Collector(pool, db, SchedulerConfig(stats_all_worker_count=1))
     seen: list[int] = []

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1858,6 +1858,41 @@ async def test_collect_all_stats_respects_max_channels():
 
 
 @pytest.mark.anyio
+async def test_collect_all_stats_prioritizes_channels_without_or_stale_stats():
+    old = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    new = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    pool = make_mock_pool()
+    db = MagicMock()
+    db.get_channels = AsyncMock(
+        return_value=[
+            Channel(channel_id=1, title="Fresh"),
+            Channel(channel_id=2, title="Missing"),
+            Channel(channel_id=3, title="Stale"),
+        ]
+    )
+    db.get_latest_stats_for_all = AsyncMock(
+        return_value={
+            1: ChannelStats(channel_id=1, subscriber_count=10, collected_at=new),
+            3: ChannelStats(channel_id=3, subscriber_count=10, collected_at=old),
+        }
+    )
+
+    collector = Collector(pool, db, SchedulerConfig(stats_all_worker_count=1))
+    seen: list[int] = []
+
+    async def _collect_stats(channel):
+        seen.append(channel.channel_id)
+        return ChannelStats(channel_id=channel.channel_id, subscriber_count=10)
+
+    collector._collect_channel_stats = _collect_stats
+
+    stats = await collector.collect_all_stats(max_channels=2)
+    assert seen == [2, 3]
+    assert stats["remaining"] == 1
+    assert stats["limited"] is True
+
+
+@pytest.mark.anyio
 async def test_collect_all_stats_generic_error():
     pool = make_mock_pool()
     db = MagicMock()

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -354,7 +354,7 @@ async def test_handle_stats_all_respects_worker_count(
         mock_channel_bundle,
         mock_tasks_repo,
         poll_interval_sec=0.01,
-        config=SimpleNamespace(scheduler=SimpleNamespace(stats_worker_count=2)),
+        config=SimpleNamespace(scheduler=SimpleNamespace(stats_all_worker_count=2)),
     )
 
     await dispatcher._handle_stats_all(task)
@@ -363,7 +363,7 @@ async def test_handle_stats_all_respects_worker_count(
 
 
 @pytest.mark.anyio
-async def test_handle_stats_all_uses_available_stats_worker_count(
+async def test_handle_stats_all_uses_available_stats_all_worker_count(
     mock_channel_bundle, mock_tasks_repo
 ):
     """Stats-all concurrency follows non-flooded available stats account count."""
@@ -374,7 +374,7 @@ async def test_handle_stats_all_uses_available_stats_worker_count(
         is_running = False
         delay_between_channels_sec = 0
 
-        async def available_stats_worker_count(self):
+        async def available_stats_all_worker_count(self):
             return 1
 
         async def collect_channel_stats(self, _channel):
@@ -400,12 +400,56 @@ async def test_handle_stats_all_uses_available_stats_worker_count(
         mock_channel_bundle,
         mock_tasks_repo,
         poll_interval_sec=0.01,
-        config=SimpleNamespace(scheduler=SimpleNamespace(stats_worker_count=3)),
+        config=SimpleNamespace(scheduler=SimpleNamespace(stats_all_worker_count=3)),
     )
 
     await dispatcher._handle_stats_all(task)
 
     assert max_active == 1
+
+
+@pytest.mark.anyio
+async def test_handle_stats_all_reschedules_after_batch_limit(
+    mock_collector, mock_channel_bundle, mock_tasks_repo
+):
+    """Stats-all processes only the configured batch and defers the rest."""
+    mock_collector.delay_between_channels_sec = 0
+    mock_collector.collect_channel_stats = AsyncMock(return_value=MagicMock(subscriber_count=100))
+    mock_tasks_repo.get_collection_task = AsyncMock(return_value=None)
+    task = CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.STATS_ALL,
+        status=CollectionTaskStatus.RUNNING,
+        payload=StatsAllTaskPayload(channel_ids=[100, 101, 102]),
+    )
+
+    dispatcher = UnifiedDispatcher(
+        mock_collector,
+        mock_channel_bundle,
+        mock_tasks_repo,
+        poll_interval_sec=0.01,
+        config=SimpleNamespace(
+            scheduler=SimpleNamespace(
+                stats_all_max_channels_per_run=2,
+                stats_all_cooldown_sec=600,
+                stats_all_worker_count=1,
+            )
+        ),
+    )
+
+    before = datetime.now(timezone.utc)
+    await dispatcher._handle_stats_all(task)
+
+    assert mock_collector.collect_channel_stats.await_count == 2
+    mock_tasks_repo.reschedule_stats_task.assert_called_once()
+    args, kwargs = mock_tasks_repo.reschedule_stats_task.call_args
+    assert args[0] == 1
+    assert kwargs["payload"].next_index == 2
+    assert kwargs["payload"].channels_ok == 2
+    assert kwargs["payload"].remaining_channel_ids == [102]
+    assert kwargs["messages_collected"] == 2
+    assert 590 <= (kwargs["run_after"] - before).total_seconds() <= 610
+    mock_tasks_repo.update_collection_task.assert_not_called()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #691.

## Summary

- Add conservative stats-all budgeting defaults: 10 channels per batch, one worker, and 600s cooldown between queued batches.
- Bound direct `channel stats --all` runs with `--max-channels` and return `remaining`/`limited` metadata instead of running every active channel.
- Reschedule queued stats-all work after each bounded batch, and defer immediately on all-client Flood Wait instead of sleeping inside the worker.
- Add a heavy live CLI guard that fails if `channel stats --all` creates or extends blocking account Flood Wait state.

## Validation

- `python3 -m ruff check src/ tests/ conftest.py`
- `python3 -m pytest tests/test_telegram_client_pool_collector.py::test_collect_all_stats_defers_on_flood_without_sleep tests/test_telegram_client_pool_collector.py::test_collect_all_stats_respects_max_channels tests/test_unified_dispatcher.py::test_handle_stats_all_processes_batch tests/test_unified_dispatcher.py::test_handle_stats_all_respects_worker_count tests/test_unified_dispatcher.py::test_handle_stats_all_uses_available_stats_all_worker_count tests/test_unified_dispatcher.py::test_handle_stats_all_reschedules_after_batch_limit tests/test_unified_dispatcher.py::test_handle_stats_all_flood_wait_reschedules_same_task tests/test_cli_extended.py::TestCLIChannelExtended::test_stats_all_success tests/test_cli_extended.py::TestCLIChannelExtended::test_stats_all_passes_max_channels -q`
- `python3 -m pytest tests/test_unified_dispatcher.py -q`
- `python3 -m pytest tests/test_cli_extended.py::TestCLIChannelExtended tests/test_cli_channel_pipeline_route_paths.py -q`
- `python3 -m pytest tests/test_telegram_client_pool_collector.py::test_available_stats_worker_count_uses_available_stats_clients tests/test_telegram_client_pool_collector.py::test_collect_all_stats_defers_on_flood_without_sleep tests/test_telegram_client_pool_collector.py::test_collect_all_stats_respects_max_channels tests/test_telegram_client_pool_collector.py::test_collect_all_stats_generic_error tests/test_collector_extended.py::test_collect_all_stats_no_clients tests/test_channel_stats.py::test_collect_all_stats -q`
- `python3 -m pytest tests/test_flood_wait.py tests/test_account_availability.py tests/test_agent_tools_registry.py::TestResolveLiveReadPhone::test_explicit_transient_flood_wait_is_waited_inline -q`
