### PR TITLE
refactor(689): split ProviderConfigService into model-cache + compatibility mixins

### DIFF
--- a/src/services/agent_provider_service.py
+++ b/src/services/agent_provider_service.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import importlib.metadata
 import json
 import logging
 import tomllib
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-
-import aiohttp
 
 from src.agent.provider_registry import (
     PROVIDER_ORDER,
@@ -26,50 +20,49 @@ from src.agent.provider_registry import (
     normalize_ollama_base_url,
     normalize_provider_plain_fields,
     normalize_urlish,
-    normalize_zai_base_url,
     provider_spec,
     runtime_options_for_config,
 )
 from src.config import AppConfig, resolve_session_encryption_secret
 from src.database import Database
 from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
-from src.utils.datetime import try_parse_datetime
+from src.services.provider_model_cache import (
+    MODEL_CACHE_SETTINGS_KEY,
+    ProviderModelCacheEntry,
+    ProviderModelCacheMixin,
+)
+from src.services.provider_model_compatibility import (
+    COMMUNITY_COMPATIBILITY_CATALOG_PATH,
+    MODEL_COMPATIBILITY_FRESHNESS_HOURS,
+    ProviderModelCompatibilityMixin,
+    ProviderModelCompatibilityRecord,
+)
 from src.utils.json import safe_json_dumps
 
 logger = logging.getLogger(__name__)
 
 PROVIDER_SETTINGS_KEY = "agent_deepagents_providers_v1"
-MODEL_CACHE_SETTINGS_KEY = "agent_deepagents_model_cache_v1"
-MODEL_COMPATIBILITY_FRESHNESS_HOURS = 24
 _PACKAGE_NAME = "tg-agent"
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _PYPROJECT_PATH = _PROJECT_ROOT / "pyproject.toml"
-COMMUNITY_COMPATIBILITY_CATALOG_PATH = (
-    _PROJECT_ROOT / "data" / "deepagents_model_compatibility_catalog.json"
-)
 _PROVIDER_SECRET_ACTION = "restore_key_or_reenter_secret"
 
-@dataclass(slots=True)
-class ProviderModelCompatibilityRecord:
-    model: str
-    status: str
-    reason: str = ""
-    tested_at: str = ""
-    config_fingerprint: str = ""
-    probe_kind: str = "auto-select"
+# Re-exported so importers keep using src.services.agent_provider_service.* (the dataclasses
+# and constants moved into the mixin modules in #689). __all__ marks these intentional.
+__all__ = [
+    "PROVIDER_SETTINGS_KEY",
+    "MODEL_CACHE_SETTINGS_KEY",
+    "MODEL_COMPATIBILITY_FRESHNESS_HOURS",
+    "COMMUNITY_COMPATIBILITY_CATALOG_PATH",
+    "ProviderConfigService",
+    "ProviderModelCacheEntry",
+    "ProviderModelCompatibilityRecord",
+    "ProviderModelCacheMixin",
+    "ProviderModelCompatibilityMixin",
+]
 
 
-@dataclass(slots=True)
-class ProviderModelCacheEntry:
-    provider: str
-    models: list[str]
-    source: str
-    fetched_at: str = ""
-    error: str = ""
-    compatibility: dict[str, ProviderModelCompatibilityRecord] = field(default_factory=dict)
-
-
-class ProviderConfigService:
+class ProviderConfigService(ProviderModelCacheMixin, ProviderModelCompatibilityMixin):
     def __init__(self, db: Database, config: AppConfig) -> None:
         self._db = db
         self._config = config
@@ -160,126 +153,6 @@ class ProviderConfigService:
             )
         await self._db.set_setting(PROVIDER_SETTINGS_KEY, safe_json_dumps(payload, ensure_ascii=False))
 
-    async def load_model_cache(self) -> dict[str, ProviderModelCacheEntry]:
-        raw = await self._db.get_setting(MODEL_CACHE_SETTINGS_KEY)
-        if not raw:
-            return {}
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError:
-            logger.warning("Invalid model cache JSON in settings", exc_info=True)
-            return {}
-        if not isinstance(parsed, dict):
-            return {}
-        cache: dict[str, ProviderModelCacheEntry] = {}
-        for provider, item in parsed.items():
-            if not isinstance(item, dict):
-                continue
-            compatibility: dict[str, ProviderModelCompatibilityRecord] = {}
-            compat_raw = item.get("compatibility", {})
-            if isinstance(compat_raw, dict):
-                for fingerprint, record in compat_raw.items():
-                    if not isinstance(record, dict):
-                        continue
-                    fingerprint_key = str(fingerprint).strip()
-                    if not fingerprint_key:
-                        continue
-                    compatibility[fingerprint_key] = ProviderModelCompatibilityRecord(
-                        model=str(record.get("model", "")).strip(),
-                        status=str(record.get("status", "unknown")).strip() or "unknown",
-                        reason=str(record.get("reason", "")).strip(),
-                        tested_at=str(record.get("tested_at", "")).strip(),
-                        config_fingerprint=(
-                            str(record.get("config_fingerprint", "")).strip() or fingerprint_key
-                        ),
-                        probe_kind=str(record.get("probe_kind", "auto-select")).strip()
-                        or "auto-select",
-                    )
-            cache[provider] = ProviderModelCacheEntry(
-                provider=provider,
-                models=[str(model) for model in item.get("models", []) if str(model).strip()],
-                source=str(item.get("source", "static")).strip() or "static",
-                fetched_at=str(item.get("fetched_at", "")).strip(),
-                error=str(item.get("error", "")).strip(),
-                compatibility=compatibility,
-            )
-        return cache
-
-    async def save_model_cache(self, cache: dict[str, ProviderModelCacheEntry]) -> None:
-        payload = {
-            provider: {
-                "models": entry.models,
-                "source": entry.source,
-                "fetched_at": entry.fetched_at,
-                "error": entry.error,
-                "compatibility": {
-                    fingerprint: {
-                        "model": record.model,
-                        "status": record.status,
-                        "reason": record.reason,
-                        "tested_at": record.tested_at,
-                        "config_fingerprint": record.config_fingerprint,
-                        "probe_kind": record.probe_kind,
-                    }
-                    for fingerprint, record in entry.compatibility.items()
-                },
-            }
-            for provider, entry in cache.items()
-        }
-        await self._db.set_setting(
-            MODEL_CACHE_SETTINGS_KEY, safe_json_dumps(payload, ensure_ascii=False)
-        )
-
-    async def refresh_models_for_provider(
-        self, provider_name: str, cfg: ProviderRuntimeConfig | None = None
-    ) -> ProviderModelCacheEntry:
-        spec = provider_spec(provider_name)
-        if spec is None:
-            raise RuntimeError(f"Unknown provider: {provider_name}")
-        if cfg is None:
-            configs = await self.load_provider_configs()
-            cfg = next((item for item in configs if item.provider == provider_name), None)
-        cache = await self.load_model_cache()
-        existing_entry = cache.get(provider_name, self._empty_model_cache_entry(provider_name))
-        live_error = ""
-        try:
-            models = await self._fetch_live_models(spec, cfg)
-            models = sorted(dict.fromkeys(models))
-            if not models:
-                raise RuntimeError("live model list is empty")
-            entry = ProviderModelCacheEntry(
-                provider=provider_name,
-                models=models,
-                source="live",
-                fetched_at=datetime.now(UTC).isoformat(),
-                compatibility=existing_entry.compatibility,
-            )
-        except Exception as exc:
-            live_error = str(exc)
-            logger.warning("Provider model refresh failed for %s: %s", provider_name, exc)
-            entry = ProviderModelCacheEntry(
-                provider=provider_name,
-                models=list(existing_entry.models or list(spec.static_models)),
-                source="static cache",
-                fetched_at=datetime.now(UTC).isoformat(),
-                error=live_error,
-                compatibility=existing_entry.compatibility,
-            )
-        cache[provider_name] = entry
-        await self.save_model_cache(cache)
-        return entry
-
-    async def refresh_all_models(
-        self,
-        configs: list[ProviderRuntimeConfig] | None = None,
-    ) -> dict[str, ProviderModelCacheEntry]:
-        if configs is None:
-            configs = await self.load_provider_configs()
-        results: dict[str, ProviderModelCacheEntry] = {}
-        for cfg in configs:
-            results[cfg.provider] = await self.refresh_models_for_provider(cfg.provider, cfg)
-        return results
-
     def build_provider_views(
         self,
         configs: list[ProviderRuntimeConfig],
@@ -355,35 +228,6 @@ class ProviderConfigService:
                 }
             )
         return views
-
-    def build_compatibility_payload(
-        self,
-        cfg: ProviderRuntimeConfig,
-        cache_entry: ProviderModelCacheEntry,
-    ) -> dict[str, dict[str, Any]]:
-        payload: dict[str, dict[str, Any]] = {}
-        models = list(cache_entry.models)
-        if cfg.selected_model and cfg.selected_model not in models:
-            models.insert(0, cfg.selected_model)
-        for model in models:
-            record = self.get_compatibility_record(
-                cache_entry,
-                cfg,
-                model=model,
-                fresh_only=False,
-            )
-            if record is None:
-                payload[model] = {"status": "unknown", "reason": "", "tested_at": ""}
-                continue
-            payload[model] = {
-                "status": record.status,
-                "reason": record.reason,
-                "tested_at": record.tested_at,
-                "config_fingerprint": record.config_fingerprint,
-                "probe_kind": record.probe_kind,
-                "is_fresh": self.is_compatibility_record_fresh(record),
-            }
-        return payload
 
     def parse_provider_form(
         self,
@@ -468,218 +312,6 @@ class ProviderConfigService:
         # Single source of truth shared with the runtime-registry stack (#658).
         return runtime_options_for_config(cfg)
 
-    def config_fingerprint(
-        self,
-        cfg: ProviderRuntimeConfig,
-        *,
-        model: str | None = None,
-    ) -> str:
-        selected_model = (model or cfg.selected_model).strip()
-        spec = provider_spec(cfg.provider)
-        if spec is None:
-            raise RuntimeError(f"Unknown provider: {cfg.provider}")
-        normalized_plain = self.normalize_provider_plain_fields(cfg)
-        secret_payload = {
-            field.name: cfg.secret_fields.get(field.name, "").strip()
-            for field in spec.secret_fields
-            if cfg.secret_fields.get(field.name, "").strip()
-        }
-        auth_mode = "+".join(sorted(secret_payload)) if secret_payload else "no-auth"
-        secret_hash = ""
-        if secret_payload:
-            secret_hash = hashlib.sha256(
-                safe_json_dumps(secret_payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
-            ).hexdigest()[:16]
-        payload = {
-            "provider": cfg.provider,
-            "model": selected_model,
-            "plain_fields": normalized_plain,
-            "auth_mode": auth_mode,
-            "secret_hash": secret_hash,
-        }
-        return hashlib.sha256(
-            safe_json_dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
-        ).hexdigest()
-
-    def get_compatibility_record(
-        self,
-        cache_entry: ProviderModelCacheEntry | None,
-        cfg: ProviderRuntimeConfig,
-        *,
-        model: str | None = None,
-        fresh_only: bool = False,
-        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
-    ) -> ProviderModelCompatibilityRecord | None:
-        if cache_entry is None:
-            return None
-        fingerprint = self.config_fingerprint(cfg, model=model)
-        record = cache_entry.compatibility.get(fingerprint)
-        if record is None:
-            return None
-        if fresh_only and not self.is_compatibility_record_fresh(
-            record, max_age_hours=max_age_hours
-        ):
-            return None
-        return record
-
-    def compatibility_error_for_config(
-        self,
-        cfg: ProviderRuntimeConfig,
-        cache_entry: ProviderModelCacheEntry | None,
-    ) -> str:
-        record = self.get_compatibility_record(cache_entry, cfg, fresh_only=True)
-        if record is None or record.status != "unsupported":
-            return ""
-        return record.reason or "Compatibility probe marked this model as unsupported."
-
-    def compatibility_warning_for_config(
-        self,
-        cfg: ProviderRuntimeConfig,
-        cache_entry: ProviderModelCacheEntry | None,
-    ) -> str:
-        record = self.get_compatibility_record(cache_entry, cfg, fresh_only=False)
-        if record is None:
-            return "Совместимость модели с deepagents ещё не проверялась."
-        if record.status == "unknown":
-            return record.reason or "Совместимость модели с deepagents не подтверждена."
-        if not self.is_compatibility_record_fresh(record):
-            return (
-                "Результат проверки совместимости устарел и будет обновлён при следующей проверке."
-            )
-        return ""
-
-    def is_compatibility_record_fresh(
-        self,
-        record: ProviderModelCompatibilityRecord,
-        *,
-        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
-    ) -> bool:
-        if not record.tested_at:
-            return False
-        tested_at = try_parse_datetime(record.tested_at)
-        if tested_at is None:
-            return False
-        if tested_at.tzinfo is None:
-            tested_at = tested_at.replace(tzinfo=UTC)
-        return datetime.now(UTC) - tested_at <= timedelta(hours=max_age_hours)
-
-    async def ensure_model_compatibility(
-        self,
-        cfg: ProviderRuntimeConfig,
-        *,
-        probe_runner: Callable[
-            [ProviderRuntimeConfig, str], Awaitable[ProviderModelCompatibilityRecord]
-        ],
-        probe_kind: str = "auto-select",
-        force: bool = False,
-        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
-    ) -> ProviderModelCompatibilityRecord:
-        cache = await self.load_model_cache()
-        cache_entry = cache.get(cfg.provider, self._empty_model_cache_entry(cfg.provider))
-        existing = None
-        if not force:
-            existing = self.get_compatibility_record(
-                cache_entry,
-                cfg,
-                fresh_only=True,
-                max_age_hours=max_age_hours,
-            )
-        if existing is not None:
-            logger.info(
-                "Compatibility cache hit: provider=%s model=%s status=%s kind=%s fresh=%s",
-                cfg.provider,
-                existing.model or cfg.selected_model or "<empty>",
-                existing.status,
-                existing.probe_kind,
-                self.is_compatibility_record_fresh(existing, max_age_hours=max_age_hours),
-            )
-            return existing
-
-        logger.info(
-            "Compatibility cache miss: provider=%s model=%s kind=%s force=%s",
-            cfg.provider,
-            cfg.selected_model or "<empty>",
-            probe_kind,
-            force,
-        )
-        result = await probe_runner(cfg, probe_kind)
-        if not result.config_fingerprint:
-            result.config_fingerprint = self.config_fingerprint(cfg)
-        if not result.model:
-            result.model = cfg.selected_model
-        if not result.tested_at:
-            result.tested_at = datetime.now(UTC).isoformat()
-        if not result.probe_kind:
-            result.probe_kind = probe_kind
-
-        cache_entry.compatibility[result.config_fingerprint] = result
-        if result.model and result.model not in cache_entry.models:
-            cache_entry.models.insert(0, result.model)
-        cache[cfg.provider] = cache_entry
-        await self.save_model_cache(cache)
-        return result
-
-    async def export_compatibility_catalog(
-        self,
-        configs: list[ProviderRuntimeConfig],
-        cache: dict[str, ProviderModelCacheEntry] | None = None,
-        *,
-        path: Path | None = None,
-    ) -> Path:
-        if cache is None:
-            cache = await self.load_model_cache()
-        export_path = path or COMMUNITY_COMPATIBILITY_CATALOG_PATH
-        providers_payload: list[dict[str, Any]] = []
-
-        for cfg in sorted(configs, key=self._config_sort_key):
-            endpoint_fingerprint = self.canonical_endpoint_fingerprint(cfg)
-            if endpoint_fingerprint is None:
-                continue
-            cache_entry = cache.get(cfg.provider)
-            if cache_entry is None:
-                continue
-            models = list(cache_entry.models)
-            if cfg.selected_model and cfg.selected_model not in models:
-                models.insert(0, cfg.selected_model)
-            model_payload: list[dict[str, Any]] = []
-            for model in models:
-                record = self.get_compatibility_record(
-                    cache_entry,
-                    cfg,
-                    model=model,
-                    fresh_only=False,
-                )
-                if record is None:
-                    continue
-                model_payload.append(
-                    {
-                        "model": model,
-                        "status": record.status,
-                        "reason": record.reason,
-                        "tested_at": record.tested_at,
-                    }
-                )
-            if not model_payload:
-                continue
-            providers_payload.append(
-                {
-                    "provider": cfg.provider,
-                    "endpoint_fingerprint": endpoint_fingerprint,
-                    "models": model_payload,
-                }
-            )
-
-        payload = {
-            "generated_at": datetime.now(UTC).isoformat(),
-            "generated_by": f"tg-agent {self._app_version()}",
-            "providers": providers_payload,
-        }
-        export_path.write_text(
-            safe_json_dumps(payload, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
-        return export_path
-
     def canonical_endpoint_fingerprint(self, cfg: ProviderRuntimeConfig) -> str | None:
         return canonical_endpoint_fingerprint_for_config(cfg)
 
@@ -689,186 +321,12 @@ class ProviderConfigService:
     def normalize_ollama_base_url(self, base_url: str, api_key: str = "") -> str:
         return normalize_ollama_base_url(base_url, api_key)
 
-    async def _fetch_live_models(
-        self,
-        spec: ProviderSpec,
-        cfg: ProviderRuntimeConfig | None,
-    ) -> list[str]:
-        provider = spec.name
-        if provider == "zai":
-            assert cfg is not None
-            return await self._fetch_zai_models(
-                cfg.plain_fields.get("base_url", ""),
-                cfg.secret_fields.get("api_key", ""),
-            )
-        if spec.openai_compatible and spec.default_base_url:
-            assert cfg is not None
-            base_url = cfg.plain_fields.get("base_url", "").strip() or spec.default_base_url
-            return await self._fetch_openai_models(base_url, cfg.secret_fields.get("api_key", ""))
-        if provider == "anthropic":
-            assert cfg is not None
-            return await self._fetch_anthropic_models(cfg.secret_fields.get("api_key", ""))
-        if provider == "google_genai":
-            assert cfg is not None
-            return await self._fetch_google_genai_models(cfg.secret_fields.get("api_key", ""))
-        if provider == "cohere":
-            assert cfg is not None
-            return await self._fetch_cohere_models(cfg.secret_fields.get("api_key", ""))
-        if provider == "ollama":
-            assert cfg is not None
-            return await self._fetch_ollama_models(
-                cfg.plain_fields.get("base_url", ""),
-                cfg.secret_fields.get("api_key", ""),
-            )
-        if provider == "huggingface":
-            api_key = cfg.secret_fields.get("api_key", "") if cfg else ""
-            return await self._fetch_huggingface_models(api_key)
-        raise RuntimeError("live model fetch adapter is not available for this provider yet")
-
-    async def _fetch_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
-        timeout = aiohttp.ClientTimeout(total=20)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(url, headers=headers) as response:
-                response.raise_for_status()
-                return await response.json()
-
-    async def _fetch_openai_models(self, base_url: str, api_key: str) -> list[str]:
-        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-        payload = await self._fetch_json(base_url.rstrip("/") + "/models", headers=headers)
-        return [
-            str(item.get("id", "")).strip() for item in payload.get("data", []) if item.get("id")
-        ]
-
-    async def _fetch_anthropic_models(self, api_key: str) -> list[str]:
-        headers = {
-            "x-api-key": api_key,
-            "anthropic-version": "2023-06-01",
-        }
-        payload = await self._fetch_json("https://api.anthropic.com/v1/models", headers=headers)
-        return [
-            str(item.get("id", "")).strip() for item in payload.get("data", []) if item.get("id")
-        ]
-
-    async def _fetch_google_genai_models(self, api_key: str) -> list[str]:
-        headers = {"x-goog-api-key": api_key} if api_key else None
-        payload = await self._fetch_json(
-            "https://generativelanguage.googleapis.com/v1beta/models",
-            headers=headers,
-        )
-        models = []
-        for item in payload.get("models", []):
-            name = str(item.get("name", "")).strip()
-            if name.startswith("models/"):
-                name = name.split("/", 1)[1]
-            if name:
-                models.append(name)
-        return models
-
-    async def _fetch_cohere_models(self, api_key: str) -> list[str]:
-        headers = {"Authorization": f"Bearer {api_key}"}
-        payload = await self._fetch_json("https://api.cohere.com/v1/models", headers=headers)
-        return [
-            str(item.get("name", "")).strip()
-            for item in payload.get("models", [])
-            if item.get("name")
-        ]
-
-    async def _fetch_ollama_models(self, base_url: str, api_key: str) -> list[str]:
-        resolved_base_url = self.normalize_ollama_base_url(base_url, api_key)
-        headers = {"Authorization": f"Bearer {api_key}"} if api_key.strip() else None
-        payload = await self._fetch_json(
-            resolved_base_url.rstrip("/") + "/api/tags", headers=headers
-        )
-        return [
-            str(item.get("name", "")).strip()
-            for item in payload.get("models", [])
-            if item.get("name")
-        ]
-
-    async def _fetch_huggingface_models(self, api_key: str) -> list[str]:
-        headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
-        payload = await self._fetch_json(
-            "https://huggingface.co/api/models?pipeline_tag=text-generation&limit=50",
-            headers=headers,
-        )
-        return [str(item.get("id", "")).strip() for item in payload if item.get("id")]
-
-    async def _fetch_zai_models(self, base_url: str, api_key: str) -> list[str]:
-        if is_zai_legacy_anthropic_base_url(base_url):
-            raise RuntimeError(
-                "The Z.AI Anthropic-compatible proxy does not expose OpenAI-compatible "
-                f"/models. Use {ZAI_GENERAL_BASE_URL} or {ZAI_CODING_BASE_URL}."
-            )
-        resolved_base_url = normalize_zai_base_url(base_url)
-        headers = {"Authorization": f"Bearer {api_key}"}
-        payload = await self._fetch_json(
-            f"{resolved_base_url.rstrip('/')}/models", headers=headers
-        )
-        return [
-            str(item.get("id", "")).strip()
-            for item in payload.get("data", [])
-            if item.get("id")
-        ]
-
-    def _build_model_option(
-        self,
-        model: str,
-        cfg: ProviderRuntimeConfig,
-        cache_entry: ProviderModelCacheEntry,
-    ) -> dict[str, Any]:
-        record = self.get_compatibility_record(
-            cache_entry,
-            cfg,
-            model=model,
-            fresh_only=False,
-        )
-        label = model
-        status = ""
-        if record is not None:
-            status = record.status
-            label = f"{model} [{record.status}]"
-        return {
-            "value": model,
-            "label": label,
-            "status": status,
-            "reason": record.reason if record is not None else "",
-            "tested_at": record.tested_at if record is not None else "",
-            "is_fresh": self.is_compatibility_record_fresh(record) if record is not None else False,
-            "config_fingerprint": record.config_fingerprint if record is not None else "",
-        }
-
-    def _compatibility_view(
-        self,
-        record: ProviderModelCompatibilityRecord | None,
-    ) -> dict[str, Any] | None:
-        if record is None:
-            return None
-        return {
-            "model": record.model,
-            "status": record.status,
-            "reason": record.reason,
-            "tested_at": record.tested_at,
-            "config_fingerprint": record.config_fingerprint,
-            "probe_kind": record.probe_kind,
-            "is_fresh": self.is_compatibility_record_fresh(record),
-        }
-
     def _config_sort_key(self, cfg: ProviderRuntimeConfig) -> tuple[int, int]:
         try:
             provider_index = PROVIDER_ORDER.index(cfg.provider)
         except ValueError:
             provider_index = len(PROVIDER_ORDER)
         return (cfg.priority, provider_index)
-
-    def _empty_model_cache_entry(self, provider_name: str) -> ProviderModelCacheEntry:
-        spec = provider_spec(provider_name)
-        if spec is None:
-            raise RuntimeError(f"Unknown provider: {provider_name}")
-        return ProviderModelCacheEntry(
-            provider=provider_name,
-            models=list(spec.static_models),
-            source="static cache",
-        )
 
     def _normalize_plain_fields(
         self,

--- a/src/services/provider_model_cache.py
+++ b/src/services/provider_model_cache.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import aiohttp
+
+from src.agent.provider_registry import (
+    ZAI_CODING_BASE_URL,
+    ZAI_GENERAL_BASE_URL,
+    ProviderRuntimeConfig,
+    ProviderSpec,
+    is_zai_legacy_anthropic_base_url,
+    normalize_zai_base_url,
+    provider_spec,
+)
+from src.services.provider_model_compatibility import ProviderModelCompatibilityRecord
+from src.utils.json import safe_json_dumps
+
+logger = logging.getLogger(__name__)
+
+MODEL_CACHE_SETTINGS_KEY = "agent_deepagents_model_cache_v1"
+
+
+@dataclass(slots=True)
+class ProviderModelCacheEntry:
+    provider: str
+    models: list[str]
+    source: str
+    fetched_at: str = ""
+    error: str = ""
+    compatibility: dict[str, ProviderModelCompatibilityRecord] = field(default_factory=dict)
+
+
+class ProviderModelCacheMixin:
+    """Model-cache persistence and live-model fetch adapters for provider configs.
+
+    Mixed into ``ProviderConfigService``; ``self`` calls into sibling helpers
+    (``self._fetch_json``, ``self._fetch_live_models``, ``self.normalize_ollama_base_url``)
+    resolve through the concrete class so both instance and class monkeypatching
+    of these methods keeps working.
+    """
+
+    async def load_model_cache(self) -> dict[str, ProviderModelCacheEntry]:
+        raw = await self._db.get_setting(MODEL_CACHE_SETTINGS_KEY)
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Invalid model cache JSON in settings", exc_info=True)
+            return {}
+        if not isinstance(parsed, dict):
+            return {}
+        cache: dict[str, ProviderModelCacheEntry] = {}
+        for provider, item in parsed.items():
+            if not isinstance(item, dict):
+                continue
+            compatibility: dict[str, ProviderModelCompatibilityRecord] = {}
+            compat_raw = item.get("compatibility", {})
+            if isinstance(compat_raw, dict):
+                for fingerprint, record in compat_raw.items():
+                    if not isinstance(record, dict):
+                        continue
+                    fingerprint_key = str(fingerprint).strip()
+                    if not fingerprint_key:
+                        continue
+                    compatibility[fingerprint_key] = ProviderModelCompatibilityRecord(
+                        model=str(record.get("model", "")).strip(),
+                        status=str(record.get("status", "unknown")).strip() or "unknown",
+                        reason=str(record.get("reason", "")).strip(),
+                        tested_at=str(record.get("tested_at", "")).strip(),
+                        config_fingerprint=(
+                            str(record.get("config_fingerprint", "")).strip() or fingerprint_key
+                        ),
+                        probe_kind=str(record.get("probe_kind", "auto-select")).strip()
+                        or "auto-select",
+                    )
+            cache[provider] = ProviderModelCacheEntry(
+                provider=provider,
+                models=[str(model) for model in item.get("models", []) if str(model).strip()],
+                source=str(item.get("source", "static")).strip() or "static",
+                fetched_at=str(item.get("fetched_at", "")).strip(),
+                error=str(item.get("error", "")).strip(),
+                compatibility=compatibility,
+            )
+        return cache
+
+    async def save_model_cache(self, cache: dict[str, ProviderModelCacheEntry]) -> None:
+        payload = {
+            provider: {
+                "models": entry.models,
+                "source": entry.source,
+                "fetched_at": entry.fetched_at,
+                "error": entry.error,
+                "compatibility": {
+                    fingerprint: {
+                        "model": record.model,
+                        "status": record.status,
+                        "reason": record.reason,
+                        "tested_at": record.tested_at,
+                        "config_fingerprint": record.config_fingerprint,
+                        "probe_kind": record.probe_kind,
+                    }
+                    for fingerprint, record in entry.compatibility.items()
+                },
+            }
+            for provider, entry in cache.items()
+        }
+        await self._db.set_setting(
+            MODEL_CACHE_SETTINGS_KEY, safe_json_dumps(payload, ensure_ascii=False)
+        )
+
+    async def refresh_models_for_provider(
+        self, provider_name: str, cfg: ProviderRuntimeConfig | None = None
+    ) -> ProviderModelCacheEntry:
+        spec = provider_spec(provider_name)
+        if spec is None:
+            raise RuntimeError(f"Unknown provider: {provider_name}")
+        if cfg is None:
+            configs = await self.load_provider_configs()
+            cfg = next((item for item in configs if item.provider == provider_name), None)
+        cache = await self.load_model_cache()
+        existing_entry = cache.get(provider_name, self._empty_model_cache_entry(provider_name))
+        live_error = ""
+        try:
+            models = await self._fetch_live_models(spec, cfg)
+            models = sorted(dict.fromkeys(models))
+            if not models:
+                raise RuntimeError("live model list is empty")
+            entry = ProviderModelCacheEntry(
+                provider=provider_name,
+                models=models,
+                source="live",
+                fetched_at=datetime.now(UTC).isoformat(),
+                compatibility=existing_entry.compatibility,
+            )
+        except Exception as exc:
+            live_error = str(exc)
+            logger.warning("Provider model refresh failed for %s: %s", provider_name, exc)
+            entry = ProviderModelCacheEntry(
+                provider=provider_name,
+                models=list(existing_entry.models or list(spec.static_models)),
+                source="static cache",
+                fetched_at=datetime.now(UTC).isoformat(),
+                error=live_error,
+                compatibility=existing_entry.compatibility,
+            )
+        cache[provider_name] = entry
+        await self.save_model_cache(cache)
+        return entry
+
+    async def refresh_all_models(
+        self,
+        configs: list[ProviderRuntimeConfig] | None = None,
+    ) -> dict[str, ProviderModelCacheEntry]:
+        if configs is None:
+            configs = await self.load_provider_configs()
+        results: dict[str, ProviderModelCacheEntry] = {}
+        for cfg in configs:
+            results[cfg.provider] = await self.refresh_models_for_provider(cfg.provider, cfg)
+        return results
+
+    def _empty_model_cache_entry(self, provider_name: str) -> ProviderModelCacheEntry:
+        spec = provider_spec(provider_name)
+        if spec is None:
+            raise RuntimeError(f"Unknown provider: {provider_name}")
+        return ProviderModelCacheEntry(
+            provider=provider_name,
+            models=list(spec.static_models),
+            source="static cache",
+        )
+
+    async def _fetch_live_models(
+        self,
+        spec: ProviderSpec,
+        cfg: ProviderRuntimeConfig | None,
+    ) -> list[str]:
+        provider = spec.name
+        if provider == "zai":
+            assert cfg is not None
+            return await self._fetch_zai_models(
+                cfg.plain_fields.get("base_url", ""),
+                cfg.secret_fields.get("api_key", ""),
+            )
+        if spec.openai_compatible and spec.default_base_url:
+            assert cfg is not None
+            base_url = cfg.plain_fields.get("base_url", "").strip() or spec.default_base_url
+            return await self._fetch_openai_models(base_url, cfg.secret_fields.get("api_key", ""))
+        if provider == "anthropic":
+            assert cfg is not None
+            return await self._fetch_anthropic_models(cfg.secret_fields.get("api_key", ""))
+        if provider == "google_genai":
+            assert cfg is not None
+            return await self._fetch_google_genai_models(cfg.secret_fields.get("api_key", ""))
+        if provider == "cohere":
+            assert cfg is not None
+            return await self._fetch_cohere_models(cfg.secret_fields.get("api_key", ""))
+        if provider == "ollama":
+            assert cfg is not None
+            return await self._fetch_ollama_models(
+                cfg.plain_fields.get("base_url", ""),
+                cfg.secret_fields.get("api_key", ""),
+            )
+        if provider == "huggingface":
+            api_key = cfg.secret_fields.get("api_key", "") if cfg else ""
+            return await self._fetch_huggingface_models(api_key)
+        raise RuntimeError("live model fetch adapter is not available for this provider yet")
+
+    async def _fetch_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
+        timeout = aiohttp.ClientTimeout(total=20)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url, headers=headers) as response:
+                response.raise_for_status()
+                return await response.json()
+
+    async def _fetch_openai_models(self, base_url: str, api_key: str) -> list[str]:
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        payload = await self._fetch_json(base_url.rstrip("/") + "/models", headers=headers)
+        return [
+            str(item.get("id", "")).strip() for item in payload.get("data", []) if item.get("id")
+        ]
+
+    async def _fetch_anthropic_models(self, api_key: str) -> list[str]:
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        }
+        payload = await self._fetch_json("https://api.anthropic.com/v1/models", headers=headers)
+        return [
+            str(item.get("id", "")).strip() for item in payload.get("data", []) if item.get("id")
+        ]
+
+    async def _fetch_google_genai_models(self, api_key: str) -> list[str]:
+        headers = {"x-goog-api-key": api_key} if api_key else None
+        payload = await self._fetch_json(
+            "https://generativelanguage.googleapis.com/v1beta/models",
+            headers=headers,
+        )
+        models = []
+        for item in payload.get("models", []):
+            name = str(item.get("name", "")).strip()
+            if name.startswith("models/"):
+                name = name.split("/", 1)[1]
+            if name:
+                models.append(name)
+        return models
+
+    async def _fetch_cohere_models(self, api_key: str) -> list[str]:
+        headers = {"Authorization": f"Bearer {api_key}"}
+        payload = await self._fetch_json("https://api.cohere.com/v1/models", headers=headers)
+        return [
+            str(item.get("name", "")).strip()
+            for item in payload.get("models", [])
+            if item.get("name")
+        ]
+
+    async def _fetch_ollama_models(self, base_url: str, api_key: str) -> list[str]:
+        resolved_base_url = self.normalize_ollama_base_url(base_url, api_key)
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key.strip() else None
+        payload = await self._fetch_json(
+            resolved_base_url.rstrip("/") + "/api/tags", headers=headers
+        )
+        return [
+            str(item.get("name", "")).strip()
+            for item in payload.get("models", [])
+            if item.get("name")
+        ]
+
+    async def _fetch_huggingface_models(self, api_key: str) -> list[str]:
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+        payload = await self._fetch_json(
+            "https://huggingface.co/api/models?pipeline_tag=text-generation&limit=50",
+            headers=headers,
+        )
+        return [str(item.get("id", "")).strip() for item in payload if item.get("id")]
+
+    async def _fetch_zai_models(self, base_url: str, api_key: str) -> list[str]:
+        if is_zai_legacy_anthropic_base_url(base_url):
+            raise RuntimeError(
+                "The Z.AI Anthropic-compatible proxy does not expose OpenAI-compatible "
+                f"/models. Use {ZAI_GENERAL_BASE_URL} or {ZAI_CODING_BASE_URL}."
+            )
+        resolved_base_url = normalize_zai_base_url(base_url)
+        headers = {"Authorization": f"Bearer {api_key}"}
+        payload = await self._fetch_json(
+            f"{resolved_base_url.rstrip('/')}/models", headers=headers
+        )
+        return [
+            str(item.get("id", "")).strip()
+            for item in payload.get("data", [])
+            if item.get("id")
+        ]

--- a/src/services/provider_model_compatibility.py
+++ b/src/services/provider_model_compatibility.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from src.agent.provider_registry import (
+    ProviderRuntimeConfig,
+    provider_spec,
+)
+from src.utils.datetime import try_parse_datetime
+from src.utils.json import safe_json_dumps
+
+if TYPE_CHECKING:
+    from src.services.provider_model_cache import ProviderModelCacheEntry
+
+logger = logging.getLogger(__name__)
+
+MODEL_COMPATIBILITY_FRESHNESS_HOURS = 24
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+COMMUNITY_COMPATIBILITY_CATALOG_PATH = (
+    _PROJECT_ROOT / "data" / "deepagents_model_compatibility_catalog.json"
+)
+
+
+@dataclass(slots=True)
+class ProviderModelCompatibilityRecord:
+    model: str
+    status: str
+    reason: str = ""
+    tested_at: str = ""
+    config_fingerprint: str = ""
+    probe_kind: str = "auto-select"
+
+
+class ProviderModelCompatibilityMixin:
+    """Compatibility-probe caching and catalog export for provider configs.
+
+    Mixed into ``ProviderConfigService``; cross-mixin ``self`` calls
+    (``load_model_cache``, ``save_model_cache``, ``_empty_model_cache_entry``,
+    ``canonical_endpoint_fingerprint``, ``_config_sort_key``, ``_app_version``,
+    ``normalize_provider_plain_fields``) resolve via the concrete class MRO.
+    """
+
+    def config_fingerprint(
+        self,
+        cfg: ProviderRuntimeConfig,
+        *,
+        model: str | None = None,
+    ) -> str:
+        selected_model = (model or cfg.selected_model).strip()
+        spec = provider_spec(cfg.provider)
+        if spec is None:
+            raise RuntimeError(f"Unknown provider: {cfg.provider}")
+        normalized_plain = self.normalize_provider_plain_fields(cfg)
+        secret_payload = {
+            field.name: cfg.secret_fields.get(field.name, "").strip()
+            for field in spec.secret_fields
+            if cfg.secret_fields.get(field.name, "").strip()
+        }
+        auth_mode = "+".join(sorted(secret_payload)) if secret_payload else "no-auth"
+        secret_hash = ""
+        if secret_payload:
+            secret_hash = hashlib.sha256(
+                safe_json_dumps(secret_payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+            ).hexdigest()[:16]
+        payload = {
+            "provider": cfg.provider,
+            "model": selected_model,
+            "plain_fields": normalized_plain,
+            "auth_mode": auth_mode,
+            "secret_hash": secret_hash,
+        }
+        return hashlib.sha256(
+            safe_json_dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
+
+    def get_compatibility_record(
+        self,
+        cache_entry: ProviderModelCacheEntry | None,
+        cfg: ProviderRuntimeConfig,
+        *,
+        model: str | None = None,
+        fresh_only: bool = False,
+        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
+    ) -> ProviderModelCompatibilityRecord | None:
+        if cache_entry is None:
+            return None
+        fingerprint = self.config_fingerprint(cfg, model=model)
+        record = cache_entry.compatibility.get(fingerprint)
+        if record is None:
+            return None
+        if fresh_only and not self.is_compatibility_record_fresh(
+            record, max_age_hours=max_age_hours
+        ):
+            return None
+        return record
+
+    def compatibility_error_for_config(
+        self,
+        cfg: ProviderRuntimeConfig,
+        cache_entry: ProviderModelCacheEntry | None,
+    ) -> str:
+        record = self.get_compatibility_record(cache_entry, cfg, fresh_only=True)
+        if record is None or record.status != "unsupported":
+            return ""
+        return record.reason or "Compatibility probe marked this model as unsupported."
+
+    def compatibility_warning_for_config(
+        self,
+        cfg: ProviderRuntimeConfig,
+        cache_entry: ProviderModelCacheEntry | None,
+    ) -> str:
+        record = self.get_compatibility_record(cache_entry, cfg, fresh_only=False)
+        if record is None:
+            return "Совместимость модели с deepagents ещё не проверялась."
+        if record.status == "unknown":
+            return record.reason or "Совместимость модели с deepagents не подтверждена."
+        if not self.is_compatibility_record_fresh(record):
+            return (
+                "Результат проверки совместимости устарел и будет обновлён при следующей проверке."
+            )
+        return ""
+
+    def is_compatibility_record_fresh(
+        self,
+        record: ProviderModelCompatibilityRecord,
+        *,
+        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
+    ) -> bool:
+        if not record.tested_at:
+            return False
+        tested_at = try_parse_datetime(record.tested_at)
+        if tested_at is None:
+            return False
+        if tested_at.tzinfo is None:
+            tested_at = tested_at.replace(tzinfo=UTC)
+        return datetime.now(UTC) - tested_at <= timedelta(hours=max_age_hours)
+
+    async def ensure_model_compatibility(
+        self,
+        cfg: ProviderRuntimeConfig,
+        *,
+        probe_runner: Callable[
+            [ProviderRuntimeConfig, str], Awaitable[ProviderModelCompatibilityRecord]
+        ],
+        probe_kind: str = "auto-select",
+        force: bool = False,
+        max_age_hours: int = MODEL_COMPATIBILITY_FRESHNESS_HOURS,
+    ) -> ProviderModelCompatibilityRecord:
+        cache = await self.load_model_cache()
+        cache_entry = cache.get(cfg.provider, self._empty_model_cache_entry(cfg.provider))
+        existing = None
+        if not force:
+            existing = self.get_compatibility_record(
+                cache_entry,
+                cfg,
+                fresh_only=True,
+                max_age_hours=max_age_hours,
+            )
+        if existing is not None:
+            logger.info(
+                "Compatibility cache hit: provider=%s model=%s status=%s kind=%s fresh=%s",
+                cfg.provider,
+                existing.model or cfg.selected_model or "<empty>",
+                existing.status,
+                existing.probe_kind,
+                self.is_compatibility_record_fresh(existing, max_age_hours=max_age_hours),
+            )
+            return existing
+
+        logger.info(
+            "Compatibility cache miss: provider=%s model=%s kind=%s force=%s",
+            cfg.provider,
+            cfg.selected_model or "<empty>",
+            probe_kind,
+            force,
+        )
+        result = await probe_runner(cfg, probe_kind)
+        if not result.config_fingerprint:
+            result.config_fingerprint = self.config_fingerprint(cfg)
+        if not result.model:
+            result.model = cfg.selected_model
+        if not result.tested_at:
+            result.tested_at = datetime.now(UTC).isoformat()
+        if not result.probe_kind:
+            result.probe_kind = probe_kind
+
+        cache_entry.compatibility[result.config_fingerprint] = result
+        if result.model and result.model not in cache_entry.models:
+            cache_entry.models.insert(0, result.model)
+        cache[cfg.provider] = cache_entry
+        await self.save_model_cache(cache)
+        return result
+
+    async def export_compatibility_catalog(
+        self,
+        configs: list[ProviderRuntimeConfig],
+        cache: dict[str, ProviderModelCacheEntry] | None = None,
+        *,
+        path: Path | None = None,
+    ) -> Path:
+        if cache is None:
+            cache = await self.load_model_cache()
+        export_path = path or COMMUNITY_COMPATIBILITY_CATALOG_PATH
+        providers_payload: list[dict[str, Any]] = []
+
+        for cfg in sorted(configs, key=self._config_sort_key):
+            endpoint_fingerprint = self.canonical_endpoint_fingerprint(cfg)
+            if endpoint_fingerprint is None:
+                continue
+            cache_entry = cache.get(cfg.provider)
+            if cache_entry is None:
+                continue
+            models = list(cache_entry.models)
+            if cfg.selected_model and cfg.selected_model not in models:
+                models.insert(0, cfg.selected_model)
+            model_payload: list[dict[str, Any]] = []
+            for model in models:
+                record = self.get_compatibility_record(
+                    cache_entry,
+                    cfg,
+                    model=model,
+                    fresh_only=False,
+                )
+                if record is None:
+                    continue
+                model_payload.append(
+                    {
+                        "model": model,
+                        "status": record.status,
+                        "reason": record.reason,
+                        "tested_at": record.tested_at,
+                    }
+                )
+            if not model_payload:
+                continue
+            providers_payload.append(
+                {
+                    "provider": cfg.provider,
+                    "endpoint_fingerprint": endpoint_fingerprint,
+                    "models": model_payload,
+                }
+            )
+
+        payload = {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "generated_by": f"tg-agent {self._app_version()}",
+            "providers": providers_payload,
+        }
+        export_path.write_text(
+            safe_json_dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return export_path
+
+    def build_compatibility_payload(
+        self,
+        cfg: ProviderRuntimeConfig,
+        cache_entry: ProviderModelCacheEntry,
+    ) -> dict[str, dict[str, Any]]:
+        payload: dict[str, dict[str, Any]] = {}
+        models = list(cache_entry.models)
+        if cfg.selected_model and cfg.selected_model not in models:
+            models.insert(0, cfg.selected_model)
+        for model in models:
+            record = self.get_compatibility_record(
+                cache_entry,
+                cfg,
+                model=model,
+                fresh_only=False,
+            )
+            if record is None:
+                payload[model] = {"status": "unknown", "reason": "", "tested_at": ""}
+                continue
+            payload[model] = {
+                "status": record.status,
+                "reason": record.reason,
+                "tested_at": record.tested_at,
+                "config_fingerprint": record.config_fingerprint,
+                "probe_kind": record.probe_kind,
+                "is_fresh": self.is_compatibility_record_fresh(record),
+            }
+        return payload
+
+    def _build_model_option(
+        self,
+        model: str,
+        cfg: ProviderRuntimeConfig,
+        cache_entry: ProviderModelCacheEntry,
+    ) -> dict[str, Any]:
+        record = self.get_compatibility_record(
+            cache_entry,
+            cfg,
+            model=model,
+            fresh_only=False,
+        )
+        label = model
+        status = ""
+        if record is not None:
+            status = record.status
+            label = f"{model} [{record.status}]"
+        return {
+            "value": model,
+            "label": label,
+            "status": status,
+            "reason": record.reason if record is not None else "",
+            "tested_at": record.tested_at if record is not None else "",
+            "is_fresh": self.is_compatibility_record_fresh(record) if record is not None else False,
+            "config_fingerprint": record.config_fingerprint if record is not None else "",
+        }
+
+    def _compatibility_view(
+        self,
+        record: ProviderModelCompatibilityRecord | None,
+    ) -> dict[str, Any] | None:
+        if record is None:
+            return None
+        return {
+            "model": record.model,
+            "status": record.status,
+            "reason": record.reason,
+            "tested_at": record.tested_at,
+            "config_fingerprint": record.config_fingerprint,
+            "probe_kind": record.probe_kind,
+            "is_fresh": self.is_compatibility_record_fresh(record),
+        }


### PR DESCRIPTION
## Контекст (#689)

`src/services/agent_provider_service.py` разросся до 1044 строк, смешивая три зоны ответственности: CRUD конфигов провайдеров, model-cache/live-fetch и compatibility (probe/catalog/freshness).

## Изменения (чистое перемещение, нулевое изменение логики)

Выделены два миксина:
- **`src/services/provider_model_cache.py`** — `ProviderModelCacheMixin` + `ProviderModelCacheEntry`: `load/save_model_cache`, `refresh_models_for_provider`, `refresh_all_models`, `_fetch_live_models` и per-provider `_fetch_*`.
- **`src/services/provider_model_compatibility.py`** — `ProviderModelCompatibilityMixin` + `ProviderModelCompatibilityRecord`: `config_fingerprint`, `get/ensure_compatibility`, freshness-проверки, `export_compatibility_catalog`, `build_compatibility_payload`.

`ProviderConfigService(ProviderModelCacheMixin, ProviderModelCompatibilityMixin)` наследует оба.

**Почему миксины, а не композиция/делегирование:** тесты делают `monkeypatch.setattr(service, '_fetch_json'/'_fetch_live_models'/'refresh_models_for_provider', ...)` на инстансе (и на классе) и рассчитывают, что соседние методы вызовут их через `self`. Композиция сделала бы эти патчи невидимыми и сломала 12+ тестов. Mixin-MRO сохраняет self-dispatch.

Public API **byte-identical** (45 атрибутов через MRO); dataclasses и settings-key константы re-export'ятся из `agent_provider_service` через явный импорт + `__all__`, поэтому 4 caller'а (web settings handlers, agent manager, CLI provider, provider_service) и ~18 тестовых файлов импортируют без изменений.

## Проверка

```
ruff check (3 файла)                                          # clean
python -c "проверка 45 публичных методов + re-exports"        # API OK
pytest tests/test_agent_provider_service.py tests/test_cli_provider.py  # 81 passed (56+25)
pytest -k "provider or compatibility or agent_provider" -q    # 687 passed, 3 skip
```
(workflow дополнительно прогнал полный сьют в worktree: 7392+846 passed, 0 fail)

Diff: 3 файла, +654/−569 (net +85, перемещение).

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)