### PR TITLE
fix(561): agent test_notification accepts custom text (CLI/Web/agent parity)

### DIFF
--- a/src/agent/tools/notifications.py
+++ b/src/agent/tools/notifications.py
@@ -9,7 +9,7 @@ from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
 from src.agent.tools._formatters import format_notification_status
-from src.agent.tools._registry import _text_response, require_confirmation, require_pool
+from src.agent.tools._registry import _text_response, arg_str, require_confirmation, require_pool
 
 
 async def _describe_target(target_service):
@@ -98,7 +98,12 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(delete_notification_bot)
 
-    @tool("test_notification", "Send a test notification message via the bot", {})
+    @tool(
+        "test_notification",
+        "Send a test notification message via the bot. "
+        "Optionally pass custom text; if omitted, a default test message is used.",
+        {"text": Annotated[str, "Опционально: текст уведомления (пусто — дефолтное тестовое сообщение)"]},
+    )
     async def test_notification(args):
         pool_gate = require_pool(client_pool, "Тестовое уведомление")
         if pool_gate:
@@ -111,7 +116,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             bot = await svc.get_status()
             if bot is None:
                 return _text_response("Бот уведомлений не настроен. Сначала вызовите setup_notification_bot.")
-            await svc.send_notification("🔔 Тестовое уведомление от агента")
+            text = arg_str(args, "text", "🔔 Тестовое уведомление от агента")
+            await svc.send_notification(text)
             return _text_response("Тестовое уведомление отправлено.")
         except Exception as e:
             return _text_response(f"Ошибка отправки уведомления: {e}")

--- a/tests/test_agent_tools_notifications.py
+++ b/tests/test_agent_tools_notifications.py
@@ -277,3 +277,35 @@ class TestTestNotificationTool:
             result = await handlers["test_notification"]({})
         text = _text(result)
         assert "отправлено" in text
+
+    @pytest.mark.anyio
+    async def test_sends_custom_text(self, mock_db):
+        pool = MagicMock()
+        bot = SimpleNamespace(bot_username="testbot", bot_id=1, tg_user_id=111)
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            inst = mock_ns.return_value
+            inst.get_status = AsyncMock(return_value=bot)
+            inst.send_notification = AsyncMock()
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["test_notification"]({"text": "Привет от агента"})
+        assert "отправлено" in _text(result)
+        inst.send_notification.assert_awaited_once_with("Привет от агента")
+
+    @pytest.mark.anyio
+    async def test_sends_default_text_when_omitted(self, mock_db):
+        pool = MagicMock()
+        bot = SimpleNamespace(bot_username="testbot", bot_id=1, tg_user_id=111)
+        with (
+            patch("src.services.notification_service.NotificationService") as mock_ns,
+            patch("src.services.notification_target_service.NotificationTargetService"),
+        ):
+            inst = mock_ns.return_value
+            inst.get_status = AsyncMock(return_value=bot)
+            inst.send_notification = AsyncMock()
+            handlers = _get_tool_handlers(mock_db, client_pool=pool)
+            result = await handlers["test_notification"]({})
+        assert "отправлено" in _text(result)
+        inst.send_notification.assert_awaited_once_with("🔔 Тестовое уведомление от агента")


### PR DESCRIPTION
## Что

Закрывает единственный живой пункт аудита #561 (CLI Contract Audit). Agent-tool `test_notification` слал жёстко зашитый текст `"🔔 Тестовое уведомление от агента"`, тогда как CLI (`--message`) и Web (поле формы) уже позволяют задать свой. Паритет восстановлен.

## Изменения — `src/agent/tools/notifications.py`

- В `@tool("test_notification", …)` добавлен опциональный параметр `text` (не `required`).
- Тело: `text = arg_str(args, "text", "🔔 Тестовое уведомление от агента")` → `send_notification(text)`.
- Передан `text` → используется он; не передан → прежний дефолт (видимое поведение не меняется).

## Совместимость

- Параметр опционален → deepagents-зеркало (`deepagents_sync.py`) и read-only smoke-контракт не требуют правок.
- `docs/reference/parity.md` не трогаем — маппинг операция↔слои не меняется, восстанавливается лишь фактический паритет «можно задать свой текст».

## Контекст аудита #561

Остальные категории расхождений уже закрыты недавними PR #736 (batch send_reactions agent tool) и #737 (CLI equivalents for web-only ops, #564); `parity.md` актуален. Этот PR закрывает оставшийся пункт.

## Тесты — `tests/test_agent_tools_notifications.py`

+2 теста: `test_sends_custom_text` (передан text → вызов с ним), `test_sends_default_text_when_omitted` (без text → дефолт).

\`\`\`
pytest tests/test_agent_tools_notifications.py tests/test_agent_tool_smoke_contract.py \
  tests/test_agent_tools_deepagents_sync.py → 75 passed
ruff check → All checks passed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)