### PR TITLE
fix(telegram): route fetch_channel_meta to the right account (#808)

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -178,6 +178,24 @@ class ClientPool(ResolveGuardMixin):
                 exc_info=True,
             )
 
+    async def forget_channel_phone(self, channel_id: int) -> None:
+        """Drop the channel→phone mapping in memory and clear preferred in DB.
+
+        Used during error recovery when the routed account turned out to be stale
+        (lost access / can no longer resolve), so the next pass rediscovers a
+        working account. Best-effort: a failed DB write only repeats next pass.
+        """
+        self.clear_channel_phone(channel_id)
+        try:
+            await self._db.repos.channels.update_channel_preferred_phone(channel_id, None)
+        except Exception:
+            logger.debug(
+                "forget_channel_phone: failed to clear stale preferred_phone "
+                "for channel %d",
+                channel_id,
+                exc_info=True,
+            )
+
     def is_warming(self) -> bool:
         """True while warm_all_dialogs() is still running."""
         return self._warming_task is not None and not self._warming_task.done()
@@ -1349,18 +1367,7 @@ class ClientPool(ResolveGuardMixin):
             # next pass rediscovers. Leave it alone on the available-client path —
             # we'd be erasing a good record on a guess.
             if used_preferred:
-                self.clear_channel_phone(channel_id)
-                try:
-                    await self._db.repos.channels.update_channel_preferred_phone(
-                        channel_id, None
-                    )
-                except Exception:
-                    logger.debug(
-                        "fetch_channel_meta: failed to clear stale preferred_phone "
-                        "for channel_id %s",
-                        channel_id,
-                        exc_info=True,
-                    )
+                await self.forget_channel_phone(channel_id)
             return None
         except (ValueError, TypeError):
             # Telethon raises ValueError("Could not find the input entity ...")
@@ -1371,6 +1378,11 @@ class ClientPool(ResolveGuardMixin):
                 "(not in any warmed account)",
                 channel_id,
             )
+            # A stored preferred phone that can no longer resolve the entity is
+            # stale (membership change) — clear it so the next pass rediscovers
+            # instead of pinning the same dead account (Codex review on #809).
+            if used_preferred:
+                await self.forget_channel_phone(channel_id)
             return None
         except Exception as e:
             logger.warning(

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -151,21 +151,32 @@ class ClientPool(ResolveGuardMixin):
         self._channel_phone_map.pop(channel_id, None)
 
     async def remember_channel_phone(
-        self, channel_id: int, phone: str, *, known_preferred: str | None = None
+        self,
+        channel_id: int,
+        phone: str,
+        *,
+        known_preferred: str | None = None,
+        force: bool = False,
     ) -> None:
-        """Cache channel→phone in memory and persist to DB only if no preferred set.
+        """Cache channel→phone in memory and persist to DB.
 
-        Avoids overwriting a valid preferred_phone from previous error recovery
-        (same gate as warm_all_dialogs). Pass ``known_preferred`` when the caller
-        already read the DB value to skip a redundant SELECT. Best-effort: a
-        failed DB write only means rediscovery repeats next pass.
+        By default persists only if no preferred is set yet (same gate as
+        warm_all_dialogs), avoiding clobbering a valid value from previous error
+        recovery. Pass ``known_preferred`` when the caller already read the DB
+        value to skip a redundant SELECT. Pass ``force=True`` to overwrite a
+        stale preferred with an account that just confirmably resolved the channel
+        (e.g. a successful fallback when the stored preferred was unavailable).
+        Best-effort: a failed DB write only means rediscovery repeats next pass.
         """
         self.register_channel_phone(channel_id, phone)
-        if known_preferred:
+        if known_preferred and not force:
             return
         try:
-            existing = await self._db.repos.channels.get_preferred_phone(channel_id)
-            if not existing:
+            existing = known_preferred
+            if existing is None:
+                existing = await self._db.repos.channels.get_preferred_phone(channel_id)
+            should_write = existing != phone if force else not existing
+            if should_write:
                 await self._db.repos.channels.update_channel_preferred_phone(
                     channel_id, phone
                 )
@@ -178,15 +189,26 @@ class ClientPool(ResolveGuardMixin):
                 exc_info=True,
             )
 
-    async def forget_channel_phone(self, channel_id: int) -> None:
+    async def forget_channel_phone(
+        self, channel_id: int, *, only_if_phone: str | None = None
+    ) -> None:
         """Drop the channel→phone mapping in memory and clear preferred in DB.
 
         Used during error recovery when the routed account turned out to be stale
         (lost access / can no longer resolve), so the next pass rediscovers a
-        working account. Best-effort: a failed DB write only repeats next pass.
+        working account. The in-memory map (which pointed at the failed account)
+        is always cleared. Pass ``only_if_phone`` to clear the DB preferred_phone
+        only when it still matches the account that just failed — avoids erasing a
+        valid persisted mapping when the in-memory map was stale but the DB row
+        points at a different, working account. Best-effort: a failed DB write
+        only repeats next pass.
         """
         self.clear_channel_phone(channel_id)
         try:
+            if only_if_phone is not None:
+                existing = await self._db.repos.channels.get_preferred_phone(channel_id)
+                if existing and existing != only_if_phone:
+                    return
             await self._db.repos.channels.update_channel_preferred_phone(channel_id, None)
         except Exception:
             logger.debug(
@@ -1337,9 +1359,15 @@ class ClientPool(ResolveGuardMixin):
             has_comments = linked_chat_id is not None
             # Self-heal the channel→phone map on success: remember which account
             # resolved this channel so the next bulk pass routes there directly.
-            # db_preferred (if read above) skips a redundant SELECT.
+            # When we fell back to a different account than the stored preferred,
+            # that preferred was stale/unavailable — force-update the DB to the
+            # account that just confirmably worked. When we used the preferred
+            # account, just fill the DB if it was empty (the warm_all_dialogs gate).
             await self.remember_channel_phone(
-                channel_id, phone, known_preferred=db_preferred
+                channel_id,
+                phone,
+                known_preferred=db_preferred,
+                force=not used_preferred,
             )
             return {
                 "about": about,
@@ -1365,9 +1393,11 @@ class ClientPool(ResolveGuardMixin):
             )
             # If the preferred account lost access, drop the stale mapping so the
             # next pass rediscovers. Leave it alone on the available-client path —
-            # we'd be erasing a good record on a guess.
+            # we'd be erasing a good record on a guess. Clear the DB only if it
+            # still points at the account that just failed (the in-memory map may
+            # be stale while the DB holds a different, valid account).
             if used_preferred:
-                await self.forget_channel_phone(channel_id)
+                await self.forget_channel_phone(channel_id, only_if_phone=phone)
             return None
         except (ValueError, TypeError):
             # Telethon raises ValueError("Could not find the input entity ...")
@@ -1381,8 +1411,9 @@ class ClientPool(ResolveGuardMixin):
             # A stored preferred phone that can no longer resolve the entity is
             # stale (membership change) — clear it so the next pass rediscovers
             # instead of pinning the same dead account (Codex review on #809).
+            # Clear the DB only if it still matches the failed account.
             if used_preferred:
-                await self.forget_channel_phone(channel_id)
+                await self.forget_channel_phone(channel_id, only_if_phone=phone)
             return None
         except Exception as e:
             logger.warning(

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -1233,7 +1233,33 @@ class ClientPool(ResolveGuardMixin):
         if channel_type == "group":
             return None
 
-        result = await self.get_available_client()
+        # Route to the account that can actually see this (possibly private)
+        # channel instead of a random available one (#808). Mirrors
+        # Collector._collect_channel: in-memory map → DB preferred_phone →
+        # wait_for_warm → fall back to any available client.
+        db_preferred: str | None = None
+        preferred = self.get_phone_for_channel(channel_id)
+        if not preferred:
+            try:
+                db_preferred = await self._db.repos.channels.get_preferred_phone(channel_id)
+            except Exception:
+                logger.debug(
+                    "fetch_channel_meta: failed to read preferred_phone for channel_id %s",
+                    channel_id,
+                    exc_info=True,
+                )
+            preferred = db_preferred
+        if not preferred and self.is_warming():
+            await self.wait_for_warm(timeout=30.0)
+            preferred = self.get_phone_for_channel(channel_id)
+
+        used_preferred = False
+        result = None
+        if preferred:
+            result = await self.get_client_by_phone(preferred)
+            used_preferred = result is not None
+        if result is None:
+            result = await self.get_available_client()
         if not result:
             logger.warning("fetch_channel_meta: no available client for channel_id %s", channel_id)
             return None
@@ -1241,6 +1267,29 @@ class ClientPool(ResolveGuardMixin):
         session, phone = result
         session = adapt_transport_session(session, disconnect_on_close=False)
         try:
+            # Pre-warm the entity cache when routing through a preferred account
+            # whose dialogs haven't been fetched this process (StringSession loses
+            # the cache between restarts). Mirrors Collector._collect_channel.
+            if used_preferred and not self.is_dialogs_fetched(phone):
+                try:
+                    await run_with_flood_wait(
+                        session.warm_dialog_cache(),
+                        operation="fetch_channel_meta_warm_dialog_cache",
+                        phone=phone,
+                        pool=self,
+                        logger_=logger,
+                        timeout=30.0,
+                    )
+                    self.mark_dialogs_fetched(phone)
+                except HandledFloodWaitError as exc:
+                    logger.info(
+                        "fetch_channel_meta: flood wait warming %s for channel_id %s: %s",
+                        phone,
+                        channel_id,
+                        exc.info.detail,
+                    )
+                    return None
+
             entity = await self.resolve_entity_with_warm(
                 session, phone, PeerChannel(channel_id), operation="fetch_channel_meta"
             )
@@ -1257,6 +1306,25 @@ class ClientPool(ResolveGuardMixin):
                 full.full_chat.linked_chat_id if full and full.full_chat else None
             )
             has_comments = linked_chat_id is not None
+            # Self-heal the channel→phone map on success: remember which account
+            # resolved this channel so the next bulk pass routes there directly.
+            self.register_channel_phone(channel_id, phone)
+            if not db_preferred:
+                # Persist only if no preferred_phone was set yet (avoid clobbering
+                # a valid value from previous error recovery — same gate as
+                # warm_all_dialogs).
+                try:
+                    existing = await self._db.repos.channels.get_preferred_phone(channel_id)
+                    if not existing:
+                        await self._db.repos.channels.update_channel_preferred_phone(
+                            channel_id, phone
+                        )
+                except Exception:
+                    logger.debug(
+                        "fetch_channel_meta: failed to persist preferred_phone for channel_id %s",
+                        channel_id,
+                        exc_info=True,
+                    )
             return {
                 "about": about,
                 "linked_chat_id": linked_chat_id,
@@ -1277,6 +1345,32 @@ class ClientPool(ResolveGuardMixin):
         except (ChannelPrivateError, ChatAdminRequiredError):
             logger.debug(
                 "fetch_channel_meta: access denied for channel_id %s (expected for private channels)",
+                channel_id,
+            )
+            # If the preferred account lost access, drop the stale mapping so the
+            # next pass rediscovers. Leave it alone on the available-client path —
+            # we'd be erasing a good record on a guess.
+            if used_preferred:
+                self.clear_channel_phone(channel_id)
+                try:
+                    await self._db.repos.channels.update_channel_preferred_phone(
+                        channel_id, None
+                    )
+                except Exception:
+                    logger.debug(
+                        "fetch_channel_meta: failed to clear stale preferred_phone "
+                        "for channel_id %s",
+                        channel_id,
+                        exc_info=True,
+                    )
+            return None
+        except (ValueError, TypeError):
+            # Telethon raises ValueError("Could not find the input entity ...")
+            # when no warmed account can resolve the peer. Not unexpected during
+            # bulk passes — keep it at DEBUG so it doesn't drown the logs (#808).
+            logger.debug(
+                "fetch_channel_meta: entity unresolved for channel_id %s "
+                "(not in any warmed account)",
                 channel_id,
             )
             return None

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -150,6 +150,34 @@ class ClientPool(ResolveGuardMixin):
         """Remove cached phone mapping for a channel (used during error recovery)."""
         self._channel_phone_map.pop(channel_id, None)
 
+    async def remember_channel_phone(
+        self, channel_id: int, phone: str, *, known_preferred: str | None = None
+    ) -> None:
+        """Cache channel→phone in memory and persist to DB only if no preferred set.
+
+        Avoids overwriting a valid preferred_phone from previous error recovery
+        (same gate as warm_all_dialogs). Pass ``known_preferred`` when the caller
+        already read the DB value to skip a redundant SELECT. Best-effort: a
+        failed DB write only means rediscovery repeats next pass.
+        """
+        self.register_channel_phone(channel_id, phone)
+        if known_preferred:
+            return
+        try:
+            existing = await self._db.repos.channels.get_preferred_phone(channel_id)
+            if not existing:
+                await self._db.repos.channels.update_channel_preferred_phone(
+                    channel_id, phone
+                )
+        except Exception:
+            # exc_info keeps the traceback for DB-lock diagnosis (#676).
+            logger.debug(
+                "remember_channel_phone: failed to read or persist preferred_phone "
+                "for channel %d",
+                channel_id,
+                exc_info=True,
+            )
+
     def is_warming(self) -> bool:
         """True while warm_all_dialogs() is still running."""
         return self._warming_task is not None and not self._warming_task.done()
@@ -223,24 +251,7 @@ class ClientPool(ResolveGuardMixin):
                         continue
                     eid = getattr(entity, "id", None)
                     if eid and eid not in self._channel_phone_map:
-                        self._channel_phone_map[eid] = p
-                        # Persist to DB only if no preferred_phone set yet
-                        # (avoid overwriting a valid value from previous error recovery)
-                        try:
-                            existing = await self._db.repos.channels.get_preferred_phone(eid)
-                            if not existing:
-                                await self._db.repos.channels.update_channel_preferred_phone(
-                                    eid, p
-                                )
-                        except Exception:
-                            # Best-effort warming hint; the in-memory map is already set.
-                            # exc_info keeps the traceback for DB-lock diagnosis (#676).
-                            logger.debug(
-                                "warm_all_dialogs: failed to read or persist preferred_phone "
-                                "for channel %d",
-                                eid,
-                                exc_info=True,
-                            )
+                        await self.remember_channel_phone(eid, p)
                 logger.info(
                     "warm_all_dialogs: warmed %s (%d dialogs)", p, len(dialogs or [])
                 )
@@ -1308,23 +1319,10 @@ class ClientPool(ResolveGuardMixin):
             has_comments = linked_chat_id is not None
             # Self-heal the channel→phone map on success: remember which account
             # resolved this channel so the next bulk pass routes there directly.
-            self.register_channel_phone(channel_id, phone)
-            if not db_preferred:
-                # Persist only if no preferred_phone was set yet (avoid clobbering
-                # a valid value from previous error recovery — same gate as
-                # warm_all_dialogs).
-                try:
-                    existing = await self._db.repos.channels.get_preferred_phone(channel_id)
-                    if not existing:
-                        await self._db.repos.channels.update_channel_preferred_phone(
-                            channel_id, phone
-                        )
-                except Exception:
-                    logger.debug(
-                        "fetch_channel_meta: failed to persist preferred_phone for channel_id %s",
-                        channel_id,
-                        exc_info=True,
-                    )
+            # db_preferred (if read above) skips a redundant SELECT.
+            await self.remember_channel_phone(
+                channel_id, phone, known_preferred=db_preferred
+            )
             return {
                 "about": about,
                 "linked_chat_id": linked_chat_id,

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from telethon.errors import (
     ChannelInvalidError,
+    ChannelPrivateError,
     FloodWaitError,
     UsernameInvalidError,
     UsernameNotOccupiedError,
@@ -751,6 +752,203 @@ async def test_fetch_channel_meta_generic_error(pool):
             with patch.object(session, "invoke_request", side_effect=RuntimeError("fail")):
                 result = await pool.fetch_channel_meta(123, "channel")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ClientPool: fetch_channel_meta account routing (#808)
+# ---------------------------------------------------------------------------
+
+
+def _meta_session_with_full(linked_chat_id=42):
+    """Build a transport session whose fetch returns a full-channel result."""
+    client = AsyncMock()
+    entity = SimpleNamespace()
+    full_chat = MagicMock()
+    full_chat.about = "About"
+    full_chat.linked_chat_id = linked_chat_id
+    full_result = MagicMock()
+    full_result.full_chat = full_chat
+    session = TelegramTransportSession(client, disconnect_on_close=False)
+    return session, entity, full_result
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_routes_to_preferred_phone_from_map(pool):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    pool.register_channel_phone(123, "+7001")
+    pool.mark_dialogs_fetched("+7001")
+
+    by_phone = AsyncMock(return_value=(session, "+7001"))
+    avail = AsyncMock()
+    with patch.object(pool, "get_client_by_phone", by_phone):
+        with patch.object(pool, "get_available_client", avail):
+            with patch.object(session, "resolve_entity", return_value=entity):
+                with patch.object(session, "invoke_request", return_value=full_result):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    by_phone.assert_awaited_once_with("+7001")
+    avail.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_routes_to_preferred_phone_from_db(pool, mock_db):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7001"
+
+    by_phone = AsyncMock(return_value=(session, "+7001"))
+    avail = AsyncMock()
+    with patch.object(pool, "get_client_by_phone", by_phone):
+        with patch.object(pool, "get_available_client", avail):
+            with patch.object(session, "resolve_entity", return_value=entity):
+                with patch.object(session, "invoke_request", return_value=full_result):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    by_phone.assert_awaited_once_with("+7001")
+    avail.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_waits_for_warm_when_unmapped(pool, mock_db):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = None
+
+    async def _warm(timeout=30.0):
+        pool.register_channel_phone(123, "+7001")
+
+    with patch.object(pool, "is_warming", return_value=True):
+        with patch.object(pool, "wait_for_warm", AsyncMock(side_effect=_warm)) as waiter:
+            with patch.object(
+                pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+            ):
+                with patch.object(session, "resolve_entity", return_value=entity):
+                    with patch.object(session, "invoke_request", return_value=full_result):
+                        result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    waiter.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_falls_back_to_available_client(pool, mock_db):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    mock_db.repos.channels.get_preferred_phone.return_value = None
+
+    avail = AsyncMock(return_value=(session, "+7001"))
+    with patch.object(pool, "is_warming", return_value=False):
+        with patch.object(pool, "get_available_client", avail):
+            with patch.object(session, "resolve_entity", return_value=entity):
+                with patch.object(session, "invoke_request", return_value=full_result):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    avail.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_unresolved_entity_logs_debug_not_warning(pool, caplog):
+    session = TelegramTransportSession(AsyncMock(), disconnect_on_close=False)
+    pool.clients["+7001"] = session
+
+    with patch.object(pool, "get_available_client", return_value=(session, "+7001")):
+        with patch.object(
+            session,
+            "resolve_entity",
+            side_effect=ValueError("Could not find the input entity for PeerChannel"),
+        ):
+            with caplog.at_level(logging.DEBUG):
+                result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is None
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("entity unresolved" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_registers_phone_on_success(pool, mock_db):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    mock_db.repos.channels.get_preferred_phone.return_value = None
+
+    with patch.object(pool, "is_warming", return_value=False):
+        with patch.object(pool, "get_available_client", return_value=(session, "+7001")):
+            with patch.object(session, "resolve_entity", return_value=entity):
+                with patch.object(session, "invoke_request", return_value=full_result):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    assert pool.get_phone_for_channel(123) == "+7001"
+    mock_db.repos.channels.update_channel_preferred_phone.assert_awaited_once_with(
+        123, "+7001"
+    )
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_does_not_persist_when_preferred_exists(pool, mock_db):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7001"
+
+    with patch.object(
+        pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+    ):
+        with patch.object(session, "resolve_entity", return_value=entity):
+            with patch.object(session, "invoke_request", return_value=full_result):
+                result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    mock_db.repos.channels.update_channel_preferred_phone.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_clears_stale_preferred_on_channel_private(pool, mock_db):
+    session = TelegramTransportSession(AsyncMock(), disconnect_on_close=False)
+    pool.clients["+7001"] = session
+    pool.register_channel_phone(123, "+7001")
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7001"
+
+    with patch.object(
+        pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+    ):
+        with patch.object(
+            session, "resolve_entity", side_effect=ChannelPrivateError(request=None)
+        ):
+            result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is None
+    assert pool.get_phone_for_channel(123) is None
+    mock_db.repos.channels.update_channel_preferred_phone.assert_awaited_once_with(
+        123, None
+    )
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_prewarms_when_dialogs_not_fetched(pool):
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7001"] = session
+    pool.register_channel_phone(123, "+7001")
+    # dialogs NOT marked fetched → must warm first
+
+    with patch.object(
+        pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+    ):
+        with patch.object(session, "warm_dialog_cache", AsyncMock()) as warm:
+            with patch.object(session, "resolve_entity", return_value=entity):
+                with patch.object(session, "invoke_request", return_value=full_result):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    warm.assert_awaited()
+    assert pool.is_dialogs_fetched("+7001")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1005,6 +1005,59 @@ async def test_fetch_channel_meta_unresolved_keeps_map_on_available_client(pool,
     mock_db.repos.channels.update_channel_preferred_phone.assert_not_awaited()
 
 
+@pytest.mark.anyio
+async def test_fetch_channel_meta_updates_db_when_fallback_account_differs(pool, mock_db):
+    # DB preferred is "+7001" but unavailable (flood) → fall back to "+7002" and
+    # succeed. The DB must be corrected to the account that actually worked,
+    # not left pointing at the stale preferred (Claude review #1 on #809).
+    session, entity, full_result = _meta_session_with_full()
+    pool.clients["+7002"] = session
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7001"
+
+    with patch.object(pool, "is_warming", return_value=False):
+        with patch.object(pool, "get_client_by_phone", AsyncMock(return_value=None)):
+            with patch.object(
+                pool, "get_available_client", AsyncMock(return_value=(session, "+7002"))
+            ):
+                with patch.object(session, "resolve_entity", return_value=entity):
+                    with patch.object(
+                        session, "invoke_request", return_value=full_result
+                    ):
+                        result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is not None
+    assert pool.get_phone_for_channel(123) == "+7002"
+    mock_db.repos.channels.update_channel_preferred_phone.assert_awaited_once_with(
+        123, "+7002"
+    )
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_keeps_db_preferred_when_map_stale(pool, mock_db):
+    # In-memory map points at "+7001" (stale) but DB preferred is a different
+    # valid account "+7002". A failure on "+7001" must NOT erase the good DB
+    # value (Codex review P2 on #809).
+    session = TelegramTransportSession(AsyncMock(), disconnect_on_close=False)
+    pool.clients["+7001"] = session
+    pool.register_channel_phone(123, "+7001")
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7002"
+
+    with patch.object(
+        pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+    ):
+        with patch.object(
+            session, "resolve_entity", side_effect=ChannelPrivateError(request=None)
+        ):
+            result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is None
+    # in-memory map cleared (it pointed at the failed account)...
+    assert pool.get_phone_for_channel(123) is None
+    # ...but the valid DB preferred is left intact.
+    mock_db.repos.channels.update_channel_preferred_phone.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # ClientPool: _classify_entity edge cases
 # ---------------------------------------------------------------------------

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -951,6 +951,60 @@ async def test_fetch_channel_meta_prewarms_when_dialogs_not_fetched(pool):
     assert pool.is_dialogs_fetched("+7001")
 
 
+@pytest.mark.anyio
+async def test_fetch_channel_meta_clears_stale_preferred_on_unresolved(pool, mock_db):
+    # A stored preferred phone that can no longer resolve the entity is stale
+    # (membership change) — ValueError path must clear it like ChannelPrivateError.
+    session = TelegramTransportSession(AsyncMock(), disconnect_on_close=False)
+    pool.clients["+7001"] = session
+    pool.register_channel_phone(123, "+7001")
+    pool.mark_dialogs_fetched("+7001")
+    mock_db.repos.channels.get_preferred_phone.return_value = "+7001"
+
+    with patch.object(
+        pool, "get_client_by_phone", AsyncMock(return_value=(session, "+7001"))
+    ):
+        with patch.object(
+            session,
+            "resolve_entity",
+            side_effect=ValueError("Could not find the input entity"),
+        ):
+            result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is None
+    assert pool.get_phone_for_channel(123) is None
+    mock_db.repos.channels.update_channel_preferred_phone.assert_awaited_once_with(
+        123, None
+    )
+
+
+@pytest.mark.anyio
+async def test_fetch_channel_meta_unresolved_keeps_map_on_available_client(pool, mock_db):
+    # On the available-client (non-preferred) path a ValueError just means no
+    # warmed account sees the channel — must NOT erase a good mapping on a guess.
+    session = TelegramTransportSession(AsyncMock(), disconnect_on_close=False)
+    pool.clients["+7001"] = session
+    # No mapping for channel 123 → routing falls back to get_available_client.
+    mock_db.repos.channels.get_preferred_phone.return_value = None
+    clear = MagicMock()
+
+    with patch.object(pool, "is_warming", return_value=False):
+        with patch.object(pool, "clear_channel_phone", clear):
+            with patch.object(
+                pool, "get_available_client", AsyncMock(return_value=(session, "+7001"))
+            ):
+                with patch.object(
+                    session,
+                    "resolve_entity",
+                    side_effect=ValueError("Could not find the input entity"),
+                ):
+                    result = await pool.fetch_channel_meta(123, "channel")
+
+    assert result is None
+    clear.assert_not_called()
+    mock_db.repos.channels.update_channel_preferred_phone.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # ClientPool: _classify_entity edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Проблема

При bulk-обходе каналов (`channel refresh-meta --all`, search-persistence, telegram_command_dispatcher) в лог сыпался каскад `Could not find the input entity for PeerChannel(...)` на уровне **WARNING** — симптом бага маршрутизации, а не битых каналов.

## Корневая причина

`ClientPool.fetch_channel_meta` брал **случайный** доступный аккаунт через `get_available_client()` и пытался резолвить `PeerChannel`. Для приватного канала, видимого лишь одному аккаунту, у случайного нет `access_hash` → `ValueError` → ретрай на том же неправильном аккаунте → снова `ValueError` → generic `except Exception` → WARNING. Один недогретый аккаунт размножался на весь хвост списка.

## Фикс

Зеркалит уже существующий эталон `Collector._collect_channel`. Сигнатура `fetch_channel_meta(channel_id, channel_type)` **не меняется** — ноль изменений в вызывающих местах, CLI/Web parity сохранена.

1. **Маршрутизация на правильный аккаунт**: in-memory карта → `get_preferred_phone` из БД → `wait_for_warm` если идёт прогрев → fallback на `get_available_client`.
2. **Пред-прогрев** entity-кэша через `warm_dialog_cache`, если шли через preferred и диалоги ещё не fetched (на FloodWait → release + None).
3. **Самоисцеление карты канал→телефон**: `register_channel_phone` на успехе + persist в БД только если preferred ещё не было (гейт «only if not existing»); на `ChannelPrivateError` с preferred-аккаунта — `clear_channel_phone` + сброс preferred.
4. **Классификация шума**: `except (ValueError, TypeError)` перед generic `except Exception` понижает «Could not find the input entity» до DEBUG; generic остаётся WARNING.

## Тесты

+9 тестов: routing из карты/БД, wait-for-warm, fallback, debug-not-warning, register-on-success, no-persist-if-exists, clear-stale-on-private, prewarm. Существующие 5 тестов `fetch_channel_meta` не сломаны.

## Verification

- `ruff check` — чисто
- `pytest tests/test_telegram_client_pool_collector.py` — 157 passed
- pool/collector-срез — 532 passed, 2 skipped, без warnings (warnings-as-errors активны)

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)