### PR TITLE
fix(676): RSS/Atom feeds call non-existent db.get_messages (#723)

### DIFF
--- a/src/web/routes/rss.py
+++ b/src/web/routes/rss.py
@@ -45,10 +45,7 @@ async def rss_feed(
     limit = max(1, min(limit, 200))
 
     try:
-        if channel_id is not None:
-            messages = await db.get_messages(channel_id=channel_id, limit=limit)
-        else:
-            messages = await db.get_messages(limit=limit)
+        messages, _ = await db.search_messages(query="", channel_id=channel_id, limit=limit)
     except Exception:
         logger.exception("Failed to fetch messages for RSS feed")
         messages = []
@@ -104,10 +101,7 @@ async def atom_feed(
     limit = max(1, min(limit, 200))
 
     try:
-        if channel_id is not None:
-            messages = await db.get_messages(channel_id=channel_id, limit=limit)
-        else:
-            messages = await db.get_messages(limit=limit)
+        messages, _ = await db.search_messages(query="", channel_id=channel_id, limit=limit)
     except Exception:
         logger.exception("Failed to fetch messages for Atom feed")
         messages = []

--- a/tests/routes/test_rss_routes.py
+++ b/tests/routes/test_rss_routes.py
@@ -71,17 +71,24 @@ async def test_rss_feed_with_messages(route_client, base_app):
     msg = Message(channel_id=100, message_id=1, text="Hello world", date=NOW)
     await db.insert_message(msg)
 
-    # db.get_messages() doesn't exist on Database facade; monkeypatch it
-    async def _get_messages(channel_id=None, limit=50):
-        rows, _ = await db.search_messages("", channel_id=channel_id, limit=limit)
-        return rows
-
-    db.get_messages = _get_messages
-
     resp = await route_client.get("/rss.xml")
     assert resp.status_code == 200
     assert "Hello world" in resp.text
     assert "<item>" in resp.text
+
+
+@pytest.mark.anyio
+async def test_rss_feed_channel_filter(route_client, base_app):
+    """A channel_id query must scope the feed to that channel only (#676)."""
+    _, db, _ = base_app
+
+    await db.insert_message(Message(channel_id=100, message_id=1, text="From channel 100", date=NOW))
+    await db.insert_message(Message(channel_id=200, message_id=2, text="From channel 200", date=NOW))
+
+    resp = await route_client.get("/rss.xml?channel_id=100")
+    assert resp.status_code == 200
+    assert "From channel 100" in resp.text
+    assert "From channel 200" not in resp.text
 
 
 # --- Atom feed route tests ---
@@ -103,12 +110,6 @@ async def test_atom_feed_with_messages(route_client, base_app):
 
     msg = Message(channel_id=100, message_id=1, text="Atom test message", date=NOW)
     await db.insert_message(msg)
-
-    async def _get_messages(channel_id=None, limit=50):
-        rows, _ = await db.search_messages("", channel_id=channel_id, limit=limit)
-        return rows
-
-    db.get_messages = _get_messages
 
     resp = await route_client.get("/atom.xml")
     assert resp.status_code == 200


### PR DESCRIPTION
## Что и почему

Часть мета-аудита #676 (silent error swallowing), пункт **#1 (HIGH)**.

`src/web/routes/rss.py` вызывал `await db.get_messages(...)` в обоих обработчиках (`/rss.xml`, `/atom.xml`). Метода `get_messages` **не существует** на `Database`-фасаде. В проде каждый запрос фида бросал `AttributeError`, который ловился broad `except Exception` → возвращался валидный-но-пустой XML с **200 OK**. Потребители RSS получали фид с нулём элементов, без признаков ошибки.

Тесты маскировали баг: monkeypatch `db.get_messages = _get_messages`, внутри которого вызывался реальный `db.search_messages("", ...)`. Сьют был зелёным, прод сломан.

## Изменения

- Заменил 4 вызова `db.get_messages(...)` на `db.search_messages(query="", channel_id=..., limit=...)` (распаковка `(messages, total)`).
- Убрал маскирующий monkeypatch из `test_rss_feed_with_messages` / `test_atom_feed_with_messages` — теперь тесты бьют по реальному пути фасада.
- Добавил `test_rss_feed_channel_filter` на scoping по `channel_id`.

## Проверки

- `pytest tests/routes/test_rss_routes.py` — 9 passed (тесты теперь регрессируют на реальный баг).
- `ruff check` — clean.

Closes #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)