### PR TITLE
feat(agent): auto-resolve omitted image model for generate_image

### DIFF
--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -8,11 +8,17 @@ from collections.abc import Awaitable, Callable
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Literal, TypeVar
 
 _T = TypeVar("_T")
 RuntimeKind = Literal["live", "snapshot", "none"]
 DEFAULT_SYNC_TIMEOUT_SEC = 120.0
+# Per-tool sync-bridge deadline overrides. generate_image must exceed the
+# slowest image adapter's own timeout (CODEX_IMAGE_TIMEOUT_SECONDS = 180s in
+# provider_adapters.py) so the adapter times out first with its specific
+# message and subprocess kill — the generic bridge deadline is only a backstop.
+DEFAULT_TOOL_SYNC_TIMEOUT_SEC = MappingProxyType({"generate_image": 240.0})
 
 
 class AgentToolRuntimeError(RuntimeError):
@@ -43,6 +49,11 @@ class AgentRuntimeContext:
     runtime_kind: RuntimeKind = "none"
     owner_loop: asyncio.AbstractEventLoop | None = None
     sync_timeout_sec: float | None = DEFAULT_SYNC_TIMEOUT_SEC
+    tool_sync_timeout_sec: dict[str, float | None] | None = None
+
+    def __post_init__(self) -> None:
+        if self.tool_sync_timeout_sec is None:
+            self.tool_sync_timeout_sec = dict(DEFAULT_TOOL_SYNC_TIMEOUT_SEC)
 
     @classmethod
     def build(
@@ -82,6 +93,11 @@ class AgentRuntimeContext:
                 return
         self.owner_loop = loop
 
+    def _sync_timeout_for_tool(self, tool_name: str) -> float | None:
+        if self.tool_sync_timeout_sec and tool_name in self.tool_sync_timeout_sec:
+            return self.tool_sync_timeout_sec[tool_name]
+        return self.sync_timeout_sec
+
     def run_sync(self, tool_name: str, operation: Callable[[], Awaitable[_T]]) -> _T:
         """Run an async operation from a sync tool thread."""
         try:
@@ -109,11 +125,8 @@ class AgentRuntimeContext:
                 cancel_event = None
                 permission_wait_tracker = None
 
-            deadline = (
-                time.monotonic() + self.sync_timeout_sec
-                if self.sync_timeout_sec is not None
-                else None
-            )
+            sync_timeout_sec = self._sync_timeout_for_tool(tool_name)
+            deadline = time.monotonic() + sync_timeout_sec if sync_timeout_sec is not None else None
             while True:
                 if cancel_event is not None and cancel_event.is_set():
                     future.cancel()
@@ -133,7 +146,7 @@ class AgentRuntimeContext:
                     if remaining <= 0:
                         future.cancel()
                         raise AgentToolRuntimeError(
-                            f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime.",
+                            _tool_timeout_message(tool_name, sync_timeout_sec),
                             retryable=True,
                         )
                     poll_timeout = min(poll_timeout, remaining)
@@ -151,6 +164,8 @@ class AgentRuntimeContext:
                         retryable=True,
                     ) from exc
                 except FutureTimeoutError as exc:
+                    if future.done():
+                        return future.result(timeout=0)
                     permission_waiting = (
                         permission_wait_tracker is not None
                         and permission_wait_tracker.is_waiting()
@@ -160,7 +175,7 @@ class AgentRuntimeContext:
                     elif deadline is not None and deadline <= time.monotonic():
                         future.cancel()
                         raise AgentToolRuntimeError(
-                            f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime.",
+                            _tool_timeout_message(tool_name, sync_timeout_sec),
                             retryable=True,
                         ) from exc
 
@@ -171,3 +186,13 @@ class AgentRuntimeContext:
             f"Agent tool '{tool_name}' cannot run inside an active event loop without a sync bridge.",
             retryable=True,
         )
+
+
+def _tool_timeout_message(tool_name: str, timeout_sec: float | None) -> str:
+    if tool_name == "generate_image" and timeout_sec is not None:
+        seconds = int(timeout_sec)
+        return (
+            f"Генерация изображения заняла больше {seconds} секунд и была остановлена. "
+            "Это не означает, что Telegram-аккаунт отключен."
+        )
+    return f"Agent tool '{tool_name}' timed out while waiting for the live Telegram runtime."

--- a/src/agent/tools/deepagents_sync.py
+++ b/src/agent/tools/deepagents_sync.py
@@ -189,10 +189,13 @@ def _tool_error_text(tool_name: str, exc: Exception) -> str:
     if isinstance(exc, AgentToolRuntimeError):
         error_type = "runtime_error"
         retryable = True
-        message = (
-            f"Ошибка runtime инструмента {tool_name}: {exc}. "
-            "Это не означает, что аккаунт отключён или чат не существует."
-        )
+        if tool_name == "generate_image":
+            message = str(exc)
+        else:
+            message = (
+                f"Ошибка runtime инструмента {tool_name}: {exc}. "
+                "Это не означает, что аккаунт отключён или чат не существует."
+            )
     elif isinstance(exc, RuntimeError):
         error_type = "runtime_error"
         retryable = True

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -154,6 +154,9 @@ def register(db, client_pool, embedding_service, **kwargs):
                 )
             if result:
                 return _text_response(f"Изображение сгенерировано:\n{result}")
+            failure = getattr(svc, "last_failure", None)
+            if failure is not None and getattr(failure, "is_timeout", False):
+                return _text_response(failure.user_message(lang="ru"))
             return _text_response("Генерация не вернула результат.")
         except Exception as e:
             return _text_response(f"Ошибка генерации изображения: {e}")

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -31,17 +31,6 @@ GENERATE_IMAGE_SCHEMA = {
 }
 
 
-async def _read_image_setting(db, key: str) -> str:
-    if db is None:
-        return ""
-    try:
-        value = await db.get_setting(key)
-    except Exception:
-        logger.warning("Failed to read image setting %s", key, exc_info=True)
-        return ""
-    return value.strip() if isinstance(value, str) else ""
-
-
 def _default_model_for_adapters(adapter_names) -> str:
     from src.services.image_provider_service import IMAGE_PROVIDER_ORDER, image_provider_spec
 
@@ -72,9 +61,16 @@ async def resolve_default_image_model(requested_model, db, image_service) -> str
     if isinstance(requested_model, str) and requested_model.strip():
         return requested_model.strip()
 
-    configured_model = await _read_image_setting(db, "default_image_model")
-    if configured_model:
-        return configured_model
+    if db is not None:
+        try:
+            value = await db.get_setting("default_image_model")
+        except Exception:
+            logger.warning("Failed to read default_image_model setting", exc_info=True)
+            value = None
+        # get_setting's contract is str | None; the isinstance guard also coerces
+        # bare-MagicMock returns to "" on the deepagents-sync test path.
+        if isinstance(value, str) and value.strip():
+            return value.strip()
 
     return _default_model_for_adapters(image_service.adapter_names)
 

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -56,6 +56,13 @@ def _no_default_model_message(adapter_names) -> str:
     return message
 
 
+def _is_model_provider_available(model: str, adapter_names) -> bool:
+    provider, sep, _ = model.partition(":")
+    if not sep:
+        return True
+    return provider in set(adapter_names)
+
+
 async def resolve_default_image_model(requested_model, db, image_service) -> str:
     """Return the explicit image model to use for an agent generate_image call."""
     if isinstance(requested_model, str) and requested_model.strip():
@@ -70,7 +77,14 @@ async def resolve_default_image_model(requested_model, db, image_service) -> str
         # get_setting's contract is str | None; the isinstance guard also coerces
         # bare-MagicMock returns to "" on the deepagents-sync test path.
         if isinstance(value, str) and value.strip():
-            return value.strip()
+            saved_model = value.strip()
+            if _is_model_provider_available(saved_model, image_service.adapter_names):
+                return saved_model
+            logger.warning(
+                "Ignoring default_image_model=%s because its provider is not available; adapters=%s",
+                saved_model,
+                image_service.adapter_names,
+            )
 
     return _default_model_for_adapters(image_service.adapter_names)
 

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -14,6 +14,42 @@ from src.web.paths import DATA_IMAGE_DIR
 logger = logging.getLogger(__name__)
 
 
+async def _read_image_setting(db, key: str) -> str:
+    if db is None:
+        return ""
+    try:
+        value = await db.get_setting(key)
+    except Exception:
+        logger.warning("Failed to read image setting %s", key, exc_info=True)
+        return ""
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _default_model_for_adapters(adapter_names) -> str:
+    from src.services.image_provider_service import IMAGE_PROVIDER_ORDER, image_provider_spec
+
+    available = set(adapter_names)
+    for provider in IMAGE_PROVIDER_ORDER:
+        if provider not in available:
+            continue
+        spec = image_provider_spec(provider)
+        if spec and spec.default_model:
+            return spec.default_model
+    return ""
+
+
+async def resolve_default_image_model(requested_model, db, image_service) -> str:
+    """Return the explicit image model to use for an agent generate_image call."""
+    if isinstance(requested_model, str) and requested_model.strip():
+        return requested_model.strip()
+
+    configured_model = await _read_image_setting(db, "default_image_model")
+    if configured_model:
+        return configured_model
+
+    return _default_model_for_adapters(image_service.adapter_names)
+
+
 def register(db, client_pool, embedding_service, **kwargs):
     config = kwargs.get("config")
     tools = []
@@ -37,12 +73,12 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     @tool(
         "generate_image",
-        "Generate an image from a text prompt. Model format: 'provider:model_id' "
+        "Generate an image from a text prompt. Optional model format: 'provider:model_id' "
         "(e.g. 'together:black-forest-labs/FLUX.1-schnell'). "
-        "Use list_image_providers to see available providers, list_image_models for models.",
+        "When omitted, the configured/default image model is used automatically.",
         {
             "prompt": Annotated[str, "Текстовый промпт для генерации изображения"],
-            "model": Annotated[str, "Модель в формате provider:model_id (например together:FLUX.1-schnell)"],
+            "model": Annotated[str, "Необязательная модель в формате provider:model_id"],
         },
     )
     async def generate_image(args):
@@ -54,7 +90,14 @@ def register(db, client_pool, embedding_service, **kwargs):
             svc = await _build_image_service()
             if not await svc.is_available():
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
-            result = await svc.generate(model=model, text=prompt)
+            resolved_model = await resolve_default_image_model(model, db, svc)
+            if not resolved_model:
+                return _text_response(
+                    "Не удалось выбрать модель изображения автоматически. "
+                    "Задайте default_image_model в настройках или передайте model явно "
+                    "(например codex:gpt-5.4)."
+                )
+            result = await svc.generate(model=resolved_model, text=prompt)
             if result and (result.startswith("https://") or result.startswith("http://")):
                 import hashlib
                 from urllib.parse import urlparse
@@ -85,7 +128,7 @@ def register(db, client_pool, embedding_service, **kwargs):
                 logger.info("Image downloaded to %s", local_path)
                 if db:
                     await db.repos.generated_images.save(
-                        prompt=prompt, model=model, image_url=result, local_path=local_path,
+                        prompt=prompt, model=resolved_model, image_url=result, local_path=local_path,
                     )
                 return _text_response(
                     f"Изображение создано!\n\n"

--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -14,6 +14,23 @@ from src.web.paths import DATA_IMAGE_DIR
 logger = logging.getLogger(__name__)
 
 
+GENERATE_IMAGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": "Текстовый промпт для генерации изображения",
+        },
+        "model": {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "description": "Необязательная модель в формате provider:model_id",
+        },
+    },
+    "required": ["prompt"],
+    "additionalProperties": False,
+}
+
+
 async def _read_image_setting(db, key: str) -> str:
     if db is None:
         return ""
@@ -36,6 +53,18 @@ def _default_model_for_adapters(adapter_names) -> str:
         if spec and spec.default_model:
             return spec.default_model
     return ""
+
+
+def _no_default_model_message(adapter_names) -> str:
+    names = sorted({str(name) for name in adapter_names if name})
+    message = (
+        "Не удалось выбрать модель изображения автоматически. "
+        "Задайте default_image_model в настройках или передайте model явно "
+        "в формате provider:model_id (например together:black-forest-labs/FLUX.1-schnell)."
+    )
+    if names:
+        message += f" Доступные adapters: {', '.join(names)}."
+    return message
 
 
 async def resolve_default_image_model(requested_model, db, image_service) -> str:
@@ -76,10 +105,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         "Generate an image from a text prompt. Optional model format: 'provider:model_id' "
         "(e.g. 'together:black-forest-labs/FLUX.1-schnell'). "
         "When omitted, the configured/default image model is used automatically.",
-        {
-            "prompt": Annotated[str, "Текстовый промпт для генерации изображения"],
-            "model": Annotated[str, "Необязательная модель в формате provider:model_id"],
-        },
+        GENERATE_IMAGE_SCHEMA,
     )
     async def generate_image(args):
         prompt = args.get("prompt", "")
@@ -92,11 +118,7 @@ def register(db, client_pool, embedding_service, **kwargs):
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
             resolved_model = await resolve_default_image_model(model, db, svc)
             if not resolved_model:
-                return _text_response(
-                    "Не удалось выбрать модель изображения автоматически. "
-                    "Задайте default_image_model в настройках или передайте model явно "
-                    "(например codex:gpt-5.4)."
-                )
+                return _text_response(_no_default_model_message(svc.adapter_names))
             result = await svc.generate(model=resolved_model, text=prompt)
             if result and (result.startswith("https://") or result.startswith("http://")):
                 import hashlib

--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -9,6 +9,13 @@ from src.cli import runtime
 from src.services.image_generation_service import ImageGenerationService
 
 
+def _generation_failure_text(svc: ImageGenerationService, model: str | None) -> str:
+    failure = svc.last_failure
+    if failure is not None and getattr(failure, "is_timeout", False):
+        return failure.user_message(lang="en")
+    return "Generation failed — check logs"
+
+
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         action = args.image_action
@@ -25,7 +32,7 @@ def run(args: argparse.Namespace) -> None:
             if result:
                 print(f"Result: {result}")
             else:
-                print("Generation failed — check logs")
+                print(_generation_failure_text(svc, model))
 
         elif action == "models":
             provider = args.provider

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -10,6 +11,51 @@ if TYPE_CHECKING:
     from src.services.s3_store import S3Store
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ImageGenerationFailure:
+    kind: str
+    provider: str | None
+    model: str | None
+    message: str
+    retryable: bool = True
+
+    @property
+    def is_timeout(self) -> bool:
+        return self.kind == "timeout"
+
+    def user_message(self, *, lang: str = "ru") -> str:
+        """User-facing explanation of the failure, in Russian (``ru``) or English (``en``).
+
+        Centralizes the timeout wording so the agent/CLI/web callers don't each
+        re-derive it (and re-import the Codex timeout constant)."""
+        if not self.is_timeout:
+            return "Генерация не вернула результат." if lang == "ru" else "Generation failed — check logs"
+
+        model = self.model or ("по умолчанию" if lang == "ru" else "default")
+        if (self.model or "").startswith("codex:"):
+            from src.services.provider_adapters import CODEX_IMAGE_TIMEOUT_SECONDS
+
+            seconds = int(CODEX_IMAGE_TIMEOUT_SECONDS)
+            if lang == "ru":
+                return (
+                    f"Генерация изображения через {model} не успела завершиться за {seconds} секунд. "
+                    "Процесс Codex остановлен; попробуйте позже или передайте model другого провайдера."
+                )
+            return (
+                f"Generation timed out for model={model} after {seconds}s. "
+                "The Codex process was stopped; try again later or choose another image provider/model."
+            )
+        if lang == "ru":
+            return (
+                f"Генерация изображения через {model} не успела завершиться за таймаут. "
+                "Попробуйте позже или выберите другую модель."
+            )
+        return (
+            f"Generation timed out for model={model}. "
+            "Try again later or choose another image provider/model."
+        )
 
 
 class ImageGenerationService:
@@ -24,6 +70,7 @@ class ImageGenerationService:
     def __init__(self, adapters: dict[str, "ImageAdapter"] | None = None) -> None:
         self._adapters: dict[str, ImageAdapter] = {}
         self._s3: S3Store | None = None
+        self._last_failure: ImageGenerationFailure | None = None
         if adapters is not None:
             self._adapters = dict(adapters)
         else:
@@ -34,20 +81,52 @@ class ImageGenerationService:
 
     async def generate(self, model: str | None, text: str) -> str | None:
         """Generate an image for *text* using *model*.  Returns URL/path or ``None``."""
+        self._last_failure = None
         if not text or not self._adapters:
             return None
         provider_name, model_id = self._parse_model_string(model)
         adapter = self._resolve_adapter(provider_name)
         if adapter is None:
             logger.warning("No image adapter available for model=%s", model)
+            self._set_failure(
+                kind="no_adapter",
+                provider=provider_name,
+                model=model,
+                message=f"No image adapter available for model={model}",
+                retryable=False,
+            )
             return None
         try:
             result = await adapter(text, model_id)
-        except (OSError, asyncio.TimeoutError) as exc:
-            logger.warning("Image generation failed (model=%s): %s", model, exc)
+        except TimeoutError as exc:
+            logger.warning("Image generation timed out (model=%s): %s", model, exc)
+            self._set_failure(
+                kind="timeout",
+                provider=provider_name,
+                model=model,
+                message=str(exc),
+                retryable=True,
+            )
             return None
-        except Exception:
+        except OSError as exc:
+            logger.warning("Image generation failed (model=%s): %s", model, exc)
+            self._set_failure(
+                kind="error",
+                provider=provider_name,
+                model=model,
+                message=str(exc),
+                retryable=True,
+            )
+            return None
+        except Exception as exc:
             logger.exception("Image generation unexpected error (model=%s)", model)
+            self._set_failure(
+                kind="error",
+                provider=provider_name,
+                model=model,
+                message=str(exc),
+                retryable=True,
+            )
             return None
         if result and not result.startswith("http") and getattr(self, "_s3", None) is not None:
             s3_url = await self._s3.upload_file(result)
@@ -66,7 +145,28 @@ class ImageGenerationService:
     def adapter_names(self) -> list[str]:
         return list(self._adapters.keys())
 
+    @property
+    def last_failure(self) -> ImageGenerationFailure | None:
+        return self._last_failure
+
     # ── internals ──
+
+    def _set_failure(
+        self,
+        *,
+        kind: str,
+        provider: str | None,
+        model: str | None,
+        message: str,
+        retryable: bool,
+    ) -> None:
+        self._last_failure = ImageGenerationFailure(
+            kind=kind,
+            provider=provider,
+            model=model,
+            message=message,
+            retryable=retryable,
+        )
 
     def _init_s3(self) -> None:
         from src.services.s3_store import S3Store

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -64,10 +64,10 @@ class ImageProviderSpec:
     # search_models(refresh=True) live fetch; receives the service so instance
     # monkeypatching of the underlying _fetch_* methods is honoured
     fetch_models: Callable[..., Awaitable[list[dict]]] | None = None
-    # When True, never chosen as the implicit default adapter — only on explicit
-    # ``provider:model`` selection. Set for adapters that are slow/expensive to
-    # invoke (Codex spawns a blocking subprocess), so an unqualified generate()
-    # never silently triggers them.
+    # When True, ImageGenerationService._resolve_adapter never chooses this as
+    # the unqualified fallback adapter. Callers may still intentionally resolve
+    # an omitted UI/tool model into this provider's fully qualified
+    # ``provider:model`` default before calling generate().
     explicit_only: bool = False
     # Default model override for providers without a static catalog. Providers
     # that declare a static_catalog derive their default from its first entry

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -69,10 +69,26 @@ class ImageProviderSpec:
     # invoke (Codex spawns a blocking subprocess), so an unqualified generate()
     # never silently triggers them.
     explicit_only: bool = False
+    # Default model override for providers without a static catalog. Providers
+    # that declare a static_catalog derive their default from its first entry
+    # (see the `default_model` property) so the two never drift.
+    _default_model_override: str = ""
 
     @property
     def keyless(self) -> bool:
         return self.detect is not None
+
+    @property
+    def default_model(self) -> str:
+        """Fully qualified ``provider:model_id`` to use when a caller resolves an
+        omitted model before invoking ImageGenerationService.generate().
+
+        Derived from the first static-catalog entry when one exists, so the
+        advertised default and the catalog can never diverge.
+        """
+        if self.static_catalog:
+            return self.static_catalog[0]["model_string"]
+        return self._default_model_override
 
 
 IMAGE_PROVIDER_SPECS: dict[str, ImageProviderSpec] = {
@@ -91,6 +107,7 @@ IMAGE_PROVIDER_SPECS: dict[str, ImageProviderSpec] = {
         "HuggingFace",
         ["HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN"],
         keyed_factory=lambda key: _pa().make_huggingface_image_adapter(key),
+        _default_model_override="huggingface:stabilityai/stable-diffusion-xl-base-1.0",
     ),
     "openai": ImageProviderSpec(
         "openai",
@@ -118,6 +135,7 @@ IMAGE_PROVIDER_SPECS: dict[str, ImageProviderSpec] = {
         "Replicate",
         ["REPLICATE_API_TOKEN"],
         keyed_factory=lambda key: _pa().make_replicate_image_adapter(key),
+        _default_model_override="replicate:black-forest-labs/flux-schnell",
     ),
     # Codex is keyless — auth comes from the Codex CLI (~/.codex/auth.json), so
     # there are no env vars to configure; it is registered on detection and its

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -357,6 +357,7 @@ CODEX_DEFAULT_IMAGE_MODEL = "gpt-5.4"
 # worker thread, so the executor slot is freed shortly after — not leaked for
 # the process lifetime.
 CODEX_IMAGE_TIMEOUT_SECONDS = 180.0
+CODEX_IMAGE_CLOSE_TIMEOUT_SECONDS = 15.0
 
 
 def _build_codex_image_prompt(prompt: str, output_path: str) -> str:
@@ -472,6 +473,26 @@ _CODEX_RUN_EXECUTOR = ThreadPoolExecutor(max_workers=4, thread_name_prefix="code
 _CODEX_CLOSE_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="codex-image-close")
 
 
+async def _close_codex_image_subprocess(
+    loop: asyncio.AbstractEventLoop,
+    codex: Any,
+    *,
+    reason: str,
+    image_timeout: float,
+) -> None:
+    if reason == "timeout":
+        logger.warning("Codex image generation timed out after %.0fs; closing Codex subprocess", image_timeout)
+    elif reason == "cancelled":
+        logger.warning("Codex image generation was cancelled by caller; closing Codex subprocess")
+    try:
+        await asyncio.wait_for(
+            loop.run_in_executor(_CODEX_CLOSE_EXECUTOR, codex.close),
+            timeout=CODEX_IMAGE_CLOSE_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.warning("Codex image: failed to close stalled subprocess", exc_info=True)
+
+
 def make_codex_image_adapter(
     output_dir: str = DEFAULT_IMAGE_OUTPUT_DIR,
     image_timeout: float = CODEX_IMAGE_TIMEOUT_SECONDS,
@@ -525,7 +546,7 @@ def make_codex_image_adapter(
             saved = await asyncio.wait_for(
                 loop.run_in_executor(_CODEX_RUN_EXECUTOR, _run_codex), timeout=image_timeout
             )
-        except (TimeoutError, asyncio.TimeoutError):
+        except TimeoutError:
             codex = codex_box.get("codex")
             if codex is not None:
                 # close() → terminate()/kill(); the SDK's reader thread then
@@ -533,10 +554,14 @@ def make_codex_image_adapter(
                 # Submit on the SEPARATE close pool: when the run pool is
                 # saturated by hangs, close() still gets a free slot — it's what
                 # kills the subprocess and frees the parked run slot.
-                try:
-                    await loop.run_in_executor(_CODEX_CLOSE_EXECUTOR, codex.close)
-                except Exception:
-                    logger.warning("Codex image: failed to close stalled subprocess", exc_info=True)
+                await _close_codex_image_subprocess(loop, codex, reason="timeout", image_timeout=image_timeout)
+            raise
+        except asyncio.CancelledError:
+            codex = codex_box.get("codex")
+            if codex is not None:
+                await asyncio.shield(
+                    _close_codex_image_subprocess(loop, codex, reason="cancelled", image_timeout=image_timeout)
+                )
             raise
         # Prefer the path Codex reported (it may pick its own filename inside our
         # output dir), but confine it to the requested directory: the prompt is

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -73,6 +73,12 @@ async def generate_image(request: Request) -> ImagesJson:
 
     result = await svc.generate(form.model or None, form.prompt)
     if result is None:
+        failure = svc.last_failure
+        if getattr(failure, "kind", "") == "timeout":
+            return ImagesJson(
+                {"ok": False, "error": "Image generation timed out. Try again later or choose another model."},
+                status_code=500,
+            )
         return ImagesJson({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
 
     return ImagesJson(

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -90,6 +91,7 @@ async def test_generate_failure(route_client, monkeypatch):
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=True)
     mock_svc.generate = AsyncMock(return_value=None)
+    mock_svc.last_failure = None
     monkeypatch.setattr(
         "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
@@ -99,6 +101,23 @@ async def test_generate_failure(route_client, monkeypatch):
     body = resp.json()
     assert body["ok"] is False
     assert "Generation failed" in body["error"]
+
+
+@pytest.mark.anyio
+async def test_generate_timeout_failure(route_client, monkeypatch):
+    mock_svc = MagicMock()
+    mock_svc.is_available = AsyncMock(return_value=True)
+    mock_svc.generate = AsyncMock(return_value=None)
+    mock_svc.last_failure = SimpleNamespace(kind="timeout")
+    monkeypatch.setattr(
+        "src.web.images.handlers._get_image_service",
+        AsyncMock(return_value=mock_svc),
+    )
+    resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"] == "Image generation timed out. Try again later or choose another model."
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_tool_smoke_contract.py
+++ b/tests/test_agent_tool_smoke_contract.py
@@ -62,7 +62,10 @@ def _minimal_deepagents_kwargs(tool_name: str) -> dict[str, object]:
         "to_chat": "@to_chat",
         "user_id": "@user",
     }
-    return {name: samples.get(name, "contract") for name in _REQUIRED_ARGS_BY_TOOL.get(tool_name, frozenset())}
+    kwargs = {name: samples.get(name, "contract") for name in _REQUIRED_ARGS_BY_TOOL.get(tool_name, frozenset())}
+    if tool_name == "generate_image":
+        kwargs["model"] = "stub:contract"
+    return kwargs
 
 
 async def _seed_read_only_contract_data(db) -> None:

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -689,6 +689,7 @@ class TestImageToolsDBProviders:
             # Setup image service mock
             img_instance = mock_img_svc.return_value
             img_instance.is_available = AsyncMock(return_value=True)
+            img_instance.adapter_names = ["together"]
             img_instance.generate = AsyncMock(return_value="/tmp/image.png")
 
             handlers = _get_tool_handlers(mock_db, config=fake_config)

--- a/tests/test_agent_tools_images.py
+++ b/tests/test_agent_tools_images.py
@@ -10,6 +10,18 @@ from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
 class TestImagesToolGenerateImage:
+    def test_mcp_schema_allows_omitted_model(self, mock_db):
+        from src.agent.tools import images
+
+        tools = images.register(mock_db, None, MagicMock(), config={})
+        schema = next(tool.input_schema for tool in tools if tool.name == "generate_image")
+
+        assert schema["type"] == "object"
+        assert schema["required"] == ["prompt"]
+        assert "model" in schema["properties"]
+        assert "model" not in schema["required"]
+        assert {"type": "null"} in schema["properties"]["model"]["anyOf"]
+
     @pytest.mark.anyio
     async def test_missing_prompt(self, mock_db):
         handlers = _get_tool_handlers(mock_db)
@@ -117,6 +129,8 @@ class TestImagesToolGenerateImage:
             result = await handlers["generate_image"]({"prompt": "a cat"})
         text = _text(result)
         assert "default_image_model" in text
+        assert "custom" in text
+        assert "codex:gpt-5.4" not in text
         mock_svc.return_value.generate.assert_not_called()
 
 

--- a/tests/test_agent_tools_images.py
+++ b/tests/test_agent_tools_images.py
@@ -28,6 +28,7 @@ class TestImagesToolGenerateImage:
     async def test_local_path_result(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["together"]
             mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["generate_image"]({"prompt": "a dog"})
@@ -38,6 +39,7 @@ class TestImagesToolGenerateImage:
     async def test_no_result(self, mock_db):
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["together"]
             mock_svc.return_value.generate = AsyncMock(return_value=None)
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["generate_image"]({"prompt": "something"})
@@ -50,6 +52,72 @@ class TestImagesToolGenerateImage:
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["generate_image"]({"prompt": "test"})
         assert "Ошибка" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_omitted_model_uses_db_default(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value="openai:gpt-image-1")
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["codex"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+        assert "/local/path/image.png" in _text(result)
+        mock_svc.return_value.generate.assert_awaited_once_with(
+            model="openai:gpt-image-1", text="a cat"
+        )
+
+    @pytest.mark.anyio
+    async def test_none_model_codex_only_uses_codex_default(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["codex"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": None})
+        assert "/local/path/image.png" in _text(result)
+        mock_svc.return_value.generate.assert_awaited_once_with(
+            model="codex:gpt-5.4", text="a cat"
+        )
+
+    @pytest.mark.anyio
+    async def test_blank_model_uses_adapter_default(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["together"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": ""})
+        assert "/local/path/image.png" in _text(result)
+        mock_svc.return_value.generate.assert_awaited_once_with(
+            model="together:black-forest-labs/FLUX.1-schnell", text="a cat"
+        )
+
+    @pytest.mark.anyio
+    async def test_explicit_model_is_not_overwritten(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value="openai:gpt-image-1")
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["codex"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": "codex:gpt-5.4"})
+        assert "/local/path/image.png" in _text(result)
+        mock_svc.return_value.generate.assert_awaited_once_with(
+            model="codex:gpt-5.4", text="a cat"
+        )
+
+    @pytest.mark.anyio
+    async def test_available_service_without_default_returns_actionable_message(self, mock_db):
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["custom"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+        text = _text(result)
+        assert "default_image_model" in text
+        mock_svc.return_value.generate.assert_not_called()
 
 
 class TestImagesToolListImageModels:

--- a/tests/test_agent_tools_images.py
+++ b/tests/test_agent_tools_images.py
@@ -90,13 +90,27 @@ class TestImagesToolGenerateImage:
         mock_db.get_setting = AsyncMock(return_value="openai:gpt-image-1")
         with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
-            mock_svc.return_value.adapter_names = ["codex"]
+            mock_svc.return_value.adapter_names = ["openai"]
             mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["generate_image"]({"prompt": "a cat"})
         assert "/local/path/image.png" in _text(result)
         mock_svc.return_value.generate.assert_awaited_once_with(
             model="openai:gpt-image-1", text="a cat"
+        )
+
+    @pytest.mark.anyio
+    async def test_stale_db_default_falls_back_to_available_adapter_default(self, mock_db):
+        mock_db.get_setting = AsyncMock(return_value="openai:gpt-image-1")
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["together"]
+            mock_svc.return_value.generate = AsyncMock(return_value="/local/path/image.png")
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+        assert "/local/path/image.png" in _text(result)
+        mock_svc.return_value.generate.assert_awaited_once_with(
+            model="together:black-forest-labs/FLUX.1-schnell", text="a cat"
         )
 
     @pytest.mark.anyio

--- a/tests/test_agent_tools_images.py
+++ b/tests/test_agent_tools_images.py
@@ -53,9 +53,29 @@ class TestImagesToolGenerateImage:
             mock_svc.return_value.is_available = AsyncMock(return_value=True)
             mock_svc.return_value.adapter_names = ["together"]
             mock_svc.return_value.generate = AsyncMock(return_value=None)
+            mock_svc.return_value.last_failure = None
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["generate_image"]({"prompt": "something"})
         assert "не вернула результат" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_timeout_failure_returns_specific_text(self, mock_db):
+        from src.services.image_generation_service import ImageGenerationFailure
+
+        with patch("src.services.image_generation_service.ImageGenerationService") as mock_svc:
+            mock_svc.return_value.is_available = AsyncMock(return_value=True)
+            mock_svc.return_value.adapter_names = ["codex"]
+            mock_svc.return_value.generate = AsyncMock(return_value=None)
+            mock_svc.return_value.last_failure = ImageGenerationFailure(
+                kind="timeout", provider="codex", model="codex:gpt-5.4", message="timed out"
+            )
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["generate_image"]({"prompt": "a cat"})
+        text = _text(result)
+        assert "Генерация изображения через codex:gpt-5.4" in text
+        assert "180 секунд" in text
+        assert "Процесс Codex остановлен" in text
+        assert "не вернула результат" not in text
 
     @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):

--- a/tests/test_cli_image_scheduler_web_routes.py
+++ b/tests/test_cli_image_scheduler_web_routes.py
@@ -112,11 +112,31 @@ class TestCLIImageCommand:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=True)
             svc.generate = AsyncMock(return_value=None)
+            svc.last_failure = None
             mock_svc_cls.return_value = svc
 
             run(_run_ns(image_action="generate", model=None, prompt="a cat"))
             out = capsys.readouterr().out
             assert "Generation failed" in out
+
+    def test_generate_timeout_failure(self, capsys):
+        """generate action prints actionable timeout message when the service reports timeout."""
+        from src.cli.commands.image import run
+        from src.services.image_generation_service import ImageGenerationFailure
+
+        with patch("src.cli.commands.image.ImageGenerationService") as mock_svc_cls:
+            svc = MagicMock()
+            svc.is_available = AsyncMock(return_value=True)
+            svc.generate = AsyncMock(return_value=None)
+            svc.last_failure = ImageGenerationFailure(
+                kind="timeout", provider="codex", model="codex:gpt-5.4", message="timed out"
+            )
+            mock_svc_cls.return_value = svc
+
+            run(_run_ns(image_action="generate", model="codex:gpt-5.4", prompt="a cat"))
+            out = capsys.readouterr().out
+            assert "Generation timed out for model=codex:gpt-5.4 after 180s" in out
+            assert "choose another image provider/model" in out
 
     def test_models_no_results(self, capsys):
         """models action with no results prints message."""

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -1088,7 +1088,11 @@ class TestAgentRuntimeContextRunSync:
         assert result == 42
 
     def test_sync_bridge_keeps_runtime_timeout_independent_from_permission_timeout(self):
-        from src.agent.runtime_context import DEFAULT_SYNC_TIMEOUT_SEC, AgentRuntimeContext
+        from src.agent.runtime_context import (
+            DEFAULT_SYNC_TIMEOUT_SEC,
+            DEFAULT_TOOL_SYNC_TIMEOUT_SEC,
+            AgentRuntimeContext,
+        )
 
         config = MagicMock()
         config.agent.permission_timeout = 77
@@ -1096,11 +1100,15 @@ class TestAgentRuntimeContextRunSync:
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
         assert ctx.sync_timeout_sec == DEFAULT_SYNC_TIMEOUT_SEC
+        assert DEFAULT_TOOL_SYNC_TIMEOUT_SEC["generate_image"] == 240.0
+        assert ctx._sync_timeout_for_tool("test_tool") == DEFAULT_SYNC_TIMEOUT_SEC
+        assert ctx._sync_timeout_for_tool("generate_image") == 240.0
 
         config.agent.permission_timeout = 130
         ctx = AgentRuntimeContext.build(db=MagicMock(), config=config)
 
         assert ctx.sync_timeout_sec == DEFAULT_SYNC_TIMEOUT_SEC
+        assert ctx._sync_timeout_for_tool("test_tool") == DEFAULT_SYNC_TIMEOUT_SEC
 
     @pytest.mark.anyio
     async def test_inside_event_loop_raises(self):
@@ -1182,6 +1190,28 @@ class TestAgentRuntimeContextRunSync:
         with pytest.raises(AgentToolRuntimeError, match="timed out"):
             await asyncio.wait_for(task, timeout=2.0)
         await asyncio.wait_for(cancelled.wait(), timeout=2.0)
+
+    @pytest.mark.anyio
+    async def test_generate_image_sync_bridge_allows_adapter_timeout_before_runtime_timeout(self):
+        from src.agent.runtime_context import AgentRuntimeContext
+
+        ctx = AgentRuntimeContext.build(
+            db=MagicMock(),
+            client_pool=MagicMock(),
+            runtime_kind="live",
+            owner_loop=asyncio.get_running_loop(),
+        )
+        ctx.sync_timeout_sec = 0.02
+        ctx.tool_sync_timeout_sec = {"generate_image": 0.2}
+
+        async def _op():
+            await asyncio.sleep(0.05)
+            raise TimeoutError("adapter timeout")
+
+        task = asyncio.create_task(asyncio.to_thread(ctx.run_sync, "generate_image", _op))
+
+        with pytest.raises(TimeoutError, match="adapter timeout"):
+            await asyncio.wait_for(task, timeout=2.0)
 
     @pytest.mark.anyio
     async def test_sync_bridge_excludes_permission_waits_from_runtime_timeout(self):

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -1716,7 +1716,7 @@ class TestImageToolEdgeCases:
                     new_callable=AsyncMock, return_value=True), \
              patch("src.services.image_generation_service.ImageGenerationService.generate",
                    new_callable=AsyncMock, return_value="/local/path.png"):
-            result = await handlers["generate_image"]({"prompt": "cat"})
+            result = await handlers["generate_image"]({"prompt": "cat", "model": "together:flux"})
             assert "/local/path.png" in _text(result)
 
     async def test_generate_image_returns_none(self, image_setup):
@@ -1725,7 +1725,7 @@ class TestImageToolEdgeCases:
                     new_callable=AsyncMock, return_value=True), \
              patch("src.services.image_generation_service.ImageGenerationService.generate",
                    new_callable=AsyncMock, return_value=None):
-            result = await handlers["generate_image"]({"prompt": "cat"})
+            result = await handlers["generate_image"]({"prompt": "cat", "model": "together:flux"})
             assert "не вернул" in _text(result).lower()
 
     async def test_generate_image_exception(self, image_setup):
@@ -1734,7 +1734,7 @@ class TestImageToolEdgeCases:
                     new_callable=AsyncMock, return_value=True), \
              patch("src.services.image_generation_service.ImageGenerationService.generate",
                    new_callable=AsyncMock, side_effect=RuntimeError("fail")):
-            result = await handlers["generate_image"]({"prompt": "cat"})
+            result = await handlers["generate_image"]({"prompt": "cat", "model": "together:flux"})
             assert "ошибка" in _text(result).lower()
 
     async def test_list_image_models_empty_provider(self, image_setup):
@@ -2516,7 +2516,7 @@ class TestDeepagentsSyncExceptions:
             "src.services.image_generation_service.ImageGenerationService.generate",
             side_effect=RuntimeError("fail"),
         ):
-            result = tools["generate_image"]("test prompt")
+            result = tools["generate_image"]("test prompt", model="together:flux")
             assert "ошибка" in result.lower()
 
     def test_list_image_providers_exception(self, sync_tools):

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -864,7 +864,7 @@ class TestDeepagentsSyncGenerateImage:
         img_svc_mock = MagicMock()
         img_svc_mock.is_available = AsyncMock(return_value=True)
         img_svc_mock.generate = AsyncMock(return_value=None)
-        img_svc_mock.adapter_names = []
+        img_svc_mock.adapter_names = ["together"]
         with patch(
             "src.services.image_generation_service.ImageGenerationService",
             return_value=img_svc_mock,
@@ -877,7 +877,7 @@ class TestDeepagentsSyncGenerateImage:
         img_svc_mock = MagicMock()
         img_svc_mock.is_available = AsyncMock(return_value=True)
         img_svc_mock.generate = AsyncMock(side_effect=Exception("gen fail"))
-        img_svc_mock.adapter_names = []
+        img_svc_mock.adapter_names = ["together"]
         with patch(
             "src.services.image_generation_service.ImageGenerationService",
             return_value=img_svc_mock,
@@ -885,6 +885,21 @@ class TestDeepagentsSyncGenerateImage:
             tool_map = _build_sync_tools(mock_db)
             result = tool_map["generate_image"](prompt="error")
         assert "Ошибка" in result
+
+    def test_codex_only_omitted_model_uses_codex_default(self, mock_db):
+        img_svc_mock = MagicMock()
+        img_svc_mock.is_available = AsyncMock(return_value=True)
+        img_svc_mock.generate = AsyncMock(return_value="/generated/codex.png")
+        img_svc_mock.adapter_names = ["codex"]
+        with patch(
+            "src.services.image_generation_service.ImageGenerationService",
+            return_value=img_svc_mock,
+        ):
+            tool_map = _build_sync_tools(mock_db)
+            result = tool_map["generate_image"](prompt="a cat")
+        assert "не вернула результат" not in result
+        assert "/generated/codex.png" in result
+        img_svc_mock.generate.assert_awaited_once_with(model="codex:gpt-5.4", text="a cat")
 
 
 # ===========================================================================

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -865,6 +865,7 @@ class TestDeepagentsSyncGenerateImage:
         img_svc_mock.is_available = AsyncMock(return_value=True)
         img_svc_mock.generate = AsyncMock(return_value=None)
         img_svc_mock.adapter_names = ["together"]
+        img_svc_mock.last_failure = None
         with patch(
             "src.services.image_generation_service.ImageGenerationService",
             return_value=img_svc_mock,
@@ -900,6 +901,52 @@ class TestDeepagentsSyncGenerateImage:
         assert "не вернула результат" not in result
         assert "/generated/codex.png" in result
         img_svc_mock.generate.assert_awaited_once_with(model="codex:gpt-5.4", text="a cat")
+
+    @pytest.mark.anyio
+    async def test_codex_only_live_sync_uses_tool_specific_timeout(self, mock_db):
+        import asyncio
+
+        from src.agent.runtime_context import AgentRuntimeContext
+
+        img_svc_mock = MagicMock()
+        img_svc_mock.is_available = AsyncMock(return_value=True)
+        img_svc_mock.adapter_names = ["codex"]
+
+        async def _generate(*, model, text):
+            await asyncio.sleep(0.05)
+            return "/generated/codex.png"
+
+        img_svc_mock.generate = AsyncMock(side_effect=_generate)
+        runtime_context = AgentRuntimeContext.build(
+            db=mock_db,
+            client_pool=MagicMock(),
+            runtime_kind="live",
+            owner_loop=asyncio.get_running_loop(),
+        )
+        runtime_context.sync_timeout_sec = 0.02
+        runtime_context.tool_sync_timeout_sec = {"generate_image": 0.2}
+        with patch(
+            "src.services.image_generation_service.ImageGenerationService",
+            return_value=img_svc_mock,
+        ):
+            tool_map = _build_sync_tools(mock_db, runtime_context=runtime_context)
+            result = await asyncio.to_thread(tool_map["generate_image"], prompt="a cat")
+        assert "/generated/codex.png" in result
+        assert "runtime_error" not in result
+
+    def test_generate_image_runtime_error_uses_image_timeout_text(self):
+        from src.agent.runtime_context import AgentToolRuntimeError
+        from src.agent.tools.deepagents_sync import _tool_error_text
+
+        message = (
+            "Генерация изображения заняла больше 240 секунд и была остановлена. "
+            "Это не означает, что Telegram-аккаунт отключен."
+        )
+        payload = json.loads(_tool_error_text("generate_image", AgentToolRuntimeError(message)))
+
+        assert payload["message"] == message
+        assert payload["error_type"] == "runtime_error"
+        assert payload["retryable"] is True
 
 
 # ===========================================================================

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -135,6 +135,17 @@ async def test_generate_catches_adapter_error():
     svc.register_adapter("broken", broken_adapter)
     result = await svc.generate("broken:m", "test prompt")
     assert result is None
+    assert svc.last_failure is not None
+    assert svc.last_failure.kind == "error"
+    assert svc.last_failure.model == "broken:m"
+
+    async def fixed_adapter(prompt: str, model: str) -> str:
+        return "https://img.example.com/fixed.png"
+
+    svc.register_adapter("broken", fixed_adapter)
+    result = await svc.generate("broken:m", "test prompt")
+    assert result == "https://img.example.com/fixed.png"
+    assert svc.last_failure is None
 
 
 # ── is_available() ──
@@ -413,6 +424,10 @@ async def test_generate_catches_os_error():
     svc.register_adapter("oserr", oserr_adapter)
     result = await svc.generate("oserr:m", "test")
     assert result is None
+    assert svc.last_failure is not None
+    assert svc.last_failure.kind == "error"
+    assert svc.last_failure.provider == "oserr"
+    assert svc.last_failure.retryable is True
 
 
 @pytest.mark.anyio
@@ -425,6 +440,11 @@ async def test_generate_catches_timeout_error():
     svc.register_adapter("timeout", timeout_adapter)
     result = await svc.generate("timeout:m", "test")
     assert result is None
+    assert svc.last_failure is not None
+    assert svc.last_failure.kind == "timeout"
+    assert svc.last_failure.provider == "timeout"
+    assert svc.last_failure.model == "timeout:m"
+    assert svc.last_failure.retryable is True
 
 
 # ── generate() no adapter for provider ──
@@ -437,6 +457,24 @@ async def test_generate_no_adapter_for_named_provider():
     # No adapters at all — _resolve_adapter returns None
     result = await svc.generate("beta:m", "test")
     assert result is None
+    assert svc.last_failure is None
+
+
+@pytest.mark.anyio
+async def test_generate_records_no_adapter_failure_for_explicit_only_default():
+    svc = _make_clean_service()
+
+    async def codex_adapter(prompt: str, model: str) -> str:
+        return "should-not-run"
+
+    svc.register_adapter("codex", codex_adapter)
+    result = await svc.generate(None, "test")
+    assert result is None
+    assert svc.last_failure is not None
+    assert svc.last_failure.kind == "no_adapter"
+    assert svc.last_failure.provider is None
+    assert svc.last_failure.model is None
+    assert svc.last_failure.retryable is False
 
 
 # ── _register_from_env with env vars ──

--- a/tests/test_image_provider_service.py
+++ b/tests/test_image_provider_service.py
@@ -297,6 +297,16 @@ def test_every_spec_is_keyed_xor_keyless():
             assert spec.env_vars, name  # keyed providers declare at least one env var
 
 
+def test_every_spec_has_fully_qualified_default_model():
+    from src.services.image_provider_service import IMAGE_PROVIDER_SPECS
+
+    for name, spec in IMAGE_PROVIDER_SPECS.items():
+        provider, sep, model_id = spec.default_model.partition(":")
+        assert sep == ":", name
+        assert provider == name
+        assert model_id
+
+
 @pytest.mark.anyio
 async def test_build_adapters_keyless_skipped_when_undetected(db, pin_codex):
     """A keyless provider whose detect() is False is simply not registered."""

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -858,9 +858,11 @@ def _install_fake_codex(
     import threading
 
     closed_event = threading.Event()
+    started_event = threading.Event()
 
     class FakeThread:
         def run(self, instruction):
+            started_event.set()
             if hang_seconds:
                 # Block as the real SDK does inside a blocking queue.get(); the
                 # only way out is close() firing closed_event (mirrors the SDK's
@@ -907,6 +909,7 @@ def _install_fake_codex(
     fake_mod.Codex = FakeCodex
     fake_mod.Sandbox = SimpleNamespace(workspace_write="workspace-write")
     monkeypatch.setitem(sys.modules, "openai_codex", fake_mod)
+    captured["started_event"] = started_event
     return captured
 
 
@@ -967,6 +970,25 @@ async def test_codex_image_adapter_times_out_and_kills_subprocess(monkeypatch, t
     with pytest.raises((asyncio.TimeoutError, TimeoutError)):
         await adapter("x", "gpt-5.4")
     # close() was called on timeout — without it the worker thread would leak.
+    assert captured.get("closed") is True
+
+
+@pytest.mark.anyio
+async def test_codex_image_adapter_cancel_closes_subprocess(monkeypatch, tmp_path):
+    """Caller cancellation also closes the Codex subprocess."""
+    import asyncio
+
+    from src.services.provider_adapters import make_codex_image_adapter
+
+    captured = _install_fake_codex(monkeypatch, hang_seconds=5.0)
+    adapter = make_codex_image_adapter(output_dir=str(tmp_path), image_timeout=5.0)
+
+    task = asyncio.create_task(adapter("x", "gpt-5.4"))
+    assert await asyncio.to_thread(captured["started_event"].wait, 1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
     assert captured.get("closed") is True
 
 

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -992,7 +992,7 @@ class TestGenerateImageTool:
             patch(f"{_svc_path}.generate", new=AsyncMock(return_value="/local/path/img.png")),
         ):
             handlers = _get_channel_tool_handlers(mock_db)
-            result = await handlers["generate_image"]({"prompt": "a cat"})
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": "together:flux"})
         text = _text(result)
         assert "/local/path/img.png" in text
 
@@ -1005,7 +1005,7 @@ class TestGenerateImageTool:
             patch(f"{_svc_path}.generate", new=AsyncMock(return_value=None)),
         ):
             handlers = _get_channel_tool_handlers(mock_db)
-            result = await handlers["generate_image"]({"prompt": "a cat"})
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": "together:flux"})
         text = _text(result)
         assert "не вернула" in text
 
@@ -1018,7 +1018,7 @@ class TestGenerateImageTool:
             patch(f"{_svc_path}.generate", new=AsyncMock(side_effect=Exception("api down"))),
         ):
             handlers = _get_channel_tool_handlers(mock_db)
-            result = await handlers["generate_image"]({"prompt": "a cat"})
+            result = await handlers["generate_image"]({"prompt": "a cat", "model": "together:flux"})
         text = _text(result)
         assert "Ошибка" in text
 


### PR DESCRIPTION
## Summary

- Make the agent `generate_image` `model` argument optional: when omitted, resolve it from the DB setting `default_image_model`, then fall back to the default model of the first available adapter (in `IMAGE_PROVIDER_ORDER`).
- An available-but-no-default image service now returns an actionable message ("set `default_image_model` or pass `model` explicitly") instead of failing silently.
- Explicit `model` selection is always passed through unchanged, including `explicit_only` providers like Codex — resolving an omitted model into an explicit `provider:model_id` string is intentional and distinct from the unqualified-`generate()` fallback that skips Codex.
- Add `ImageProviderSpec.default_model` as a property derived from `static_catalog[0]` when a catalog exists; `_default_model_override` is used only for catalog-less providers (huggingface/replicate), so the advertised default and the catalog can't drift.

## Test plan

- `pytest tests/test_agent_tools_images.py tests/test_image_provider_service.py tests/test_agent_tools.py::TestImageToolsDBProviders` — new cases cover DB-default, codex-only default, blank→adapter-default, explicit-not-overwritten, and the no-default actionable message.
- `pytest tests/test_deepagents_sync_provider_paths.py tests/test_cross_domain_regression_paths.py tests/test_settings_scheduler_pipeline_search_paths.py` — all green.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)