### PR TITLE
fix(633): correct t.me/c message links for bare-positive channel ids (#703)

### DIFF
--- a/src/parsers.py
+++ b/src/parsers.py
@@ -129,3 +129,22 @@ def deduplicate_identifiers(identifiers: list[str]) -> list[str]:
             seen.add(key)
             result.append(ident)
     return result
+
+
+# Telegram marks supergroup/channel peers as ``-100<bare>`` (e.g. ``-1001234567890``).
+_MTPROTO_CHANNEL_MARKER = 1_000_000_000_000
+
+
+def bare_channel_id(channel_id: int) -> int:
+    """Return the bare (positive, no ``-100`` marker) channel id for a t.me/c link.
+
+    Storage convention is bare-positive (e.g. ``1001079551``), but a value may
+    also arrive in Telethon's marked form ``-100<bare>`` (e.g.
+    ``-1001234567890``). Only the marked form carries the ``100`` prefix that
+    must be stripped; a bare-positive id is already correct and must be left
+    untouched — stripping ``100`` from ``1001079551`` would corrupt the link.
+    """
+    cid = abs(channel_id)
+    if channel_id < 0 and cid > _MTPROTO_CHANNEL_MARKER:
+        return cid - _MTPROTO_CHANNEL_MARKER
+    return cid

--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from src.models import Channel, Message, SearchQuery
+from src.parsers import bare_channel_id
 from src.telegram.notifier import Notifier
 from src.utils.search_query_chat_filter import chat_filter_matches_message
 
@@ -77,8 +78,7 @@ def _make_message_link(msg: Message) -> str:
     """Build a t.me link for the message."""
     if msg.channel_username:
         return f"https://t.me/{msg.channel_username}/{msg.message_id}"
-    bare_id = str(msg.channel_id).lstrip("-").removeprefix("100")
-    return f"https://t.me/c/{bare_id}/{msg.message_id}"
+    return f"https://t.me/c/{bare_channel_id(msg.channel_id)}/{msg.message_id}"
 
 
 def _fts_query_matches(fts_query: str, text: str) -> bool:

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -12,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 from markupsafe import Markup, escape
 
 from src.config import AppConfig, is_provider_model_ref
+from src.parsers import bare_channel_id
 from src.web.paths import TEMPLATES_DIR
 
 logger = logging.getLogger(__name__)
@@ -283,4 +284,5 @@ def configure_template_globals(
     templates.env.globals["flash_messages"] = FLASH_MESSAGES
     templates.env.globals["flash_errors"] = FLASH_ERRORS
     templates.env.filters["local_dt"] = local_dt_filter
+    templates.env.filters["tme_channel_id"] = bare_channel_id
     return templates

--- a/src/web/templates/analytics.html
+++ b/src/web/templates/analytics.html
@@ -66,7 +66,7 @@
                     {% if msg.channel_username %}
                     <a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>
                     {% else %}
-                    <a href="https://t.me/c/{{ (msg.channel_id | abs) - 1000000000000 }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>
+                    <a href="https://t.me/c/{{ msg.channel_id | tme_channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>
                     {% endif %}
                 </td>
             </tr>
@@ -88,7 +88,7 @@
                 {% if msg.channel_username %}
                 <a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary">Открыть {{ icon("link") }}</a>
                 {% else %}
-                <a href="https://t.me/c/{{ (msg.channel_id | abs) - 1000000000000 }}/{{ msg.message_id }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary">Открыть {{ icon("link") }}</a>
+                <a href="https://t.me/c/{{ msg.channel_id | tme_channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary">Открыть {{ icon("link") }}</a>
                 {% endif %}
             </div>
         </div>

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -70,6 +70,43 @@ async def test_content_analytics_pipeline_links_use_edit_route(route_client):
 
 
 @pytest.mark.anyio
+async def test_analytics_top_message_link_uses_bare_channel_id(route_client):
+    """Regression #633-9: t.me/c link for a no-username channel keeps the bare id.
+
+    The id starts with ``100`` (1005551782); the old template truncated it via
+    ``(channel_id | abs) - 1000000000000`` producing a broken/negative link.
+    """
+    from datetime import datetime, timezone
+
+    from src.models import Channel, Message
+
+    db = route_client._transport_app.state.db
+    channel_id = 1005551782
+    await db.add_channel(
+        Channel(channel_id=channel_id, title="No Username Channel", username=None)
+    )
+    await db.insert_messages_batch(
+        [
+            Message(
+                channel_id=channel_id,
+                message_id=789,
+                text="top reacted message",
+                reactions_json='[{"emoji": "👍", "count": 42}]',
+                date=datetime(2024, 6, 1, 12, 0, tzinfo=timezone.utc),
+            )
+        ]
+    )
+
+    resp = await route_client.get("/analytics")
+
+    assert resp.status_code == 200
+    assert "https://t.me/c/1005551782/789" in resp.text
+    # The broken legacy forms must be gone.
+    assert "t.me/c/5551782/" not in resp.text
+    assert "-998994448218" not in resp.text
+
+
+@pytest.mark.anyio
 async def test_api_content_summary_returns_json(route_client):
     """Test content summary API returns JSON."""
     resp = await route_client.get("/analytics/content/api/summary")

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -325,13 +325,31 @@ def test_make_message_link_with_username():
     assert link == "https://t.me/mychannel/456"
 
 
-def test_make_message_link_without_username():
-    """t.me/c/{bare_id}/{message_id} when no channel_username."""
+def test_make_message_link_legacy_marked_id():
+    """Telethon marked form -100<bare> is normalised to the bare id."""
     msg = make_message("test", channel_id=-1001234567890, message_id=789)
     link = _make_message_link(msg)
 
-    # -1001234567890 -> bare_id = 1234567890 (strip -100 prefix)
+    # -1001234567890 -> bare_id = 1234567890 (strip -100 marker)
     assert link == "https://t.me/c/1234567890/789"
+
+
+def test_make_message_link_bare_positive_id():
+    """Bare-positive stored ids are used verbatim (storage convention)."""
+    msg = make_message("test", channel_id=1234567890, message_id=789)
+    link = _make_message_link(msg)
+
+    assert link == "https://t.me/c/1234567890/789"
+
+
+def test_make_message_link_bare_id_starting_with_100():
+    """Regression #633-9: ids starting with 100 must NOT be truncated."""
+    # 1005551782 is a real-shaped bare id; the old code stripped the leading
+    # "100" and produced a broken https://t.me/c/5551782/... link.
+    msg = make_message("test", channel_id=1005551782, message_id=789)
+    link = _make_message_link(msg)
+
+    assert link == "https://t.me/c/1005551782/789"
 
 
 # === _fts_query_matches pure function tests ===

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -3,12 +3,33 @@ from __future__ import annotations
 import pytest
 
 from src.parsers import (
+    bare_channel_id,
     deduplicate_identifiers,
     extract_identifiers,
     normalize_identifier,
     parse_file,
     parse_identifiers,
 )
+
+
+class TestBareChannelId:
+    @pytest.mark.parametrize(
+        "channel_id,expected",
+        [
+            # Bare-positive storage convention — used verbatim.
+            (1234567890, 1234567890),
+            # Regression #633-9: a bare id starting with 100 must NOT be truncated.
+            (1005551782, 1005551782),
+            (1001079551, 1001079551),
+            # Telethon marked form -100<bare> is normalised to the bare id.
+            (-1001234567890, 1234567890),
+            (-1001005551782, 1005551782),
+            # A plain negative id without the -100 marker just loses the sign.
+            (-1234567890, 1234567890),
+        ],
+    )
+    def test_bare_channel_id(self, channel_id, expected):
+        assert bare_channel_id(channel_id) == expected
 
 
 class TestParseIdentifiers:

--- a/tests/test_template_globals.py
+++ b/tests/test_template_globals.py
@@ -1,8 +1,13 @@
 from datetime import datetime, timezone
 
+from fastapi.templating import Jinja2Templates
 from markupsafe import Markup
 
-from src.web.template_globals import FILTER_FLAG_EMOJI, local_dt_filter
+from src.web.template_globals import (
+    FILTER_FLAG_EMOJI,
+    configure_template_globals,
+    local_dt_filter,
+)
 
 
 def test_none_returns_dash():
@@ -100,6 +105,20 @@ def test_fallback_text_present_for_string():
     result = str(local_dt_filter("2024-03-15T10:30:00"))
     # fallback is str(value)[:16] of original string
     assert "2024-03-15T10:30" in result
+
+
+def test_tme_channel_id_filter_registered_and_renders_link():
+    """The tme_channel_id filter is wired up and builds a correct t.me/c link."""
+    from src.web.paths import TEMPLATES_DIR
+
+    templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+    configure_template_globals(templates)
+
+    assert "tme_channel_id" in templates.env.filters
+    rendered = templates.env.from_string(
+        "https://t.me/c/{{ cid | tme_channel_id }}/{{ mid }}"
+    ).render(cid=1005551782, mid=789)
+    assert rendered == "https://t.me/c/1005551782/789"
 
 
 def test_filter_flag_emoji_uses_bootstrap_icons():


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #703 (баг #9 из мета-issue #633): ссылки `https://t.me/c/<id>/<msg>` на сообщения приватных каналов строились неправильно.

`channels.channel_id` хранится как **bare-positive** id (напр. `1001079551`; на боевой БД — 751 канал, все положительные, без `-100` префикса). Корректная ссылка использует id **как есть** (эталон — `search.html`). Но два места делали лишние манипуляции:

- `notification_matcher._make_message_link` — `.removeprefix("100")` срезал `100` у id вроде `1001079551` → `1079551` (битая ссылка).
- `analytics.html` — `(channel_id | abs) - 1000000000000` для bare-positive id давало **отрицательное** число (битая ссылка).

## Решение

- Единый источник истины `bare_channel_id()` в `src/parsers.py`: bare-positive id оставляет как есть, и только у legacy marked-формы `-100<bare>` (Telethon) снимает маркер.
- `notification_matcher` использует эту функцию; в шаблонах она доступна как Jinja-фильтр `tme_channel_id`.
- `search.html` уже был корректен — не тронут.

## Тесты

- `tests/test_parsers.py::TestBareChannelId` — unit на bare-positive, id со `100`, marked-форму.
- `tests/test_notification_matcher.py` — регрессия на id, начинающийся со `100` + marked + bare.
- `tests/test_template_globals.py` — фильтр `tme_channel_id` зарегистрирован и рендерит ссылку.
- `tests/routes/test_analytics_routes.py` — реальный рендеринг `/analytics` отдаёт `https://t.me/c/1005551782/789`, а битых форм нет.

## Проверка

- `ruff check src/ tests/ conftest.py` — чисто
- 627 связанных тестов зелёные; дифф 124 строки.

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
