### PR TITLE
perf(filters): run 5 analysis map queries in parallel via asyncio.gather

### DIFF
--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -9,12 +11,94 @@ import aiosqlite
 # depend on the filters package to keep DB initialisation self-contained.
 _CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
 
+logger = logging.getLogger(__name__)
+
 
 def _has_cyrillic_udf(text: str | None) -> int:
     if not text:
         return 0
     return 1 if _CYRILLIC_RE.search(text) else 0
 
+
+# ── SQL templates ─────────────────────────────────────────────────────────
+# Used by both the sequential fetch_* methods and the parallel
+# _fetch_*_conn helpers below.
+
+_SQL_CHANNELS = """
+    SELECT
+        c.channel_id,
+        c.title,
+        c.username,
+        c.channel_type,
+        COALESCE(cnt.total, 0) AS message_count
+    FROM channels c
+    LEFT JOIN (
+        SELECT channel_id, COUNT(*) AS total
+        FROM messages
+        GROUP BY channel_id
+    ) cnt ON c.channel_id = cnt.channel_id
+"""
+
+_SQL_UNIQUENESS = """
+    SELECT
+        channel_id,
+        COUNT(*) AS total,
+        COUNT(DISTINCT substr(text, 1,100)) AS uniq
+    FROM messages
+    WHERE text IS NOT NULL AND text != ''
+"""
+
+_SQL_SUBSCRIBER_BASE = """
+    SELECT channel_id, subscriber_count
+    FROM (
+        SELECT
+            channel_id,
+            subscriber_count,
+            ROW_NUMBER() OVER (
+                PARTITION BY channel_id
+                ORDER BY collected_at DESC, id DESC
+            ) AS rn
+        FROM channel_stats
+        WHERE subscriber_count IS NOT NULL
+"""
+
+_SQL_SHORT_MESSAGE = """
+    SELECT
+        channel_id,
+        COUNT(*) AS total,
+        SUM(CASE WHEN text IS NOT NULL AND length(text) <= 10
+            THEN 1 ELSE 0 END) AS short
+    FROM messages
+"""
+
+_SQL_CROSS_DUPE = """
+    WITH channel_prefixes AS (
+        SELECT channel_id, substr(text, 1, 100) AS prefix
+        FROM messages
+        WHERE text IS NOT NULL AND length(text) > 10
+        GROUP BY channel_id, prefix
+    ),
+    prefix_channel_counts AS (
+        SELECT prefix, COUNT(*) AS channel_count
+        FROM channel_prefixes
+        GROUP BY prefix
+    )
+    SELECT
+        cp.channel_id,
+        COUNT(*) AS uniq_total,
+        SUM(CASE WHEN pcc.channel_count > 1 THEN 1 ELSE 0 END) AS duped
+    FROM channel_prefixes cp
+    JOIN prefix_channel_counts pcc ON pcc.prefix = cp.prefix
+"""
+
+_SQL_CYRILLIC = """
+    SELECT
+        channel_id,
+        COUNT(*) AS total,
+        SUM(has_cyrillic(text)) AS cyr
+    FROM messages
+    WHERE text IS NOT NULL AND text != ''
+"""
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -36,23 +120,12 @@ class FilterRepository:
             await self._db.create_function("has_cyrillic", 1, _has_cyrillic_udf, deterministic=True)
             self._udf_registered = True
 
+    # ── Sequential fetch methods (original, used for single-channel) ──────
+
     async def fetch_channels_for_analysis(
         self, channel_id: int | None = None
     ) -> list[aiosqlite.Row]:
-        sql = """
-            SELECT
-                c.channel_id,
-                c.title,
-                c.username,
-                c.channel_type,
-                COALESCE(cnt.total, 0) AS message_count
-            FROM channels c
-            LEFT JOIN (
-                SELECT channel_id, COUNT(*) AS total
-                FROM messages
-                GROUP BY channel_id
-            ) cnt ON c.channel_id = cnt.channel_id
-        """
+        sql = _SQL_CHANNELS
         params: tuple = ()
         if channel_id is not None:
             sql += " WHERE c.channel_id = ?"
@@ -64,14 +137,7 @@ class FilterRepository:
     async def fetch_uniqueness_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
-        sql = """
-            SELECT
-                channel_id,
-                COUNT(*) AS total,
-                COUNT(DISTINCT substr(text, 1, 100)) AS uniq
-            FROM messages
-            WHERE text IS NOT NULL AND text != ''
-        """
+        sql = _SQL_UNIQUENESS
         params: tuple = ()
         if channel_id is not None:
             sql += " AND channel_id = ?"
@@ -82,19 +148,7 @@ class FilterRepository:
         return {row["channel_id"]: (row["total"], row["uniq"]) for row in rows}
 
     async def fetch_subscriber_map(self, channel_id: int | None = None) -> dict[int, int]:
-        sql = """
-            SELECT channel_id, subscriber_count
-            FROM (
-                SELECT
-                    channel_id,
-                    subscriber_count,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY channel_id
-                        ORDER BY collected_at DESC, id DESC
-                    ) AS rn
-                FROM channel_stats
-                WHERE subscriber_count IS NOT NULL
-        """
+        sql = _SQL_SUBSCRIBER_BASE
         params: tuple = ()
         if channel_id is not None:
             sql += " AND channel_id = ?"
@@ -110,14 +164,7 @@ class FilterRepository:
     async def fetch_short_message_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
-        sql = """
-            SELECT
-                channel_id,
-                COUNT(*) AS total,
-                SUM(CASE WHEN text IS NOT NULL AND length(text) <= 10
-                    THEN 1 ELSE 0 END) AS short
-            FROM messages
-        """
+        sql = _SQL_SHORT_MESSAGE
         params: tuple = ()
         if channel_id is not None:
             sql += " WHERE channel_id = ?"
@@ -148,25 +195,7 @@ class FilterRepository:
     async def fetch_cross_dupe_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
-        sql = """
-            WITH channel_prefixes AS (
-                SELECT channel_id, substr(text, 1, 100) AS prefix
-                FROM messages
-                WHERE text IS NOT NULL AND length(text) > 10
-                GROUP BY channel_id, prefix
-            ),
-            prefix_channel_counts AS (
-                SELECT prefix, COUNT(*) AS channel_count
-                FROM channel_prefixes
-                GROUP BY prefix
-            )
-            SELECT
-                cp.channel_id,
-                COUNT(*) AS uniq_total,
-                SUM(CASE WHEN pcc.channel_count > 1 THEN 1 ELSE 0 END) AS duped
-            FROM channel_prefixes cp
-            JOIN prefix_channel_counts pcc ON pcc.prefix = cp.prefix
-        """
+        sql = _SQL_CROSS_DUPE
         params: tuple = ()
         if channel_id is not None:
             sql += " WHERE cp.channel_id = ?"
@@ -178,14 +207,7 @@ class FilterRepository:
 
     async def fetch_cyrillic_map(self, channel_id: int | None = None) -> dict[int, tuple[int, int]]:
         await self._ensure_udf()
-        sql = """
-            SELECT
-                channel_id,
-                COUNT(*) AS total,
-                SUM(has_cyrillic(text)) AS cyr
-            FROM messages
-            WHERE text IS NOT NULL AND text != ''
-        """
+        sql = _SQL_CYRILLIC
         params: tuple = ()
         if channel_id is not None:
             sql += " AND channel_id = ?"
@@ -194,3 +216,96 @@ class FilterRepository:
         cur = await self._db.execute(sql, params)
         rows = await cur.fetchall()
         return {row["channel_id"]: (row["total"], row["cyr"] or 0) for row in rows}
+
+    # ── Parallel fetch: separate read-only connections ─────────────────────
+
+    def _can_parallel(self) -> bool:
+        """True if we have a file-based DB (not :memory:) and a Database reference."""
+        if self._database is None:
+            return False
+        db_path = getattr(self._database, "_db_path", None)
+        return db_path is not None and db_path != ":memory:"
+
+    async def _open_readonly_conn(self) -> aiosqlite.Connection:
+        """Open a temporary read-only connection for parallel queries."""
+        db_path = self._database._db_path  # noqa: SLF001
+        conn = await aiosqlite.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            timeout=10.0,
+        )
+        conn.row_factory = aiosqlite.Row
+        await conn.create_function("has_cyrillic", 1, _has_cyrillic_udf, deterministic=True)
+        return conn
+
+    @staticmethod
+    async def _run_on_conn(
+        conn: aiosqlite.Connection,
+        sql: str,
+        params: tuple = (),
+    ) -> list[aiosqlite.Row]:
+        cur = await conn.execute(sql, params)
+        return await cur.fetchall()
+
+    async def fetch_maps_parallel(
+        self, channel_id: int | None = None
+    ) -> tuple[
+        dict[int, tuple[int, int]],  # uniqueness_map
+        dict[int, int],               # subscriber_map
+        dict[int, tuple[int, int]],  # short_map
+        dict[int, tuple[int, int]],  # cross_dupe_map
+        dict[int, tuple[int, int]],  # cyrillic_map
+    ]:
+        """Run all 5 map queries in parallel on separate read-only connections."""
+        # Build parameterised SQL for each query
+        u_sql = _SQL_UNIQUENESS + (" AND channel_id = ?" if channel_id is not None else "") + " GROUP BY channel_id"
+        u_params: tuple = (channel_id,) if channel_id is not None else ()
+
+        s_sql = (
+            _SQL_SUBSCRIBER_BASE
+            + (" AND channel_id = ?" if channel_id is not None else "")
+            + "\n)\nWHERE rn = 1"
+        )
+        s_params: tuple = (channel_id,) if channel_id is not None else ()
+
+        sm_sql = (
+            _SQL_SHORT_MESSAGE
+            + (" WHERE channel_id = ?" if channel_id is not None else "")
+            + " GROUP BY channel_id"
+        )
+        sm_params: tuple = (channel_id,) if channel_id is not None else ()
+
+        cd_sql = (
+            _SQL_CROSS_DUPE
+            + (" WHERE cp.channel_id = ?" if channel_id is not None else "")
+            + " GROUP BY cp.channel_id"
+        )
+        cd_params: tuple = (channel_id,) if channel_id is not None else ()
+
+        cy_sql = (
+            _SQL_CYRILLIC
+            + (" AND channel_id = ?" if channel_id is not None else "")
+            + " GROUP BY channel_id"
+        )
+        cy_params: tuple = (channel_id,) if channel_id is not None else ()
+
+        conns = [await self._open_readonly_conn() for _ in range(5)]
+        try:
+            rows_u, rows_s, rows_sm, rows_cd, rows_cy = await asyncio.gather(
+                self._run_on_conn(conns[0], u_sql, u_params),
+                self._run_on_conn(conns[1], s_sql, s_params),
+                self._run_on_conn(conns[2], sm_sql, sm_params),
+                self._run_on_conn(conns[3], cd_sql, cd_params),
+                self._run_on_conn(conns[4], cy_sql, cy_params),
+            )
+        finally:
+            for conn in conns:
+                await conn.close()
+
+        return (
+            {r["channel_id"]: (r["total"], r["uniq"]) for r in rows_u},
+            {r["channel_id"]: r["subscriber_count"] for r in rows_s},
+            {r["channel_id"]: (r["total"], r["short"] or 0) for r in rows_sm},
+            {r["channel_id"]: (r["uniq_total"], r["duped"] or 0) for r in rows_cd},
+            {r["channel_id"]: (r["total"], r["cyr"] or 0) for r in rows_cy},
+        )

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -50,11 +50,23 @@ class ChannelAnalyzer:
         if not channels:
             return FilterReport()
 
-        uniqueness_map = await _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id))
-        subscriber_map = await _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id))
-        short_map = await _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id))
-        cross_dupe_map = await _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id))
-        cyrillic_map = await _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id))
+        if self._repo._can_parallel():
+            logger.info("filter/analyze: all maps — started (parallel)")
+            t_map = time.monotonic()
+            uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = (
+                await self._repo.fetch_maps_parallel(channel_id)
+            )
+            logger.info(
+                "filter/analyze: all maps in %.1fs (parallel) — %d channels",
+                time.monotonic() - t_map,
+                len(uniqueness_map),
+            )
+        else:
+            uniqueness_map = await _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id))
+            subscriber_map = await _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id))
+            short_map = await _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id))
+            cross_dupe_map = await _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id))
+            cyrillic_map = await _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id))
 
         min_subs = await self._load_min_subscribers_filter()
 

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 
@@ -51,15 +50,11 @@ class ChannelAnalyzer:
         if not channels:
             return FilterReport()
 
-        t_map = time.monotonic()
-        uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = await asyncio.gather(
-            _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id)),
-            _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id)),
-            _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id)),
-            _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id)),
-            _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id)),
-        )
-        logger.info("filter/analyze: all maps in %.1fs", time.monotonic() - t_map)
+        uniqueness_map = await _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id))
+        subscriber_map = await _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id))
+        short_map = await _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id))
+        cross_dupe_map = await _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id))
+        cyrillic_map = await _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id))
 
         min_subs = await self._load_min_subscribers_filter()
 

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -17,6 +18,14 @@ from src.filters.models import ChannelFilterResult, FilterReport
 from src.settings_utils import parse_int_setting
 
 logger = logging.getLogger(__name__)
+
+
+async def _timed_fetch(label: str, coro):
+    """Await coro, log elapsed time and row count, return result."""
+    t = time.monotonic()
+    result = await coro
+    logger.info("filter/analyze: %s (%d) in %.1fs", label, len(result), time.monotonic() - t)
+    return result
 
 
 class ChannelAnalyzer:
@@ -41,25 +50,15 @@ class ChannelAnalyzer:
         if not channels:
             return FilterReport()
 
-        t1 = time.monotonic()
-        uniqueness_map = await self._repo.fetch_uniqueness_map(channel_id)
-        logger.info("filter/analyze: uniqueness map (%d) in %.1fs", len(uniqueness_map), time.monotonic() - t1)
-
-        t1 = time.monotonic()
-        subscriber_map = await self._repo.fetch_subscriber_map(channel_id)
-        logger.info("filter/analyze: subscriber map (%d) in %.1fs", len(subscriber_map), time.monotonic() - t1)
-
-        t1 = time.monotonic()
-        short_map = await self._repo.fetch_short_message_map(channel_id)
-        logger.info("filter/analyze: short-message map (%d) in %.1fs", len(short_map), time.monotonic() - t1)
-
-        t1 = time.monotonic()
-        cross_dupe_map = await self._repo.fetch_cross_dupe_map(channel_id)
-        logger.info("filter/analyze: cross-dupe map (%d) in %.1fs", len(cross_dupe_map), time.monotonic() - t1)
-
-        t1 = time.monotonic()
-        cyrillic_map = await self._repo.fetch_cyrillic_map(channel_id)
-        logger.info("filter/analyze: cyrillic map (%d) in %.1fs", len(cyrillic_map), time.monotonic() - t1)
+        t_map = time.monotonic()
+        uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = await asyncio.gather(
+            _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id)),
+            _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id)),
+            _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id)),
+            _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id)),
+            _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id)),
+        )
+        logger.info("filter/analyze: all maps in %.1fs", time.monotonic() - t_map)
 
         min_subs = await self._load_min_subscribers_filter()
 

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 async def _timed_fetch(label: str, coro):
     """Await coro, log elapsed time and row count, return result."""
+    logger.info("filter/analyze: %s — started", label)
     t = time.monotonic()
     result = await coro
     logger.info("filter/analyze: %s (%d) in %.1fs", label, len(result), time.monotonic() - t)


### PR DESCRIPTION
## Problem

Кнопка «Обновить» выполняет 5 независимых SQL-запросов к `messages` (7M+ строк) последовательно — **543 секунды** (9 минут).

Данные из логов (после добавления per-query logging в #800):
```
uniqueness map (1146)    128.2s
subscriber map (1053)      0.0s
short-message map (1148) 122.1s
cross-dupe map (1146)    153.8s
cyrillic map (1146)      139.2s
```

## Fix

Все 5 запросов независимы — запускаем через `asyncio.gather()`. aiosqlite с WAL mode поддерживает параллельные reads.

Также рефакторинг per-query timing в `_timed_fetch` helper + summary «all maps» лог.

## Expected effect

Wall-clock = max(128, 0, 122, 154, 139) ≈ **154s** вместо 543s. Ускорение **3.5x**.

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)