### PR TITLE
feat(search): опция «Все» — поиск по всем каналам включая отфильтрованные

### DIFF
--- a/src/cli/commands/search.py
+++ b/src/cli/commands/search.py
@@ -45,6 +45,7 @@ def run(args: argparse.Namespace) -> None:
                 return
 
             engine = SearchEngine(db, pool, config=config)
+            include_filtered = getattr(args, "all", False)
 
             if args.mode == "telegram":
                 result = await engine.search_telegram(args.query, limit=args.limit)
@@ -60,6 +61,7 @@ def run(args: argparse.Namespace) -> None:
                     limit=args.limit,
                     min_length=args.min_length,
                     max_length=args.max_length,
+                    include_filtered=include_filtered,
                 )
             elif args.mode == "hybrid":
                 result = await engine.search_hybrid(
@@ -68,6 +70,7 @@ def run(args: argparse.Namespace) -> None:
                     min_length=args.min_length,
                     max_length=args.max_length,
                     is_fts=args.fts,
+                    include_filtered=include_filtered,
                 )
             else:
                 result = await engine.search_local(
@@ -76,6 +79,7 @@ def run(args: argparse.Namespace) -> None:
                     min_length=args.min_length,
                     max_length=args.max_length,
                     is_fts=args.fts,
+                    include_filtered=include_filtered,
                 )
 
             print(f"Found {result.total} results for '{result.query}':\n")

--- a/src/cli/parser_domains/search.py
+++ b/src/cli/parser_domains/search.py
@@ -25,6 +25,10 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         "--fts", action="store_true", default=False, help="Use FTS5 boolean syntax"
     )
     search_parser.add_argument(
+        "--all", action="store_true", default=False,
+        help="Search all channels including filtered ones",
+    )
+    search_parser.add_argument(
         "--index-now",
         action="store_true",
         default=False,

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -445,6 +445,7 @@ class CollectionBundle:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         return await self.messages.search_messages(
             query=query,
@@ -456,6 +457,7 @@ class CollectionBundle:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:
@@ -691,6 +693,7 @@ class SearchBundle:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         return await self.messages.search_messages(
             query=query,
@@ -702,6 +705,7 @@ class SearchBundle:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def add_channel(self, channel: Channel) -> int:

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -627,6 +627,7 @@ class Database:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         self._require()
         return await self._messages.search_messages(
@@ -640,6 +641,7 @@ class Database:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def search_semantic_messages(
@@ -654,6 +656,7 @@ class Database:
         min_length: int | None = None,
         max_length: int | None = None,
         candidate_limit: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         self._require()
         return await self._messages.search_semantic_messages(
@@ -666,6 +669,7 @@ class Database:
             min_length=min_length,
             max_length=max_length,
             candidate_limit=candidate_limit,
+            include_filtered=include_filtered,
         )
 
     async def search_hybrid_messages(
@@ -682,6 +686,7 @@ class Database:
         min_length: int | None = None,
         max_length: int | None = None,
         candidate_limit: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         self._require()
         return await self._messages.search_hybrid_messages(
@@ -696,6 +701,7 @@ class Database:
             min_length=min_length,
             max_length=max_length,
             candidate_limit=candidate_limit,
+            include_filtered=include_filtered,
         )
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -454,8 +454,11 @@ class MessagesRepository:
         min_length: int | None = None,
         max_length: int | None = None,
         topic_id: int | None = None,
-    ) -> tuple[list[str], list]:
-        conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
+        include_filtered: bool = False,
+    ) -> tuple[str, list]:
+        conditions: list[str] = []
+        if not include_filtered:
+            conditions.append("(c.is_filtered IS NULL OR c.is_filtered = 0)")
         params: list = []
         if channel_id:
             conditions.append("m.channel_id = ?")
@@ -479,7 +482,8 @@ class MessagesRepository:
         if max_length is not None:
             conditions.append("LENGTH(m.text) < ?")
             params.append(max_length)
-        return conditions, params
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        return where, params
 
     async def _load_messages_by_ids(self, message_ids: list[int]) -> list[Message]:
         if not message_ids:
@@ -514,18 +518,19 @@ class MessagesRepository:
         max_length: int | None = None,
         topic_id: int | None = None,
         limit: int = 100,
+        include_filtered: bool = False,
     ) -> list[int]:
-        conditions, params = self._build_message_filters(
+        where, params = self._build_message_filters(
             channel_id=channel_id,
             date_from=date_from,
             date_to=date_to,
             min_length=min_length,
             max_length=max_length,
             topic_id=topic_id,
+            include_filtered=include_filtered,
         )
 
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
-        where = " WHERE " + " AND ".join(conditions)
         if self._fts_available:
             fts_query = self._build_fts_match(query, is_fts)
             fts_join = (
@@ -544,14 +549,13 @@ class MessagesRepository:
             )
         else:
             logger.debug("FTS5 unavailable, falling back to LIKE search")
-            conditions.append("m.text LIKE ?")
             params.append(f"%{query}%")
-            where = " WHERE " + " AND ".join(conditions)
+            like_where = (where + " AND m.text LIKE ?") if where else " WHERE m.text LIKE ?"
             cur = await self._db.execute(
                 f"""
                 SELECT m.id
                 FROM messages m{channel_join}
-                {where}
+                {like_where}
                 ORDER BY m.date DESC
                 LIMIT ?
                 """,
@@ -572,17 +576,18 @@ class MessagesRepository:
         min_length: int | None = None,
         max_length: int | None = None,
         topic_id: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
-        conditions, params = self._build_message_filters(
+        where, params = self._build_message_filters(
             channel_id=channel_id,
             date_from=date_from,
             date_to=date_to,
             min_length=min_length,
             max_length=max_length,
             topic_id=topic_id,
+            include_filtered=include_filtered,
         )
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
-        where = " WHERE " + " AND ".join(conditions)
 
         if query:
             if self._fts_available:
@@ -608,12 +613,11 @@ class MessagesRepository:
                 )
             else:
                 logger.debug("FTS5 unavailable, falling back to LIKE search")
-                conditions.append("m.text LIKE ?")
                 params.append(f"%{query}%")
-                where = " WHERE " + " AND ".join(conditions)
+                like_where = (where + " AND m.text LIKE ?") if where else " WHERE m.text LIKE ?"
 
                 count_cur = await self._db.execute(
-                    f"SELECT COUNT(*) as cnt FROM messages m{channel_join}{where}",
+                    f"SELECT COUNT(*) as cnt FROM messages m{channel_join}{like_where}",
                     tuple(params),
                 )
                 row = await count_cur.fetchone()
@@ -622,7 +626,7 @@ class MessagesRepository:
                 cur = await self._db.execute(
                     f"""SELECT m.*, c.title as channel_title, c.username as channel_username
                         FROM messages m{channel_join}
-                        {where}
+                        {like_where}
                         ORDER BY m.date DESC
                         LIMIT ? OFFSET ?""",
                     (*params, limit, offset),
@@ -658,6 +662,7 @@ class MessagesRepository:
         topic_id: int | None = None,
         limit: int = 100,
         max_candidates: int = 50_000,
+        include_filtered: bool = False,
     ) -> list[tuple[int, float]]:
         dimensions = await self.get_embedding_dimensions()
         if dimensions is None:
@@ -667,22 +672,23 @@ class MessagesRepository:
                 "Query embedding dimensions "
                 f"{len(query_embedding)} do not match index {dimensions}."
             )
-        conditions, params = self._build_message_filters(
+        where, params = self._build_message_filters(
             channel_id=channel_id,
             date_from=date_from,
             date_to=date_to,
             min_length=min_length,
             max_length=max_length,
             topic_id=topic_id,
+            include_filtered=include_filtered,
         )
-        where = " AND ".join(conditions)
+        where_clause = where.replace(" WHERE ", "WHERE ", 1) if where else ""
         cur = await self._db.execute(
             f"""
             SELECT e.message_id, e.embedding
             FROM message_embeddings e
             JOIN messages m ON m.id = e.message_id
             LEFT JOIN channels c ON m.channel_id = c.channel_id
-            WHERE {where}
+            {where_clause}
             LIMIT ?
             """,
             (*params, max_candidates),
@@ -724,6 +730,7 @@ class MessagesRepository:
         max_length: int | None = None,
         topic_id: int | None = None,
         candidate_limit: int | None = None,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         fetch_limit = candidate_limit or max(offset + limit, 50)
         candidates = await self._search_semantic_candidates(
@@ -735,6 +742,7 @@ class MessagesRepository:
             max_length=max_length,
             topic_id=topic_id,
             limit=fetch_limit,
+            include_filtered=include_filtered,
         )
         page_ids = [message_id for message_id, _distance in candidates[offset : offset + limit]]
         messages = await self._load_messages_by_ids(page_ids)
@@ -756,6 +764,7 @@ class MessagesRepository:
         topic_id: int | None = None,
         candidate_limit: int | None = None,
         rrf_k: int = 60,
+        include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         fetch_limit = candidate_limit or max(offset + limit, 50)
         text_ids = await self._search_text_candidate_ids(
@@ -768,6 +777,7 @@ class MessagesRepository:
             max_length=max_length,
             topic_id=topic_id,
             limit=fetch_limit,
+            include_filtered=include_filtered,
         )
         semantic_candidates = await self._search_semantic_candidates(
             query_embedding,
@@ -778,6 +788,7 @@ class MessagesRepository:
             max_length=max_length,
             topic_id=topic_id,
             limit=fetch_limit,
+            include_filtered=include_filtered,
         )
         if not text_ids and not semantic_candidates:
             return [], 0

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -58,6 +58,7 @@ class SearchEngine:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         return await self._local.search(
             query=query,
@@ -69,6 +70,7 @@ class SearchEngine:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def check_search_quota(self, query: str = "") -> dict | None:
@@ -84,6 +86,7 @@ class SearchEngine:
         offset: int = 0,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         if not self.semantic_available:
             return SearchResult(messages=[], total=0, query=query, error=_SEMANTIC_UNAVAILABLE)
@@ -96,6 +99,7 @@ class SearchEngine:
             offset=offset,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def search_hybrid(
@@ -109,6 +113,7 @@ class SearchEngine:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         if not self.semantic_available:
             return SearchResult(messages=[], total=0, query=query, error=_SEMANTIC_UNAVAILABLE)
@@ -122,6 +127,7 @@ class SearchEngine:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def search_telegram(self, query: str, limit: int = 50) -> SearchResult:

--- a/src/search/local_search.py
+++ b/src/search/local_search.py
@@ -31,6 +31,7 @@ class LocalSearch:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         messages, total = await self._search.search_messages(
             query=query,
@@ -42,6 +43,7 @@ class LocalSearch:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
         return SearchResult(messages=messages, total=total, query=query)
 
@@ -66,6 +68,7 @@ class LocalSearch:
         offset: int = 0,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         if self._embedding_service is None:
             raise RuntimeError("Semantic search is unavailable.")
@@ -81,6 +84,7 @@ class LocalSearch:
                 offset=offset,
                 min_length=min_length,
                 max_length=max_length,
+                include_filtered=include_filtered,
             )
             return SearchResult(messages=messages, total=total, query=query)
 
@@ -94,11 +98,12 @@ class LocalSearch:
             return SearchResult(messages=[], total=0, query=query)
         # Build set of filtered channel IDs to exclude (matches vec SQL behavior)
         filtered_channels: set[int] = set()
-        cur = await self._search.messages._db.execute(
-            "SELECT channel_id FROM channels WHERE is_filtered = 1"
-        )
-        for row in await cur.fetchall():
-            filtered_channels.add(int(row["channel_id"]))
+        if not include_filtered:
+            cur = await self._search.messages._db.execute(
+                "SELECT channel_id FROM channels WHERE is_filtered = 1"
+            )
+            for row in await cur.fetchall():
+                filtered_channels.add(int(row["channel_id"]))
         # Over-fetch to allow for post-filtering
         fetch_k = min(index.size, max((limit + offset) * 4, 200))
         top_ids = [mid for mid, _score in index.search(query_embedding, k=fetch_k)]
@@ -142,6 +147,7 @@ class LocalSearch:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         if self._embedding_service is None:
             raise RuntimeError("Hybrid search is unavailable.")
@@ -157,5 +163,6 @@ class LocalSearch:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
         return SearchResult(messages=messages, total=total, query=query)

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -22,6 +22,7 @@ class SearchService:
         is_fts: bool = False,
         min_length: int | None = None,
         max_length: int | None = None,
+        include_filtered: bool = False,
     ) -> SearchResult:
         if mode == "ai" and self._ai_search:
             return await self._ai_search.search(query)
@@ -41,6 +42,7 @@ class SearchService:
                 offset=offset,
                 min_length=min_length,
                 max_length=max_length,
+                include_filtered=include_filtered,
             )
         if mode == "hybrid":
             return await self._engine.search_hybrid(
@@ -53,6 +55,7 @@ class SearchService:
                 is_fts=is_fts,
                 min_length=min_length,
                 max_length=max_length,
+                include_filtered=include_filtered,
             )
         return await self._engine.search_local(
             query=query,
@@ -64,6 +67,7 @@ class SearchService:
             is_fts=is_fts,
             min_length=min_length,
             max_length=max_length,
+            include_filtered=include_filtered,
         )
 
     async def check_quota(self, query: str = "") -> dict | None:

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -56,6 +56,7 @@ async def search_page(
     date_to: str = Query(""),
     mode: str = Query("local"),
     is_fts: bool = Query(False),
+    include_filtered: bool = Query(False),
     page: int = Query(1),
 ):
     return search_response(
@@ -68,6 +69,7 @@ async def search_page(
             date_to=date_to,
             mode=mode,
             is_fts=is_fts,
+            include_filtered=include_filtered,
             page=page,
         ),
     )

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -172,6 +172,7 @@ async def render_search_page(
     date_to: str = "",
     mode: str = "local",
     is_fts: bool = False,
+    include_filtered: bool = False,
     page: int = 1,
 ) -> SearchTemplate | SearchRedirect:
     # Onboarding: redirect if no accounts configured
@@ -207,6 +208,7 @@ async def render_search_page(
                 date_to=None,
                 offset=offset,
                 is_fts=False,
+                include_filtered=include_filtered,
             )
         except Exception as exc:
             logger.exception("Browse mode failed: channel_id=%s", channel_id_int)
@@ -245,6 +247,7 @@ async def render_search_page(
                     is_fts=is_fts,
                     min_length=min_length,
                     max_length=max_length,
+                    include_filtered=include_filtered,
                 )
             except Exception as exc:
                 logger.exception(
@@ -289,6 +292,7 @@ async def render_search_page(
             "date_to": date_to,
             "mode": mode,
             "is_fts": is_fts,
+            "include_filtered": include_filtered,
             "page": page,
             "total_pages": total_pages,
             "semantic_available": semantic_available,

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -74,6 +74,10 @@
             <input class="form-check-input" type="checkbox" name="is_fts" value="1" id="fts-checkbox" {{ 'checked' if is_fts else '' }}>
             <label class="form-check-label" for="fts-checkbox">FTS5 <span class="hint" data-tooltip="Полнотекстовый поиск с поддержкой операторов: OR, AND, NOT, префикс*, «точная фраза», len&lt;400, len&gt;100">?</span></label>
         </div>
+        <div class="col-12 col-sm-6 col-lg-auto form-check" id="all-posts-label" title="Искать по всем каналам, включая отфильтрованные">
+            <input class="form-check-input" type="checkbox" name="include_filtered" value="1" id="all-posts-checkbox" {{ 'checked' if include_filtered else '' }}>
+            <label class="form-check-label" for="all-posts-checkbox">Все <span class="hint" data-tooltip="Включить в результаты сообщения из отфильтрованных каналов">?</span></label>
+        </div>
         <div class="col-12 col-sm-auto ms-sm-auto">
             <button type="submit" class="btn btn-primary w-100">Найти</button>
         </div>
@@ -185,11 +189,11 @@
 <nav>
     <ul class="pagination justify-content-center">
         {% if page > 1 %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&page={{ page - 1 }}">Назад</a></li>
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page - 1 }}">Назад</a></li>
         {% endif %}
         <li class="page-item disabled"><span class="page-link">Страница {{ page }} из {{ total_pages }}</span></li>
         {% if page < total_pages %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&page={{ page + 1 }}">Далее</a></li>
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page + 1 }}">Далее</a></li>
         {% endif %}
     </ul>
 </nav>
@@ -209,6 +213,8 @@
     var dateTo = document.getElementById('date-to');
     var ftsLabel = document.getElementById('fts-label');
     var ftsCheckbox = document.getElementById('fts-checkbox');
+    var allPostsLabel = document.getElementById('all-posts-label');
+    var allPostsCheckbox = document.getElementById('all-posts-checkbox');
 
     function updateState() {
         var mode = document.querySelector('input[name="mode"]:checked').value;
@@ -219,6 +225,8 @@
         dateTo.disabled = !usesLocalDb;
         ftsLabel.style.display = supportsFtsToggle ? '' : 'none';
         ftsCheckbox.disabled = !supportsFtsToggle;
+        allPostsLabel.style.display = usesLocalDb ? '' : 'none';
+        allPostsCheckbox.disabled = !usesLocalDb;
     }
 
     radios.forEach(function(r) {


### PR DESCRIPTION
Closes #803

## Что добавлено

Параметр `include_filtered` через весь стек поиска. Когда включён, условие `is_filtered` убирается из SQL — результаты включают сообщения из отфильтрованных каналов.

### Web
- Чекбокс «Все» рядом с FTS5 на странице `/search`
- Виден только для режимов local/semantic/hybrid
- Сохраняется в pagination-ссылках

### CLI
- Флаг `--all`: `python -m src.main search "запрос" --all`

### Изменённые файлы (11)
| Слой | Файл |
|------|------|
| SQL-ядро | `src/database/repositories/messages.py` |
| Фасад | `src/database/facade.py` |
| Бандлы | `src/database/bundles.py` |
| Поиск | `src/search/local_search.py`, `src/search/engine.py` |
| Сервис | `src/services/search_service.py` |
| Web | `routes/search.py`, `handlers.py`, `templates/search.html` |
| CLI | `parser_domains/search.py`, `commands/search.py` |

### Исправлено в рамках /simplify
- **Критический баг**: при `include_filtered=True` без других фильтров формировался пустой `WHERE `` → SQL syntax error. `_build_message_filters()` теперь возвращает готовую `where`-строку с защитой от пустого conditions.

### Тесты
- 6060 parallel + 853 serial — зелёные
- 124 search-specific — зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)