### PR TITLE
fix(search): bound premium Telegram search and log worker state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
 dev = [
     "import-linter>=2.11",
     "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
     "pytest-timeout>=2.4.0",
     "pytest-xdist>=3.8.0",
     "ruff>=0.15.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ select = ["E", "F", "I", "N", "W"]
 
 [tool.pytest.ini_options]
 anyio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 timeout = 30
 addopts = "--dist=loadfile"

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
+import time
 from datetime import timezone
 
 from src.models import Channel, Message, SearchResult
@@ -10,6 +12,7 @@ from src.search.transformers import TelegramMessageTransformer
 from src.telegram.backends import adapt_transport_session
 from src.telegram.client_pool import ClientPool
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
+from src.utils.safe_logging import mask_phone, query_log_fields
 
 try:
     from telethon.tl.types import PeerChannel
@@ -17,6 +20,18 @@ except ImportError:  # pragma: no cover
     PeerChannel = None  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
+PREMIUM_SEARCH_RPC_TIMEOUT_SEC = 60.0
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return int((time.monotonic() - started_at) * 1000)
+
+
+def _timeout_error(stage: str) -> str:
+    return (
+        f"Telegram Premium search timed out after {PREMIUM_SEARCH_RPC_TIMEOUT_SEC:.0f}s "
+        f"(stage={stage}). Попробуйте позже или используйте другой режим поиска."
+    )
 
 
 class TelegramSearch:
@@ -59,11 +74,14 @@ class TelegramSearch:
             return await run_with_flood_wait(
                 self._check_search_quota_with_client(session, query),
                 operation=operation,
-                phone=phone,
+                phone=mask_phone(phone),
                 pool=None,
                 logger_=logger,
+                timeout=PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
             )
         except HandledFloodWaitError:
+            raise
+        except asyncio.TimeoutError:
             raise
         except Exception as exc:
             logger.debug("checkSearchPostsFlood unavailable: %s", exc)
@@ -90,7 +108,19 @@ class TelegramSearch:
             reporter = getattr(self._pool, "report_premium_flood", None)
             if callable(reporter):
                 await reporter(phone, exc.info.wait_seconds)
-            logger.debug("checkSearchPostsFlood flood-waited for %s: %s", phone, exc.info.detail)
+            logger.debug("checkSearchPostsFlood flood-waited for %s: %s", mask_phone(phone), exc.info.detail)
+            return None
+        except asyncio.TimeoutError:
+            fields = query_log_fields(query)
+            logger.warning(
+                "premium_search_quota timeout stage=quota phone=%s timeout_sec=%.0f "
+                "query_hash=%s query_len=%d query_preview=%r",
+                mask_phone(phone),
+                PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
+                fields["query_hash"],
+                fields["query_len"],
+                fields["query_preview"],
+            )
             return None
         finally:
             await self._pool.release_client(phone)
@@ -126,7 +156,21 @@ class TelegramSearch:
         return "Нет аккаунтов с Telegram Premium. Добавьте Premium-аккаунт в настройках."
 
     async def search_telegram(self, query: str, limit: int = 50) -> SearchResult:
+        search_started_at = time.monotonic()
+        fields = query_log_fields(query)
+        logger.info(
+            "premium_search start mode=telegram limit=%d query_hash=%s query_len=%d query_preview=%r",
+            limit,
+            fields["query_hash"],
+            fields["query_len"],
+            fields["query_preview"],
+        )
         if not self._pool:
+            logger.warning(
+                "premium_search unavailable reason=no_pool limit=%d query_hash=%s",
+                limit,
+                fields["query_hash"],
+            )
             return SearchResult(
                 messages=[],
                 total=0,
@@ -137,19 +181,69 @@ class TelegramSearch:
         result = await self._pool.get_premium_client()
         if result is None:
             reason = await self._get_premium_unavailability_reason()
-            logger.warning("search_telegram: no premium client for query=%r: %s", query, reason)
+            logger.warning(
+                "premium_search unavailable reason=no_premium_client detail=%s limit=%d "
+                "query_hash=%s query_len=%d query_preview=%r",
+                reason,
+                limit,
+                fields["query_hash"],
+                fields["query_len"],
+                fields["query_preview"],
+            )
             return SearchResult(messages=[], total=0, query=query, error=reason)
 
         session, phone = result
         session = adapt_transport_session(session, disconnect_on_close=False)
+        masked_phone = mask_phone(phone)
+        logger.info(
+            "premium_search acquired phone=%s limit=%d query_hash=%s",
+            masked_phone,
+            limit,
+            fields["query_hash"],
+        )
         try:
-            quota = await self._load_search_quota_with_flood_handling(
-                session,
-                phone,
-                query=query,
-                operation="search_telegram_check_quota",
+            quota_started_at = time.monotonic()
+            try:
+                quota = await self._load_search_quota_with_flood_handling(
+                    session,
+                    phone,
+                    query=query,
+                    operation="search_telegram_check_quota",
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "premium_search timeout stage=quota phone=%s elapsed_ms=%d timeout_sec=%.0f "
+                    "limit=%d query_hash=%s query_len=%d query_preview=%r",
+                    masked_phone,
+                    _elapsed_ms(quota_started_at),
+                    PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
+                    limit,
+                    fields["query_hash"],
+                    fields["query_len"],
+                    fields["query_preview"],
+                )
+                return SearchResult(
+                    messages=[],
+                    total=0,
+                    query=query,
+                    error=_timeout_error("quota"),
+                )
+            logger.info(
+                "premium_search quota_ok phone=%s elapsed_ms=%d remains=%s query_is_free=%s "
+                "query_hash=%s",
+                masked_phone,
+                _elapsed_ms(quota_started_at),
+                quota.get("remains") if quota else None,
+                quota.get("query_is_free") if quota else None,
+                fields["query_hash"],
             )
             if quota and quota.get("remains") == 0 and not quota.get("query_is_free"):
+                logger.warning(
+                    "premium_search quota_exhausted phone=%s elapsed_ms=%d query_hash=%s",
+                    masked_phone,
+                    _elapsed_ms(search_started_at),
+                    fields["query_hash"],
+                )
                 return SearchResult(
                     messages=[],
                     total=0,
@@ -160,12 +254,23 @@ class TelegramSearch:
                     ),
                 )
 
+            rpc_started_at = time.monotonic()
             messages, seen_channels = await run_with_flood_wait(
                 self._search_posts_global(session, query, limit),
                 operation="search_telegram",
-                phone=phone,
+                phone=masked_phone,
                 pool=None,
                 logger_=logger,
+                timeout=PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
+            )
+            logger.info(
+                "premium_search telegram_rpc_ok phone=%s elapsed_ms=%d raw_messages=%d "
+                "channels=%d query_hash=%s",
+                masked_phone,
+                _elapsed_ms(rpc_started_at),
+                len(messages),
+                len(seen_channels),
+                fields["query_hash"],
             )
             clearer = getattr(self._pool, "clear_premium_flood", None)
             if callable(clearer):
@@ -173,11 +278,43 @@ class TelegramSearch:
                 if inspect.isawaitable(result):
                     await result
             messages = await self._persistence.cache_search_results(seen_channels, messages, phone, query)
+            logger.info(
+                "premium_search success phone=%s elapsed_ms=%d total=%d query_hash=%s",
+                masked_phone,
+                _elapsed_ms(search_started_at),
+                len(messages),
+                fields["query_hash"],
+            )
             return SearchResult(messages=messages, total=len(messages), query=query)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "premium_search timeout stage=telegram_rpc phone=%s elapsed_ms=%d timeout_sec=%.0f "
+                "limit=%d query_hash=%s query_len=%d query_preview=%r",
+                masked_phone,
+                _elapsed_ms(search_started_at),
+                PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
+                limit,
+                fields["query_hash"],
+                fields["query_len"],
+                fields["query_preview"],
+            )
+            return SearchResult(
+                messages=[],
+                total=0,
+                query=query,
+                error=_timeout_error("telegram_rpc"),
+            )
         except HandledFloodWaitError as exc:
             reporter = getattr(self._pool, "report_premium_flood", None)
             if callable(reporter):
                 await reporter(phone, exc.info.wait_seconds)
+            logger.warning(
+                "premium_search flood_wait phone=%s wait_seconds=%d operation=%s query_hash=%s",
+                masked_phone,
+                exc.info.wait_seconds,
+                exc.info.operation,
+                fields["query_hash"],
+            )
             return SearchResult(
                 messages=[],
                 total=0,
@@ -186,7 +323,15 @@ class TelegramSearch:
                 flood_wait=exc.info,
             )
         except Exception as exc:
-            logger.exception("Telegram global search failed for query=%r", query)
+            logger.exception(
+                "premium_search error phone=%s elapsed_ms=%d query_hash=%s query_len=%d "
+                "query_preview=%r",
+                masked_phone,
+                _elapsed_ms(search_started_at),
+                fields["query_hash"],
+                fields["query_len"],
+                fields["query_preview"],
+            )
             return SearchResult(
                 messages=[],
                 total=0,

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -114,12 +114,11 @@ class TelegramSearch:
             fields = query_log_fields(query)
             logger.warning(
                 "premium_search_quota timeout stage=quota phone=%s timeout_sec=%.0f "
-                "query_hash=%s query_len=%d query_preview=%r",
+                "query_hash=%s query_len=%d",
                 mask_phone(phone),
                 PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
                 fields["query_hash"],
                 fields["query_len"],
-                fields["query_preview"],
             )
             return None
         finally:
@@ -159,11 +158,10 @@ class TelegramSearch:
         search_started_at = time.monotonic()
         fields = query_log_fields(query)
         logger.info(
-            "premium_search start mode=telegram limit=%d query_hash=%s query_len=%d query_preview=%r",
+            "premium_search start mode=telegram limit=%d query_hash=%s query_len=%d",
             limit,
             fields["query_hash"],
             fields["query_len"],
-            fields["query_preview"],
         )
         if not self._pool:
             logger.warning(
@@ -183,12 +181,11 @@ class TelegramSearch:
             reason = await self._get_premium_unavailability_reason()
             logger.warning(
                 "premium_search unavailable reason=no_premium_client detail=%s limit=%d "
-                "query_hash=%s query_len=%d query_preview=%r",
+                "query_hash=%s query_len=%d",
                 reason,
                 limit,
                 fields["query_hash"],
                 fields["query_len"],
-                fields["query_preview"],
             )
             return SearchResult(messages=[], total=0, query=query, error=reason)
 
@@ -213,14 +210,13 @@ class TelegramSearch:
             except asyncio.TimeoutError:
                 logger.warning(
                     "premium_search timeout stage=quota phone=%s elapsed_ms=%d timeout_sec=%.0f "
-                    "limit=%d query_hash=%s query_len=%d query_preview=%r",
+                    "limit=%d query_hash=%s query_len=%d",
                     masked_phone,
                     _elapsed_ms(quota_started_at),
                     PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
                     limit,
                     fields["query_hash"],
                     fields["query_len"],
-                    fields["query_preview"],
                 )
                 return SearchResult(
                     messages=[],
@@ -289,14 +285,13 @@ class TelegramSearch:
         except asyncio.TimeoutError:
             logger.warning(
                 "premium_search timeout stage=telegram_rpc phone=%s elapsed_ms=%d timeout_sec=%.0f "
-                "limit=%d query_hash=%s query_len=%d query_preview=%r",
+                "limit=%d query_hash=%s query_len=%d",
                 masked_phone,
                 _elapsed_ms(search_started_at),
                 PREMIUM_SEARCH_RPC_TIMEOUT_SEC,
                 limit,
                 fields["query_hash"],
                 fields["query_len"],
-                fields["query_preview"],
             )
             return SearchResult(
                 messages=[],
@@ -324,13 +319,11 @@ class TelegramSearch:
             )
         except Exception as exc:
             logger.exception(
-                "premium_search error phone=%s elapsed_ms=%d query_hash=%s query_len=%d "
-                "query_preview=%r",
+                "premium_search error phone=%s elapsed_ms=%d query_hash=%s query_len=%d",
                 masked_phone,
                 _elapsed_ms(search_started_at),
                 fields["query_hash"],
                 fields["query_len"],
-                fields["query_preview"],
             )
             return SearchResult(
                 messages=[],

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -152,14 +152,13 @@ class TelegramCommandDispatcher:
                 search_fields = query_log_fields(str(command.payload.get("query", "")))
                 logger.info(
                     "telegram_search_command start command_id=%s mode=%s limit=%s channel_id=%s "
-                    "query_hash=%s query_len=%d query_preview=%r",
+                    "query_hash=%s query_len=%d",
                     command.id,
                     command.payload.get("mode", "telegram"),
                     command.payload.get("limit", 50),
                     command.payload.get("channel_id"),
                     search_fields["query_hash"],
                     search_fields["query_len"],
-                    search_fields["query_preview"],
                 )
             try:
                 result = await self._dispatch(command.command_type, command.payload)

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -40,6 +40,7 @@ from src.telegram.notifier import Notifier
 from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
 from src.telegram.utils import normalize_utc
 from src.utils.datetime import parse_required_datetime, parse_required_schedule_datetime
+from src.utils.safe_logging import query_log_fields
 
 try:  # telethon is an optional dependency at test-time
     from telethon.errors import ReactionInvalidError
@@ -138,6 +139,7 @@ class TelegramCommandDispatcher:
                 continue
             started_at = time.monotonic()
             is_auth_command = command.command_type.startswith("auth.")
+            is_search_command = command.command_type == "search.telegram"
             phone = str(command.payload.get("phone", "")).strip()
             if is_auth_command:
                 logger.info(
@@ -145,6 +147,19 @@ class TelegramCommandDispatcher:
                     command.id,
                     command.command_type,
                     phone,
+                )
+            elif is_search_command:
+                search_fields = query_log_fields(str(command.payload.get("query", "")))
+                logger.info(
+                    "telegram_search_command start command_id=%s mode=%s limit=%s channel_id=%s "
+                    "query_hash=%s query_len=%d query_preview=%r",
+                    command.id,
+                    command.payload.get("mode", "telegram"),
+                    command.payload.get("limit", 50),
+                    command.payload.get("channel_id"),
+                    search_fields["query_hash"],
+                    search_fields["query_len"],
+                    search_fields["query_preview"],
                 )
             try:
                 result = await self._dispatch(command.command_type, command.payload)
@@ -227,6 +242,17 @@ class TelegramCommandDispatcher:
                         duration_ms,
                         str(exc),
                     )
+                elif is_search_command:
+                    search_fields = query_log_fields(str(command.payload.get("query", "")))
+                    logger.exception(
+                        "telegram_search_command error command_id=%s mode=%s duration_ms=%d "
+                        "error=%s query_hash=%s",
+                        command.id,
+                        command.payload.get("mode", "telegram"),
+                        duration_ms,
+                        str(exc),
+                        search_fields["query_hash"],
+                    )
                 else:
                     logger.exception("Telegram command failed: id=%s type=%s", command.id, command.command_type)
                 await self._update_command_safely(
@@ -245,6 +271,18 @@ class TelegramCommandDispatcher:
                         command.command_type,
                         phone,
                         duration_ms,
+                    )
+                elif is_search_command:
+                    duration_ms = int((time.monotonic() - started_at) * 1000)
+                    result_payload = result.get("result") or {}
+                    logger.info(
+                        "telegram_search_command success command_id=%s mode=%s duration_ms=%d "
+                        "total=%s result_error=%s",
+                        command.id,
+                        command.payload.get("mode", "telegram"),
+                        duration_ms,
+                        result_payload.get("total"),
+                        bool(result_payload.get("error")),
                     )
                 await self._update_command_safely(
                     command.id,

--- a/src/utils/safe_logging.py
+++ b/src/utils/safe_logging.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+
+
+def mask_phone(phone: str | None) -> str:
+    if not phone:
+        return ""
+    value = str(phone)
+    if len(value) <= 7:
+        return f"{value[:2]}..."
+    return f"{value[:3]}...{value[-4:]}"
+
+
+def text_preview(value: str, *, limit: int = 80) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def text_hash(value: str) -> str:
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
+
+
+def query_log_fields(query: str) -> dict[str, object]:
+    return {
+        "query_hash": text_hash(query),
+        "query_len": len(query),
+        "query_preview": text_preview(query),
+    }

--- a/src/utils/safe_logging.py
+++ b/src/utils/safe_logging.py
@@ -12,13 +12,6 @@ def mask_phone(phone: str | None) -> str:
     return f"{value[:3]}...{value[-4:]}"
 
 
-def text_preview(value: str, *, limit: int = 80) -> str:
-    text = " ".join(str(value).split())
-    if len(text) <= limit:
-        return text
-    return text[: max(0, limit - 3)] + "..."
-
-
 def text_hash(value: str) -> str:
     return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
 
@@ -27,5 +20,4 @@ def query_log_fields(query: str) -> dict[str, object]:
     return {
         "query_hash": text_hash(query),
         "query_len": len(query),
-        "query_preview": text_preview(query),
     }

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Telegram-backed search modes need a live ClientPool. The web container has
 # none (runtime_mode="web"), so these are proxied to the worker process (#643).
 _TELEGRAM_SEARCH_MODES = {"telegram", "my_chats", "channel"}
-_WORKER_SEARCH_TIMEOUT_SEC = 45.0
+_WORKER_SEARCH_TIMEOUT_SEC = 130.0
 _WORKER_SEARCH_POLL_SEC = 0.4
 
 

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -10,6 +10,7 @@ from fastapi import Request
 from pydantic import ValidationError
 
 from src.models import SearchResult, TelegramCommandStatus
+from src.utils.safe_logging import query_log_fields
 from src.web import deps
 from src.web.search.forms import extract_length, parse_channel_id
 from src.web.search.responses import SearchJson, SearchRedirect, SearchTemplate
@@ -22,6 +23,12 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_SEARCH_MODES = {"telegram", "my_chats", "channel"}
 _WORKER_SEARCH_TIMEOUT_SEC = 45.0
 _WORKER_SEARCH_POLL_SEC = 0.4
+
+
+def _status_value(status: TelegramCommandStatus | str | None) -> str:
+    if status is None:
+        return "unknown"
+    return getattr(status, "value", str(status))
 
 
 async def _telegram_search_via_worker(
@@ -55,30 +62,101 @@ async def _telegram_search_via_worker(
     command_id = await cmd_service.enqueue(
         "search.telegram", payload=payload, requested_by="web:search"
     )
+    fields = query_log_fields(query)
+    started_at = time.monotonic()
+    logger.info(
+        "telegram_search_worker enqueue command_id=%s mode=%s limit=%d channel_id=%s "
+        "query_hash=%s query_len=%d query_preview=%r",
+        command_id,
+        mode,
+        limit,
+        channel_id,
+        fields["query_hash"],
+        fields["query_len"],
+        fields["query_preview"],
+    )
     deadline = time.monotonic() + _WORKER_SEARCH_TIMEOUT_SEC
+    last_status = "unknown"
     while time.monotonic() < deadline:
         command = await cmd_service.get(command_id)
         if command is None:
+            logger.warning(
+                "telegram_search_worker missing command_id=%s elapsed_ms=%d mode=%s query_hash=%s",
+                command_id,
+                int((time.monotonic() - started_at) * 1000),
+                mode,
+                fields["query_hash"],
+            )
             break
+        last_status = _status_value(command.status)
         if command.status == TelegramCommandStatus.SUCCEEDED:
             try:
-                return SearchResult.model_validate(command.result_payload or {})
+                result = SearchResult.model_validate(command.result_payload or {})
+                logger.info(
+                    "telegram_search_worker success command_id=%s elapsed_ms=%d mode=%s "
+                    "total=%d result_error=%s query_hash=%s",
+                    command_id,
+                    int((time.monotonic() - started_at) * 1000),
+                    mode,
+                    result.total,
+                    bool(result.error),
+                    fields["query_hash"],
+                )
+                return result
             except ValidationError:
-                logger.warning("Malformed worker search result for command %s", command_id)
+                logger.warning(
+                    "Malformed worker search result for command %s mode=%s query_hash=%s",
+                    command_id,
+                    mode,
+                    fields["query_hash"],
+                )
                 return SearchResult(messages=[], total=0, query=query, error="Некорректный ответ worker.")
         if command.status == TelegramCommandStatus.FAILED:
+            logger.warning(
+                "telegram_search_worker failed command_id=%s elapsed_ms=%d mode=%s error=%s "
+                "query_hash=%s",
+                command_id,
+                int((time.monotonic() - started_at) * 1000),
+                mode,
+                command.error,
+                fields["query_hash"],
+            )
             return SearchResult(
                 messages=[], total=0, query=query,
                 error=command.error or "Ошибка поиска в worker.",
             )
         if command.status == TelegramCommandStatus.CANCELLED:
+            logger.warning(
+                "telegram_search_worker cancelled command_id=%s elapsed_ms=%d mode=%s query_hash=%s",
+                command_id,
+                int((time.monotonic() - started_at) * 1000),
+                mode,
+                fields["query_hash"],
+            )
             return SearchResult(messages=[], total=0, query=query, error="Поиск отменён.")
         await asyncio.sleep(_WORKER_SEARCH_POLL_SEC)
+    logger.warning(
+        "telegram_search_worker timeout command_id=%s elapsed_ms=%d timeout_sec=%.0f "
+        "last_status=%s mode=%s limit=%d query_hash=%s query_len=%d query_preview=%r",
+        command_id,
+        int((time.monotonic() - started_at) * 1000),
+        _WORKER_SEARCH_TIMEOUT_SEC,
+        last_status,
+        mode,
+        limit,
+        fields["query_hash"],
+        fields["query_len"],
+        fields["query_preview"],
+    )
     return SearchResult(
         messages=[],
         total=0,
         query=query,
-        error="Worker не ответил вовремя. Проверьте, что Telegram-worker запущен.",
+        error=(
+            f"Worker не ответил за {_WORKER_SEARCH_TIMEOUT_SEC:.0f}с "
+            f"(command_id={command_id}, status={last_status}). "
+            "Задача могла ещё выполняться в Telegram-worker; проверьте логи."
+        ),
     )
 
 

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -66,14 +66,13 @@ async def _telegram_search_via_worker(
     started_at = time.monotonic()
     logger.info(
         "telegram_search_worker enqueue command_id=%s mode=%s limit=%d channel_id=%s "
-        "query_hash=%s query_len=%d query_preview=%r",
+        "query_hash=%s query_len=%d",
         command_id,
         mode,
         limit,
         channel_id,
         fields["query_hash"],
         fields["query_len"],
-        fields["query_preview"],
     )
     deadline = time.monotonic() + _WORKER_SEARCH_TIMEOUT_SEC
     last_status = "unknown"
@@ -137,7 +136,7 @@ async def _telegram_search_via_worker(
         await asyncio.sleep(_WORKER_SEARCH_POLL_SEC)
     logger.warning(
         "telegram_search_worker timeout command_id=%s elapsed_ms=%d timeout_sec=%.0f "
-        "last_status=%s mode=%s limit=%d query_hash=%s query_len=%d query_preview=%r",
+        "last_status=%s mode=%s limit=%d query_hash=%s query_len=%d",
         command_id,
         int((time.monotonic() - started_at) * 1000),
         _WORKER_SEARCH_TIMEOUT_SEC,
@@ -146,7 +145,6 @@ async def _telegram_search_via_worker(
         limit,
         fields["query_hash"],
         fields["query_len"],
-        fields["query_preview"],
     )
     return SearchResult(
         messages=[],

--- a/tests/test_packaging_deps.py
+++ b/tests/test_packaging_deps.py
@@ -9,7 +9,7 @@ from pathlib import Path
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 # Pure dev/test tooling that must never ship as a runtime dependency.
-_DEV_ONLY = {"pytest", "pytest-timeout", "pytest-xdist", "ruff", "pytest-cov"}
+_DEV_ONLY = {"pytest", "pytest-asyncio", "pytest-timeout", "pytest-xdist", "ruff", "pytest-cov"}
 _DIST_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -8,6 +10,7 @@ import pytest
 from telethon.errors import FloodWaitError
 
 from src.models import Message
+from src.search import telegram_search as telegram_search_module
 from src.search.engine import SearchEngine
 from src.services.embedding_service import EmbeddingService
 from src.web.routes.search import _extract_length
@@ -283,6 +286,135 @@ async def test_search_telegram_ignores_quota_probe_failure_when_search_succeeds(
     assert result.total == 1
     assert result.error is None
     assert result.messages[0].message_id == 42
+
+
+@pytest.mark.anyio
+async def test_search_telegram_quota_timeout_returns_diagnostic_error_and_releases_client(
+    db,
+    real_pool_harness_factory,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(telegram_search_module, "PREMIUM_SEARCH_RPC_TIMEOUT_SEC", 0.01)
+    caplog.set_level(logging.WARNING, logger="src.search.telegram_search")
+
+    request_names: list[str] = []
+
+    async def _invoke(request):
+        request_names.append(request.__class__.__name__)
+        if request.__class__.__name__ == "CheckSearchPostsFloodRequest":
+            await asyncio.sleep(0.1)
+        return _make_search_response([])
+
+    harness = real_pool_harness_factory()
+    phone = "+1234567890"
+    client = FakeCliTelethonClient(me=SimpleNamespace(premium=True))
+    client.invoke = AsyncMock(side_effect=_invoke)
+    await _connect_search_account(
+        harness,
+        phone=phone,
+        session_string="premium-session",
+        is_premium=True,
+        client=client,
+    )
+
+    engine = SearchEngine(db, pool=harness.pool)
+    result = await engine.search_telegram("slow quota", limit=10)
+
+    assert result.total == 0
+    assert result.error is not None
+    assert "stage=quota" in result.error
+    assert request_names == ["CheckSearchPostsFloodRequest"]
+    assert "premium_search timeout stage=quota" in caplog.text
+    assert phone not in caplog.text
+    assert "+12...7890" in caplog.text
+
+    leased = await harness.pool.get_premium_client()
+    assert leased is not None
+    _, leased_phone = leased
+    await harness.pool.release_client(leased_phone)
+
+
+@pytest.mark.anyio
+async def test_search_telegram_rpc_timeout_returns_diagnostic_error_and_releases_client(
+    db,
+    real_pool_harness_factory,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(telegram_search_module, "PREMIUM_SEARCH_RPC_TIMEOUT_SEC", 0.01)
+    caplog.set_level(logging.WARNING, logger="src.search.telegram_search")
+
+    async def _invoke(request):
+        if request.__class__.__name__ == "CheckSearchPostsFloodRequest":
+            return SimpleNamespace(total_daily=100, remains=10, wait_till=None, query_is_free=False)
+        await asyncio.sleep(0.1)
+        return _make_search_response([])
+
+    harness = real_pool_harness_factory()
+    phone = "+1234567890"
+    client = FakeCliTelethonClient(me=SimpleNamespace(premium=True))
+    client.invoke = AsyncMock(side_effect=_invoke)
+    await _connect_search_account(
+        harness,
+        phone=phone,
+        session_string="premium-session",
+        is_premium=True,
+        client=client,
+    )
+
+    engine = SearchEngine(db, pool=harness.pool)
+    result = await engine.search_telegram("slow rpc", limit=10)
+
+    assert result.total == 0
+    assert result.error is not None
+    assert "stage=telegram_rpc" in result.error
+    assert "premium_search timeout stage=telegram_rpc" in caplog.text
+    assert phone not in caplog.text
+    assert "+12...7890" in caplog.text
+
+    leased = await harness.pool.get_premium_client()
+    assert leased is not None
+    _, leased_phone = leased
+    await harness.pool.release_client(leased_phone)
+
+
+@pytest.mark.anyio
+async def test_search_telegram_success_logs_safe_diagnostics(
+    db,
+    real_pool_harness_factory,
+    caplog,
+):
+    mock_msg = _make_mock_api_message()
+    mock_chat = MagicMock()
+    mock_chat.id = 100123
+    mock_chat.title = "Test Channel"
+    mock_chat.username = "test_channel"
+
+    response = _make_search_response([mock_msg], chats=[mock_chat])
+    harness = real_pool_harness_factory()
+    phone = "+1234567890"
+    await _connect_search_account(
+        harness,
+        phone=phone,
+        session_string="premium-session",
+        is_premium=True,
+        client=FakeCliTelethonClient(
+            me=SimpleNamespace(premium=True),
+            invoke_side_effect=lambda request: response,
+        ),
+    )
+
+    caplog.set_level(logging.INFO, logger="src.search.telegram_search")
+    engine = SearchEngine(db, pool=harness.pool)
+    result = await engine.search_telegram("AI", limit=10)
+
+    assert result.total == 1
+    assert "premium_search start mode=telegram" in caplog.text
+    assert "premium_search success" in caplog.text
+    assert "query_hash=" in caplog.text
+    assert phone not in caplog.text
+    assert "+12...7890" in caplog.text
 
 
 @pytest.mark.anyio

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -326,6 +326,7 @@ async def test_search_telegram_quota_timeout_returns_diagnostic_error_and_releas
     assert "stage=quota" in result.error
     assert request_names == ["CheckSearchPostsFloodRequest"]
     assert "premium_search timeout stage=quota" in caplog.text
+    assert "slow quota" not in caplog.text
     assert phone not in caplog.text
     assert "+12...7890" in caplog.text
 
@@ -370,6 +371,7 @@ async def test_search_telegram_rpc_timeout_returns_diagnostic_error_and_releases
     assert result.error is not None
     assert "stage=telegram_rpc" in result.error
     assert "premium_search timeout stage=telegram_rpc" in caplog.text
+    assert "slow rpc" not in caplog.text
     assert phone not in caplog.text
     assert "+12...7890" in caplog.text
 
@@ -413,6 +415,7 @@ async def test_search_telegram_success_logs_safe_diagnostics(
     assert "premium_search start mode=telegram" in caplog.text
     assert "premium_search success" in caplog.text
     assert "query_hash=" in caplog.text
+    assert "AI" not in caplog.text
     assert phone not in caplog.text
     assert "+12...7890" in caplog.text
 

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2128,6 +2129,37 @@ async def test_search_telegram_handler_without_engine_raises():
     d = _dispatcher(search_engine=None)
     with pytest.raises(RuntimeError, match="Search engine unavailable"):
         await d._handle_search_telegram({"mode": "telegram", "query": "q"})
+
+
+async def test_run_loop_logs_search_telegram_command_context(caplog):
+    from src.models import SearchResult
+
+    db = _mock_db()
+    pool = _mock_pool()
+    engine = MagicMock()
+    engine.search_telegram = AsyncMock(return_value=SearchResult(messages=[], total=0, query="q"))
+    command = TelegramCommand(
+        id=44,
+        command_type="search.telegram",
+        payload={"mode": "telegram", "query": "q", "limit": 5},
+    )
+    dispatcher = _dispatcher(db=db, pool=pool, search_engine=engine)
+
+    async def claim_once():
+        dispatcher._stop_event.set()
+        return command
+
+    db.repos.telegram_commands.claim_next_command = claim_once
+    caplog.set_level(logging.INFO, logger="src.services.telegram_command_dispatcher")
+
+    await dispatcher._run_loop()
+
+    assert "telegram_search_command start command_id=44" in caplog.text
+    assert "telegram_search_command success command_id=44" in caplog.text
+    assert "query_hash=" in caplog.text
+    update_call = db.repos.telegram_commands.update_command.call_args
+    assert update_call is not None
+    assert update_call[1]["status"] == TelegramCommandStatus.SUCCEEDED
 
 
 async def test_collection_pause_sets_setting_and_pauses():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1646,6 +1646,13 @@ async def test_search_telegram_proxy_renders_worker_result(client, monkeypatch):
     assert fake_cmd_service.enqueue.await_args.args[0] == "search.telegram"
 
 
+def test_search_telegram_proxy_timeout_covers_premium_worker_bounds():
+    from src.search.telegram_search import PREMIUM_SEARCH_RPC_TIMEOUT_SEC
+    from src.web.search import handlers as search_handlers
+
+    assert search_handlers._WORKER_SEARCH_TIMEOUT_SEC >= (PREMIUM_SEARCH_RPC_TIMEOUT_SEC * 2) + 5
+
+
 @pytest.mark.anyio
 async def test_search_telegram_proxy_timeout_logs_command_context(client, monkeypatch, caplog):
     """A slow worker response exposes command context instead of a generic timeout."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1646,6 +1646,40 @@ async def test_search_telegram_proxy_renders_worker_result(client, monkeypatch):
     assert fake_cmd_service.enqueue.await_args.args[0] == "search.telegram"
 
 
+@pytest.mark.anyio
+async def test_search_telegram_proxy_timeout_logs_command_context(client, monkeypatch, caplog):
+    """A slow worker response exposes command context instead of a generic timeout."""
+    from src.models import TelegramCommand, TelegramCommandStatus
+    from src.web import deps
+    from src.web.search import handlers as search_handlers
+
+    monkeypatch.setattr("src.web.routes.scheduler._is_worker_alive", AsyncMock(return_value=True))
+    monkeypatch.setattr(search_handlers, "_WORKER_SEARCH_TIMEOUT_SEC", 0.01)
+    monkeypatch.setattr(search_handlers, "_WORKER_SEARCH_POLL_SEC", 0.001)
+    caplog.set_level(logging.WARNING, logger="src.web.search.handlers")
+
+    command = TelegramCommand(
+        id=123,
+        command_type="search.telegram",
+        status=TelegramCommandStatus.RUNNING,
+        result_payload=None,
+    )
+    fake_cmd_service = SimpleNamespace(
+        enqueue=AsyncMock(return_value=123),
+        get=AsyncMock(return_value=command),
+    )
+    monkeypatch.setattr(deps, "telegram_command_service", lambda request: fake_cmd_service)
+
+    resp = await client.get("/search?q=test&mode=telegram")
+
+    assert resp.status_code == 200
+    assert "command_id=123" in resp.text
+    assert "status=running" in resp.text
+    assert "telegram_search_worker timeout command_id=123" in caplog.text
+    assert "last_status=running" in caplog.text
+    fake_cmd_service.enqueue.assert_awaited_once()
+
+
 @pytest.fixture
 async def unauth_client(client):
     """Client without auth headers, reusing the same app from client fixture."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1684,6 +1684,7 @@ async def test_search_telegram_proxy_timeout_logs_command_context(client, monkey
     assert "status=running" in resp.text
     assert "telegram_search_worker timeout command_id=123" in caplog.text
     assert "last_status=running" in caplog.text
+    assert "test" not in caplog.text
     fake_cmd_service.enqueue.assert_awaited_once()
 
 


### PR DESCRIPTION
## What changed

- Added a 60s bound for Telegram Premium quota check and global search RPC.
- Added diagnostic logs for web proxy, worker command dispatch, and premium search stages.
- Added safe logging helpers for masked phones plus query hash/preview.
- Updated the web timeout error to include `command_id` and last worker status.
- Set `asyncio_default_fixture_loop_scope = "function"` to remove the pytest-asyncio deprecation warning.

## Why

Premium search could show `Worker не ответил вовремя` while the worker was alive and the `search.telegram` command kept running. The missing bound was in the live Telegram Premium path, so logs did not clearly show whether the worker accepted the command, which stage was active, or whether Telegram RPC was stuck.

## Validation

- `python3 -m pytest tests/test_search.py -q` -> `34 passed`
- `python3 -m pytest tests/test_web.py::test_search_telegram_proxy_timeout_logs_command_context tests/test_telegram_command_dispatcher.py::test_run_loop_logs_search_telegram_command_context -q` -> `2 passed`
- `ruff check src/ tests/ conftest.py` -> `All checks passed`

Live Premium smoke was intentionally not run to avoid spending the limited Premium search quota.

Closes #783