### PR TITLE
fix(collector): cap stuck collection by idle timeout, diagnose by stalled progress

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,8 @@ scheduler:
   collect_interval_minutes: 30
   delay_between_channels_sec: 2
   delay_between_requests_sec: 1
+  collection_stream_timeout_sec: 120
+  snapshot_publish_timeout_sec: 30
   max_flood_wait_sec: 300
   stats_all_max_channels_per_run: 10
   stats_all_cooldown_sec: 600

--- a/src/config.py
+++ b/src/config.py
@@ -26,6 +26,12 @@ class SchedulerConfig(BaseModel):
     collect_interval_minutes: int = 60
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1
+    # Per-post idle timeout while streaming a channel. 0/negative = disabled.
+    collection_stream_timeout_sec: float = 120.0
+    # asyncio.wait_for timeout around runtime-snapshot publishing. 0/negative or
+    # garbage is NOT "disabled" — it falls back to the safe default (a zero
+    # timeout would abort every heartbeat); see resolve_snapshot_publish_timeout.
+    snapshot_publish_timeout_sec: float = 30.0
     max_flood_wait_sec: int = 300
     stats_worker_count: int = 3
     stats_all_max_channels_per_run: int = 10

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -59,6 +59,7 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "run_after": "run_after TEXT",
         "payload": "payload TEXT",
         "parent_task_id": "parent_task_id INTEGER",
+        "last_progress_at": "last_progress_at TEXT",
     },
     "telegram_commands": {
         "run_after": "run_after TEXT",

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -338,6 +338,7 @@ class CollectionTasksRepository:
             "status = ?",
             "started_at = NULL",
             "completed_at = NULL",
+            "last_progress_at = NULL",
             "error = NULL",
         ]
         params: list[Any] = [CollectionTaskStatus.PENDING.value]

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -307,6 +307,7 @@ class CollectionTasksRepository:
             "run_after = ?",
             "started_at = NULL",
             "completed_at = NULL",
+            "last_progress_at = NULL",
             "error = NULL",
             "messages_collected = ?",
         ]

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -121,6 +121,11 @@ class CollectionTasksRepository:
             created_at=parse_datetime(row["created_at"]),
             started_at=parse_datetime(row["started_at"]),
             completed_at=parse_datetime(row["completed_at"]),
+            last_progress_at=(
+                parse_datetime(row["last_progress_at"])
+                if "last_progress_at" in row.keys()
+                else None
+            ),
         )
 
     async def create_collection_task(
@@ -221,9 +226,10 @@ class CollectionTasksRepository:
         return cur.lastrowid or 0
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
+        now = datetime.now(tz=timezone.utc).isoformat()
         await self._database.execute_write(
-            "UPDATE collection_tasks SET messages_collected = ? WHERE id = ?",
-            (messages_collected, task_id),
+            "UPDATE collection_tasks SET messages_collected = ?, last_progress_at = ? WHERE id = ?",
+            (messages_collected, now, task_id),
         )
 
     async def persist_stats_progress(
@@ -254,6 +260,10 @@ class CollectionTasksRepository:
         params: list[Any] = [status_value]
         if status_value == CollectionTaskStatus.RUNNING.value:
             sets.append("started_at = ?")
+            params.append(now)
+            # Seed the progress clock so a just-started task reads as fresh
+            # rather than "stuck since NULL" before its first batch flushes.
+            sets.append("last_progress_at = ?")
             params.append(now)
         terminal = (CollectionTaskStatus.COMPLETED.value, CollectionTaskStatus.FAILED.value)
         if status_value in terminal:
@@ -578,7 +588,7 @@ class CollectionTasksRepository:
         placeholders = ", ".join("?" for _ in handled_types)
         cur = await self._database.execute_write(
             f"UPDATE collection_tasks "
-            f"SET status = 'running', started_at = ?, completed_at = NULL "
+            f"SET status = 'running', started_at = ?, last_progress_at = ?, completed_at = NULL "
             f"WHERE id = ("
             f"    SELECT id FROM collection_tasks "
             f"    WHERE task_type IN ({placeholders}) "
@@ -586,7 +596,7 @@ class CollectionTasksRepository:
             f"    AND (run_after IS NULL OR run_after <= ?) "
             f"    ORDER BY COALESCE(run_after, ''), id ASC LIMIT 1"
             f") RETURNING *",
-            (now_iso, *handled_types, CollectionTaskStatus.PENDING.value, now_iso),
+            (now_iso, now_iso, *handled_types, CollectionTaskStatus.PENDING.value, now_iso),
         )
         row = await cur.fetchone()
         if row is None:

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -83,7 +83,8 @@ CREATE TABLE IF NOT EXISTS collection_tasks (
     parent_task_id INTEGER,
     created_at TEXT DEFAULT (datetime('now')),
     started_at TEXT,
-    completed_at TEXT
+    completed_at TEXT,
+    last_progress_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS telegram_commands (

--- a/src/models.py
+++ b/src/models.py
@@ -206,6 +206,9 @@ class CollectionTask(BaseModel):
     created_at: datetime | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    # When progress (messages_collected) last advanced — used by the scheduler
+    # health page to tell a genuinely stuck collection apart from a downed worker.
+    last_progress_at: datetime | None = None
 
 
 class ChannelStats(BaseModel):

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -11,12 +11,15 @@ from src.config import AppConfig
 from src.database.repositories.accounts import AccountSessionDecryptError
 from src.models import RuntimeSnapshot
 from src.services.notification_service import NotificationService
+from src.services.runtime_diagnostics import HEARTBEAT_INTERVAL_SEC, resolve_snapshot_publish_timeout
 from src.telegram.utils import normalize_utc
 from src.web.bootstrap import build_worker_container, start_container, stop_container
 from src.web.log_handler import LogBuffer
 
 logger = logging.getLogger(__name__)
-HEARTBEAT_INTERVAL_SEC = 5.0
+# HEARTBEAT_INTERVAL_SEC is the single source of truth in runtime_diagnostics.
+# The snapshot-publish timeout comes from config
+# (scheduler.snapshot_publish_timeout_sec).
 
 
 def _current_task_is_cancelling() -> bool:
@@ -234,10 +237,14 @@ async def _run_worker_async(config: AppConfig) -> None:
         await _publish_worker_down_snapshot(container, exc)
         await stop_container(container)
         return
+    publish_timeout = resolve_snapshot_publish_timeout(config.scheduler.snapshot_publish_timeout_sec)
     try:
         while not stop_event.is_set():
             try:
-                await _publish_snapshots(container, stop_event=stop_event)
+                await asyncio.wait_for(
+                    _publish_snapshots(container, stop_event=stop_event),
+                    timeout=publish_timeout,
+                )
             except asyncio.CancelledError:
                 if _current_task_is_cancelling():
                     raise
@@ -245,6 +252,11 @@ async def _run_worker_async(config: AppConfig) -> None:
                     logger.info("Worker stopping during snapshot publish")
                     break
                 logger.warning("Worker snapshot publish was cancelled; continuing worker loop")
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Worker snapshot publish timed out after %.1fs; continuing worker loop",
+                    publish_timeout,
+                )
             try:
                 await asyncio.wait_for(stop_event.wait(), timeout=HEARTBEAT_INTERVAL_SEC)
             except asyncio.TimeoutError:

--- a/src/services/runtime_diagnostics.py
+++ b/src/services/runtime_diagnostics.py
@@ -12,10 +12,67 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+# How often the worker (both the standalone `src/runtime/worker.py` and the
+# embedded `src/web/embedded_worker.py`) republishes `worker_heartbeat` and the
+# other runtime snapshots. Single source of truth so the two worker flavours
+# cannot drift apart.
+HEARTBEAT_INTERVAL_SEC = 5.0
+
 # The worker publishes `worker_heartbeat` every ~5s
 # (src/runtime/worker.py:_publish_snapshots). Anything older than this means the
-# worker process is effectively down.
+# worker process is effectively down. 60s = 12 missed beats of slack.
 WORKER_HEARTBEAT_STALE_AFTER_SEC = 60.0
+
+# Floor for "a RUNNING channel-collect task whose progress hasn't advanced is
+# stuck". The effective threshold is derived per-request as
+# max(RUNNING_TASK_STALE_AFTER_SEC, collection_stream_timeout_sec + grace) — see
+# running_task_stale_after() — so raising the per-channel idle timeout in config
+# automatically pushes the "stuck" verdict out instead of the UI crying stuck
+# while the collector is still legally waiting for the next post.
+RUNNING_TASK_STALE_AFTER_SEC = 300.0
+
+# Extra slack on top of the per-channel idle timeout before a stalled task is
+# called stuck — covers between-channel pauses and one in-flight DB flush.
+RUNNING_TASK_STALE_GRACE_SEC = 60.0
+
+# Default snapshot-publish timeout (asyncio.wait_for around _publish_snapshots).
+# A configured 0/negative/garbage value is coerced back to this by
+# resolve_snapshot_publish_timeout(), because wait_for(timeout<=0) would abort
+# every heartbeat on its first pass and silently flip the UI to worker_down.
+DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC = 30.0
+
+
+def running_task_stale_after(idle_timeout_sec: float | None) -> float:
+    """Threshold (seconds) past which a non-progressing RUNNING task is stuck.
+
+    Derived from the per-channel idle timeout so the two stay in lock-step: the
+    collector may legitimately wait up to ``collection_stream_timeout_sec`` for
+    the next post, so "stuck" must be at least that plus grace. A disabled
+    (0/None) idle timeout leaves only the static floor.
+    """
+    try:
+        idle = float(idle_timeout_sec) if idle_timeout_sec else 0.0
+    except (TypeError, ValueError):
+        idle = 0.0
+    if idle <= 0:
+        return RUNNING_TASK_STALE_AFTER_SEC
+    return max(RUNNING_TASK_STALE_AFTER_SEC, idle + RUNNING_TASK_STALE_GRACE_SEC)
+
+
+def resolve_snapshot_publish_timeout(value: object) -> float:
+    """Coerce a configured snapshot-publish timeout to a safe positive float.
+
+    0, negative, None or non-numeric all fall back to
+    DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC so a misconfiguration can never make
+    asyncio.wait_for abort every heartbeat instantly.
+    """
+    try:
+        timeout = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
+    if timeout <= 0:
+        return DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
+    return timeout
 
 
 @dataclass(frozen=True)

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 from abc import ABC, abstractmethod
@@ -19,6 +20,8 @@ from src.telegram.reactions import normalize_outgoing_reaction_emoji
 from src.telegram.session_materializer import SessionMaterializer
 
 logger = logging.getLogger(__name__)
+
+STREAM_ITERATOR_CLOSE_TIMEOUT_SEC = 10.0
 
 
 async def fetch_message_reaction_users_raw(client: Any, peer: Any, message_id: int, *, limit: int) -> Any:
@@ -123,7 +126,18 @@ class TelegramTransportSession:
                 if aclose is not None:
                     result = aclose()
                     if inspect.isawaitable(result):
-                        await result
+                        try:
+                            await asyncio.wait_for(
+                                result, timeout=STREAM_ITERATOR_CLOSE_TIMEOUT_SEC
+                            )
+                        except asyncio.TimeoutError:
+                            self._logger.warning(
+                                "%s: iterator close timed out after %.1fs",
+                                operation,
+                                STREAM_ITERATOR_CLOSE_TIMEOUT_SEC,
+                            )
+                        except Exception:
+                            self._logger.debug("%s: iterator close failed", operation, exc_info=True)
         except HandledFloodWaitError:
             raise
         except Exception as exc:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -48,6 +48,7 @@ from src.telegram.session_materializer import SessionMaterializer
 from src.telegram.utils import normalize_utc
 
 logger = logging.getLogger(__name__)
+REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC = 5.0
 
 
 @dataclass
@@ -699,22 +700,32 @@ class ClientPool:
         self._session_overrides.pop(phone, None)
         async with self._lock:
             leases = list(self._active_leases.pop(phone, []))
-        for lease in reversed(leases):
-            if lease.disconnect_on_release:
-                try:
-                    await self._backend_router.release(lease)
-                except Exception:
-                    logger.debug("Failed to release live lease for %s", phone, exc_info=True)
         client = self.clients.pop(phone, None)
-        if isinstance(client, TelegramTransportSession):
-            try:
-                await client.raw_client.disconnect()
-            except Exception:
-                logger.debug("Failed to disconnect session for %s", phone, exc_info=True)
         self._in_use.discard(phone)
         self._dialogs_fetched.discard(phone)
         self.invalidate_dialogs_cache(phone)
         self.clear_premium_flood(phone)
+        for lease in reversed(leases):
+            if lease.disconnect_on_release:
+                try:
+                    await asyncio.wait_for(
+                        self._backend_router.release(lease),
+                        timeout=REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning("Timeout releasing live lease for %s", phone)
+                except Exception:
+                    logger.debug("Failed to release live lease for %s", phone, exc_info=True)
+        if isinstance(client, TelegramTransportSession):
+            try:
+                await asyncio.wait_for(
+                    client.raw_client.disconnect(),
+                    timeout=REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC,
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Timeout disconnecting session for %s", phone)
+            except Exception:
+                logger.debug("Failed to disconnect session for %s", phone, exc_info=True)
 
     def _premium_flooded_phones(self) -> set[str]:
         now = datetime.now(timezone.utc)

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -686,6 +686,47 @@ class Collector:
             return "game"
         return "unknown"
 
+    async def _release_collection_client(
+        self,
+        phone: str,
+        session,
+        *,
+        retire: bool = False,
+    ) -> None:
+        if not retire:
+            await self._pool.release_client(phone)
+            return
+
+        logger.warning(
+            "Retiring Telegram client for %s because a message stream read did not finish cancellation",
+            phone,
+        )
+        pool_dict = getattr(self._pool, "__dict__", {})
+        remove_client = None
+        if "remove_client" in pool_dict or hasattr(type(self._pool), "remove_client"):
+            remove_client = getattr(self._pool, "remove_client", None)
+        if remove_client is not None:
+            try:
+                result = remove_client(phone)
+                if isawaitable(result):
+                    await result
+                    return
+            except Exception:
+                logger.debug("Failed to remove dirty Telegram client for %s", phone, exc_info=True)
+
+        raw_client = getattr(session, "raw_client", None)
+        disconnect = getattr(raw_client, "disconnect", None) if raw_client is not None else None
+        if disconnect is None:
+            disconnect = getattr(session, "disconnect", None)
+        if disconnect is not None:
+            try:
+                result = disconnect()
+                if isawaitable(result):
+                    await asyncio.wait_for(result, timeout=STREAM_CLEANUP_TIMEOUT_SEC)
+            except Exception:
+                logger.debug("Failed to disconnect dirty Telegram client for %s", phone, exc_info=True)
+        await self._pool.release_client(phone)
+
     async def _collect_channel(
         self,
         channel: Channel,
@@ -781,6 +822,7 @@ class Collector:
             flood_wait_operation: str | None = None
             stop_due_to_persistence_error = False
             stream_idle_timeout = False
+            retire_client_after_stream_timeout = False
 
             is_first_run = channel.last_collected_id == 0
             should_notify = self._notifier is not None and not is_first_run
@@ -1082,7 +1124,7 @@ class Collector:
                             return total_collected
 
                 async def _collect_messages() -> None:
-                    nonlocal stop_due_to_persistence_error, messages_batch
+                    nonlocal messages_batch, retire_client_after_stream_timeout, stop_due_to_persistence_error
                     # Idle timeout caps the wait for the *next* post, not the whole
                     # channel: a healthy channel that streams post-by-post is never
                     # aborted, only a stream gone silent (dead socket) is. 0/negative
@@ -1102,7 +1144,7 @@ class Collector:
                     stream_close_allowed = True
 
                     async def _next_message():
-                        nonlocal stream_close_allowed
+                        nonlocal retire_client_after_stream_timeout, stream_close_allowed
                         if idle_timeout is None:
                             return await agen.__anext__()
 
@@ -1122,7 +1164,7 @@ class Collector:
                                 )
 
                         async def _cancel_next_task(reason: str) -> None:
-                            nonlocal stream_close_allowed
+                            nonlocal retire_client_after_stream_timeout, stream_close_allowed
                             if next_task.done():
                                 return
                             stream_close_allowed = False
@@ -1134,6 +1176,7 @@ class Collector:
                             if next_task in done:
                                 stream_close_allowed = True
                             else:
+                                retire_client_after_stream_timeout = True
                                 logger.warning(
                                     "Channel %d (%s): message stream %s timed out after %.1fs",
                                     channel_id,
@@ -1311,7 +1354,11 @@ class Collector:
                         channel_id,
                         update_err,
                     )
-                await self._pool.release_client(phone)
+                await self._release_collection_client(
+                    phone,
+                    session,
+                    retire=retire_client_after_stream_timeout,
+                )
 
             if stop_due_to_persistence_error or stream_idle_timeout:
                 # Idle timeout and persistence errors both stop this pass; the

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -6,6 +6,7 @@ import logging
 from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import date, datetime, timedelta, timezone
+from inspect import isawaitable
 from math import ceil
 
 from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
@@ -66,6 +67,7 @@ GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC = 300
 GLOBAL_RESOLVE_BACKOFF_CAP_SEC = 3600
 MESSAGE_FLUSH_BATCH_SIZE = 500
 PERSISTED_ID_VERIFY_CHUNK_SIZE = 500
+STREAM_CLEANUP_TIMEOUT_SEC = 10.0
 
 
 def _format_channel_log_name(channel: Channel) -> str:
@@ -1097,9 +1099,51 @@ class Collector:
                         wait_time=self._config.delay_between_requests_sec,
                     )
                     agen = stream.__aiter__()
+
+                    async def _next_message():
+                        if idle_timeout is None:
+                            return await agen.__anext__()
+
+                        next_task = asyncio.create_task(agen.__anext__())
+                        done, _ = await asyncio.wait({next_task}, timeout=idle_timeout)
+                        if next_task in done:
+                            return await next_task
+
+                        next_task.cancel()
+
+                        def _consume_late_next_task(task: asyncio.Task) -> None:
+                            try:
+                                exc = task.exception()
+                            except asyncio.CancelledError:
+                                return
+                            if exc is not None:
+                                logger.debug(
+                                    "Channel %d (%s): message stream next failed after timeout",
+                                    channel_id,
+                                    channel.username or channel.title or "",
+                                    exc_info=(type(exc), exc, exc.__traceback__),
+                                )
+
+                        next_task.add_done_callback(_consume_late_next_task)
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.shield(next_task),
+                                timeout=STREAM_CLEANUP_TIMEOUT_SEC,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "Channel %d (%s): message stream next-cancel timed out after %.1fs",
+                                channel_id,
+                                channel.username or channel.title or "",
+                                STREAM_CLEANUP_TIMEOUT_SEC,
+                            )
+                        except asyncio.CancelledError:
+                            pass
+                        raise asyncio.TimeoutError
+
                     try:
                         while True:
-                            msg = await asyncio.wait_for(agen.__anext__(), timeout=idle_timeout)
+                            msg = await _next_message()
 
                             topic_id = None
                             reply_to = getattr(msg, "reply_to", None)
@@ -1169,7 +1213,26 @@ class Collector:
                     finally:
                         aclose = getattr(agen, "aclose", None)
                         if aclose is not None:
-                            await aclose()
+                            try:
+                                close_result = aclose()
+                                if isawaitable(close_result):
+                                    await asyncio.wait_for(
+                                        close_result, timeout=STREAM_CLEANUP_TIMEOUT_SEC
+                                    )
+                            except asyncio.TimeoutError:
+                                logger.warning(
+                                    "Channel %d (%s): message stream close timed out after %.1fs",
+                                    channel_id,
+                                    channel.username or channel.title or "",
+                                    STREAM_CLEANUP_TIMEOUT_SEC,
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "Channel %d (%s): message stream close failed",
+                                    channel_id,
+                                    channel.username or channel.title or "",
+                                    exc_info=True,
+                                )
 
                 await run_with_flood_wait(
                     _collect_messages(),

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -834,6 +834,16 @@ class Collector:
 
             is_first_run = channel.last_collected_id == 0
             should_notify = self._notifier is not None and not is_first_run
+
+            async def _check_collected_notification_queries() -> None:
+                nonlocal all_messages
+                if not should_notify or not all_messages:
+                    return
+                for message in all_messages:
+                    message.channel_username = channel.username
+                await self._check_notification_queries(all_messages)
+                all_messages = []
+
             limit = None
             channel_log_name = _format_channel_log_name(channel)
             logger.info(
@@ -1368,6 +1378,9 @@ class Collector:
                     retire=retire_client_after_stream_timeout,
                 )
 
+            if stream_idle_timeout and not stop_due_to_persistence_error:
+                await _check_collected_notification_queries()
+
             if stop_due_to_persistence_error or stream_idle_timeout:
                 # Idle timeout and persistence errors both stop this pass; the
                 # finally block above already flushed any pending batch and
@@ -1442,10 +1455,7 @@ class Collector:
                     continue
                 return total_collected + collected_count
 
-            if should_notify and all_messages:
-                for m in all_messages:
-                    m.channel_username = channel.username
-                await self._check_notification_queries(all_messages)
+            await _check_collected_notification_queries()
 
             # Update forum topics in DB if messages with topic_id
             # were collected

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1099,17 +1099,14 @@ class Collector:
                         wait_time=self._config.delay_between_requests_sec,
                     )
                     agen = stream.__aiter__()
+                    stream_close_allowed = True
 
                     async def _next_message():
+                        nonlocal stream_close_allowed
                         if idle_timeout is None:
                             return await agen.__anext__()
 
                         next_task = asyncio.create_task(agen.__anext__())
-                        done, _ = await asyncio.wait({next_task}, timeout=idle_timeout)
-                        if next_task in done:
-                            return await next_task
-
-                        next_task.cancel()
 
                         def _consume_late_next_task(task: asyncio.Task) -> None:
                             try:
@@ -1124,21 +1121,36 @@ class Collector:
                                     exc_info=(type(exc), exc, exc.__traceback__),
                                 )
 
-                        next_task.add_done_callback(_consume_late_next_task)
+                        async def _cancel_next_task(reason: str) -> None:
+                            nonlocal stream_close_allowed
+                            if next_task.done():
+                                return
+                            stream_close_allowed = False
+                            next_task.cancel()
+                            next_task.add_done_callback(_consume_late_next_task)
+                            done, _ = await asyncio.wait(
+                                {next_task}, timeout=STREAM_CLEANUP_TIMEOUT_SEC
+                            )
+                            if next_task in done:
+                                stream_close_allowed = True
+                            else:
+                                logger.warning(
+                                    "Channel %d (%s): message stream %s timed out after %.1fs",
+                                    channel_id,
+                                    channel.username or channel.title or "",
+                                    reason,
+                                    STREAM_CLEANUP_TIMEOUT_SEC,
+                                )
+
                         try:
-                            await asyncio.wait_for(
-                                asyncio.shield(next_task),
-                                timeout=STREAM_CLEANUP_TIMEOUT_SEC,
-                            )
-                        except asyncio.TimeoutError:
-                            logger.warning(
-                                "Channel %d (%s): message stream next-cancel timed out after %.1fs",
-                                channel_id,
-                                channel.username or channel.title or "",
-                                STREAM_CLEANUP_TIMEOUT_SEC,
-                            )
+                            done, _ = await asyncio.wait({next_task}, timeout=idle_timeout)
                         except asyncio.CancelledError:
-                            pass
+                            await _cancel_next_task("next-cancel on collector cancellation")
+                            raise
+                        if next_task in done:
+                            return await next_task
+
+                        await _cancel_next_task("next-cancel")
                         raise asyncio.TimeoutError
 
                     try:
@@ -1212,7 +1224,7 @@ class Collector:
                         pass
                     finally:
                         aclose = getattr(agen, "aclose", None)
-                        if aclose is not None:
+                        if aclose is not None and stream_close_allowed:
                             try:
                                 close_result = aclose()
                                 if isawaitable(close_result):
@@ -1233,6 +1245,13 @@ class Collector:
                                     channel.username or channel.title or "",
                                     exc_info=True,
                                 )
+                        elif aclose is not None:
+                            logger.debug(
+                                "Channel %d (%s): skipping message stream close because "
+                                "a pending next read did not finish cancellation",
+                                channel_id,
+                                channel.username or channel.title or "",
+                            )
 
                 await run_with_flood_wait(
                     _collect_messages(),

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -778,6 +778,7 @@ class Collector:
             flood_wait_sec: int | None = None
             flood_wait_operation: str | None = None
             stop_due_to_persistence_error = False
+            stream_idle_timeout = False
 
             is_first_run = channel.last_collected_id == 0
             should_notify = self._notifier is not None and not is_first_run
@@ -1080,76 +1081,95 @@ class Collector:
 
                 async def _collect_messages() -> None:
                     nonlocal stop_due_to_persistence_error, messages_batch
-                    async for msg in session.stream_messages(
+                    # Idle timeout caps the wait for the *next* post, not the whole
+                    # channel: a healthy channel that streams post-by-post is never
+                    # aborted, only a stream gone silent (dead socket) is. 0/negative
+                    # disables the cap (wait_for(timeout=None) == a bare await).
+                    # asyncio.TimeoutError propagates to the outer handler, which
+                    # releases the client.
+                    configured = self._config.collection_stream_timeout_sec
+                    idle_timeout = configured if configured and configured > 0 else None
+                    stream = session.stream_messages(
                         entity,
                         min_id=min_id,
                         limit=limit,
                         reverse=True,
                         wait_time=self._config.delay_between_requests_sec,
-                    ):
-                        topic_id = None
-                        reply_to = getattr(msg, "reply_to", None)
-                        if reply_to and getattr(reply_to, "forum_topic", False):
-                            topic_id = (
-                                getattr(reply_to, "reply_to_top_id", None)
-                                or getattr(reply_to, "reply_to_msg_id", None)
-                                or 1
+                    )
+                    agen = stream.__aiter__()
+                    try:
+                        while True:
+                            msg = await asyncio.wait_for(agen.__anext__(), timeout=idle_timeout)
+
+                            topic_id = None
+                            reply_to = getattr(msg, "reply_to", None)
+                            if reply_to and getattr(reply_to, "forum_topic", False):
+                                topic_id = (
+                                    getattr(reply_to, "reply_to_top_id", None)
+                                    or getattr(reply_to, "reply_to_msg_id", None)
+                                    or 1
+                                )
+                            elif reply_to:
+                                pass
+                            # Extract forward source channel for cross-channel citation tracking
+                            fwd_from_channel_id = None
+                            fwd_from = getattr(msg, "fwd_from", None)
+                            if fwd_from and getattr(fwd_from, "from_id", None):
+                                from_id = fwd_from.from_id
+                                if hasattr(from_id, "channel_id"):
+                                    fwd_from_channel_id = from_id.channel_id
+
+                            sender_identity = extract_message_sender_identity(msg)
+                            message = Message(
+                                channel_id=channel_id,
+                                message_id=msg.id,
+                                sender_id=sender_identity.sender_id,
+                                sender_name=sender_identity.sender_name,
+                                sender_first_name=sender_identity.sender_first_name,
+                                sender_last_name=sender_identity.sender_last_name,
+                                sender_username=sender_identity.sender_username,
+                                text=msg.text,
+                                message_kind=self._get_message_kind(msg),
+                                detected_lang=TranslationService.detect_language(msg.text),
+                                media_type=self._get_media_type(msg),
+                                service_action_raw=self._get_service_action_raw(msg),
+                                service_action_semantic=self._get_service_action_semantic(msg),
+                                service_action_payload_json=self._get_service_action_payload(msg),
+                                sender_kind=self._get_sender_kind(msg),
+                                topic_id=topic_id,
+                                reactions_json=self._extract_reactions(msg),
+                                views=getattr(msg, "views", None),
+                                forwards=getattr(msg, "forwards", None),
+                                reply_count=getattr(getattr(msg, "replies", None), "replies", None),
+                                date=(
+                                    msg.date.replace(tzinfo=timezone.utc)
+                                    if msg.date and msg.date.tzinfo is None
+                                    else msg.date
+                                ),
+                                forward_from_channel_id=fwd_from_channel_id,
                             )
-                        elif reply_to:
-                            pass
-                        # Extract forward source channel for cross-channel citation tracking
-                        fwd_from_channel_id = None
-                        fwd_from = getattr(msg, "fwd_from", None)
-                        if fwd_from and getattr(fwd_from, "from_id", None):
-                            from_id = fwd_from.from_id
-                            if hasattr(from_id, "channel_id"):
-                                fwd_from_channel_id = from_id.channel_id
+                            messages_batch.append(message)
 
-                        sender_identity = extract_message_sender_identity(msg)
-                        message = Message(
-                            channel_id=channel_id,
-                            message_id=msg.id,
-                            sender_id=sender_identity.sender_id,
-                            sender_name=sender_identity.sender_name,
-                            sender_first_name=sender_identity.sender_first_name,
-                            sender_last_name=sender_identity.sender_last_name,
-                            sender_username=sender_identity.sender_username,
-                            text=msg.text,
-                            message_kind=self._get_message_kind(msg),
-                            detected_lang=TranslationService.detect_language(msg.text),
-                            media_type=self._get_media_type(msg),
-                            service_action_raw=self._get_service_action_raw(msg),
-                            service_action_semantic=self._get_service_action_semantic(msg),
-                            service_action_payload_json=self._get_service_action_payload(msg),
-                            sender_kind=self._get_sender_kind(msg),
-                            topic_id=topic_id,
-                            reactions_json=self._extract_reactions(msg),
-                            views=getattr(msg, "views", None),
-                            forwards=getattr(msg, "forwards", None),
-                            reply_count=getattr(getattr(msg, "replies", None), "replies", None),
-                            date=(
-                                msg.date.replace(tzinfo=timezone.utc)
-                                if msg.date and msg.date.tzinfo is None
-                                else msg.date
-                            ),
-                            forward_from_channel_id=fwd_from_channel_id,
-                        )
-                        messages_batch.append(message)
+                            if len(messages_batch) % 10 == 0 and self._cancel_event.is_set():
+                                logger.info("Channel %d collection interrupted", channel_id)
+                                break
 
-                        if len(messages_batch) % 10 == 0 and self._cancel_event.is_set():
-                            logger.info("Channel %d collection interrupted", channel_id)
-                            break
-
-                        if len(messages_batch) >= MESSAGE_FLUSH_BATCH_SIZE:
-                            if not await self._channel_still_exists(channel_id):
+                            if len(messages_batch) >= MESSAGE_FLUSH_BATCH_SIZE:
+                                if not await self._channel_still_exists(channel_id):
+                                    messages_batch = []
+                                    break
+                                if not await _flush_batch(messages_batch):
+                                    stop_due_to_persistence_error = True
+                                    break
                                 messages_batch = []
-                                break
-                            if not await _flush_batch(messages_batch):
-                                stop_due_to_persistence_error = True
-                                break
-                            messages_batch = []
-                            if self._cancel_event.is_set():
-                                break
+                                if self._cancel_event.is_set():
+                                    break
+                    except StopAsyncIteration:
+                        pass
+                    finally:
+                        aclose = getattr(agen, "aclose", None)
+                        if aclose is not None:
+                            await aclose()
 
                 await run_with_flood_wait(
                     _collect_messages(),
@@ -1171,6 +1191,15 @@ class Collector:
             except HandledFloodWaitError as exc:
                 flood_wait_sec = exc.info.wait_seconds
                 flood_wait_operation = flood_wait_operation or exc.info.operation
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Channel %d (%s): no new message for %.1fs (stream idle); "
+                    "stopping this pass and releasing the client",
+                    channel_id,
+                    channel.username or channel.title or "",
+                    self._config.collection_stream_timeout_sec,
+                )
+                stream_idle_timeout = True
             finally:
                 # Flush remaining messages — each operation is protected
                 # independently so a failure in one doesn't prevent the
@@ -1202,7 +1231,10 @@ class Collector:
                     )
                 await self._pool.release_client(phone)
 
-            if stop_due_to_persistence_error:
+            if stop_due_to_persistence_error or stream_idle_timeout:
+                # Idle timeout and persistence errors both stop this pass; the
+                # finally block above already flushed any pending batch and
+                # advanced last_collected_id, so progress is never lost.
                 return total_collected + collected_count
 
             # Handle FloodWait AFTER finally has flushed progress.

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -709,8 +709,16 @@ class Collector:
             try:
                 result = remove_client(phone)
                 if isawaitable(result):
-                    await result
-                    return
+                    await asyncio.wait_for(result, timeout=STREAM_CLEANUP_TIMEOUT_SEC)
+                return
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Timed out removing dirty Telegram client for %s after %.1fs; "
+                    "not returning it to the pool",
+                    phone,
+                    STREAM_CLEANUP_TIMEOUT_SEC,
+                )
+                return
             except Exception:
                 logger.debug("Failed to remove dirty Telegram client for %s", phone, exc_info=True)
 

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -37,17 +37,16 @@ from src.runtime.worker import (
     _publish_snapshots,
     _publish_worker_down_snapshot,
 )
+from src.services.runtime_diagnostics import HEARTBEAT_INTERVAL_SEC, resolve_snapshot_publish_timeout
 from src.web.bootstrap import build_worker_container, start_container, stop_container
 from src.web.container import AppContainer
 from src.web.log_handler import LogBuffer
 
 logger = logging.getLogger(__name__)
 
-# How often the embedded worker republishes `worker_heartbeat` and the other
-# runtime snapshots. Matches `src/runtime/worker.py:_run_worker_async` and is
-# what `_is_worker_alive` compares against (`WORKER_HEARTBEAT_STALE_AFTER_SEC`
-# is 60s, so 5s gives 12 beats of slack before the UI marks the worker down).
-HEARTBEAT_INTERVAL_SEC = 5.0
+# HEARTBEAT_INTERVAL_SEC is imported from src.services.runtime_diagnostics — the
+# single source of truth shared with the standalone worker. The snapshot-publish
+# timeout comes from config (scheduler.snapshot_publish_timeout_sec).
 
 
 class EmbeddedWorker:
@@ -159,10 +158,16 @@ class EmbeddedWorker:
                 self._container = None
             return
 
+        publish_timeout = resolve_snapshot_publish_timeout(
+            self._config.scheduler.snapshot_publish_timeout_sec
+        )
         try:
             while not self._stop_event.is_set():
                 try:
-                    await _publish_snapshots(self._container, stop_event=self._stop_event)
+                    await asyncio.wait_for(
+                        _publish_snapshots(self._container, stop_event=self._stop_event),
+                        timeout=publish_timeout,
+                    )
                     self._ready_event.set()
                 except asyncio.CancelledError:
                     if _current_task_is_cancelling():
@@ -171,6 +176,11 @@ class EmbeddedWorker:
                         logger.info("[embedded-worker] stopping during snapshot publish")
                         break
                     logger.warning("[embedded-worker] snapshot publish was cancelled; continuing")
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "[embedded-worker] snapshot publish timed out after %.1fs; continuing",
+                        publish_timeout,
+                    )
                 except DatabaseBusyError:
                     # Transient lock — back off quietly. A full traceback every
                     # heartbeat (~5s) floods the log while contended; the next

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -340,8 +340,9 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     state = "healthy"
     if running_task_stale:
         # Genuinely stuck: a RUNNING task whose progress hasn't advanced for a
-        # long time. Decided by stalled progress, NOT by a stale heartbeat — an
-        # orphaned RUNNING row under a downed worker is `worker_down` below.
+        # long time. Stale progress is more specific than a stale heartbeat:
+        # a worker can be alive enough to serve web/runtime paths while its
+        # collection task is no longer moving.
         state = "collector_stuck"
     elif not worker_alive:
         # Worker-process absent dominates: without it `no_clients` /

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -339,16 +339,14 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     task_is_progressing = worker_alive and running_task is not None and not running_task_stale
     collector_is_running = worker_alive and (collector.is_running or task_is_progressing)
     state = "healthy"
-    if running_task_stale:
-        # Genuinely stuck: a RUNNING task whose progress hasn't advanced for a
-        # long time. Stale progress is more specific than a stale heartbeat:
-        # a worker can be alive enough to serve web/runtime paths while its
-        # collection task is no longer moving.
-        state = "collector_stuck"
-    elif not worker_alive:
+    if not worker_alive:
         # Worker-process absent dominates: without it `no_clients` /
         # `all_flooded` are symptoms, not the root cause.
         state = "worker_down"
+    elif running_task_stale:
+        # Genuinely stuck: a live worker has a RUNNING task whose progress
+        # hasn't advanced for a long time.
+        state = "collector_stuck"
     elif degraded_session_accounts and not active_accounts:
         state = "session_degraded"
     elif not connected_active_accounts:

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -336,7 +336,8 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
     # last_progress_at). Used instead of "any RUNNING row exists" so the UI
     # never claims a collection is in flight when the row is an orphan left by
     # a crashed worker.
-    task_is_progressing = running_task is not None and not running_task_stale
+    task_is_progressing = worker_alive and running_task is not None and not running_task_stale
+    collector_is_running = worker_alive and (collector.is_running or task_is_progressing)
     state = "healthy"
     if running_task_stale:
         # Genuinely stuck: a RUNNING task whose progress hasn't advanced for a
@@ -365,7 +366,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         state=state,
     )
     current_status_label, current_status_detail, current_status_severity = _current_status_presentation(
-        state, is_running=collector.is_running or task_is_progressing
+        state, is_running=collector_is_running
     )
     load_label, load_severity = _load_presentation(load_level)
     capacity_accounts = max(1, available_accounts_now)
@@ -404,7 +405,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
             interval_minutes=interval_minutes,
             active_unfiltered_channels=active_unfiltered_channels,
             available_accounts_now=available_accounts_now,
-            is_running=collector.is_running or task_is_progressing,
+            is_running=collector_is_running,
             pending_count=len(pending_channel_tasks),
         ),
         "current_status_label": current_status_label,
@@ -420,7 +421,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         "running_task_messages_collected": running_task.messages_collected if running_task else 0,
         "recent_zero_collect_count": recent_zero_collect_count,
         "recent_unavailability_events": recent_unavailability_events,
-        "is_running": collector.is_running or task_is_progressing,
+        "is_running": collector_is_running,
         "next_available_label": _format_retry_hint(next_available_at or availability_next),
     }
 

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -20,7 +20,10 @@ from src.services.pipeline_result import result_kind_label
 from src.services.runtime_diagnostics import (
     WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
 )
-from src.services.runtime_diagnostics import evaluate_worker_heartbeat
+from src.services.runtime_diagnostics import (
+    evaluate_worker_heartbeat,
+    running_task_stale_after,
+)
 from src.telegram.flood_wait import (
     is_blocking_flood_wait_until,
     is_transient_flood_wait_seconds,
@@ -42,6 +45,36 @@ JOB_LABELS = {
 # staleness window + classification now live in src.services.runtime_diagnostics
 # so the agent's get_runtime_diagnostics tool stays in lock-step with this banner.
 WORKER_HEARTBEAT_STALE_AFTER_SEC = WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC
+
+
+def _is_running_task_stale(
+    running_task,
+    *,
+    idle_timeout_sec: float | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """True when a RUNNING task's progress hasn't advanced for too long.
+
+    'Stuck' is decided by stalled progress, not by the mere existence of a
+    RUNNING row: a worker that simply crashed leaves an orphaned RUNNING row
+    whose progress clock is recent, and that must read as `worker_down`, not
+    `collector_stuck`. Falls back to `started_at` when no batch has flushed yet,
+    and treats an unknown timestamp as NOT stale (we can't prove it's stuck).
+
+    The threshold is derived from ``idle_timeout_sec`` (the per-channel
+    collection_stream_timeout_sec) so it tracks how long the collector is
+    actually allowed to wait for the next post — a large idle timeout pushes the
+    'stuck' verdict out instead of firing while the worker still legally waits.
+    """
+    if running_task is None:
+        return False
+    marker = running_task.last_progress_at or running_task.started_at
+    if marker is None:
+        return False
+    now = now or datetime.now(timezone.utc)
+    if marker.tzinfo is None:
+        marker = marker.replace(tzinfo=timezone.utc)
+    return (now - marker).total_seconds() > running_task_stale_after(idle_timeout_sec)
 
 
 def _job_label(job_id: str) -> str:
@@ -69,7 +102,7 @@ def _compute_load_level(
     available_accounts_now: int,
     state: str,
 ) -> str:
-    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
+    if state in {"worker_down", "collector_stuck", "all_flooded", "no_clients", "session_degraded"}:
         return "overload"
     capacity_accounts = max(1, available_accounts_now)
     pressure = active_unfiltered_channels / capacity_accounts
@@ -85,6 +118,8 @@ def _compute_load_level(
 def _current_status_presentation(state: str, *, is_running: bool) -> tuple[str, str, str]:
     if state == "worker_down":
         return "Telegram-воркер не запущен", "Задачи копятся в БД, но воркер их не исполняет.", "danger"
+    if state == "collector_stuck":
+        return "Сбор завис", "Текущая задача не завершилась, остальные задачи ждут.", "danger"
     if state == "all_flooded":
         return "Все аккаунты во Flood Wait", "Сбор заблокирован до ближайшего окна доступности.", "danger"
     if state == "no_clients":
@@ -107,7 +142,7 @@ def _load_presentation(load_level: str) -> tuple[str, str]:
 
 
 def _collector_health_border_severity(*, state: str, load_level: str) -> str:
-    if state in {"worker_down", "all_flooded", "no_clients", "session_degraded"}:
+    if state in {"worker_down", "collector_stuck", "all_flooded", "no_clients", "session_degraded"}:
         return "danger"
     if state == "degraded" or load_level in {"high", "overload"}:
         return "warning"
@@ -130,6 +165,11 @@ def _collector_health_recommendations(
             "Telegram-воркер не запущен. Если используете `serve` — перезапустите его; "
             "если `serve --no-worker` — запустите воркер отдельно: `python -m src.main worker`. "
             "Без воркера задачи сбора копятся в БД, но не исполняются."
+        )
+    if state == "collector_stuck":
+        recommendations.append(
+            "Текущая задача сбора зависла. Перезапустите `serve` или отдельный воркер, "
+            "затем проверьте, что очередь снова разбирается."
         )
     if state == "all_flooded":
         recommendations.append("Дождаться ближайшего окна после Flood Wait и не запускать ручной collect-all повторно.")
@@ -287,8 +327,23 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         None,
     )
 
+    # Derive the "stuck" threshold from the configured per-channel idle timeout
+    # so the two stay in lock-step (a large idle timeout must not trip a false
+    # "stuck"). running_task_stale_after() coerces None/garbage to the floor.
+    idle_timeout_sec = deps.get_container(request).config.scheduler.collection_stream_timeout_sec
+    running_task_stale = _is_running_task_stale(running_task, idle_timeout_sec=idle_timeout_sec)
+    # A task that is RUNNING and actually making progress (recent
+    # last_progress_at). Used instead of "any RUNNING row exists" so the UI
+    # never claims a collection is in flight when the row is an orphan left by
+    # a crashed worker.
+    task_is_progressing = running_task is not None and not running_task_stale
     state = "healthy"
-    if not worker_alive:
+    if running_task_stale:
+        # Genuinely stuck: a RUNNING task whose progress hasn't advanced for a
+        # long time. Decided by stalled progress, NOT by a stale heartbeat — an
+        # orphaned RUNNING row under a downed worker is `worker_down` below.
+        state = "collector_stuck"
+    elif not worker_alive:
         # Worker-process absent dominates: without it `no_clients` /
         # `all_flooded` are symptoms, not the root cause.
         state = "worker_down"
@@ -309,7 +364,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         state=state,
     )
     current_status_label, current_status_detail, current_status_severity = _current_status_presentation(
-        state, is_running=collector.is_running
+        state, is_running=collector.is_running or task_is_progressing
     )
     load_label, load_severity = _load_presentation(load_level)
     capacity_accounts = max(1, available_accounts_now)
@@ -348,7 +403,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
             interval_minutes=interval_minutes,
             active_unfiltered_channels=active_unfiltered_channels,
             available_accounts_now=available_accounts_now,
-            is_running=collector.is_running,
+            is_running=collector.is_running or task_is_progressing,
             pending_count=len(pending_channel_tasks),
         ),
         "current_status_label": current_status_label,
@@ -364,7 +419,7 @@ async def _build_collector_health_context(request: Request) -> dict[str, object]
         "running_task_messages_collected": running_task.messages_collected if running_task else 0,
         "recent_zero_collect_count": recent_zero_collect_count,
         "recent_unavailability_events": recent_unavailability_events,
-        "is_running": collector.is_running,
+        "is_running": collector.is_running or task_is_progressing,
         "next_available_label": _format_retry_hint(next_available_at or availability_next),
     }
 

--- a/src/web/templates/scheduler.html
+++ b/src/web/templates/scheduler.html
@@ -134,7 +134,10 @@
         <p class="mb-2"><strong>Сейчас собирается:</strong> {{ collector_health.running_task_title }}, собрано {{ collector_health.running_task_messages_collected }} сообщений; остальные задачи ждут.</p>
         {% endif %}
 
-        {% if collector_health.state == 'worker_down' %}
+        {% if collector_health.state == 'collector_stuck' %}
+        <p class="mb-2"><strong>Почему сейчас не собираем:</strong> текущая задача сбора{% if collector_health.running_task_title %} (<strong>{{ collector_health.running_task_title }}</strong>){% endif %} давно не двигается с места, поэтому остальные задачи ждут в очереди.</p>
+        <p class="mb-2"><strong>Как починить:</strong> перезапустите процесс с воркером и проверьте, что очередь снова разбирается.</p>
+        {% elif collector_health.state == 'worker_down' %}
         <p class="mb-2"><strong>Почему сейчас не собираем:</strong> веб-процесс принимает задачи и пишет их в БД, но Telegram-коннекты держит отдельный воркер-процесс — он сейчас не запущен (нет свежего heartbeat в <code>runtime_snapshots</code>). Задачи из <code>collection_tasks</code> копятся в статусе <em>pending</em>, но никто их не исполняет.</p>
         {% if collector_health.worker_reason %}
         <p class="mb-2"><strong>Причина:</strong> {{ collector_health.worker_reason }}</p>

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -565,6 +565,29 @@ async def test_reschedule_collection_task_does_not_overwrite_cancelled(collectio
     assert task.messages_collected == 0
 
 
+async def test_reschedule_collection_task_clears_last_progress_at(collection_tasks_repo):
+    task_id = await collection_tasks_repo.create_collection_task(1, "Channel 1")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+    started = await collection_tasks_repo.get_collection_task(task_id)
+    assert started is not None
+    assert started.last_progress_at is not None
+
+    await collection_tasks_repo.reschedule_collection_task(
+        task_id,
+        run_after=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        note="flood wait",
+        messages_collected=10,
+    )
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task is not None
+    assert task.status == CollectionTaskStatus.PENDING
+    assert task.started_at is None
+    assert task.completed_at is None
+    assert task.last_progress_at is None
+    assert task.messages_collected == 10
+
+
 # fail_running_collection_tasks_on_startup tests
 
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -171,6 +171,35 @@ async def test_update_collection_task_progress(collection_tasks_repo):
     assert task.messages_collected == 100
 
 
+async def test_update_collection_task_progress_stamps_last_progress_at(collection_tasks_repo):
+    """Progress updates must record *when* progress last moved.
+
+    The scheduler health page uses this timestamp to tell a genuinely stuck
+    collection ("no progress for a long time") apart from a worker that simply
+    isn't running — so every progress write must refresh last_progress_at.
+    """
+    before = datetime.now(tz=timezone.utc)
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task_progress(task_id, 100)
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.last_progress_at is not None
+    assert task.last_progress_at >= before - timedelta(seconds=5)
+
+
+async def test_update_collection_task_to_running_seeds_last_progress_at(collection_tasks_repo):
+    """A freshly RUNNING task must have a progress timestamp seeded.
+
+    Without it, a task that hasn't flushed its first batch yet would look
+    "stuck since NULL" instead of "just started".
+    """
+    task_id = await collection_tasks_repo.create_collection_task(1, "Test")
+    await collection_tasks_repo.update_collection_task(task_id, CollectionTaskStatus.RUNNING)
+
+    task = await collection_tasks_repo.get_collection_task(task_id)
+    assert task.last_progress_at is not None
+
+
 # update_collection_task tests
 
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -531,6 +531,7 @@ async def test_reset_collection_task_to_pending(collection_tasks_repo):
     assert task.status == CollectionTaskStatus.PENDING
     assert task.started_at is None
     assert task.completed_at is None
+    assert task.last_progress_at is None
     assert task.error is None
     assert task.note == "shutdown"
 

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -623,11 +623,122 @@ async def test_scheduler_page_renders_worker_down_banner(client, base_app):
 
 
 @pytest.mark.anyio
+async def test_scheduler_page_renders_stuck_collector_banner_for_stale_progress(client, base_app):
+    """A running task whose progress hasn't moved for a long time is stuck.
+
+    'Stuck' is decided by stalled progress (last_progress_at far in the past),
+    NOT merely by a running row existing alongside a stale heartbeat — that
+    second case is just a downed worker (see the test below).
+    """
+    _, db, _ = base_app
+    task_id = await db.create_collection_task(
+        channel_id=-100404,
+        channel_title="Stuck Channel",
+    )
+    await db.update_collection_task(
+        task_id,
+        CollectionTaskStatus.RUNNING,
+        messages_collected=42,
+    )
+    # Force the progress timestamp far into the past → genuinely stalled.
+    stale = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+    await db.execute_write(
+        "UPDATE collection_tasks SET last_progress_at = ? WHERE id = ?",
+        (stale, task_id),
+    )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Сбор завис" in body
+    assert "Stuck Channel" in body
+    assert "Telegram-воркер не запущен" not in body
+
+
+@pytest.mark.anyio
+async def test_scheduler_page_shows_worker_down_when_progress_fresh_but_heartbeat_stale(client, base_app):
+    """Stale heartbeat + a freshly-progressing running task = worker_down, not stuck.
+
+    Anti-regression: the buggy version flagged any running row under a stale
+    heartbeat as 'collector_stuck', mislabelling a simply-crashed worker (which
+    left an orphaned RUNNING row) as a hung collection.
+    """
+    from src.models import RuntimeSnapshot
+
+    _, db, _ = base_app
+    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=stale,
+        )
+    )
+    task_id = await db.create_collection_task(
+        channel_id=-100405,
+        channel_title="Fresh Channel",
+    )
+    await db.update_collection_task(
+        task_id,
+        CollectionTaskStatus.RUNNING,
+        messages_collected=42,
+    )
+    # Progress is recent → not stuck, the worker just isn't beating.
+    fresh = datetime.now(timezone.utc).isoformat()
+    await db.execute_write(
+        "UPDATE collection_tasks SET last_progress_at = ? WHERE id = ?",
+        (fresh, task_id),
+    )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Telegram-воркер не запущен" in body
+    assert "Сбор завис" not in body
+
+
+@pytest.mark.anyio
 async def test_scheduler_page_no_worker_banner_when_heartbeat_fresh(client, base_app):
     """Fresh heartbeat must NOT render the worker_down banner."""
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
     assert "Telegram-воркер не запущен" not in resp.text
+
+
+# ── _is_running_task_stale: stuck threshold tracks the idle timeout ────
+
+
+def _running_task(*, last_progress_at):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(last_progress_at=last_progress_at, started_at=last_progress_at)
+
+
+def test_running_task_stale_with_default_idle_timeout():
+    """With the default idle timeout, ~6min of no progress reads as stuck."""
+    from src.web.scheduler.context import _is_running_task_stale
+
+    now = datetime.now(timezone.utc)
+    task = _running_task(last_progress_at=now - timedelta(seconds=360))
+    assert _is_running_task_stale(task, idle_timeout_sec=120.0, now=now) is True
+
+
+def test_running_task_not_stale_when_idle_timeout_is_large():
+    """A large collection_stream_timeout_sec must push the stuck threshold out.
+
+    The collector legitimately waits up to idle_timeout_sec for the next post,
+    so a stall shorter than that (plus grace) is NOT stuck — otherwise the page
+    cries 'stuck' while the worker is still legally waiting.
+    """
+    from src.web.scheduler.context import _is_running_task_stale
+
+    now = datetime.now(timezone.utc)
+    # 7 minutes of no progress, but the configured idle timeout is 10 minutes.
+    task = _running_task(last_progress_at=now - timedelta(seconds=420))
+    assert _is_running_task_stale(task, idle_timeout_sec=600.0, now=now) is False
+    # Once the stall clearly exceeds the idle timeout + grace, it IS stuck.
+    very_stale = _running_task(last_progress_at=now - timedelta(seconds=900))
+    assert _is_running_task_stale(very_stale, idle_timeout_sec=600.0, now=now) is True
 
 
 # ── web_mode fixture sanity (#457 round 3) ─────────────────────────────

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -624,7 +624,7 @@ async def test_scheduler_page_renders_worker_down_banner(client, base_app):
 
 @pytest.mark.anyio
 async def test_scheduler_page_renders_stuck_collector_banner_for_stale_progress(client, base_app):
-    """A running task whose progress hasn't moved for a long time is stuck.
+    """A live worker with a task whose progress hasn't moved for a long time is stuck.
 
     'Stuck' is decided by stalled progress (last_progress_at far in the past),
     NOT merely by a running row existing alongside a stale heartbeat — that
@@ -653,6 +653,43 @@ async def test_scheduler_page_renders_stuck_collector_banner_for_stale_progress(
     assert "Сбор завис" in body
     assert "Stuck Channel" in body
     assert "Telegram-воркер не запущен" not in body
+
+
+@pytest.mark.anyio
+async def test_scheduler_page_shows_worker_down_when_progress_stale_and_heartbeat_stale(client, base_app):
+    """Stale heartbeat + stale RUNNING row = worker_down, because no worker is alive."""
+    from src.models import RuntimeSnapshot
+
+    _, db, _ = base_app
+    heartbeat_stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="worker_heartbeat",
+            payload={"status": "alive"},
+            updated_at=heartbeat_stale,
+        )
+    )
+    task_id = await db.create_collection_task(
+        channel_id=-100406,
+        channel_title="Orphaned Stale Channel",
+    )
+    await db.update_collection_task(
+        task_id,
+        CollectionTaskStatus.RUNNING,
+        messages_collected=42,
+    )
+    progress_stale = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+    await db.execute_write(
+        "UPDATE collection_tasks SET last_progress_at = ? WHERE id = ?",
+        (progress_stale, task_id),
+    )
+
+    resp = await client.get("/scheduler/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Telegram-воркер не запущен" in body
+    assert "Сбор завис" not in body
+    assert "Сейчас собирается:" not in body
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -695,6 +695,8 @@ async def test_scheduler_page_shows_worker_down_when_progress_fresh_but_heartbea
     body = resp.text
     assert "Telegram-воркер не запущен" in body
     assert "Сбор завис" not in body
+    assert "Сейчас собирается:" not in body
+    assert "Дождаться завершения текущего первичного сбора" not in body
 
 
 @pytest.mark.anyio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1014,7 +1014,7 @@ async def test_collect_channel_hanging_stream_close_times_out_and_releases_clien
         async def aclose(self):
             await asyncio.Event().wait()
 
-    monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.05)
     monkeypatch.setattr("src.telegram.backends.STREAM_ITERATOR_CLOSE_TIMEOUT_SEC", 0.01)
 
     mock_client = AsyncMock()
@@ -1032,6 +1032,47 @@ async def test_collect_channel_hanging_stream_close_times_out_and_releases_clien
 
     assert count == 0
     pool.release_client.assert_awaited_with("+7003")
+
+
+@pytest.mark.anyio
+async def test_collect_channel_abandoned_stream_read_retires_client(db, monkeypatch):
+    ch = Channel(channel_id=-100139, title="Dirty Stream Client")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    class SlowCloseStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr("src.telegram.backends.STREAM_ITERATOR_CLOSE_TIMEOUT_SEC", 0.05)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=SlowCloseStream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7005")))
+    pool.remove_client = AsyncMock()
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.01)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=0.3,
+    )
+    await asyncio.sleep(0.06)
+
+    assert count == 0
+    pool.remove_client.assert_awaited_with("+7005")
+    pool.release_client.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -966,6 +966,108 @@ async def test_persist_progress_log_includes_channel_username(db, caplog):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_hanging_stream_times_out_and_releases_client(db):
+    ch = Channel(channel_id=-100134, title="Hanging Stream")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    async def _hanging_stream(*_args, **_kwargs):
+        await asyncio.Event().wait()
+        yield  # pragma: no cover - keeps this as an async generator
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=_hanging_stream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.02)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=0.2,
+    )
+
+    assert count == 0
+    pool.release_client.assert_awaited_with("+7000")
+    updated = await db.get_channel_by_pk(ch_id)
+    assert updated is not None
+    assert updated.last_collected_id == 0
+
+
+@pytest.mark.anyio
+async def test_collect_channel_slow_but_alive_stream_not_aborted(db):
+    """A healthy channel that streams post-by-post must NOT be aborted.
+
+    The idle-timeout caps the wait for the *next* post, not the whole channel.
+    Here each post arrives faster than the idle limit, but the channel as a
+    whole takes longer than the limit — it must still collect every message.
+    Regression guard: the old per-channel timeout killed large live channels.
+    """
+    ch = Channel(channel_id=-100135, title="Slow But Alive")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    # 5 posts, ~0.02s apart → ~0.1s total, well past the 0.05s idle limit,
+    # but no single gap exceeds it.
+    async def _slow_stream(*_args, **_kwargs):
+        for i in range(1, 6):
+            await asyncio.sleep(0.02)
+            yield _make_mock_message(i, text=f"msg {i}")
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=_slow_stream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7001")))
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.05)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=2.0,
+    )
+
+    assert count == 5
+    pool.release_client.assert_awaited_with("+7001")
+
+
+@pytest.mark.anyio
+async def test_collect_channel_zero_timeout_disables_abort(db):
+    """`collection_stream_timeout_sec=0` disables the idle abort entirely.
+
+    With the timeout off, even a slow stream collects fully and nothing is cut.
+    """
+    ch = Channel(channel_id=-100136, title="Timeout Disabled")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    async def _slow_stream(*_args, **_kwargs):
+        for i in range(1, 4):
+            await asyncio.sleep(0.01)
+            yield _make_mock_message(i, text=f"msg {i}")
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=_slow_stream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7002")))
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=2.0,
+    )
+
+    assert count == 3
+    pool.release_client.assert_awaited_with("+7002")
+
+
+@pytest.mark.anyio
 async def test_incremental_batch_flushes_to_avoid_huge_final_flush(db):
     """Incremental collection should flush large channels before the final flush."""
     ch = Channel(channel_id=-100130, title="Test", username="test130", last_collected_id=50)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1414,6 +1414,50 @@ async def test_incremental_collection_sends_notification_queries(db):
 
 
 @pytest.mark.anyio
+async def test_incremental_collection_sends_notifications_before_idle_timeout_return(db):
+    from src.models import SearchQuery
+
+    ch = Channel(channel_id=-100141, title="Test", username="test141", last_collected_id=10)
+    await db.add_channel(ch)
+    repo = db.repos.search_queries
+    await repo.add(SearchQuery(query="urgent", notify_on_collect=True))
+
+    class OneThenHangStream:
+        def __init__(self, msg):
+            self.msg = msg
+            self.sent = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self.sent:
+                self.sent = True
+                return self.msg
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+    mock_msg = _make_mock_message(11, text="urgent update")
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=OneThenHangStream(mock_msg))
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
+    notifier = AsyncMock()
+
+    collector = Collector(
+        pool,
+        db,
+        SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.01),
+        notifier,
+    )
+    count = await asyncio.wait_for(collector._collect_channel(ch), timeout=0.3)
+
+    assert count == 1
+    notifier.notify.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_first_run_detects_topics_without_retaining_messages(db):
     """First-run forum-topic detection runs via the saw_topic_message flag (#633).
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -997,6 +997,43 @@ async def test_collect_channel_hanging_stream_times_out_and_releases_client(db):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_hanging_stream_close_times_out_and_releases_client(db, monkeypatch):
+    ch = Channel(channel_id=-100137, title="Hanging Close")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    class HangingCloseStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.01)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=HangingCloseStream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7003")))
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.01)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=0.2,
+    )
+
+    assert count == 0
+    pool.release_client.assert_awaited_with("+7003")
+
+
+@pytest.mark.anyio
 async def test_collect_channel_slow_but_alive_stream_not_aborted(db):
     """A healthy channel that streams post-by-post must NOT be aborted.
 

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1076,6 +1076,50 @@ async def test_collect_channel_abandoned_stream_read_retires_client(db, monkeypa
 
 
 @pytest.mark.anyio
+async def test_collect_channel_dirty_client_remove_timeout_does_not_release(db, monkeypatch):
+    ch = Channel(channel_id=-100140, title="Dirty Remove Timeout")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    class SlowCloseStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await asyncio.Event().wait()
+            raise StopAsyncIteration
+
+        async def aclose(self):
+            await asyncio.Event().wait()
+
+    async def _hung_remove(_phone):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr("src.telegram.backends.STREAM_ITERATOR_CLOSE_TIMEOUT_SEC", 0.05)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=SlowCloseStream())
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7006")))
+    pool.remove_client = AsyncMock(side_effect=_hung_remove)
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=0.01)
+    collector = Collector(pool, db, config)
+
+    count = await asyncio.wait_for(
+        collector._collect_channel(stored, force=True),
+        timeout=0.3,
+    )
+    await asyncio.sleep(0.06)
+
+    assert count == 0
+    pool.remove_client.assert_awaited_with("+7006")
+    pool.release_client.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_channel_cancels_pending_stream_read_on_shutdown(db):
     ch = Channel(channel_id=-100138, title="Cancelled Stream")
     ch_id = await db.add_channel(ch)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1015,6 +1015,7 @@ async def test_collect_channel_hanging_stream_close_times_out_and_releases_clien
             await asyncio.Event().wait()
 
     monkeypatch.setattr("src.telegram.collector.STREAM_CLEANUP_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr("src.telegram.backends.STREAM_ITERATOR_CLOSE_TIMEOUT_SEC", 0.01)
 
     mock_client = AsyncMock()
     mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
@@ -1031,6 +1032,48 @@ async def test_collect_channel_hanging_stream_close_times_out_and_releases_clien
 
     assert count == 0
     pool.release_client.assert_awaited_with("+7003")
+
+
+@pytest.mark.anyio
+async def test_collect_channel_cancels_pending_stream_read_on_shutdown(db):
+    ch = Channel(channel_id=-100138, title="Cancelled Stream")
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    class CancellableStream:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = asyncio.Event()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                self.cancelled.set()
+
+    stream = CancellableStream()
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(return_value=stream)
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7004")))
+    config = SchedulerConfig(delay_between_requests_sec=0, collection_stream_timeout_sec=30)
+    collector = Collector(pool, db, config)
+
+    task = asyncio.create_task(collector._collect_channel(stored, force=True))
+    await asyncio.wait_for(stream.started.wait(), timeout=0.2)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.wait_for(stream.cancelled.wait(), timeout=0.2)
+    pool.release_client.assert_awaited_with("+7004")
 
 
 @pytest.mark.anyio

--- a/tests/test_runtime_diagnostics.py
+++ b/tests/test_runtime_diagnostics.py
@@ -5,9 +5,32 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 from src.services.runtime_diagnostics import (
+    DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC,
     WORKER_HEARTBEAT_STALE_AFTER_SEC,
     evaluate_worker_heartbeat,
+    resolve_snapshot_publish_timeout,
 )
+
+
+def test_resolve_snapshot_publish_timeout_passes_through_positive():
+    assert resolve_snapshot_publish_timeout(30.0) == 30.0
+    assert resolve_snapshot_publish_timeout(5) == 5.0
+
+
+def test_resolve_snapshot_publish_timeout_rejects_zero_and_negative():
+    """A misconfigured 0/negative must not make every heartbeat time out instantly.
+
+    asyncio.wait_for(timeout<=0) aborts the publish on the first pass, so a bad
+    value would silently stop heartbeats and flip the UI to worker_down. Fall
+    back to the safe default instead.
+    """
+    assert resolve_snapshot_publish_timeout(0) == DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
+    assert resolve_snapshot_publish_timeout(-1) == DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
+
+
+def test_resolve_snapshot_publish_timeout_handles_none_and_garbage():
+    assert resolve_snapshot_publish_timeout(None) == DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
+    assert resolve_snapshot_publish_timeout("nonsense") == DEFAULT_SNAPSHOT_PUBLISH_TIMEOUT_SEC
 
 
 def _snapshot(*, updated_at, payload=None):

--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -226,7 +226,12 @@ async def test_publish_worker_down_snapshot_for_decrypt_failure():
 
 
 async def test_worker_loop_continues_after_transient_snapshot_cancel():
+    from src.config import AppConfig
+
     container = MagicMock()
+    # The publish timeout is read from config now, so a real AppConfig is needed
+    # (a MagicMock would feed asyncio.wait_for a non-numeric timeout).
+    config = AppConfig()
     publish_calls = 0
 
     async def publish_snapshot(_container, *, stop_event=None):
@@ -246,7 +251,7 @@ async def test_worker_loop_continues_after_transient_snapshot_cancel():
         patch("src.runtime.worker._publish_snapshots", new=publish_snapshot),
         patch("src.runtime.worker.HEARTBEAT_INTERVAL_SEC", 0.001),
     ):
-        worker_task = asyncio.create_task(_run_worker_async(MagicMock()))
+        worker_task = asyncio.create_task(_run_worker_async(config))
         with pytest.raises(asyncio.CancelledError):
             await worker_task
 
@@ -255,8 +260,10 @@ async def test_worker_loop_continues_after_transient_snapshot_cancel():
 
 
 async def test_embedded_worker_stop_suppresses_cancelled_snapshot_publish():
+    from src.config import AppConfig
+
     container = MagicMock()
-    worker = EmbeddedWorker(MagicMock())
+    worker = EmbeddedWorker(AppConfig())
 
     with (
         patch("src.web.embedded_worker.build_worker_container", AsyncMock(return_value=container)),
@@ -278,3 +285,39 @@ async def test_embedded_worker_stop_suppresses_cancelled_snapshot_publish():
 
     stop_container.assert_awaited_once_with(container)
     assert worker.container is None
+
+
+async def test_embedded_worker_retries_after_hanging_snapshot_publish():
+    from src.config import AppConfig
+
+    container = MagicMock()
+    # The publish timeout now comes from config, not a hard-coded module
+    # constant — a single source of truth instead of the old duplicate.
+    config = AppConfig()
+    config.scheduler.snapshot_publish_timeout_sec = 0.01
+    worker = EmbeddedWorker(config)
+    publish_started = asyncio.Event()
+    publish_calls = 0
+
+    async def hanging_publish(_container, *, stop_event=None):
+        nonlocal publish_calls
+        publish_calls += 1
+        publish_started.set()
+        await asyncio.Event().wait()
+
+    with (
+        patch("src.web.embedded_worker.build_worker_container", AsyncMock(return_value=container)),
+        patch("src.web.embedded_worker.start_container", AsyncMock()),
+        patch("src.web.embedded_worker.stop_container", AsyncMock()) as stop_container,
+        patch("src.web.embedded_worker._publish_snapshots", new=hanging_publish),
+        patch("src.web.embedded_worker.HEARTBEAT_INTERVAL_SEC", 0.001),
+    ):
+        await worker.start()
+        try:
+            await asyncio.wait_for(publish_started.wait(), timeout=0.05)
+            await asyncio.sleep(0.05)
+            assert publish_calls >= 2
+        finally:
+            await worker.stop(timeout=0.01)
+
+    stop_container.assert_awaited_once_with(container)

--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -233,15 +233,15 @@ async def test_worker_loop_continues_after_transient_snapshot_cancel():
     # (a MagicMock would feed asyncio.wait_for a non-numeric timeout).
     config = AppConfig()
     publish_calls = 0
+    worker_task: asyncio.Task[None] | None = None
 
     async def publish_snapshot(_container, *, stop_event=None):
         nonlocal publish_calls
         publish_calls += 1
         if publish_calls == 1:
             raise asyncio.CancelledError
-        task = asyncio.current_task()
-        assert task is not None
-        task.cancel()
+        assert worker_task is not None
+        worker_task.cancel()
         raise asyncio.CancelledError
 
     with (

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -930,6 +930,26 @@ async def test_remove_client_cleans_up_all_state(pool, mock_auth, mock_db):
 
 
 @pytest.mark.anyio
+async def test_remove_client_disconnect_timeout_marks_client_removed(pool, monkeypatch):
+    async def _hung_disconnect():
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("src.telegram.client_pool.REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC", 0.01)
+    client = AsyncMock()
+    client.disconnect = AsyncMock(side_effect=_hung_disconnect)
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+    pool._in_use.add("+7001")
+    pool._dialogs_fetched.add("+7001")
+
+    await asyncio.wait_for(pool.remove_client("+7001"), timeout=0.1)
+
+    client.disconnect.assert_awaited_once()
+    assert "+7001" not in pool.clients
+    assert "+7001" not in pool._in_use
+    assert "+7001" not in pool._dialogs_fetched
+
+
+@pytest.mark.anyio
 async def test_remove_client_with_active_leases(pool, mock_auth, mock_db):
     client = AsyncMock()
     pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)


### PR DESCRIPTION
## Контекст

Закрывает изъяны предыдущей попытки лечить «зависший сбор» Telegram (issue #771, план в #772).

### Что было не так
1. **Будильник на весь канал.** Таймаут оборачивал всю корутину сбора канала → большой живой канал с десятками тысяч постов рубился на каждом проходе и **никогда не докачивался**.
2. **Ноль ломал всё.** `max(0.001, …)` превращал настройку `0` (по смыслу «выключить») в обрыв через 1 мс.
3. **Диагноз «завис» по факту пометки.** `not worker_alive and has_running_task` → упавший воркер с осиротевшей `running`-строкой ложно показывался как «Сбор завис».
4. Дубли констант `SNAPSHOT_PUBLISH_TIMEOUT_SEC` / `HEARTBEAT_INTERVAL_SEC` в двух воркер-файлах.

## Что сделано

**Таймаут по простою (`collector.py`)**
- Лимит применяется к ожиданию **каждого следующего поста** (`asyncio.wait_for(agen.__anext__(), …)`), а не ко всему каналу. Здоровый канал, отдающий пост за постом, не рубится; молчащий сокет — рубится.
- `0`/отрицательное = выключено (`wait_for(timeout=None)`), безопасный `max(0.001,…)` убран.
- Отдельный честный флаг `stream_idle_timeout`; прогресс не теряется (флаш в `finally`).

**Диагноз «завис» по остановке прогресса (`context.py`, схема/миграции/репозиторий/модель)**
- Новая колонка `collection_tasks.last_progress_at`, пишется при каждом продвижении и при старте задачи.
- `collector_stuck` ставится **только** при реально стоящем прогрессе дольше порога — независимо от heartbeat. Упавший воркер снова даёт правильный `worker_down`.
- Порог производный: `max(RUNNING_TASK_STALE_AFTER_SEC, collection_stream_timeout_sec + grace)` — большой idle-таймаут не вызывает ложного «завис».
- Убрано «привирание»: «Сейчас собирается…» показывается только для реально двигающейся задачи; баннер называет зависший канал.

**Централизация констант (`runtime_diagnostics.py`, оба воркера, конфиг)**
- `snapshot_publish_timeout_sec` — поле конфига; оба воркера читают из него.
- `HEARTBEAT_INTERVAL_SEC` — единый источник в `runtime_diagnostics`.
- `resolve_snapshot_publish_timeout()` санитизирует `≤0`/мусор → дефолт 30, чтобы кривое значение не обрывало heartbeat. Семантика «0» у обоих таймаутов задокументирована в `SchedulerConfig`.

## Проверка
- TDD: новые/переписанные тесты красные до правок → зелёные после (медленный живой канал не рубится; `0` = выключено; диагноз по прогрессу; санитизация publish-таймаута; связь порогов).
- Полный прогон: **8429 passed** (7576 parallel + 853 serial), 0 failed. `ruff check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)