### PR TITLE
fix(codex): require writable Codex runtime in codex_available()

### DIFF
--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -422,7 +422,7 @@ def _codex_runtime_state_writable(codex_home: Path) -> bool:
         if not codex_home.is_dir() or not _codex_path_writable(codex_home):
             return False
         for path in codex_home.glob("state*.sqlite*"):
-            if path.exists() and not _codex_path_writable(path):
+            if not _codex_path_writable(path):
                 return False
     except OSError:
         return False

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -400,20 +400,51 @@ def _codex_sdk_installed() -> bool:
     return importlib.util.find_spec("openai_codex") is not None
 
 
+def _codex_home_path() -> Path:
+    """Return the Codex runtime home used by the CLI/SDK."""
+    configured = os.environ.get("CODEX_HOME", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".codex"
+
+
+def _codex_path_writable(path: Path) -> bool:
+    """True when *path* can be written by this process."""
+    try:
+        return os.access(path, os.W_OK)
+    except OSError:
+        return False
+
+
+def _codex_runtime_state_writable(codex_home: Path) -> bool:
+    """True when Codex can initialize/update runtime state under *codex_home*."""
+    try:
+        if not codex_home.is_dir() or not _codex_path_writable(codex_home):
+            return False
+        for path in codex_home.glob("state*.sqlite*"):
+            if path.exists() and not _codex_path_writable(path):
+                return False
+    except OSError:
+        return False
+    return True
+
+
 @functools.lru_cache(maxsize=1)
 def codex_available() -> bool:
-    """True when the Codex SDK is installed and the Codex CLI is authenticated.
+    """True when the Codex SDK is installed and its CLI runtime is usable.
 
     Single source of truth for "is the keyless codex provider usable", shared by
     both registration paths (``ImageGenerationService._register_from_env`` and
-    ``ImageProviderService.build_adapters``). Cached because the inputs — a
-    package being installed and ``~/.codex/auth.json`` existing — are static for
-    the process lifetime, and the check otherwise runs an import-machinery scan
-    plus a filesystem stat on every image request.
+    ``ImageProviderService.build_adapters``). Cached because the inputs — SDK
+    install state, ``$CODEX_HOME``/``~/.codex`` auth, and runtime-state
+    writability — are static for the process lifetime, and the check otherwise
+    runs import-machinery and filesystem probes on every image request.
     """
     if not _codex_sdk_installed():
         return False
-    return (Path.home() / ".codex" / "auth.json").exists()
+    codex_home = _codex_home_path()
+    return (codex_home / "auth.json").exists() and _codex_runtime_state_writable(codex_home)
+
 
 
 # Dedicated thread pools for the Codex image path, kept OFF the default asyncio

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -525,6 +525,78 @@ def test_codex_available_false_without_sdk(monkeypatch):
     provider_adapters.codex_available.cache_clear()
 
 
+def test_codex_available_true_with_writable_codex_home(monkeypatch, tmp_path):
+    """A usable Codex home needs SDK, auth, and writable runtime state."""
+    from src.services import provider_adapters
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    (codex_home / "state_5.sqlite").write_bytes(b"")
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(provider_adapters, "_codex_sdk_installed", lambda: True)
+    provider_adapters.codex_available.cache_clear()
+    try:
+        assert provider_adapters.codex_available() is True
+    finally:
+        provider_adapters.codex_available.cache_clear()
+
+
+def test_codex_available_false_without_auth_in_codex_home(monkeypatch, tmp_path):
+    """CODEX_HOME is authoritative; missing auth there means unavailable."""
+    from src.services import provider_adapters
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(provider_adapters, "_codex_sdk_installed", lambda: True)
+    provider_adapters.codex_available.cache_clear()
+    try:
+        assert provider_adapters.codex_available() is False
+    finally:
+        provider_adapters.codex_available.cache_clear()
+
+
+def test_codex_available_false_when_codex_home_not_writable(monkeypatch, tmp_path):
+    """Sandboxed readonly Codex homes should not register the provider."""
+    from src.services import provider_adapters
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(provider_adapters, "_codex_sdk_installed", lambda: True)
+    monkeypatch.setattr(provider_adapters, "_codex_path_writable", lambda path: path != codex_home)
+    provider_adapters.codex_available.cache_clear()
+    try:
+        assert provider_adapters.codex_available() is False
+    finally:
+        provider_adapters.codex_available.cache_clear()
+
+
+def test_codex_available_false_when_state_db_not_writable(monkeypatch, tmp_path):
+    """Existing Codex state DB files must be writable before live SDK use."""
+    from src.services import provider_adapters
+
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    state_db = codex_home / "state_5.sqlite"
+    (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+    state_db.write_bytes(b"")
+
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr(provider_adapters, "_codex_sdk_installed", lambda: True)
+    monkeypatch.setattr(provider_adapters, "_codex_path_writable", lambda path: path != state_db)
+    provider_adapters.codex_available.cache_clear()
+    try:
+        assert provider_adapters.codex_available() is False
+    finally:
+        provider_adapters.codex_available.cache_clear()
+
+
 @pytest.mark.anyio
 async def test_search_models_codex_static_catalog():
     svc = _make_clean_service()


### PR DESCRIPTION
## Summary

`codex_available()` previously checked only that the Codex SDK was installed and `~/.codex/auth.json` existed. In environments where the Codex runtime is **not writable** (sandboxed CI, restricted filesystem), this returned `True` — the provider registered as usable, but every live agent turn through the Codex backend **stalled until `agent.total_timeout` (300s)**: Codex spawns the `mcp-server` subprocess and calls project tools (verified via `CallToolRequest` in logs), but can't update its runtime state DB, so the turn never completes and gets killed by the timeout.

This made `test_agent_test_tools_via_codex_backend` (opt-in `RUN_CODEX_CLI_LIVE`, never run in CI) fail by timeout (~12 min) on any machine with a read-only Codex home.

## Changes

- `codex_available()` now also verifies the Codex runtime is writable:
  - `$CODEX_HOME` (or `~/.codex`) directory must be writable
  - any existing `state*.sqlite*` files must be writable
- `$CODEX_HOME` is now honored as authoritative (was hardcoded to `~/.codex`).
- New helpers: `_codex_home_path()`, `_codex_path_writable()`, `_codex_runtime_state_writable()`.

When the runtime isn't usable the provider stays unregistered, and `_require_codex()` in the live suite skips the cases cleanly instead of hanging.

## Tests

4 new unit tests covering: writable home (True), missing auth (False), read-only home (False), read-only state DB (False). Full image/codex/provider suites green (150 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)