### PR TITLE
fix(telegram): prevent warm_all_dialogs FloodWait loop from blocking 12+ minutes

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -42,7 +42,6 @@ from src.telegram.flood_wait import (
     is_blocking_flood_wait_until,
     is_transient_flood_wait_seconds,
     run_with_flood_wait,
-    run_with_flood_wait_retry,
 )
 from src.telegram.rate_limiter import ResolveRateLimiter
 from src.telegram.resolve_guard import ResolveGuardMixin
@@ -51,6 +50,9 @@ from src.telegram.utils import normalize_utc
 
 logger = logging.getLogger(__name__)
 REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC = 5.0
+WARM_SINGLE_PHONE_TIMEOUT_SEC = 30.0
+WARM_ALL_PHONES_TOTAL_SEC = 150.0
+WARM_STAGGER_DELAY_SEC = 1.0
 
 
 @dataclass
@@ -167,8 +169,13 @@ class ClientPool(ResolveGuardMixin):
         Records which channels are accessible from which account so that
         private-group collection can target the right phone without guessing.
         Stores self._warming_task so the collector can wait during a race.
+
+        Uses run_with_flood_wait (single-shot) instead of the retry variant —
+        warm is a cache-preheating optimisation and should fail fast rather than
+        blocking on FloodWait sleep/retry loops.
         """
         self._warming_task = asyncio.current_task()
+        deadline = time.monotonic() + WARM_ALL_PHONES_TOTAL_SEC
         now = datetime.now(timezone.utc)
         flood_waited: set[str] = set()
         try:
@@ -183,7 +190,14 @@ class ClientPool(ResolveGuardMixin):
             }
         except Exception:
             logger.debug("warm_all_dialogs: failed to load flood-wait status", exc_info=True)
-        for phone in list(self._connected_phones()):
+        phones_list = list(self._connected_phones())
+        for idx, phone in enumerate(phones_list):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.info("warm_all_dialogs: budget exhausted after %d phones", idx)
+                break
+            if idx > 0:
+                await asyncio.sleep(WARM_STAGGER_DELAY_SEC)
             if phone in flood_waited:
                 logger.info("warm_all_dialogs: skip %s because active flood-wait is stored", phone)
                 continue
@@ -192,13 +206,13 @@ class ClientPool(ResolveGuardMixin):
                 continue
             session, p = result
             try:
-                dialogs = await run_with_flood_wait_retry(
-                    lambda: session.warm_dialog_cache(),
+                dialogs = await run_with_flood_wait(
+                    session.warm_dialog_cache(),
                     operation="telegram_warm_dialog_cache",
                     phone=p,
                     pool=self,
                     logger_=logger,
-                    timeout=60.0,
+                    timeout=WARM_SINGLE_PHONE_TIMEOUT_SEC,
                 )
                 self.mark_dialogs_fetched(p)
                 for dialog in dialogs or []:
@@ -220,9 +234,7 @@ class ClientPool(ResolveGuardMixin):
                                 )
                         except Exception:
                             # Best-effort warming hint; the in-memory map is already set.
-                            # The except covers both the read and the write, so the message
-                            # says "read or persist". exc_info keeps the traceback for
-                            # DB-lock diagnosis, matching collector.py (#676 review).
+                            # exc_info keeps the traceback for DB-lock diagnosis (#676).
                             logger.debug(
                                 "warm_all_dialogs: failed to read or persist preferred_phone "
                                 "for channel %d",

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -346,3 +346,151 @@ async def test_resolve_channel_strips_post_id_from_url(real_pool_harness_factory
     assert result is not None
     assert result["channel_id"] == 555
     client.get_entity.assert_awaited_with("https://t.me/ruarms_com")
+
+
+# ---------------------------------------------------------------------------
+# warm_all_dialogs: fail-fast on FloodWait, per-phone timeout, overall budget
+# ---------------------------------------------------------------------------
+
+
+async def _setup_warm_harness(harness, phones_and_clients):
+    """Add accounts and initialize, returning {phone: FakeCliTelethonClient}."""
+    for phone, client in phones_and_clients.items():
+        harness.queue_cli_client(phone=phone, client=client)
+        await harness.add_account(phone, session_string=f"s-{phone}", is_primary=(phone == list(phones_and_clients)[0]))
+    await harness.initialize_connected_accounts()
+    return phones_and_clients
+
+
+@pytest.mark.anyio
+async def test_warm_flood_wait_fail_fast(real_pool_harness_factory, monkeypatch, caplog):
+    """FloodWait on one phone should NOT sleep+retry — fail fast, move to next."""
+    import time
+
+    monkeypatch.setattr("src.telegram.client_pool.WARM_SINGLE_PHONE_TIMEOUT_SEC", 5.0)
+    monkeypatch.setattr("src.telegram.client_pool.WARM_STAGGER_DELAY_SEC", 0.0)
+
+    harness = real_pool_harness_factory()
+    fw_client = FakeCliTelethonClient(dialogs=FloodWaitError(24))
+    ok_client = FakeCliTelethonClient(dialogs=[])
+
+    await _setup_warm_harness(harness, {
+        "+70000000001": fw_client,
+        "+70000000002": ok_client,
+    })
+
+    caplog.clear()
+    t0 = time.monotonic()
+    await harness.pool.warm_all_dialogs()
+    elapsed = time.monotonic() - t0
+
+    # Must complete quickly — no 24s sleep
+    assert elapsed < 5.0, f"warm took {elapsed:.1f}s, expected fail-fast < 5s"
+    # Second phone should still be processed
+    ok_client.get_dialogs.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_warm_single_phone_timeout(real_pool_harness_factory, monkeypatch):
+    """A hanging get_dialogs should time out and not block other phones."""
+    import asyncio
+    import time
+
+    monkeypatch.setattr("src.telegram.client_pool.WARM_SINGLE_PHONE_TIMEOUT_SEC", 1.0)
+    monkeypatch.setattr("src.telegram.client_pool.WARM_STAGGER_DELAY_SEC", 0.0)
+
+    harness = real_pool_harness_factory()
+
+    async def _hang_forever():
+        await asyncio.Event().wait()
+
+    hang_client = FakeCliTelethonClient()
+    hang_client.get_dialogs = AsyncMock(side_effect=_hang_forever)
+
+    ok_client = FakeCliTelethonClient(dialogs=[])
+
+    await _setup_warm_harness(harness, {
+        "+70000000001": hang_client,
+        "+70000000002": ok_client,
+    })
+
+    t0 = time.monotonic()
+    await harness.pool.warm_all_dialogs()
+    elapsed = time.monotonic() - t0
+
+    # 1s timeout on first phone + near-instant on second
+    assert elapsed < 10.0, f"warm took {elapsed:.1f}s, expected < 10s"
+    ok_client.get_dialogs.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_warm_overall_budget_exhausted(real_pool_harness_factory, monkeypatch):
+    """Overall budget stops processing remaining phones."""
+    import asyncio
+    import time
+
+    monkeypatch.setattr("src.telegram.client_pool.WARM_SINGLE_PHONE_TIMEOUT_SEC", 2.0)
+    monkeypatch.setattr("src.telegram.client_pool.WARM_ALL_PHONES_TOTAL_SEC", 3.0)
+    monkeypatch.setattr("src.telegram.client_pool.WARM_STAGGER_DELAY_SEC", 0.0)
+
+    harness = real_pool_harness_factory()
+
+    async def _slow_dialogs():
+        await asyncio.sleep(2.0)
+        return []
+
+    clients = {}
+    for i in range(1, 5):
+        c = FakeCliTelethonClient(dialogs=[])
+        c.get_dialogs = AsyncMock(side_effect=_slow_dialogs)
+        clients[f"+7000000000{i}"] = c
+
+    await _setup_warm_harness(harness, clients)
+
+    t0 = time.monotonic()
+    await harness.pool.warm_all_dialogs()
+    elapsed = time.monotonic() - t0
+
+    # Budget 3s: first phone takes 2s, second starts but budget runs out
+    assert elapsed < 8.0, f"warm took {elapsed:.1f}s, budget should cap it"
+    # Not all 4 phones should have been called
+    called_count = sum(1 for c in clients.values() if c.get_dialogs.await_count > 0)
+    assert called_count < 4, f"all {called_count} phones called, budget should have stopped early"
+
+
+@pytest.mark.anyio
+async def test_warm_stagger_between_phones(real_pool_harness_factory, monkeypatch):
+    """Phones are staggered with a small delay between them."""
+    import time
+
+    stagger = 0.3
+    monkeypatch.setattr("src.telegram.client_pool.WARM_STAGGER_DELAY_SEC", stagger)
+    monkeypatch.setattr("src.telegram.client_pool.WARM_SINGLE_PHONE_TIMEOUT_SEC", 5.0)
+
+    harness = real_pool_harness_factory()
+
+    timestamps: list[float] = []
+
+    async def _record_and_return():
+        timestamps.append(time.monotonic())
+        return []
+
+    clients = {}
+    for i in range(1, 4):
+        c = FakeCliTelethonClient(dialogs=[])
+        c.get_dialogs = AsyncMock(side_effect=_record_and_return)
+        clients[f"+7000000000{i}"] = c
+
+    await _setup_warm_harness(harness, clients)
+    await harness.pool.warm_all_dialogs()
+
+    # 3 phones → 2 gaps between them
+    assert len(timestamps) == 3, f"expected 3 timestamps, got {len(timestamps)}"
+    gap1 = timestamps[1] - timestamps[0]
+    gap2 = timestamps[2] - timestamps[1]
+    # Each gap should be at least the stagger delay (0.3s)
+    assert gap1 >= stagger - 0.05, f"gap1={gap1:.2f}s, expected >= {stagger}s"
+    assert gap2 >= stagger - 0.05, f"gap2={gap2:.2f}s, expected >= {stagger}s"
+    # But no stagger before the first phone — total ~ 2*stagger, not 3
+    total_elapsed = timestamps[-1] - timestamps[0]
+    assert total_elapsed < 3 * stagger, f"total={total_elapsed:.2f}s, should be ~2*stagger"


### PR DESCRIPTION
## Problem

`warm_all_dialogs` при старте использует `run_with_flood_wait_retry` для каждого аккаунта. Когда Telegram возвращает FloodWait (~24s), retry-loop спит 25s и повторяет до 5 раз (бюджет 120s). С учётом `asyncio.wait_for(get_dialogs(), timeout=60)` на каждую попытку, один аккаунт может держать warm **12+ минут**.

Это провоцирует IP-бан → cascade reconnect всех 4 клиентов одновременно (`Network is unreachable`).

## Fix

- Заменить `run_with_flood_wait_retry` → `run_with_flood_wait` (single-shot, без retry)
- Per-phone timeout: 30s (`WARM_SINGLE_PHONE_TIMEOUT_SEC`)
- Overall budget: 150s (`WARM_ALL_PHONES_TOTAL_SEC`)
- Stagger: 1s пауза между телефонами (`WARM_STAGGER_DELAY_SEC`)

## Tests (TDD)

4 новых теста в `tests/test_client_pool.py`:
- `test_warm_flood_wait_fail_fast` — FloodWait не вызывает sleep/retry
- `test_warm_single_phone_timeout` — висящий get_dialogs таймаутится, следующий телефон обрабатывается
- `test_warm_overall_budget_exhausted` — бюджет останавливает обработку оставшихся телефонов
- `test_warm_stagger_between_phones` — пауза между телефонами

## Effect

| | Before | After |
|---|---|---|
| FloodWait per phone | 5 retry × 25s sleep = 125s+ | 0s, skip |
| Single phone max | 60s × 5 retry = 300s+ | 30s |
| All phones max | unlimited | 150s budget |
| Stagger | none | 1s between phones |

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)