### PR TITLE
fix(386): adaptive generate page — conditional LLM fields + no-provider warning

### DIFF
--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -457,9 +457,17 @@ async def generate_page(request: Request, pipeline_id: int):
         return _pipeline_redirect("pipeline_invalid", error=True)
     db = deps.get_db(request)
     runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
+    needs_llm = pipeline_needs_llm(pipeline)
+    llm_configured = deps.get_llm_provider_service(request).has_providers()
     return PipelineTemplate(
         "pipelines/generate.html",
-        {"pipeline": pipeline, "runs": runs, "request": request},
+        {
+            "pipeline": pipeline,
+            "runs": runs,
+            "request": request,
+            "needs_llm": needs_llm,
+            "llm_configured": llm_configured,
+        },
     )
 
 

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -583,11 +583,24 @@ async def generate_pipeline(
         runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id)
         return PipelineTemplate(
             "pipelines/generate.html",
-            {"pipeline": pipeline, "runs": runs, "error": "Generation failed", "request": request},
+            {
+                "pipeline": pipeline,
+                "runs": runs,
+                "error": "Generation failed",
+                "needs_llm": pipeline_needs_llm(pipeline),
+                "llm_configured": provider_service.has_providers(),
+                "request": request,
+            },
         )
     return PipelineTemplate(
         "pipelines/generate.html",
-        {"pipeline": pipeline, "run": run, "request": request},
+        {
+            "pipeline": pipeline,
+            "run": run,
+            "needs_llm": pipeline_needs_llm(pipeline),
+            "llm_configured": provider_service.has_providers(),
+            "request": request,
+        },
     )
 
 

--- a/src/web/templates/pipelines/generate.html
+++ b/src/web/templates/pipelines/generate.html
@@ -40,7 +40,7 @@
 {% endif %}
 
 <form method="post" action="/pipelines/{{ pipeline.id }}/run" data-busy class="mt-3">
-    <button type="submit" class="btn btn-success"><i class="bi bi-play-fill"></i> Run now</button>
+    <button type="submit" class="btn btn-success" {{ "disabled" if _needs_llm and not _llm_configured }}><i class="bi bi-play-fill"></i> Run now</button>
 </form>
 
 <pre id="stream-output" style="white-space: pre-wrap; margin-top: 1rem;"></pre>

--- a/src/web/templates/pipelines/generate.html
+++ b/src/web/templates/pipelines/generate.html
@@ -3,6 +3,20 @@
 {% block content %}
 <h1>Генерация: {{ pipeline.name }}</h1>
 
+{# needs_llm/llm_configured passed by generate_page; default to LLM mode for safety. #}
+{% set _needs_llm = needs_llm if needs_llm is defined else true %}
+{% set _llm_configured = llm_configured if llm_configured is defined else true %}
+
+{% if _needs_llm and not _llm_configured %}
+<div class="alert alert-warning">
+    <i class="bi bi-exclamation-triangle"></i>
+    Этот пайплайн использует LLM, но ни один провайдер не настроен.
+    Превью и запуск недоступны, пока вы не добавите провайдера в
+    <a href="/settings">настройках</a>.
+</div>
+{% endif %}
+
+{% if _needs_llm %}
 <form method="post" action="/pipelines/{{ pipeline.id }}/generate" data-busy>
     <div class="row g-3 mb-3">
         <div class="col-12 col-md-6">
@@ -18,9 +32,12 @@
             <input class="form-control" type="number" step="0.1" name="temperature" value="0.0">
         </div>
     </div>
-    <button type="submit" class="btn btn-primary"><i class="bi bi-eye"></i> Preview</button>
-    <button type="button" id="stream-btn" class="btn btn-outline-secondary"><i class="bi bi-arrow-repeat"></i> Stream Preview</button>
+    <button type="submit" class="btn btn-primary" {{ "disabled" if not _llm_configured }}><i class="bi bi-eye"></i> Preview</button>
+    <button type="button" id="stream-btn" class="btn btn-outline-secondary" {{ "disabled" if not _llm_configured }}><i class="bi bi-arrow-repeat"></i> Stream Preview</button>
 </form>
+{% else %}
+<p class="text-muted">Этот пайплайн не использует LLM (forward/publish/filter) — параметры модели не требуются.</p>
+{% endif %}
 
 <form method="post" action="/pipelines/{{ pipeline.id }}/run" data-busy class="mt-3">
     <button type="submit" class="btn btn-success"><i class="bi bi-play-fill"></i> Run now</button>

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -284,6 +284,22 @@ async def test_generate_page_renders(client):
 
 
 @pytest.mark.anyio
+async def test_generate_page_warns_when_llm_pipeline_has_no_provider(client):
+    """#386: an LLM-requiring pipeline with no provider configured must show a
+    warning banner and disable the preview controls (instead of failing only on
+    click). The _ADD_DATA pipeline uses the legacy chain backend ⇒ needs_llm, and
+    the test fixture has no LLM provider registered."""
+    await client.post("/pipelines/add", data=_ADD_DATA)
+
+    resp = await client.get("/pipelines/1/generate")
+    assert resp.status_code == 200
+    # LLM fields are still rendered (it IS an LLM pipeline) but gated:
+    assert 'name="model"' in resp.text
+    assert "ни один провайдер не настроен" in resp.text
+    assert "disabled" in resp.text
+
+
+@pytest.mark.anyio
 async def test_generate_page_not_found(client):
     """Test generate page with invalid pipeline."""
     resp = await client.get("/pipelines/999999/generate", follow_redirects=False)

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -297,6 +298,9 @@ async def test_generate_page_warns_when_llm_pipeline_has_no_provider(client):
     assert 'name="model"' in resp.text
     assert "ни один провайдер не настроен" in resp.text
     assert "disabled" in resp.text
+    # The warning says "Превью и запуск недоступны" — the "Run now" button must
+    # actually be disabled to match it, not just Preview/Stream (#735 review).
+    assert re.search(r'btn btn-success[^>]*disabled[^>]*>\s*<i class="bi bi-play-fill"', resp.text)
 
 
 @pytest.mark.anyio
@@ -399,6 +403,57 @@ async def test_generate_pipeline_failure(client):
         )
         assert resp.status_code == 200
         assert "Generation failed" in resp.text
+
+
+@pytest.mark.anyio
+async def test_generate_pipeline_error_render_hides_llm_fields_for_non_llm(client):
+    """#735 review (Bug 2): on a POST that re-renders generate.html, the handler must
+    propagate needs_llm/llm_configured. For a non-LLM pipeline the LLM model field must
+    stay hidden instead of defaulting to shown."""
+    from unittest.mock import patch
+
+    from src.models import (
+        PipelineEdge,
+        PipelineGenerationBackend,
+        PipelineGraph,
+        PipelineNode,
+        PipelineNodeType,
+    )
+
+    await client.post("/pipelines/add", data=_ADD_DATA)
+
+    non_llm_pipeline = MagicMock(
+        id=1,
+        name="non-llm",
+        is_active=True,
+        pipeline_json=PipelineGraph(
+            nodes=[
+                PipelineNode(id="src", type=PipelineNodeType.SOURCE, name="src"),
+                PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="pub"),
+            ],
+            edges=[PipelineEdge(from_node="src", to_node="pub")],
+        ),
+    )
+    non_llm_pipeline.generation_backend = PipelineGenerationBackend.CHAIN
+
+    with patch("src.web.pipelines.handlers.deps.pipeline_service") as mock_svc:
+        mock_svc.return_value.get = AsyncMock(return_value=non_llm_pipeline)
+        with patch(
+            "src.services.content_generation_service.ContentGenerationService"
+        ) as mock_gen:
+            mock_gen.return_value.generate = AsyncMock(side_effect=Exception("boom"))
+            resp = await client.post(
+                "/pipelines/1/generate",
+                data={"model": "", "max_tokens": "256", "temperature": "0.0"},
+            )
+            assert resp.status_code == 200
+            assert "Generation failed" in resp.text
+            # non-LLM pipeline ⇒ the LLM parameter block (model/max_tokens/temperature
+            # inputs + Preview button) must not be rendered. The "model" string still
+            # appears in the always-present <script>, so match the unique LLM markers.
+            assert ">Max tokens<" not in resp.text
+            assert ">Temperature<" not in resp.text
+            assert "не использует LLM" in resp.text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Проблема (#386, часть B)

Страница генерации `/pipelines/<id>/generate` безусловно показывала LLM-поля (model / max_tokens / temperature + Preview / Stream):
- для non-LLM пайплайнов (forward/publish/filter DAG) они бессмысленны;
- для LLM-пайплайна при отключённом провайдере не было предупреждения — ошибка появлялась только при клике.

## Изменения

- `src/web/pipelines/handlers.py` — `generate_page` передаёт в шаблон `needs_llm` (`pipeline_needs_llm`) и `llm_configured` (`get_llm_provider_service().has_providers()`).
- `src/web/templates/pipelines/generate.html`:
  - LLM-пайплайн + нет провайдера → warning-баннер + disabled Preview/Stream;
  - LLM-пайплайн + провайдер есть → как раньше;
  - non-LLM пайплайн → LLM-поля скрыты, только «Run now».
  - `needs_llm`/`llm_configured` по умолчанию `true`, если не переданы — поведение для прочих вызовов не меняется.
- `tests/routes/test_pipelines_routes.py` — тест: LLM-пайплайн без провайдера показывает warning + disabled.

Часть A (модалка `templates.html` — условное LLM-поле vs source/target/account пикеры) уже была реализована в main.

## Проверка

```
ruff check src/web/pipelines/handlers.py tests/routes/test_pipelines_routes.py   # clean
pytest tests/routes/test_pipelines_routes.py tests/routes/test_pipelines_routes_dag_and_templates.py tests/test_pipeline_llm_requirements.py -q   # 129 passed
```

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)