### PR TITLE
feat(accounts): set primary account from Settings UI and CLI

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -143,6 +143,7 @@
 |----------|-----|-------------|------------|
 | Список | `account list` | `GET /settings/` | `list_accounts` |
 | Вкл/выкл | `account toggle` | `POST /settings/{id}/toggle` | `toggle_account` |
+| Сделать Primary | `account set-primary` | `POST /settings/{id}/set-primary` | — |
 | Удалить | `account delete` | `POST /settings/{id}/delete` | `delete_account` |
 | Flood статус | `account flood-status` | `GET /settings/flood-status` | `get_flood_status` |
 | Сбросить flood | `account flood-clear` | `POST /settings/{id}/flood-clear` | `clear_flood_status` |

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -608,7 +608,7 @@ async def resolve_phone(db: object, raw_phone: object) -> tuple[str, dict | None
     usable_accounts = [
         account
         for account in accounts
-        if account_session_status(account) == "ok"
+        if getattr(account, "is_active", True) and account_session_status(account) == "ok"
     ]
     if not usable_accounts:
         return "", _text_response("Ошибка: нет подключённых аккаунтов.")

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -187,6 +187,12 @@ def run(args: argparse.Namespace) -> None:
                 new_state = not acc.is_active
                 await db.set_account_active(args.id, new_state)
                 print(f"Account id={args.id} ({acc.phone}): active={new_state}")
+            elif args.account_action == "set-primary":
+                changed = await db.repos.accounts.set_account_primary(args.id)
+                if changed:
+                    print(f"Account id={args.id} set as primary")
+                else:
+                    print(f"Account id={args.id} not found")
             elif args.account_action == "delete":
                 await db.delete_account(args.id)
                 print(f"Deleted account id={args.id}")

--- a/src/cli/parser_domains/account.py
+++ b/src/cli/parser_domains/account.py
@@ -14,6 +14,9 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     acc_toggle = acc_sub.add_parser("toggle", help="Toggle account active state")
     acc_toggle.add_argument("id", type=int, help="Account id")
 
+    acc_set_primary = acc_sub.add_parser("set-primary", help="Make account the primary one")
+    acc_set_primary.add_argument("id", type=int, help="Account id")
+
     acc_del = acc_sub.add_parser("delete", help="Delete account")
     acc_del.add_argument("id", type=int, help="Account id")
 

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -334,9 +334,50 @@ class AccountsRepository:
         )
 
     async def set_account_active(self, account_id: int, active: bool) -> None:
-        await self._database.execute_write(
-            "UPDATE accounts SET is_active = ? WHERE id = ?", (int(active), account_id)
+        assert self._database is not None, (
+            "AccountsRepository.set_account_active requires a Database reference"
         )
+        async with self._database.transaction() as conn:
+            await conn.execute(
+                "UPDATE accounts SET is_active = ? WHERE id = ?", (int(active), account_id)
+            )
+            if not active:
+                # Deactivating the current primary: demote it and promote the
+                # lowest-id remaining ACTIVE account. If none stay active, leave
+                # zero primary (acceptable — the user may disable everything).
+                await conn.execute(
+                    "UPDATE accounts SET is_primary = 0 WHERE id = ? AND is_primary = 1",
+                    (account_id,),
+                )
+                await conn.execute(
+                    """
+                    UPDATE accounts SET is_primary = 1
+                    WHERE id = (
+                        SELECT id FROM accounts
+                        WHERE is_active = 1
+                        ORDER BY id ASC LIMIT 1
+                    )
+                    AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1)
+                    """
+                )
+
+    async def set_account_primary(self, account_id: int) -> bool:
+        """Atomically make *account_id* the sole primary, demoting the previous one.
+
+        Returns False if the account does not exist (no-op). The partial unique
+        index idx_accounts_single_primary (#733) is the hard backstop; doing both
+        UPDATEs inside one transaction keeps the intermediate state valid at COMMIT.
+        """
+        assert self._database is not None, (
+            "AccountsRepository.set_account_primary requires a Database reference"
+        )
+        async with self._database.transaction() as conn:
+            cur = await conn.execute("SELECT 1 FROM accounts WHERE id = ?", (account_id,))
+            if await cur.fetchone() is None:
+                return False
+            await conn.execute("UPDATE accounts SET is_primary = 0 WHERE is_primary = 1")
+            await conn.execute("UPDATE accounts SET is_primary = 1 WHERE id = ?", (account_id,))
+        return True
 
     async def delete_account(self, account_id: int) -> None:
         assert self._database is not None, (

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -338,10 +338,21 @@ class AccountsRepository:
             "AccountsRepository.set_account_active requires a Database reference"
         )
         async with self._database.transaction() as conn:
-            await conn.execute(
+            cur = await conn.execute(
                 "UPDATE accounts SET is_active = ? WHERE id = ?", (int(active), account_id)
             )
-            if not active:
+            if (cur.rowcount or 0) == 0:
+                return
+            if active:
+                await conn.execute(
+                    """
+                    UPDATE accounts SET is_primary = 1
+                    WHERE id = ?
+                    AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1)
+                    """,
+                    (account_id,),
+                )
+            else:
                 # Deactivating the current primary: demote it and promote the
                 # lowest-id remaining ACTIVE account. If none stay active, leave
                 # zero primary (acceptable — the user may disable everything).

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -43,6 +43,15 @@ async def delete_account(request: Request, account_id: int):
     )
 
 
+@router.post("/{account_id}/set-primary")
+async def set_primary_account(request: Request, account_id: int):
+    db = deps.get_db(request)
+    changed = await db.repos.accounts.set_account_primary(account_id)
+    if not changed:
+        return RedirectResponse(url="/settings?error=invalid_account", status_code=303)
+    return RedirectResponse(url="/settings?msg=account_set_primary", status_code=303)
+
+
 @router.get("/flood-status")
 async def flood_status(request: Request):
     db = deps.get_db(request)

--- a/src/web/static/settings.js
+++ b/src/web/static/settings.js
@@ -331,6 +331,7 @@ async function bulkTestAgentProviders() {
 const FLASH_TAB_MAP = {
     account_connected: 'accounts',
     account_toggled: 'accounts',
+    account_set_primary: 'accounts',
     account_deleted: 'accounts',
     credentials_saved: 'credentials',
     scheduler_saved: 'scheduler',

--- a/src/web/template_globals.py
+++ b/src/web/template_globals.py
@@ -55,6 +55,7 @@ FLASH_MESSAGES = {
     "filters_saved": "Фильтры сохранены.",
     "scheduler_saved": "Настройки планировщика сохранены.",
     "account_toggled": "Статус аккаунта изменён.",
+    "account_set_primary": "Аккаунт назначен основным (Primary).",
     "account_deleted": "Аккаунт удалён.",
     "notification_account_saved": "Аккаунт для уведомлений сохранён.",
     "notification_bot_created": "Notification bot создан.",

--- a/src/web/templates/settings/_accounts.html
+++ b/src/web/templates/settings/_accounts.html
@@ -53,6 +53,13 @@
                     <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
                 </a>
                 {% endif %}
+                {% if not acc.is_primary %}
+                <form method="post" action="/settings/{{ acc.id }}/set-primary" class="d-inline" data-busy>
+                    <button type="submit" class="btn btn-outline-warning btn-sm" aria-label="Сделать Primary" title="Сделать Primary">
+                        <i class="bi bi-star" aria-hidden="true"></i>
+                    </button>
+                </form>
+                {% endif %}
                 <form method="post" action="/settings/{{ acc.id }}/toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm"
                             aria-label="{{ 'Отключить' if acc.is_active else 'Включить' }}" title="{{ 'Отключить' if acc.is_active else 'Включить' }}">
@@ -94,6 +101,13 @@
                 <a href="/auth/login?phone={{ acc.phone|urlencode }}" class="btn btn-outline-primary btn-sm" title="Переподключить аккаунт" aria-label="Переподключить">
                     <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
                 </a>
+                {% endif %}
+                {% if not acc.is_primary %}
+                <form method="post" action="/settings/{{ acc.id }}/set-primary" class="d-inline" data-busy>
+                    <button type="submit" class="btn btn-outline-warning btn-sm" aria-label="Сделать Primary" title="Сделать Primary">
+                        <i class="bi bi-star" aria-hidden="true"></i>
+                    </button>
+                </form>
                 {% endif %}
                 <form method="post" action="/settings/{{ acc.id }}/toggle" class="d-inline" data-busy>
                     <button type="submit" class="btn btn-outline-secondary btn-sm"

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -158,6 +158,7 @@ CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS: dict[tuple[str, ...], str] = {
     ("account", "delete"): "dangerous live account deletion; intentionally blocked from live testing",
     ("account", "flood-clear"): "local flood state mutation",
     ("account", "send-code"): "Telegram auth flow",
+    ("account", "set-primary"): "local account state mutation",
     ("account", "toggle"): "local account state mutation",
     ("account", "verify-code"): "Telegram auth flow",
     ("agent", "context"): "local agent-thread mutation requiring chosen target",

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -398,6 +398,105 @@ async def test_delete_primary_promotes_with_wrong_session_key(repo_with_cipher):
     assert summaries[0].session_status == AccountSessionStatus.DECRYPT_FAILED
 
 
+# set_account_primary tests
+
+
+async def test_set_account_primary_demotes_previous(accounts_repo):
+    """Setting a new primary demotes the old one; exactly one stays primary."""
+    old_primary = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    new_primary = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+
+    changed = await accounts_repo.set_account_primary(new_primary)
+    assert changed is True
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc.is_primary for acc in summaries}
+    assert by_id == {old_primary: False, new_primary: True}
+    assert sum(1 for acc in summaries if acc.is_primary) == 1
+
+
+async def test_set_account_primary_missing_id_is_noop(accounts_repo):
+    """Promoting a non-existent id returns False and leaves state untouched."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    other_id = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+
+    changed = await accounts_repo.set_account_primary(999)
+    assert changed is False
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert {acc.id: acc.is_primary for acc in summaries} == {primary_id: True, other_id: False}
+
+
+async def test_set_account_primary_on_inactive_account(accounts_repo):
+    """An inactive account may still be promoted to primary (user choice)."""
+    active_primary = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    inactive_id = await accounts_repo.add_account(make_account("+2222222222", is_active=False))
+
+    changed = await accounts_repo.set_account_primary(inactive_id)
+    assert changed is True
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc.is_primary for acc in summaries}
+    assert by_id == {active_primary: False, inactive_id: True}
+
+
+# set_account_active primary-demotion tests
+
+
+async def test_deactivate_primary_promotes_next_active(accounts_repo):
+    """Deactivating the primary promotes the lowest-id remaining active account."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    next_active = await accounts_repo.add_account(make_account("+2222222222", is_active=True))
+    later_active = await accounts_repo.add_account(make_account("+3333333333", is_active=True))
+
+    await accounts_repo.set_account_active(primary_id, False)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc.is_primary for acc in summaries}
+    assert by_id[primary_id] is False
+    assert by_id[next_active] is True
+    assert by_id[later_active] is False
+
+
+async def test_deactivate_primary_skips_inactive_when_promoting(accounts_repo):
+    """Promotion on deactivation considers only active accounts."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    inactive_id = await accounts_repo.add_account(make_account("+2222222222", is_active=False))
+    active_id = await accounts_repo.add_account(make_account("+3333333333", is_active=True))
+
+    await accounts_repo.set_account_active(primary_id, False)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc.is_primary for acc in summaries}
+    assert by_id[primary_id] is False
+    assert by_id[inactive_id] is False
+    assert by_id[active_id] is True
+
+
+async def test_deactivate_last_active_primary_leaves_zero_primary(accounts_repo):
+    """Disabling the only active account is allowed and leaves no primary."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    inactive_id = await accounts_repo.add_account(make_account("+2222222222", is_active=False))
+
+    await accounts_repo.set_account_active(primary_id, False)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert all(acc.is_primary is False for acc in summaries)
+    assert {acc.id for acc in summaries} == {primary_id, inactive_id}
+
+
+async def test_deactivate_non_primary_keeps_primary(accounts_repo):
+    """Deactivating a secondary account does not touch the primary flag."""
+    primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+    secondary_id = await accounts_repo.add_account(make_account("+2222222222", is_active=True))
+
+    await accounts_repo.set_account_active(secondary_id, False)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc.is_primary for acc in summaries}
+    assert by_id == {primary_id: True, secondary_id: False}
+
+
 # migrate_sessions tests
 
 

--- a/tests/repositories/test_accounts_repository.py
+++ b/tests/repositories/test_accounts_repository.py
@@ -485,6 +485,33 @@ async def test_deactivate_last_active_primary_leaves_zero_primary(accounts_repo)
     assert {acc.id for acc in summaries} == {primary_id, inactive_id}
 
 
+async def test_reactivate_account_restores_primary_when_none_exists(accounts_repo):
+    """Re-enabling an account restores a missing primary instead of leaving a broken state."""
+    account_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))
+
+    await accounts_repo.set_account_active(account_id, False)
+    await accounts_repo.set_account_active(account_id, True)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    by_id = {acc.id: acc for acc in summaries}
+    assert by_id[account_id].is_active is True
+    assert by_id[account_id].is_primary is True
+
+
+async def test_set_account_active_missing_id_is_noop(accounts_repo):
+    """Toggling a missing account must not repair or otherwise mutate primary flags."""
+    first_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=False))
+    second_id = await accounts_repo.add_account(make_account("+2222222222", is_primary=False))
+
+    await accounts_repo.set_account_active(999, False)
+
+    summaries = await accounts_repo.get_account_summaries(active_only=False)
+    assert [(acc.id, acc.is_primary) for acc in summaries] == [
+        (first_id, False),
+        (second_id, False),
+    ]
+
+
 async def test_deactivate_non_primary_keeps_primary(accounts_repo):
     """Deactivating a secondary account does not touch the primary flag."""
     primary_id = await accounts_repo.add_account(make_account("+1111111111", is_primary=True))

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -172,6 +172,17 @@ class TestResolvePhone:
         assert err is None
 
     @pytest.mark.anyio
+    async def test_empty_phone_skips_inactive_primary(self):
+        primary = SimpleNamespace(phone="+11111111111", is_active=False, is_primary=True)
+        secondary = SimpleNamespace(phone="+22222222222", is_active=True, is_primary=False)
+        db = MagicMock()
+        db.get_accounts = AsyncMock(return_value=[primary, secondary])
+
+        phone, err = await resolve_phone(db, "")
+        assert phone == "+22222222222"
+        assert err is None
+
+    @pytest.mark.anyio
     async def test_none_phone_defaults_to_primary(self):
         primary = SimpleNamespace(phone="+11111111111", is_primary=True)
         db = MagicMock()

--- a/tests/test_cli_image_scheduler_web_routes.py
+++ b/tests/test_cli_image_scheduler_web_routes.py
@@ -634,6 +634,32 @@ class TestWebAccountsRoutes:
         assert resp.status_code == 303
         assert "settings" in resp.headers["location"]
 
+    @pytest.mark.anyio
+    async def test_set_primary_account(self, route_client, base_app):
+        """POST /settings/{id}/set-primary promotes the account and demotes the old primary."""
+        _, db, _ = base_app
+        await db.add_account(Account(phone="+1888888888", session_string="primary_session", is_primary=True))
+        await db.add_account(Account(phone="+1999999999", session_string="second_session"))
+        accounts = await db.get_account_summaries(active_only=False)
+        old_primary = next(a for a in accounts if a.is_primary)
+        target = next(a for a in accounts if not a.is_primary and a.id != old_primary.id)
+
+        resp = await route_client.post(f"/settings/{target.id}/set-primary", follow_redirects=False)
+        assert resp.status_code == 303
+        assert "msg=account_set_primary" in resp.headers["location"]
+
+        after = {a.id: a.is_primary for a in await db.get_account_summaries(active_only=False)}
+        assert after[target.id] is True
+        assert after[old_primary.id] is False
+        assert sum(1 for v in after.values() if v) == 1
+
+    @pytest.mark.anyio
+    async def test_set_primary_account_not_found(self, route_client):
+        """POST /settings/999/set-primary for a missing account redirects with an error."""
+        resp = await route_client.post("/settings/999/set-primary", follow_redirects=False)
+        assert resp.status_code == 303
+        assert "error=invalid_account" in resp.headers["location"]
+
 
 # ---------------------------------------------------------------------------
 # Web: /calendar routes


### PR DESCRIPTION
## Summary

Добавляет возможность назначить аккаунт основным (Primary) как из веб-UI настроек, так и из CLI.

- **CLI**: новая команда `account set-primary <id>`
- **Web**: маршрут `POST /settings/{id}/set-primary` + кнопка-звёздочка в списке аккаунтов и flash-сообщение
- **Repo**: `AccountsRepository.set_account_primary()` атомарно (в одной транзакции) снимает старый primary и назначает новый; partial unique index `idx_accounts_single_primary` (#733) остаётся жёстким backstop'ом
- **Деактивация primary**: `set_account_active()` теперь демотит отключаемый primary и промотит активный аккаунт с наименьшим id; если активных не остаётся — ноль primary (это допустимо)

## Test plan

- `tests/repositories/test_accounts_repository.py` — 7 новых кейсов: демоут предыдущего primary, no-op для несуществующего id, промоут неактивного аккаунта, промоут следующего активного при деактивации, пропуск неактивных при промоуте, ноль primary при отключении последнего активного, сохранение primary при деактивации secondary
- `tests/test_cli_image_scheduler_web_routes.py::TestWebAccountsRoutes` — `test_set_primary_account`, `test_set_primary_account_not_found`
- Parity: `docs/reference/parity.md` обновлён; `command_manifest.py` помечает `account set-primary` как local-state-mutation (исключён из live-тестов)

🤖 Generated with [Claude Code](https://claude.com/claude-code)