### PR TITLE
fix(agent): SSE keepalive + shared total deadline instead of idle timeout

### DIFF
--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -426,6 +426,15 @@ async def chat(request: Request, thread_id: int):
                 if done_data is not None:
                     break
         finally:
+            if pending_chunk_task is not None and not pending_chunk_task.done():
+                pending_chunk_task.cancel()
+                pending_chunk_task.add_done_callback(_consume_abandoned_next_chunk)
+                done, _ = await asyncio.wait({pending_chunk_task}, timeout=1.0)
+                if not done:
+                    logger.debug(
+                        "Agent stream next-chunk task did not finish after cancellation for thread %d",
+                        thread_id,
+                    )
             if pending_chunk_task is None or pending_chunk_task.done():
                 try:
                     await agen.aclose()

--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -10,15 +10,17 @@ import sqlite3
 from fastapi import HTTPException, Request
 
 from src.agent.models import CLAUDE_MODELS
+from src.utils.json import safe_json_dumps
 from src.web import deps
 from src.web.agent.forms import select_model
 from src.web.agent.responses import AgentJson, AgentRedirect, AgentStream, AgentTemplate
 
 logger = logging.getLogger(__name__)
 
-# Max seconds the agent SSE stream may go without emitting a chunk before we
-# abort it. This prevents a hung LLM/backend from holding the connection open.
-_SSE_IDLE_TIMEOUT = 180.0
+# How often the agent SSE wrapper wakes up while the backend has not emitted a
+# chunk yet. This is a keepalive cadence, not a cancellation deadline. The hard
+# cancellation deadline is config.agent.total_timeout (shared with the backends).
+_SSE_KEEPALIVE_INTERVAL = 15.0
 
 _SAVE_FAILED_WARNING = (
     "❗ Ответ не удалось сохранить — он пропадёт при перезагрузке страницы."
@@ -319,6 +321,7 @@ async def chat(request: Request, thread_id: int):
 
     # Use HTTP session cookie as session_id so per-user overrides are isolated
     session_id = request.cookies.get("session", "web")
+    total_timeout_sec = request.app.state.config.agent.total_timeout
 
     async def generate():
         def _consume_abandoned_next_chunk(task: asyncio.Task) -> None:
@@ -339,28 +342,43 @@ async def chat(request: Request, thread_id: int):
         agen = stream.__aiter__()
         waiting_for_permission = False
         pending_chunk_task: asyncio.Task | None = None
+        loop = asyncio.get_running_loop()
+        stream_started_at = loop.time()
+        deadline = stream_started_at + total_timeout_sec
         try:
             while True:
                 try:
                     if waiting_for_permission:
                         chunk = await agen.__anext__()
                     else:
-                        next_chunk_task = asyncio.create_task(agen.__anext__())
-                        done, _ = await asyncio.wait({next_chunk_task}, timeout=_SSE_IDLE_TIMEOUT)
-                        if not done:
-                            pending_chunk_task = next_chunk_task
-                            next_chunk_task.cancel()
-                            next_chunk_task.add_done_callback(_consume_abandoned_next_chunk)
+                        if pending_chunk_task is None:
+                            pending_chunk_task = asyncio.create_task(agen.__anext__())
+                        remaining_total = deadline - loop.time()
+                        if remaining_total <= 0:
                             raise asyncio.TimeoutError
-                        chunk = next_chunk_task.result()
+                        wait_timeout = min(_SSE_KEEPALIVE_INTERVAL, remaining_total)
+                        done, _ = await asyncio.wait({pending_chunk_task}, timeout=wait_timeout)
+                        if not done:
+                            elapsed = int(loop.time() - stream_started_at)
+                            status = {
+                                "type": "status",
+                                "text": f"Агент всё ещё работает... {elapsed}с",
+                            }
+                            yield f"data: {safe_json_dumps(status, ensure_ascii=False)}\n\n"
+                            continue
+                        chunk = pending_chunk_task.result()
+                        pending_chunk_task = None
                 except StopAsyncIteration:
                     break
                 except asyncio.TimeoutError:
                     logger.warning(
-                        "Agent SSE stream for thread %d idle >%.0fs; aborting",
+                        "Agent SSE stream for thread %d exceeded total timeout %.0fs; aborting",
                         thread_id,
-                        _SSE_IDLE_TIMEOUT,
+                        total_timeout_sec,
                     )
+                    if pending_chunk_task is not None and not pending_chunk_task.done():
+                        pending_chunk_task.cancel()
+                        pending_chunk_task.add_done_callback(_consume_abandoned_next_chunk)
                     try:
                         await agent_manager.cancel_stream(thread_id, wait_timeout=5.0)
                     except Exception:
@@ -405,6 +423,8 @@ async def chat(request: Request, thread_id: int):
                     yield f"data: {json.dumps(done_data, ensure_ascii=False)}\n\n"
                 else:
                     yield chunk
+                if done_data is not None:
+                    break
         finally:
             if pending_chunk_task is None or pending_chunk_task.done():
                 try:

--- a/tests/routes/test_agent_routes_streaming.py
+++ b/tests/routes/test_agent_routes_streaming.py
@@ -256,6 +256,45 @@ async def test_chat_streaming_second_message_survives_keepalive_after_first_turn
 
 
 @pytest.mark.anyio
+async def test_chat_streaming_client_disconnect_closes_pending_stream(client, db, monkeypatch):
+    from src.web.agent import handlers
+
+    thread_id = await db.create_agent_thread("Chat")
+    mock_mgr = client._transport_app.state.agent_manager
+    monkeypatch.setattr(handlers, "_SSE_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(client._transport_app.state.config.agent, "total_timeout", 1)
+    closed = asyncio.Event()
+
+    class HangingStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            closed.set()
+
+    def _hanging_stream(*a, **kw):
+        return HangingStream()
+
+    mock_mgr.chat_stream = _hanging_stream
+
+    async with client.stream(
+        "POST",
+        f"/agent/threads/{thread_id}/chat",
+        json={"message": "hello"},
+    ) as resp:
+        assert resp.status_code == 200
+        async for line in resp.aiter_lines():
+            if '"type": "status"' in line:
+                break
+
+    await asyncio.wait_for(closed.wait(), timeout=0.2)
+
+
+@pytest.mark.anyio
 async def test_chat_permission_request_waits_without_idle_timeout(client, db, monkeypatch):
     from src.web.agent import handlers
 

--- a/tests/routes/test_agent_routes_streaming.py
+++ b/tests/routes/test_agent_routes_streaming.py
@@ -136,13 +136,14 @@ async def test_chat_rejects_malformed_json(client, db):
 
 
 @pytest.mark.anyio
-async def test_chat_streaming_idle_timeout_cancels_with_bounded_wait(client, db, monkeypatch):
+async def test_chat_streaming_total_timeout_cancels_with_bounded_wait(client, db, monkeypatch):
     from src.web.agent import handlers
 
     thread_id = await db.create_agent_thread("Chat")
     mock_mgr = client._transport_app.state.agent_manager
     mock_mgr.cancel_stream = AsyncMock(return_value=True)
-    monkeypatch.setattr(handlers, "_SSE_IDLE_TIMEOUT", 0.01)
+    monkeypatch.setattr(handlers, "_SSE_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(client._transport_app.state.config.agent, "total_timeout", 0.02)
     cleanup_started = asyncio.Event()
     cleanup_release = asyncio.Event()
 
@@ -174,13 +175,95 @@ async def test_chat_streaming_idle_timeout_cancels_with_bounded_wait(client, db,
 
 
 @pytest.mark.anyio
+async def test_chat_streaming_keepalive_does_not_cancel_active_stream(client, db, monkeypatch):
+    from src.web.agent import handlers
+
+    thread_id = await db.create_agent_thread("Chat")
+    mock_mgr = client._transport_app.state.agent_manager
+    mock_mgr.cancel_stream = AsyncMock(return_value=True)
+    monkeypatch.setattr(handlers, "_SSE_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(client._transport_app.state.config.agent, "total_timeout", 1)
+
+    async def _slow_stream(*a, **kw):
+        await asyncio.sleep(0.03)
+        yield 'data: {"done": true, "full_text": "finished"}\n\n'
+
+    mock_mgr.chat_stream = _slow_stream
+
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        json={"message": "hello"},
+    )
+
+    assert resp.status_code == 200
+    assert '"type": "status"' in resp.text
+    assert "finished" in resp.text
+    assert "Agent response timed out" not in resp.text
+    mock_mgr.cancel_stream.assert_not_awaited()
+
+    messages = await db.get_agent_messages(thread_id)
+    assistant_msgs = [m for m in messages if m["role"] == "assistant"]
+    assert len(assistant_msgs) == 1
+    assert assistant_msgs[0]["content"] == "finished"
+
+
+@pytest.mark.anyio
+async def test_chat_streaming_second_message_survives_keepalive_after_first_turn(client, db, monkeypatch):
+    from src.web.agent import handlers
+
+    thread_id = await db.create_agent_thread("Chat")
+    mock_mgr = client._transport_app.state.agent_manager
+    mock_mgr.cancel_stream = AsyncMock(return_value=True)
+    monkeypatch.setattr(handlers, "_SSE_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(client._transport_app.state.config.agent, "total_timeout", 1)
+    prompts: list[str] = []
+
+    async def _two_turn_stream(_thread_id, prompt, **_kw):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            yield 'data: {"done": true, "full_text": "first answer"}\n\n'
+            return
+        await asyncio.sleep(0.03)
+        yield 'data: {"done": true, "full_text": "second answer"}\n\n'
+
+    mock_mgr.chat_stream = _two_turn_stream
+
+    first_resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        json={"message": "first prompt"},
+    )
+    second_resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        json={"message": "second prompt"},
+    )
+
+    assert first_resp.status_code == 200
+    assert second_resp.status_code == 200
+    assert "first answer" in first_resp.text
+    assert '"type": "status"' in second_resp.text
+    assert "second answer" in second_resp.text
+    assert "Agent response timed out" not in second_resp.text
+    assert prompts == ["first prompt", "second prompt"]
+    mock_mgr.cancel_stream.assert_not_awaited()
+
+    messages = await db.get_agent_messages(thread_id)
+    assert [(m["role"], m["content"]) for m in messages] == [
+        ("user", "first prompt"),
+        ("assistant", "first answer"),
+        ("user", "second prompt"),
+        ("assistant", "second answer"),
+    ]
+
+
+@pytest.mark.anyio
 async def test_chat_permission_request_waits_without_idle_timeout(client, db, monkeypatch):
     from src.web.agent import handlers
 
     thread_id = await db.create_agent_thread("Chat")
     mock_mgr = client._transport_app.state.agent_manager
     mock_mgr.cancel_stream = AsyncMock(return_value=True)
-    monkeypatch.setattr(handlers, "_SSE_IDLE_TIMEOUT", 0.01)
+    monkeypatch.setattr(handlers, "_SSE_KEEPALIVE_INTERVAL", 0.01)
+    monkeypatch.setattr(client._transport_app.state.config.agent, "total_timeout", 0.02)
 
     async def _permission_then_done(*a, **kw):
         yield 'data: {"type": "permission_request", "request_id": "r1", "tool": "WebSearch"}\n\n'

--- a/tests/test_cli_agent_commands.py
+++ b/tests/test_cli_agent_commands.py
@@ -485,6 +485,50 @@ def test_run_chat_status_events(capsys):
         run(_args(agent_action="chat", prompt="test", thread_id=1, model=None))
 
 
+def test_run_chat_two_messages_same_thread_with_status_on_second_turn(capsys):
+    db = make_cli_db()
+    config = make_cli_config()
+    mgr_first = _make_mgr(available=True)
+    mgr_second = _make_mgr(available=True)
+    auth = MagicMock(cleanup=AsyncMock())
+    pool = MagicMock(disconnect_all=AsyncMock())
+
+    async def _first_stream(*a, **kw):
+        yield f'data: {json.dumps({"text": "First reply"})}\n'
+        yield f'data: {json.dumps({"done": True})}\n'
+
+    async def _second_stream(*a, **kw):
+        yield f'data: {json.dumps({"type": "status", "text": "still working"})}\n'
+        yield f'data: {json.dumps({"type": "countdown", "text": "3s left"})}\n'
+        yield f'data: {json.dumps({"text": "Second reply"})}\n'
+        yield f'data: {json.dumps({"done": True})}\n'
+
+    mgr_first.chat_stream = _first_stream
+    mgr_second.chat_stream = _second_stream
+
+    with patch("src.cli.commands.agent.runtime.init_db", AsyncMock(return_value=(config, db))), \
+         patch("src.cli.commands.agent.runtime.init_pool", AsyncMock(return_value=(auth, pool))), \
+         patch("src.cli.commands.agent.runtime.redirect_logging_to_file", return_value=None), \
+         patch("src.cli.commands.agent.runtime.restore_logging"), \
+         patch("src.agent.manager.AgentManager", side_effect=[mgr_first, mgr_second]), \
+         patch("asyncio.run", fake_asyncio_run):
+        run(_args(agent_action="chat", prompt="first prompt", thread_id=7, model=None))
+        run(_args(agent_action="chat", prompt="second prompt", thread_id=7, model=None))
+
+    captured = capsys.readouterr()
+    assert "Агент: First reply" in captured.out
+    assert "Агент: Second reply" in captured.out
+    assert "still working" in captured.err
+    assert "3s left" in captured.err
+    assert [call.args for call in db.save_agent_message.await_args_list] == [
+        (7, "user", "first prompt"),
+        (7, "assistant", "First reply"),
+        (7, "user", "second prompt"),
+        (7, "assistant", "Second reply"),
+    ]
+    db.delete_last_agent_exchange.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # run() — chat interactive TUI mode
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The agent chat SSE wrapper previously aborted the stream after 180s without a chunk from the backend (`_SSE_IDLE_TIMEOUT`), which killed long-but-healthy agent turns. This replaces the per-chunk idle timeout with:

- a **15s keepalive cadence** (`_SSE_KEEPALIVE_INTERVAL`) that emits a visible `{"type": "status", "text": "Агент всё ещё работает... Nс"}` frame instead of cancelling, and
- a **hard total deadline** read from the shared `config.agent.total_timeout` (default 300s) — the same knob the `ClaudeSdkBackend`/`codex_backend` already enforce, so the web layer no longer carries an uncoordinated magic constant.

## Quality cleanups (from `/simplify`)

- Reuse one `pending_chunk_task` across keepalive wakeups instead of cancel-and-recreate, so non-resumable backend work is not abandoned.
- Read `config.agent.total_timeout` directly (typed Pydantic `int`) instead of a defensive `getattr`+`float()` chain with a duplicate default constant — matching `manager.py:642` / `codex_backend.py:164`.
- Emit the keepalive frame via `safe_json_dumps`, consistent with the rest of the agent SSE stack.
- Drop the throwaway temp-var when reading the chunk result.

## Test plan

- `pytest tests/routes/test_agent_routes_streaming.py tests/test_cli_agent_commands.py` — 55 passed.
- New coverage: keepalive does not cancel an active slow stream; a second message on the same thread survives keepalive after the first turn; total-timeout cancels with bounded wait; CLI consumes `status`/`countdown` frames on a second turn.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)