### PR TITLE
fix(676): add logging to four silent except blocks (#727)

### DIFF
--- a/src/cli/commands/search_query.py
+++ b/src/cli/commands/search_query.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import logging
 
 from pydantic import ValidationError
 
 from src.cli import runtime
 from src.database.bundles import SearchQueryBundle
 from src.services.search_query_service import SearchQueryService
+
+logger = logging.getLogger(__name__)
 
 
 async def _chat_filter_warning(svc: SearchQueryService, chat_filter: str) -> str:
@@ -22,6 +25,9 @@ async def _chat_filter_warning(svc: SearchQueryService, chat_filter: str) -> str
         text = warning_text() if callable(warning_text) else ""
         return text if isinstance(text, str) else ""
     except Exception:
+        # Returning "" silently hides a validation failure as "no warning". Log so the
+        # operator can tell a clean filter from a broken validator (#676).
+        logger.warning("Failed to validate chat filter %r", chat_filter, exc_info=True)
         return ""
 
 

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -283,6 +283,9 @@ class SchedulerManager:
             self._jobs_cache_ts = now
             return self._jobs_cache
         except Exception:
+            # Empty dict renders an empty scheduler page; without a log the APScheduler
+            # failure is invisible. The warm-dialogs path in this file already logs (#676).
+            logger.exception("Scheduler: failed to list APScheduler jobs")
             return {}
 
     async def trigger_now(self) -> dict:

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -266,7 +266,14 @@ class TrendService:
         )
         try:
             tfidf_matrix = vectorizer.fit_transform(tokenized_texts)
-        except ValueError:
+        except ValueError as exc:
+            # min_df=2 can prune the entire vocabulary on tiny corpora — empty result
+            # is expected, but log it so an unexpectedly empty trend list is diagnosable.
+            logger.debug(
+                "TF-IDF trending: empty vocabulary after pruning (%d texts): %s",
+                len(tokenized_texts),
+                exc,
+            )
             return []
 
         feature_names = vectorizer.get_feature_names_out()

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -52,7 +52,8 @@ async def _get_provider_api_key(request: Request, provider: str) -> str:
                 if val:
                     return val
     except Exception:
-        pass
+        # Consistent with the sibling _get_image_service above, which logs the same way (#676).
+        logger.warning("Failed to load API key for provider %s", provider, exc_info=True)
     return ""
 
 

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -179,10 +179,16 @@ async def test_get_provider_api_key_env_fallback(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_get_provider_api_key_exception_returns_empty():
-    """Returns empty string on any exception."""
+async def test_get_provider_api_key_exception_returns_empty(caplog):
+    """Returns empty string on any exception — and logs it instead of swallowing (#676)."""
+    import logging
+
     from src.web.images.handlers import _get_provider_api_key
 
     with patch("src.services.image_provider_service.ImageProviderService", side_effect=Exception("boom")):
-        result = await _get_provider_api_key(MagicMock(), "anything")
+        with caplog.at_level(logging.WARNING, logger="src.web.images.handlers"):
+            result = await _get_provider_api_key(MagicMock(), "anything")
     assert result == ""
+    assert any(
+        "Failed to load API key for provider anything" in rec.message for rec in caplog.records
+    )

--- a/tests/test_cli_commands_edge_cases.py
+++ b/tests/test_cli_commands_edge_cases.py
@@ -11,12 +11,14 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.cli.commands.filter import _build_deletion_service, _parse_pks, _print_result
 from src.cli.commands.messages import _print_live_messages, _print_messages
+from src.cli.commands.search_query import _chat_filter_warning
 from src.models import Account, Channel, Message, SearchQuery, SearchQueryDailyStat
 from tests.helpers import AsyncIterMessages, cli_ns
 
@@ -1726,3 +1728,29 @@ class TestMessagesReadLiveMode:
         assert "reaction users: 👍 @ivan" in out
         assert client.await_args.args[0].id == 10
         assert client.await_args.args[0].limit == 10
+
+
+# ---------------------------------------------------------------------------
+# search_query.py — _chat_filter_warning (#676: log instead of swallowing)
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_filter_warning_logs_on_validator_error(caplog):
+    """A validator that raises must be logged, not silently turned into "" (#676)."""
+    svc = MagicMock()
+    svc.validate_chat_filter = MagicMock(side_effect=RuntimeError("validator boom"))
+
+    with caplog.at_level(logging.WARNING, logger="src.cli.commands.search_query"):
+        result = await _chat_filter_warning(svc, "@somechat")
+
+    # Behaviour unchanged for the caller (empty warning text)...
+    assert result == ""
+    # ...but the failure is now visible in the logs.
+    assert any("Failed to validate chat filter" in rec.message for rec in caplog.records)
+
+
+async def test_chat_filter_warning_no_validator_returns_empty():
+    """When the service has no validator, returns "" without logging."""
+    svc = MagicMock(spec=[])  # no validate_chat_filter attribute
+    result = await _chat_filter_warning(svc, "@somechat")
+    assert result == ""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -84,3 +85,21 @@ async def test_run_collection_enqueuer_error():
 
     assert stats["errors"] == 1
     assert stats["enqueued"] == 0
+
+
+@pytest.mark.anyio
+async def test_get_all_jobs_next_run_logs_on_apscheduler_error(caplog):
+    """A get_jobs() failure must log, not silently return {} (#676)."""
+    manager = SchedulerManager(SchedulerConfig())
+    scheduler = MagicMock()
+    scheduler.get_jobs = MagicMock(side_effect=RuntimeError("scheduler down"))
+    manager._scheduler = scheduler
+    manager._jobs_cache_ts = -1e9  # force a fresh (non-cached) read
+
+    with caplog.at_level(logging.ERROR, logger="src.scheduler.service"):
+        result = manager.get_all_jobs_next_run()
+
+    # Safe fallback preserved...
+    assert result == {}
+    # ...but the failure is now logged.
+    assert any("failed to list APScheduler jobs" in rec.message for rec in caplog.records)

--- a/tests/test_trend_service.py
+++ b/tests/test_trend_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -42,6 +43,22 @@ async def test_get_trending_topics_empty_db(service, mock_db):
     result = await service.get_trending_topics(days=7, limit=20)
 
     assert result == []
+
+
+@pytest.mark.anyio
+async def test_get_trending_topics_logs_empty_vocabulary(service, mock_db, caplog):
+    """min_df pruning the whole vocabulary returns [] but is logged at debug (#676)."""
+    # Each token appears in exactly one document, so min_df=2 prunes everything and
+    # TfidfVectorizer.fit_transform raises ValueError("empty vocabulary").
+    mock_db.execute_fetchall = AsyncMock(
+        return_value=[{"text": "alphaword"}, {"text": "bravoword"}, {"text": "charlieword"}]
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="src.services.trend_service"):
+        result = await service.get_trending_topics(days=7, limit=20)
+
+    assert result == []
+    assert any("empty vocabulary" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Что и почему

Часть мета-аудита #676 (silent error swallowing), пункты **#9, #10, #11, #12 (LOW)** — чистое добавление логирования, control flow не меняется.

- **#9 `scheduler/service.py`** — `get_all_jobs_next_run()` возвращал `{}` при любой ошибке APScheduler без лога → страница планировщика молча выглядела пустой. Добавлен `logger.exception` (как в warm-dialogs пути этого же файла).
- **#11 `services/trend_service.py`** — `TfidfVectorizer.fit_transform` `ValueError` (min_df=2 отфильтровал весь словарь) возвращал `[]` без лога. Добавлен `logger.debug` с размером корпуса.
- **#10 `cli/commands/search_query.py`** — `_chat_filter_warning` глотал все исключения и возвращал `""`, пряча сломанный валидатор как «нет предупреждения». Добавлен module-logger + `logger.warning`.
- **#12 `web/images/handlers.py`** — `_get_provider_api_key` глотал ошибки lookup ключа провайдера через `except Exception: pass`. Добавлен `logger.warning(exc_info=True)`, согласованно с sibling `_get_image_service`.

## Проверки

- `pytest` (scheduler, trend_service, cli edge cases, images routes) — 153 passed; каждый тест проверяет, что путь логирует, сохраняя прежнее возвращаемое значение.
- `ruff check` — clean.

Closes #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)