### PR TITLE
fix(437): thread config into ABTesting/QualityScoring provider registries

### DIFF
--- a/src/services/ab_testing_service.py
+++ b/src/services/ab_testing_service.py
@@ -31,9 +31,17 @@ class ABTestingService:
     Generates multiple variants and allows selection of the best one.
     """
 
-    def __init__(self, db: Database, default_variants: int = 3):
+    def __init__(
+        self,
+        db: Database,
+        default_variants: int = 3,
+        provider_service=None,
+        config=None,
+    ):
         self._db = db
         self._default_variants = default_variants
+        self._provider_service = provider_service
+        self._config = config
 
     async def generate_variants(
         self,
@@ -55,13 +63,13 @@ class ABTestingService:
         variants: list[str] = [base_text]
 
         try:
-            from src.services.provider_service import RuntimeProviderRegistry
+            from src.services.provider_service import build_provider_service
         except ImportError:
             logger.warning("Provider service not available for variant generation")
             return variants
 
         try:
-            provider_service = RuntimeProviderRegistry(self._db)
+            provider_service = self._provider_service or await build_provider_service(self._db, self._config)
 
             for i in range(1, num_variants):
                 prompt = (

--- a/src/services/quality_scoring_service.py
+++ b/src/services/quality_scoring_service.py
@@ -53,10 +53,12 @@ class QualityScoringService:
         db: Database,
         default_threshold: float = 0.7,
         provider_service=None,
+        config=None,
     ):
         self._db = db
         self._default_threshold = default_threshold
         self._provider_service = provider_service
+        self._config = config
 
     async def score_content(
         self,
@@ -81,13 +83,13 @@ class QualityScoringService:
             issues=["Scoring failed"],
         )
         try:
-            from src.services.provider_service import RuntimeProviderRegistry
+            from src.services.provider_service import build_provider_service
         except ImportError:
             logger.warning("Provider service not available for quality scoring")
             return _default_score
 
         try:
-            provider_service = self._provider_service or RuntimeProviderRegistry(self._db)
+            provider_service = self._provider_service or await build_provider_service(self._db, self._config)
             provider_callable = provider_service.get_provider_callable(model)
 
             prompt = f"{QUALITY_RUBRIC}\n\nКонтент для оценки:\n{text}"

--- a/tests/test_ab_testing_service.py
+++ b/tests/test_ab_testing_service.py
@@ -183,3 +183,55 @@ async def test_ab_testing_service_auto_select_without_scoring_picks_longest(db):
     best_index = await service.auto_select_best(run_id, scoring_service=None)
 
     assert best_index == 2  # Index of "the longest one here"
+
+
+@pytest.mark.anyio
+async def test_generate_variants_builds_provider_service_with_config(db):
+    """When no provider_service is injected, the registry is built WITH config so DB providers load."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    cfg = MagicMock()
+    service = ABTestingService(db, config=cfg)
+    pipeline = ContentPipeline(
+        id=1,
+        name="Digest",
+        prompt_template="Summarize {source_messages}",
+        llm_model="test-model",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=PipelinePublishMode.MODERATED,
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider_callable.return_value = AsyncMock(return_value="variant-x")
+    builder = AsyncMock(return_value=mock_registry)
+
+    with patch("src.services.provider_service.build_provider_service", builder):
+        variants = await service.generate_variants(pipeline, "base", num_variants=2)
+
+    builder.assert_awaited_once_with(db, cfg)
+    assert variants == ["base", "variant-x"]
+
+
+@pytest.mark.anyio
+async def test_generate_variants_accepts_injected_provider_service(db):
+    """An injected provider_service short-circuits the builder entirely."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    injected = MagicMock()
+    injected.get_provider_callable.return_value = AsyncMock(return_value="variant-y")
+    service = ABTestingService(db, provider_service=injected)
+    pipeline = ContentPipeline(
+        id=1,
+        name="Digest",
+        prompt_template="Summarize {source_messages}",
+        llm_model="test-model",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=PipelinePublishMode.MODERATED,
+    )
+
+    builder = AsyncMock()
+    with patch("src.services.provider_service.build_provider_service", builder):
+        variants = await service.generate_variants(pipeline, "base", num_variants=2)
+
+    builder.assert_not_awaited()
+    assert variants == ["base", "variant-y"]

--- a/tests/test_quality_scoring_service.py
+++ b/tests/test_quality_scoring_service.py
@@ -266,3 +266,45 @@ def test_quality_score_max_values():
         issues=[],
     )
     assert score.overall == 1.0
+
+
+# === provider-service plumbing tests (issue #437/#447) ===
+
+
+@pytest.mark.anyio
+async def test_score_content_builds_provider_service_with_config(mock_db):
+    """When no provider_service is injected, the registry is built WITH config so DB providers load."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    cfg = MagicMock()
+    service = QualityScoringService(mock_db, config=cfg)
+
+    mock_registry = MagicMock()
+    mock_registry.get_provider_callable.return_value = AsyncMock(
+        return_value=json.dumps(
+            {
+                "relevance": 0.9,
+                "language_quality": 0.9,
+                "informativeness": 0.9,
+                "structure": 0.9,
+                "overall": 0.9,
+                "issues": [],
+            }
+        )
+    )
+    builder = AsyncMock(return_value=mock_registry)
+
+    with patch("src.services.provider_service.build_provider_service", builder):
+        score = await service.score_content("text")
+
+    builder.assert_awaited_once_with(mock_db, cfg)
+    assert score.overall == 0.9
+
+
+@pytest.mark.anyio
+async def test_score_content_fallback_without_config_uses_default(mock_db):
+    """Without config or provider_service the default-stub path is unchanged (overall 0.5)."""
+    service = QualityScoringService(mock_db)
+    score = await service.score_content("text")
+    assert score.overall == 0.5


### PR DESCRIPTION
## Что

Закрывает два последних живых бага из аудита #437/#446 (это #447 Fix 2). Оба сервиса строили `RuntimeProviderRegistry(self._db)` **без `config`**, из-за чего `load_db_providers()` короткозамыкался (`if self.db is None or self._config is None: return 0`) и провайдеры, настроенные через UI/Settings, молча не регистрировались — работали только env-провайдеры.

## Изменения

- **`ABTestingService`** — `__init__` теперь принимает `provider_service=None` и `config=None` (зеркало `QualityScoringService`); `generate_variants` использует инжектированный `provider_service` или строит через `build_provider_service(db, config)`.
- **`QualityScoringService`** — `__init__` принимает `config=None`; fallback в `score_content` строит реестр через `build_provider_service(db, config)` вместо config-less `RuntimeProviderRegistry`.
- `build_provider_service(db, config)` (`provider_service.py:18`) — уже существующий канонический способ: создаёт реестр и делает `await load_db_providers()`, когда оба не None.

## Совместимость

Сигнатуры обратно-совместимы (новые аргументы — keyword с `None`). Все продакшн-вызовы `QualityScoringService` уже инжектят загруженный `provider_service`, поэтому **не тронуты**. `ABTestingService` в проде пока не подключён — фикс по консистентности на будущее.

## Про остальной аудит

7 из 9 находок #437/#447 (ZAI URL, регистрация `ZAI_API_KEY`, fail-open ACL, RAG query, fallback hybrid→local и др.) уже исправлены в `main` — этот PR закрывает оставшиеся два.

## Тесты

+4 теста: config доходит до builder; инжектированный `provider_service` короткозамыкает builder; fallback без config неизменён (`overall == 0.5`).

```
pytest tests/test_quality_scoring_service.py tests/test_ab_testing_service.py \
  tests/test_registry_and_quality.py tests/test_cross_domain_regression_paths.py
→ 570 passed
ruff check → All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)