### PR TITLE
fix(633): log exceptions from the warm-dialogs startup task (#717)

### DIFF
--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -12,6 +12,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from src.config import SchedulerConfig
 from src.database.bundles import PipelineBundle, SchedulerBundle, SearchQueryBundle
 from src.settings_utils import parse_int_setting
+from src.utils.asyncio import make_log_task_exception_callback
 
 if TYPE_CHECKING:
     from src.services.task_enqueuer import TaskEnqueuer
@@ -19,13 +20,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _log_task_exception(task: asyncio.Task) -> None:
-    """Done-callback that logs unhandled exceptions from fire-and-forget tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc is not None:
-        logger.error("Background task %s failed: %s", task.get_name(), exc)
+_log_task_exception = make_log_task_exception_callback(
+    logger,
+    level="error",
+    message="Background task %s failed: %s",
+    include_exception_in_message=True,
+    exc_info=False,
+)
 
 
 class SchedulerManager:

--- a/src/utils/asyncio.py
+++ b/src/utils/asyncio.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+
+
+def make_log_task_exception_callback(
+    logger: logging.Logger,
+    *,
+    level: str,
+    message: str,
+    include_exception_in_message: bool = False,
+    exc_info: bool = True,
+) -> Callable[[asyncio.Task], None]:
+    """Build a done-callback that logs unhandled fire-and-forget task failures."""
+
+    def _log_task_exception(task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+
+        args = (task.get_name(), exc) if include_exception_in_message else (task.get_name(),)
+        getattr(logger, level)(message, *args, exc_info=exc if exc_info else None)
+
+    return _log_task_exception

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -107,6 +107,19 @@ async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
                 return
 
 
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Done-callback that surfaces a fire-and-forget task's failure as a log line.
+
+    Without this, an exception in a background task is only reported by CPython
+    as a "Task exception was never retrieved" warning at GC time (#633 bug #31).
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("startup background task %s failed", task.get_name(), exc_info=exc)
+
+
 def _schedule_telegram_pool_retry(container: AppContainer) -> None:
     bg_tasks = getattr(container, "bg_tasks", None)
     if not isinstance(bg_tasks, set):
@@ -415,6 +428,7 @@ async def start_container(container: AppContainer) -> None:
             _warm_task = asyncio.create_task(
                 container.pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
             )
+            _warm_task.add_done_callback(_log_task_exception)
             container.pool._warming_task = _warm_task
     logger.info("startup: telegram pool done (%.1fs)", time.monotonic() - t_start)
     if _is_dev:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -40,6 +40,7 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
+from src.utils.asyncio import make_log_task_exception_callback
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
 from src.web.paths import TEMPLATES_DIR
@@ -53,6 +54,11 @@ _POOL_INIT_TIMEOUT = 20
 _POOL_RETRY_INTERVAL_SEC = 60.0
 _SHUTDOWN_DEFAULT_TIMEOUT = 15.0
 _SHUTDOWN_COLLECTION_QUEUE_TIMEOUT = 140.0
+_log_task_exception = make_log_task_exception_callback(
+    logger,
+    level="warning",
+    message="startup background task %s failed",
+)
 
 
 def _connected_pool_count(pool: object) -> int:
@@ -105,19 +111,6 @@ async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
                     connected_count,
                 )
                 return
-
-
-def _log_task_exception(task: asyncio.Task) -> None:
-    """Done-callback that surfaces a fire-and-forget task's failure as a log line.
-
-    Without this, an exception in a background task is only reported by CPython
-    as a "Task exception was never retrieved" warning at GC time (#633 bug #31).
-    """
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc is not None:
-        logger.warning("startup background task %s failed", task.get_name(), exc_info=exc)
 
 
 def _schedule_telegram_pool_retry(container: AppContainer) -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -11,7 +11,7 @@ from src.config import AppConfig, DatabaseConfig
 from src.database import Database
 from src.database.repositories.accounts import AccountSessionDecryptError
 from src.search.engine import SearchEngine
-from src.web.bootstrap import build_web_container, start_container
+from src.web.bootstrap import _log_task_exception, build_web_container, start_container
 from src.web.log_handler import LogBuffer
 from src.web.runtime_shims import SnapshotClientPool
 
@@ -284,3 +284,57 @@ async def test_build_web_container_does_not_connect_telethon(tmp_path, monkeypat
         )
     finally:
         await container.db.close()
+
+
+@pytest.mark.anyio
+async def test_log_task_exception_logs_failed_task(caplog):
+    """#633 bug #31: a failed background task is surfaced as a warning log."""
+
+    async def _boom():
+        raise RuntimeError("warm failed")
+
+    task = asyncio.create_task(_boom(), name="warm_all_dialogs_startup")
+    with pytest.raises(RuntimeError):
+        await task
+
+    with caplog.at_level("WARNING", logger="src.web.bootstrap"):
+        _log_task_exception(task)
+
+    assert any(
+        "warm_all_dialogs_startup" in r.getMessage() and r.exc_info is not None
+        for r in caplog.records
+    )
+
+
+@pytest.mark.anyio
+async def test_log_task_exception_silent_on_success(caplog):
+    """A successful task produces no warning."""
+
+    async def _ok():
+        return 1
+
+    task = asyncio.create_task(_ok())
+    await task
+
+    with caplog.at_level("WARNING", logger="src.web.bootstrap"):
+        _log_task_exception(task)
+
+    assert caplog.records == []
+
+
+@pytest.mark.anyio
+async def test_log_task_exception_silent_on_cancel(caplog):
+    """A cancelled task is not treated as a failure."""
+
+    async def _sleep():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(_sleep())
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with caplog.at_level("WARNING", logger="src.web.bootstrap"):
+        _log_task_exception(task)
+
+    assert caplog.records == []


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #717 (баг #31 из мета-issue #633): фоновая задача `warm_all_dialogs_startup` создавалась fire-and-forget без done-callback. Её падение всплывало бы лишь как «Task exception was never retrieved» при GC, без структурного лога (в отличие от соседней `telegram_pool_reconnect_retry`).

## Решение

- Переиспользуемый хелпер `_log_task_exception(task)`: в done-callback логирует необработанное исключение задачи как warning с `exc_info`, игнорирует cancelled/успешные.
- Прицеплен к `_warm_task`.

## Тесты

- failed → warning с exc_info; success → тишина; cancelled → тишина.

## Проверка

- `ruff check` — чисто
- `pytest tests/test_bootstrap.py` — 14 passed. Дифф 69 строк.

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
