### PR TITLE
fix(745): photo-loader --target me parity, drop legacy pipelines table, fix flaky live CLI tests

### DIFF
--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -18,13 +18,21 @@ from src.utils.datetime import parse_required_schedule_datetime
 
 async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
     """Resolve "me"/"self" to the account's own Saved Messages dialog id."""
-    result = None
     if phone:
+        # A specific account was requested. Its Saved Messages id is account-specific,
+        # and deferred paths (schedule-send/batch-create/auto-create) persist `phone`
+        # separately from this dialog_id. Falling back to another account here would
+        # store *that* account's self-id against the requested phone, so a later
+        # publish would deliver to the wrong account's chat. Fail instead.
         result = await pool.get_client_by_phone(phone)
-    if result is None:
+        if result is None:
+            raise ValueError(
+                f"Could not resolve target 'me': account {phone} is not connected/available"
+            )
+    else:
         result = await pool.get_available_client()
-    if result is None:
-        raise ValueError("Could not resolve target 'me': no connected Telegram account")
+        if result is None:
+            raise ValueError("Could not resolve target 'me': no connected Telegram account")
     session, _acquired_phone = result
     session = adapt_transport_session(session, disconnect_on_close=False)
     me = await session.fetch_me()

--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
 from datetime import datetime
 
 from src.cli import runtime
@@ -11,10 +12,34 @@ from src.services.channel_service import ChannelService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+from src.telegram.backends import adapt_transport_session
 from src.utils.datetime import parse_required_schedule_datetime
 
 
-async def _resolve_target(raw: str, pool) -> PhotoTarget:
+async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
+    """Resolve "me"/"self" to the account's own Saved Messages dialog id."""
+    result = None
+    if phone:
+        result = await pool.get_client_by_phone(phone)
+    if result is None:
+        result = await pool.get_available_client()
+    if result is None:
+        raise ValueError("Could not resolve target 'me': no connected Telegram account")
+    session, _acquired_phone = result
+    session = adapt_transport_session(session, disconnect_on_close=False)
+    me = await session.fetch_me()
+    self_id = getattr(me, "id", None)
+    if self_id is None:
+        raise ValueError("Could not resolve target 'me': failed to fetch account id")
+    return PhotoTarget(dialog_id=int(self_id), title="Saved Messages", target_type="user")
+
+
+async def _resolve_target(raw: str, pool, phone: str | None = None) -> PhotoTarget:
+    # "me"/"self" is the account's Saved Messages — parity with `dialogs send`,
+    # which resolves it natively. resolve_channel() rejects it (it is a user, not a
+    # channel), so handle it explicitly here instead of crashing in int(raw).
+    if raw.strip().lower() in {"me", "self"}:
+        return await _resolve_self_target(pool, phone)
     try:
         return PhotoTarget(dialog_id=int(raw))
     except ValueError:
@@ -60,7 +85,7 @@ def run(args: argparse.Namespace) -> None:
             if action == "send":
                 item = await tasks.send_now(
                     phone=args.phone,
-                    target=await _resolve_target(args.target, pool),
+                    target=await _resolve_target(args.target, pool, phone=args.phone),
                     file_paths=args.files,
                     mode=args.mode,
                     caption=args.caption,
@@ -71,7 +96,7 @@ def run(args: argparse.Namespace) -> None:
             if action == "schedule-send":
                 item = await tasks.schedule_send(
                     phone=args.phone,
-                    target=await _resolve_target(args.target, pool),
+                    target=await _resolve_target(args.target, pool, phone=args.phone),
                     file_paths=args.files,
                     mode=args.mode,
                     schedule_at=_parse_schedule_at(args.at),
@@ -84,7 +109,7 @@ def run(args: argparse.Namespace) -> None:
                 manifest = tasks.load_manifest(args.manifest)
                 batch_id = await tasks.create_batch(
                     phone=args.phone,
-                    target=await _resolve_target(args.target, pool),
+                    target=await _resolve_target(args.target, pool, phone=args.phone),
                     entries=manifest,
                     caption=args.caption,
                 )
@@ -118,7 +143,7 @@ def run(args: argparse.Namespace) -> None:
                 return
 
             if action == "auto-create":
-                target = await _resolve_target(args.target, pool)
+                target = await _resolve_target(args.target, pool, phone=args.phone)
                 job_id = await auto.create_job(
                     PhotoAutoUploadJob(
                         phone=args.phone,
@@ -178,6 +203,11 @@ def run(args: argparse.Namespace) -> None:
                 jobs = await auto.run_due()
                 print(f"Processed due photo items={items} auto_jobs={jobs}")
                 return
+        except ValueError as exc:
+            # Unresolvable target (bad username, "me" without a connected account,
+            # etc.) — fail with a clear message instead of a raw traceback.
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
         finally:
             await pool.disconnect_all()
             await db.close()

--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -33,9 +33,15 @@ async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
         result = await pool.get_available_client()
         if result is None:
             raise ValueError("Could not resolve target 'me': no connected Telegram account")
-    session, _acquired_phone = result
+    session, acquired_phone = result
     session = adapt_transport_session(session, disconnect_on_close=False)
-    me = await session.fetch_me()
+    try:
+        me = await session.fetch_me()
+    finally:
+        # Release the lease promptly (mirrors channel.py); the subsequent send/
+        # schedule call re-acquires it. disconnect_all() in run()'s finally is the
+        # backstop, but explicit release keeps the pool tidy for other callers.
+        await pool.release_client(acquired_phone)
     self_id = getattr(me, "id", None)
     if self_id is None:
         raise ValueError("Could not resolve target 'me': failed to fetch account id")

--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -39,7 +39,10 @@ async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
     self_id = getattr(me, "id", None)
     if self_id is None:
         raise ValueError("Could not resolve target 'me': failed to fetch account id")
-    return PhotoTarget(dialog_id=int(self_id), title="Saved Messages", target_type="user")
+    # target_type="saved" so PhotoPublishService → resolve_dialog_entity maps it to
+    # PeerUser (Saved Messages). Any other value (e.g. "user") falls through to
+    # PeerChannel(abs(id)), which mis-resolves the self user-id as a channel.
+    return PhotoTarget(dialog_id=int(self_id), title="Saved Messages", target_type="saved")
 
 
 async def _resolve_target(raw: str, pool, phone: str | None = None) -> PhotoTarget:

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -347,6 +347,24 @@ async def _repair_channel_last_collected_ids_from_messages(db: aiosqlite.Connect
     )
 
 
+async def _drop_legacy_pipelines_table_if_empty(db: aiosqlite.Connection) -> None:
+    """Remove the obsolete denormalized ``pipelines`` table (schema v1).
+
+    It was superseded by ``content_pipelines`` (+ ``pipeline_sources`` /
+    ``pipeline_targets``) and is never read or written by the app. Older
+    databases still carry an empty leftover copy. We only drop it when it holds
+    no rows, so a database that somehow still has v1 data is left untouched
+    instead of silently losing it.
+    """
+    if not await table_exists(db, "pipelines"):
+        return
+    cur = await db.execute("SELECT COUNT(*) FROM pipelines")
+    row = await cur.fetchone()
+    count = (row[0] if row is not None else 0) or 0
+    if count == 0:
+        await db.execute("DROP TABLE pipelines")
+
+
 async def run_migrations(db: aiosqlite.Connection) -> bool:
     """Repair the SQLite schema without rewriting existing user data.
 
@@ -367,6 +385,9 @@ async def run_migrations(db: aiosqlite.Connection) -> bool:
     await _dedupe_primary_accounts(db)
 
     await db.executescript(SCHEMA_SQL)
+
+    # Drop the obsolete v1 ``pipelines`` table left behind in older databases.
+    await _drop_legacy_pipelines_table_if_empty(db)
 
     for table, columns in SCHEMA_REPAIR_COLUMNS.items():
         await ensure_columns(db, table, columns)

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -368,18 +368,11 @@ CREATE INDEX IF NOT EXISTS idx_message_reactions_emoji
     ON message_reactions(emoji);
 CREATE INDEX IF NOT EXISTS idx_messages_collected_at ON messages(collected_at);
 
-CREATE TABLE IF NOT EXISTS pipelines (
-    id INTEGER PRIMARY KEY,
-    name TEXT NOT NULL,
-    phone TEXT NOT NULL,
-    source_channel_ids TEXT,
-    targets TEXT,
-    prompt_template TEXT,
-    llm_model TEXT,
-    publish_mode TEXT NOT NULL DEFAULT 'draft',
-    is_active INTEGER NOT NULL DEFAULT 1,
-    created_at TEXT DEFAULT (datetime('now'))
-);
+-- NOTE: the legacy denormalized `pipelines` table (schema v1, with JSON
+-- `source_channel_ids`/`targets` columns) was superseded by the normalized
+-- `content_pipelines` + `pipeline_sources` + `pipeline_targets` tables above and
+-- is no longer created here. `run_migrations()` drops the empty leftover table
+-- from older databases (see src/database/migrations.py).
 
 CREATE TABLE IF NOT EXISTS message_embeddings (
     message_id INTEGER PRIMARY KEY,

--- a/tests/cli_real_tg_integration/conftest.py
+++ b/tests/cli_real_tg_integration/conftest.py
@@ -181,6 +181,45 @@ def _fetch_live_channel(db_path: Path) -> tuple[str | None, int | None, str | No
     return pk, channel_id, username
 
 
+def _fetch_live_owned_broadcast_channel(
+    db_path: Path, phones: tuple[str, ...]
+) -> tuple[str, str] | None:
+    """Return a (chat_ref, phone) for a broadcast channel the account administers.
+
+    ``dialogs broadcast-stats`` (GetBroadcastStatsRequest) requires channel admin
+    rights, so the first arbitrary active channel is unusable. We pick a cached
+    own (``is_own=1``) broadcast ``channel`` that has a username and a connected
+    account recorded in ``dialog_cache`` — the account that cached an own channel
+    is the one able to request its stats.
+    """
+    phone_set = set(phones)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT
+                NULLIF(c.username, '') AS username,
+                d.phone AS dialog_phone
+            FROM dialog_cache d
+            JOIN channels c ON c.channel_id = d.dialog_id
+            WHERE COALESCE(d.is_own, 0) = 1
+              AND COALESCE(d.deactivate, 0) = 0
+              AND LOWER(COALESCE(NULLIF(d.channel_type, ''), '')) = 'channel'
+              AND NULLIF(c.username, '') IS NOT NULL
+              AND d.phone IS NOT NULL
+            ORDER BY d.dialog_id ASC
+            """
+        ).fetchall()
+    for row in rows:
+        username = str(row["username"]) if row["username"] else None
+        dialog_phone = str(row["dialog_phone"]) if row["dialog_phone"] else None
+        if not username or dialog_phone not in phone_set:
+            continue
+        chat_ref = username if username.startswith("@") else f"@{username}"
+        return chat_ref, dialog_phone
+    return None
+
+
 def _normalize_chat_ref(raw: object) -> str | None:
     chat_ref = str(raw) if raw else None
     if (
@@ -775,6 +814,25 @@ def live_channel_username(cli_real_cli_env: CliRealCliEnv) -> str:
 
 
 @pytest.fixture
+def live_owned_broadcast_channel(cli_real_cli_env: CliRealCliEnv) -> LiveCliDialogTarget:
+    try:
+        target = _fetch_live_owned_broadcast_channel(
+            cli_real_cli_env.db_path, cli_real_cli_env.phones
+        )
+    except sqlite3.Error as exc:
+        pytest.skip(
+            f"failed to discover an own broadcast channel from {cli_real_cli_env.db_path}: {exc}"
+        )
+    if target is None:
+        pytest.skip(
+            "live CLI database has no cached own broadcast channel with a username; "
+            "`dialogs broadcast-stats` requires channel admin rights"
+        )
+    chat_ref, phone = target
+    return LiveCliDialogTarget(chat_ref=chat_ref, phone=phone)
+
+
+@pytest.fixture
 def live_phone(cli_real_cli_env: CliRealCliEnv) -> str:
     return cli_real_cli_env.primary_phone
 
@@ -822,20 +880,13 @@ def live_scratch_message_dialog(cli_real_cli_env: CliRealCliEnv) -> LiveCliDialo
     if chat_ref is not None:
         return LiveCliDialogTarget(chat_ref=chat_ref, phone=phone or cli_real_cli_env.primary_phone)
 
-    try:
-        target = _fetch_live_message_target(
-            cli_real_cli_env.db_path,
-            cli_real_cli_env.phones,
-            require_own_dialog=True,
-        )
-    except sqlite3.Error as exc:
-        pytest.skip(f"failed to discover live scratch-message dialog from {cli_real_cli_env.db_path}: {exc}")
-    if target is None:
-        pytest.skip(
-            f"set {CLI_REAL_TG_MUTATION_CHAT_ENV} or cache an own live dialog "
-            "before running scratch-message mutation tests"
-        )
-    return LiveCliDialogTarget(chat_ref=target.chat_ref, phone=phone or target.phone)
+    # Default to "Saved Messages" (`me`): the account can always send/edit/forward/
+    # delete there, so scratch-message mutation tests do not depend on the live DB
+    # happening to cache an own dialog the account is *also* allowed to post in.
+    # A cached own dialog (e.g. a broadcast channel the account merely follows)
+    # would raise ChatAdminRequiredError on SendMessageRequest. Override the target
+    # via the CLI_REAL_TG_MUTATION_CHAT env var when a specific chat is required.
+    return LiveCliDialogTarget(chat_ref="me", phone=phone or cli_real_cli_env.primary_phone)
 
 
 @pytest.fixture

--- a/tests/cli_real_tg_integration/mutation_safe/test_photo_loader_schedule_send_sandbox.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_photo_loader_schedule_send_sandbox.py
@@ -67,9 +67,11 @@ def test_photo_loader_schedule_send_sandbox(run_cli, assert_cli_ok, cli_real_cli
         assert match is not None, f"schedule-send stdout did not include item id: {combined!r}"
         item_id = match.group(1)
 
-        # Verify the DB row was created with expected status.
+        # Verify the DB row was created with the scheduled status (schedule_send
+        # creates the batch with PhotoBatchStatus.SCHEDULED; run-due flips it to
+        # running/completed later, which we avoid by scheduling 24h out).
         status = _fetch_item_status(cli_real_cli_env.db_path, item_id)
-        assert status == "pending", f"expected pending status for scheduled item #{item_id}, got {status!r}"
+        assert status == "scheduled", f"expected scheduled status for scheduled item #{item_id}, got {status!r}"
 
     finally:
         tmpdir_obj.cleanup()

--- a/tests/cli_real_tg_integration/mutation_safe/test_pipeline_publish_sandbox.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_pipeline_publish_sandbox.py
@@ -13,8 +13,35 @@ pytestmark = pytest.mark.real_tg_mutation_safe
 _PUBLISHED_MSG_RE = re.compile(r"published_message_id=(\d+)\s+phone=(\S+)\s+dialog_id=(\d+)")
 
 
+def _pipeline_has_targets(run_cli, assert_cli_ok, pipeline_id: str) -> bool:
+    """Return True if `pipeline show` lists at least one publish target.
+
+    `pipeline show` prints a `targets:` header followed by one ` - <phone>:<id>`
+    line per target. A pipeline without targets has nowhere to publish, so the
+    publish run is a no-op rather than a product bug.
+    """
+    result = run_cli("pipeline", "show", pipeline_id)
+    assert_cli_ok(result)
+    in_targets = False
+    for line in result.stdout.splitlines():
+        if line.rstrip() == "targets:":
+            in_targets = True
+            continue
+        if in_targets:
+            if line.startswith(" - "):
+                return True
+            if line and not line.startswith(" "):
+                break
+    return False
+
+
 @pytest.mark.timeout(180)
-def test_pipeline_publish_sandbox(run_cli, assert_cli_ok, cli_real_cli_env, discover_first_run_id):
+def test_pipeline_publish_sandbox(
+    run_cli, assert_cli_ok, cli_real_cli_env, discover_first_pipeline_id, discover_first_run_id
+):
+    pipeline_id = discover_first_pipeline_id()
+    if not _pipeline_has_targets(run_cli, assert_cli_ok, pipeline_id):
+        pytest.skip(f"pipeline id={pipeline_id} has no publish targets; nothing to publish")
     run_id = discover_first_run_id()
     leak_msg: str | None = None
     published_entries: list[tuple[str, str, str]] = []  # (message_id, phone, dialog_id)

--- a/tests/cli_real_tg_integration/safe_ro/test_dialogs_broadcast_stats_first.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_dialogs_broadcast_stats_first.py
@@ -4,8 +4,17 @@ pytestmark = pytest.mark.real_tg_safe
 
 
 @pytest.mark.timeout(180)
-def test_dialogs_broadcast_stats_first(run_cli, assert_cli_ok, live_channel_username):
-    result = run_cli("dialogs", "broadcast-stats", live_channel_username, timeout=120)
+def test_dialogs_broadcast_stats_first(run_cli, assert_cli_ok, live_owned_broadcast_channel):
+    # broadcast-stats requires channel admin rights, so target an own broadcast
+    # channel via the account that administers it (not an arbitrary monitored one).
+    result = run_cli(
+        "dialogs",
+        "broadcast-stats",
+        "--phone",
+        live_owned_broadcast_channel.phone,
+        live_owned_broadcast_channel.chat_ref,
+        timeout=120,
+    )
     assert_cli_ok(result)
     assert "Error fetching broadcast stats" not in result.stdout
     assert result.stdout.strip(), "`dialogs broadcast-stats` produced empty stdout"


### PR DESCRIPTION
## Summary

Found while running the live (real Telegram) CLI test suite across `safe_ro`, `safe_write`, `mutation_safe`, `heavy`. Fixes 1 product bug, removes a dead schema table, and repairs 4 flaky tests. See #745 for full findings.

### Product fixes
- **`photo-loader --target me` crashed** with a raw traceback (`ValueError` in `_resolve_target`, exit 1) — it didn't understand `me`/`self`, unlike `dialogs send`. Now resolves `me`/`self` → account self-id (Saved Messages), parity with `dialogs send`; unresolvable targets fail with a clear message + exit 1 instead of a traceback. Verified live (photo sent to Saved Messages).
- **Dead legacy `pipelines` table** (schema v1, 0 code references, empty in all DBs; superseded by `content_pipelines` + `pipeline_sources`/`pipeline_targets`): removed `CREATE` from `schema.py`; added a **safe** idempotent DROP in `run_migrations()` that only drops when the table is empty (no data loss).

### Test fixes (flaky live-target selection)
| Test | Was | Now |
|---|---|---|
| `broadcast-stats` | picked an arbitrary channel without admin rights → `ChatAdminRequiredError` | new `live_owned_broadcast_channel` fixture (own broadcast channel + administering account) |
| scratch send/edit/forward | `live_scratch_message_dialog` picked a cached `is_own` dialog the account couldn't post in | defaults to `me` (always writable) |
| `pipeline publish` | failed when the pipeline had 0 targets | `pytest.skip` when no publish targets |
| photo `schedule-send` | asserted `pending` (unreachable — crashed earlier on `me`) | asserts correct `scheduled` status |

## Verification
- `ruff check src/ tests/ conftest.py` — clean
- Non-live suite: **8269 passed, 0 failed**
- Migrations: verified on fresh / empty-legacy (dropped, data intact) / non-empty-legacy (preserved) DBs
- All previously failing live tests pass or skip cleanly; `photo-loader send --target me` verified live

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)