### PR TITLE
test(633): remove unused _consume_stream helper (#711)

### DIFF
--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -1624,15 +1624,6 @@ class TestAgentManagerCancelStream:
         assert thread_id not in mgr._active_tasks
 
 
-async def _consume_stream(mgr, thread_id, msg):
-    """Helper to consume a stream."""
-    try:
-        async for _ in mgr.chat_stream(thread_id, msg):
-            pass
-    except Exception:
-        pass
-
-
 # ===========================================================================
 # agent_provider_service — compatibility record methods
 # ===========================================================================


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #711 (баг #33 из мета-issue #633).

Хелпер `_consume_stream` в `tests/test_deepagents_sync_provider_paths.py` нигде не использовался (единственное вхождение — определение) и содержал `except Exception: pass`, маскирующий любые ошибки. Удалён как мёртвый код.

## Проверка

- `grep -rn _consume_stream src/ tests/` — нет вхождений
- `ruff check` — чисто
- `pytest tests/test_deepagents_sync_provider_paths.py` — 138 passed

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
