### PR TITLE
fix(collector): deactivate bot/dm channels in stats instead of silent error loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ markers = [
     "aiosqlite_serial: test must run without xdist parallelism because it exercises aiosqlite-backed database paths",
     "codex_image_live: opt-in live Codex SDK image generation test; gate: RUN_CODEX_IMAGE_LIVE=1",
     "codex_cli_live: opt-in live Codex CLI smoke (image + agent backend via real MCP); gate: RUN_CODEX_CLI_LIVE=1",
+    "e2e: end-to-end browser test using Playwright",
 ]
 
 [tool.coverage.run]

--- a/src/config.py
+++ b/src/config.py
@@ -40,6 +40,7 @@ class SchedulerConfig(BaseModel):
     stats_all_max_channels_per_run: int = 10
     stats_all_cooldown_sec: int = 600
     stats_all_worker_count: int = 1
+    stats_all_skip_fresh_hours: int = 24
 
 
 class NotificationsConfig(BaseModel):

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -138,6 +138,21 @@ class ChannelsRepository:
         rows = await cur.fetchall()
         return [self._map_channel(r) for r in rows]
 
+    async def count_channels(
+        self, active_only: bool = False, include_filtered: bool = True
+    ) -> int:
+        conditions = []
+        if active_only:
+            conditions.append("is_active = 1")
+        if not include_filtered:
+            conditions.append("is_filtered = 0")
+        sql = "SELECT COUNT(*) FROM channels"
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
+        cur = await self._db.execute(sql)
+        row = await cur.fetchone()
+        return row[0] if row else 0
+
     async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
         await self._database.execute_write(
             """

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1857,7 +1857,9 @@ class Collector:
             configured = int(getattr(self._config, "stats_all_max_channels_per_run", 10) or 10)
         return max(1, int(configured))
 
-    async def _order_stats_all_channels(self, channels: list[Channel]) -> list[Channel]:
+    async def _order_stats_all_channels(
+        self, channels: list[Channel], *, skip_fresh_hours: int = 0
+    ) -> list[Channel]:
         try:
             latest_stats = await self._db.get_latest_stats_for_all()
         except Exception:
@@ -1874,14 +1876,31 @@ class Collector:
                 collected_at = collected_at.replace(tzinfo=timezone.utc)
             return (1, collected_at, index)
 
-        return [channel for _index, channel in sorted(enumerate(channels), key=_sort_key)]
+        ordered = [channel for _index, channel in sorted(enumerate(channels), key=_sort_key)]
+
+        if skip_fresh_hours > 0:
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=skip_fresh_hours)
+            result = []
+            for ch in ordered:
+                latest = latest_stats.get(ch.channel_id)
+                if latest is None:
+                    result.append(ch)
+                    continue
+                collected_at = latest.collected_at or datetime.min.replace(tzinfo=timezone.utc)
+                if collected_at.tzinfo is None:
+                    collected_at = collected_at.replace(tzinfo=timezone.utc)
+                if collected_at < cutoff:
+                    result.append(ch)
+            ordered = result
+
+        return ordered
 
     async def collect_all_stats(self, *, max_channels: int | None = None) -> dict:
         async with self._stats_all_lock:
             self._stats_all_running = True
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
-                channels = await self._order_stats_all_channels(channels)
+                channels = await self._order_stats_all_channels(channels, skip_fresh_hours=24)
                 channel_limit = self._stats_all_channel_limit(max_channels)
                 total_channels = len(channels)
                 selected_channels = channels[:channel_limit]

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1775,6 +1775,22 @@ class Collector:
                         timeout=30.0,
                     )
 
+                # Guard: entity resolved as a User/Bot (no ``title``) — not a channel.
+                # Reuse the pool's canonical classifier (bot/dm) so the channel
+                # stops re-entering stats payloads forever instead of failing
+                # silently on every run.
+                if not hasattr(entity, "title"):
+                    entity_type = self._pool._entity_to_dict(entity)["channel_type"]
+                    logger.warning(
+                        "Stats: channel %d resolved as non-channel entity (%s), "
+                        "deactivating",
+                        channel.channel_id,
+                        entity_type,
+                    )
+                    await self._db.repos.channels.set_channel_type(channel.channel_id, entity_type)
+                    await self._db.set_channel_active(channel.id, False)
+                    return None
+
                 full = await run_with_flood_wait(
                     session.fetch_full_channel(entity),
                     operation="collect_channel_stats_fetch_full_channel",
@@ -1866,41 +1882,35 @@ class Collector:
             logger.debug("Failed to load latest channel stats for stats-all ordering", exc_info=True)
             return channels
 
-        def _sort_key(item: tuple[int, Channel]) -> tuple[int, datetime, int]:
-            index, channel = item
+        def _collected_at(channel: Channel) -> datetime:
+            """UTC-normalized last-stats timestamp; ``datetime.min`` if never collected."""
             latest = latest_stats.get(channel.channel_id)
-            if latest is None:
-                return (0, datetime.min.replace(tzinfo=timezone.utc), index)
-            collected_at = latest.collected_at or datetime.min.replace(tzinfo=timezone.utc)
+            collected_at = (latest.collected_at if latest else None) or datetime.min.replace(tzinfo=timezone.utc)
             if collected_at.tzinfo is None:
                 collected_at = collected_at.replace(tzinfo=timezone.utc)
-            return (1, collected_at, index)
-
-        ordered = [channel for _index, channel in sorted(enumerate(channels), key=_sort_key)]
+            return collected_at
 
         if skip_fresh_hours > 0:
             cutoff = datetime.now(timezone.utc) - timedelta(hours=skip_fresh_hours)
-            result = []
-            for ch in ordered:
-                latest = latest_stats.get(ch.channel_id)
-                if latest is None:
-                    result.append(ch)
-                    continue
-                collected_at = latest.collected_at or datetime.min.replace(tzinfo=timezone.utc)
-                if collected_at.tzinfo is None:
-                    collected_at = collected_at.replace(tzinfo=timezone.utc)
-                if collected_at < cutoff:
-                    result.append(ch)
-            ordered = result
+            channels = [
+                ch for ch in channels
+                if ch.channel_id not in latest_stats or _collected_at(ch) < cutoff
+            ]
 
-        return ordered
+        def _sort_key(item: tuple[int, Channel]) -> tuple[int, datetime, int]:
+            index, channel = item
+            has_stats = channel.channel_id in latest_stats
+            return (1 if has_stats else 0, _collected_at(channel), index)
+
+        return [channel for _index, channel in sorted(enumerate(channels), key=_sort_key)]
 
     async def collect_all_stats(self, *, max_channels: int | None = None) -> dict:
         async with self._stats_all_lock:
             self._stats_all_running = True
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
-                channels = await self._order_stats_all_channels(channels, skip_fresh_hours=24)
+                skip_fresh_hours = int(getattr(self._config, "stats_all_skip_fresh_hours", 24) or 0)
+                channels = await self._order_stats_all_channels(channels, skip_fresh_hours=skip_fresh_hours)
                 channel_limit = self._stats_all_channel_limit(max_channels)
                 total_channels = len(channels)
                 selected_channels = channels[:channel_limit]

--- a/src/web/channels/handlers.py
+++ b/src/web/channels/handlers.py
@@ -30,12 +30,8 @@ async def channels_list(request: Request) -> ChannelsTemplate:
     channels, latest_stats, prev_subscriber_counts = await service.list_for_page(
         include_filtered=show_all
     )
-    if show_all:
-        total_count = len(channels)
-        active_count = await db.repos.channels.count_channels(include_filtered=False)
-    else:
-        active_count = len(channels)
-        total_count = await db.repos.channels.count_channels()
+    active_count = await db.repos.channels.count_channels(active_only=True, include_filtered=False)
+    total_count = await db.repos.channels.count_channels()
     return ChannelsTemplate(
         "channels.html",
         {

--- a/src/web/channels/handlers.py
+++ b/src/web/channels/handlers.py
@@ -25,10 +25,17 @@ async def _enqueue_channel_command(request: Request, command_type: str, payload:
 
 async def channels_list(request: Request) -> ChannelsTemplate:
     service = deps.channel_service(request)
+    db = deps.get_db(request)
     show_all = request.query_params.get("view") == "all"
     channels, latest_stats, prev_subscriber_counts = await service.list_for_page(
         include_filtered=show_all
     )
+    if show_all:
+        total_count = len(channels)
+        active_count = await db.repos.channels.count_channels(include_filtered=False)
+    else:
+        active_count = len(channels)
+        total_count = await db.repos.channels.count_channels()
     return ChannelsTemplate(
         "channels.html",
         {
@@ -38,6 +45,8 @@ async def channels_list(request: Request) -> ChannelsTemplate:
             "error": request.query_params.get("error"),
             "msg": request.query_params.get("msg"),
             "show_all": show_all,
+            "active_count": active_count,
+            "total_count": total_count,
         },
     )
 

--- a/src/web/filter/handlers.py
+++ b/src/web/filter/handlers.py
@@ -33,6 +33,7 @@ async def filter_manage(request: Request) -> FilterTemplate:
     db = deps.get_db(request)
     channels = await db.get_channels_with_counts(active_only=False, include_filtered=True)
     filtered = [ch for ch in channels if ch.is_filtered]
+    total_channels = len(channels)
     dev_mode = await _dev_mode_enabled(request)
     pending_rename_count = await db.count_pending_rename_events()
     return FilterTemplate(
@@ -40,6 +41,7 @@ async def filter_manage(request: Request) -> FilterTemplate:
         {
             "channels": filtered,
             "total": len(filtered),
+            "total_channels": total_channels,
             "dev_mode": dev_mode,
             "pending_rename_count": pending_rename_count,
         },

--- a/src/web/routes/channel_collection.py
+++ b/src/web/routes/channel_collection.py
@@ -163,10 +163,10 @@ async def collect_all_stats(request: Request):
     channels = await db.repos.channels.get_channels(active_only=True, include_filtered=False)
     latest_stats = await db.get_latest_stats_for_all()
     channels_without_stats = [ch for ch in channels if ch.channel_id not in latest_stats]
-    channels_with_stats = [ch for ch in channels if ch.channel_id in latest_stats]
-    ordered_channels = channels_without_stats + channels_with_stats
+    if not channels_without_stats:
+        return RedirectResponse(url="/channels?msg=stats_already_ready", status_code=303)
     payload = StatsAllTaskPayload(
-        channel_ids=[ch.channel_id for ch in ordered_channels],
+        channel_ids=[ch.channel_id for ch in channels_without_stats],
     )
     await db.create_stats_task(
         payload,

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -25,8 +25,8 @@
 
 {% if channels or show_all %}
 <div class="d-flex gap-2 align-items-center flex-wrap mb-3">
-    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-primary' }}">Активные</a>
-    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-primary' }}">Все каналы</a>
+    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-primary' }}">Активные ({{ active_count }})</a>
+    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-primary' }}">Все каналы ({{ total_count }})</a>
     <span class="flex-fill"></span>
     <form method="post" action="/channels/stats/all" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Обновить статистику</button>

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -43,7 +43,7 @@
 </div>
 
 {% if channels %}
-<p>Отфильтровано: <strong>{{ total }}</strong> каналов</p>
+<p>Отфильтровано: <strong>{{ total }}</strong> каналов из {{ total_channels }}</p>
 
 <div class="table-responsive">
 <table class="tga-table-striped">

--- a/tests/test_collector_runtime.py
+++ b/tests/test_collector_runtime.py
@@ -161,3 +161,98 @@ async def test_collect_channel_stats_uses_transport_session_and_persists_stats(
     saved = await db.get_channel_stats(-100123)
     assert len(saved) == 1
     assert saved[0].subscriber_count == 5000
+
+
+def _resolved_bot_entity(user_id: int, username: str | None = None):
+    """A Telegram User entity (bot) — no ``title`` attribute."""
+    return SimpleNamespace(
+        id=user_id,
+        username=username,
+        first_name="BotUser",
+        last_name=None,
+        bot=True,
+    )
+
+
+@pytest.mark.anyio
+async def test_collect_channel_stats_deactivates_bot_channel(
+    db,
+    real_pool_harness_factory,
+):
+    """A channel whose username resolves to a bot (User entity without ``title``)
+    must be deactivated and typed as ``'bot'`` instead of silently failing
+    on every stats run forever.
+    """
+    await db.add_channel(Channel(channel_id=-100999, title="Bot Channel", username="some_bot"))
+    channel = (await db.get_channels())[0]
+
+    entity = _resolved_bot_entity(-100999, "some_bot")
+
+    harness = real_pool_harness_factory()
+    harness.queue_cli_client(
+        phone="+7000",
+        client=FakeCliTelethonClient(
+            entity_resolver=lambda _peer: entity,
+        ),
+    )
+    await harness.add_account("+7000", session_string="session-bot-test", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    collector = Collector(harness.pool, db, SchedulerConfig())
+    result = await collector.collect_channel_stats(channel)
+
+    # Stats must not be collected for a bot
+    assert result is None
+
+    # Channel must be deactivated — not left in eternal "no stats" limbo
+    updated = (await db.get_channels())[0]
+    assert updated.is_active is False
+
+    # Channel type must be explicitly 'bot' for visibility in UI/CLI
+    assert updated.channel_type == "bot"
+
+    # No stats row should exist for a bot
+    saved = await db.get_channel_stats(-100999)
+    assert len(saved) == 0
+
+
+@pytest.mark.anyio
+async def test_collect_channel_stats_deactivates_dm_user_channel(
+    db,
+    real_pool_harness_factory,
+):
+    """A channel whose ID resolves to a regular user (not a bot) must be
+    deactivated and typed as ``'dm'`` — whatever Telegram returns.
+    """
+    await db.add_channel(Channel(channel_id=-100998, title="DM Channel"))
+    channel = (await db.get_channels())[0]
+
+    user_entity = SimpleNamespace(
+        id=-100998,
+        username=None,
+        first_name="Plain",
+        last_name="User",
+        bot=False,  # not a bot — just a regular user
+    )
+
+    harness = real_pool_harness_factory()
+    harness.queue_cli_client(
+        phone="+7000",
+        client=FakeCliTelethonClient(
+            entity_resolver=lambda _peer: user_entity,
+        ),
+    )
+    await harness.add_account("+7000", session_string="session-dm-test", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    collector = Collector(harness.pool, db, SchedulerConfig())
+    result = await collector.collect_channel_stats(channel)
+
+    assert result is None
+
+    updated = (await db.get_channels())[0]
+    assert updated.is_active is False
+    assert updated.channel_type == "dm"
+
+    saved = await db.get_channel_stats(-100998)
+    assert len(saved) == 0

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2606,6 +2606,51 @@ async def test_filter_toggle_sets_manual_flag(client):
 
 
 @pytest.mark.anyio
+async def test_has_stats_returns_true_when_all_channels_have_stats(client):
+    from src.models import Channel, ChannelStats
+
+    db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100710, title="Ch1"))
+    await db.add_channel(Channel(channel_id=-100711, title="Ch2"))
+    await db.save_channel_stats(ChannelStats(channel_id=-100710, subscriber_count=10))
+    await db.save_channel_stats(ChannelStats(channel_id=-100711, subscriber_count=20))
+
+    resp = await client.get("/channels/filter/has-stats")
+    assert resp.status_code == 200
+    assert resp.json() == {"has_stats": True}
+
+
+@pytest.mark.anyio
+async def test_has_stats_returns_false_when_channel_missing_stats(client):
+    from src.models import Channel, ChannelStats
+
+    db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100720, title="With stats"))
+    await db.add_channel(Channel(channel_id=-100721, title="No stats"))
+    await db.save_channel_stats(ChannelStats(channel_id=-100720, subscriber_count=10))
+
+    resp = await client.get("/channels/filter/has-stats")
+    assert resp.status_code == 200
+    assert resp.json() == {"has_stats": False}
+
+
+@pytest.mark.anyio
+async def test_stats_all_redirects_when_all_channels_have_stats(client):
+    from src.models import Channel, ChannelStats
+
+    db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100730, title="Ch"))
+    await db.save_channel_stats(ChannelStats(channel_id=-100730, subscriber_count=5))
+
+    resp = await client.post("/channels/stats/all", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "msg=stats_already_ready" in resp.headers["location"]
+
+    tasks = await db.get_collection_tasks()
+    assert len(tasks) == 0
+
+
+@pytest.mark.anyio
 async def test_collect_filtered_channel_is_allowed(client):
     """Manual collect (web UI) must proceed even when channel is filtered."""
     from src.models import Channel

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2656,7 +2656,10 @@ async def test_delete_channel_cancels_pending_collection_tasks(client):
 
 @pytest.mark.anyio
 async def test_stats_all_creates_pending_task(client):
+    from src.models import Channel
+
     db = client._transport.app.state.db
+    await db.add_channel(Channel(channel_id=-100800, title="Test"))
 
     resp = await client.post("/channels/stats/all", follow_redirects=False)
     assert resp.status_code == 303
@@ -2673,8 +2676,11 @@ async def test_stats_all_creates_pending_task(client):
 
 @pytest.mark.anyio
 async def test_stats_all_queued_when_collector_running(client):
+    from src.models import Channel
+
     app = client._transport.app.state
     db = app.db
+    await db.add_channel(Channel(channel_id=-100810, title="Test"))
     app.collector._running = True
     try:
         resp = await client.post("/channels/stats/all", follow_redirects=False)
@@ -2700,7 +2706,7 @@ async def test_stats_all_blocks_duplicate_active_task(client):
 
 
 @pytest.mark.anyio
-async def test_stats_all_prioritizes_channels_without_stats(client):
+async def test_stats_all_only_channels_without_stats(client):
     from src.models import Channel, ChannelStats
 
     db = client._transport.app.state.db
@@ -2718,8 +2724,9 @@ async def test_stats_all_prioritizes_channels_without_stats(client):
     payload = tasks[0].payload
     assert isinstance(payload, StatsAllTaskPayload)
     channel_ids = payload.channel_ids
-    assert channel_ids.index(-100901) > channel_ids.index(-100902)
-    assert channel_ids.index(-100901) > channel_ids.index(-100903)
+    assert -100901 not in channel_ids
+    assert -100902 in channel_ids
+    assert -100903 in channel_ids
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Что исправлено

Канал-бот (entity без `title`) бесконечно попадал в `_collect_channel_stats`, падал на `fetch_full_channel(User)`, ошибка тихо проглатывалась — без деактивации, без типа, без stats. Каждый запуск stats снова включал этот канал.

## Фикс

`_collect_channel_stats` теперь проверяет `hasattr(entity, "title")` после `resolve_entity`. Если entity — бот/пользователь:
- `channel_type` = фактический тип из Telegram (`"bot"` или `"dm"`)
- `is_active = False` — канал исключается из будущих stats-запусков

## TDD-тесты

- `test_collect_channel_stats_deactivates_bot_channel` — бот деактивируется, тип `"bot"`
- `test_collect_channel_stats_deactivates_dm_user_channel` — юзер деактивируется, тип `"dm"`

## Попутно (из #788)

- Счётчики на страницах каналов и фильтров: «Активные (X) / Все каналы (Y)», «Отфильтровано: X из Y»
- `count_channels()` в channels repository
- `skip_fresh_hours=24` для CLI stats

## Связанные issue

Fixes #788
See also #793 (analyze_channels timeout — обнаружен при этом фиксе)