### PR TITLE
fix(telegram): centralize Telethon calls to eliminate FloodWait bypasses

### DIFF
--- a/src/services/notification_target_service.py
+++ b/src/services/notification_target_service.py
@@ -151,9 +151,9 @@ class NotificationTargetService:
         if status.state != "available" or status.effective_phone is None:
             raise RuntimeError(status.message)
 
-        getter = getattr(self._pool, "get_native_client_by_phone", None)
+        getter = getattr(self._pool, "get_client_by_phone", None)
         if not callable(getter):
-            raise RuntimeError("Notification target pool does not support native client access.")
+            raise RuntimeError("Notification target pool does not support client access.")
         result = await getter(status.effective_phone)
         if result is None:
             raise RuntimeError(f"Аккаунт {status.effective_phone} временно недоступен.")

--- a/src/services/publish_service.py
+++ b/src/services/publish_service.py
@@ -178,10 +178,9 @@ class PublishService:
         try:
             resolver = getattr(self._client_pool, "resolve_dialog_entity", None)
             if callable(resolver):
-                resolved = resolver(session, phone, target.dialog_id, target.dialog_type)
-                return await asyncio.wait_for(resolved, timeout=30.0)
+                return await resolver(session, phone, target.dialog_id, target.dialog_type)
 
-            return await asyncio.wait_for(session.resolve_input_entity(target.dialog_id), timeout=30.0)
+            return await session.resolve_input_entity(target.dialog_id)
         except Exception as e:
             logger.warning("Could not resolve dialog_id %s: %s", target.dialog_id, e)
             return None

--- a/src/web/runtime_shims.py
+++ b/src/web/runtime_shims.py
@@ -54,6 +54,9 @@ class SnapshotClientPool:
     async def disconnect_all(self) -> None:
         return None
 
+    async def get_client_by_phone(self, phone: str):
+        raise RuntimeError("Telegram runtime is only available in the worker process.")
+
     async def get_native_client_by_phone(self, phone: str):
         raise RuntimeError("Telegram runtime is only available in the worker process.")
 

--- a/tests/test_channel_stats.py
+++ b/tests/test_channel_stats.py
@@ -209,7 +209,7 @@ async def test_collect_channel_stats_success(db):
     ch = Channel(channel_id=-100123, title="Test", username="test_chan")
     await db.add_channel(ch)
 
-    mock_entity = SimpleNamespace()
+    mock_entity = SimpleNamespace(title="Test", id=-100123)
     mock_full_chat = SimpleNamespace(participants_count=5000)
     mock_full = SimpleNamespace(full_chat=mock_full_chat)
 
@@ -249,7 +249,7 @@ async def test_collect_channel_stats_rotates_on_flood_wait(db):
     client1 = AsyncMock()
     client1.get_entity = AsyncMock(side_effect=flood_err)
 
-    mock_entity = SimpleNamespace()
+    mock_entity = SimpleNamespace(title="Test", id=-100123)
     mock_full_chat = SimpleNamespace(participants_count=123)
     mock_full = SimpleNamespace(full_chat=mock_full_chat)
     client2 = AsyncMock()
@@ -388,7 +388,7 @@ async def test_collect_all_stats(db):
     await db.add_channel(ch1)
     await db.add_channel(ch2)
 
-    mock_entity = SimpleNamespace()
+    mock_entity = SimpleNamespace(title="Test", id=-100123)
     mock_full_chat = SimpleNamespace(participants_count=1000)
     mock_full = SimpleNamespace(full_chat=mock_full_chat)
     mock_messages = [_make_mock_msg(i) for i in range(1, 3)]

--- a/tests/test_client_pool_runtime.py
+++ b/tests/test_client_pool_runtime.py
@@ -238,15 +238,13 @@ async def test_get_native_client_by_phone_uses_native_backend_and_disconnects(
 
 @pytest.mark.anyio
 @pytest.mark.native_backend_allowed
-async def test_notification_target_uses_real_pool_native_getter(
+async def test_notification_target_uses_real_pool_client_getter(
     real_pool_harness_factory,
 ):
+    """use_client() routes through get_client_by_phone, reusing the
+    persistent pool session instead of creating a new TCP connection."""
     harness = real_pool_harness_factory()
-    harness.queue_cli_client(phone="+70000000001", client=FakeCliTelethonClient())
-    native_client = harness.queue_native_client(
-        session_string="session-1",
-        client=FakeCliTelethonClient(),
-    )
+    pool_client = harness.queue_cli_client(phone="+70000000001", client=FakeCliTelethonClient())
 
     await harness.add_account(
         phone="+70000000001",
@@ -259,10 +257,9 @@ async def test_notification_target_uses_real_pool_native_getter(
 
     async with service.use_client() as (acquired_client, phone):
         assert isinstance(acquired_client, TelegramTransportSession)
-        assert acquired_client.raw_client is native_client
+        # get_client_by_phone reuses the persistent pool session
+        assert acquired_client.raw_client is pool_client
         assert phone == "+70000000001"
-
-    native_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.anyio

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -58,7 +59,15 @@ async def _connect_notification_account(
     entity_id: int = 987654321,
     is_primary: bool = False,
 ):
-    harness.queue_cli_client(phone=phone, client=FakeCliTelethonClient())
+    # Pool client must have me/entity configured since use_client() now
+    # routes through get_client_by_phone which reuses the pool session.
+    harness.queue_cli_client(
+        phone=phone,
+        client=FakeCliTelethonClient(
+            me=SimpleNamespace(id=me_id, username=me_username),
+            entity_resolver=lambda _peer: SimpleNamespace(id=entity_id),
+        ),
+    )
     native_client = harness.queue_native_client(
         session_string=session_string,
         client=FakeCliTelethonClient(
@@ -177,7 +186,7 @@ async def test_delete_bot_success():
 @pytest.mark.anyio
 async def test_setup_bot_success(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
-    native_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70001111111",
         session_string="session-1",
@@ -197,7 +206,6 @@ async def test_setup_bot_success(db, real_pool_harness_factory):
     assert bot.tg_user_id == 111
     assert bot.bot_username == "leadhunter_alice_bot"
     assert bot.bot_id == 987654321
-    native_client.disconnect.assert_awaited_once()
 
     saved = await db.get_notification_bot(111)
     assert saved is not None
@@ -207,7 +215,7 @@ async def test_setup_bot_success(db, real_pool_harness_factory):
 @pytest.mark.anyio
 async def test_setup_bot_custom_prefix(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
-    native_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70001111111",
         session_string="session-1",
@@ -231,7 +239,9 @@ async def test_setup_bot_custom_prefix(db, real_pool_harness_factory):
 
     assert bot.bot_username == "acme_bob_bot"
     created_client = mock_create.await_args.args[0]
-    assert created_client.raw_client is native_client
+    # use_client() now returns pool session (reuses persistent connection)
+    pool_session = harness.pool.clients["+70001111111"]
+    assert created_client.raw_client is pool_session.raw_client
     assert mock_create.await_args.args[1:] == ("Acme (bob)", "acme_bob_bot")
 
 
@@ -273,8 +283,14 @@ async def test_setup_bot_no_client(db, real_pool_harness_factory):
 @pytest.mark.anyio
 async def test_setup_bot_bot_id_none_if_entity_fails(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
-    harness.queue_cli_client(phone="+70001111111", client=FakeCliTelethonClient())
-    native_client = harness.queue_native_client(
+    harness.queue_cli_client(
+        phone="+70001111111",
+        client=FakeCliTelethonClient(
+            me=SimpleNamespace(id=444, username="carol"),
+            entity_resolver=lambda _peer: Exception("peer not found"),
+        ),
+    )
+    harness.queue_native_client(
         session_string="session-1",
         client=FakeCliTelethonClient(
             me=SimpleNamespace(id=444, username="carol"),
@@ -297,7 +313,6 @@ async def test_setup_bot_bot_id_none_if_entity_fails(db, real_pool_harness_facto
         bot = await svc.setup_bot()
 
     assert bot.bot_id is None
-    native_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -356,7 +371,7 @@ async def test_teardown_bot_success(db, real_pool_harness_factory):
     await db.save_notification_bot(saved)
 
     harness = real_pool_harness_factory()
-    native_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70001111111",
         session_string="session-1",
@@ -373,13 +388,12 @@ async def test_teardown_bot_success(db, real_pool_harness_factory):
         await svc.teardown_bot()
 
     assert await db.get_notification_bot(777) is None
-    native_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.anyio
 async def test_teardown_bot_no_bot_raises(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
-    native_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70001111111",
         session_string="session-1",
@@ -392,13 +406,11 @@ async def test_teardown_bot_no_bot_raises(db, real_pool_harness_factory):
     with pytest.raises(RuntimeError, match="No notification bot"):
         await svc.teardown_bot()
 
-    native_client.disconnect.assert_awaited_once()
-
 
 @pytest.mark.anyio
 async def test_notifier_uses_primary_account_by_default(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
-    native_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70001111111",
         session_string="session-1",
@@ -411,8 +423,9 @@ async def test_notifier_uses_primary_account_by_default(db, real_pool_harness_fa
     sent = await notifier.notify("hello")
 
     assert sent is True
-    native_client.send_message.assert_awaited_once_with(123456, "hello")
-    native_client.disconnect.assert_awaited_once()
+    # Verify send went through the pool session's raw_client (cli_client)
+    pool_session = harness.pool.clients["+70001111111"]
+    pool_session.raw_client.send_message.assert_awaited_once_with(123456, "hello")
 
 
 @pytest.mark.anyio
@@ -435,16 +448,8 @@ async def test_notifier_does_not_fallback_from_selected_account(db, real_pool_ha
         is_primary=False,
     )
     await db.set_setting("notification_account_phone", "+70002222222")
-    harness.native_auth_spy.by_session.pop("session-selected", None)
-
-    def _raise_native(session_string: str):
-        if session_string == "session-selected":
-            raise ConnectionError("selected account unavailable")
-        return FakeCliTelethonClient(
-            me=SimpleNamespace(id=111, username="primary"),
-        )
-
-    harness.native_auth_spy.factory = _raise_native
+    # Put selected account in flood wait so describe_target() returns non-available
+    await db.update_account_flood("+70002222222", datetime.now(timezone.utc) + timedelta(seconds=300))
 
     notifier = Notifier(NotificationTargetService(db, harness.pool), admin_chat_id=123456)
     sent = await notifier.notify("hello")
@@ -464,7 +469,7 @@ async def test_notification_service_uses_selected_account(db, real_pool_harness_
         me_username="primary",
         is_primary=True,
     )
-    selected_client = await _connect_notification_account(
+    await _connect_notification_account(
         harness,
         phone="+70002222222",
         session_string="session-selected",
@@ -484,7 +489,6 @@ async def test_notification_service_uses_selected_account(db, real_pool_harness_
         bot = await svc.setup_bot()
 
     assert bot.tg_user_id == 222
-    assert selected_client.disconnect.await_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notification_target_service.py
+++ b/tests/test_notification_target_service.py
@@ -33,7 +33,7 @@ def _make_service(accounts=None, clients=None, configured_phone=None):
 
     pool = MagicMock()
     pool.clients = clients if clients is not None else {}
-    pool.get_native_client_by_phone = AsyncMock(return_value=(MagicMock(), "phone"))
+    pool.get_client_by_phone = AsyncMock(return_value=(MagicMock(), "phone"))
     pool.release_client = AsyncMock()
 
     svc = NotificationTargetService(notifications, pool)
@@ -149,7 +149,7 @@ async def test_use_client_success():
         clients={"+70001112233": MagicMock()},
     )
     mock_client = MagicMock()
-    svc._pool.get_native_client_by_phone = AsyncMock(
+    svc._pool.get_client_by_phone = AsyncMock(
         return_value=(mock_client, "+70001112233")
     )
 
@@ -158,6 +158,32 @@ async def test_use_client_success():
         assert phone == "+70001112233"
 
     svc._pool.release_client.assert_called_once_with("+70001112233")
+
+
+@pytest.mark.anyio
+async def test_use_client_uses_client_by_phone_not_native():
+    """use_client() must route through get_client_by_phone (reuses pool
+    connection) instead of get_native_client_by_phone (creates new TCP
+    connection each call).  Issue #795."""
+    acc = _make_account(phone="+70001112233")
+    svc, _ = _make_service(
+        accounts=[acc],
+        clients={"+70001112233": MagicMock()},
+    )
+    mock_client = MagicMock()
+    svc._pool.get_client_by_phone = AsyncMock(
+        return_value=(mock_client, "+70001112233")
+    )
+    svc._pool.get_native_client_by_phone = AsyncMock(
+        return_value=(MagicMock(), "+70001112233")
+    )
+
+    async with svc.use_client() as (client, phone):
+        assert client == mock_client
+        assert phone == "+70001112233"
+
+    svc._pool.get_client_by_phone.assert_called_once_with("+70001112233")
+    svc._pool.get_native_client_by_phone.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -593,3 +593,45 @@ async def test_publish_service_resolve_entity_fallback():
     results = await service.publish_run(run, make_pipeline(publish_mode=PipelinePublishMode.AUTO))
     # Should succeed via fallback resolve_input_entity
     assert results[0].success is True
+
+
+@pytest.mark.anyio
+async def test_publish_service_resolve_entity_no_wait_for():
+    """_resolve_entity must await resolve_dialog_entity directly without
+    asyncio.wait_for to avoid orphaned background Telethon requests on
+    timeout.  Issue #795."""
+
+    import asyncio
+    from unittest.mock import patch
+
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+
+    resolved_entity = {"phone": "+1234567890", "dialog_id": -1001234567890, "dialog_type": None}
+
+    class DirectAwaitPool(FakeClientPool):
+        async def resolve_dialog_entity(self, session, phone, dialog_id, dialog_type):
+            return resolved_entity
+
+    pool = DirectAwaitPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    with patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for:
+        run = GenerationRun(
+            id=1, pipeline_id=1, generated_text="Test",
+            moderation_status="approved",
+        )
+        results = await service.publish_run(run, make_pipeline(publish_mode=PipelinePublishMode.AUTO))
+
+    assert results[0].success is True
+    # wait_for must NOT be called — resolve_dialog_entity is awaited directly
+    for call in mock_wait_for.call_args_list:
+        # The only allowed wait_for calls are for send_message/publish_files in _publish_to_target
+        pos_args = call[0]
+        if pos_args:
+            coro_name = getattr(pos_args[0], "__name__", "") or ""
+            assert "resolve" not in str(coro_name).lower(), (
+                f"asyncio.wait_for called on resolve operation: {call}"
+            )

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1775,7 +1775,7 @@ async def test_collect_stats_username_fallback_fails():
 @pytest.mark.anyio
 async def test_collect_stats_no_username_resolves_numeric():
     channel = Channel(channel_id=123)
-    entity = SimpleNamespace(id=123, date=None)
+    entity = SimpleNamespace(id=123, title="Test", date=None)
     full_result = MagicMock()
     full_result.full_chat.participants_count = 100
 
@@ -1786,6 +1786,7 @@ async def test_collect_stats_no_username_resolves_numeric():
     db = MagicMock()
     db.save_channel_stats = AsyncMock()
     db.set_channel_type = AsyncMock()
+    db.repos.channels.set_channel_type = AsyncMock()
     db.repos.channels.update_channel_created_at = AsyncMock()
 
     collector = Collector(pool, db, SchedulerConfig())
@@ -1806,7 +1807,7 @@ async def test_collect_stats_no_username_resolves_numeric():
 @pytest.mark.anyio
 async def test_collect_stats_timeout_during_messages():
     channel = Channel(channel_id=123, username="test")
-    entity = SimpleNamespace(id=123, date=None)
+    entity = SimpleNamespace(id=123, title="Test", date=None)
     full_result = MagicMock()
     full_result.full_chat.participants_count = 50
 
@@ -1817,6 +1818,7 @@ async def test_collect_stats_timeout_during_messages():
     db = MagicMock()
     db.save_channel_stats = AsyncMock()
     db.set_channel_type = AsyncMock()
+    db.repos.channels.set_channel_type = AsyncMock()
     db.repos.channels.update_channel_created_at = AsyncMock()
 
     collector = Collector(pool, db, SchedulerConfig())
@@ -1838,7 +1840,7 @@ async def test_collect_stats_timeout_during_messages():
 @pytest.mark.anyio
 async def test_collect_stats_updates_channel_type():
     channel = Channel(channel_id=123, username="test", channel_type=None)
-    entity = SimpleNamespace(id=123, date=None, broadcast=True, megagroup=False,
+    entity = SimpleNamespace(id=123, title="Test Channel", date=None, broadcast=True, megagroup=False,
                              gigagroup=False, forum=False, monoforum=False,
                              scam=False, fake=False, restricted=False)
     full_result = MagicMock()
@@ -1860,6 +1862,7 @@ async def test_collect_stats_updates_channel_type():
     db = MagicMock()
     db.save_channel_stats = AsyncMock()
     db.set_channel_type = AsyncMock()
+    db.repos.channels.set_channel_type = AsyncMock()
     db.repos.channels.update_channel_created_at = AsyncMock()
 
     collector = Collector(pool, db, SchedulerConfig())


### PR DESCRIPTION
## Summary

Closes #795

Two FloodWait bypass paths fixed:

### 1. `NotificationTargetService.use_client()` — новое TCP-соединение на каждое уведомление

**Было:** `get_native_client_by_phone()` с `force_native=True` создавало **новый Telethon-клиент** каждый раз (новое TCP-соединение к Telegram). Pool уже имел постоянное соединение, но оно не использовалось. Telegram видел частые подключения/отключения + запросы → FloodWait.

**Стало:** `get_client_by_phone()` переиспользует постоянное pool-соединение (`self.clients[phone]`). Flood-контекст сохраняется (`with_flood_context()`).

### 2. `PublishService._resolve_entity()` — `asyncio.wait_for` wrapper

**Было:** `asyncio.wait_for(resolved, timeout=30.0)` поверх `resolve_dialog_entity()`. При таймауте Telethon-вызов продолжался в фоне, накапливая «зависшие» запросы.

**Стало:** прямой `await resolver(...)`. `resolve_dialog_entity()` внутри уже имеет timeout-параметры.

## Test plan

- [x] `test_use_client_uses_client_by_phone_not_native` — verifies `get_client_by_phone` вызван, `get_native_client_by_phone` не вызван
- [x] `test_publish_service_resolve_entity_no_wait_for` — verifies `asyncio.wait_for` не оборачивает resolve-операции
- [x] Все 33 теста в `test_notification_target_service` + `test_publish_service` проходят
- [x] `ruff check` — без ошибок
- [ ] Full parallel suite (1074 passed, 1 pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)