### PR TITLE
fix(633): log expected 2FA-required outcome as info, not ERROR (#707)

### DIFF
--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -41,6 +41,20 @@ class TelegramAuthTimeoutError(TimeoutError):
     """Raised when a Telegram auth operation exceeds its explicit timeout."""
 
 
+class TwoFactorRequiredError(ValueError):
+    """Raised when sign-in needs a 2FA password that was not supplied.
+
+    Subclasses ``ValueError`` and keeps the ``"2FA password required"`` message
+    so existing callers that branch on ``isinstance(exc, ValueError)`` or on the
+    ``"2FA"``/``"password"`` substring keep working. It exists so the auth flow
+    can log this *expected* outcome at info level instead of as an ERROR
+    stack trace (#633 bug #27).
+    """
+
+    def __init__(self, message: str = "2FA password required") -> None:
+        super().__init__(message)
+
+
 def _format_timeout(seconds: float) -> str:
     if float(seconds).is_integer():
         return f"{int(seconds)}s"
@@ -258,7 +272,7 @@ class TelegramAuth:
             except SessionPasswordNeededError:
                 if not password_2fa:
                     needs_2fa = True
-                    raise ValueError("2FA password required")
+                    raise TwoFactorRequiredError()
                 logger.info(
                     "auth.verify_code rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
                     phone,
@@ -270,6 +284,10 @@ class TelegramAuth:
                     AUTH_RPC_TIMEOUT_SECONDS,
                 )
             session_string = client.session.save()
+        except TwoFactorRequiredError:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.info("auth.verify_code needs 2FA password phone=%s duration_ms=%d", phone, duration_ms)
+            raise
         except Exception:
             duration_ms = int((time.monotonic() - started_at) * 1000)
             logger.exception("auth.verify_code error phone=%s duration_ms=%d", phone, duration_ms)
@@ -312,7 +330,7 @@ class TelegramAuth:
             await _with_auth_timeout(client.connect(), "connect", AUTH_CONNECT_TIMEOUT_SECONDS)
             if code_consumed:
                 if not password_2fa:
-                    raise ValueError("2FA password required")
+                    raise TwoFactorRequiredError()
                 logger.info(
                     "auth.sign_in_fresh rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
                     phone,
@@ -337,7 +355,7 @@ class TelegramAuth:
                     )
                 except SessionPasswordNeededError:
                     if not password_2fa:
-                        raise ValueError("2FA password required")
+                        raise TwoFactorRequiredError()
                     logger.info(
                         "auth.sign_in_fresh rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
                         phone,
@@ -349,6 +367,10 @@ class TelegramAuth:
                         AUTH_RPC_TIMEOUT_SECONDS,
                     )
             session_string = client.session.save()
+        except TwoFactorRequiredError:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.info("auth.sign_in_fresh needs 2FA password phone=%s duration_ms=%d", phone, duration_ms)
+            raise
         except Exception:
             duration_ms = int((time.monotonic() - started_at) * 1000)
             logger.exception("auth.sign_in_fresh error phone=%s duration_ms=%d", phone, duration_ms)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from telethon.errors import SessionPasswordNeededError
 
-from src.telegram.auth import TelegramAuth, _describe_code_type, _describe_next_type
+from src.telegram.auth import (
+    TelegramAuth,
+    TwoFactorRequiredError,
+    _describe_code_type,
+    _describe_next_type,
+)
 
 pytestmark = pytest.mark.native_backend_allowed
 
@@ -170,3 +177,25 @@ class TestVerifyCode:
         )
         mock_client.disconnect.assert_awaited_once()
         assert "+1234567890" not in auth._pending
+
+    @pytest.mark.anyio
+    async def test_verify_code_2fa_required_logs_info_not_error(self, caplog):
+        """#633 bug #27: needing a 2FA password is expected, not an ERROR."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+        mock_client.session = SimpleNamespace(save=lambda: "session123")
+        mock_client.sign_in.side_effect = SessionPasswordNeededError(request=None)
+        auth._pending["+1234567890"] = (mock_client, "hash123")
+
+        with caplog.at_level(logging.INFO, logger="src.telegram.auth"):
+            with pytest.raises(TwoFactorRequiredError):
+                await auth.verify_code("+1234567890", "11111", "hash123")
+
+        # Expected outcome must not be logged as an ERROR with a stack trace.
+        assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+        assert any(
+            "needs 2FA password" in r.getMessage() and r.levelno == logging.INFO
+            for r in caplog.records
+        )
+        # needs_2fa keeps the pending client alive for the follow-up password step.
+        assert "+1234567890" in auth._pending


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #707 (баг #27 из мета-issue #633): штатный сценарий «нужен 2FA-пароль» писался в лог как ERROR со стектрейсом.

При `SessionPasswordNeededError` без переданного пароля код бросал `ValueError("2FA password required")`, который ловился общим `except Exception:` и логировался через `logger.exception(...)` (ERROR + traceback) в `verify_code` и `sign_in_fresh`. Логи засорялись ошибками для ожидаемого потока.

## Решение

- Новое исключение `TwoFactorRequiredError(ValueError)` с тем же сообщением `"2FA password required"` — контракт вызывающих (`isinstance(.., ValueError)`, подстроки `"2FA"`/`"password"` в `cli/commands/account.py` и `web/routes/auth.py`) не меняется.
- В `verify_code` и `sign_in_fresh` добавлен `except TwoFactorRequiredError:` перед общим обработчиком, логирующий на уровне **INFO**.

## Тесты

- `test_verify_code_2fa_required_logs_info_not_error` — при `SessionPasswordNeededError` без пароля: бросается `TwoFactorRequiredError`, в логах нет ERROR, есть INFO «needs 2FA password», pending-клиент жив для шага ввода пароля.

## Проверка

- `ruff check` — чисто
- 311 связанных тестов зелёные (auth / auth_flow_cli / web_auth / telegram_command_dispatcher). Дифф 59 строк.

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
