### PR TITLE
feat(parity): close CLI ↔ Web ↔ Agent-tool parity gaps

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,8 @@ _REAL_TG_PARALLEL_GATES = (
 )
 _AIOSQLITE_SERIAL_FIXTURES = {"cli_db"}
 _AIOSQLITE_SERIAL_TOKENS = ("import aiosqlite",)
+_DEFAULT_XDIST_AUTO_WORKERS = 4
+_XDIST_WORKER_CAP_ENV = "TGCF_PYTEST_XDIST_WORKERS"
 
 
 def _should_force_single_worker(args: list[str]) -> bool:
@@ -22,10 +24,32 @@ def _should_force_single_worker(args: list[str]) -> bool:
     return any("::" in arg for arg in args)
 
 
+def _xdist_auto_worker_cap() -> int:
+    raw_value = os.environ.get(_XDIST_WORKER_CAP_ENV)
+    if raw_value is None:
+        return _DEFAULT_XDIST_AUTO_WORKERS
+    try:
+        parsed_value = int(raw_value)
+    except ValueError:
+        return _DEFAULT_XDIST_AUTO_WORKERS
+    return max(1, parsed_value)
+
+
+def _xdist_available_workers_for_load(cpu_count: int) -> int:
+    try:
+        current_load = os.getloadavg()[0]
+    except (AttributeError, OSError):
+        current_load = 0.0
+    busy_cores = max(0, int(current_load))
+    return max(1, cpu_count - busy_cores - 1)
+
+
 def pytest_xdist_auto_num_workers(config) -> int:
     if _should_force_single_worker(list(config.args)):
         return 1
-    return max(1, (os.cpu_count() or 1) - 1)
+    cpu_count = os.cpu_count() or 1
+    available_workers = _xdist_available_workers_for_load(cpu_count)
+    return min(available_workers, _xdist_auto_worker_cap())
 
 
 @lru_cache(maxsize=None)

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 import re
 from functools import lru_cache
@@ -40,7 +41,7 @@ def _xdist_available_workers_for_load(cpu_count: int) -> int:
         current_load = os.getloadavg()[0]
     except (AttributeError, OSError):
         current_load = 0.0
-    busy_cores = max(0, int(current_load))
+    busy_cores = max(0, math.ceil(current_load))
     return max(1, cpu_count - busy_cores - 1)
 
 

--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -15,6 +15,7 @@
 | `search_my_chats` | READ | Поиск по личным чатам аккаунта |
 | `search_in_channel` | READ | Поиск внутри конкретного канала через Telegram |
 | `search_hybrid` | READ | Гибридный поиск (FTS + семантика) |
+| `purge_search_cache` | DELETE | Очистка кэша Premium-поиска по запросу |
 
 ## Каналы
 
@@ -32,6 +33,9 @@
 | `create_tag` | WRITE | Создать тег |
 | `delete_tag` | DELETE | Удалить тег |
 | `set_channel_tags` | WRITE | Обновить теги канала |
+| `get_channel_tags` | READ | Получить теги конкретного канала |
+| `add_channels_bulk` | WRITE | Массовое добавление каналов из кеша диалогов |
+| `list_dialogs_for_import` | READ | Список диалогов для импорта (с флагом already_added) |
 
 ## Сбор
 
@@ -65,6 +69,7 @@
 | `list_pipeline_templates` | READ | Список шаблонов |
 | `create_pipeline_from_template` | WRITE | Создать pipeline из шаблона |
 | `ai_edit_pipeline` | WRITE | AI-редактирование pipeline |
+| `get_pipeline_dry_run_count` | READ | Подсчёт сообщений-кандидатов dry-run |
 
 ## Модерация
 
@@ -114,6 +119,7 @@
 | `purge_filtered_channels` | DELETE | Очистить сообщения |
 | `hard_delete_channels` | DELETE | Удалить из БД |
 | `precheck_filters` | WRITE | Pre-check |
+| `purge_channel_messages` | DELETE | Очистить сообщения конкретного канала (по channel_id) |
 
 ## Аналитика
 
@@ -130,6 +136,8 @@
 | `get_top_messages` | READ | Топ сообщений по реакциям |
 | `get_content_type_stats` | READ | Статистика по типам контента |
 | `get_hourly_activity` | READ | Почасовая активность |
+| `get_trending_emojis` | READ | Трендовые эмодзи за период |
+| `get_channel_analytics` | READ | Обзорная аналитика одного канала |
 
 ## Планировщик
 
@@ -206,6 +214,7 @@
 | `pin_message` | WRITE | Закрепить сообщение |
 | `unpin_message` | WRITE | Открепить |
 | `download_media` | READ | Скачать медиа |
+| `translate_message` | WRITE | Перевод одного сообщения по его DB id |
 
 ## Управление чатом
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -203,7 +203,7 @@
 | Топики форума | `dialogs topics` | `GET /agent/forum-topics` | `get_forum_topics` |
 | Создать канал | `dialogs create-channel` | `POST /dialogs/create-channel` | `create_telegram_channel` |
 | Отправить сообщение | `dialogs send` | `POST /dialogs/send` | `send_message` |
-| Переслать сообщение | `dialogs forward` | `POST /dialogs/forward` | `forward_messages` |
+| Переслать сообщение | `dialogs forward` | `POST /dialogs/forward-messages` | `forward_messages` |
 | Редактировать | `dialogs edit-message` | `POST /dialogs/edit-message` | `edit_message` |
 | Удалить | `dialogs delete-message` | `POST /dialogs/delete-message` | `delete_message` |
 | Закрепить | `dialogs pin-message` | `POST /dialogs/pin-message` | `pin_message` |

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -103,7 +103,7 @@
 | Генерация контента | `pipeline generate` | `POST /pipelines/{id}/generate` | `generate_draft` |
 | История запусков | `pipeline runs` | `GET /pipelines/{id}/runs` | `list_pipeline_runs` |
 | Детали запуска | `pipeline run-show` | `GET /pipelines/{id}/runs/{run_id}` | `get_pipeline_run` |
-| Очередь | `pipeline queue` | `GET /pipelines/{id}/queue` | `get_pipeline_queue` |
+| Очередь модерации | `pipeline queue` | `GET /pipelines/{id}/queue` | `get_pipeline_queue` |
 | Опубликовать | `pipeline publish` | `POST /pipelines/{id}/publish` | `publish_pipeline_run` |
 | Одобрить | `pipeline approve` | `POST /moderation/{id}/approve` | `approve_run` |
 | Отклонить | `pipeline reject` | `POST /moderation/{id}/reject` | `reject_run` |
@@ -177,17 +177,17 @@
 |----------|-----|-------------|------------|
 | Сводка | `analytics summary` | `GET /analytics/content/api/summary` | `get_analytics_summary` |
 | Топ сообщений | `analytics top` | `GET /analytics/messages/top` | `get_top_messages` |
-| Типы контента | `analytics content-types` | `GET /analytics/content` | `get_content_type_stats` |
-| Почасовая активность | `analytics hourly` | `GET /analytics` | `get_hourly_activity` |
-| Ежедневная статистика | `analytics daily` | `GET /analytics/content/api/pipelines` | `get_daily_stats` |
+| Типы контента | `analytics content-types` | `GET /analytics/content/api/types` | `get_content_type_stats` |
+| Почасовая активность | `analytics hourly` | `GET /analytics/messages/hourly` | `get_hourly_activity` |
+| Ежедневная статистика | `analytics daily` | `GET /analytics/content/api/daily` | `get_daily_stats` |
 | Статистика пайплайнов | `analytics pipeline-stats` | `GET /analytics/pipelines/stats` | `get_pipeline_stats` |
-| Трендовые темы | `analytics trending-topics` | `GET /analytics/trends` | `get_trending_topics` |
-| Топ каналов | `analytics trending-channels` | `GET /analytics/trends` | `get_trending_channels` |
-| Трендовые эмодзи | `analytics trending-emojis` | `GET /analytics/trends` | `get_trending_emojis` |
+| Трендовые темы | `analytics trending-topics` | `GET /analytics/trends/topics` | `get_trending_topics` |
+| Топ каналов | `analytics trending-channels` | `GET /analytics/trends/channels` | `get_trending_channels` |
+| Трендовые эмодзи | `analytics trending-emojis` | `GET /analytics/trends/emojis` | `get_trending_emojis` |
 | Скорость сообщений | `analytics velocity` | `GET /analytics/messages/velocity` | `get_message_velocity` |
 | Пиковые часы | `analytics peak-hours` | `GET /analytics/peak-hours` | `get_peak_hours` |
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
-| Аналитика канала | `analytics channel` | `GET /analytics/channels` | `get_channel_analytics` |
+| Аналитика канала | `analytics channel` | `GET /analytics/channels/api/overview` | `get_channel_analytics` |
 
 ## Dialogs
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -14,13 +14,21 @@
 | Импорт каналов | `channel import` | `POST /channels/import` | `import_channels` |
 | Обновить типы | `channel refresh-types` | `POST /channels/refresh-types` | `refresh_channel_types` |
 | Обновить метаданные | `channel refresh-meta` | `POST /channels/refresh-meta` | `refresh_channel_meta` |
-| Массовое добавление из диалогов | `channel add-bulk` | `POST /channels/add-bulk` | — |
+| Массовое добавление из диалогов | `channel add-bulk` | `POST /channels/add-bulk` | `add_channels_bulk` |
 | Список тегов | `channel tag list` | `GET /channels/tags` | `list_tags` |
 | Создать тег | `channel tag add` | `POST /channels/tags` | `create_tag` |
 | Удалить тег | `channel tag delete` | `DELETE /channels/tags/{name}` | `delete_tag` |
-| Получить теги канала | `channel tag get` | `GET /channels/{pk}/tags` | — |
+| Получить теги канала | `channel tag get` | `GET /channels/{pk}/tags` | `get_channel_tags` |
 | Обновить теги канала | `channel tag set` | `POST /channels/{pk}/tags` | `set_channel_tags` |
-| Список диалогов для импорта | `channel list-for-import` | `GET /channels/dialogs` | — |
+| Список диалогов для импорта | `channel list-for-import` | `GET /channels/dialogs` | `list_dialogs_for_import` |
+
+## Переименования каналов
+
+| Операция | CLI | Web Endpoint | Agent Tool |
+|----------|-----|-------------|------------|
+| Список переименований | *исключение: web-only UI модерации* | `GET /channels/renames` | *исключение: web-only UI модерации* |
+| Отфильтровать переименование | *исключение: web-only UI модерации* | `POST /channels/renames/{event_id}/filter` | *исключение: web-only UI модерации* |
+| Оставить переименование | *исключение: web-only UI модерации* | `POST /channels/renames/{event_id}/keep` | *исключение: web-only UI модерации* |
 
 ## Сбор сообщений
 
@@ -29,7 +37,7 @@
 | Собрать все каналы | `collect` | `POST /channels/collect-all` | `collect_all_channels` |
 | Собрать один канал | `channel collect` | `POST /channels/{pk}/collect` | `collect_channel` |
 | Статистика всех | `channel stats --all` | `POST /channels/stats/all` | `collect_all_stats` |
-| Превью без сохранения | `collect sample` | — | — |
+| Превью без сохранения | `collect sample` | *исключение: превью без сохранения, UI-only* | *исключение: превью без сохранения, UI-only* |
 | Отменить задачу | `scheduler task-cancel` | `POST /scheduler/tasks/{id}/cancel` | `cancel_scheduler_task` |
 | Очистить очередь | `scheduler clear-pending` | `POST /scheduler/tasks/clear-pending-collect` | `clear_pending_tasks` |
 
@@ -44,15 +52,15 @@
 | Поиск по чатам | `search --mode my_chats` | `GET /search?mode=my_chats` | `search_my_chats` |
 | Поиск в канале | `search --mode channel` | `GET /search?mode=channel` | `search_in_channel` |
 | Индексация | `search --index-now` | `POST /settings/semantic-index` | `index_messages` |
-| Очистка кэша Premium-поиска | `search --purge-cache` | `POST /search/purge-cache` | — |
+| Очистка кэша Premium-поиска | `search --purge-cache` | `POST /search/purge-cache` | `purge_search_cache` |
 
 ## Сообщения
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
-| Чтение сообщений | `messages read` | — | `read_messages` |
-| Перевод одного сообщения | `translate message` | `POST /search/translate/{message_db_id}` | — |
-| Экспорт сообщений | `export json|csv|rss` | — | — |
+| Чтение сообщений | `messages read` | `GET /messages/{identifier}` | `read_messages` |
+| Перевод одного сообщения | `translate message` | `POST /search/translate/{message_db_id}` | `translate_message` |
+| Экспорт сообщений | `export json|csv|rss` | *исключение: файловый экспорт вне web* | *исключение: файловый экспорт вне tool-контракта* |
 
 ## Поисковые запросы
 
@@ -64,8 +72,8 @@
 | Удалить | `search-query delete` | `POST /search-queries/{id}/delete` | `delete_search_query` |
 | Вкл/выкл | `search-query toggle` | `POST /search-queries/{id}/toggle` | `toggle_search_query` |
 | Запустить вручную | `search-query run` | `POST /search-queries/{id}/run` | `run_search_query` |
-| Получить | `search-query get` | — | `get_search_query` |
-| Статистика | `search-query stats` | — | `get_search_query_stats` |
+| Получить | `search-query get` | `GET /search-queries/{id}` | `get_search_query` |
+| Статистика | `search-query stats` | `GET /search-queries/{id}/stats` | `get_search_query_stats` |
 
 ## Фильтры
 
@@ -77,35 +85,35 @@
 | Pre-check | `filter precheck` | `POST /channels/filter/precheck` | `precheck_filters` |
 | Вкл/выкл фильтр | `filter toggle` | `POST /channels/{pk}/filter-toggle` | `toggle_channel_filter` |
 | Очистить filtered-каналы | `filter purge` | `POST /channels/filter/purge-all` | `purge_filtered_channels` |
-| Выбранные очистить | — | `POST /channels/filter/purge-selected` | — |
+| Выбранные очистить | *исключение: batch UI-выбор* | `POST /channels/filter/purge-selected` | *исключение: batch UI-выбор* |
 | Hard delete | `filter hard-delete` | `POST /channels/filter/hard-delete-selected` | `hard_delete_channels` |
-| Очистить сообщения канала | `filter purge-messages` | `POST /channels/{id}/purge-messages` | — |
+| Очистить сообщения канала | `filter purge-messages` | `POST /channels/{id}/purge-messages` | `purge_channel_messages` |
 
 ## Пайплайны
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
 | Список | `pipeline list` | `GET /pipelines/` | `list_pipelines` |
-| Детали | `pipeline show` | — | `get_pipeline_detail` |
+| Детали | `pipeline show` | `GET /pipelines/{id}/show` | `get_pipeline_detail` |
 | Добавить | `pipeline add` | `POST /pipelines/add` | `add_pipeline` |
 | Редактировать | `pipeline edit` | `POST /pipelines/{id}/edit` | `edit_pipeline` |
 | Удалить | `pipeline delete` | `POST /pipelines/{id}/delete` | `delete_pipeline` |
 | Вкл/выкл | `pipeline toggle` | `POST /pipelines/{id}/toggle` | `toggle_pipeline` |
 | Запустить | `pipeline run` | `POST /pipelines/{id}/run` | `run_pipeline` |
 | Генерация контента | `pipeline generate` | `POST /pipelines/{id}/generate` | `generate_draft` |
-| История запусков | `pipeline runs` | — | `list_pipeline_runs` |
-| Детали запуска | `pipeline run-show` | — | `get_pipeline_run` |
-| Очередь | `pipeline queue` | — | `get_pipeline_queue` |
+| История запусков | `pipeline runs` | `GET /pipelines/{id}/runs` | `list_pipeline_runs` |
+| Детали запуска | `pipeline run-show` | `GET /pipelines/{id}/runs/{run_id}` | `get_pipeline_run` |
+| Очередь | `pipeline queue` | `GET /pipelines/{id}/queue` | `get_pipeline_queue` |
 | Опубликовать | `pipeline publish` | `POST /pipelines/{id}/publish` | `publish_pipeline_run` |
 | Одобрить | `pipeline approve` | `POST /moderation/{id}/approve` | `approve_run` |
 | Отклонить | `pipeline reject` | `POST /moderation/{id}/reject` | `reject_run` |
 | Одобрить (bulk) | `pipeline bulk-approve` | `POST /moderation/bulk-approve` | `bulk_approve_runs` |
 | Отклонить (bulk) | `pipeline bulk-reject` | `POST /moderation/bulk-reject` | `bulk_reject_runs` |
 | Шаги refinement | `pipeline refinement-steps` | `GET/POST /pipelines/{id}/refinement-steps` | `get_refinement_steps`, `set_refinement_steps` |
-| Подсчёт dry-run | `pipeline dry-run-count` | `GET /pipelines/{id}/dry-run-count` | — |
-| Узлы графа (CRUD) | `pipeline node` | — | — |
-| Связи графа (CRUD) | `pipeline edge` | — | — |
-| Граф (ASCII) | `pipeline graph` | — | — |
+| Подсчёт dry-run | `pipeline dry-run-count` | `GET /pipelines/{id}/dry-run-count` | `get_pipeline_dry_run_count` |
+| Узлы графа (CRUD) | `pipeline node` | *исключение: графовый CRUD только-CLI* | *исключение: графовый CRUD только-CLI* |
+| Связи графа (CRUD) | `pipeline edge` | *исключение: графовый CRUD только-CLI* | *исключение: графовый CRUD только-CLI* |
+| Граф (ASCII) | `pipeline graph` | *исключение: ASCII-вывод терминал* | *исключение: ASCII-вывод терминал* |
 | Экспорт JSON | `pipeline export` | `GET /pipelines/{id}/export` | `export_pipeline_json` |
 | Импорт JSON | `pipeline import` | `POST /pipelines/import` | `import_pipeline_json` |
 | Список шаблонов | `pipeline templates` | `GET /pipelines/templates` | `list_pipeline_templates` |
@@ -113,7 +121,12 @@
 | AI edit | `pipeline ai-edit` | `POST /pipelines/{id}/ai-edit` | `ai_edit_pipeline` |
 | Страница модерации | `pipeline moderation-list` | `GET /moderation/` | `list_pending_moderation` |
 | Просмотр модерации | `pipeline moderation-view` | `GET /moderation/{id}/view` | `view_moderation_run` |
-| Стрим генерации | `pipeline generate-stream` | `GET /pipelines/{id}/generate-stream` | — |
+| Стрим генерации | `pipeline generate-stream` | `GET /pipelines/{id}/generate-stream` | *исключение: SSE вне tool-контракта* |
+| Фильтр контента: задать | `pipeline filter set` | *исключение: filter CRUD только-CLI* | *исключение: filter CRUD только-CLI* |
+| Фильтр контента: показать | `pipeline filter show` | *исключение: filter CRUD только-CLI* | *исключение: filter CRUD только-CLI* |
+| Фильтр контента: очистить | `pipeline filter clear` | *исключение: filter CRUD только-CLI* | *исключение: filter CRUD только-CLI* |
+| Мастер создания | *исключение: web-only (CLI≈pipeline add)* | `POST /pipelines/create-wizard` | *исключение: web-only мастер (CLI≈pipeline add)* |
+| Превью dry-run | *исключение: web-only (CLI≈dry-run-count)* | `POST /pipelines/{id}/dry-run` | *исключение: web-only превью (CLI≈dry-run-count)* |
 
 ## Планировщик
 
@@ -126,6 +139,9 @@
 | Вкл/выкл job | `scheduler job-toggle` | `POST /scheduler/jobs/{id}/toggle` | `toggle_scheduler_job` |
 | Изменить интервал | `scheduler set-interval` | `POST /scheduler/jobs/{id}/set-interval` | `set_scheduler_interval` |
 | Сохранить настройки | `settings set` | `POST /settings/save-scheduler` | `save_scheduler_settings` |
+| Пауза очереди сбора | `scheduler queue-pause` | `POST /scheduler/pause` | *исключение: служебное управление очередью* |
+| Возобновить очередь | `scheduler queue-resume` | `POST /scheduler/resume` | *исключение: служебное управление очередью* |
+| Прогрев диалогов | — | `POST /scheduler/trigger-warm` | *исключение: служебный прогрев кеша* |
 
 ## Уведомления
 
@@ -136,7 +152,7 @@
 | Удалить | `notification delete` | `POST /settings/notifications/delete` | `delete_notification_bot` |
 | Тест | `notification test` | `POST /settings/notifications/test`, `POST /scheduler/test-notification` | `test_notification` |
 | Dry-run | `notification dry-run` | `POST /scheduler/dry-run-notifications` | `notification_dry_run` |
-| Выбрать аккаунт | `notification set-account` | `POST /settings/save-notification-account` | — |
+| Выбрать аккаунт | `notification set-account` | `POST /settings/save-notification-account` | *исключение: привязка аккаунта, чувствительно* |
 
 ## Аккаунты
 
@@ -144,34 +160,34 @@
 |----------|-----|-------------|------------|
 | Список | `account list` | `GET /settings/` | `list_accounts` |
 | Вкл/выкл | `account toggle` | `POST /settings/{id}/toggle` | `toggle_account` |
-| Сделать Primary | `account set-primary` | `POST /settings/{id}/set-primary` | — |
+| Сделать Primary | `account set-primary` | `POST /settings/{id}/set-primary` | *исключение: системное управление primary* |
 | Удалить | `account delete` | `POST /settings/{id}/delete` | `delete_account` |
 | Flood статус | `account flood-status` | `GET /settings/flood-status` | `get_flood_status` |
 | Сбросить flood | `account flood-clear` | `POST /settings/{id}/flood-clear` | `clear_flood_status` |
-| Инфо | `account info` | — | `get_account_info` |
+| Инфо | `account info` | `GET /settings/{id}/info` | `get_account_info` |
 | Доступность | `account list` | `GET /settings/` | `get_account_availability` |
 | Диагностика рантайма | `scheduler status` | `GET /settings/` | `get_runtime_diagnostics` |
-| Добавить аккаунт | `account add` | `POST /auth/send-code`, `POST /auth/verify-code` | — |
-| Отправить код авторизации | `account send-code` | `POST /auth/send-code` | — |
-| Подтвердить код авторизации | `account verify-code` | `POST /auth/verify-code` | — |
+| Добавить аккаунт | `account add` | `POST /auth/send-code`, `POST /auth/verify-code` | *исключение: интерактивный 2FA-flow* |
+| Отправить код авторизации | `account send-code` | `POST /auth/send-code` | *исключение: интерактивный 2FA-flow* |
+| Подтвердить код авторизации | `account verify-code` | `POST /auth/verify-code` | *исключение: интерактивный 2FA-flow* |
 
 ## Аналитика
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
 | Сводка | `analytics summary` | `GET /analytics/content/api/summary` | `get_analytics_summary` |
-| Топ сообщений | `analytics top` | — | `get_top_messages` |
+| Топ сообщений | `analytics top` | `GET /analytics/messages/top` | `get_top_messages` |
 | Типы контента | `analytics content-types` | `GET /analytics/content` | `get_content_type_stats` |
 | Почасовая активность | `analytics hourly` | `GET /analytics` | `get_hourly_activity` |
 | Ежедневная статистика | `analytics daily` | `GET /analytics/content/api/pipelines` | `get_daily_stats` |
-| Статистика пайплайнов | `analytics pipeline-stats` | — | `get_pipeline_stats` |
+| Статистика пайплайнов | `analytics pipeline-stats` | `GET /analytics/pipelines/stats` | `get_pipeline_stats` |
 | Трендовые темы | `analytics trending-topics` | `GET /analytics/trends` | `get_trending_topics` |
 | Топ каналов | `analytics trending-channels` | `GET /analytics/trends` | `get_trending_channels` |
-| Трендовые эмодзи | `analytics trending-emojis` | `GET /analytics/trends` | — |
-| Скорость сообщений | `analytics velocity` | — | `get_message_velocity` |
-| Пиковые часы | `analytics peak-hours` | — | `get_peak_hours` |
+| Трендовые эмодзи | `analytics trending-emojis` | `GET /analytics/trends` | `get_trending_emojis` |
+| Скорость сообщений | `analytics velocity` | `GET /analytics/messages/velocity` | `get_message_velocity` |
+| Пиковые часы | `analytics peak-hours` | `GET /analytics/peak-hours` | `get_peak_hours` |
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
-| Аналитика канала | `analytics channel` | `GET /analytics/channels` | — |
+| Аналитика канала | `analytics channel` | `GET /analytics/channels` | `get_channel_analytics` |
 
 ## Dialogs
 
@@ -180,8 +196,8 @@
 | Список диалогов | `dialogs list` | `GET /dialogs/` | `search_dialogs` |
 | Обновить кеш | `dialogs refresh` | `POST /dialogs/refresh` | `refresh_dialogs` |
 | Покинуть диалоги | `dialogs leave` | `POST /dialogs/leave` | `leave_dialogs` |
-| Подписаться/вступить | `dialogs join` | — | `join_channel`, `join_chat`, `subscribe_channel` |
-| Resolve entity | `dialogs resolve` | — | `resolve_entity` |
+| Подписаться/вступить | `dialogs join` | `POST /dialogs/join` | `join_channel`, `join_chat`, `subscribe_channel` |
+| Resolve entity | `dialogs resolve` | `POST /dialogs/resolve` | `resolve_entity` |
 | Статус кеша | `dialogs cache-status` | `GET /dialogs/cache-status` | `get_cache_status` |
 | Очистить кеш | `dialogs cache-clear` | `POST /dialogs/cache-clear` | `clear_dialog_cache` |
 | Топики форума | `dialogs topics` | `GET /agent/forum-topics` | `get_forum_topics` |
@@ -212,15 +228,15 @@
 | Отправить фото | `photo-loader send` | `POST /dialogs/photos/send` | `send_photos_now` |
 | Запланировать | `photo-loader schedule-send` | `POST /dialogs/photos/schedule` | `schedule_photos` |
 | Создать батч | `photo-loader batch-create` | `POST /dialogs/photos/batch` | `create_photo_batch` |
-| Список батчей | `photo-loader batch-list` | — | `list_photo_batches` |
+| Список батчей | `photo-loader batch-list` | `GET /dialogs/photos/batches` | `list_photo_batches` |
 | Отменить батч | `photo-loader batch-cancel` | `POST /dialogs/photos/items/{id}/cancel` | `cancel_photo_item` |
 | Авто-загрузка | `photo-loader auto-create` | `POST /dialogs/photos/auto` | `create_auto_upload` |
-| Список авто | `photo-loader auto-list` | — | `list_auto_uploads` |
+| Список авто | `photo-loader auto-list` | `GET /dialogs/photos/auto` | `list_auto_uploads` |
 | Обновить авто | `photo-loader auto-update` | `POST /dialogs/photos/auto/{id}/update` | `update_auto_upload` |
 | Вкл/выкл авто | `photo-loader auto-toggle` | `POST /dialogs/photos/auto/{id}/toggle` | `toggle_auto_upload` |
 | Удалить авто | `photo-loader auto-delete` | `POST /dialogs/photos/auto/{id}/delete` | `delete_auto_upload` |
 | Запустить due | `photo-loader run-due` | `POST /dialogs/photos/run-due` | `run_photo_due` |
-| Список items | `photo-loader items` | — | `list_photo_items` |
+| Список items | `photo-loader items` | `GET /dialogs/photos/items` | `list_photo_items` |
 
 ## Изображения
 
@@ -230,18 +246,18 @@
 | Поиск моделей | `image models` | `GET /images/models/search` | `list_image_models` |
 | Поиск моделей (живой запрос) | `image models --refresh` | `GET /images/models/search?refresh=1` | `list_image_models` |
 | Список провайдеров | `image providers` | `GET /images/` | `list_image_providers` |
-| Список генераций | `image generated` | — | `list_generated_images` |
+| Список генераций | `image generated` | `GET /images/generated` | `list_generated_images` |
 
 ## LLM-провайдеры
 
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
-| Список | `provider list` | `GET /settings/` | — |
-| Добавить | `provider add` | `POST /settings/agent-providers/add` | — |
-| Удалить | `provider delete` | `POST /settings/agent-providers/{name}/delete` | — |
-| Probe | `provider probe` | `POST /settings/agent-providers/{name}/probe` | — |
-| Обновить модели | `provider refresh` | `POST /settings/agent-providers/{name}/refresh`, `POST /settings/agent-providers/refresh-all` | — |
-| Тест всех | `provider test-all` | `POST /settings/agent-providers/test-all` | — |
+| Список | `provider list` | `GET /settings/` | *исключение: управление ключами провайдеров* |
+| Добавить | `provider add` | `POST /settings/agent-providers/add` | *исключение: управление ключами провайдеров* |
+| Удалить | `provider delete` | `POST /settings/agent-providers/{name}/delete` | *исключение: управление ключами провайдеров* |
+| Probe | `provider probe` | `POST /settings/agent-providers/{name}/probe` | *исключение: управление ключами провайдеров* |
+| Обновить модели | `provider refresh` | `POST /settings/agent-providers/{name}/refresh`, `POST /settings/agent-providers/refresh-all` | *исключение: управление ключами провайдеров* |
+| Тест всех | `provider test-all` | `POST /settings/agent-providers/test-all` | *исключение: управление ключами провайдеров* |
 
 ## AI-агент
 
@@ -251,13 +267,13 @@
 | Создать тред | `agent thread-create` | `POST /agent/threads` | `create_agent_thread` |
 | Удалить тред | `agent thread-delete` | `DELETE /agent/threads/{id}` | `delete_agent_thread` |
 | Переименовать | `agent thread-rename` | `POST /agent/threads/{id}/rename` | `rename_agent_thread` |
-| Сообщения треда | `agent messages` | — | `get_thread_messages` |
-| Чат (многоходовой) | `agent chat` | `POST /agent/threads/{id}/chat` | — |
+| Сообщения треда | `agent messages` | `GET /agent/threads/{id}/messages` | `get_thread_messages` |
+| Чат (многоходовой) | `agent chat` | `POST /agent/threads/{id}/chat` | *исключение: self-control агента (рекурсия)* |
 | Статус Telegram-очереди | `dialogs queue status` | `POST /agent/threads/{id}/chat` | `get_telegram_queue_status` |
 | Отменить задание очереди | `dialogs queue cancel` | `POST /dialogs/queue/{id}/cancel` | `cancel_telegram_command` |
 | Очистить ожидающие в очереди | `dialogs queue clear-pending` | `POST /dialogs/queue/clear-pending` | `clear_pending_telegram_commands` |
-| Контекст | `agent context` | `POST /agent/threads/{id}/context` | — |
-| Остановить | `agent thread-stop` | `POST /agent/threads/{id}/stop` | — |
+| Контекст | `agent context` | `POST /agent/threads/{id}/context` | *исключение: self-control агента* |
+| Остановить | `agent thread-stop` | `POST /agent/threads/{id}/stop` | *исключение: self-control агента* |
 
 > **Многоходовой чат (паритет CLI ↔ Web).** Обе стороны идут через единый
 > `AgentManager.chat_stream`, который на каждом ходе загружает полную историю треда
@@ -270,13 +286,13 @@
 | Операция | CLI | Web Endpoint | Agent Tool |
 |----------|-----|-------------|------------|
 | Получить | `settings get` | `GET /settings/` | `get_settings` |
-| Установить raw key/value | `settings set` | `POST /settings/save-*` | — |
-| Диагностика | `settings info` | — | `get_system_info` |
-| Время сервера | `settings server-time` | — | `get_server_time` |
+| Установить raw key/value | `settings set` | `POST /settings/save-*` | *исключение: raw/чувствительные настройки* |
+| Диагностика | `settings info` | *исключение: debug read-only* | `get_system_info` |
+| Время сервера | `settings server-time` | *исключение: debug read-only* | `get_server_time` |
 | Агент | `settings agent` | `POST /settings/save-agent` | `save_agent_settings` |
 | Фильтры | `settings filter-criteria` | `POST /settings/save-filters` | `save_filter_settings` |
-| Интервал реакций | `settings reactions` | `POST /settings/save-scheduler` | — |
-| Семантический поиск | `settings semantic` | `POST /settings/save-semantic-search` | — |
+| Интервал реакций | `settings reactions` | `POST /settings/save-scheduler` | *исключение: чувствительные настройки* |
+| Семантический поиск | `settings semantic` | `POST /settings/save-semantic-search` | *исключение: чувствительные настройки* |
 
 ## Сервер и диагностика
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,8 @@ select = ["E", "F", "I", "N", "W"]
 [tool.pytest.ini_options]
 anyio_mode = "auto"
 testpaths = ["tests"]
-timeout = 30
+# Keep pytest-timeout as a deadlock guard; xdist workers can be CPU-starved on shared dev hosts.
+timeout = 120
 addopts = "--dist=loadfile"
 filterwarnings = ["error"]
 markers = [

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -181,7 +181,7 @@ def make_mcp_server(db, client_pool=None, scheduler_manager=None, config=None, a
     )
 
 
-# Tool names safe for unattended pipeline execution (read-only subset).
+# Tool names safe for unattended pipeline execution (read-only and non-private subset).
 _PIPELINE_SAFE_TOOLS: frozenset[str] = frozenset({
     "search_messages",
     "semantic_search",
@@ -215,7 +215,6 @@ _PIPELINE_SAFE_TOOLS: frozenset[str] = frozenset({
     "get_peak_hours",
     "get_calendar",
     "list_tags",
-    "list_dialogs_for_import",
     "list_search_queries",
     "get_search_query_stats",
     "get_pipeline_dry_run_count",

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -215,8 +215,11 @@ _PIPELINE_SAFE_TOOLS: frozenset[str] = frozenset({
     "get_peak_hours",
     "get_calendar",
     "list_tags",
+    "list_dialogs_for_import",
     "list_search_queries",
     "get_search_query_stats",
+    "get_pipeline_dry_run_count",
+    "get_trending_emojis",
 })
 
 

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -339,4 +339,68 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(get_hourly_activity)
 
+    @tool(
+        "get_trending_emojis",
+        "Get the most-used reaction emojis across collected channels over the last N days.",
+        {
+            "days": Annotated[int, "Период в днях (по умолчанию 7)"],
+            "limit": Annotated[int, "Максимум эмодзи (по умолчанию 15)"],
+        },
+    )
+    async def get_trending_emojis(args):
+        try:
+            from src.services.trend_service import TrendService
+
+            days = int(args.get("days", 7))
+            limit = int(args.get("limit", 15))
+            emojis = await TrendService(db).get_trending_emojis(days=days, limit=limit)
+            if not emojis:
+                return _text_response("Нет данных по трендовым эмодзи.")
+            lines = [f"Трендовые эмодзи за {days} дн.:"]
+            for item in emojis:
+                lines.append(f"- {item.emoji}: {item.count}")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка получения трендовых эмодзи: {e}")
+
+    tools.append(get_trending_emojis)
+
+    @tool(
+        "get_channel_analytics",
+        "Get an analytics overview for a single channel: subscribers and deltas, ERR, post "
+        "frequency, average views/forwards/reactions. channel_id = Telegram numeric ID.",
+        {
+            "channel_id": Annotated[int, "Числовой Telegram ID канала"],
+            "days": Annotated[int, "Период в днях (по умолчанию 30)"],
+        },
+    )
+    async def get_channel_analytics(args):
+        channel_id = args.get("channel_id")
+        if not channel_id:
+            return _text_response("Ошибка: channel_id обязателен.")
+        try:
+            from src.services.channel_analytics_service import ChannelAnalyticsService
+
+            days = int(args.get("days", 30))
+            ov = await ChannelAnalyticsService(db).get_channel_overview(int(channel_id), days=days)
+            if ov.title is None and ov.subscriber_count is None:
+                return _text_response(f"Канал channel_id={channel_id} не найден или без данных.")
+            title = ov.title or "(без названия)"
+            lines = [
+                f"Аналитика канала: {title} (channel_id={ov.channel_id}), период {days} дн.",
+                f"- Подписчиков: {ov.subscriber_count if ov.subscriber_count is not None else '—'} "
+                f"(Δ {ov.subscriber_delta if ov.subscriber_delta is not None else '—'})",
+                f"- ERR: {f'{ov.err:.2f}%' if ov.err is not None else '—'}",
+                f"- Постов: всего {ov.total_posts}, сегодня {ov.posts_today}, "
+                f"неделя {ov.posts_week}, месяц {ov.posts_month}",
+                f"- Ср. просмотры: {ov.avg_views if ov.avg_views is not None else '—'}, "
+                f"ср. репосты: {ov.avg_forwards if ov.avg_forwards is not None else '—'}, "
+                f"ср. реакции: {ov.avg_reactions if ov.avg_reactions is not None else '—'}",
+            ]
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка аналитики канала: {e}")
+
+    tools.append(get_channel_analytics)
+
     return tools

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -8,6 +8,9 @@ from claude_agent_sdk import tool
 
 from src.agent.tools._registry import _text_response
 
+_MAX_TREND_DAYS = 365
+_MAX_TREND_LIMIT = 100
+
 
 def _daily_stat_value(row: object, attr: str, legacy_key: str | None = None, default: int | str = 0) -> object:
     if hasattr(row, attr):
@@ -15,6 +18,10 @@ def _daily_stat_value(row: object, attr: str, legacy_key: str | None = None, def
     if isinstance(row, dict):
         return row.get(legacy_key or attr, default)
     return default
+
+
+def _clamp_positive(value: int, upper: int) -> int:
+    return max(1, min(value, upper))
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -119,8 +126,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.trend_service import TrendService
 
             svc = TrendService(db)
-            days = int(args.get("days", 7))
-            limit = int(args.get("limit", 20))
+            days = _clamp_positive(int(args.get("days", 7)), _MAX_TREND_DAYS)
+            limit = _clamp_positive(int(args.get("limit", 20)), _MAX_TREND_LIMIT)
             topics = await svc.get_trending_topics(days=days, limit=limit)
             if not topics:
                 return _text_response("Трендовые темы не найдены.")
@@ -146,8 +153,8 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.trend_service import TrendService
 
             svc = TrendService(db)
-            days = int(args.get("days", 7))
-            limit = int(args.get("limit", 20))
+            days = _clamp_positive(int(args.get("days", 7)), _MAX_TREND_DAYS)
+            limit = _clamp_positive(int(args.get("limit", 20)), _MAX_TREND_LIMIT)
             channels = await svc.get_trending_channels(days=days, limit=limit)
             if not channels:
                 return _text_response("Данные о каналах не найдены.")
@@ -174,7 +181,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.trend_service import TrendService
 
             svc = TrendService(db)
-            days = int(args.get("days", 30))
+            days = _clamp_positive(int(args.get("days", 30)), _MAX_TREND_DAYS)
             velocity = await svc.get_message_velocity(days=days)
             if not velocity:
                 return _text_response("Данные о скорости сообщений не найдены.")
@@ -187,16 +194,21 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(get_message_velocity)
 
-    @tool("get_peak_hours", "Get peak activity hours across all channels", {})
+    @tool(
+        "get_peak_hours",
+        "Get peak activity hours across all channels",
+        {"days": Annotated[int, "Количество дней для анализа"]},
+    )
     async def get_peak_hours(args):
         try:
             from src.services.trend_service import TrendService
 
             svc = TrendService(db)
-            hours = await svc.get_peak_hours()
+            days = _clamp_positive(int(args.get("days", 30)), _MAX_TREND_DAYS)
+            hours = await svc.get_peak_hours(days=days)
             if not hours:
                 return _text_response("Данные о пиковых часах не найдены.")
-            lines = ["Пиковые часы активности:"]
+            lines = [f"Пиковые часы активности за {days} дней:"]
             for h in hours:
                 bar = "█" * max(1, h.count // 10)
                 lines.append(f"- {h.hour:02d}:00 — {h.count} сообщений {bar}")
@@ -351,8 +363,8 @@ def register(db, client_pool, embedding_service, **kwargs):
         try:
             from src.services.trend_service import TrendService
 
-            days = int(args.get("days", 7))
-            limit = int(args.get("limit", 15))
+            days = _clamp_positive(int(args.get("days", 7)), _MAX_TREND_DAYS)
+            limit = _clamp_positive(int(args.get("limit", 15)), _MAX_TREND_LIMIT)
             emojis = await TrendService(db).get_trending_emojis(days=days, limit=limit)
             if not emojis:
                 return _text_response("Нет данных по трендовым эмодзи.")

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -444,4 +444,83 @@ def register(db, client_pool, embedding_service, **kwargs):
 
     tools.append(set_channel_tags)
 
+    @tool(
+        "get_channel_tags",
+        "Get tags assigned to a specific channel. pk = DB primary key from list_channels.",
+        {
+            "pk": Annotated[int, "ID записи в БД (первичный ключ из list_channels)"],
+        },
+    )
+    async def get_channel_tags(args):
+        try:
+            pk = arg_int(args, "pk", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        try:
+            ch = await db.get_channel_by_pk(pk)
+            if ch is None:
+                return _text_response(f"Канал pk={pk} не найден.")
+            tags = await db.repos.channels.get_channel_tags(pk)
+            if not tags:
+                return _text_response(f"У канала '{ch.title}' нет тегов.")
+            return _text_response(f"Теги канала '{ch.title}': {', '.join(tags)}")
+        except Exception as e:
+            return _text_response(f"Ошибка получения тегов канала: {e}")
+
+    tools.append(get_channel_tags)
+
+    # ------------------------------------------------------------------
+    # Bulk add / list-for-import (dialog cache, no live pool needed)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "list_dialogs_for_import",
+        "List cached dialogs available for import as channels. Each row includes channel_id, "
+        "title, username and already_added (true if the dialog is already saved as a channel). "
+        "Uses the cached dialog list; call refresh_dialogs first if it looks stale.",
+        {},
+    )
+    async def list_dialogs_for_import(args):
+        try:
+            dialogs = await ctx.channel_service().get_dialogs_with_added_flags()
+            if not dialogs:
+                return _text_response("Диалоги в кеше не найдены. Сначала выполните refresh_dialogs.")
+            lines = [f"Диалоги для импорта ({len(dialogs)}):"]
+            for d in dialogs:
+                added = "уже добавлен" if d.get("already_added") else "новый"
+                title = d.get("title") or "(без названия)"
+                username = f" @{d['username']}" if d.get("username") else ""
+                lines.append(f"- {d.get('channel_id')} {title}{username} [{added}]")
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка получения диалогов для импорта: {e}")
+
+    tools.append(list_dialogs_for_import)
+
+    @tool(
+        "add_channels_bulk",
+        "Bulk-add channels from the cached dialog list by their channel_id. "
+        "channel_ids = comma-separated dialog channel_id values (from list_dialogs_for_import). "
+        "Uses cached dialogs; refresh_dialogs first if stale. Requires confirm=true.",
+        {
+            "channel_ids": Annotated[str, "ID диалогов через запятую (из list_dialogs_for_import)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
+    )
+    async def add_channels_bulk(args):
+        raw = arg_str(args, "channel_ids", "")
+        ids = [c.strip() for c in raw.split(",") if c.strip()]
+        if not ids:
+            return _text_response("Укажите channel_ids (через запятую).")
+        gate = require_confirmation(f"добавит {len(ids)} диалог(ов) как каналы", args)
+        if gate:
+            return gate
+        try:
+            await ctx.channel_service().add_bulk_by_dialog_ids(ids)
+            return _text_response(f"Обработано {len(ids)} диалог(ов) для добавления в каналы.")
+        except Exception as e:
+            return _text_response(f"Ошибка массового добавления: {e}")
+
+    tools.append(add_channels_bulk)
+
     return tools

--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -516,7 +516,19 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            await ctx.channel_service().add_bulk_by_dialog_ids(ids)
+            result = await ctx.channel_service().add_bulk_by_dialog_ids(ids)
+            if isinstance(result, dict):
+                processed = int(result.get("processed", 0))
+                skipped = int(result.get("skipped", 0))
+                text = f"Обработано {processed} из {len(ids)} диалог(ов) для добавления в каналы."
+                if skipped:
+                    skipped_ids = result.get("skipped_ids", [])
+                    skipped_text = ", ".join(str(cid) for cid in skipped_ids) if isinstance(skipped_ids, list) else ""
+                    if skipped_text:
+                        text += f"\nПропущено {skipped}: {skipped_text}"
+                    else:
+                        text += f"\nПропущено {skipped} диалог(ов)."
+                return _text_response(text)
             return _text_response(f"Обработано {len(ids)} диалог(ов) для добавления в каналы.")
         except Exception as e:
             return _text_response(f"Ошибка массового добавления: {e}")

--- a/src/agent/tools/filters.py
+++ b/src/agent/tools/filters.py
@@ -8,7 +8,12 @@ from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
 from src.agent.tools._formatters import format_filter_report
-from src.agent.tools._registry import _text_response, require_confirmation
+from src.agent.tools._registry import (
+    ToolInputError,
+    _text_response,
+    arg_int,
+    require_confirmation,
+)
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -197,5 +202,32 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка pre-filter: {e}")
 
     tools.append(precheck_filters)
+
+    @tool(
+        "purge_channel_messages",
+        "⚠️ DANGEROUS: Delete all collected messages of ONE channel. "
+        "channel_id = Telegram numeric ID (from list_channels), NOT the DB pk. "
+        "Requires confirm=true.",
+        {
+            "channel_id": Annotated[int, "Числовой Telegram ID канала (НЕ pk)"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
+        annotations=ToolAnnotations(destructiveHint=True),
+    )
+    async def purge_channel_messages(args):
+        try:
+            channel_id = arg_int(args, "channel_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        gate = require_confirmation(f"удалит все сообщения канала channel_id={channel_id}", args)
+        if gate:
+            return gate
+        try:
+            deleted = await db.delete_messages_for_channel(channel_id)
+            return _text_response(f"Удалено {deleted} сообщений канала channel_id={channel_id}.")
+        except Exception as e:
+            return _text_response(f"Ошибка очистки сообщений канала: {e}")
+
+    tools.append(purge_channel_messages)
 
     return tools

--- a/src/agent/tools/messaging_write.py
+++ b/src/agent/tools/messaging_write.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Annotated, Any
 
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
@@ -10,6 +10,7 @@ from src.agent.tools._registry import (
     ToolInputError,
     _text_response,
     arg_csv_ints,
+    arg_int,
     arg_str,
     get_accounts_with_flood_cleanup,
     is_flood_wait_active,
@@ -414,4 +415,52 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         return _text_response("\n".join(lines))
 
     tools.append(send_reactions)
+
+    @tool(
+        "translate_message",
+        "Translate a single collected message into a target language by its DB id. "
+        "message_db_id = DB id of the message (not the Telegram message_id). "
+        "target = ISO language code (default 'en'). Stores the translation.",
+        {
+            "message_db_id": Annotated[int, "ID сообщения в БД"],
+            "target": Annotated[str, "Целевой язык (например en)"],
+        },
+    )
+    async def translate_message(args):
+        try:
+            message_db_id = arg_int(args, "message_db_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        target = arg_str(args, "target", "en") or "en"
+        db = ctx.db
+        try:
+            msg = await db.repos.messages.get_by_id(message_db_id)
+            if msg is None:
+                return _text_response(f"Сообщение id={message_db_id} не найдено.")
+            if not (msg.text or "").strip():
+                return _text_response("В сообщении нет текста для перевода.")
+
+            from src.services.provider_service import build_provider_service
+            from src.services.translation_service import TranslationService
+
+            provider_name = await db.get_setting("translation_provider")
+            model = await db.get_setting("translation_model")
+            provider_service = await build_provider_service(db, ctx.config)
+            svc = TranslationService(db, provider_service=provider_service)
+
+            results = await svc.translate_batch([msg], target, provider_name=provider_name, model=model)
+            if not results:
+                return _text_response(
+                    "Перевод не выполнен (язык совпадает с целевым или провайдер не настроен)."
+                )
+            _, translated = results[0]
+            await db.repos.messages.update_translation(message_db_id, target, translated)
+            original = (msg.text or "")[:500]
+            return _text_response(
+                f"Оригинал:\n  {original}\n\nПеревод ({target}):\n  {translated[:500]}"
+            )
+        except Exception as e:
+            return _text_response(f"Ошибка перевода сообщения: {e}")
+
+    tools.append(translate_message)
     return tools

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -106,6 +106,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "search_my_chats": ToolCategory.READ,
     "search_in_channel": ToolCategory.READ,
     "search_hybrid": ToolCategory.READ,
+    "purge_search_cache": ToolCategory.DELETE,
     # Channels
     "list_channels": ToolCategory.READ,
     "get_channel_stats": ToolCategory.READ,
@@ -119,6 +120,9 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "create_tag": ToolCategory.WRITE,
     "delete_tag": ToolCategory.DELETE,
     "set_channel_tags": ToolCategory.WRITE,
+    "get_channel_tags": ToolCategory.READ,
+    "add_channels_bulk": ToolCategory.WRITE,
+    "list_dialogs_for_import": ToolCategory.READ,
     # Collection
     "collect_channel": ToolCategory.WRITE,
     "collect_all_channels": ToolCategory.WRITE,
@@ -138,6 +142,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "publish_pipeline_run": ToolCategory.WRITE,
     "get_pipeline_queue": ToolCategory.READ,
     "get_refinement_steps": ToolCategory.READ,
+    "get_pipeline_dry_run_count": ToolCategory.READ,
     "set_refinement_steps": ToolCategory.WRITE,
     "export_pipeline_json": ToolCategory.READ,
     "import_pipeline_json": ToolCategory.WRITE,
@@ -177,6 +182,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "purge_filtered_channels": ToolCategory.DELETE,
     "hard_delete_channels": ToolCategory.DELETE,
     "precheck_filters": ToolCategory.WRITE,
+    "purge_channel_messages": ToolCategory.DELETE,
     # Analytics
     "get_analytics_summary": ToolCategory.READ,
     "get_pipeline_stats": ToolCategory.READ,
@@ -189,6 +195,8 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "get_top_messages": ToolCategory.READ,
     "get_content_type_stats": ToolCategory.READ,
     "get_hourly_activity": ToolCategory.READ,
+    "get_trending_emojis": ToolCategory.READ,
+    "get_channel_analytics": ToolCategory.READ,
     # Scheduler
     "get_scheduler_status": ToolCategory.READ,
     "start_scheduler": ToolCategory.WRITE,
@@ -244,6 +252,7 @@ TOOL_CATEGORIES: dict[str, ToolCategory] = {
     "pin_message": ToolCategory.WRITE,
     "unpin_message": ToolCategory.WRITE,
     "download_media": ToolCategory.READ,
+    "translate_message": ToolCategory.WRITE,
     "get_participants": ToolCategory.READ,
     "edit_admin": ToolCategory.WRITE,
     "edit_permissions": ToolCategory.WRITE,
@@ -285,11 +294,13 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Поиск", [
         "search_messages", "semantic_search", "index_messages",
         "search_telegram", "search_my_chats", "search_in_channel", "search_hybrid",
+        "purge_search_cache",
     ]),
     ("Каналы", [
         "list_channels", "get_channel_stats", "add_channel", "delete_channel",
         "toggle_channel", "import_channels", "refresh_channel_types", "refresh_channel_meta",
         "list_tags", "create_tag", "delete_tag", "set_channel_tags",
+        "get_channel_tags", "add_channels_bulk", "list_dialogs_for_import",
     ]),
     ("Сбор", [
         "collect_channel", "collect_all_channels", "collect_channel_stats", "collect_all_stats",
@@ -300,7 +311,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "list_pipeline_runs", "get_pipeline_run", "publish_pipeline_run",
         "get_pipeline_queue", "get_refinement_steps", "set_refinement_steps",
         "export_pipeline_json", "import_pipeline_json", "list_pipeline_templates",
-        "create_pipeline_from_template", "ai_edit_pipeline",
+        "create_pipeline_from_template", "ai_edit_pipeline", "get_pipeline_dry_run_count",
     ]),
     ("Модерация", [
         "list_pending_moderation", "view_moderation_run", "approve_run", "reject_run",
@@ -319,12 +330,14 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
     ("Фильтры", [
         "analyze_filters", "apply_filters", "reset_filters", "toggle_channel_filter",
         "purge_filtered_channels", "hard_delete_channels", "precheck_filters",
+        "purge_channel_messages",
     ]),
     ("Аналитика", [
         "get_analytics_summary", "get_pipeline_stats", "get_daily_stats",
         "get_trending_topics", "get_trending_channels", "get_message_velocity",
         "get_peak_hours", "get_calendar",
         "get_top_messages", "get_content_type_stats", "get_hourly_activity",
+        "get_trending_emojis", "get_channel_analytics",
     ]),
     ("Планировщик", [
         "get_scheduler_status", "start_scheduler", "stop_scheduler",
@@ -350,6 +363,7 @@ MODULE_GROUPS: OrderedDict[str, list[str]] = OrderedDict([
         "send_message", "send_reaction", "send_reactions", "forward_messages", "edit_message", "delete_message",
         "pin_message", "unpin_message", "download_media", "read_messages",
         "get_telegram_queue_status", "cancel_telegram_command", "clear_pending_telegram_commands",
+        "translate_message",
     ]),
     ("Управление чатом", [
         "get_participants", "edit_admin", "edit_permissions", "kick_participant",

--- a/src/agent/tools/pipeline_read.py
+++ b/src/agent/tools/pipeline_read.py
@@ -89,24 +89,38 @@ def register_pipeline_read_tools(db: Any, ctx: Any) -> list[Any]:
 
     @tool(
         "get_pipeline_queue",
-        "List pending and running generation runs across all pipelines (the generation queue). "
-        "Shows run_id, pipeline_id, status, and text preview. "
+        "List generation runs awaiting moderation for one pipeline. "
+        "Shows run_id, status, created timestamp, and text preview. "
         "Use get_pipeline_run to see full text of a specific run.",
         GET_PIPELINE_QUEUE_SCHEMA,
     )
     async def get_pipeline_queue(args):
         try:
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
             limit = arg_int(args, "limit", 20) or 20
-            runs = await db.repos.generation_runs.list_by_status(["pending", "running"], limit=limit)
+            pipeline = await db.repos.content_pipelines.get_by_id(pipeline_id)
+            if pipeline is None:
+                return _text_response(f"Пайплайн id={pipeline_id} не найден.")
+            runs = await db.repos.generation_runs.list_pending_moderation(
+                pipeline_id=pipeline_id,
+                limit=limit,
+            )
             if not runs:
-                return _text_response("Очередь генерации пуста.")
-            lines = [f"Очередь генерации ({len(runs)} шт.):"]
+                return _text_response(f"Нет черновиков на модерации для пайплайна id={pipeline_id}.")
+            lines = [f"Очередь модерации пайплайна id={pipeline_id} ({len(runs)} шт.):"]
             for run in runs:
                 preview = (run.generated_text or "")[:100]
+                created_at = getattr(run, "created_at", None)
+                if hasattr(created_at, "strftime"):
+                    created = created_at.strftime("%Y-%m-%d %H:%M:%S")
+                else:
+                    created = created_at or "—"
                 lines.append(
-                    f"- run_id={run.id}, pipeline_id={run.pipeline_id}, status={run.status}: {preview}"
+                    f"- run_id={run.id}, status={run.status}, created={created}: {preview}"
                 )
             return _text_response("\n".join(lines))
+        except ToolInputError as exc:
+            return exc.to_response()
         except Exception as exc:
             return _text_response(f"Ошибка получения очереди: {exc}")
 

--- a/src/agent/tools/pipeline_read.py
+++ b/src/agent/tools/pipeline_read.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from claude_agent_sdk import tool
 
-from src.agent.tools._registry import ToolInputError, _text_response, arg_bool, arg_int
+from src.agent.tools._registry import ToolInputError, _text_response, arg_bool, arg_int, arg_str
 from src.agent.tools.pipeline_schemas import (
     GET_PIPELINE_DETAIL_SCHEMA,
     GET_PIPELINE_QUEUE_SCHEMA,
@@ -139,4 +139,39 @@ def register_pipeline_read_tools(db: Any, ctx: Any) -> list[Any]:
             return _text_response(f"Ошибка получения шагов рефайнмента: {exc}")
 
     tools.append(get_refinement_steps)
+
+    @tool(
+        "get_pipeline_dry_run_count",
+        "Count how many source messages a pipeline would consider within a recent time window "
+        "(dry-run, nothing is generated). since_unit is one of m/h/d (default 6h).",
+        {
+            "pipeline_id": Annotated[int, "ID пайплайна"],
+            "since_value": Annotated[int, "Значение периода (по умолчанию 6)"],
+            "since_unit": Annotated[str, "Единица периода: m/h/d (по умолчанию h)"],
+        },
+    )
+    async def get_pipeline_dry_run_count(args):
+        try:
+            pipeline_id = arg_int(args, "pipeline_id", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        since_value = arg_int(args, "since_value", 6)
+        since_unit = arg_str(args, "since_unit", "h")
+        try:
+            from src.services.pipeline_service import to_since_hours
+
+            detail = await ctx.pipeline_service().get_detail(pipeline_id)
+            if detail is None:
+                return _text_response(f"Пайплайн id={pipeline_id} не найден.")
+            source_ids = detail.get("source_ids", [])
+            since_h = to_since_hours(since_value, since_unit)
+            msgs = await db.repos.messages.get_recent_for_channels(source_ids, since_h)
+            return _text_response(
+                f"Сообщений-кандидатов: {len(msgs)} "
+                f"(источников={len(source_ids)}, период={since_value}{since_unit})."
+            )
+        except Exception as exc:
+            return _text_response(f"Ошибка подсчёта dry-run: {exc}")
+
+    tools.append(get_pipeline_dry_run_count)
     return tools

--- a/src/agent/tools/pipeline_runs.py
+++ b/src/agent/tools/pipeline_runs.py
@@ -132,14 +132,13 @@ def register_pipeline_run_tools(db: Any, client_pool: Any, config: Any, ctx: Any
         try:
             limit = int(args.get("limit", 20))
             status_filter = args.get("status")
+            moderation_status_filter = args.get("moderation_status")
             runs = await db.repos.generation_runs.list_by_pipeline(
                 int(pipeline_id),
                 limit=limit,
                 status=status_filter,
-                include_moderation_status=bool(status_filter),
+                moderation_status=moderation_status_filter,
             )
-            if status_filter:
-                runs = [run for run in runs if run.status == status_filter or run.moderation_status == status_filter]
             if not runs:
                 return _text_response(f"Нет генераций для пайплайна id={pipeline_id}.")
             lines = [f"Генерации пайплайна id={pipeline_id} ({len(runs)} шт.):"]

--- a/src/agent/tools/pipeline_runs.py
+++ b/src/agent/tools/pipeline_runs.py
@@ -132,11 +132,14 @@ def register_pipeline_run_tools(db: Any, client_pool: Any, config: Any, ctx: Any
         try:
             limit = int(args.get("limit", 20))
             status_filter = args.get("status")
-            fetch_limit = limit * 10 if status_filter else limit
-            runs = await db.repos.generation_runs.list_by_pipeline(int(pipeline_id), limit=fetch_limit)
+            runs = await db.repos.generation_runs.list_by_pipeline(
+                int(pipeline_id),
+                limit=limit,
+                status=status_filter,
+                include_moderation_status=bool(status_filter),
+            )
             if status_filter:
                 runs = [run for run in runs if run.status == status_filter or run.moderation_status == status_filter]
-                runs = runs[:limit]
             if not runs:
                 return _text_response(f"Нет генераций для пайплайна id={pipeline_id}.")
             lines = [f"Генерации пайплайна id={pipeline_id} ({len(runs)} шт.):"]

--- a/src/agent/tools/pipeline_schemas.py
+++ b/src/agent/tools/pipeline_schemas.py
@@ -53,7 +53,8 @@ GENERATE_DRAFT_SCHEMA = {
 LIST_PIPELINE_RUNS_SCHEMA = {
     "pipeline_id": PIPELINE_ID_ARG,
     "limit": LIMIT_ARG,
-    "status": Annotated[str, "Фильтр по статусу (pending/completed/approved/rejected)"],
+    "status": Annotated[str, "Фильтр по статусу выполнения (pending/running/completed/failed)"],
+    "moderation_status": Annotated[str, "Фильтр по статусу модерации (pending/approved/rejected/published)"],
 }
 
 GET_PIPELINE_RUN_SCHEMA = {"run_id": RUN_ID_ARG}

--- a/src/agent/tools/pipeline_schemas.py
+++ b/src/agent/tools/pipeline_schemas.py
@@ -9,7 +9,7 @@ LIMIT_ARG = Annotated[int, "Максимальное количество рез
 
 LIST_PIPELINES_SCHEMA = {"active_only": Annotated[bool, "Показывать только активные"]}
 GET_PIPELINE_DETAIL_SCHEMA = {"pipeline_id": PIPELINE_ID_ARG}
-GET_PIPELINE_QUEUE_SCHEMA = {"limit": LIMIT_ARG}
+GET_PIPELINE_QUEUE_SCHEMA = {"pipeline_id": PIPELINE_ID_ARG, "limit": LIMIT_ARG}
 GET_REFINEMENT_STEPS_SCHEMA = {"pipeline_id": PIPELINE_ID_ARG}
 
 ADD_PIPELINE_SCHEMA = {

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 from typing import Annotated
 
 from claude_agent_sdk import tool
+from mcp.types import ToolAnnotations
 
 from src.agent.tools._formatters import format_channel_identity, format_sender_identity
-from src.agent.tools._registry import _text_response, require_pool
+from src.agent.tools._registry import (
+    ToolInputError,
+    _text_response,
+    arg_str,
+    require_confirmation,
+    require_pool,
+)
 
 
 def register(db, client_pool, embedding_service, **kwargs):
@@ -286,5 +293,36 @@ def register(db, client_pool, embedding_service, **kwargs):
         return _text_response(text)
 
     tools.append(search_hybrid)
+
+    # ------------------------------------------------------------------
+    # purge_search_cache  (DELETE — Premium search cache by query)
+    # ------------------------------------------------------------------
+
+    @tool(
+        "purge_search_cache",
+        "⚠️ DANGEROUS: Delete messages cached solely by a Premium global search for a given query. "
+        "Only premium-search-tagged rows are removed; collected user data is never touched. "
+        "Requires confirm=true.",
+        {
+            "query": Annotated[str, "Поисковый запрос, кэш которого нужно очистить"],
+            "confirm": Annotated[bool, "Установите true для подтверждения действия"],
+        },
+        annotations=ToolAnnotations(destructiveHint=True),
+    )
+    async def purge_search_cache(args):
+        try:
+            query = arg_str(args, "query", required=True)
+        except ToolInputError as exc:
+            return exc.to_response()
+        gate = require_confirmation(f"очистит кэш Premium-поиска по запросу '{query}'", args)
+        if gate:
+            return gate
+        try:
+            deleted = await db.repos.messages.delete_premium_search_results(query)
+            return _text_response(f"Удалено из кэша Premium-поиска: {deleted} сообщений (запрос '{query}').")
+        except Exception as e:
+            return _text_response(f"Ошибка очистки кэша поиска: {e}")
+
+    tools.append(purge_search_cache)
 
     return tools

--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -202,33 +202,17 @@ def run(args: argparse.Namespace) -> None:
                         str(e.preview)[:40],
                     ))
             elif action == "trending-emojis":
-                import re
-                from collections import Counter
+                from src.services.trend_service import TrendService
 
                 days = getattr(args, "days", 7)
                 limit = getattr(args, "limit", 20)
-                from datetime import datetime, timedelta, timezone
-
-                since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
-                messages, _ = await db.search_messages(date_from=since, limit=10000)
-                emoji_pattern = re.compile(
-                    r"[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF"
-                    r"\U0001F680-\U0001F6FF\U0001F1E0-\U0001F1FF"
-                    r"\U00002702-\U000027B0\U0001F900-\U0001F9FF"
-                    r"\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF"
-                    r"\U00002600-\U000026FF\U0000FE0F]"
-                )
-                counter: Counter[str] = Counter()
-                for msg in messages:
-                    text = msg.text or ""
-                    for match in emoji_pattern.finditer(text):
-                        counter[match.group()] += 1
-                if not counter:
-                    print("No emojis found in recent messages.")
+                emojis = await TrendService(db).get_trending_emojis(days=days, limit=limit)
+                if not emojis:
+                    print("No emoji reactions found.")
                 else:
-                    print(f"Top {limit} emojis (last {days} days):\n")
-                    for emoji, count in counter.most_common(limit):
-                        print(f"  {emoji}  {count}")
+                    print(f"Top {limit} emoji reactions (last {days} days):\n")
+                    for item in emojis:
+                        print(f"  {item.emoji}  {item.count}")
 
             elif action == "channel":
                 from src.services.channel_analytics_service import ChannelAnalyticsService

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -181,17 +181,16 @@ class GenerationRunsRepository:
         limit: int = 20,
         offset: int = 0,
         status: str | None = None,
-        include_moderation_status: bool = False,
+        moderation_status: str | None = None,
     ) -> list[GenerationRun]:
         where = "pipeline_id = ?"
         params: list[object] = [pipeline_id]
         if status:
-            if include_moderation_status:
-                where += " AND (status = ? OR moderation_status = ?)"
-                params.extend([status, status])
-            else:
-                where += " AND status = ?"
-                params.append(status)
+            where += " AND status = ?"
+            params.append(status)
+        if moderation_status:
+            where += " AND moderation_status = ?"
+            params.append(moderation_status)
         cur = await self._db.execute(
             f"SELECT * FROM generation_runs WHERE {where} ORDER BY id DESC LIMIT ? OFFSET ?",
             (*params, limit, offset),

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -176,11 +176,25 @@ class GenerationRunsRepository:
         return [self._to_generation_run(row) for row in rows]
 
     async def list_by_pipeline(
-        self, pipeline_id: int, limit: int = 20, offset: int = 0
+        self,
+        pipeline_id: int,
+        limit: int = 20,
+        offset: int = 0,
+        status: str | None = None,
+        include_moderation_status: bool = False,
     ) -> list[GenerationRun]:
+        where = "pipeline_id = ?"
+        params: list[object] = [pipeline_id]
+        if status:
+            if include_moderation_status:
+                where += " AND (status = ? OR moderation_status = ?)"
+                params.extend([status, status])
+            else:
+                where += " AND status = ?"
+                params.append(status)
         cur = await self._db.execute(
-            "SELECT * FROM generation_runs WHERE pipeline_id = ? ORDER BY id DESC LIMIT ? OFFSET ?",
-            (pipeline_id, limit, offset),
+            f"SELECT * FROM generation_runs WHERE {where} ORDER BY id DESC LIMIT ? OFFSET ?",
+            (*params, limit, offset),
         )
         rows = await cur.fetchall()
         return [self._to_generation_run(row) for row in rows]

--- a/src/services/channel_service.py
+++ b/src/services/channel_service.py
@@ -72,7 +72,7 @@ class ChannelService:
             dialog["already_added"] = dialog["channel_id"] in existing_ids
         return dialogs
 
-    async def add_bulk_by_dialog_ids(self, channel_ids: list[str]) -> None:
+    async def add_bulk_by_dialog_ids(self, channel_ids: list[str]) -> dict[str, int | list[str]]:
         if self._db is not None:
             dialogs = []
             for phone in await self._db.repos.dialog_cache.get_all_phones():
@@ -81,8 +81,11 @@ class ChannelService:
             dialogs = await self._pool.get_dialogs()
         dialogs_map = {str(d["channel_id"]): d for d in dialogs}
         stats_channel_ids: list[int] = []
+        processed = 0
+        skipped_ids: list[str] = []
         for cid in channel_ids:
             if cid not in dialogs_map:
+                skipped_ids.append(cid)
                 continue
             dialog = dialogs_map[cid]
             channel_id = int(dialog["channel_id"])
@@ -100,6 +103,7 @@ class ChannelService:
             )
             channel = channel_with_meta(channel, meta)
             await self._channels.add_channel(channel)
+            processed += 1
             if existing is None and channel.is_active:
                 stats_channel_ids.append(channel.channel_id)
         await enqueue_stats_for_new_channels(
@@ -107,6 +111,12 @@ class ChannelService:
             stats_channel_ids,
             context="bulk dialog add",
         )
+        return {
+            "requested": len(channel_ids),
+            "processed": processed,
+            "skipped": len(skipped_ids),
+            "skipped_ids": skipped_ids,
+        }
 
     async def get_my_dialogs(self, phone: str, refresh: bool = False) -> list[dict]:
         """Get all dialogs for a specific account, enriched with already_added flag."""

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -23,7 +23,7 @@ from src.models import (
     PipelineTemplate,
 )
 from src.services.pipeline_filters import normalize_filter_config
-from src.services.pipeline_llm_requirements import pipeline_needs_llm
+from src.services.pipeline_llm_requirements import get_dag_source_channel_ids, pipeline_needs_llm
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +110,28 @@ class PipelineService:
             ],
         )
         return pipeline.model_copy(update={"pipeline_json": graph})
+
+    @staticmethod
+    def _effective_source_ids(
+        pipeline: ContentPipeline,
+        sources: list[PipelineSource],
+    ) -> list[int]:
+        """Return source IDs from the runtime graph for DAGs, sidecar rows for legacy pipelines."""
+        dag_source_ids = get_dag_source_channel_ids(pipeline)
+        if dag_source_ids is not None:
+            return dag_source_ids
+        return [source.channel_id for source in sources]
+
+    @staticmethod
+    def _source_titles(source_ids: list[int], channels_by_id: dict[int, Any]) -> list[str]:
+        return [
+            (
+                channels_by_id.get(source_id).title or str(source_id)
+                if channels_by_id.get(source_id)
+                else str(source_id)
+            )
+            for source_id in source_ids
+        ]
 
     async def add(
         self,
@@ -279,20 +301,14 @@ class PipelineService:
         )
         pipeline = self._hydrate_runtime_refs(pipeline, sources, targets)
         channels_by_id = {channel.channel_id: channel for channel in channels}
+        source_ids = self._effective_source_ids(pipeline, sources)
         return {
             "pipeline": pipeline,
             "sources": sources,
             "targets": targets,
-            "source_ids": [source.channel_id for source in sources],
+            "source_ids": source_ids,
             "target_refs": [f"{target.phone}|{target.dialog_id}" for target in targets],
-            "source_titles": [
-                (
-                    channels_by_id.get(source.channel_id).title or str(source.channel_id)
-                    if channels_by_id.get(source.channel_id)
-                    else str(source.channel_id)
-                )
-                for source in sources
-            ],
+            "source_titles": self._source_titles(source_ids, channels_by_id),
         }
 
     async def get_with_relations(self, active_only: bool = False) -> list[dict]:
@@ -308,30 +324,23 @@ class PipelineService:
         channels_by_id = {channel.channel_id: channel for channel in channels}
         sources_by_pid = _group_by_pipeline(all_sources)
         targets_by_pid = _group_by_pipeline(all_targets)
-        return [
-            {
-                "pipeline": self._hydrate_runtime_refs(
-                    p,
-                    sources_by_pid.get(p.id, []),
-                    targets_by_pid.get(p.id, []),
-                ) if p.id is not None and p.pipeline_json is not None else p,
-                "sources": sources_by_pid.get(p.id, []),
-                "targets": targets_by_pid.get(p.id, []),
-                "source_ids": [s.channel_id for s in sources_by_pid.get(p.id, [])],
+        results = []
+        for p in pipelines:
+            sources = sources_by_pid.get(p.id, []) if p.id is not None else []
+            targets = targets_by_pid.get(p.id, []) if p.id is not None else []
+            hydrated = self._hydrate_runtime_refs(p, sources, targets) if p.id is not None and p.pipeline_json else p
+            source_ids = self._effective_source_ids(hydrated, sources)
+            results.append({
+                "pipeline": hydrated,
+                "sources": sources,
+                "targets": targets,
+                "source_ids": source_ids,
                 "target_refs": [
-                    f"{t.phone}|{t.dialog_id}" for t in targets_by_pid.get(p.id, [])
+                    f"{t.phone}|{t.dialog_id}" for t in targets
                 ],
-                "source_titles": [
-                    (
-                        channels_by_id.get(s.channel_id).title or str(s.channel_id)
-                        if channels_by_id.get(s.channel_id)
-                        else str(s.channel_id)
-                    )
-                    for s in sources_by_pid.get(p.id, [])
-                ],
-            }
-            for p in pipelines
-        ]
+                "source_titles": self._source_titles(source_ids, channels_by_id),
+            })
+        return results
 
     async def list_cached_dialogs_by_phone(
         self,

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -453,11 +453,12 @@ class TelegramCommandDispatcher:
         return {"phone": result.phone, "target": result.target, "via_invite": result.via_invite}
 
     async def _handle_dialogs_resolve(self, payload: dict[str, Any]) -> dict[str, Any]:
+        identifier = str(payload["identifier"])
         entity = await self._pool.resolve_any_entity(
-            payload["identifier"], phone=str(payload.get("phone") or "") or None
+            identifier, phone=str(payload.get("phone") or "") or None
         )
         if not entity:
-            raise RuntimeError("resolve failed")
+            raise RuntimeError(f"resolve failed: {identifier!r} not found")
         return {"entity": entity}
 
     async def _handle_dialogs_edit_message(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -784,7 +785,7 @@ class TelegramCommandDispatcher:
         identifier = str(payload["identifier"]).strip()
         info = await self._pool.resolve_channel(identifier)
         if not info:
-            raise RuntimeError("resolve failed")
+            raise RuntimeError(f"resolve failed: {identifier!r} not found")
         existing = await get_existing_channel(self._db, int(info["channel_id"]))
         meta = await fetch_channel_meta(
             self._pool, int(info["channel_id"]), info.get("channel_type")

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -445,6 +445,21 @@ class TelegramCommandDispatcher:
         )
         return {"phone": result.phone, "message_id": result.message_id}
 
+    async def _handle_dialogs_join(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).join_dialog(
+            phone=str(payload["phone"]),
+            target=payload["target"],
+        )
+        return {"phone": result.phone, "target": result.target, "via_invite": result.via_invite}
+
+    async def _handle_dialogs_resolve(self, payload: dict[str, Any]) -> dict[str, Any]:
+        entity = await self._pool.resolve_any_entity(
+            payload["identifier"], phone=str(payload.get("phone") or "") or None
+        )
+        if not entity:
+            raise RuntimeError("resolve failed")
+        return {"entity": entity}
+
     async def _handle_dialogs_edit_message(self, payload: dict[str, Any]) -> dict[str, Any]:
         result = await TelegramActionService(self._pool).edit_message(
             phone=str(payload["phone"]),

--- a/src/web/dialogs/forms.py
+++ b/src/web/dialogs/forms.py
@@ -42,6 +42,16 @@ class SendMessageForm(_FrozenForm):
     text: str = ""
 
 
+class JoinDialogForm(_FrozenForm):
+    phone: str = ""
+    target: str = ""
+
+
+class ResolveEntityForm(_FrozenForm):
+    phone: str = ""
+    identifier: str = ""
+
+
 class EditMessageForm(_FrozenForm):
     phone: str = ""
     chat_id: str = ""

--- a/src/web/dialogs/handlers.py
+++ b/src/web/dialogs/handlers.py
@@ -19,6 +19,7 @@ from src.web.dialogs.forms import (
     EditMessageForm,
     EditPermissionsForm,
     ForwardMessagesForm,
+    JoinDialogForm,
     KickParticipantForm,
     LeaveDialogsForm,
     MarkReadForm,
@@ -26,6 +27,7 @@ from src.web.dialogs.forms import (
     PinMessageForm,
     ReactionForm,
     RefreshDialogsForm,
+    ResolveEntityForm,
     SendMessageForm,
     UnpinMessageForm,
     parse_dialog_form,
@@ -161,6 +163,30 @@ async def send_message(request: Request) -> CommandRedirect | DialogRedirect:
         request,
         "dialogs.send",
         payload={"phone": form.phone, "recipient": form.recipient, "text": form.text},
+        phone=form.phone,
+    )
+
+
+async def join_dialog(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, JoinDialogForm)
+    if not form.phone or not form.target:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.join",
+        payload={"phone": form.phone, "target": form.target},
+        phone=form.phone,
+    )
+
+
+async def resolve_entity(request: Request) -> CommandRedirect | DialogRedirect:
+    form = await parse_dialog_form(request, ResolveEntityForm)
+    if not form.identifier:
+        return DialogRedirect(form.phone, error="missing_fields")
+    return await _enqueue(
+        request,
+        "dialogs.resolve",
+        payload={"phone": form.phone, "identifier": form.identifier},
         phone=form.phone,
     )
 

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -867,9 +867,8 @@ async def list_pipeline_runs(
     moderation_status: str | None = None,
 ):
     """GET /pipelines/{id}/runs — run history (parity with CLI `pipeline runs`)."""
-    svc = deps.pipeline_service(request)
     db = deps.get_db(request)
-    if await svc.get(pipeline_id) is None:
+    if await db.repos.content_pipelines.get_by_id(pipeline_id) is None:
         return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
     runs = await db.repos.generation_runs.list_by_pipeline(
         pipeline_id,
@@ -896,9 +895,8 @@ async def show_pipeline_run(request: Request, pipeline_id: int, run_id: int):
 
 async def pipeline_queue(request: Request, pipeline_id: int, limit: int = 50):
     """GET /pipelines/{id}/queue — moderation queue (parity with CLI `pipeline queue`)."""
-    svc = deps.pipeline_service(request)
     db = deps.get_db(request)
-    if await svc.get(pipeline_id) is None:
+    if await db.repos.content_pipelines.get_by_id(pipeline_id) is None:
         return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
     runs = await db.repos.generation_runs.list_pending_moderation(pipeline_id=pipeline_id, limit=limit)
     return PipelineJson({

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -858,13 +858,22 @@ async def show_pipeline(request: Request, pipeline_id: int):
     })
 
 
-async def list_pipeline_runs(request: Request, pipeline_id: int, limit: int = 20, offset: int = 0):
+async def list_pipeline_runs(
+    request: Request,
+    pipeline_id: int,
+    limit: int = 20,
+    offset: int = 0,
+    status: str | None = None,
+):
     """GET /pipelines/{id}/runs — run history (parity with CLI `pipeline runs`)."""
     svc = deps.pipeline_service(request)
     db = deps.get_db(request)
     if await svc.get(pipeline_id) is None:
         return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
-    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id, limit=limit, offset=offset)
+    fetch_limit = limit * 10 if status else limit
+    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id, limit=fetch_limit, offset=offset)
+    if status:
+        runs = [run for run in runs if run.status == status][:limit]
     return PipelineJson({"pipeline_id": pipeline_id, "runs": [_run_to_dict(r) for r in runs]})
 
 

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -870,10 +870,12 @@ async def list_pipeline_runs(
     db = deps.get_db(request)
     if await svc.get(pipeline_id) is None:
         return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
-    fetch_limit = limit * 10 if status else limit
-    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id, limit=fetch_limit, offset=offset)
-    if status:
-        runs = [run for run in runs if run.status == status][:limit]
+    runs = await db.repos.generation_runs.list_by_pipeline(
+        pipeline_id,
+        limit=limit,
+        offset=offset,
+        status=status,
+    )
     return PipelineJson({"pipeline_id": pipeline_id, "runs": [_run_to_dict(r) for r in runs]})
 
 

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -828,3 +828,70 @@ async def set_refinement_steps(request: Request, pipeline_id: int):
         return PipelineJson({"ok": False, "error": str(exc)}, status_code=400)
     await db.repos.content_pipelines.set_refinement_steps(pipeline_id, validated)
     return PipelineJson({"ok": True, "steps": validated})
+
+
+def _run_to_dict(run) -> dict:
+    return run.model_dump(
+        mode="json",
+        include={"id", "pipeline_id", "status", "moderation_status", "created_at", "published_at"},
+    )
+
+
+async def show_pipeline(request: Request, pipeline_id: int):
+    """GET /pipelines/{id}/show — pipeline details as JSON (parity with CLI `pipeline show`)."""
+    svc = deps.pipeline_service(request)
+    detail = await svc.get_detail(pipeline_id)
+    if detail is None:
+        return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
+    p = detail["pipeline"]
+    return PipelineJson({
+        "id": p.id,
+        "name": p.name,
+        "is_active": p.is_active,
+        "llm_model": p.llm_model,
+        "publish_mode": p.publish_mode.value,
+        "generation_backend": p.generation_backend.value,
+        "generate_interval_minutes": p.generate_interval_minutes,
+        "source_ids": detail.get("source_ids", []),
+        "source_titles": detail.get("source_titles", []),
+        "target_refs": detail.get("target_refs", []),
+    })
+
+
+async def list_pipeline_runs(request: Request, pipeline_id: int, limit: int = 20, offset: int = 0):
+    """GET /pipelines/{id}/runs — run history (parity with CLI `pipeline runs`)."""
+    svc = deps.pipeline_service(request)
+    db = deps.get_db(request)
+    if await svc.get(pipeline_id) is None:
+        return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
+    runs = await db.repos.generation_runs.list_by_pipeline(pipeline_id, limit=limit, offset=offset)
+    return PipelineJson({"pipeline_id": pipeline_id, "runs": [_run_to_dict(r) for r in runs]})
+
+
+async def show_pipeline_run(request: Request, pipeline_id: int, run_id: int):
+    """GET /pipelines/{id}/runs/{run_id} — run details (parity with CLI `pipeline run-show`)."""
+    db = deps.get_db(request)
+    run = await db.repos.generation_runs.get(run_id)
+    if run is None or run.pipeline_id != pipeline_id:
+        return PipelineJson({"error": "run_not_found"}, status_code=404)
+    data = _run_to_dict(run)
+    data["generated_text"] = run.generated_text
+    data["image_url"] = run.image_url
+    data["quality_score"] = run.quality_score
+    return PipelineJson(data)
+
+
+async def pipeline_queue(request: Request, pipeline_id: int, limit: int = 50):
+    """GET /pipelines/{id}/queue — moderation queue (parity with CLI `pipeline queue`)."""
+    svc = deps.pipeline_service(request)
+    db = deps.get_db(request)
+    if await svc.get(pipeline_id) is None:
+        return PipelineJson({"error": "pipeline_not_found"}, status_code=404)
+    runs = await db.repos.generation_runs.list_pending_moderation(pipeline_id=pipeline_id, limit=limit)
+    return PipelineJson({
+        "pipeline_id": pipeline_id,
+        "queue": [
+            {**_run_to_dict(r), "preview": (r.generated_text or "")[:100]}
+            for r in runs
+        ],
+    })

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -864,6 +864,7 @@ async def list_pipeline_runs(
     limit: int = 20,
     offset: int = 0,
     status: str | None = None,
+    moderation_status: str | None = None,
 ):
     """GET /pipelines/{id}/runs — run history (parity with CLI `pipeline runs`)."""
     svc = deps.pipeline_service(request)
@@ -875,6 +876,7 @@ async def list_pipeline_runs(
         limit=limit,
         offset=offset,
         status=status,
+        moderation_status=moderation_status,
     )
     return PipelineJson({"pipeline_id": pipeline_id, "runs": [_run_to_dict(r) for r in runs]})
 

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -80,6 +80,17 @@ async def flood_status(request: Request):
     return JSONResponse(result)
 
 
+@router.get("/{account_id}/info")
+async def account_info(request: Request, account_id: int):
+    """Account summary from the DB as JSON (parity with CLI `account info`)."""
+    db = deps.get_db(request)
+    accounts = await db.get_account_summaries(active_only=False)
+    acc = next((a for a in accounts if a.id == account_id), None)
+    if acc is None:
+        return JSONResponse({"error": "account_not_found"}, status_code=404)
+    return JSONResponse(acc.model_dump(mode="json"))
+
+
 @router.post("/{account_id}/flood-clear")
 async def flood_clear(request: Request, account_id: int):
     db = deps.get_db(request)

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 
+from src.agent.runtime_context import AgentRuntimeContext
+from src.agent.tools.accounts import get_live_account_info_text
 from src.web import deps
 
 router = APIRouter()
@@ -82,13 +84,28 @@ async def flood_status(request: Request):
 
 @router.get("/{account_id}/info")
 async def account_info(request: Request, account_id: int):
-    """Account summary from the DB as JSON (parity with CLI `account info`)."""
+    """Account summary plus live diagnostics as JSON (parity with CLI `account info`)."""
     db = deps.get_db(request)
     accounts = await db.get_account_summaries(active_only=False)
     acc = next((a for a in accounts if a.id == account_id), None)
     if acc is None:
         return JSONResponse({"error": "account_not_found"}, status_code=404)
-    return JSONResponse(acc.model_dump(mode="json"))
+    try:
+        client_pool = deps.get_pool(request)
+    except RuntimeError:
+        client_pool = None
+    runtime = AgentRuntimeContext.build(
+        db=db,
+        config=getattr(request.app.state, "config", None),
+        client_pool=client_pool,
+    )
+    try:
+        live_info = await get_live_account_info_text(runtime, acc.phone)
+    except Exception as exc:
+        live_info = f"Ошибка получения live Telegram account info: {exc}"
+    data = acc.model_dump(mode="json")
+    data["live_info"] = live_info
+    return JSONResponse(data)
 
 
 @router.post("/{account_id}/flood-clear")

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.web import deps
 from src.web.agent import handlers
 from src.web.agent.responses import agent_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+@router.get("/threads/{thread_id}/messages", response_class=JSONResponse)
+async def get_thread_messages(request: Request, thread_id: int):
+    """List messages of an agent thread as JSON (parity with CLI `agent messages`)."""
+    db = deps.get_db(request)
+    thread = await db.get_agent_thread(thread_id)
+    if thread is None:
+        return JSONResponse({"error": "thread_not_found"}, status_code=404)
+    messages = await db.get_agent_messages(thread_id)
+    return JSONResponse({"thread_id": thread_id, "title": thread.get("title"), "messages": messages})
 
 
 @router.get("", response_class=HTMLResponse)

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -12,6 +12,13 @@ from src.web import deps
 
 router = APIRouter()
 
+_MAX_TREND_DAYS = 365
+_MAX_TREND_LIMIT = 100
+
+
+def _clamp_positive(value: int, upper: int) -> int:
+    return max(1, min(value, upper))
+
 
 @router.get("", response_class=HTMLResponse)
 async def analytics_page(
@@ -137,7 +144,10 @@ async def api_trending_topics(request: Request, days: int = 7, limit: int = 20):
     """Get trending topics as JSON."""
     db = deps.get_db(request)
     trend = TrendService(db)
-    topics = await trend.get_trending_topics(days=max(1, days), limit=max(1, limit))
+    topics = await trend.get_trending_topics(
+        days=_clamp_positive(days, _MAX_TREND_DAYS),
+        limit=_clamp_positive(limit, _MAX_TREND_LIMIT),
+    )
     return JSONResponse([dataclasses.asdict(row) for row in topics])
 
 
@@ -146,7 +156,10 @@ async def api_trending_channels(request: Request, days: int = 7, limit: int = 10
     """Get trending channels as JSON."""
     db = deps.get_db(request)
     trend = TrendService(db)
-    channels = await trend.get_trending_channels(days=max(1, days), limit=max(1, limit))
+    channels = await trend.get_trending_channels(
+        days=_clamp_positive(days, _MAX_TREND_DAYS),
+        limit=_clamp_positive(limit, _MAX_TREND_LIMIT),
+    )
     return JSONResponse([dataclasses.asdict(row) for row in channels])
 
 
@@ -155,7 +168,10 @@ async def api_trending_emojis(request: Request, days: int = 7, limit: int = 15):
     """Get trending reaction emojis as JSON."""
     db = deps.get_db(request)
     trend = TrendService(db)
-    emojis = await trend.get_trending_emojis(days=max(1, days), limit=max(1, limit))
+    emojis = await trend.get_trending_emojis(
+        days=_clamp_positive(days, _MAX_TREND_DAYS),
+        limit=_clamp_positive(limit, _MAX_TREND_LIMIT),
+    )
     return JSONResponse([dataclasses.asdict(row) for row in emojis])
 
 
@@ -277,7 +293,7 @@ async def api_pipeline_stats_alias(request: Request, pipeline_id: int | None = N
 async def api_message_velocity(request: Request, days: int = 30):
     """Daily message velocity (parity with CLI `analytics velocity`)."""
     db = deps.get_db(request)
-    data = await TrendService(db).get_message_velocity(days=days)
+    data = await TrendService(db).get_message_velocity(days=_clamp_positive(days, _MAX_TREND_DAYS))
     return JSONResponse([dataclasses.asdict(v) for v in data])
 
 
@@ -285,5 +301,5 @@ async def api_message_velocity(request: Request, days: int = 30):
 async def api_peak_hours(request: Request, days: int = 30):
     """Peak posting hours (parity with CLI `analytics peak-hours`)."""
     db = deps.get_db(request)
-    data = await TrendService(db).get_peak_hours(days=days)
+    data = await TrendService(db).get_peak_hours(days=_clamp_positive(days, _MAX_TREND_DAYS))
     return JSONResponse([dataclasses.asdict(h) for h in data])

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -70,6 +70,18 @@ async def api_content_summary(request: Request):
     return JSONResponse(await analytics.get_summary())
 
 
+@router.get("/content/api/types")
+async def api_content_type_stats(
+    request: Request,
+    date_from: str = "",
+    date_to: str = "",
+):
+    """Get engagement stats grouped by media/content type as JSON."""
+    db = deps.get_db(request)
+    rows = await db.get_engagement_by_media_type(date_from=date_from or None, date_to=date_to or None)
+    return JSONResponse(rows)
+
+
 @router.get("/content/api/pipelines")
 async def api_pipeline_stats(request: Request, pipeline_id: int | None = None):
     """Get pipeline statistics as JSON."""
@@ -88,6 +100,15 @@ async def api_pipeline_stats(request: Request, pipeline_id: int | None = None):
         }
         for s in stats
     ])
+
+
+@router.get("/content/api/daily")
+async def api_daily_stats(request: Request, days: int = 30, pipeline_id: int | None = None):
+    """Get daily generation/publication/rejection stats as JSON."""
+    db = deps.get_db(request)
+    analytics = ContentAnalyticsService(db)
+    stats = await analytics.get_daily_stats(days=max(1, days), pipeline_id=pipeline_id)
+    return JSONResponse([dataclasses.asdict(row) for row in stats])
 
 
 @router.get("/trends", response_class=HTMLResponse)
@@ -109,6 +130,33 @@ async def trends_page(request: Request, days: int = 7):
             "days": days,
         },
     )
+
+
+@router.get("/trends/topics")
+async def api_trending_topics(request: Request, days: int = 7, limit: int = 20):
+    """Get trending topics as JSON."""
+    db = deps.get_db(request)
+    trend = TrendService(db)
+    topics = await trend.get_trending_topics(days=max(1, days), limit=max(1, limit))
+    return JSONResponse([dataclasses.asdict(row) for row in topics])
+
+
+@router.get("/trends/channels")
+async def api_trending_channels(request: Request, days: int = 7, limit: int = 10):
+    """Get trending channels as JSON."""
+    db = deps.get_db(request)
+    trend = TrendService(db)
+    channels = await trend.get_trending_channels(days=max(1, days), limit=max(1, limit))
+    return JSONResponse([dataclasses.asdict(row) for row in channels])
+
+
+@router.get("/trends/emojis")
+async def api_trending_emojis(request: Request, days: int = 7, limit: int = 15):
+    """Get trending reaction emojis as JSON."""
+    db = deps.get_db(request)
+    trend = TrendService(db)
+    emojis = await trend.get_trending_emojis(days=max(1, days), limit=max(1, limit))
+    return JSONResponse([dataclasses.asdict(row) for row in emojis])
 
 
 # ── Channel analytics ────────────────────────────────────────────
@@ -137,8 +185,8 @@ def _svc(request: Request) -> ChannelAnalyticsService:
 
 
 @router.get("/channels/api/overview")
-async def api_channel_overview(request: Request, channel_id: int):
-    overview = await _svc(request).get_channel_overview(channel_id)
+async def api_channel_overview(request: Request, channel_id: int, days: int = 30):
+    overview = await _svc(request).get_channel_overview(channel_id, days=max(1, days))
     return JSONResponse(dataclasses.asdict(overview))
 
 
@@ -202,6 +250,18 @@ async def api_messages_top(
     db = deps.get_db(request)
     limit = max(1, min(limit, 100))
     rows = await db.get_top_messages(limit=limit, date_from=date_from or None, date_to=date_to or None)
+    return JSONResponse(rows)
+
+
+@router.get("/messages/hourly")
+async def api_messages_hourly(
+    request: Request,
+    date_from: str = "",
+    date_to: str = "",
+):
+    """Message distribution by hour as JSON (parity with CLI `analytics hourly`)."""
+    db = deps.get_db(request)
+    rows = await db.get_hourly_activity(date_from=date_from or None, date_to=date_to or None)
     return JSONResponse(rows)
 
 

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -192,3 +192,38 @@ async def api_cross_citations(
 ):
     data = await _svc(request).get_cross_channel_citations(channel_id, days, limit)
     return JSONResponse(data)
+
+
+@router.get("/messages/top")
+async def api_messages_top(
+    request: Request, limit: int = 20, date_from: str = "", date_to: str = "",
+):
+    """Top messages by reactions (parity with CLI `analytics top`)."""
+    db = deps.get_db(request)
+    limit = max(1, min(limit, 100))
+    rows = await db.get_top_messages(limit=limit, date_from=date_from or None, date_to=date_to or None)
+    return JSONResponse(rows)
+
+
+@router.get("/pipelines/stats")
+async def api_pipeline_stats_alias(request: Request, pipeline_id: int | None = None):
+    """Pipeline statistics (parity with CLI `analytics pipeline-stats`)."""
+    db = deps.get_db(request)
+    stats = await ContentAnalyticsService(db).get_pipeline_stats(pipeline_id)
+    return JSONResponse([dataclasses.asdict(s) for s in stats])
+
+
+@router.get("/messages/velocity")
+async def api_message_velocity(request: Request, days: int = 30):
+    """Daily message velocity (parity with CLI `analytics velocity`)."""
+    db = deps.get_db(request)
+    data = await TrendService(db).get_message_velocity(days=days)
+    return JSONResponse([dataclasses.asdict(v) for v in data])
+
+
+@router.get("/peak-hours")
+async def api_peak_hours(request: Request, days: int = 30):
+    """Peak posting hours (parity with CLI `analytics peak-hours`)."""
+    db = deps.get_db(request)
+    data = await TrendService(db).get_peak_hours(days=days)
+    return JSONResponse([dataclasses.asdict(h) for h in data])

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -55,6 +55,16 @@ async def send_message(request: Request):
     return dialog_response(request, await handle_send_message(request))
 
 
+@router.post("/join")
+async def join_dialog(request: Request):
+    return dialog_response(request, await handlers.join_dialog(request))
+
+
+@router.post("/resolve")
+async def resolve_entity(request: Request):
+    return dialog_response(request, await handlers.resolve_entity(request))
+
+
 @router.post("/edit-message")
 async def edit_message(request: Request):
     return dialog_response(request, await handle_edit_message(request))

--- a/src/web/routes/images.py
+++ b/src/web/routes/images.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.web import deps
 from src.web.images import handlers
 from src.web.images.responses import images_response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+@router.get("/generated", response_class=JSONResponse)
+async def list_generated_images(request: Request, limit: int = 50):
+    """List recently generated images as JSON (parity with CLI `image generated`)."""
+    db = deps.get_db(request)
+    images = await db.repos.generated_images.list_recent(limit=limit)
+    return JSONResponse([img.model_dump(mode="json") for img in images])
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/src/web/routes/photo_loader.py
+++ b/src/web/routes/photo_loader.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, File, Form, Request, UploadFile
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from src.models import PhotoSendMode
+from src.web import deps
 from src.web.photo_loader.forms import (
     PhotoAutoCreateForm,
     PhotoBatchForm,
@@ -174,3 +175,24 @@ async def photo_update_auto(request: Request, job_id: int):
 async def photo_delete_auto(request: Request, job_id: int, phone: str = Form("")):
     result = await handle_photo_delete_auto(request, job_id, PhotoPhoneForm(phone=phone))
     return photo_loader_response(request, result)
+
+
+@router.get("/batches", response_class=JSONResponse)
+async def list_photo_batches(request: Request, limit: int = 50):
+    """List photo batches as JSON (parity with CLI `photo-loader batch-list`)."""
+    batches = await deps.get_photo_task_service(request).list_batches(limit=limit)
+    return JSONResponse([b.model_dump(mode="json") for b in batches])
+
+
+@router.get("/auto", response_class=JSONResponse)
+async def list_auto_uploads(request: Request, active_only: bool = False):
+    """List auto-upload jobs as JSON (parity with CLI `photo-loader auto-list`)."""
+    jobs = await deps.get_photo_auto_upload_service(request).list_jobs(active_only=active_only)
+    return JSONResponse([j.model_dump(mode="json") for j in jobs])
+
+
+@router.get("/items", response_class=JSONResponse)
+async def list_photo_items(request: Request, limit: int = 100):
+    """List photo batch items as JSON (parity with CLI `photo-loader items`)."""
+    items = await deps.get_photo_task_service(request).list_items(limit=limit)
+    return JSONResponse([i.model_dump(mode="json") for i in items])

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -146,6 +146,28 @@ async def get_refinement_steps(request: Request, pipeline_id: int):
     return pipeline_response(request, await handlers.get_refinement_steps(request, pipeline_id))
 
 
+@router.get("/{pipeline_id}/show", response_class=JSONResponse)
+async def show_pipeline(request: Request, pipeline_id: int):
+    return pipeline_response(request, await handlers.show_pipeline(request, pipeline_id))
+
+
+@router.get("/{pipeline_id}/runs", response_class=JSONResponse)
+async def list_pipeline_runs(request: Request, pipeline_id: int, limit: int = 20, offset: int = 0):
+    return pipeline_response(
+        request, await handlers.list_pipeline_runs(request, pipeline_id, limit=limit, offset=offset)
+    )
+
+
+@router.get("/{pipeline_id}/runs/{run_id}", response_class=JSONResponse)
+async def show_pipeline_run(request: Request, pipeline_id: int, run_id: int):
+    return pipeline_response(request, await handlers.show_pipeline_run(request, pipeline_id, run_id))
+
+
+@router.get("/{pipeline_id}/queue", response_class=JSONResponse)
+async def pipeline_queue(request: Request, pipeline_id: int, limit: int = 50):
+    return pipeline_response(request, await handlers.pipeline_queue(request, pipeline_id, limit=limit))
+
+
 @router.get("/dry-run-count", response_class=JSONResponse)
 async def dry_run_count_new(request: Request, source_ids: str = "",
                              since_value: int = 6, since_unit: str = "h"):

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -158,10 +158,18 @@ async def list_pipeline_runs(
     limit: int = 20,
     offset: int = 0,
     status: str | None = None,
+    moderation_status: str | None = None,
 ):
     return pipeline_response(
         request,
-        await handlers.list_pipeline_runs(request, pipeline_id, limit=limit, offset=offset, status=status),
+        await handlers.list_pipeline_runs(
+            request,
+            pipeline_id,
+            limit=limit,
+            offset=offset,
+            status=status,
+            moderation_status=moderation_status,
+        ),
     )
 
 

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -152,9 +152,16 @@ async def show_pipeline(request: Request, pipeline_id: int):
 
 
 @router.get("/{pipeline_id}/runs", response_class=JSONResponse)
-async def list_pipeline_runs(request: Request, pipeline_id: int, limit: int = 20, offset: int = 0):
+async def list_pipeline_runs(
+    request: Request,
+    pipeline_id: int,
+    limit: int = 20,
+    offset: int = 0,
+    status: str | None = None,
+):
     return pipeline_response(
-        request, await handlers.list_pipeline_runs(request, pipeline_id, limit=limit, offset=offset)
+        request,
+        await handlers.list_pipeline_runs(request, pipeline_id, limit=limit, offset=offset, status=status),
     )
 
 

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -26,6 +26,7 @@ async def read_messages(
     ch = resolve_channel(channels, identifier)
     if ch is None:
         return JSONResponse({"error": "channel_not_found"}, status_code=404)
+    limit = max(1, min(limit, 500))
     messages, total = await db.search_messages(
         query=query,
         channel_id=ch.channel_id,

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -1,11 +1,44 @@
 from fastapi import APIRouter, Query, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.cli.commands.common import resolve_channel
+from src.web import deps
 from src.web.search import handlers
 from src.web.search.forms import extract_length as _extract_length  # noqa: F401  (back-compat import)
 from src.web.search.responses import search_response
 
 router = APIRouter()
+
+
+@router.get("/messages/{identifier}", response_class=JSONResponse)
+async def read_messages(
+    request: Request,
+    identifier: str,
+    query: str = Query(""),
+    limit: int = Query(50),
+    date_from: str = Query(""),
+    date_to: str = Query(""),
+    topic_id: int | None = Query(None),
+):
+    """Read collected messages of a channel from the DB (parity with CLI `messages read`)."""
+    db = deps.get_db(request)
+    channels = await db.get_channels()
+    ch = resolve_channel(channels, identifier)
+    if ch is None:
+        return JSONResponse({"error": "channel_not_found"}, status_code=404)
+    messages, total = await db.search_messages(
+        query=query,
+        channel_id=ch.channel_id,
+        date_from=date_from or None,
+        date_to=date_to or None,
+        limit=limit,
+        topic_id=topic_id,
+    )
+    return JSONResponse({
+        "channel_id": ch.channel_id,
+        "total": total,
+        "messages": [m.model_dump(mode="json") for m in messages],
+    })
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,11 +1,31 @@
 from fastapi import APIRouter, Form, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.web import deps
 from src.web.search_queries import handlers
 from src.web.search_queries.forms import SearchQueryForm
 from src.web.search_queries.responses import search_query_response
 
 router = APIRouter()
+
+
+@router.get("/{sq_id}", response_class=JSONResponse)
+async def get_search_query(request: Request, sq_id: int):
+    """Get one search query as JSON (parity with CLI `search-query get`)."""
+    sq = await deps.search_query_service(request).get(sq_id)
+    if sq is None:
+        return JSONResponse({"error": "search_query_not_found"}, status_code=404)
+    return JSONResponse(sq.model_dump(mode="json"))
+
+
+@router.get("/{sq_id}/stats", response_class=JSONResponse)
+async def get_search_query_stats(request: Request, sq_id: int, days: int = 30):
+    """Get daily match stats for a search query (parity with CLI `search-query stats`)."""
+    svc = deps.search_query_service(request)
+    if await svc.get(sq_id) is None:
+        return JSONResponse({"error": "search_query_not_found"}, status_code=404)
+    stats = await svc.get_daily_stats(sq_id, days=days)
+    return JSONResponse([s.model_dump(mode="json") for s in stats])
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -191,15 +192,37 @@ async def test_flood_clear_not_found(route_client, base_app):
 
 @pytest.mark.anyio
 async def test_account_info_json(route_client, base_app):
-    """GET /settings/{id}/info returns account summary JSON (parity: account info)."""
+    """GET /settings/{id}/info returns account summary and live diagnostics."""
     _, db, _ = base_app
     accounts = await db.get_account_summaries(active_only=False)
     acc = accounts[0]
-    resp = await route_client.get(f"/settings/{acc.id}/info")
+    with patch("src.web.routes.accounts.get_live_account_info_text", AsyncMock(return_value="live ok")) as mock_live:
+        resp = await route_client.get(f"/settings/{acc.id}/info")
     assert resp.status_code == 200
     data = resp.json()
     assert data["id"] == acc.id
     assert data["phone"] == acc.phone
+    assert data["live_info"] == "live ok"
+    assert "session_string" not in data
+    runtime_arg, phone_arg = mock_live.await_args.args
+    assert runtime_arg.db is db
+    assert phone_arg == acc.phone
+
+
+@pytest.mark.anyio
+async def test_account_info_json_without_live_runtime(route_client, base_app):
+    """GET /settings/{id}/info returns no-live diagnostic instead of failing."""
+    _, db, _ = base_app
+    accounts = await db.get_account_summaries(active_only=False)
+    acc = accounts[0]
+    with patch("src.web.routes.accounts.deps.get_pool", side_effect=RuntimeError("missing pool")):
+        resp = await route_client.get(f"/settings/{acc.id}/info")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == acc.id
+    assert "live Telegram runtime unavailable" in data["live_info"]
+    assert "session_string" not in data
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_accounts_routes.py
+++ b/tests/routes/test_accounts_routes.py
@@ -187,3 +187,22 @@ async def test_flood_clear_not_found(route_client, base_app):
     resp = await route_client.post("/settings/99999/flood-clear", follow_redirects=False)
     assert resp.status_code in (303, 302)
     assert "error=account_not_found" in resp.headers.get("location", "")
+
+
+@pytest.mark.anyio
+async def test_account_info_json(route_client, base_app):
+    """GET /settings/{id}/info returns account summary JSON (parity: account info)."""
+    _, db, _ = base_app
+    accounts = await db.get_account_summaries(active_only=False)
+    acc = accounts[0]
+    resp = await route_client.get(f"/settings/{acc.id}/info")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == acc.id
+    assert data["phone"] == acc.phone
+
+
+@pytest.mark.anyio
+async def test_account_info_not_found(route_client, base_app):
+    resp = await route_client.get("/settings/99999/info")
+    assert resp.status_code == 404

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -352,6 +352,29 @@ async def test_chat_auto_renames_thread(client, db):
     assert thread["title"] == "My first message"
 
 
+# ── thread messages JSON (parity: agent messages) ─────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_thread_messages_json(client, db):
+    thread_id = await db.create_agent_thread("Conv")
+    await db.save_agent_message(thread_id, "user", "hi there")
+    await db.save_agent_message(thread_id, "assistant", "hello")
+
+    resp = await client.get(f"/agent/threads/{thread_id}/messages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["thread_id"] == thread_id
+    assert len(data["messages"]) == 2
+    assert data["messages"][0]["content"] == "hi there"
+
+
+@pytest.mark.anyio
+async def test_get_thread_messages_not_found(client):
+    resp = await client.get("/agent/threads/9999/messages")
+    assert resp.status_code == 404
+
+
 @pytest.mark.anyio
 async def test_chat_does_not_rename_custom_thread(client, db):
     """Test chat does not rename thread with custom title."""

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
+
+from src.services.content_analytics_service import DailyStats
 
 
 @pytest.mark.anyio
@@ -117,6 +121,14 @@ async def test_api_content_summary_returns_json(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_content_type_stats_returns_json(route_client):
+    """GET /analytics/content/api/types returns a JSON list."""
+    resp = await route_client.get("/analytics/content/api/types")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
 async def test_api_pipelines_returns_json(route_client):
     """Test pipeline stats API returns JSON."""
     resp = await route_client.get("/analytics/content/api/pipelines")
@@ -206,9 +218,36 @@ async def test_api_pipelines_filter_by_id(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_daily_stats(route_client):
+    """GET /analytics/content/api/daily returns daily content stats."""
+    with patch("src.web.routes.analytics.ContentAnalyticsService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_daily_stats = AsyncMock(
+            return_value=[
+                DailyStats(date="2026-06-06", generations=2, publications=1, rejections=0)
+            ]
+        )
+        resp = await route_client.get("/analytics/content/api/daily?days=7&pipeline_id=5")
+
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"date": "2026-06-06", "generations": 2, "publications": 1, "rejections": 0}
+    ]
+    instance.get_daily_stats.assert_awaited_once_with(days=7, pipeline_id=5)
+
+
+@pytest.mark.anyio
 async def test_api_messages_top_returns_json(route_client):
     """GET /analytics/messages/top returns a JSON list (parity: analytics top)."""
     resp = await route_client.get("/analytics/messages/top?limit=5")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_api_hourly_activity_returns_json(route_client):
+    """GET /analytics/messages/hourly returns a JSON list."""
+    resp = await route_client.get("/analytics/messages/hourly")
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
 

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -203,3 +203,57 @@ async def test_api_pipelines_filter_by_id(route_client):
     data = json.loads(resp.text)
     assert len(data) == 1
     assert data[0]["pipeline_id"] == pipeline_id
+
+
+@pytest.mark.anyio
+async def test_api_messages_top_returns_json(route_client):
+    """GET /analytics/messages/top returns a JSON list (parity: analytics top)."""
+    resp = await route_client.get("/analytics/messages/top?limit=5")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_api_messages_top_with_data(route_client):
+    from datetime import datetime, timezone
+
+    from src.models import Channel, Message
+
+    db = route_client._transport_app.state.db
+    await db.add_channel(Channel(channel_id=500, title="Top Chan", username="top"))
+    await db.insert_messages_batch([
+        Message(
+            channel_id=500, message_id=1, text="reacted",
+            reactions_json='[{"emoji": "👍", "count": 99}]',
+            date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+        )
+    ])
+    resp = await route_client.get("/analytics/messages/top?limit=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert any(row.get("total_reactions") for row in data)
+
+
+@pytest.mark.anyio
+async def test_api_pipeline_stats_alias_returns_json(route_client):
+    """GET /analytics/pipelines/stats returns a JSON list (parity: analytics pipeline-stats)."""
+    resp = await route_client.get("/analytics/pipelines/stats")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_api_message_velocity_returns_json(route_client):
+    """GET /analytics/messages/velocity returns a JSON list (parity: analytics velocity)."""
+    resp = await route_client.get("/analytics/messages/velocity?days=30")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_api_peak_hours_returns_json(route_client):
+    """GET /analytics/peak-hours returns a JSON list (parity: analytics peak-hours)."""
+    resp = await route_client.get("/analytics/peak-hours?days=30")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/routes/test_analytics_routes.py
+++ b/tests/routes/test_analytics_routes.py
@@ -291,8 +291,32 @@ async def test_api_message_velocity_returns_json(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_message_velocity_clamps_days(route_client):
+    """GET /analytics/messages/velocity clamps expensive day windows."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_message_velocity = AsyncMock(return_value=[])
+        resp = await route_client.get("/analytics/messages/velocity?days=999999")
+
+    assert resp.status_code == 200
+    instance.get_message_velocity.assert_awaited_once_with(days=365)
+
+
+@pytest.mark.anyio
 async def test_api_peak_hours_returns_json(route_client):
     """GET /analytics/peak-hours returns a JSON list (parity: analytics peak-hours)."""
     resp = await route_client.get("/analytics/peak-hours?days=30")
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_api_peak_hours_clamps_days(route_client):
+    """GET /analytics/peak-hours clamps expensive day windows."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_peak_hours = AsyncMock(return_value=[])
+        resp = await route_client.get("/analytics/peak-hours?days=0")
+
+    assert resp.status_code == 200
+    instance.get_peak_hours.assert_awaited_once_with(days=1)

--- a/tests/routes/test_analytics_routes_channel_trends.py
+++ b/tests/routes/test_analytics_routes_channel_trends.py
@@ -45,6 +45,18 @@ async def test_api_trending_topics(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_trending_topics_clamps_days_and_limit(route_client):
+    """GET /analytics/trends/topics clamps expensive query bounds."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_topics = AsyncMock(return_value=[])
+        resp = await route_client.get("/analytics/trends/topics?days=999999&limit=999999")
+
+    assert resp.status_code == 200
+    instance.get_trending_topics.assert_awaited_once_with(days=365, limit=100)
+
+
+@pytest.mark.anyio
 async def test_api_trending_channels(route_client):
     """GET /analytics/trends/channels returns channel JSON."""
     with patch("src.web.routes.analytics.TrendService") as mock_svc:
@@ -68,6 +80,18 @@ async def test_api_trending_channels(route_client):
 
 
 @pytest.mark.anyio
+async def test_api_trending_channels_clamps_floor(route_client):
+    """GET /analytics/trends/channels clamps lower bounds to one."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_channels = AsyncMock(return_value=[])
+        resp = await route_client.get("/analytics/trends/channels?days=-5&limit=0")
+
+    assert resp.status_code == 200
+    instance.get_trending_channels.assert_awaited_once_with(days=1, limit=1)
+
+
+@pytest.mark.anyio
 async def test_api_trending_emojis(route_client):
     """GET /analytics/trends/emojis returns reaction emoji JSON."""
     with patch("src.web.routes.analytics.TrendService") as mock_svc:
@@ -78,6 +102,18 @@ async def test_api_trending_emojis(route_client):
     assert resp.status_code == 200
     assert resp.json() == [{"emoji": "🔥", "count": 9}]
     instance.get_trending_emojis.assert_awaited_once_with(days=14, limit=3)
+
+
+@pytest.mark.anyio
+async def test_api_trending_emojis_clamps_days_and_limit(route_client):
+    """GET /analytics/trends/emojis clamps expensive query bounds."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_emojis = AsyncMock(return_value=[])
+        resp = await route_client.get("/analytics/trends/emojis?days=999999&limit=999999")
+
+    assert resp.status_code == 200
+    instance.get_trending_emojis.assert_awaited_once_with(days=365, limit=100)
 
 
 # ── Channel analytics page ─────────────────────────────────────────

--- a/tests/routes/test_analytics_routes_channel_trends.py
+++ b/tests/routes/test_analytics_routes_channel_trends.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.services.trend_service import TrendingChannel, TrendingEmoji, TrendingTopic
+
 # ── Trends page ─────────────────────────────────────────────────────
 
 
@@ -27,6 +29,55 @@ async def test_trends_page_invalid_days(route_client):
     """Test trends page with invalid days falls back to 7."""
     resp = await route_client.get("/analytics/trends?days=99")
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_api_trending_topics(route_client):
+    """GET /analytics/trends/topics returns topic JSON."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_topics = AsyncMock(return_value=[TrendingTopic(keyword="ai", count=3)])
+        resp = await route_client.get("/analytics/trends/topics?days=7&limit=5")
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"keyword": "ai", "count": 3}]
+    instance.get_trending_topics.assert_awaited_once_with(days=7, limit=5)
+
+
+@pytest.mark.anyio
+async def test_api_trending_channels(route_client):
+    """GET /analytics/trends/channels returns channel JSON."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_channels = AsyncMock(
+            return_value=[
+                TrendingChannel(
+                    channel_id=100,
+                    title="Test",
+                    username="test",
+                    avg_views=10.5,
+                    message_count=4,
+                )
+            ]
+        )
+        resp = await route_client.get("/analytics/trends/channels?days=7&limit=5")
+
+    assert resp.status_code == 200
+    assert resp.json()[0]["channel_id"] == 100
+    instance.get_trending_channels.assert_awaited_once_with(days=7, limit=5)
+
+
+@pytest.mark.anyio
+async def test_api_trending_emojis(route_client):
+    """GET /analytics/trends/emojis returns reaction emoji JSON."""
+    with patch("src.web.routes.analytics.TrendService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_trending_emojis = AsyncMock(return_value=[TrendingEmoji(emoji="🔥", count=9)])
+        resp = await route_client.get("/analytics/trends/emojis?days=14&limit=3")
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"emoji": "🔥", "count": 9}]
+    instance.get_trending_emojis.assert_awaited_once_with(days=14, limit=3)
 
 
 # ── Channel analytics page ─────────────────────────────────────────
@@ -72,11 +123,12 @@ async def test_api_channel_overview(route_client):
     with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
         instance = mock_svc.return_value
         instance.get_channel_overview = AsyncMock(return_value=overview)
-        resp = await route_client.get("/analytics/channels/api/overview?channel_id=100")
+        resp = await route_client.get("/analytics/channels/api/overview?channel_id=100&days=14")
         assert resp.status_code == 200
         data = resp.json()
         assert data["channel_id"] == 100
         assert data["title"] == "Test"
+        instance.get_channel_overview.assert_awaited_once_with(100, days=14)
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_dialogs_routes_actions.py
+++ b/tests/routes/test_dialogs_routes_actions.py
@@ -280,6 +280,43 @@ async def test_mark_read_no_max_id(route_client):
     assert resp.status_code == 303
 
 
+# === join / resolve (parity: dialogs join / dialogs resolve) ===
+
+
+@pytest.mark.anyio
+async def test_join_dialog_missing_fields(route_client):
+    resp = await route_client.post("/dialogs/join", data={"phone": ""}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.anyio
+async def test_join_dialog_enqueues(route_client):
+    resp = await route_client.post(
+        "/dialogs/join",
+        data={"phone": "+1234567890", "target": "@somechannel"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "command_id=" in resp.headers.get("location", "")
+
+
+@pytest.mark.anyio
+async def test_resolve_entity_missing_fields(route_client):
+    resp = await route_client.post("/dialogs/resolve", data={"identifier": ""}, follow_redirects=False)
+    assert resp.status_code == 303
+
+
+@pytest.mark.anyio
+async def test_resolve_entity_enqueues(route_client):
+    resp = await route_client.post(
+        "/dialogs/resolve",
+        data={"phone": "+1234567890", "identifier": "@someuser"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "command_id=" in resp.headers.get("location", "")
+
+
 # === queue cancel / clear-pending (issue #621) ===
 
 

--- a/tests/routes/test_images_routes.py
+++ b/tests/routes/test_images_routes.py
@@ -263,3 +263,16 @@ async def test_get_provider_api_key_exception_returns_empty(caplog):
     assert any(
         "Failed to load API key for provider anything" in rec.message for rec in caplog.records
     )
+
+
+@pytest.mark.anyio
+async def test_list_generated_images_json(route_client):
+    """GET /images/generated returns a JSON list (parity with CLI `image generated`)."""
+    db = route_client._transport_app.state.db
+    await db.repos.generated_images.save("a cat", "together:flux", "http://img/1.png", None)
+
+    resp = await route_client.get("/images/generated")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert any(img.get("prompt") == "a cat" for img in data)

--- a/tests/routes/test_photo_loader_routes.py
+++ b/tests/routes/test_photo_loader_routes.py
@@ -362,3 +362,27 @@ async def test_photos_auto_missing_interval_minutes(route_client):
         follow_redirects=False,
     )
     assert resp.status_code == 303
+
+
+# === read-only JSON GET routes (parity: photo-loader batch-list/auto-list/items) ===
+
+
+@pytest.mark.anyio
+async def test_list_photo_batches_json(route_client):
+    resp = await route_client.get("/dialogs/photos/batches")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_list_auto_uploads_json(route_client):
+    resp = await route_client.get("/dialogs/photos/auto")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.anyio
+async def test_list_photo_items_json(route_client):
+    resp = await route_client.get("/dialogs/photos/items")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import base64
 import re
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -580,6 +580,18 @@ async def test_list_pipeline_runs_json(client):
     data = resp.json()
     assert data["pipeline_id"] == 1
     assert any(r["id"] == run_id for r in data["runs"])
+
+
+@pytest.mark.anyio
+async def test_pipeline_run_and_queue_reads_do_not_hydrate_pipeline_service(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+
+    with patch("src.web.pipelines.handlers.deps.pipeline_service", side_effect=AssertionError("hydrated")):
+        runs_resp = await client.get("/pipelines/1/runs")
+        queue_resp = await client.get("/pipelines/1/queue")
+
+    assert runs_resp.status_code == 200
+    assert queue_resp.status_code == 200
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -547,6 +547,77 @@ async def test_toggle_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
+# === read-only JSON GET routes (parity: pipeline show/runs/run-show/queue) ===
+
+
+@pytest.mark.anyio
+async def test_show_pipeline_json(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    resp = await client.get("/pipelines/1/show")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == 1
+    assert data["name"] == "Test Pipeline"
+    assert "source_ids" in data
+
+
+@pytest.mark.anyio
+async def test_show_pipeline_not_found(client):
+    resp = await client.get("/pipelines/999/show")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_list_pipeline_runs_json(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    app = client._transport.app  # type: ignore
+    db = app.state.db
+    run_id = await db.repos.generation_runs.create_run(1, "prompt")
+    await db.repos.generation_runs.save_result(run_id, "txt", {})
+
+    resp = await client.get("/pipelines/1/runs")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pipeline_id"] == 1
+    assert any(r["id"] == run_id for r in data["runs"])
+
+
+@pytest.mark.anyio
+async def test_show_pipeline_run_json(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    app = client._transport.app  # type: ignore
+    db = app.state.db
+    run_id = await db.repos.generation_runs.create_run(1, "prompt")
+    await db.repos.generation_runs.save_result(run_id, "hello run", {})
+
+    resp = await client.get(f"/pipelines/1/runs/{run_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == run_id
+    assert data["generated_text"] == "hello run"
+
+
+@pytest.mark.anyio
+async def test_show_pipeline_run_wrong_pipeline(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    app = client._transport.app  # type: ignore
+    db = app.state.db
+    run_id = await db.repos.generation_runs.create_run(1, "prompt")
+
+    resp = await client.get(f"/pipelines/2/runs/{run_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_pipeline_queue_json(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    resp = await client.get("/pipelines/1/queue")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["pipeline_id"] == 1
+    assert isinstance(data["queue"], list)
+
+
 # === _target_refs error paths ===
 
 

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -600,6 +600,23 @@ async def test_list_pipeline_runs_filters_by_status(client):
 
 
 @pytest.mark.anyio
+async def test_list_pipeline_runs_filters_by_moderation_status(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    app = client._transport.app  # type: ignore
+    db = app.state.db
+    approved_id = await db.repos.generation_runs.create_run(1, "prompt approved")
+    await db.repos.generation_runs.set_moderation_status(approved_id, "approved")
+    rejected_id = await db.repos.generation_runs.create_run(1, "prompt rejected")
+    await db.repos.generation_runs.set_moderation_status(rejected_id, "rejected")
+
+    resp = await client.get("/pipelines/1/runs?moderation_status=approved")
+
+    assert resp.status_code == 200
+    run_ids = [r["id"] for r in resp.json()["runs"]]
+    assert run_ids == [approved_id]
+
+
+@pytest.mark.anyio
 async def test_show_pipeline_run_json(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     app = client._transport.app  # type: ignore

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -583,6 +583,23 @@ async def test_list_pipeline_runs_json(client):
 
 
 @pytest.mark.anyio
+async def test_list_pipeline_runs_filters_by_status(client):
+    await client.post("/pipelines/add", data=_ADD_DATA)
+    app = client._transport.app  # type: ignore
+    db = app.state.db
+    completed_id = await db.repos.generation_runs.create_run(1, "prompt completed")
+    await db.repos.generation_runs.save_result(completed_id, "done", {})
+    failed_id = await db.repos.generation_runs.create_run(1, "prompt failed")
+    await db.repos.generation_runs.set_status(failed_id, "failed")
+
+    resp = await client.get("/pipelines/1/runs?status=failed")
+
+    assert resp.status_code == 200
+    run_ids = [r["id"] for r in resp.json()["runs"]]
+    assert run_ids == [failed_id]
+
+
+@pytest.mark.anyio
 async def test_show_pipeline_run_json(client):
     await client.post("/pipelines/add", data=_ADD_DATA)
     app = client._transport.app  # type: ignore

--- a/tests/routes/test_pipelines_routes_dag_and_templates.py
+++ b/tests/routes/test_pipelines_routes_dag_and_templates.py
@@ -808,6 +808,38 @@ async def test_dry_run_count_dag_pipeline_falls_back_to_sidecar_sources(route_cl
     assert resp.json() == {"total": 1, "after_filter": 1}
 
 
+@pytest.mark.anyio
+async def test_show_pipeline_returns_dag_source_ids(route_client, base_app):
+    """GET /pipelines/<id>/show reports source IDs from DAG source node."""
+    _, db, _ = base_app
+    dag = PipelineGraph(
+        nodes=[
+            PipelineNode(
+                id="src",
+                type=PipelineNodeType.SOURCE,
+                name="src",
+                config={"channel_ids": [100]},
+            ),
+            PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="pub"),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="pub")],
+    )
+    pipeline = ContentPipeline(
+        name="DAG Show",
+        prompt_template=".",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        pipeline_json=dag,
+    )
+    pipeline_id = await db.repos.content_pipelines.add(pipeline, [], [])
+
+    resp = await route_client.get(f"/pipelines/{pipeline_id}/show")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_ids"] == [100]
+    assert data["source_titles"] == ["Test Channel"]
+
+
 # ── dry_run_count_new ───────────────────────────────────────────────
 
 

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -199,3 +199,31 @@ async def test_edit_search_query_missing_query(route_client):
     """POST /search-queries/{id}/edit without query returns 422."""
     resp = await route_client.post("/search-queries/1/edit", data={}, follow_redirects=False)
     assert resp.status_code == 303
+
+
+@pytest.mark.anyio
+async def test_get_search_query_json(route_client, db):
+    from src.models import SearchQuery
+
+    sq_id = await db.repos.search_queries.add(SearchQuery(query="btc", interval_minutes=60))
+    resp = await route_client.get(f"/search-queries/{sq_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == sq_id
+    assert data["query"] == "btc"
+
+
+@pytest.mark.anyio
+async def test_get_search_query_not_found(route_client):
+    resp = await route_client.get("/search-queries/9999")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_search_query_stats_json(route_client, db):
+    from src.models import SearchQuery
+
+    sq_id = await db.repos.search_queries.add(SearchQuery(query="eth", interval_minutes=60))
+    resp = await route_client.get(f"/search-queries/{sq_id}/stats?days=7")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -620,3 +620,28 @@ async def test_translate_message_non_en_target(route_client, base_app):
     assert data["ok"] is True
     assert data["cached"] is True
     assert data["translation"] == "Bonjour monde"
+
+
+@pytest.mark.anyio
+async def test_read_messages_route_returns_json(route_client):
+    """GET /messages/{identifier} reads collected messages (parity: messages read)."""
+    from src.models import Channel
+
+    db = route_client._transport_app.state.db
+    await db.add_channel(Channel(channel_id=777, title="ReadChan", username="readchan"))
+    await db.insert_messages_batch([
+        Message(channel_id=777, message_id=1, text="hello world", date=datetime(2024, 6, 1, tzinfo=timezone.utc)),
+    ])
+
+    resp = await route_client.get("/messages/readchan")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["channel_id"] == 777
+    assert data["total"] >= 1
+    assert any("hello world" in (m.get("text") or "") for m in data["messages"])
+
+
+@pytest.mark.anyio
+async def test_read_messages_route_channel_not_found(route_client):
+    resp = await route_client.get("/messages/nonexistent_channel")
+    assert resp.status_code == 404

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models import Message, SearchResult
+from src.models import Channel, Message, SearchResult
 
 
 @pytest.mark.anyio
@@ -625,8 +625,6 @@ async def test_translate_message_non_en_target(route_client, base_app):
 @pytest.mark.anyio
 async def test_read_messages_route_returns_json(route_client):
     """GET /messages/{identifier} reads collected messages (parity: messages read)."""
-    from src.models import Channel
-
     db = route_client._transport_app.state.db
     await db.add_channel(Channel(channel_id=777, title="ReadChan", username="readchan"))
     await db.insert_messages_batch([
@@ -639,6 +637,19 @@ async def test_read_messages_route_returns_json(route_client):
     assert data["channel_id"] == 777
     assert data["total"] >= 1
     assert any("hello world" in (m.get("text") or "") for m in data["messages"])
+
+
+@pytest.mark.anyio
+async def test_read_messages_route_clamps_limit(route_client, monkeypatch):
+    db = route_client._transport_app.state.db
+    await db.add_channel(Channel(channel_id=778, title="ClampChan", username="clampchan"))
+    search_messages = AsyncMock(return_value=([], 0))
+    monkeypatch.setattr(db, "search_messages", search_messages)
+
+    resp = await route_client.get("/messages/clampchan?limit=100000")
+
+    assert resp.status_code == 200
+    assert search_messages.await_args.kwargs["limit"] == 500
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_tools_analytics.py
+++ b/tests/test_agent_tools_analytics.py
@@ -383,3 +383,64 @@ class TestAnalyticsToolGetHourlyActivity:
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["get_hourly_activity"]({})
         assert "Ошибка" in _text(result)
+
+
+class TestGetTrendingEmojisTool:
+    @pytest.mark.anyio
+    async def test_empty(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_emojis = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_emojis"]({})
+        assert "Нет данных" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_data(self, mock_db):
+        emojis = [SimpleNamespace(emoji="👍", count=42), SimpleNamespace(emoji="🔥", count=10)]
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_emojis = AsyncMock(return_value=emojis)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_emojis"]({"days": 30, "limit": 5})
+        text = _text(result)
+        assert "👍" in text
+        assert "42" in text
+
+    @pytest.mark.anyio
+    async def test_error(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_trending_emojis = AsyncMock(side_effect=Exception("boom"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_trending_emojis"]({})
+        assert "Ошибка" in _text(result)
+
+
+class TestGetChannelAnalyticsTool:
+    @pytest.mark.anyio
+    async def test_missing_channel_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_analytics"]({})
+        assert "channel_id обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_overview(self, mock_db):
+        overview = SimpleNamespace(
+            channel_id=100, title="MyChan", username="mychan",
+            subscriber_count=1000, subscriber_delta=5, err=2.5,
+            total_posts=50, posts_today=2, posts_week=10, posts_month=30,
+            avg_views=500.0, avg_forwards=3.0, avg_reactions=20.0,
+        )
+        with patch("src.services.channel_analytics_service.ChannelAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_channel_overview = AsyncMock(return_value=overview)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_channel_analytics"]({"channel_id": 100, "days": 30})
+        text = _text(result)
+        assert "MyChan" in text
+        assert "1000" in text
+
+    @pytest.mark.anyio
+    async def test_error(self, mock_db):
+        with patch("src.services.channel_analytics_service.ChannelAnalyticsService") as mock_svc:
+            mock_svc.return_value.get_channel_overview = AsyncMock(side_effect=Exception("boom"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_channel_analytics"]({"channel_id": 100})
+        assert "Ошибка" in _text(result)

--- a/tests/test_agent_tools_analytics.py
+++ b/tests/test_agent_tools_analytics.py
@@ -184,11 +184,21 @@ class TestAnalyticsToolGetPeakHours:
         with patch("src.services.trend_service.TrendService") as mock_svc:
             mock_svc.return_value.get_peak_hours = AsyncMock(return_value=hours)
             handlers = _get_tool_handlers(mock_db)
-            result = await handlers["get_peak_hours"]({})
+            result = await handlers["get_peak_hours"]({"days": 14})
         text = _text(result)
+        mock_svc.return_value.get_peak_hours.assert_awaited_once_with(days=14)
+        assert "за 14 дней" in text
         assert "09:00" in text
         assert "500 сообщений" in text
         assert "18:00" in text
+
+    @pytest.mark.anyio
+    async def test_days_are_clamped(self, mock_db):
+        with patch("src.services.trend_service.TrendService") as mock_svc:
+            mock_svc.return_value.get_peak_hours = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            await handlers["get_peak_hours"]({"days": 999999})
+        mock_svc.return_value.get_peak_hours.assert_awaited_once_with(days=365)
 
     @pytest.mark.anyio
     async def test_error(self, mock_db):

--- a/tests/test_agent_tools_channels.py
+++ b/tests/test_agent_tools_channels.py
@@ -388,6 +388,18 @@ class TestAddChannelsBulkTool:
         mock_svc.return_value.add_bulk_by_dialog_ids.assert_called_once_with(["100", "200"])
 
     @pytest.mark.anyio
+    async def test_with_confirm_reports_skipped_ids(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_bulk_by_dialog_ids = AsyncMock(
+                return_value={"processed": 1, "skipped": 1, "skipped_ids": ["200"]}
+            )
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channels_bulk"]({"channel_ids": "100, 200", "confirm": True})
+        text = _text(result)
+        assert "Обработано 1 из 2" in text
+        assert "Пропущено 1: 200" in text
+
+    @pytest.mark.anyio
     async def test_error_returns_text(self, mock_db):
         with patch("src.services.channel_service.ChannelService") as mock_svc:
             mock_svc.return_value.add_bulk_by_dialog_ids = AsyncMock(side_effect=Exception("boom"))

--- a/tests/test_agent_tools_channels.py
+++ b/tests/test_agent_tools_channels.py
@@ -305,3 +305,92 @@ class TestSetChannelTagsTool:
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["set_channel_tags"]({"pk": 1, "tags": ""})
         assert "очищены" in _text(result)
+
+
+class TestGetChannelTagsTool:
+    @pytest.mark.anyio
+    async def test_missing_pk(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_tags"]({})
+        assert "pk обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_channel_not_found(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_tags"]({"pk": 999})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_no_tags(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel(title="TestChan"))
+        mock_db.repos.channels.get_channel_tags = AsyncMock(return_value=[])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_tags"]({"pk": 1})
+        assert "нет тегов" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_tags(self, mock_db):
+        mock_db.get_channel_by_pk = AsyncMock(return_value=_make_channel(title="TestChan"))
+        mock_db.repos.channels.get_channel_tags = AsyncMock(return_value=["news", "tech"])
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_channel_tags"]({"pk": 1})
+        text = _text(result)
+        assert "TestChan" in text
+        assert "news" in text
+
+
+class TestListDialogsForImportTool:
+    @pytest.mark.anyio
+    async def test_empty(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_dialogs_with_added_flags = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_dialogs_for_import"]({})
+        assert "не найдены" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_with_dialogs_shows_added_flag(self, mock_db):
+        dialogs = [
+            {"channel_id": 100, "title": "Already", "username": "a", "already_added": True},
+            {"channel_id": 200, "title": "New", "username": None, "already_added": False},
+        ]
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.get_dialogs_with_added_flags = AsyncMock(return_value=dialogs)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["list_dialogs_for_import"]({})
+        text = _text(result)
+        assert "уже добавлен" in text
+        assert "новый" in text
+        assert "Already" in text
+
+
+class TestAddChannelsBulkTool:
+    @pytest.mark.anyio
+    async def test_missing_ids(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_channels_bulk"]({})
+        assert "channel_ids" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["add_channels_bulk"]({"channel_ids": "100,200"})
+        assert "confirm=true" in _text(result).lower()
+
+    @pytest.mark.anyio
+    async def test_with_confirm_adds(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_bulk_by_dialog_ids = AsyncMock()
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channels_bulk"]({"channel_ids": "100, 200", "confirm": True})
+        assert "Обработано 2" in _text(result)
+        mock_svc.return_value.add_bulk_by_dialog_ids.assert_called_once_with(["100", "200"])
+
+    @pytest.mark.anyio
+    async def test_error_returns_text(self, mock_db):
+        with patch("src.services.channel_service.ChannelService") as mock_svc:
+            mock_svc.return_value.add_bulk_by_dialog_ids = AsyncMock(side_effect=Exception("boom"))
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["add_channels_bulk"]({"channel_ids": "100", "confirm": True})
+        assert "Ошибка массового добавления" in _text(result)

--- a/tests/test_agent_tools_filters.py
+++ b/tests/test_agent_tools_filters.py
@@ -286,3 +286,32 @@ class TestHardDeleteChannelsTool:
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["hard_delete_channels"]({"pks": "1", "confirm": True})
         assert "Ошибка удаления каналов" in _text(result)
+
+
+class TestPurgeChannelMessagesTool:
+    @pytest.mark.anyio
+    async def test_missing_channel_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_channel_messages"]({})
+        assert "channel_id обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_channel_messages"]({"channel_id": 100})
+        assert "confirm=true" in _text(result).lower()
+
+    @pytest.mark.anyio
+    async def test_with_confirm_purges(self, mock_db):
+        mock_db.delete_messages_for_channel = AsyncMock(return_value=42)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_channel_messages"]({"channel_id": 100, "confirm": True})
+        assert "42" in _text(result)
+        mock_db.delete_messages_for_channel.assert_called_once_with(100)
+
+    @pytest.mark.anyio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.delete_messages_for_channel = AsyncMock(side_effect=Exception("boom"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_channel_messages"]({"channel_id": 100, "confirm": True})
+        assert "Ошибка очистки сообщений канала" in _text(result)

--- a/tests/test_agent_tools_init.py
+++ b/tests/test_agent_tools_init.py
@@ -312,6 +312,17 @@ class TestBuildAgentToolsDict:
         for tool_name in tools_dict:
             assert tool_name in _PIPELINE_SAFE_TOOLS, f"build_agent_tools_dict included unsafe tool: {tool_name}"
 
+    def test_dialog_import_listing_is_interactive_only(self):
+        from src.agent.tools import _PIPELINE_SAFE_TOOLS, build_agent_tools_dict
+
+        mock_db = MagicMock()
+
+        with patch("src.services.embedding_service.EmbeddingService"):
+            tools_dict = build_agent_tools_dict(mock_db)
+
+        assert "list_dialogs_for_import" not in _PIPELINE_SAFE_TOOLS
+        assert "list_dialogs_for_import" not in tools_dict
+
     @pytest.mark.anyio
     async def test_tool_functions_are_async_callable(self):
         from claude_agent_sdk import SdkMcpTool

--- a/tests/test_agent_tools_messaging.py
+++ b/tests/test_agent_tools_messaging.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -618,3 +618,50 @@ class TestEditPermissions:
             }
         )
         assert "обновлены" in _text(result)
+
+
+class TestTranslateMessage:
+    @pytest.mark.anyio
+    async def test_missing_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["translate_message"]({})
+        assert "message_db_id обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_message_not_found(self, mock_db):
+        mock_db.repos.messages.get_by_id = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["translate_message"]({"message_db_id": 5})
+        assert "не найдено" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_empty_text(self, mock_db):
+        mock_db.repos.messages.get_by_id = AsyncMock(return_value=SimpleNamespace(text="   "))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["translate_message"]({"message_db_id": 5})
+        assert "нет текста" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_success(self, mock_db):
+        mock_db.repos.messages.get_by_id = AsyncMock(return_value=SimpleNamespace(text="Привет мир"))
+        mock_db.repos.messages.update_translation = AsyncMock()
+        mock_db.get_setting = AsyncMock(return_value=None)
+        with patch("src.services.provider_service.build_provider_service", AsyncMock(return_value=MagicMock())), \
+             patch("src.services.translation_service.TranslationService") as mock_svc:
+            mock_svc.return_value.translate_batch = AsyncMock(return_value=[(5, "Hello world")])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["translate_message"]({"message_db_id": 5, "target": "en"})
+        text = _text(result)
+        assert "Hello world" in text
+        mock_db.repos.messages.update_translation.assert_called_once_with(5, "en", "Hello world")
+
+    @pytest.mark.anyio
+    async def test_no_result(self, mock_db):
+        mock_db.repos.messages.get_by_id = AsyncMock(return_value=SimpleNamespace(text="text"))
+        mock_db.get_setting = AsyncMock(return_value=None)
+        with patch("src.services.provider_service.build_provider_service", AsyncMock(return_value=MagicMock())), \
+             patch("src.services.translation_service.TranslationService") as mock_svc:
+            mock_svc.return_value.translate_batch = AsyncMock(return_value=[])
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["translate_message"]({"message_db_id": 5})
+        assert "Перевод не выполнен" in _text(result)

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -1,11 +1,14 @@
 """Tests for agent tools: pipelines.py MCP tools."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.models import Channel, Message, PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
+from src.services.pipeline_service import PipelineService
 from tests.agent_tools_helpers import _get_tool_handlers, _text
 
 
@@ -177,20 +180,38 @@ class TestPipelinesToolGetPipelineDetail:
 class TestGetPipelineQueueTool:
     @pytest.mark.anyio
     async def test_empty_queue(self, mock_db):
-        mock_db.repos.generation_runs.list_by_status = AsyncMock(return_value=[])
+        mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=_make_pipeline(pk=1))
+        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[])
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
-        result = await handlers["get_pipeline_queue"]({})
-        assert "Очередь генерации пуста" in _text(result)
+        result = await handlers["get_pipeline_queue"]({"pipeline_id": 1})
+        assert "Нет черновиков на модерации для пайплайна id=1" in _text(result)
+        mock_db.repos.generation_runs.list_pending_moderation.assert_awaited_once_with(
+            pipeline_id=1,
+            limit=20,
+        )
 
     @pytest.mark.anyio
     async def test_with_runs(self, mock_db):
         run = _make_run(run_id=1, status="pending", text="Generated content preview")
-        mock_db.repos.generation_runs.list_by_status = AsyncMock(return_value=[run])
+        mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=_make_pipeline(pk=1))
+        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(return_value=[run])
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
-        result = await handlers["get_pipeline_queue"]({"limit": 10})
+        result = await handlers["get_pipeline_queue"]({"pipeline_id": 1, "limit": 10})
         text = _text(result)
-        assert "Очередь генерации (1 шт.)" in text
+        assert "Очередь модерации пайплайна id=1 (1 шт.)" in text
         assert "run_id=1" in text
+        assert "Generated content preview" in text
+        mock_db.repos.generation_runs.list_pending_moderation.assert_awaited_once_with(
+            pipeline_id=1,
+            limit=10,
+        )
+
+    @pytest.mark.anyio
+    async def test_pipeline_not_found(self, mock_db):
+        mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db, config=MagicMock())
+        result = await handlers["get_pipeline_queue"]({"pipeline_id": 999})
+        assert "Пайплайн id=999 не найден" in _text(result)
 
 
 class TestPipelinesToolAddPipeline:
@@ -650,3 +671,40 @@ class TestGetPipelineDryRunCountTool:
         text = _text(result)
         assert "3" in text
         mock_db.repos.messages.get_recent_for_channels.assert_called_once_with([100, 200], 12.0)
+
+    @pytest.mark.anyio
+    async def test_counts_dag_source_node_messages(self, db):
+        await db.add_channel(Channel(channel_id=1001, title="DAG Source"))
+        await db.insert_message(
+            Message(
+                channel_id=1001,
+                message_id=1,
+                text="Recent DAG message",
+                date=datetime.now(timezone.utc),
+            )
+        )
+        graph = PipelineGraph(
+            nodes=[
+                PipelineNode(
+                    id="src",
+                    type=PipelineNodeType.SOURCE,
+                    name="Source",
+                    config={"channel_ids": [1001]},
+                ),
+                PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="Publish"),
+            ],
+            edges=[PipelineEdge(from_node="src", to_node="pub")],
+        )
+        pipeline_id = await PipelineService(db).import_json({
+            "name": "DAG dry-run",
+            "pipeline_json": graph.model_dump(mode="json"),
+        })
+
+        handlers = _get_tool_handlers(db)
+        result = await handlers["get_pipeline_dry_run_count"](
+            {"pipeline_id": pipeline_id, "since_value": 1, "since_unit": "d"}
+        )
+
+        text = _text(result)
+        assert "Сообщений-кандидатов: 1" in text
+        assert "источников=1" in text

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -421,19 +421,23 @@ class TestPipelinesToolListPipelineRuns:
         assert "run_id=1" in text
 
     @pytest.mark.anyio
-    async def test_status_filter_is_passed_to_repository(self, mock_db):
+    async def test_moderation_status_filter_is_passed_to_repository(self, mock_db):
         run = _make_run(run_id=1, status="completed", moderation_status="approved")
         mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[run])
         handlers = _get_tool_handlers(mock_db, config=MagicMock())
 
-        result = await handlers["list_pipeline_runs"]({"pipeline_id": 1, "limit": 5, "status": "approved"})
+        result = await handlers["list_pipeline_runs"]({
+            "pipeline_id": 1,
+            "limit": 5,
+            "moderation_status": "approved",
+        })
 
         assert "run_id=1" in _text(result)
         mock_db.repos.generation_runs.list_by_pipeline.assert_awaited_once_with(
             1,
             limit=5,
-            status="approved",
-            include_moderation_status=True,
+            status=None,
+            moderation_status="approved",
         )
 
 

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -420,6 +420,22 @@ class TestPipelinesToolListPipelineRuns:
         assert "Генерации пайплайна id=1" in text
         assert "run_id=1" in text
 
+    @pytest.mark.anyio
+    async def test_status_filter_is_passed_to_repository(self, mock_db):
+        run = _make_run(run_id=1, status="completed", moderation_status="approved")
+        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[run])
+        handlers = _get_tool_handlers(mock_db, config=MagicMock())
+
+        result = await handlers["list_pipeline_runs"]({"pipeline_id": 1, "limit": 5, "status": "approved"})
+
+        assert "run_id=1" in _text(result)
+        mock_db.repos.generation_runs.list_by_pipeline.assert_awaited_once_with(
+            1,
+            limit=5,
+            status="approved",
+            include_moderation_status=True,
+        )
+
 
 class TestPipelinesToolGetPipelineRun:
     @pytest.mark.anyio

--- a/tests/test_agent_tools_pipelines.py
+++ b/tests/test_agent_tools_pipelines.py
@@ -620,3 +620,33 @@ class TestPipelineRunsToolResultSemantics:
         assert "Сгенерировано" in text
         assert "generated_items:2" in text
         assert "hello" in text
+
+
+class TestGetPipelineDryRunCountTool:
+    @pytest.mark.anyio
+    async def test_missing_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_dry_run_count"]({})
+        assert "pipeline_id обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_not_found(self, mock_db):
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get_detail = AsyncMock(return_value=None)
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_dry_run_count"]({"pipeline_id": 9})
+        assert "не найден" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_counts_messages(self, mock_db):
+        mock_db.repos = MagicMock()
+        mock_db.repos.messages.get_recent_for_channels = AsyncMock(return_value=[1, 2, 3])
+        with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+            mock_svc.return_value.get_detail = AsyncMock(return_value={"source_ids": [100, 200]})
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["get_pipeline_dry_run_count"](
+                {"pipeline_id": 1, "since_value": 12, "since_unit": "h"}
+            )
+        text = _text(result)
+        assert "3" in text
+        mock_db.repos.messages.get_recent_for_channels.assert_called_once_with([100, 200], 12.0)

--- a/tests/test_agent_tools_pipelines_write_paths.py
+++ b/tests/test_agent_tools_pipelines_write_paths.py
@@ -60,15 +60,22 @@ def _make_pipeline(
 class TestGetPipelineQueueErrors:
     @pytest.mark.anyio
     async def test_exception_returns_error(self, mock_db):
-        mock_db.repos.generation_runs.list_by_status = AsyncMock(
+        mock_db.repos.content_pipelines.get_by_id = AsyncMock(return_value=_make_pipeline(id=1))
+        mock_db.repos.generation_runs.list_pending_moderation = AsyncMock(
             side_effect=Exception("DB error")
         )
         handlers = _get_tool_handlers(mock_db)
-        result = await handlers["get_pipeline_queue"]({})
+        result = await handlers["get_pipeline_queue"]({"pipeline_id": 1})
 
         text = _text(result)
         assert "Ошибка получения очереди" in text
         assert "DB error" in text
+
+    @pytest.mark.anyio
+    async def test_missing_pipeline_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["get_pipeline_queue"]({})
+        assert "pipeline_id обязателен" in _text(result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_tools_pipelines_write_paths.py
+++ b/tests/test_agent_tools_pipelines_write_paths.py
@@ -473,7 +473,7 @@ class TestListPipelineRunsErrors:
         assert "Нет генераций" in _text(result)
 
     @pytest.mark.anyio
-    async def test_with_status_filter(self, mock_db):
+    async def test_with_moderation_status_filter(self, mock_db):
         runs = [
             SimpleNamespace(
                 id=1, pipeline_id=1, status="completed",
@@ -486,16 +486,22 @@ class TestListPipelineRunsErrors:
                 created_at="2025-01-02",
             ),
         ]
-        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=runs)
+        mock_db.repos.generation_runs.list_by_pipeline = AsyncMock(return_value=[runs[0]])
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["list_pipeline_runs"]({
             "pipeline_id": 1,
-            "status": "approved",
+            "moderation_status": "approved",
         })
 
         text = _text(result)
         assert "text A" in text
         assert "text B" not in text
+        mock_db.repos.generation_runs.list_by_pipeline.assert_awaited_once_with(
+            1,
+            limit=20,
+            status=None,
+            moderation_status="approved",
+        )
 
     @pytest.mark.anyio
     async def test_exception(self, mock_db):

--- a/tests/test_agent_tools_search_telegram.py
+++ b/tests/test_agent_tools_search_telegram.py
@@ -517,3 +517,32 @@ class TestSearchMessagesOptionalFilters:
 
         call_kwargs = mock_db.search_messages.await_args.kwargs
         assert call_kwargs["channel_id"] == 300
+
+
+class TestPurgeSearchCacheTool:
+    @pytest.mark.anyio
+    async def test_missing_query(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_search_cache"]({})
+        assert "query обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_search_cache"]({"query": "btc"})
+        assert "confirm=true" in _text(result).lower()
+
+    @pytest.mark.anyio
+    async def test_with_confirm_purges(self, mock_db):
+        mock_db.repos.messages.delete_premium_search_results = AsyncMock(return_value=7)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_search_cache"]({"query": "btc", "confirm": True})
+        assert "7" in _text(result)
+        mock_db.repos.messages.delete_premium_search_results.assert_called_once_with("btc")
+
+    @pytest.mark.anyio
+    async def test_error_returns_text(self, mock_db):
+        mock_db.repos.messages.delete_premium_search_results = AsyncMock(side_effect=Exception("boom"))
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["purge_search_cache"]({"query": "btc", "confirm": True})
+        assert "Ошибка очистки кэша" in _text(result)

--- a/tests/test_channel_service.py
+++ b/tests/test_channel_service.py
@@ -237,9 +237,15 @@ class TestAddBulkByDialogIds:
         bundle = _make_bundle()
 
         service = _make_service(bundle=bundle, pool=pool)
-        await service.add_bulk_by_dialog_ids(["-999"])
+        result = await service.add_bulk_by_dialog_ids(["-999"])
 
         bundle.add_channel.assert_not_awaited()
+        assert result == {
+            "requested": 1,
+            "processed": 0,
+            "skipped": 1,
+            "skipped_ids": ["-999"],
+        }
 
 
 class TestToggle:

--- a/tests/test_cli_agent_parity.py
+++ b/tests/test_cli_agent_parity.py
@@ -45,6 +45,70 @@ def _parity_rows() -> list[tuple[str, str, list[str]]]:
     return rows
 
 
+def _actual_web_routes() -> set[tuple[str, str]]:
+    from src.web.app import create_app
+
+    routes: set[tuple[str, str]] = set()
+    for route in create_app().routes:
+        path = getattr(route, "path", "")
+        methods = getattr(route, "methods", set()) or set()
+        for method in methods:
+            if method not in {"HEAD", "OPTIONS"}:
+                routes.add((method, path))
+    return routes
+
+
+def _documented_web_routes() -> list[tuple[str, str, str]]:
+    routes: list[tuple[str, str, str]] = []
+    for line in (ROOT / "docs/reference/parity.md").read_text(encoding="utf-8").splitlines():
+        if not line.startswith("|") or line.startswith("|---") or "Операция" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 4:
+            continue
+        operation = cells[0]
+        web_cell = cells[2]
+        if "исключение" in web_cell:
+            continue
+        for endpoint in re.findall(r"`([^`]+)`", web_cell):
+            for method, path in _expand_web_endpoint(endpoint):
+                if "*" not in path:
+                    routes.append((operation, method, path.split("?", 1)[0]))
+    return routes
+
+
+def _expand_web_endpoint(endpoint: str) -> list[tuple[str, str]]:
+    if endpoint.startswith("GET/POST "):
+        path = endpoint.removeprefix("GET/POST ").strip()
+        return [("GET", path), ("POST", path)]
+    match = re.match(r"^(GET|POST|DELETE|PUT|PATCH)\s+(.+)$", endpoint)
+    if match is None:
+        return []
+    return [(match.group(1), match.group(2).strip())]
+
+
+def _route_exists(actual_routes: set[tuple[str, str]], method: str, documented_path: str) -> bool:
+    return any(
+        actual_method == method and _paths_match(actual_path, documented_path)
+        for actual_method, actual_path in actual_routes
+    )
+
+
+def _paths_match(actual_path: str, documented_path: str) -> bool:
+    actual_parts = actual_path.strip("/").split("/") if actual_path.strip("/") else []
+    documented_parts = documented_path.strip("/").split("/") if documented_path.strip("/") else []
+    if len(actual_parts) != len(documented_parts):
+        return False
+    return all(
+        actual == documented or _is_path_param(actual) or _is_path_param(documented)
+        for actual, documented in zip(actual_parts, documented_parts, strict=True)
+    )
+
+
+def _is_path_param(part: str) -> bool:
+    return part.startswith("{") and part.endswith("}")
+
+
 def test_all_agent_tools_are_documented_in_parity_table():
     documented = {tool for _, _, tools in _parity_rows() for tool in tools}
     assert _actual_agent_tools() - documented == set()
@@ -57,3 +121,13 @@ def test_documented_agent_operations_have_cli_entrypoint():
         if cli in {"", "—"}
     ]
     assert missing_cli == []
+
+
+def test_documented_web_endpoints_exist_in_app_routes():
+    actual_routes = _actual_web_routes()
+    missing_routes = [
+        (operation, f"{method} {path}")
+        for operation, method, path in _documented_web_routes()
+        if not _route_exists(actual_routes, method, path)
+    ]
+    assert missing_routes == []

--- a/tests/test_cli_analytics_commands.py
+++ b/tests/test_cli_analytics_commands.py
@@ -1,6 +1,7 @@
 """Tests for src/cli/commands/analytics.py — CLI analytics subcommands."""
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.cli.commands.analytics import run
@@ -287,20 +288,26 @@ def test_calendar_with_data(capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_trending_emojis_no_messages(capsys):
-    db = make_cli_db(search_messages=AsyncMock(return_value=([], 0)))
-    with _init_patches(db)[0], _init_patches(db)[1]:
+def test_trending_emojis_no_reactions(capsys):
+    db = make_cli_db()
+    init_db_patch, run_patch = _init_patches(db)
+    with init_db_patch, run_patch, patch("src.services.trend_service.TrendService") as mock_svc:
+        mock_svc.return_value.get_trending_emojis = AsyncMock(return_value=[])
         run(_args(analytics_action="trending-emojis", days=7, limit=20))
-    assert "No emojis" in capsys.readouterr().out
+    assert "No emoji reactions" in capsys.readouterr().out
+    mock_svc.return_value.get_trending_emojis.assert_awaited_once_with(days=7, limit=20)
 
 
-def test_trending_emojis_with_emojis(capsys):
-    msg = MagicMock(text="Hello 🎉 world 🌍 test 🎉")
-    db = make_cli_db(search_messages=AsyncMock(return_value=([msg], 1)))
-    with _init_patches(db)[0], _init_patches(db)[1]:
+def test_trending_emojis_with_reaction_emojis(capsys):
+    db = make_cli_db()
+    rows = [SimpleNamespace(emoji="🎉", count=2), SimpleNamespace(emoji="🌍", count=1)]
+    init_db_patch, run_patch = _init_patches(db)
+    with init_db_patch, run_patch, patch("src.services.trend_service.TrendService") as mock_svc:
+        mock_svc.return_value.get_trending_emojis = AsyncMock(return_value=rows)
         run(_args(analytics_action="trending-emojis", days=7, limit=20))
     out = capsys.readouterr().out
     assert "🎉" in out
+    assert "2" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conftest_xdist.py
+++ b/tests/test_conftest_xdist.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_root_conftest():
+    path = Path(__file__).resolve().parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("root_conftest_for_tests", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+root_conftest = _load_root_conftest()
+
+
+def _config(args: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(args=args)
+
+
+def _set_cpu_state(monkeypatch, *, cpu_count: int, load_average: float) -> None:
+    monkeypatch.setattr(root_conftest.os, "cpu_count", lambda: cpu_count)
+    monkeypatch.setattr(
+        root_conftest.os,
+        "getloadavg",
+        lambda: (load_average, load_average, load_average),
+        raising=False,
+    )
+
+
+def test_xdist_auto_workers_are_capped_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("TGCF_PYTEST_XDIST_WORKERS", raising=False)
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 4
+
+
+def test_xdist_auto_workers_reduce_worker_count_when_cpu_is_busy(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "8")
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=12.8)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 3
+
+
+def test_xdist_auto_workers_keep_one_worker_when_cpu_is_saturated(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "8")
+    _set_cpu_state(monkeypatch, cpu_count=8, load_average=20.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 1
+
+
+def test_xdist_auto_workers_can_be_capped_by_env(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "2")
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 2
+
+
+def test_xdist_auto_workers_never_exceed_available_cpu(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "8")
+    _set_cpu_state(monkeypatch, cpu_count=2, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 1
+
+
+def test_xdist_auto_workers_use_default_cap_for_invalid_env(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "invalid")
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 4
+
+
+def test_xdist_auto_workers_force_single_worker_for_nodeid(monkeypatch) -> None:
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "4")
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests/test_cli.py::test_one"])) == 1
+
+
+def test_xdist_auto_workers_force_single_worker_for_real_tg_gate(monkeypatch) -> None:
+    monkeypatch.setenv("RUN_REAL_TELEGRAM_SAFE", "1")
+    monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "4")
+    _set_cpu_state(monkeypatch, cpu_count=16, load_average=0.0)
+
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 1

--- a/tests/test_conftest_xdist.py
+++ b/tests/test_conftest_xdist.py
@@ -43,7 +43,13 @@ def test_xdist_auto_workers_reduce_worker_count_when_cpu_is_busy(monkeypatch) ->
     monkeypatch.setenv("TGCF_PYTEST_XDIST_WORKERS", "8")
     _set_cpu_state(monkeypatch, cpu_count=16, load_average=12.8)
 
-    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 3
+    assert root_conftest.pytest_xdist_auto_num_workers(_config(["tests"])) == 2
+
+
+def test_xdist_auto_workers_round_fractional_load_up(monkeypatch) -> None:
+    _set_cpu_state(monkeypatch, cpu_count=4, load_average=0.95)
+
+    assert root_conftest._xdist_available_workers_for_load(4) == 2
 
 
 def test_xdist_auto_workers_keep_one_worker_when_cpu_is_saturated(monkeypatch) -> None:

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -65,7 +65,7 @@ async def test_list_by_pipeline_can_filter_moderation_status(db):
     run_id = await repo.create_run(42, "approved-prompt")
     await repo.set_moderation_status(run_id, "approved")
 
-    rows = await repo.list_by_pipeline(42, status="approved", include_moderation_status=True)
+    rows = await repo.list_by_pipeline(42, moderation_status="approved")
 
     assert [run.id for run in rows] == [run_id]
 

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -44,6 +44,33 @@ async def test_generation_runs_repo_hydrates_moderation_fields(db):
 
 
 @pytest.mark.anyio
+async def test_list_by_pipeline_filters_status_before_offset(db):
+    repo = db.repos.generation_runs
+    failed_ids: list[int] = []
+    for idx in range(5):
+        completed_id = await repo.create_run(42, f"completed-{idx}")
+        await repo.save_result(completed_id, "done", {})
+        failed_id = await repo.create_run(42, f"failed-{idx}")
+        await repo.set_status(failed_id, "failed")
+        failed_ids.append(failed_id)
+
+    rows = await repo.list_by_pipeline(42, limit=2, offset=1, status="failed")
+
+    assert [run.id for run in rows] == list(reversed(failed_ids))[1:3]
+
+
+@pytest.mark.anyio
+async def test_list_by_pipeline_can_filter_moderation_status(db):
+    repo = db.repos.generation_runs
+    run_id = await repo.create_run(42, "approved-prompt")
+    await repo.set_moderation_status(run_id, "approved")
+
+    rows = await repo.list_by_pipeline(42, status="approved", include_moderation_status=True)
+
+    assert [run.id for run in rows] == [run_id]
+
+
+@pytest.mark.anyio
 async def test_list_pending_moderation_returns_runs(db):
     repo = db.repos.generation_runs
     pending_id = await repo.create_run(42, "pending-prompt")

--- a/tests/test_pipeline_service_edge_cases.py
+++ b/tests/test_pipeline_service_edge_cases.py
@@ -10,6 +10,7 @@ from src.database.bundles import PipelineBundle
 from src.models import (
     Account,
     Channel,
+    ContentPipeline,
     PipelineEdge,
     PipelineGraph,
     PipelineNode,
@@ -192,6 +193,37 @@ async def test_get_detail(svc, pipeline_id):
     assert detail["source_ids"] == [1001, 1002]
     assert detail["target_refs"] == ["+100|77"]
     assert len(detail["source_titles"]) == 2
+
+
+@pytest.mark.anyio
+async def test_get_detail_uses_dag_source_ids_without_sidecar_rows(svc):
+    graph = PipelineGraph(
+        nodes=[
+            PipelineNode(
+                id="src",
+                type=PipelineNodeType.SOURCE,
+                name="Source",
+                config={"channel_ids": [1002]},
+            ),
+            PipelineNode(id="pub", type=PipelineNodeType.PUBLISH, name="Publish"),
+        ],
+        edges=[PipelineEdge(from_node="src", to_node="pub")],
+    )
+    pipeline_id = await svc._bundle.add(  # noqa: SLF001 - test seeds exact storage shape.
+        ContentPipeline(name="DAG detail", prompt_template=".", pipeline_json=graph),
+        [],
+        [],
+    )
+
+    detail = await svc.get_detail(pipeline_id)
+    assert detail is not None
+    assert detail["source_ids"] == [1002]
+    assert detail["source_titles"] == ["Source B"]
+
+    rows = await svc.get_with_relations()
+    row = next(item for item in rows if item["pipeline"].id == pipeline_id)
+    assert row["source_ids"] == [1002]
+    assert row["source_titles"] == ["Source B"]
 
 
 @pytest.mark.anyio

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -417,7 +417,7 @@ async def test_dialogs_resolve_not_found_raises():
     pool = _mock_pool()
     pool.resolve_any_entity = AsyncMock(return_value=None)
     d = _dispatcher(pool=pool)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match=r"resolve failed: '@nope' not found"):
         await d._handle_dialogs_resolve({"identifier": "@nope"})
 
 
@@ -694,7 +694,7 @@ async def test_channels_add_identifier_fail():
     pool = _mock_pool()
     pool.resolve_channel.return_value = None
     d = _dispatcher(pool=pool)
-    with pytest.raises(RuntimeError, match="resolve failed"):
+    with pytest.raises(RuntimeError, match=r"resolve failed: '@x' not found"):
         await d._handle_channels_add_identifier({"identifier": "@x"})
 
 

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -395,6 +395,32 @@ async def test_dialogs_send():
     assert r["message_id"] == 42
 
 
+async def test_dialogs_join():
+    pool = _mock_pool()
+    d = _dispatcher(pool=pool)
+    result = MagicMock(phone="+1", target="@chan", via_invite=False)
+    with patch.object(mod, "TelegramActionService") as svc_cls:
+        svc_cls.return_value.join_dialog = AsyncMock(return_value=result)
+        r = await d._handle_dialogs_join({"phone": "+1", "target": "@chan"})
+    assert r == {"phone": "+1", "target": "@chan", "via_invite": False}
+
+
+async def test_dialogs_resolve():
+    pool = _mock_pool()
+    pool.resolve_any_entity = AsyncMock(return_value={"id": 123, "type": "channel"})
+    d = _dispatcher(pool=pool)
+    r = await d._handle_dialogs_resolve({"phone": "+1", "identifier": "@user"})
+    assert r["entity"]["id"] == 123
+
+
+async def test_dialogs_resolve_not_found_raises():
+    pool = _mock_pool()
+    pool.resolve_any_entity = AsyncMock(return_value=None)
+    d = _dispatcher(pool=pool)
+    with pytest.raises(RuntimeError):
+        await d._handle_dialogs_resolve({"identifier": "@nope"})
+
+
 async def test_dialogs_edit_message():
     pool = _mock_pool()
     c = _client_mock()


### PR DESCRIPTION
## Что

Закрывает ~30 пробелов паритета между тремя поверхностями (CLI / Web / Agent tools), чтобы каждая операция существовала во всех трёх — согласно инварианту паритета проекта.

### Agent tools (9 новых)
`purge_search_cache`, `get_channel_tags`, `add_channels_bulk`, `list_dialogs_for_import`, `get_pipeline_dry_run_count`, `purge_channel_messages`, `get_trending_emojis`, `get_channel_analytics`, `translate_message` — все занесены в `TOOL_CATEGORIES`, `MODULE_GROUPS` и pipeline-safe allow-list.

### Web routes (~19, read-only JSON), зеркалят CLI
- `GET /messages/{identifier}` — `messages read`
- `GET /settings/{id}/info` — `account info`
- `GET /analytics/messages/top|velocity`, `/pipelines/stats`, `/peak-hours`
- `GET /pipelines/{id}/show|runs|runs/{run_id}|queue`
- `GET /images/generated`
- `GET /dialogs/photos/batches|auto|items`
- `GET /search-queries/{id}|/stats`
- `GET /agent/threads/{id}/messages`
- `POST /dialogs/join|resolve` (+ `dialogs.join` / `dialogs.resolve` в `TelegramCommandDispatcher`)

### Docs
`docs/reference/parity.md` и `agent-tools.md` обновлены; оставшиеся пробелы помечены как явные исключения (web-only UI, SSE, интерактивный 2FA, графовый CRUD и т.п.).

### Cleanup (проход `/simplify`)
- `_run_to_dict` → `model_dump(mode="json", include=...)` вместо ручной выборки полей + `isoformat()`.
- `show_pipeline` — убраны избыточные `getattr()` по всегда-присутствующим полям модели и мёртвый ключ `schedule_cron`.
- analytics/pipeline tools — локальная идиома `int(args.get(x, N))` и снятие дублирующих `arg_int`/`arg_str` fallback'ов.

## Тесты
Новые route- и tool-тесты на каждую операцию (happy path + not-found + confirm-gate для destructive). `ruff check src/ tests/ conftest.py` — чисто; затронутые тесты зелёные локально.

🤖 Generated with [Claude Code](https://claude.com/claude-code)