### PR TITLE
docs(633): document and pin the public RSS/Atom feeds (#719)

### DIFF
--- a/docs/reference/rss-feeds.md
+++ b/docs/reference/rss-feeds.md
@@ -1,0 +1,29 @@
+# RSS / Atom feeds
+
+The web app exposes two read-only syndication endpoints:
+
+- `GET /rss.xml` — RSS 2.0 feed of recently collected messages
+- `GET /atom.xml` — Atom 1.0 feed of the same content
+
+## Public by design
+
+Both endpoints are **intentionally unauthenticated**. They are listed in
+`is_public_path()` (`src/web/panel_auth.py`), so the Basic-auth middleware lets
+them through without a session.
+
+This is deliberate: RSS/Atom readers cannot perform interactive HTTP Basic auth,
+so requiring a session would make the feeds unusable by their intended clients.
+
+## Security implication
+
+Because the feeds are public, the **message text they contain is world-readable**
+to anyone who can reach the web app. If feed content must stay confidential:
+
+- keep the deployment private (e.g. on a VPN / internal network), or
+- front the app with a reverse proxy that enforces a feed token / IP allow-list,
+  or
+- do not expose the panel publicly.
+
+The decision is pinned by tests in `tests/test_panel_auth.py`
+(`is_public_path("/rss.xml")` / `is_public_path("/atom.xml")` are asserted to be
+`True`) so it cannot be changed silently.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,4 +68,5 @@ nav:
     - Web API Reference: reference/web-api.md
     - CLI / Web Parity: reference/parity.md
     - Agent Tools: reference/agent-tools.md
+    - RSS / Atom Feeds: reference/rss-feeds.md
   - Architecture: architecture.md

--- a/src/web/panel_auth.py
+++ b/src/web/panel_auth.py
@@ -49,6 +49,12 @@ def set_session_cookie(response: Response, request: Request) -> None:
 
 
 def is_public_path(path: str) -> bool:
+    # /rss.xml and /atom.xml are intentionally public: RSS/Atom readers cannot do
+    # interactive Basic-auth, so the feeds must be reachable without a session.
+    # NOTE: this means collected message text in the feeds is world-readable — do
+    # not expose the panel publicly if the feed content must stay confidential
+    # (front it with a reverse-proxy token or keep the deployment private). See
+    # docs/reference/rss-feeds.md (#633 bug #38).
     return path in ("/health", "/logout", "/rss.xml", "/atom.xml", LOGIN_PATH) or path.startswith("/static/")
 
 

--- a/tests/test_panel_auth.py
+++ b/tests/test_panel_auth.py
@@ -71,6 +71,16 @@ def test_is_public_path():
     assert is_public_path("/settings") is False
 
 
+def test_rss_and_atom_are_public_by_design():
+    """#633 bug #38: RSS/Atom feeds are intentionally unauthenticated.
+
+    Pinning this so the decision (documented in docs/reference/rss-feeds.md)
+    cannot be flipped silently — RSS readers cannot do interactive Basic auth.
+    """
+    assert is_public_path("/rss.xml") is True
+    assert is_public_path("/atom.xml") is True
+
+
 def test_sanitize_next_empty():
     """Test sanitize_next with empty value."""
     assert sanitize_next(None) == "/"


### PR DESCRIPTION
## Что и зачем

Закрывает суб-issue #719 (баг #38 из мета-issue #633): RSS/Atom эндпоинты (`/rss.xml`, `/atom.xml`) публичны без auth — это намеренно (RSS-читалки не умеют интерактивный Basic-auth), но было нигде не задокументировано и не закреплено тестом.

## Решение

- Комментарий в `is_public_path` (`src/web/panel_auth.py`) с пояснением и предупреждением: контент фидов world-readable.
- Doc-страница `docs/reference/rss-feeds.md` + ссылка в mkdocs nav: публичны by design, как ограничить доступ (приватный деплой / reverse-proxy токен).
- Закрепляющий тест: `is_public_path("/rss.xml")` и `is_public_path("/atom.xml")` → True.

## Проверка

- `ruff check` — чисто
- 28 связанных тестов зелёные (panel_auth + web_route_helpers).

Refs #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
