### PR TITLE
fix(733): enforce single-primary-account invariant

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -15,6 +15,7 @@ ColumnSpec = Mapping[str, str]
 
 SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
     "accounts": {
+        "is_primary": "is_primary INTEGER DEFAULT 0",
         "flood_wait_until": "flood_wait_until TEXT",
         "is_premium": "is_premium INTEGER DEFAULT 0",
     },
@@ -166,6 +167,13 @@ SCHEMA_REPAIR_INDEXES: Sequence[str] = (
     CREATE INDEX IF NOT EXISTS idx_pipeline_action_log_lookup
     ON pipeline_action_log(pipeline_id, node_id, action)
     """,
+    # Enforce at-most-one primary account (#733). Partial unique index: at most
+    # one row may have is_primary = 1. Existing duplicate primaries are collapsed
+    # by _dedupe_primary_accounts() before this index is created.
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_single_primary
+    ON accounts(is_primary) WHERE is_primary = 1
+    """,
 )
 
 
@@ -196,6 +204,31 @@ async def ensure_columns(db: aiosqlite.Connection, table: str, columns: ColumnSp
 async def ensure_indexes(db: aiosqlite.Connection, index_statements: Sequence[str]) -> None:
     for statement in index_statements:
         await db.execute(statement)
+
+
+async def _dedupe_primary_accounts(db: aiosqlite.Connection) -> None:
+    """Collapse multiple primary accounts to a single one (#733).
+
+    A pre-existing race (two accounts both reading an empty table and both
+    inserting is_primary=1) could leave more than one primary row. Before the
+    partial unique index idx_accounts_single_primary can be created, any such
+    duplicates must be demoted — otherwise the CREATE UNIQUE INDEX fails. Keep
+    the lowest-id primary, demote the rest. No-op when the table is absent or
+    already has <=1 primary.
+    """
+    if not await table_exists(db, "accounts"):
+        return
+    if "is_primary" not in await table_columns(db, "accounts"):
+        return
+    cur = await db.execute("SELECT id FROM accounts WHERE is_primary = 1 ORDER BY id ASC")
+    rows = await cur.fetchall()
+    if len(rows) <= 1:
+        return
+    keep_id = rows[0][0]
+    await db.execute(
+        "UPDATE accounts SET is_primary = 0 WHERE is_primary = 1 AND id != ?",
+        (keep_id,),
+    )
 
 
 async def _rebuild_collection_tasks_if_channel_id_notnull(db: aiosqlite.Connection) -> None:
@@ -327,6 +360,11 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
 
     for table, columns in SCHEMA_REPAIR_COLUMNS.items():
         await ensure_columns(db, table, columns)
+
+    # Collapse any pre-existing duplicate primary accounts (#733) BEFORE applying
+    # SCHEMA_SQL — it contains the single-primary partial unique index, whose
+    # creation would fail on a DB that already has >1 primary row.
+    await _dedupe_primary_accounts(db)
 
     await db.executescript(SCHEMA_SQL)
 

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -48,9 +48,21 @@ class AccountsRepository:
         if self._session_cipher:
             session_string = self._session_cipher.encrypt(session_string)
 
+        # Derive is_primary atomically (#733): the requested primary flag only
+        # takes effect when no primary account exists yet. Two concurrent inserts
+        # that each pass is_primary=1 can no longer both win — the subquery is
+        # evaluated against the table at insert time, so the second insert sees
+        # the first's primary row and stores 0. The partial unique index
+        # idx_accounts_single_primary is the hard backstop behind this.
+        want_primary = int(account.is_primary)
         cur = await self._database.execute_write(
             """INSERT INTO accounts (phone, session_string, is_primary, is_active, is_premium)
-               VALUES (?, ?, ?, ?, ?)
+               VALUES (
+                   ?, ?,
+                   CASE WHEN ? = 1 AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1)
+                        THEN 1 ELSE 0 END,
+                   ?, ?
+               )
                ON CONFLICT(phone) DO UPDATE SET
                    session_string=excluded.session_string,
                    is_active=excluded.is_active,
@@ -58,7 +70,7 @@ class AccountsRepository:
             (
                 account.phone,
                 session_string,
-                int(account.is_primary),
+                want_primary,
                 int(account.is_active),
                 int(account.is_premium),
             ),

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS accounts (
     created_at TEXT DEFAULT (datetime('now'))
 );
 
+-- At most one primary account (#733): partial unique index on is_primary = 1.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_single_primary
+    ON accounts(is_primary) WHERE is_primary = 1;
+
 CREATE TABLE IF NOT EXISTS channels (
     id INTEGER PRIMARY KEY,
     channel_id INTEGER UNIQUE NOT NULL,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -78,6 +78,33 @@ async def test_account_upsert_reactivates_without_overwriting_primary(db):
 
 
 @pytest.mark.anyio
+async def test_add_account_second_primary_is_demoted(db):
+    """#733: when a primary already exists, a second account requesting primary
+    is stored as non-primary (atomic derivation), so the single-primary invariant
+    holds even if two callers both pass is_primary=True."""
+    await db.add_account(Account(phone="+70000000001", session_string="s1", is_primary=True))
+    await db.add_account(Account(phone="+70000000002", session_string="s2", is_primary=True))
+
+    accounts = await db.get_accounts()
+    primaries = [a for a in accounts if a.is_primary]
+    assert len(primaries) == 1
+    assert primaries[0].phone == "+70000000001"
+
+
+@pytest.mark.anyio
+async def test_single_primary_partial_index_rejects_raw_double_primary(db):
+    """#733: the partial unique index idx_accounts_single_primary is the hard
+    backstop — a raw write that forces a second is_primary=1 row must fail even
+    if it bypasses add_account's atomic derivation."""
+    await db.add_account(Account(phone="+70000000003", session_string="s1", is_primary=True))
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute_write(
+            "INSERT INTO accounts (phone, session_string, is_primary) VALUES (?, ?, 1)",
+            ("+70000000004", "s2"),
+        )
+
+
+@pytest.mark.anyio
 async def test_agent_message_write_retries_when_database_is_locked_once(db, monkeypatch):
     thread_id = await db.create_agent_thread("Retry")
     assert db.db is not None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -116,7 +116,13 @@ async def test_run_migrations_adds_missing_columns_and_indexes(tmp_path):
         await run_migrations(conn)
         await run_migrations(conn)
 
-        assert {"is_premium", "flood_wait_until"} <= await _columns(conn, "accounts")
+        assert {"is_primary", "is_premium", "flood_wait_until"} <= await _columns(conn, "accounts")
+        # #733: single-primary partial unique index is created on legacy DBs.
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name = ?",
+            ("idx_accounts_single_primary",),
+        )
+        assert await cur.fetchone() is not None
         assert {"preferred_phone", "channel_type", "is_filtered"} <= await _columns(conn, "channels")
         assert {
             "forward_from_channel_id",
@@ -143,6 +149,46 @@ async def test_run_migrations_adds_missing_columns_and_indexes(tmp_path):
         cur = await conn.execute("SELECT value FROM settings WHERE key = 'agent_prompt_template'")
         row = await cur.fetchone()
         assert row["value"] == "legacy"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.aiosqlite_serial
+async def test_run_migrations_dedupes_multiple_primary_accounts(tmp_path):
+    """#733: a legacy DB corrupted with >1 primary account is collapsed to a
+    single primary (lowest id wins) before the single-primary unique index is
+    created — otherwise the index creation would fail."""
+    conn = await _connect(str(tmp_path / "double_primary.db"))
+    try:
+        await conn.executescript("""
+            CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE accounts (
+                id INTEGER PRIMARY KEY,
+                phone TEXT UNIQUE NOT NULL,
+                session_string TEXT NOT NULL,
+                is_primary INTEGER DEFAULT 0
+            );
+        """)
+        await conn.execute(
+            "INSERT INTO accounts (id, phone, session_string, is_primary) VALUES (1, '+71', 's1', 1)"
+        )
+        await conn.execute(
+            "INSERT INTO accounts (id, phone, session_string, is_primary) VALUES (2, '+72', 's2', 1)"
+        )
+        await conn.commit()
+
+        await run_migrations(conn)
+
+        cur = await conn.execute("SELECT id FROM accounts WHERE is_primary = 1")
+        primaries = [row["id"] for row in await cur.fetchall()]
+        assert primaries == [1], "lowest-id primary kept, others demoted"
+
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name = ?",
+            ("idx_accounts_single_primary",),
+        )
+        assert await cur.fetchone() is not None
     finally:
         await conn.close()
 


### PR DESCRIPTION
## Контекст (#733, выделено из #449)

Ничто не гарантировало «ровно один primary-аккаунт». `is_primary` вычислялся как неатомарный read-then-write (`get_account_summaries` → `add_account`), поэтому два параллельных добавления, оба увидевшие пустую таблицу, могли оба записать `is_primary=1`. DB-level ограничения тоже не было — в отличие от уже применённого в проекте паттерна partial unique index (`idx_channel_rename_events_pending`).

## Два слоя защиты

**1. DB-backstop** — partial unique index `idx_accounts_single_primary ON accounts(is_primary) WHERE is_primary = 1` (в `schema.py` и `SCHEMA_REPAIR_INDEXES`).
- Миграция `_dedupe_primary_accounts()` схлопывает любые **существующие** дубли primary (оставляет lowest id) **до** создания индекса — иначе `CREATE UNIQUE INDEX` упал бы на уже повреждённой БД.
- `is_primary` добавлен в `SCHEMA_REPAIR_COLUMNS`, чтобы legacy-таблицы `accounts` получили колонку до того, как любой индекс на неё сошлётся. Порядок в `run_migrations`: ensure_columns → dedup → `executescript(SCHEMA_SQL)`.

**2. Атомарная деривация** — `add_account` вычисляет `is_primary` внутри INSERT:
```sql
CASE WHEN ? = 1 AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1) THEN 1 ELSE 0 END
```
Второй параллельный primary-insert сохранит 0 вместо гонки и не заденет unique-индекс на нормальном пути.

## Тесты

- `test_add_account_second_primary_is_demoted` — второй primary демоутится.
- `test_single_primary_partial_index_rejects_raw_double_primary` — сырой двойной primary отвергается индексом (IntegrityError).
- `test_run_migrations_dedupes_multiple_primary_accounts` — миграция чинит повреждённую legacy-БД.

## Проверка

```
ruff check (5 файлов)                                              # clean
pytest tests/test_migrations*.py tests/test_database.py -q          # 142 passed
pytest -k "account or migration or database or bootstrap or client_pool" # 960 passed
```

Diff: 5 файлов, +130/−3.

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)