### PR TITLE
refactor(image): drop _set_failure indirection, unify timeout wording

### DIFF
--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -9,7 +9,7 @@ from src.cli import runtime
 from src.services.image_generation_service import ImageGenerationService
 
 
-def _generation_failure_text(svc: ImageGenerationService, model: str | None) -> str:
+def _generation_failure_text(svc: ImageGenerationService) -> str:
     failure = svc.last_failure
     if failure is not None and getattr(failure, "is_timeout", False):
         return failure.user_message(lang="en")
@@ -32,7 +32,7 @@ def run(args: argparse.Namespace) -> None:
             if result:
                 print(f"Result: {result}")
             else:
-                print(_generation_failure_text(svc, model))
+                print(_generation_failure_text(svc))
 
         elif action == "models":
             provider = args.provider

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -88,7 +88,7 @@ class ImageGenerationService:
         adapter = self._resolve_adapter(provider_name)
         if adapter is None:
             logger.warning("No image adapter available for model=%s", model)
-            self._set_failure(
+            self._last_failure = ImageGenerationFailure(
                 kind="no_adapter",
                 provider=provider_name,
                 model=model,
@@ -100,32 +100,19 @@ class ImageGenerationService:
             result = await adapter(text, model_id)
         except TimeoutError as exc:
             logger.warning("Image generation timed out (model=%s): %s", model, exc)
-            self._set_failure(
-                kind="timeout",
-                provider=provider_name,
-                model=model,
-                message=str(exc),
-                retryable=True,
-            )
-            return None
-        except OSError as exc:
-            logger.warning("Image generation failed (model=%s): %s", model, exc)
-            self._set_failure(
-                kind="error",
-                provider=provider_name,
-                model=model,
-                message=str(exc),
-                retryable=True,
+            self._last_failure = ImageGenerationFailure(
+                kind="timeout", provider=provider_name, model=model, message=str(exc),
             )
             return None
         except Exception as exc:
-            logger.exception("Image generation unexpected error (model=%s)", model)
-            self._set_failure(
-                kind="error",
-                provider=provider_name,
-                model=model,
-                message=str(exc),
-                retryable=True,
+            # OSError is an expected I/O failure — log calmly without a traceback;
+            # anything else is unexpected and warrants the full stack.
+            if isinstance(exc, OSError):
+                logger.warning("Image generation failed (model=%s): %s", model, exc)
+            else:
+                logger.exception("Image generation unexpected error (model=%s)", model)
+            self._last_failure = ImageGenerationFailure(
+                kind="error", provider=provider_name, model=model, message=str(exc),
             )
             return None
         if result and not result.startswith("http") and getattr(self, "_s3", None) is not None:
@@ -150,23 +137,6 @@ class ImageGenerationService:
         return self._last_failure
 
     # ── internals ──
-
-    def _set_failure(
-        self,
-        *,
-        kind: str,
-        provider: str | None,
-        model: str | None,
-        message: str,
-        retryable: bool,
-    ) -> None:
-        self._last_failure = ImageGenerationFailure(
-            kind=kind,
-            provider=provider,
-            model=model,
-            message=message,
-            retryable=retryable,
-        )
 
     def _init_s3(self) -> None:
         from src.services.s3_store import S3Store

--- a/src/web/images/handlers.py
+++ b/src/web/images/handlers.py
@@ -74,11 +74,8 @@ async def generate_image(request: Request) -> ImagesJson:
     result = await svc.generate(form.model or None, form.prompt)
     if result is None:
         failure = svc.last_failure
-        if getattr(failure, "kind", "") == "timeout":
-            return ImagesJson(
-                {"ok": False, "error": "Image generation timed out. Try again later or choose another model."},
-                status_code=500,
-            )
+        if failure is not None and getattr(failure, "is_timeout", False):
+            return ImagesJson({"ok": False, "error": failure.user_message(lang="en")}, status_code=500)
         return ImagesJson({"ok": False, "error": "Generation failed — check server logs"}, status_code=500)
 
     return ImagesJson(

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -105,10 +104,14 @@ async def test_generate_failure(route_client, monkeypatch):
 
 @pytest.mark.anyio
 async def test_generate_timeout_failure(route_client, monkeypatch):
+    from src.services.image_generation_service import ImageGenerationFailure
+
     mock_svc = MagicMock()
     mock_svc.is_available = AsyncMock(return_value=True)
     mock_svc.generate = AsyncMock(return_value=None)
-    mock_svc.last_failure = SimpleNamespace(kind="timeout")
+    mock_svc.last_failure = ImageGenerationFailure(
+        kind="timeout", provider="together", model="together:flux", message="timed out"
+    )
     monkeypatch.setattr(
         "src.web.images.handlers._get_image_service",
         AsyncMock(return_value=mock_svc),
@@ -117,7 +120,8 @@ async def test_generate_timeout_failure(route_client, monkeypatch):
     assert resp.status_code == 500
     body = resp.json()
     assert body["ok"] is False
-    assert body["error"] == "Image generation timed out. Try again later or choose another model."
+    assert "timed out" in body["error"].lower()
+    assert "together:flux" in body["error"]
 
 
 @pytest.mark.anyio

--- a/tests/test_cli_image_scheduler_web_routes.py
+++ b/tests/test_cli_image_scheduler_web_routes.py
@@ -572,6 +572,7 @@ class TestWebImagesRoutes:
             svc = MagicMock()
             svc.is_available = AsyncMock(return_value=True)
             svc.generate = AsyncMock(return_value=None)
+            svc.last_failure = None
             mock_svc_fn.return_value = svc
             resp = await route_client.post("/images/generate", data={"prompt": "a cat"})
         assert resp.status_code == 500


### PR DESCRIPTION
## Что

Чистка слоя обработки ошибок в `ImageGenerationService` поверх failure-tracking, добавленного в `0fae9ba`.

- **Убран `_set_failure`** — однострочный хелпер только пробрасывал kwargs в `ImageGenerationFailure(...)`. Теперь объект строится на месте в каждой ветке `except`.
- **Свёрнута отдельная ветка `OSError`** в общий `except Exception`: `OSError` остаётся спокойным `logger.warning` (ожидаемый I/O-сбой), всё остальное по-прежнему пишет полный трейс через `logger.exception`.
- **Web и CLI переиспользуют централизованные `is_timeout` / `user_message(lang=...)`** на объекте failure вместо повторного вывода timeout-текста в каждом месте вызова. Формулировка живёт в одном месте и теперь показывает виновную модель.

## Почему

`_set_failure` не добавлял логики — только лишний уровень косвенности. Дублирование timeout-текста в `handlers.py` и `image.py` расходилось бы с каноном на `ImageGenerationFailure`.

## Тесты

- `tests/routes/test_images_routes.py` — timeout-роут теперь строит реальный `ImageGenerationFailure` и проверяет, что в ответе есть и текст таймаута, и имя модели (`together:flux`).
- `tests/test_cli_image_scheduler_web_routes.py` — добавлен `last_failure = None` для пути generic-сбоя.

🤖 Generated with [Claude Code](https://claude.com/claude-code)