### PR TITLE
feat(search): purge Premium-search cache via `search --purge-cache` + web endpoint

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -44,6 +44,7 @@
 | Поиск по чатам | `search --mode my_chats` | `GET /search?mode=my_chats` | `search_my_chats` |
 | Поиск в канале | `search --mode channel` | `GET /search?mode=channel` | `search_in_channel` |
 | Индексация | `search --index-now` | `POST /settings/semantic-index` | `index_messages` |
+| Очистка кэша Premium-поиска | `search --purge-cache` | `POST /search/purge-cache` | — |
 
 ## Сообщения
 

--- a/src/cli/commands/search.py
+++ b/src/cli/commands/search.py
@@ -13,6 +13,17 @@ def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         config, db = await runtime.init_db(args.config)
 
+        if getattr(args, "purge_cache", False):
+            try:
+                if not args.query:
+                    logging.error("--purge-cache requires a query (the Premium search text to purge).")
+                    return
+                deleted = await db.repos.messages.delete_premium_search_results(args.query)
+                print(f"Purged {deleted} cached message(s) from Premium search for '{args.query}'.")
+            finally:
+                await db.close()
+            return
+
         pool = None
         if args.mode in ("telegram", "my_chats", "channel"):
             _, pool = await runtime.init_pool(config, db)

--- a/src/cli/parser_domains/search.py
+++ b/src/cli/parser_domains/search.py
@@ -36,3 +36,9 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         default=False,
         help="Drop semantic vector index before --index-now",
     )
+    search_parser.add_argument(
+        "--purge-cache",
+        action="store_true",
+        default=False,
+        help="Delete messages cached by a previous Premium global search for <query> and exit",
+    )

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -429,8 +429,10 @@ class CollectionBundle:
     async def insert_message(self, msg: Message) -> bool:
         return await self.messages.insert_message(msg)
 
-    async def insert_messages_batch(self, messages: list[Message]) -> int:
-        return await self.messages.insert_messages_batch(messages)
+    async def insert_messages_batch(
+        self, messages: list[Message], premium_search_query: str | None = None
+    ) -> int:
+        return await self.messages.insert_messages_batch(messages, premium_search_query)
 
     async def search_messages(
         self,
@@ -705,8 +707,10 @@ class SearchBundle:
     async def add_channel(self, channel: Channel) -> int:
         return await self.channels.add_channel(channel)
 
-    async def insert_messages_batch(self, messages: list[Message]) -> int:
-        return await self.messages.insert_messages_batch(messages)
+    async def insert_messages_batch(
+        self, messages: list[Message], premium_search_query: str | None = None
+    ) -> int:
+        return await self.messages.insert_messages_batch(messages, premium_search_query)
 
     async def log_search(self, phone: str, query: str, results_count: int) -> None:
         await self.search_log.log_search(phone, query, results_count)

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -50,6 +50,7 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "detected_lang": "detected_lang TEXT",
         "translation_en": "translation_en TEXT",
         "translation_custom": "translation_custom TEXT",
+        "premium_search_query": "premium_search_query TEXT",
     },
     "collection_tasks": {
         "channel_username": "channel_username TEXT",
@@ -146,6 +147,10 @@ SCHEMA_REPAIR_INDEXES: Sequence[str] = (
     """
     CREATE INDEX IF NOT EXISTS idx_messages_fwd_from_channel
     ON messages(forward_from_channel_id) WHERE forward_from_channel_id IS NOT NULL
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_messages_premium_search_query
+    ON messages(premium_search_query) WHERE premium_search_query IS NOT NULL
     """,
     """
     CREATE INDEX IF NOT EXISTS idx_collection_tasks_type_status_run_after

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -333,6 +333,27 @@ class AccountsRepository:
             (int(is_premium), phone),
         )
 
+    @staticmethod
+    async def _promote_primary_if_none(conn, *, active_only: bool) -> None:
+        """Promote the lowest-id candidate to primary iff no primary exists.
+
+        Single owner of the "fill the primary gap" half of the one-primary
+        invariant (#733), shared by set_account_active and delete_account so the
+        candidate-selection rule cannot drift between call sites. With
+        ``active_only`` the candidate pool is restricted to active accounts.
+        """
+        candidate_filter = "WHERE is_active = 1\n            " if active_only else ""
+        await conn.execute(
+            f"""
+            UPDATE accounts SET is_primary = 1
+            WHERE id = (
+                SELECT id FROM accounts
+                {candidate_filter}ORDER BY id ASC LIMIT 1
+            )
+            AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1)
+            """
+        )
+
     async def set_account_active(self, account_id: int, active: bool) -> None:
         assert self._database is not None, (
             "AccountsRepository.set_account_active requires a Database reference"
@@ -360,17 +381,7 @@ class AccountsRepository:
                     "UPDATE accounts SET is_primary = 0 WHERE id = ? AND is_primary = 1",
                     (account_id,),
                 )
-                await conn.execute(
-                    """
-                    UPDATE accounts SET is_primary = 1
-                    WHERE id = (
-                        SELECT id FROM accounts
-                        WHERE is_active = 1
-                        ORDER BY id ASC LIMIT 1
-                    )
-                    AND NOT EXISTS (SELECT 1 FROM accounts WHERE is_primary = 1)
-                    """
-                )
+                await self._promote_primary_if_none(conn, active_only=True)
 
     async def set_account_primary(self, account_id: int) -> bool:
         """Atomically make *account_id* the sole primary, demoting the previous one.
@@ -383,6 +394,11 @@ class AccountsRepository:
             "AccountsRepository.set_account_primary requires a Database reference"
         )
         async with self._database.transaction() as conn:
+            # The partial unique index idx_accounts_single_primary (#733) is
+            # checked immediately, so demote MUST precede promote — two primaries
+            # can never coexist even mid-transaction. That forces the existence
+            # check up front (rowcount-on-promote would arrive too late), so the
+            # SELECT is load-bearing, not redundant.
             cur = await conn.execute("SELECT 1 FROM accounts WHERE id = ?", (account_id,))
             if await cur.fetchone() is None:
                 return False
@@ -397,20 +413,4 @@ class AccountsRepository:
         async with self._database.transaction() as conn:
             cur = await conn.execute("DELETE FROM accounts WHERE id = ?", (account_id,))
             if (cur.rowcount or 0) > 0:
-                await conn.execute(
-                    """
-                    UPDATE accounts
-                    SET is_primary = 1
-                    WHERE id = (
-                        SELECT id
-                        FROM accounts
-                        ORDER BY id ASC
-                        LIMIT 1
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM accounts
-                        WHERE is_primary = 1
-                    )
-                    """
-                )
+                await self._promote_primary_if_none(conn, active_only=False)

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -158,7 +158,7 @@ class MessagesRepository:
             )
             inserted = cur.rowcount > 0
             if not inserted:
-                await self._refresh_existing_messages([msg])
+                await self._refresh_existing_messages([msg], clear_premium_search_query=True)
             if msg.reactions_json:
                 await self._upsert_reactions(msg.channel_id, msg.message_id, msg.reactions_json)
             return inserted
@@ -254,7 +254,10 @@ class MessagesRepository:
         if existing_keys:
             duplicates = [m for m in messages if (m.channel_id, m.message_id) in existing_keys]
             if duplicates:
-                await self._refresh_existing_messages(duplicates)
+                await self._refresh_existing_messages(
+                    duplicates,
+                    clear_premium_search_query=premium_search_query is None,
+                )
 
         reactions_data = [
             (m.channel_id, m.message_id, r["emoji"], r.get("count", 0))
@@ -293,7 +296,12 @@ class MessagesRepository:
             existing.update((row["channel_id"], row["message_id"]) for row in rows)
         return existing
 
-    async def _refresh_existing_messages(self, messages: list[Message]) -> None:
+    async def _refresh_existing_messages(
+        self,
+        messages: list[Message],
+        *,
+        clear_premium_search_query: bool = False,
+    ) -> None:
         """Refresh mutable fields for already-known Telegram messages."""
         if not messages:
             return
@@ -309,6 +317,7 @@ class MessagesRepository:
                 m.reactions_json,
                 m.detected_lang,
                 m.detected_lang,
+                int(clear_premium_search_query),
                 m.channel_id,
                 m.message_id,
             )
@@ -321,7 +330,8 @@ class MessagesRepository:
                        forwards = CASE WHEN ? IS NOT NULL THEN ? ELSE forwards END,
                        reply_count = CASE WHEN ? IS NOT NULL THEN ? ELSE reply_count END,
                        reactions_json = CASE WHEN ? IS NOT NULL THEN ? ELSE reactions_json END,
-                       detected_lang = CASE WHEN ? IS NOT NULL THEN ? ELSE detected_lang END
+                       detected_lang = CASE WHEN ? IS NOT NULL THEN ? ELSE detected_lang END,
+                       premium_search_query = CASE WHEN ? = 1 THEN NULL ELSE premium_search_query END
                    WHERE channel_id = ? AND message_id = ?""",
                 data,
             )
@@ -1056,7 +1066,8 @@ class MessagesRepository:
 
         Only rows tagged with ``premium_search_query`` are removed — messages that
         already existed (collected by the worker or a prior search) are skipped by
-        ``INSERT OR IGNORE`` and never receive the tag, so user data is never touched.
+        ``INSERT OR IGNORE`` and never receive the tag, and later normal collection
+        refreshes clear stale tags, so user data is never touched.
         Used by the live Premium-search test to clean up after itself. Returns the
         number of deleted rows.
         """

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -191,7 +191,9 @@ class MessagesRepository:
                 message_id,
             )
 
-    async def insert_messages_batch(self, messages: list[Message]) -> int:
+    async def insert_messages_batch(
+        self, messages: list[Message], premium_search_query: str | None = None
+    ) -> int:
         if not messages:
             return 0
         data = [
@@ -218,6 +220,7 @@ class MessagesRepository:
                 m.date.isoformat(),
                 m.detected_lang,
                 getattr(m, "forward_from_channel_id", None),
+                premium_search_query,
             )
             for m in messages
         ]
@@ -239,8 +242,8 @@ class MessagesRepository:
                     service_action_semantic, service_action_payload_json, sender_kind,
                     topic_id, reactions_json,
                     views, forwards, reply_count, date, detected_lang,
-                    forward_from_channel_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    forward_from_channel_id, premium_search_query)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 data,
             )
             count = cur.rowcount if cur.rowcount >= 0 else len(messages)
@@ -1044,6 +1047,30 @@ class MessagesRepository:
             )
             cur = await conn.execute(
                 "DELETE FROM messages WHERE channel_id = ?", (channel_id,)
+            )
+            rowcount = cur.rowcount or 0
+        return rowcount
+
+    async def delete_premium_search_results(self, query: str) -> int:
+        """Delete messages cached solely by a Premium global search for *query*.
+
+        Only rows tagged with ``premium_search_query`` are removed — messages that
+        already existed (collected by the worker or a prior search) are skipped by
+        ``INSERT OR IGNORE`` and never receive the tag, so user data is never touched.
+        Used by the live Premium-search test to clean up after itself. Returns the
+        number of deleted rows.
+        """
+        assert self._database is not None, (
+            "MessagesRepository.delete_premium_search_results requires a Database reference"
+        )
+        async with self._database.transaction() as conn:
+            await conn.execute(
+                "DELETE FROM message_embeddings_json WHERE message_id IN "
+                "(SELECT id FROM messages WHERE premium_search_query = ?)",
+                (query,),
+            )
+            cur = await conn.execute(
+                "DELETE FROM messages WHERE premium_search_query = ?", (query,)
             )
             rowcount = cur.rowcount or 0
         return rowcount

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS messages (
     detected_lang TEXT,
     translation_en TEXT,
     translation_custom TEXT,
+    premium_search_query TEXT,
     UNIQUE(channel_id, message_id)
 );
 
@@ -140,6 +141,8 @@ CREATE INDEX IF NOT EXISTS idx_channel_stats_lookup
 CREATE INDEX IF NOT EXISTS idx_messages_text ON messages(text);
 CREATE INDEX IF NOT EXISTS idx_messages_channel_date ON messages(channel_id, date);
 CREATE INDEX IF NOT EXISTS idx_messages_date ON messages(date);
+CREATE INDEX IF NOT EXISTS idx_messages_premium_search_query
+    ON messages(premium_search_query) WHERE premium_search_query IS NOT NULL;
 
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     text,

--- a/src/search/persistence.py
+++ b/src/search/persistence.py
@@ -36,7 +36,7 @@ class SearchPersistence:
         )
 
         if messages:
-            await self._search.insert_messages_batch(messages)
+            await self._search.insert_messages_batch(messages, premium_search_query=query)
 
         await self._search.log_search(phone, query, len(messages))
         return await self._load_persisted_messages(messages)

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -39,6 +39,11 @@ async def search_page(
     )
 
 
+@router.post("/search/purge-cache")
+async def purge_premium_search_cache_endpoint(request: Request):
+    return search_response(request, await handlers.purge_premium_search_cache(request))
+
+
 @router.post("/search/translate/{message_db_id}")
 async def translate_message_endpoint(message_db_id: int, request: Request):
     return search_response(request, await handlers.translate_message(request, message_db_id))

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -217,6 +217,29 @@ async def render_search_page(
     )
 
 
+async def _json_body(request: Request) -> dict:
+    """Parse a JSON request body, tolerating a bodyless POST (returns ``{}``)."""
+    if request.headers.get("content-type", "").startswith("application/json"):
+        return await request.json()
+    return {}
+
+
+async def purge_premium_search_cache(request: Request) -> SearchJson:
+    """Delete messages cached by a previous Premium global search for a query.
+
+    JSON endpoint (no DOM swap), mirrors the CLI ``search <query> --purge-cache``.
+    Only rows tagged with ``premium_search_query`` are removed, so collected user
+    data is never touched.
+    """
+    db = deps.get_db(request)
+    body = await _json_body(request)
+    query = (body.get("query") or "").strip()
+    if not query:
+        return SearchJson({"ok": False, "error": "query is required"}, status_code=400)
+    deleted = await db.repos.messages.delete_premium_search_results(query)
+    return SearchJson({"ok": True, "deleted": deleted, "query": query})
+
+
 async def translate_message(request: Request, message_db_id: int) -> SearchJson:
     """Translate a single message on demand. Returns JSON."""
     db = deps.get_db(request)
@@ -224,7 +247,7 @@ async def translate_message(request: Request, message_db_id: int) -> SearchJson:
     if translation_service:
         translation_service = translation_service.translation_service
 
-    body = await request.json() if request.headers.get("content-type", "").startswith("application/json") else {}
+    body = await _json_body(request)
     target_lang = body.get("target_lang", "en")
 
     # Get the message

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -106,6 +106,7 @@ CLI_REAL_TG_COMMAND_CASES_BY_CATEGORY: dict[str, set[tuple[str, ...]]] = {
         ("photo-loader", "schedule-send"),
         ("photo-loader", "send"),
         ("pipeline", "publish"),
+        ("search",),
     },
     "process_control": {
         ("restart",),
@@ -150,6 +151,7 @@ CLI_REAL_TG_CLEANUP_COMMAND_CASES: set[tuple[str, ...]] = {
     ("my-telegram", "unpin-message"),
     ("photo-loader", "batch-cancel"),
     ("scheduler", "clear-pending"),
+    ("search",),
 }
 
 CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS: dict[tuple[str, ...], str] = {

--- a/tests/cli_real_tg_integration/mutation_safe/test_search_telegram_premium.py
+++ b/tests/cli_real_tg_integration/mutation_safe/test_search_telegram_premium.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+from tests.cli_real_tg_integration.conftest import (
+    _await_phone_flood_or_skip,
+    _first_premium_phone,
+    cli_run_direct,
+)
+
+pytestmark = pytest.mark.real_tg_mutation_safe
+
+# Premium global search (`search --mode=telegram`) caches its hits into the shared
+# `messages` table, tagging only newly inserted rows with `premium_search_query`
+# (existing user messages are skipped by INSERT OR IGNORE and never tagged). The
+# test searches for "тест", then deletes exactly those tagged rows via the
+# `search --purge-cache` CLI — never touching pre-existing user data.
+_FOUND_RE = re.compile(r"\bFound\s+(\d+)\s+results\b")
+_PURGED_RE = re.compile(r"\bPurged\s+(\d+)\s+cached message")
+_QUERY = "тест"
+
+
+# Two sequential live CLI round-trips (the global search itself is slow, plus a
+# cold-start purge process), so the per-test budget covers both 60s calls with
+# headroom — 90s was not enough and timed out mid-cleanup.
+@pytest.mark.timeout(180)
+def test_search_telegram_premium_caches_and_purges(run_cli, assert_cli_ok, cli_real_cli_env):
+    phone = _first_premium_phone(cli_real_cli_env.db_path, cli_real_cli_env.phones)
+    if phone is None:
+        pytest.skip("no connected Telegram Premium account; global search requires Telegram Premium")
+    _await_phone_flood_or_skip(cli_real_cli_env, phone)
+
+    leak_msg: str | None = None
+    try:
+        result = run_cli(
+            "search",
+            _QUERY,
+            "--mode",
+            "telegram",
+            "--limit",
+            "1",
+            timeout=60,
+        )
+        assert_cli_ok(result)
+
+        match = _FOUND_RE.search(result.stdout or "")
+        assert match is not None, f"search did not print a 'Found N results' line: {result.stdout!r}"
+        found = int(match.group(1))
+        if found == 0:
+            # 0 results is indistinguishable from an exhausted daily quota / flood
+            # via stdout (the command prints total, not the error). Nothing was
+            # cached, so nothing to verify or clean up — skip rather than fail.
+            pytest.skip("Premium search returned 0 results (empty or daily quota exhausted)")
+    finally:
+        # Always purge our tagged rows, even if the assertions above failed after a
+        # successful search. Deletes only rows tagged premium_search_query == _QUERY.
+        try:
+            cleanup = cli_run_direct(
+                cli_real_cli_env,
+                "search",
+                _QUERY,
+                "--purge-cache",
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            leak_msg = f"cached Premium-search rows for {_QUERY!r} may be left in DB: purge timed out"
+        else:
+            if cleanup.returncode != 0:
+                leak_msg = (
+                    f"cached Premium-search rows for {_QUERY!r} may be left in DB: "
+                    f"purge stderr={cleanup.stderr!r}"
+                )
+            elif _PURGED_RE.search(f"{cleanup.stdout}\n{cleanup.stderr}") is None:
+                leak_msg = (
+                    f"cached Premium-search rows for {_QUERY!r} may be left in DB: "
+                    f"unexpected purge output={cleanup.stdout!r} stderr={cleanup.stderr!r}"
+                )
+
+        if leak_msg and sys.exc_info()[0] is None:
+            pytest.fail(leak_msg)

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -811,6 +811,29 @@ async def test_premium_tag_not_applied_to_pre_existing_messages(messages_repo):
     assert await _premium_tag(messages_repo, 12, 2) == "тест"  # new row tagged
 
 
+async def test_normal_collection_clears_stale_premium_tag(messages_repo):
+    """A cache row becomes user data once normal collection sees the same message."""
+    await messages_repo.insert_messages_batch(
+        [make_message(12, 3, "from premium search")],
+        premium_search_query="тест",
+    )
+    assert await _premium_tag(messages_repo, 12, 3) == "тест"
+
+    inserted = await messages_repo.insert_messages_batch(
+        [make_message(12, 3, "collected by worker")]
+    )
+    assert inserted == 0
+    assert await _premium_tag(messages_repo, 12, 3) is None
+
+    assert await messages_repo.delete_premium_search_results("тест") == 0
+    cur = await messages_repo._db.execute(
+        "SELECT text FROM messages WHERE channel_id = ? AND message_id = ?",
+        (12, 3),
+    )
+    row = await cur.fetchone()
+    assert row is not None
+
+
 async def test_delete_premium_search_results_removes_only_tagged(messages_repo):
     """Cleanup deletes only rows tagged with the query, leaving everything else."""
     await messages_repo.insert_message(make_message(13, 1, "user data with тест inside"))

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -766,3 +766,76 @@ async def test_get_recent_for_channels_joins_on_channel_id_not_pk(
 async def test_get_recent_for_channels_empty_ids(messages_repo):
     """Empty channel_ids returns [] without hitting the DB."""
     assert await messages_repo.get_recent_for_channels([], since_hours=24) == []
+
+
+# premium_search_query tag + cleanup tests
+
+
+async def _premium_tag(messages_repo, channel_id: int, message_id: int) -> str | None:
+    cur = await messages_repo._db.execute(
+        "SELECT premium_search_query FROM messages WHERE channel_id = ? AND message_id = ?",
+        (channel_id, message_id),
+    )
+    row = await cur.fetchone()
+    return row[0] if row else None
+
+
+async def test_insert_batch_tags_new_rows_with_premium_search_query(messages_repo):
+    """Premium search tags freshly inserted rows with the query string."""
+    msgs = [make_message(10, 1, "a"), make_message(10, 2, "b")]
+    inserted = await messages_repo.insert_messages_batch(msgs, premium_search_query="тест")
+    assert inserted == 2
+    assert await _premium_tag(messages_repo, 10, 1) == "тест"
+    assert await _premium_tag(messages_repo, 10, 2) == "тест"
+
+
+async def test_insert_batch_without_query_leaves_tag_null(messages_repo):
+    """A normal batch insert (no query) leaves premium_search_query NULL."""
+    await messages_repo.insert_messages_batch([make_message(11, 1, "a")])
+    assert await _premium_tag(messages_repo, 11, 1) is None
+
+
+async def test_premium_tag_not_applied_to_pre_existing_messages(messages_repo):
+    """INSERT OR IGNORE skips existing rows, so a later search never tags user data."""
+    # Pre-existing user message (e.g. collected by the worker), no tag.
+    await messages_repo.insert_message(make_message(12, 1, "collected by user"))
+    assert await _premium_tag(messages_repo, 12, 1) is None
+
+    # A Premium search returns the same message_id; it must NOT overwrite the row.
+    inserted = await messages_repo.insert_messages_batch(
+        [make_message(12, 1, "from search"), make_message(12, 2, "new from search")],
+        premium_search_query="тест",
+    )
+    assert inserted == 1  # only the genuinely new row was inserted
+    assert await _premium_tag(messages_repo, 12, 1) is None  # user row untouched
+    assert await _premium_tag(messages_repo, 12, 2) == "тест"  # new row tagged
+
+
+async def test_delete_premium_search_results_removes_only_tagged(messages_repo):
+    """Cleanup deletes only rows tagged with the query, leaving everything else."""
+    await messages_repo.insert_message(make_message(13, 1, "user data with тест inside"))
+    await messages_repo.insert_messages_batch(
+        [make_message(13, 2, "search hit"), make_message(14, 1, "search hit 2")],
+        premium_search_query="тест",
+    )
+    await messages_repo.insert_messages_batch(
+        [make_message(15, 1, "other search")], premium_search_query="другое"
+    )
+
+    deleted = await messages_repo.delete_premium_search_results("тест")
+    assert deleted == 2
+
+    # Tagged-by-"тест" rows gone; user row and the "другое" row survive.
+    assert await _premium_tag(messages_repo, 13, 2) is None
+    assert await _premium_tag(messages_repo, 14, 1) is None
+    cur = await messages_repo._db.execute("SELECT channel_id, message_id FROM messages ORDER BY channel_id, message_id")
+    remaining = {(r[0], r[1]) for r in await cur.fetchall()}
+    assert remaining == {(13, 1), (15, 1)}
+
+
+async def test_delete_premium_search_results_no_match_returns_zero(messages_repo):
+    """Purging an unknown query deletes nothing and reports zero."""
+    await messages_repo.insert_message(make_message(16, 1, "untagged"))
+    assert await messages_repo.delete_premium_search_results("nothing") == 0
+    cur = await messages_repo._db.execute("SELECT COUNT(*) FROM messages")
+    assert (await cur.fetchone())[0] == 1

--- a/tests/test_real_telegram_policy.py
+++ b/tests/test_real_telegram_policy.py
@@ -148,6 +148,7 @@ _CLI_CLEANUP_COMMAND_PRODUCERS = {
     ("my-telegram", "unpin-message"): {("my-telegram", "pin-message")},
     ("photo-loader", "batch-cancel"): {("photo-loader", "schedule-send")},
     ("scheduler", "clear-pending"): {("collect",), ("scheduler", "trigger")},
+    ("search",): {("search",)},
 }
 _AUDIT_EXCLUDED_FILES = {"test_real_telegram_policy.py"}
 

--- a/tests/test_search_persistence.py
+++ b/tests/test_search_persistence.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import Channel
+from src.models import Channel, Message
 from src.search.persistence import SearchPersistence
+
+
+def _msg(channel_id: int, message_id: int) -> Message:
+    return Message(
+        channel_id=channel_id,
+        message_id=message_id,
+        text="hit",
+        date=datetime.now(timezone.utc),
+    )
 
 
 @pytest.mark.anyio
@@ -61,3 +71,48 @@ async def test_cache_search_results_skips_stats_for_existing_channels():
 
     create_stats_task.assert_not_awaited()
     fetch_channel_meta.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_cache_search_results_tags_messages_with_query():
+    """Premium search passes the query through to insert_messages_batch as the tag."""
+    bundle = MagicMock()
+    bundle.channels.get_channel_by_channel_id = AsyncMock(return_value=Channel(channel_id=100, title="X"))
+    bundle.add_channel = AsyncMock(return_value=1)
+    bundle.log_search = AsyncMock()
+    bundle.insert_messages_batch = AsyncMock(return_value=1)
+    bundle.messages.get_messages_by_channel_message_ids = AsyncMock(return_value=[])
+
+    persistence = SearchPersistence(bundle, AsyncMock(return_value=7), AsyncMock())
+
+    await persistence.cache_search_results(
+        {100: Channel(channel_id=100, title="X")},
+        [_msg(100, 1)],
+        "+1",
+        "тест",
+    )
+
+    bundle.insert_messages_batch.assert_awaited_once()
+    _, kwargs = bundle.insert_messages_batch.await_args
+    assert kwargs.get("premium_search_query") == "тест"
+
+
+@pytest.mark.anyio
+async def test_cache_messages_and_channels_does_not_tag():
+    """Non-premium caching (my_chats/channel) inserts without a premium_search_query tag."""
+    bundle = MagicMock()
+    bundle.channels.get_channel_by_channel_id = AsyncMock(return_value=Channel(channel_id=100, title="X"))
+    bundle.add_channel = AsyncMock(return_value=1)
+    bundle.insert_messages_batch = AsyncMock(return_value=1)
+    bundle.messages.get_messages_by_channel_message_ids = AsyncMock(return_value=[])
+
+    persistence = SearchPersistence(bundle, AsyncMock(return_value=7), AsyncMock())
+
+    await persistence.cache_messages_and_channels(
+        {100: Channel(channel_id=100, title="X")},
+        [_msg(100, 1)],
+    )
+
+    bundle.insert_messages_batch.assert_awaited_once()
+    _, kwargs = bundle.insert_messages_batch.await_args
+    assert "premium_search_query" not in kwargs


### PR DESCRIPTION
## Что

Добавляет очистку кэша Premium-поиска: сообщения, вставленные глобальным Premium-поиском, помечаются строкой запроса (`premium_search_query`), что позволяет удалить ровно эти строки, не трогая собранные пользовательские данные.

Ключевая гарантия: `INSERT OR IGNORE` пропускает уже существующие строки, поэтому они **никогда** не получают тег — `delete_premium_search_results()` удаляет только то, что добавил сам поиск.

## Изменения

- **DB**: колонка `premium_search_query` на `messages` + частичный индекс (`WHERE ... IS NOT NULL`, нулевая write-amplification на горячем пути сбора) + миграция
- **repo**: `insert_messages_batch(premium_search_query=...)`, `delete_premium_search_results(query)`
- **CLI**: `search <query> --purge-cache` (ранний выход без подъёма ClientPool)
- **Web**: `POST /search/purge-cache` — JSON-эндпоинт (без DOM-swap), зеркалит CLI
- **persistence**: Premium-поиск прокидывает запрос как тег; non-premium кэширование (my_chats/channel) — без тега
- **parity.md**: запись CLI↔Web

## Cleanup-рефакторинг (из /simplify)

- Общий `_json_body()` в `web/search/handlers.py` — дедуплицирует content-type guard с `translate_message`
- Вынесен `_promote_primary_if_none(conn, *, active_only)` — единственный владелец «заполнить дыру primary» инварианта (#733), переиспользован в `set_account_active` и `delete_account` (поведение каждого вызова сохранено дословно)

## Тесты

- repo: тегирование новых строк, NULL без запроса, нетронутость pre-existing строк, удаление только помеченных, zero-on-no-match
- persistence: Premium тегирует, non-premium — нет
- live mutation-safe CLI-тест (`test_search_telegram_premium.py`) чистит за собой через purge-путь; зарегистрирован в manifest + real_telegram_policy

Локально: `accounts` (38), `messages` repo, `search_persistence`, web accounts-routes — всё зелёное; ruff чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)