### PR TITLE
fix: reschedule username deferrals and stabilize heavy CLI

### DIFF
--- a/docs/testing/real-telegram.md
+++ b/docs/testing/real-telegram.md
@@ -80,7 +80,13 @@ wait — 60 секунд. Для плохой сети можно поднять
 
 - `CLI_REAL_TG_CONNECT_WAIT_SECONDS=60` — общий лимит ожидания active account + успешного probe;
 - `CLI_REAL_TG_CONNECT_POLL_SECONDS=2` — пауза между проверками DB/probe;
-- `CLI_REAL_TG_CONNECT_PROBE_TIMEOUT_SECONDS=60` — timeout одного `account info --phone` probe.
+- `CLI_REAL_TG_CONNECT_PROBE_TIMEOUT_SECONDS=60` — timeout одного `account info --phone` probe;
+- `CLI_REAL_TG_PHONE=+...` — опционально фиксирует конкретный active account для readiness probe и live CLI
+  inventory. Используйте это, когда старые active accounts еще имеют `flood_wait_until`, а проверять нужно свежий
+  подключенный аккаунт.
+
+Без `CLI_REAL_TG_PHONE` fixture сначала пробует active accounts без актуального `flood_wait_until`, и только потом
+flood-waited accounts.
 
 ## CLI Folders And Gates
 
@@ -165,6 +171,14 @@ Manual heavy inventory:
 
 ```bash
 RUN_CLI_REAL_TG_LIVE=1 RUN_REAL_TELEGRAM_SAFE=1 RUN_CLI_REAL_TG_HEAVY=1 \
+python3 -m pytest tests/cli_real_tg_integration/heavy -v
+```
+
+Чтобы прогнать heavy inventory через конкретный свежий аккаунт:
+
+```bash
+RUN_CLI_REAL_TG_LIVE=1 RUN_REAL_TELEGRAM_SAFE=1 RUN_CLI_REAL_TG_HEAVY=1 \
+CLI_REAL_TG_PHONE=+70000000000 \
 python3 -m pytest tests/cli_real_tg_integration/heavy -v
 ```
 

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from datetime import timedelta
 from pathlib import Path
 
 from src.cli import runtime
@@ -17,7 +18,12 @@ from src.services.channel_onboarding import (
 )
 from src.services.channel_service import ChannelService
 from src.telegram.backends import adapt_transport_session
-from src.telegram.collector import Collector, UsernameResolveRateLimitedError
+from src.telegram.collector import (
+    RESOLVE_USERNAME_BACKOFF_BUFFER_SEC,
+    Collector,
+    UsernameResolveFloodWaitDeferredError,
+    UsernameResolveRateLimitedError,
+)
 
 
 async def _handle_tag(args: argparse.Namespace, db) -> None:
@@ -463,6 +469,19 @@ def run(args: argparse.Namespace) -> None:
                         messages_collected=count,
                     )
                     print(f"Collected {count} messages from channel {ch.channel_id}")
+                except UsernameResolveFloodWaitDeferredError as exc:
+                    run_after = exc.next_available_at + timedelta(
+                        seconds=RESOLVE_USERNAME_BACKOFF_BUFFER_SEC
+                    )
+                    note = (
+                        "Отложено: Flood Wait на resolve_username до "
+                        f"{run_after.astimezone().isoformat()}"
+                    )
+                    await db.reschedule_collection_task(task_id, run_after=run_after, note=note)
+                    print(
+                        "Collection deferred: resolve_username Flood Wait "
+                        f"until {run_after.astimezone().isoformat()}"
+                    )
                 except UsernameResolveRateLimitedError as exc:
                     run_after = exc.run_after_with_buffer()
                     note = (

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -17,7 +17,7 @@ from src.services.channel_onboarding import (
 )
 from src.services.channel_service import ChannelService
 from src.telegram.backends import adapt_transport_session
-from src.telegram.collector import Collector
+from src.telegram.collector import Collector, UsernameResolveRateLimitedError
 
 
 async def _handle_tag(args: argparse.Namespace, db) -> None:
@@ -463,6 +463,17 @@ def run(args: argparse.Namespace) -> None:
                         messages_collected=count,
                     )
                     print(f"Collected {count} messages from channel {ch.channel_id}")
+                except UsernameResolveRateLimitedError as exc:
+                    run_after = exc.run_after_with_buffer()
+                    note = (
+                        "Отложено: resolve_username rate-limited до "
+                        f"{run_after.astimezone().isoformat()}"
+                    )
+                    await db.reschedule_collection_task(task_id, run_after=run_after, note=note)
+                    print(
+                        "Collection deferred: resolve_username rate-limited "
+                        f"on {exc.phone} until {run_after.astimezone().isoformat()}"
+                    )
                 except Exception as exc:
                     await db.update_collection_task(
                         task_id,

--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -8,7 +8,11 @@ from src.cli import runtime
 from src.database.bundles import ChannelBundle
 from src.services.collection_service import CollectionService
 from src.services.task_enqueuer import TaskEnqueuer
-from src.telegram.collector import Collector, UsernameResolveFloodWaitDeferredError
+from src.telegram.collector import (
+    Collector,
+    UsernameResolveFloodWaitDeferredError,
+    UsernameResolveRateLimitedError,
+)
 
 
 def run(args: argparse.Namespace) -> None:
@@ -45,6 +49,13 @@ def run(args: argparse.Namespace) -> None:
                 except UsernameResolveFloodWaitDeferredError as exc:
                     retry_at = exc.next_available_at.astimezone().isoformat()
                     print(f"Username resolve Flood Wait active until {retry_at}; try again later.")
+                    return
+                except UsernameResolveRateLimitedError as exc:
+                    retry_at = exc.run_after_with_buffer().astimezone().isoformat()
+                    print(
+                        "resolve_username rate-limited "
+                        f"on {exc.phone}; deferred until {retry_at}."
+                    )
                     return
                 print(f"Collected {count} messages from channel {args.channel_id}")
             else:

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import os
 import shlex
-import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -75,6 +75,39 @@ AIOSQLITE_SERIAL_PYTEST_COMMAND = (
     "-m",
     f"aiosqlite_serial and {NON_LIVE_PYTEST_MARKER_EXPR}",
 )
+BENCHMARK_ENV_DENYLIST = frozenset(
+    {
+        "AGENT_FALLBACK_API_KEY",
+        "AGENT_FALLBACK_MODEL",
+        "AGENT_MODEL",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "COHERE_API_KEY",
+        "CONTEXT7_API_KEY",
+        "CTX7_API_KEY",
+        "ENV",
+        "GROQ_API_KEY",
+        "LLM_API_KEY",
+        "OLLAMA_BASE",
+        "OLLAMA_URL",
+        "OPENAI_API_KEY",
+        "SESSION_ENCRYPTION_KEY",
+        "TG_API_HASH",
+        "TG_API_ID",
+        "TG_BACKEND_MODE",
+        "TG_CLI_TRANSPORT",
+        "TG_SESSION_CACHE_DIR",
+        "WEB_PASS",
+        "ZAI_API_KEY",
+        "ZAI_BASE_URL",
+    }
+)
+BENCHMARK_ENV_PREFIX_DENYLIST = (
+    "CLI_REAL_TG_",
+    "REAL_TG_",
+    "RUN_CLI_REAL_TG_",
+    "RUN_REAL_TELEGRAM_",
+)
 
 
 class Status(Enum):
@@ -121,13 +154,28 @@ def _run_benchmark_step(step: BenchmarkStep) -> float:
     print(f"\n=== {step.name} ===")
     print(f"$ {shlex.join(step.command)}")
     started = time.perf_counter()
-    completed = subprocess.run(step.command, cwd=REPO_ROOT, check=False)
+    completed = subprocess.run(
+        step.command,
+        cwd=REPO_ROOT,
+        check=False,
+        env=_benchmark_subprocess_env(),
+    )
     elapsed = time.perf_counter() - started
     if completed.returncode != 0:
         print(f"\nBenchmark step failed: {step.name} exited with code {completed.returncode}")
         raise SystemExit(completed.returncode)
     print(f"Completed in {elapsed:.2f}s")
     return elapsed
+
+
+def _benchmark_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for key in list(env):
+        if key in BENCHMARK_ENV_DENYLIST or any(
+            key.startswith(prefix) for prefix in BENCHMARK_ENV_PREFIX_DENYLIST
+        ):
+            env.pop(key, None)
+    return env
 
 
 def _run_pytest_benchmark() -> None:
@@ -379,7 +427,7 @@ async def _init_db_copy(config_path: str) -> tuple[Database, str, object]:
     tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
     tmp.close()
     try:
-        shutil.copy2(live_path, tmp.name)
+        _backup_sqlite_db(live_path, tmp.name)
         copy_db = Database(tmp.name, session_encryption_secret=encryption_secret)
         await copy_db.initialize()
         return copy_db, tmp.name, config
@@ -387,6 +435,21 @@ async def _init_db_copy(config_path: str) -> tuple[Database, str, object]:
         if os.path.exists(tmp.name):
             os.unlink(tmp.name)
         raise
+
+
+def _backup_sqlite_db(source_path: str, target_path: str) -> None:
+    """Create a consistent copy even when the live DB is in WAL mode."""
+    source = sqlite3.connect(
+        f"file:{source_path}?mode=ro",
+        uri=True,
+        timeout=30.0,
+    )
+    target = sqlite3.connect(target_path, timeout=30.0)
+    try:
+        source.backup(target, sleep=0.25)
+    finally:
+        target.close()
+        source.close()
 
 
 async def _run_write_checks(config_path: str) -> list[CheckResult]:

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -14,6 +14,7 @@ from src.telegram.collector import (
     Collector,
     NoActiveCollectionClientsError,
     UsernameResolveFloodWaitDeferredError,
+    UsernameResolveRateLimitedError,
 )
 
 logger = logging.getLogger(__name__)
@@ -357,6 +358,33 @@ class CollectionQueue:
                     task_id,
                     channel.channel_id,
                     run_after.isoformat(),
+                )
+            except UsernameResolveRateLimitedError as exc:
+                run_after = exc.run_after_with_buffer()
+                note = (
+                    "Отложено: resolve_username rate-limited до "
+                    f"{run_after.astimezone(timezone.utc).isoformat()}"
+                )
+                self._retried_tasks.discard(task_id)
+                await self._channels.reschedule_collection_task(
+                    task_id,
+                    run_after=run_after,
+                    note=note,
+                )
+                self._schedule_requeue_after_delay(
+                    task_id=task_id,
+                    channel=channel,
+                    force=force,
+                    full=full,
+                    run_after=run_after,
+                )
+                logger.warning(
+                    "Rescheduled collection task %d for channel %d until %s: "
+                    "username resolve rate-limited on %s",
+                    task_id,
+                    channel.channel_id,
+                    run_after.isoformat(),
+                    exc.phone,
                 )
             except NoActiveCollectionClientsError:
                 run_after = datetime.now(timezone.utc) + timedelta(

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -270,6 +270,7 @@ class CollectionQueue:
                 continue
 
             stop_after_no_clients = False
+            keep_known_task_id = False
             try:
                 self._current_task_id = task_id
                 await self._channels.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
@@ -326,6 +327,7 @@ class CollectionQueue:
                     full=full,
                     run_after=run_after,
                 )
+                keep_known_task_id = True
                 logger.warning(
                     "Rescheduled collection task %d for channel %d until %s: all clients flooded",
                     task_id,
@@ -353,6 +355,7 @@ class CollectionQueue:
                     full=full,
                     run_after=run_after,
                 )
+                keep_known_task_id = True
                 logger.warning(
                     "Rescheduled collection task %d for channel %d until %s: username resolve flood wait",
                     task_id,
@@ -378,6 +381,7 @@ class CollectionQueue:
                     full=full,
                     run_after=run_after,
                 )
+                keep_known_task_id = True
                 logger.warning(
                     "Rescheduled collection task %d for channel %d until %s: "
                     "username resolve rate-limited on %s",
@@ -410,6 +414,7 @@ class CollectionQueue:
                 )
             except ConnectionError as exc:
                 requeued = await self._try_reconnect_and_requeue(task_id, channel, full, force, exc)
+                keep_known_task_id = requeued
                 if not requeued:
                     self._retried_tasks.discard(task_id)
                     await self._channels.update_collection_task(
@@ -430,7 +435,8 @@ class CollectionQueue:
                 self._retried_tasks.discard(task_id)
             finally:
                 self._current_task_id = None
-                self._known_task_ids.discard(task_id)
+                if not keep_known_task_id:
+                    self._known_task_ids.discard(task_id)
                 self._queue.task_done()
                 if stop_after_no_clients:
                     break

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -34,6 +34,15 @@ async def fetch_message_reaction_users_raw(client: Any, peer: Any, message_id: i
     )
 
 
+async def _disconnect_client_safely(client: Any, *, phone: str) -> None:
+    try:
+        result = client.disconnect()
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        logger.debug("Failed to disconnect partially acquired client for %s", phone, exc_info=True)
+
+
 class BackendAcquireError(RuntimeError):
     """Raised when a backend cannot provide a usable authorized client."""
 
@@ -638,14 +647,16 @@ class TelethonCliBackend(TelegramBackend):
             password=None,
             env_file=env_file,
         )
+        client: TelegramClient | None = None
         try:
-            client: TelegramClient = telethon_cli_runtime.create_client(namespace)
+            client = telethon_cli_runtime.create_client(namespace)
             client._connection_retries = None
             client._retry_delay = 2
             client.flood_sleep_threshold = 0
             await client.connect()
             if not await client.is_user_authorized():
-                await client.disconnect()
+                await _disconnect_client_safely(client, phone=account.phone)
+                client = None
                 raise BackendAcquireError(f"Session is no longer valid for {account.phone}")
             return BackendClientLease(
                 phone=account.phone,
@@ -653,7 +664,13 @@ class TelethonCliBackend(TelegramBackend):
                 backend_name=self.name,
             )
         except CLIError as exc:
+            if client is not None:
+                await _disconnect_client_safely(client, phone=account.phone)
             raise BackendAcquireError(str(exc)) from exc
+        except Exception:
+            if client is not None:
+                await _disconnect_client_safely(client, phone=account.phone)
+            raise
 
 
 class BackendRouter:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -6,6 +6,7 @@ import logging
 from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import date, datetime, timedelta, timezone
+from math import ceil
 
 from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import (
@@ -125,12 +126,22 @@ class UsernameResolveRateLimitedError(RuntimeError):
     this is a short, preventive reschedule — the channel is skipped this run and
     retried shortly, not paused for hours."""
 
-    def __init__(self, phone: str, retry_after_sec: float):
+    def __init__(self, phone: str, retry_after_sec: float, *, now: datetime | None = None):
+        retry_after_sec = max(0.0, float(retry_after_sec))
+        retry_after_seconds = ceil(retry_after_sec)
+        next_available_at = (now or datetime.now(timezone.utc)) + timedelta(
+            seconds=retry_after_seconds
+        )
         super().__init__(
-            f"resolve_username rate-limited for {phone}; retry in {int(retry_after_sec)}s"
+            f"resolve_username rate-limited for {phone}; retry in {retry_after_seconds}s"
         )
         self.phone = phone
         self.retry_after_sec = retry_after_sec
+        self.retry_after_seconds = retry_after_seconds
+        self.next_available_at = next_available_at
+
+    def run_after_with_buffer(self, buffer_sec: int = RESOLVE_USERNAME_BACKOFF_BUFFER_SEC) -> datetime:
+        return self.next_available_at + timedelta(seconds=buffer_sec)
 
 
 class Collector:
@@ -604,6 +615,15 @@ class Collector:
                         )
                         stats["deferred"] = stats.get("deferred", 0) + 1
                         continue
+                    except UsernameResolveRateLimitedError as e:
+                        logger.warning(
+                            "Channel %s deferred until %s: resolve_username rate-limited on %s",
+                            channel.channel_id,
+                            e.run_after_with_buffer().isoformat(),
+                            e.phone,
+                        )
+                        stats["deferred"] = stats.get("deferred", 0) + 1
+                        continue
                     except Exception as e:
                         logger.error("Error collecting channel %s: %s", channel.channel_id, e)
                         stats["errors"] += 1
@@ -827,19 +847,6 @@ class Collector:
                         logger.warning(
                             "get_input_entity timed out for channel %d, skipping",
                             channel_id,
-                        )
-                        return total_collected
-                    except UsernameResolveRateLimitedError as exc:
-                        # Preventive throttle (#551): defer this channel briefly
-                        # rather than firing a resolve that would flood the
-                        # account. The next scheduler tick picks it up again.
-                        logger.warning(
-                            "Channel %d (%s): resolve_username rate-limited on %s, "
-                            "deferring ~%ss",
-                            channel_id,
-                            channel.username,
-                            exc.phone,
-                            int(exc.retry_after_sec),
                         )
                         return total_collected
                     except HandledFloodWaitError as exc:

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -19,6 +19,7 @@ from src.config import load_config
 CLI_REAL_TG_LIVE_GATE_ENV = "RUN_CLI_REAL_TG_LIVE"
 CLI_REAL_TG_ROOT_ENV = "CLI_REAL_TG_ROOT"
 CLI_REAL_TG_CONFIG_ENV = "CLI_REAL_TG_CONFIG"
+CLI_REAL_TG_PHONE_ENV = "CLI_REAL_TG_PHONE"
 CLI_REAL_TG_MUTATION_CHAT_ENV = "CLI_REAL_TG_MUTATION_CHAT"
 CLI_REAL_TG_MUTATION_PHONE_ENV = "CLI_REAL_TG_MUTATION_PHONE"
 CLI_REAL_TG_CONNECT_WAIT_ENV = "CLI_REAL_TG_CONNECT_WAIT_SECONDS"
@@ -123,17 +124,42 @@ def _resolve_db_path(live_root: Path, db_path: str) -> Path:
 
 
 def _fetch_live_accounts(db_path: Path) -> tuple[str, ...]:
+    requested_phone = os.environ.get(CLI_REAL_TG_PHONE_ENV, "").strip()
+    now = datetime.now(timezone.utc)
+
+    def _parse_flood_wait_until(raw: object) -> datetime | None:
+        if raw is None or raw == "":
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _sort_key(row: sqlite3.Row) -> tuple[int, int, int]:
+        flood_wait_until = _parse_flood_wait_until(row["flood_wait_until"])
+        blocked = int(flood_wait_until is not None and flood_wait_until > now)
+        is_primary = int(row["is_primary"] or 0)
+        account_id = int(row["id"] or 0)
+        return blocked, -is_primary, account_id
+
     with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
         rows = conn.execute(
             """
-            SELECT phone
+            SELECT id, phone, COALESCE(is_primary, 0) AS is_primary, flood_wait_until
             FROM accounts
             WHERE COALESCE(is_active, 1) = 1
               AND COALESCE(session_string, '') != ''
-            ORDER BY COALESCE(is_primary, 0) DESC, id ASC
             """
         ).fetchall()
-    return tuple(str(row[0]) for row in rows if row[0])
+    accounts = [row for row in rows if row["phone"]]
+    if requested_phone:
+        accounts = [row for row in accounts if str(row["phone"]) == requested_phone]
+    accounts.sort(key=_sort_key)
+    return tuple(str(row["phone"]) for row in accounts)
 
 
 def _fetch_live_channel(db_path: Path) -> tuple[str | None, int | None, str | None]:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -611,3 +612,27 @@ async def test_telethon_cli_backend_disables_flood_auto_sleep(monkeypatch, tmp_p
     assert fake_client.flood_sleep_threshold == 0
     assert lease.phone == "+70001112233"
     assert lease.backend_name == "telethon_cli"
+
+
+@pytest.mark.anyio
+async def test_telethon_cli_backend_disconnects_partial_client_on_acquire_error(monkeypatch, tmp_path):
+    fake_client = FakeCliTelethonClient()
+    fake_client.is_user_authorized = AsyncMock(side_effect=sqlite3.OperationalError("database is locked"))
+    monkeypatch.setattr(
+        "src.telegram.backends.telethon_cli_runtime.create_client",
+        lambda namespace: fake_client,
+    )
+
+    materializer = SimpleNamespace(
+        materialize=lambda phone, session_string: str(tmp_path / "session"),
+        ensure_empty_env_file=lambda: str(tmp_path / ".env"),
+    )
+    auth = SimpleNamespace(api_id=1, api_hash="hash")
+    backend = TelethonCliBackend(auth, materializer, transport="hybrid")
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        await backend.acquire_client(
+            Account(phone="+70001112233", session_string="session-xyz")
+        )
+
+    fake_client.disconnect.assert_awaited_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -969,8 +969,14 @@ class TestCLITest:
         args = parser.parse_args(["test", "benchmark"])
         assert args.test_action == "benchmark"
 
-    def test_benchmark(self, capsys):
+    def test_benchmark(self, capsys, monkeypatch):
         from src.cli.commands import test as test_cmd
+
+        monkeypatch.setenv("RUN_CLI_REAL_TG_LIVE", "1")
+        monkeypatch.setenv("CLI_REAL_TG_PHONE", "+70000000000")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "live-key")
+        monkeypatch.setenv("AGENT_FALLBACK_MODEL", "openai:gpt-4.1-mini")
+        monkeypatch.setenv("ENV", "DEV")
 
         completed = subprocess.CompletedProcess(args=["pytest"], returncode=0)
         with (
@@ -996,6 +1002,12 @@ class TestCLITest:
         assert run_mock.call_args_list[1].args[0] == test_cmd.PARALLEL_SAFE_PYTEST_COMMAND
         assert run_mock.call_args_list[2].args[0] == test_cmd.AIOSQLITE_SERIAL_PYTEST_COMMAND
         assert run_mock.call_args_list[0].kwargs["cwd"] == test_cmd.REPO_ROOT
+        env = run_mock.call_args_list[0].kwargs["env"]
+        assert "RUN_CLI_REAL_TG_LIVE" not in env
+        assert "CLI_REAL_TG_PHONE" not in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "AGENT_FALLBACK_MODEL" not in env
+        assert "ENV" not in env
 
     def test_benchmark_fails_on_failed_subprocess(self, capsys):
         from src.cli.commands.test import run
@@ -1013,6 +1025,32 @@ class TestCLITest:
 
         out = capsys.readouterr().out
         assert "Benchmark step failed: serial_full_suite exited with code 2" in out
+
+    def test_sqlite_backup_copy_includes_committed_wal_data(self, tmp_path):
+        import sqlite3
+
+        from src.cli.commands.test import _backup_sqlite_db
+
+        source_path = tmp_path / "source.db"
+        target_path = tmp_path / "target.db"
+        conn = sqlite3.connect(source_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+            conn.execute("INSERT INTO items (name) VALUES ('live')")
+            conn.commit()
+
+            _backup_sqlite_db(str(source_path), str(target_path))
+
+            copied = sqlite3.connect(target_path)
+            try:
+                rows = copied.execute("SELECT name FROM items").fetchall()
+            finally:
+                copied.close()
+        finally:
+            conn.close()
+
+        assert rows == [("live",)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_dialogs_notifications_scheduler.py
+++ b/tests/test_cli_dialogs_notifications_scheduler.py
@@ -983,5 +983,23 @@ class TestCollectCommand:
         assert "try again later" in out
 
 
+    def test_collect_single_channel_username_rate_limited(self, cli_env_with_pool, capsys):
+        from src.telegram.collector import Collector, UsernameResolveRateLimitedError
+
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+        _add_channel(cli_env, channel_id=101, title="Rate Limited Channel")
+
+        exc = UsernameResolveRateLimitedError("+7001", 28)
+        with patch.object(Collector, "collect_single_channel", new_callable=AsyncMock, side_effect=exc):
+            from src.cli.commands.collect import run
+
+            run(_ns(channel_id=101, full=True))
+
+        out = capsys.readouterr().out
+        assert "resolve_username rate-limited" in out
+        assert "Collected" not in out
+
+
 def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:
     return asyncio.run(db.add_channel(Channel(channel_id=channel_id, title=title)))

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -471,7 +471,7 @@ class TestCLIChannelExtended:
         assert "missing type: 1" in out
 
     def test_collect_error(self, cli_env_with_mock_pool, capsys):
-        db, pool = cli_env_with_mock_pool
+        db, _pool = cli_env_with_mock_pool
         ch_id = asyncio.run(
             db.add_channel(
                 Channel(channel_id=103, title="CollectMe"),
@@ -497,6 +497,41 @@ class TestCLIChannelExtended:
         tasks = asyncio.run(db.get_collection_tasks(limit=1))
         assert tasks[0].status == CollectionTaskStatus.FAILED
         assert "collect fail" in tasks[0].error
+
+    def test_collect_username_resolve_rate_limited_reschedules(self, cli_env_with_mock_pool, capsys):
+        db, _pool = cli_env_with_mock_pool
+        ch_id = asyncio.run(
+            db.add_channel(
+                Channel(channel_id=104, title="CollectRateLimited"),
+            )
+        )
+
+        from src.telegram.collector import UsernameResolveRateLimitedError
+
+        inst = None
+        with patch("src.cli.commands.channel.Collector") as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_single_channel = AsyncMock(
+                side_effect=UsernameResolveRateLimitedError("+7001", 28)
+            )
+            from src.cli.commands.channel import run
+
+            run(
+                _ns(
+                    channel_action="collect",
+                    identifier=str(ch_id),
+                )
+            )
+
+        out = capsys.readouterr().out
+        assert "resolve_username rate-limited" in out
+        assert inst is not None
+        inst.collect_single_channel.assert_awaited_once()
+        _ensure_db_open(db)
+        tasks = asyncio.run(db.get_collection_tasks(limit=1))
+        assert tasks[0].status == CollectionTaskStatus.PENDING
+        assert tasks[0].run_after is not None
+        assert "resolve_username rate-limited" in (tasks[0].note or "")
 
 
 class TestCLITestExtended:

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -533,6 +533,52 @@ class TestCLIChannelExtended:
         assert tasks[0].run_after is not None
         assert "resolve_username rate-limited" in (tasks[0].note or "")
 
+    def test_collect_username_resolve_flood_wait_reschedules(self, cli_env_with_mock_pool, capsys):
+        # A long resolve FloodWait raises UsernameResolveFloodWaitDeferredError out of
+        # collect_single_channel; the collect handler must defer (PENDING + run_after),
+        # not fall into the broad Exception handler and mark the task FAILED.
+        from datetime import datetime, timedelta, timezone
+
+        db, _pool = cli_env_with_mock_pool
+        ch_id = asyncio.run(
+            db.add_channel(
+                Channel(channel_id=105, title="CollectFloodWaitDeferred"),
+            )
+        )
+
+        from src.telegram.collector import UsernameResolveFloodWaitDeferredError
+
+        next_available_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+        inst = None
+        with patch("src.cli.commands.channel.Collector") as mock_collector:
+            inst = mock_collector.return_value
+            inst.collect_single_channel = AsyncMock(
+                side_effect=UsernameResolveFloodWaitDeferredError(
+                    wait_seconds=1800,
+                    next_available_at=next_available_at,
+                )
+            )
+            from src.cli.commands.channel import run
+
+            run(
+                _ns(
+                    channel_action="collect",
+                    identifier=str(ch_id),
+                )
+            )
+
+        out = capsys.readouterr().out
+        assert "resolve_username Flood Wait" in out
+        assert inst is not None
+        inst.collect_single_channel.assert_awaited_once()
+        _ensure_db_open(db)
+        tasks = asyncio.run(db.get_collection_tasks(limit=1))
+        assert tasks[0].status == CollectionTaskStatus.PENDING
+        assert tasks[0].error is None
+        assert tasks[0].run_after is not None
+        assert tasks[0].run_after >= next_available_at
+        assert "Flood Wait на resolve_username" in (tasks[0].note or "")
+
 
 class TestCLITestExtended:
     def test_read_checks_with_errors(self, cli_env, capsys):

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -232,6 +232,15 @@ async def test_username_resolve_rate_limit_keeps_task_pending(tmp_path):
         assert task.run_after is not None
         assert task.run_after >= before + timedelta(seconds=33)
         assert "resolve_username rate-limited" in (task.note or "")
+
+        queue.start_db_pull(interval=0.02)
+        try:
+            await asyncio.sleep(0.12)
+        finally:
+            await queue.stop_db_pull()
+
+        assert task_id in queue._known_task_ids
+        assert len(queue._delayed_requeues) == 1
     finally:
         await queue.shutdown()
         await db.close()

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -16,7 +16,10 @@ import pytest
 from src.collection_queue import CollectionQueue
 from src.database import Database
 from src.models import Channel
-from src.telegram.collector import UsernameResolveFloodWaitDeferredError
+from src.telegram.collector import (
+    UsernameResolveFloodWaitDeferredError,
+    UsernameResolveRateLimitedError,
+)
 
 
 class _FakeCollector:
@@ -58,6 +61,13 @@ class _UsernameResolveFloodCollector(_FakeCollector):
             wait_seconds=120,
             next_available_at=self.next_available_at,
         )
+
+
+class _UsernameResolveRateLimitedCollector(_FakeCollector):
+    async def collect_single_channel(self, channel, *, full=False, progress_callback=None, force=False):
+        self.calls.append(channel.channel_id)
+        self.full_calls.append(full)
+        raise UsernameResolveRateLimitedError("+7001", 28.2)
 
 
 class _BlockingCollector:
@@ -191,6 +201,37 @@ async def test_username_resolve_flood_defer_keeps_task_pending(tmp_path):
         assert task.run_after is not None
         assert task.run_after > next_available_at
         assert "Flood Wait на resolve_username" in (task.note or "")
+    finally:
+        await queue.shutdown()
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_username_resolve_rate_limit_keeps_task_pending(tmp_path):
+    db = Database(str(tmp_path / "queue.db"))
+    await db.initialize()
+    try:
+        await _seed_channel(db)
+
+        collector = _UsernameResolveRateLimitedCollector()
+        queue = CollectionQueue(collector, db)
+        channel = (await db.get_channels(active_only=True))[0]
+        before = datetime.now(timezone.utc)
+        task_id = await queue.enqueue(channel)
+
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while asyncio.get_event_loop().time() < deadline:
+            task = await db.get_collection_task(task_id)
+            if task.status == "pending" and task.run_after is not None:
+                break
+            await asyncio.sleep(0.05)
+
+        task = await db.get_collection_task(task_id)
+        assert task.status == "pending"
+        assert task.error is None
+        assert task.run_after is not None
+        assert task.run_after >= before + timedelta(seconds=33)
+        assert "resolve_username rate-limited" in (task.note or "")
     finally:
         await queue.shutdown()
         await db.close()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -15,6 +15,7 @@ from src.telegram.collector import (
     Collector,
     NoActiveCollectionClientsError,
     UsernameResolveFloodWaitDeferredError,
+    UsernameResolveRateLimitedError,
 )
 from tests.helpers import AsyncIterEmpty as _AsyncIterEmpty
 from tests.helpers import AsyncIterMessages as _AsyncIterMessages
@@ -310,8 +311,8 @@ async def test_collect_channel_username_resolve_flood_does_not_rotate(db):
 @pytest.mark.anyio
 async def test_collect_channel_defers_when_resolve_rate_limited(db):
     """#551: when the per-account resolve limiter is exhausted, the live
-    get_input_entity call must not fire — the channel is deferred (returns 0),
-    not flooded."""
+    get_input_entity call must not fire; the caller must defer the task instead
+    of completing it with zero collected messages."""
     from src.telegram.rate_limiter import ResolveRateLimiter
 
     ch = Channel(
@@ -341,9 +342,11 @@ async def test_collect_channel_defers_when_resolve_rate_limited(db):
     )
     assert collector._resolve_rate_limiter.try_acquire("+7001") == 0.0
 
-    result = await collector._collect_channel(stored)
+    with pytest.raises(UsernameResolveRateLimitedError) as exc_info:
+        await collector._collect_channel(stored)
 
-    assert result == 0
+    assert exc_info.value.phone == "+7001"
+    assert 0 < exc_info.value.retry_after_sec <= 60
     raw_client.get_input_entity.assert_not_awaited()
     pool.report_flood.assert_not_awaited()
 
@@ -351,7 +354,7 @@ async def test_collect_channel_defers_when_resolve_rate_limited(db):
 @pytest.mark.anyio
 async def test_collect_channel_cache_only_defers_on_backoff_miss(db):
     """#552: while a global resolve backoff is active, a channel whose InputPeer
-    is not cached runs in cache-only mode — it is deferred (returns 0) without
+    is not cached runs in cache-only mode — it raises a defer signal without
     ever calling the live resolve API."""
     ch = Channel(
         channel_id=1970788986,
@@ -372,9 +375,10 @@ async def test_collect_channel_cache_only_defers_on_backoff_miss(db):
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
     collector._set_resolve_username_backoff(600)
 
-    result = await collector._collect_channel(stored)
+    with pytest.raises(UsernameResolveRateLimitedError) as exc_info:
+        await collector._collect_channel(stored)
 
-    assert result == 0
+    assert exc_info.value.phone == "+7001"
     raw_client.get_input_entity.assert_not_awaited()
     pool.report_flood.assert_not_awaited()
 
@@ -405,6 +409,7 @@ async def test_collect_all_channels_continues_cache_only_during_backoff(db):
     # Run did NOT stop on the backoff; both channels were processed (deferred).
     assert stats["errors"] == 0
     assert stats["messages"] == 0
+    assert stats["deferred"] == 2
     raw1.get_input_entity.assert_not_awaited()
     raw2.get_input_entity.assert_not_awaited()
 

--- a/tests/test_real_telegram_policy.py
+++ b/tests/test_real_telegram_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import os
+import sqlite3
 import subprocess
 import sys
 import tomllib
@@ -18,12 +19,14 @@ from tests.cli_real_tg_integration.command_manifest import (
     CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS,
 )
 from tests.cli_real_tg_integration.conftest import (
+    CLI_REAL_TG_PHONE_ENV,
     LIVE_CLI_DEFAULT_PYTEST_TIMEOUT_SECONDS,
     RUN_CLI_DEFAULT_TIMEOUT_SECONDS,
     CliRealCliEnv,
     LiveCliAccountReadinessError,
     LiveCliAccountWaitTimeoutError,
     _assert_cli_result_ok,
+    _fetch_live_accounts,
     account_info_probe_failure,
     wait_for_ready_live_cli_accounts,
 )
@@ -144,6 +147,68 @@ def _live_cli_probe_env(tmp_path: Path) -> CliRealCliEnv:
         channel_id=None,
         channel_username=None,
     )
+
+
+def _create_live_accounts_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE accounts (
+                id INTEGER PRIMARY KEY,
+                phone TEXT,
+                session_string TEXT,
+                is_active INTEGER,
+                is_primary INTEGER,
+                flood_wait_until TEXT
+            )
+            """
+        )
+
+
+def test_fetch_live_accounts_prefers_accounts_not_in_flood_wait(tmp_path, monkeypatch):
+    monkeypatch.delenv(CLI_REAL_TG_PHONE_ENV, raising=False)
+    db_path = tmp_path / "live.db"
+    _create_live_accounts_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO accounts (id, phone, session_string, is_active, is_primary, flood_wait_until)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                (1, "+primary-flooded", "session", 1, 1, "2099-01-01T00:00:00+00:00"),
+                (2, "+secondary-ready", "session", 1, 0, None),
+                (3, "+primary-ready", "session", 1, 1, "2000-01-01T00:00:00+00:00"),
+            ),
+        )
+
+    assert _fetch_live_accounts(db_path) == (
+        "+primary-ready",
+        "+secondary-ready",
+        "+primary-flooded",
+    )
+
+
+def test_fetch_live_accounts_can_pin_requested_phone(tmp_path, monkeypatch):
+    db_path = tmp_path / "live.db"
+    _create_live_accounts_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO accounts (id, phone, session_string, is_active, is_primary, flood_wait_until)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                (1, "+old", "session", 1, 1, "2099-01-01T00:00:00+00:00"),
+                (2, "+fresh", "session", 1, 0, None),
+            ),
+        )
+
+    monkeypatch.setenv(CLI_REAL_TG_PHONE_ENV, "+fresh")
+
+    assert _fetch_live_accounts(db_path) == ("+fresh",)
 
 
 def test_live_cli_account_readiness_retries_until_active_account_appears(tmp_path: Path):


### PR DESCRIPTION
## Summary

- reschedule `resolve_username` rate-limit and long FloodWait deferrals instead of completing/failing collection tasks silently
- keep deferred collection tasks reserved while delayed requeues sleep, preventing duplicate DB-pull sleepers and repeated retries for one task
- surface deferrals consistently through the collector, collection queue, and direct CLI collection commands
- prefer non-flooded live CLI accounts and allow pinning a fresh account with `CLI_REAL_TG_PHONE`
- stabilize live-heavy validation by using SQLite backup for DB copies, cleaning up partially acquired Telethon clients before fallback, and sanitizing `test benchmark` subprocess env

## Root Cause

`UsernameResolveRateLimitedError` was being swallowed in the collector path and converted into a successful `0` message result. The queue then treated that as a completed task, silently losing collection work.

Follow-up review also caught that delayed requeue scheduling kept the DB row `PENDING` but released `_known_task_ids` in the worker `finally`, so the periodic DB pull could schedule duplicate sleepers for the same task.

The live-heavy validation also exposed unrelated harness instability: `test benchmark` inherited live `.env`/`ENV=DEV` settings, file-copying a live WAL SQLite DB could produce malformed DB copies, and partially failed `telethon_cli` acquisition could leave pending Telethon tasks that printed traceback-looking stderr.

## Validation

- `python3 -m ruff check ...`
- `python3 -m pytest tests/test_collection_queue_db_pull.py::test_username_resolve_rate_limit_keeps_task_pending tests/test_collection_queue_db_pull.py::test_delayed_requeue_queue_full_releases_known_task_id -q` → `2 passed`
- `python3 -m pytest tests/test_collector.py tests/test_cli_dialogs_notifications_scheduler.py tests/test_cli_extended.py tests/test_collection_queue_db_pull.py tests/test_real_telegram_policy.py tests/test_cli.py::TestCLITest tests/test_backends.py tests/test_database.py::test_agent_message_write_retries_when_database_is_locked_once tests/test_database_write_lock.py::test_execute_write_acquires_lock tests/test_session_materializer.py -q` → `286 passed`
- `python3 -m pytest tests -q -m "not real_tg_safe and not real_tg_mutation_safe and not real_tg_manual and not real_provider_smoke"` → `8190 passed, 104 deselected`
- live heavy Telegram subset on pinned fresh account → `8 passed, 1 deselected`
- live heavy benchmark on pinned fresh account → `1 passed`

Closes #696.
Closes #701.