### PR TITLE
fix(633): honor cancel arriving in the collection startup window (#705)

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -281,7 +281,19 @@ class CollectionQueue:
                 count = await self._collector.collect_single_channel(
                     channel, full=full, progress_callback=_progress, force=force
                 )
-                if self._collector.is_cancelled:
+                # A cancel arriving in the startup window (after _current_task_id
+                # is set but before the collector loop runs) sets the DB row to
+                # CANCELLED, but the collector clears its in-memory cancel flag at
+                # the start of collection — so is_cancelled can read False here even
+                # though the user cancelled. Re-read the persisted status so that
+                # cancel is the source of truth and we never clobber it with
+                # COMPLETED (#633 bug #30).
+                persisted = await self._channels.get_collection_task(task_id)
+                cancelled = self._collector.is_cancelled or (
+                    persisted is not None
+                    and persisted.status == CollectionTaskStatus.CANCELLED
+                )
+                if cancelled:
                     if self._shutdown_requested:
                         await self._reset_task_to_pending_after_shutdown(task_id)
                         logger.info("Task %d requeued after service shutdown interrupted collection", task_id)

--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -289,12 +289,14 @@ class CollectionQueue:
                 # cancel is the source of truth and we never clobber it with
                 # COMPLETED (#633 bug #30).
                 persisted = await self._channels.get_collection_task(task_id)
-                cancelled = self._collector.is_cancelled or (
+                persisted_cancelled = (
                     persisted is not None
                     and persisted.status == CollectionTaskStatus.CANCELLED
                 )
+                collector_cancelled = self._collector.is_cancelled
+                cancelled = collector_cancelled or persisted_cancelled
                 if cancelled:
-                    if self._shutdown_requested:
+                    if self._shutdown_requested and not persisted_cancelled:
                         await self._reset_task_to_pending_after_shutdown(task_id)
                         logger.info("Task %d requeued after service shutdown interrupted collection", task_id)
                     else:

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -272,8 +272,15 @@ class CollectionTasksRepository:
             sets.append("run_after = ?")
             params.append(run_after.astimezone(timezone.utc).isoformat())
         params.append(task_id)
+        # Defense in depth (#633 bug #30): a user-issued CANCELLED is terminal and
+        # must not be silently overwritten by a late RUNNING/COMPLETED/FAILED from a
+        # worker that lost the in-memory cancel flag in the task-startup race.
+        where = "WHERE id = ?"
+        if status_value != CollectionTaskStatus.CANCELLED.value:
+            where += " AND status != ?"
+            params.append(CollectionTaskStatus.CANCELLED.value)
         await self._database.execute_write(
-            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
+            f"UPDATE collection_tasks SET {', '.join(sets)} {where}",
             tuple(params),
         )
 

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -310,8 +310,11 @@ class CollectionTasksRepository:
             params.append(note)
         params.append(task_id)
         await self._database.execute_write(
-            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
-            tuple(params),
+            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ? AND status != ?",
+            (
+                *params,
+                CollectionTaskStatus.CANCELLED.value,
+            ),
         )
 
     async def reset_collection_task_to_pending(

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -332,8 +332,11 @@ class CollectionTasksRepository:
             params.append(note)
         params.append(task_id)
         await self._database.execute_write(
-            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ?",
-            tuple(params),
+            f"UPDATE collection_tasks SET {', '.join(sets)} WHERE id = ? AND status != ?",
+            (
+                *params,
+                CollectionTaskStatus.CANCELLED.value,
+            ),
         )
 
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -197,6 +197,24 @@ async def test_update_collection_task_to_completed(collection_tasks_repo):
     assert task.note == "Done"
 
 
+async def test_update_collection_task_does_not_overwrite_cancelled(collection_tasks_repo):
+    """#633 bug #30: a terminal CANCELLED must not be clobbered by a late update."""
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.cancel_collection_task(task_id)
+
+    # A worker that lost the in-memory cancel flag tries to mark it COMPLETED.
+    await collection_tasks_repo.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        messages_collected=99,
+    )
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.status == CollectionTaskStatus.CANCELLED
+    assert task.messages_collected != 99
+
+
 async def test_update_collection_task_to_failed(collection_tasks_repo):
     """Test updating task to failed status."""
     task_id = await collection_tasks_repo.create_collection_task(1, "Test")

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -513,6 +513,24 @@ async def test_reset_collection_task_to_pending_does_not_overwrite_cancelled(col
     assert task.note == "user cancel"
 
 
+async def test_reschedule_collection_task_does_not_overwrite_cancelled(collection_tasks_repo):
+    task_id = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.cancel_collection_task(task_id, note="user cancel")
+
+    await collection_tasks_repo.reschedule_collection_task(
+        task_id,
+        run_after=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        note="flood wait",
+        messages_collected=10,
+    )
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.status == CollectionTaskStatus.CANCELLED
+    assert task.note == "user cancel"
+    assert task.messages_collected == 0
+
+
 # fail_running_collection_tasks_on_startup tests
 
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -501,6 +501,18 @@ async def test_reset_collection_task_to_pending(collection_tasks_repo):
     assert task.note == "shutdown"
 
 
+async def test_reset_collection_task_to_pending_does_not_overwrite_cancelled(collection_tasks_repo):
+    task_id = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    await collection_tasks_repo.cancel_collection_task(task_id, note="user cancel")
+
+    await collection_tasks_repo.reset_collection_task_to_pending(task_id, note="shutdown")
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.status == CollectionTaskStatus.CANCELLED
+    assert task.note == "user cancel"
+
+
 # fail_running_collection_tasks_on_startup tests
 
 

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -3823,6 +3823,59 @@ class TestCollectionQueueExtraCoverage:
         ]
         assert completed_calls == []
 
+    async def test_worker_does_not_requeue_user_cancel_during_shutdown(self):
+        """A persisted user CANCELLED must not be reset to PENDING by shutdown."""
+        from src.collection_queue import CollectionQueue
+        from src.models import Channel, CollectionTask, CollectionTaskStatus
+
+        channels = MagicMock()
+        running_task = CollectionTask(
+            id=1,
+            channel_id=100,
+            title="ch",
+            status=CollectionTaskStatus.RUNNING,
+        )
+        cancelled_task = CollectionTask(
+            id=1,
+            channel_id=100,
+            title="ch",
+            status=CollectionTaskStatus.CANCELLED,
+        )
+        channels.get_collection_task = AsyncMock(side_effect=[running_task, cancelled_task])
+        channels.get_by_pk = AsyncMock(return_value=Channel(id=1, channel_id=100, title="test"))
+        channels.update_collection_task = AsyncMock()
+        channels.cancel_collection_task = AsyncMock()
+        channels.reset_collection_task_to_pending = AsyncMock()
+        collector = MagicMock()
+        collector.is_cancelled = False
+
+        queue = CollectionQueue(collector, channels)
+
+        async def collect_then_shutdown(*args, **kwargs):
+            queue._shutdown_requested = True
+            return 7
+
+        collector.collect_single_channel = AsyncMock(side_effect=collect_then_shutdown)
+        queue._queue.put_nowait((1, Channel(id=1, channel_id=100, title="test"), False, True))
+
+        worker = asyncio.create_task(queue._run_worker())
+        await asyncio.sleep(0.3)
+        worker.cancel()
+        try:
+            await worker
+        except asyncio.CancelledError:
+            pass
+
+        channels.cancel_collection_task.assert_awaited_once()
+        channels.reset_collection_task_to_pending.assert_not_awaited()
+        completed_calls = [
+            c
+            for c in channels.update_collection_task.call_args_list
+            if CollectionTaskStatus.COMPLETED in c.args
+            or c.kwargs.get("status") == CollectionTaskStatus.COMPLETED
+        ]
+        assert completed_calls == []
+
     async def test_worker_generic_exception(self):
         """Lines 174-181: generic exception during collection."""
         from src.collection_queue import CollectionQueue

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -3763,6 +3763,66 @@ class TestCollectionQueueExtraCoverage:
             pass
         channels.cancel_collection_task.assert_awaited_once()
 
+    async def test_worker_honors_db_cancel_after_collector_clears_flag(self):
+        """#633 bug #30: cancel in the task-startup window must win.
+
+        The collector clears its in-memory cancel flag at the start of
+        collection, so a cancel that arrived in the startup window leaves
+        is_cancelled False. The persisted CANCELLED status must still be
+        honored — the task must NOT be marked COMPLETED.
+        """
+        from src.collection_queue import CollectionQueue
+        from src.models import Channel, CollectionTask, CollectionTaskStatus
+
+        channels = MagicMock()
+        running_task = CollectionTask(
+            id=1,
+            channel_id=100,
+            title="ch",
+            status=CollectionTaskStatus.RUNNING,
+        )
+        cancelled_task = CollectionTask(
+            id=1,
+            channel_id=100,
+            title="ch",
+            status=CollectionTaskStatus.CANCELLED,
+        )
+        # Startup check sees a live task; the post-collection re-read sees the
+        # CANCELLED row written by cancel_task during the startup window.
+        channels.get_collection_task = AsyncMock(
+            side_effect=[running_task, cancelled_task]
+        )
+        fresh_ch = Channel(id=1, channel_id=100, title="test", is_filtered=False)
+        channels.get_by_pk = AsyncMock(return_value=fresh_ch)
+        channels.update_collection_task = AsyncMock()
+        channels.cancel_collection_task = AsyncMock()
+        collector = MagicMock()
+        # Flag was cleared by collect_single_channel — looks "not cancelled".
+        collector.is_cancelled = False
+        collector.collect_single_channel = AsyncMock(return_value=7)
+
+        queue = CollectionQueue(collector, channels)
+        ch = Channel(id=1, channel_id=100, title="test")
+        queue._queue.put_nowait((1, ch, False, True))
+
+        worker = asyncio.create_task(queue._run_worker())
+        await asyncio.sleep(0.3)
+        worker.cancel()
+        try:
+            await worker
+        except asyncio.CancelledError:
+            pass
+
+        # Task must be re-cancelled, never transitioned to COMPLETED.
+        channels.cancel_collection_task.assert_awaited_once()
+        completed_calls = [
+            c
+            for c in channels.update_collection_task.call_args_list
+            if CollectionTaskStatus.COMPLETED in c.args
+            or c.kwargs.get("status") == CollectionTaskStatus.COMPLETED
+        ]
+        assert completed_calls == []
+
     async def test_worker_generic_exception(self):
         """Lines 174-181: generic exception during collection."""
         from src.collection_queue import CollectionQueue


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #705 (баг #30 из мета-issue #633): отмена сбора, пришедшая в startup-окне worker'а, молча терялась.

### Гонка

Worker запускает задачу:
```
self._current_task_id = task_id          # (1)
await update_collection_task(RUNNING)     # (2) yield
count = await collect_single_channel(...) # (3)
if self._collector.is_cancelled: ...      # (4)
else: update_collection_task(COMPLETED)   # (5)
```
`cancel_task(task_id)` в окне (1)–(3): ставит `_cancel_event` и пишет в БД `CANCELLED`. Но `collect_single_channel` на старте делает `_cancel_event.clear()` → проверка (4) даёт `False` → worker затирает `CANCELLED` на `COMPLETED` (5). Отмена теряется.

## Решение

1. **`collection_queue.py`** — после сбора перечитываем статус из БД (`get_collection_task`); если он `CANCELLED`, трактуем задачу как отменённую (источник истины — БД, а не очищенный in-memory флаг).
2. **`collection_tasks.py`** (defense-in-depth) — `update_collection_task` не уводит задачу из терминального `CANCELLED` (`WHERE id = ? AND status != 'cancelled'`).

## Тесты

- `test_worker_honors_db_cancel_after_collector_clears_flag` — коллектор завершает с `is_cancelled=False`, но БД-статус `CANCELLED` → задача не помечается COMPLETED, вызывается `cancel_collection_task`.
- `test_update_collection_task_does_not_overwrite_cancelled` — repo-level: `CANCELLED` не перезаписывается на `COMPLETED`.

## Проверка

- `ruff check` — чисто
- 568 связанных тестов зелёные (collection_queue / collection_tasks repo / collection_service / cross-domain). Дифф 101 строка.

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
