### PR TITLE
feat(images): OpenAI gpt-image-1 + dynamic centralized model listing (#750)

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -226,6 +226,7 @@
 |----------|-----|-------------|------------|
 | Генерация | `image generate` | `POST /images/generate` | `generate_image` |
 | Поиск моделей | `image models` | `GET /images/models/search` | `list_image_models` |
+| Поиск моделей (живой запрос) | `image models --refresh` | `GET /images/models/search?refresh=1` | `list_image_models` |
 | Список провайдеров | `image providers` | `GET /images/` | `list_image_providers` |
 | Список генераций | `image generated` | — | `list_generated_images` |
 

--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -30,7 +30,8 @@ def run(args: argparse.Namespace) -> None:
         elif action == "models":
             provider = args.provider
             query = args.query or ""
-            models = await svc.search_models(provider, query)
+            refresh = getattr(args, "refresh", False)
+            models = await svc.search_models(provider, query, refresh=refresh)
             if not models:
                 print(f"No models found for provider={provider} query={query!r}")
                 return

--- a/src/cli/parser_domains/image.py
+++ b/src/cli/parser_domains/image.py
@@ -15,6 +15,11 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     image_models = image_sub.add_parser("models", help="Search available models")
     image_models.add_argument("--provider", required=True, help="Provider name (replicate, together, openai)")
     image_models.add_argument("--query", default="", help="Search query")
+    image_models.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Fetch the live model list from the provider (OpenAI: /v1/models)",
+    )
 
     image_sub.add_parser("providers", help="List configured image providers")
 

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -121,8 +121,15 @@ class ImageGenerationService:
 
     # ── model catalog ──
 
-    async def search_models(self, provider: str, query: str = "", *, api_key: str = "") -> list[dict]:
-        """Search available models for a provider. Returns list of dicts with name, description, etc."""
+    async def search_models(
+        self, provider: str, query: str = "", *, api_key: str = "", refresh: bool = False
+    ) -> list[dict]:
+        """Search available models for a provider. Returns list of dicts with name, description, etc.
+
+        For OpenAI, ``refresh=True`` fetches the live model list from ``/v1/models``
+        (filtered to image models) via the shared model-listing helper; otherwise the
+        static fallback catalog is returned.
+        """
         import aiohttp
 
         if provider == "replicate":
@@ -200,13 +207,53 @@ class ImageGenerationService:
                 _m("black-forest-labs/FLUX.1-schnell", "together", "FLUX.1 Schnell — fast"),
                 _m("black-forest-labs/FLUX.1-dev", "together", "FLUX.1 Dev — high quality"),
             ],
+            # gpt-image-1 is the current default; dall-e-* kept as legacy so saved
+            # selections keep resolving in the UI.
             "openai": [
-                _m("dall-e-3", "openai", "DALL-E 3 — OpenAI image generation"),
-                _m("dall-e-2", "openai", "DALL-E 2 — OpenAI image generation"),
+                _m("gpt-image-1", "openai", "GPT Image 1 — OpenAI image generation"),
+                _m("gpt-image-1-mini", "openai", "GPT Image 1 Mini — faster/cheaper"),
+                _m("gpt-image-1.5", "openai", "GPT Image 1.5 — higher quality"),
+                _m("dall-e-3", "openai", "DALL-E 3 — legacy"),
+                _m("dall-e-2", "openai", "DALL-E 2 — legacy"),
             ],
         }
+
+        if provider == "openai" and refresh:
+            token = api_key or os.environ.get("OPENAI_API_KEY", "")
+            live = await self._fetch_openai_image_models(token) if token else []
+            if live:
+                models = live
+                if query:
+                    q = query.lower()
+                    models = [m for m in models if q in m["id"].lower() or q in m["description"].lower()]
+                return models
+            # fall through to static catalog on missing key / fetch failure
+
         models = catalogs.get(provider, [])
         if query:
             q = query.lower()
             models = [m for m in models if q in m["id"].lower() or q in m["description"].lower()]
         return models
+
+    @staticmethod
+    async def _fetch_openai_image_models(api_key: str) -> list[dict]:
+        """Fetch live OpenAI models via the shared helper, filtered to image models."""
+        from src.services.provider_model_cache import fetch_openai_model_ids
+
+        base_url = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
+        try:
+            ids = await fetch_openai_model_ids(base_url, api_key)
+        except Exception:
+            logger.warning("Failed to fetch OpenAI image models", exc_info=True)
+            return []
+        image_ids = [m for m in ids if m.startswith("gpt-image") or m.startswith("dall-e")]
+        image_ids.sort()
+        return [
+            {
+                "id": mid,
+                "model_string": f"openai:{mid}",
+                "description": "OpenAI image model",
+                "run_count": 0,
+            }
+            for mid in image_ids
+        ]

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -207,12 +207,13 @@ class ImageGenerationService:
                 _m("black-forest-labs/FLUX.1-schnell", "together", "FLUX.1 Schnell — fast"),
                 _m("black-forest-labs/FLUX.1-dev", "together", "FLUX.1 Dev — high quality"),
             ],
-            # gpt-image-1 is the current default; dall-e-* kept as legacy so saved
+            # Only the confirmed model id goes in the static fallback; other
+            # gpt-image-* variants surface via the live `refresh` path if/when
+            # OpenAI actually reports them (offering a model that 400s would make
+            # generate() fail silently). dall-e-* kept as legacy so saved
             # selections keep resolving in the UI.
             "openai": [
                 _m("gpt-image-1", "openai", "GPT Image 1 — OpenAI image generation"),
-                _m("gpt-image-1-mini", "openai", "GPT Image 1 Mini — faster/cheaper"),
-                _m("gpt-image-1.5", "openai", "GPT Image 1.5 — higher quality"),
                 _m("dall-e-3", "openai", "DALL-E 3 — legacy"),
                 _m("dall-e-2", "openai", "DALL-E 2 — legacy"),
             ],

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import logging
 import os
 import uuid
@@ -13,6 +15,52 @@ logger = logging.getLogger(__name__)
 
 # Type alias for image generation adapters
 ImageAdapter = Callable[[str, str], Awaitable[Optional[str]]]
+
+# Default directory where binary / base64 image results are persisted.
+DEFAULT_IMAGE_OUTPUT_DIR = "data/images"
+
+
+async def save_image_bytes(image_bytes: bytes, output_dir: str | None = None) -> str:
+    """Persist raw image *bytes* to *output_dir* and return the file path.
+
+    Single place every image adapter uses to land binary results on disk, so
+    naming/flush behaviour stays consistent.  Downstream (``ImageGenerationService``)
+    uploads non-URL results to S3 when configured, so returning a path is enough.
+    ``output_dir`` defaults to :data:`DEFAULT_IMAGE_OUTPUT_DIR`, resolved at call
+    time so the module-level default stays overridable.
+    """
+    out = Path(output_dir or DEFAULT_IMAGE_OUTPUT_DIR)
+    out.mkdir(parents=True, exist_ok=True)
+    filepath = out / f"{uuid.uuid4().hex}.png"
+    await asyncio.to_thread(filepath.write_bytes, image_bytes)
+    return str(filepath)
+
+
+async def save_image_b64(b64_data: str, output_dir: str | None = None) -> str:
+    """Decode a base64 image payload and persist it via :func:`save_image_bytes`."""
+    try:
+        image_bytes = base64.b64decode(b64_data, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise RuntimeError(f"image: invalid base64 payload: {exc}") from exc
+    return await save_image_bytes(image_bytes, output_dir)
+
+
+async def finalize_image_result(
+    item: dict[str, Any], output_dir: str | None = None
+) -> Optional[str]:
+    """Normalise one provider result entry to a URL or a saved file path.
+
+    Providers return either a hosted ``url`` (kept as-is) or an inline
+    ``b64_json`` payload (decoded and saved to disk).  Centralising this keeps
+    every adapter's output shape identical.
+    """
+    url = item.get("url")
+    if url:
+        return str(url)
+    b64_data = item.get("b64_json")
+    if b64_data:
+        return await save_image_b64(str(b64_data), output_dir)
+    return None
 
 # Default network timeout for outbound HTTP calls to LLM / image providers.
 # Without it aiohttp waits indefinitely and a stalled upstream hangs the calling
@@ -153,12 +201,14 @@ def make_together_image_adapter(api_key: str) -> ImageAdapter:
                 items = data.get("data")
                 if not items:
                     raise RuntimeError(f"Together image: empty 'data' in response: {data}")
-                return items[0].get("url") or items[0].get("b64_json")
+                return await finalize_image_result(items[0])
 
     return adapter
 
 
-def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/images") -> ImageAdapter:
+def make_huggingface_image_adapter(
+    api_token: str, output_dir: str = DEFAULT_IMAGE_OUTPUT_DIR
+) -> ImageAdapter:
     """HuggingFace Inference API — returns binary image, saved to local file."""
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
@@ -181,29 +231,38 @@ def make_huggingface_image_adapter(api_token: str, output_dir: str = "data/image
                         f"HuggingFace image: expected image/* content-type, got {content_type}: {body_preview}"
                     )
                 image_bytes = await resp.read()
-                out = Path(output_dir)
-                out.mkdir(parents=True, exist_ok=True)
-                filename = f"{uuid.uuid4().hex}.png"
-                filepath = out / filename
-                await asyncio.to_thread(filepath.write_bytes, image_bytes)
-                return str(filepath)
+                return await save_image_bytes(image_bytes, output_dir)
 
     return adapter
 
 
+OPENAI_DEFAULT_IMAGE_MODEL = "gpt-image-1"
+
+
+def _build_openai_image_payload(prompt: str, model_id: str) -> Dict[str, Any]:
+    """Assemble the images/generations payload, varying params by model family.
+
+    ``gpt-image-1*`` rejects DALL·E-only fields (``response_format``), so only
+    the parameters each family accepts are sent.  ``gpt-image-1`` always returns
+    ``b64_json``; legacy ``dall-e-*`` returns a hosted ``url``.
+    """
+    payload: Dict[str, Any] = {"model": model_id, "prompt": prompt, "n": 1}
+    if model_id.startswith("gpt-image"):
+        payload["size"] = "auto"
+        payload["quality"] = "auto"
+    else:  # legacy dall-e-* family
+        payload["size"] = "1024x1024"
+    return payload
+
+
 def make_openai_image_adapter(api_key: str) -> ImageAdapter:
-    """OpenAI DALL-E image generation."""
+    """OpenAI image generation (gpt-image-1, with legacy DALL-E support)."""
 
     async def adapter(prompt: str, model: str = "") -> Optional[str]:
         base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
         url = f"{base.rstrip('/')}/images/generations"
         headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-        payload: Dict[str, Any] = {
-            "model": model or "dall-e-3",
-            "prompt": prompt,
-            "n": 1,
-            "size": "1024x1024",
-        }
+        payload = _build_openai_image_payload(prompt, model or OPENAI_DEFAULT_IMAGE_MODEL)
         async with aiohttp.ClientSession(timeout=_HTTP_TIMEOUT) as session:
             async with session.post(url, json=payload, headers=headers) as resp:
                 if resp.status != 200:
@@ -213,7 +272,7 @@ def make_openai_image_adapter(api_key: str) -> ImageAdapter:
                 items = data.get("data")
                 if not items:
                     raise RuntimeError(f"OpenAI image: empty 'data' in response: {data}")
-                return items[0].get("url") or items[0].get("b64_json")
+                return await finalize_image_result(items[0])
 
     return adapter
 

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 ImageAdapter = Callable[[str, str], Awaitable[Optional[str]]]
 
 # Default directory where binary / base64 image results are persisted.
-DEFAULT_IMAGE_OUTPUT_DIR = "data/images"
+# Must match where the web app serves generated images from — ``DATA_IMAGE_DIR``
+# (``data/image``) mounted at ``/data/image`` in src/web/assembly.py. Writing
+# elsewhere (the old ``data/images``) made saved files unreachable over HTTP, so
+# gpt-image-1 / HuggingFace results rendered as broken images in a no-S3 deploy.
+DEFAULT_IMAGE_OUTPUT_DIR = "data/image"
 
 
 async def save_image_bytes(image_bytes: bytes, output_dir: str | None = None) -> str:

--- a/src/services/provider_model_cache.py
+++ b/src/services/provider_model_cache.py
@@ -24,6 +24,34 @@ logger = logging.getLogger(__name__)
 
 MODEL_CACHE_SETTINGS_KEY = "agent_deepagents_model_cache_v1"
 
+_MODELS_HTTP_TIMEOUT = aiohttp.ClientTimeout(total=20)
+
+
+async def fetch_json(url: str, headers: dict[str, str] | None = None) -> Any:
+    """GET *url* and return parsed JSON. Shared by LLM and image model listing."""
+    async with aiohttp.ClientSession(timeout=_MODELS_HTTP_TIMEOUT) as session:
+        async with session.get(url, headers=headers) as response:
+            response.raise_for_status()
+            return await response.json()
+
+
+def _parse_openai_model_ids(payload: Any) -> list[str]:
+    """Extract ``data[].id`` from an OpenAI-compatible ``/models`` response."""
+    data = payload.get("data", []) if isinstance(payload, dict) else []
+    return [str(item.get("id", "")).strip() for item in data if item.get("id")]
+
+
+async def fetch_openai_model_ids(base_url: str, api_key: str) -> list[str]:
+    """Fetch model ids from an OpenAI-compatible ``/models`` endpoint.
+
+    Standalone helper (no DB / provider-config dependency) so both the LLM
+    provider cache and the image-generation service share one request path —
+    the single source of truth for "ask OpenAI which models exist".
+    """
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    payload = await fetch_json(base_url.rstrip("/") + "/models", headers=headers)
+    return _parse_openai_model_ids(payload)
+
 
 @dataclass(slots=True)
 class ProviderModelCacheEntry:
@@ -220,9 +248,7 @@ class ProviderModelCacheMixin:
     async def _fetch_openai_models(self, base_url: str, api_key: str) -> list[str]:
         headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
         payload = await self._fetch_json(base_url.rstrip("/") + "/models", headers=headers)
-        return [
-            str(item.get("id", "")).strip() for item in payload.get("data", []) if item.get("id")
-        ]
+        return _parse_openai_model_ids(payload)
 
     async def _fetch_anthropic_models(self, api_key: str) -> list[str]:
         headers = {

--- a/src/web/images/forms.py
+++ b/src/web/images/forms.py
@@ -25,10 +25,12 @@ async def parse_generate_form(request: Request) -> GenerateImageForm:
 class ModelsSearchQuery:
     provider: str
     query: str
+    refresh: bool
 
 
 def parse_models_search(request: Request) -> ModelsSearchQuery:
     return ModelsSearchQuery(
         provider=request.query_params.get("provider", "").strip(),
         query=request.query_params.get("q", "").strip(),
+        refresh=request.query_params.get("refresh", "").strip() in ("1", "true", "yes"),
     )

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -75,7 +75,24 @@ async def generate_image(request: Request) -> ImagesJson:
     if result is None:
         return ImagesJson({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
 
-    return ImagesJson({"ok": True, "url": result, "model": form.model, "prompt": form.prompt})
+    return ImagesJson(
+        {"ok": True, "url": _to_image_url(result), "model": form.model, "prompt": form.prompt}
+    )
+
+
+def _to_image_url(result: str) -> str:
+    """Map a generator result to a browser-usable URL.
+
+    Hosted results (S3, legacy DALL·E ``url``) start with ``http`` and pass
+    through unchanged. File results (gpt-image-1 b64, HuggingFace) are saved
+    under ``DATA_IMAGE_DIR`` and served at ``/data/image/<name>``; return that
+    URL so ``<img src>`` resolves instead of pointing at a raw filesystem path.
+    """
+    if result.startswith("http"):
+        return result
+    from pathlib import PurePath
+
+    return f"/data/image/{PurePath(result).name}"
 
 
 async def search_models(request: Request) -> ImagesJson:

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -85,5 +85,5 @@ async def search_models(request: Request) -> ImagesJson:
 
     api_key = await _get_provider_api_key(request, q.provider)
     svc = ImageGenerationService()
-    models = await svc.search_models(q.provider, q.query, api_key=api_key)
+    models = await svc.search_models(q.provider, q.query, api_key=api_key, refresh=q.refresh)
     return ImagesJson({"ok": True, "models": models, "provider": q.provider})

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -103,6 +103,28 @@ async def test_search_models_success(route_client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_search_models_refresh_param_passed_through(route_client, monkeypatch):
+    """?refresh=1 must reach ImageGenerationService.search_models(refresh=True)."""
+    monkeypatch.setattr(
+        "src.web.images.handlers._get_provider_api_key",
+        AsyncMock(return_value="fake-key"),
+    )
+    with patch("src.web.images.handlers.ImageGenerationService") as mock_cls:
+        instance = MagicMock()
+        instance.search_models = AsyncMock(return_value=[])
+        mock_cls.return_value = instance
+
+        resp = await route_client.get("/images/models/search?provider=openai&refresh=1")
+        assert resp.status_code == 200
+        _, kwargs = instance.search_models.call_args
+        assert kwargs["refresh"] is True
+
+        await route_client.get("/images/models/search?provider=openai")
+        _, kwargs2 = instance.search_models.call_args
+        assert kwargs2["refresh"] is False
+
+
+@pytest.mark.anyio
 async def test_search_models_no_api_key(route_client, monkeypatch):
     """Test search models when no API key is found."""
     monkeypatch.setattr(

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -60,6 +60,32 @@ async def test_generate_success(route_client, monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_generate_file_path_mapped_to_data_image_url(route_client, monkeypatch):
+    """A saved file path (gpt-image-1 b64 / HuggingFace) must become a /data/image URL."""
+    mock_svc = MagicMock()
+    mock_svc.is_available = AsyncMock(return_value=True)
+    mock_svc.generate = AsyncMock(return_value="data/image/abc123.png")
+    monkeypatch.setattr(
+        "src.web.images.handlers._get_image_service",
+        AsyncMock(return_value=mock_svc),
+    )
+    resp = await route_client.post("/images/generate", data={"prompt": "a cat", "model": "openai:gpt-image-1"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["url"] == "/data/image/abc123.png"
+
+
+def test_to_image_url_passthrough_and_mapping():
+    from src.web.images.handlers import _to_image_url
+
+    assert _to_image_url("https://s3.example.com/x.png") == "https://s3.example.com/x.png"
+    assert _to_image_url("http://cdn/x.png") == "http://cdn/x.png"
+    assert _to_image_url("data/image/abc.png") == "/data/image/abc.png"
+    assert _to_image_url("/abs/path/data/image/zzz.png") == "/data/image/zzz.png"
+
+
+@pytest.mark.anyio
 async def test_generate_failure(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=True)

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -460,8 +460,56 @@ async def test_search_models_together_catalog():
 async def test_search_models_openai_catalog():
     svc = _make_clean_service()
     models = await svc.search_models("openai")
-    assert len(models) == 2
-    assert any("dall-e-3" in m["id"] for m in models)
+    ids = [m["id"] for m in models]
+    # gpt-image-1 is the current default and listed first; legacy dall-e-* still present
+    assert ids[0] == "gpt-image-1"
+    assert "gpt-image-1-mini" in ids
+    assert "dall-e-3" in ids  # legacy kept for backward compatibility
+
+
+@pytest.mark.anyio
+async def test_search_models_openai_refresh_uses_live_list(monkeypatch):
+    svc = _make_clean_service()
+
+    async def _fake_fetch(api_key):
+        assert api_key == "sk-test"
+        return [
+            {"id": "gpt-image-1", "model_string": "openai:gpt-image-1", "description": "x", "run_count": 0},
+            {"id": "gpt-image-9", "model_string": "openai:gpt-image-9", "description": "x", "run_count": 0},
+        ]
+
+    monkeypatch.setattr(svc, "_fetch_openai_image_models", staticmethod(_fake_fetch))
+    models = await svc.search_models("openai", api_key="sk-test", refresh=True)
+    ids = [m["id"] for m in models]
+    assert ids == ["gpt-image-1", "gpt-image-9"]
+
+
+@pytest.mark.anyio
+async def test_search_models_openai_refresh_falls_back_on_empty(monkeypatch):
+    svc = _make_clean_service()
+
+    async def _fake_fetch(api_key):
+        return []  # fetch failure / no image models
+
+    monkeypatch.setattr(svc, "_fetch_openai_image_models", staticmethod(_fake_fetch))
+    models = await svc.search_models("openai", api_key="sk-test", refresh=True)
+    # falls through to static catalog
+    assert any(m["id"] == "gpt-image-1" for m in models)
+    assert any(m["id"] == "dall-e-3" for m in models)
+
+
+@pytest.mark.anyio
+async def test_fetch_openai_image_models_filters_image_only(monkeypatch):
+    """The image fetch helper keeps only gpt-image*/dall-e* ids from /v1/models."""
+    from src.services import provider_model_cache
+
+    async def _fake_ids(base_url, api_key):
+        return ["gpt-4o", "gpt-image-1", "dall-e-3", "text-embedding-3-small", "gpt-image-1-mini"]
+
+    monkeypatch.setattr(provider_model_cache, "fetch_openai_model_ids", _fake_ids)
+    models = await ImageGenerationService._fetch_openai_image_models("sk-test")
+    ids = [m["id"] for m in models]
+    assert ids == ["dall-e-3", "gpt-image-1", "gpt-image-1-mini"]  # sorted, image-only
 
 
 @pytest.mark.anyio

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -461,10 +461,12 @@ async def test_search_models_openai_catalog():
     svc = _make_clean_service()
     models = await svc.search_models("openai")
     ids = [m["id"] for m in models]
-    # gpt-image-1 is the current default and listed first; legacy dall-e-* still present
+    # gpt-image-1 is the current default and listed first; legacy dall-e-* still present.
+    # Unconfirmed variants (gpt-image-1-mini/1.5) are intentionally NOT in the static
+    # fallback — they only surface via the live refresh path.
     assert ids[0] == "gpt-image-1"
-    assert "gpt-image-1-mini" in ids
     assert "dall-e-3" in ids  # legacy kept for backward compatibility
+    assert "gpt-image-1-mini" not in ids
 
 
 @pytest.mark.anyio

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -453,6 +453,74 @@ async def test_openai_image_adapter_empty_data(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_openai_image_adapter_gpt_image_saves_b64(monkeypatch, tmp_path):
+    """gpt-image-1 returns b64_json — adapter must decode and persist it to a file."""
+    import base64
+
+    from src.services import provider_adapters
+    from src.services.provider_adapters import make_openai_image_adapter
+
+    fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    b64 = base64.b64encode(fake_png).decode()
+    resp = FakeResp(status=200, json_data={"data": [{"b64_json": b64}]})
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    monkeypatch.setattr(provider_adapters, "DEFAULT_IMAGE_OUTPUT_DIR", str(tmp_path))
+
+    adapter = make_openai_image_adapter("fake-key")
+    result = await adapter("a sunset", "")  # empty model → default gpt-image-1
+
+    from pathlib import Path
+
+    assert result is not None
+    assert result.startswith(str(tmp_path))
+    assert result.endswith(".png")
+    assert Path(result).read_bytes() == fake_png
+
+
+def test_openai_payload_gpt_image_omits_dalle_only_params():
+    from src.services.provider_adapters import _build_openai_image_payload
+
+    payload = _build_openai_image_payload("p", "gpt-image-1")
+    assert payload["model"] == "gpt-image-1"
+    assert payload["size"] == "auto"
+    assert payload["quality"] == "auto"
+    assert "response_format" not in payload
+    assert "style" not in payload
+
+
+def test_openai_payload_legacy_dalle_uses_fixed_size():
+    from src.services.provider_adapters import _build_openai_image_payload
+
+    payload = _build_openai_image_payload("p", "dall-e-3")
+    assert payload["model"] == "dall-e-3"
+    assert payload["size"] == "1024x1024"
+    assert "quality" not in payload
+
+
+@pytest.mark.anyio
+async def test_finalize_image_result_prefers_url():
+    from src.services.provider_adapters import finalize_image_result
+
+    result = await finalize_image_result({"url": "https://x/y.png", "b64_json": "ignored"})
+    assert result == "https://x/y.png"
+
+
+@pytest.mark.anyio
+async def test_finalize_image_result_none_when_empty():
+    from src.services.provider_adapters import finalize_image_result
+
+    assert await finalize_image_result({}) is None
+
+
+@pytest.mark.anyio
+async def test_save_image_b64_rejects_invalid_payload(tmp_path):
+    from src.services.provider_adapters import save_image_b64
+
+    with pytest.raises(RuntimeError, match="invalid base64"):
+        await save_image_b64("not-valid-base64!!!", output_dir=str(tmp_path))
+
+
+@pytest.mark.anyio
 async def test_replicate_image_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_replicate_image_adapter
 


### PR DESCRIPTION
## Что и зачем

Closes #750.

DALL·E устарел — переводим генерацию картинок через OpenAI на актуальную модель **`gpt-image-1`** и делаем список моделей динамическим, переиспользуя уже существующий централизованный механизм запроса моделей.

### Изменения по #750
- **`provider_adapters.py`** — дефолт OpenAI `dall-e-3` → `gpt-image-1`; payload собирается по семейству модели (на `gpt-image-1` не отправляются DALL·E-only параметры → нет 400); общие помощники `save_image_bytes` / `save_image_b64` / `finalize_image_result`. Together и HuggingFace переведены на них.
- **`provider_model_cache.py`** — запрос `/v1/models` вынесен в общие `fetch_openai_model_ids` / `fetch_json`; LLM-листинг и image-листинг теперь идут одним путём (один источник правды).
- **`image_generation_service.py`** — живой запрос image-моделей OpenAI (фильтр `gpt-image*` / `dall-e*`) с запасным каталогом; `gpt-image-1` первым, legacy `dall-e-*` сохранены для обратной совместимости.
- **CLI/Web parity** — флаг `image models --refresh` и параметр `?refresh=1`; обновлён `docs/reference/parity.md`.

### Обратная совместимость
- Сохранённые значения `openai:dall-e-3` / `dall-e-2` продолжают работать.
- `gpt-image-1` возвращает картинку как base64 — она декодируется в файл (как у HuggingFace-адаптера), дальше по цепочке подхватывается выгрузка в S3.

## Проверка
- `ruff check src/ tests/` — чисто.
- Без живого Telegram: **7460 + 852 теста зелёные**, 0 падений.
- `pytest -k "manifest or parity or real_telegram_policy or cli_main"` — зелёный.
- CLI вживую: `image models --provider openai` (запасной список с `gpt-image-1` вверху) и `--refresh` работают.

## ⚠️ Примечание по содержимому PR
Ветка содержит второй, **несвязанный** коммит `b4bcc10` (фича live-CLI readiness auto-gating, отслеживается в #751) — он попал в ветку до создания PR. По решению автора PR оставлен с обоими изменениями; ревью #750 — по файлам `src/services/*`, `src/cli/*image*`, `src/web/images/*`, `docs/reference/parity.md` и соответствующим тестам.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
