### PR TITLE
refactor: устранить дублирование кода (8 из 10 кластеров #807)

### DIFF
--- a/src/agent/tools/images.py
+++ b/src/agent/tools/images.py
@@ -90,25 +90,10 @@ async def resolve_default_image_model(requested_model, db, image_service) -> str
 
 
 def register(db, client_pool, embedding_service, **kwargs):
+    from src.agent.tools._pipeline_runtime import build_image_service
+
     config = kwargs.get("config")
     tools = []
-
-    async def _build_image_service():
-        """Build ImageGenerationService with DB providers + env fallback."""
-        from src.services.image_generation_service import ImageGenerationService
-
-        if db and config:
-            try:
-                from src.services.image_provider_service import ImageProviderService
-
-                svc = ImageProviderService(db, config)
-                configs = await svc.load_provider_configs()
-                adapters = svc.build_adapters(configs)
-                if adapters:
-                    return ImageGenerationService(adapters=adapters)
-            except Exception:
-                logger.warning("Failed to load image providers from DB", exc_info=True)
-        return ImageGenerationService()
 
     @tool(
         "generate_image",
@@ -123,7 +108,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: prompt обязателен.")
         model = args.get("model")
         try:
-            svc = await _build_image_service()
+            svc = await build_image_service(db, config)
             if not await svc.is_available():
                 return _text_response("Генерация изображений не настроена. Добавьте провайдера в настройках.")
             resolved_model = await resolve_default_image_model(model, db, svc)
@@ -192,7 +177,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response("Ошибка: provider обязателен.")
         query = args.get("query", "")
         try:
-            svc = await _build_image_service()
+            svc = await build_image_service(db, config)
             models = await svc.search_models(provider=provider, query=query)
             if not models:
                 return _text_response(f"Модели для {provider} не найдены.")
@@ -216,7 +201,7 @@ def register(db, client_pool, embedding_service, **kwargs):
     @tool("list_image_providers", "List configured image generation providers", {})
     async def list_image_providers(args):
         try:
-            svc = await _build_image_service()
+            svc = await build_image_service(db, config)
             names = svc.adapter_names
             if not names:
                 return _text_response("Провайдеры изображений не настроены.")

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -185,12 +185,8 @@ def run_with_dependencies(
                 if phone is None:
                     return
 
-                if not args.yes:
-                    print(f"Join/subscribe account {phone} to {args.target}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(args, f"Join/subscribe account {phone} to {args.target}"):
+                    return
 
                 try:
                     result = await TelegramActionService(pool).join_dialog(
@@ -235,13 +231,12 @@ def run_with_dependencies(
                 recipient = args.recipient
                 text = args.text
 
-                if not args.yes:
-                    print(f"Send message from {phone} to {recipient}:")
-                    print(f"  {text[:200]}{'...' if len(text) > 200 else ''}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(
+                    args,
+                    f"Send message from {phone} to {recipient}:",
+                    f"  {text[:200]}{'...' if len(text) > 200 else ''}",
+                ):
+                    return
 
                 try:
                     result = await TelegramActionService(pool).send_message(
@@ -365,17 +360,13 @@ def run_with_dependencies(
                             f"Supported reactions: {SUPPORTED_REACTION_EMOJIS_DISPLAY}"
                         )
                         return
-                if not args.yes:
-                    action = (
-                        f"Clear reaction from message #{args.message_id} in {args.chat_id}"
-                        if args.clear
-                        else f"Send reaction {emoji!r} to message #{args.message_id} in {args.chat_id}"
-                    )
-                    print(action)
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                action = (
+                    f"Clear reaction from message #{args.message_id} in {args.chat_id}"
+                    if args.clear
+                    else f"Send reaction {emoji!r} to message #{args.message_id} in {args.chat_id}"
+                )
+                if not _confirm_or_abort(args, action):
+                    return
                 try:
                     result = await TelegramActionService(pool).send_reaction(
                         phone=phone,
@@ -404,12 +395,8 @@ def run_with_dependencies(
                 phone = _resolve_phone(pool, args)
                 if phone is None:
                     return
-                if not args.yes:
-                    print(f"Pin message #{args.message_id} in {args.chat_id}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(args, f"Pin message #{args.message_id} in {args.chat_id}"):
+                    return
                 try:
                     await TelegramActionService(pool).pin_message(
                         phone=phone,
@@ -427,13 +414,9 @@ def run_with_dependencies(
                 phone = _resolve_phone(pool, args)
                 if phone is None:
                     return
-                if not args.yes:
-                    target = f"#{args.message_id}" if args.message_id else "all messages"
-                    print(f"Unpin {target} in {args.chat_id}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                target = f"#{args.message_id}" if args.message_id else "all messages"
+                if not _confirm_or_abort(args, f"Unpin {target} in {args.chat_id}"):
+                    return
                 try:
                     await TelegramActionService(pool).unpin_message(
                         phone=phone,
@@ -507,12 +490,8 @@ def run_with_dependencies(
                 phone = _resolve_phone(pool, args)
                 if phone is None:
                     return
-                if not args.yes:
-                    print(f"Edit admin rights for {args.user_id} in {args.chat_id}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(args, f"Edit admin rights for {args.user_id} in {args.chat_id}"):
+                    return
                 try:
                     await TelegramActionService(pool).edit_admin(
                         phone=phone,
@@ -531,12 +510,8 @@ def run_with_dependencies(
                 phone = _resolve_phone(pool, args)
                 if phone is None:
                     return
-                if not args.yes:
-                    print(f"Edit permissions for {args.user_id} in {args.chat_id}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(args, f"Edit permissions for {args.user_id} in {args.chat_id}"):
+                    return
                 try:
                     if args.send_messages is None and args.send_media is None:
                         print("Error: specify at least one flag (--send-messages or --send-media).")
@@ -570,12 +545,8 @@ def run_with_dependencies(
                 phone = _resolve_phone(pool, args)
                 if phone is None:
                     return
-                if not args.yes:
-                    print(f"Kick {args.user_id} from {args.chat_id}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
+                if not _confirm_or_abort(args, f"Kick {args.user_id} from {args.chat_id}"):
+                    return
                 try:
                     await TelegramActionService(pool).kick_participant(
                         phone=phone,
@@ -777,12 +748,8 @@ def run_with_dependencies(
                                 f"phone={payload_phone or '-'} run_after={run_after}"
                             )
                 elif args.queue_action == "cancel":
-                    if not args.yes:
-                        print(f"Cancel queue command #{args.command_id}")
-                        answer = input("Continue? [y/N] ").strip().lower()
-                        if answer != "y":
-                            print("Aborted.")
-                            return
+                    if not _confirm_or_abort(args, f"Cancel queue command #{args.command_id}"):
+                        return
                     ok = await service.cancel(int(args.command_id))
                     if ok:
                         print(f"Command #{args.command_id} cancelled.")
@@ -792,18 +759,14 @@ def run_with_dependencies(
                             f"(only PENDING commands can be cancelled)."
                         )
                 elif args.queue_action == "clear-pending":
-                    if not args.yes:
-                        filt = []
-                        if args.command_type:
-                            filt.append(f"type={args.command_type}")
-                        if args.phone:
-                            filt.append(f"phone={args.phone}")
-                        scope = ", ".join(filt) if filt else "ALL types and accounts"
-                        print(f"Bulk-cancel pending commands ({scope})")
-                        answer = input("Continue? [y/N] ").strip().lower()
-                        if answer != "y":
-                            print("Aborted.")
-                            return
+                    filt = []
+                    if args.command_type:
+                        filt.append(f"type={args.command_type}")
+                    if args.phone:
+                        filt.append(f"phone={args.phone}")
+                    scope = ", ".join(filt) if filt else "ALL types and accounts"
+                    if not _confirm_or_abort(args, f"Bulk-cancel pending commands ({scope})"):
+                        return
                     cancelled = await service.cancel_pending(
                         command_type=args.command_type or None,
                         phone=args.phone or None,

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -24,6 +24,55 @@ from src.telegram.reactions import (
 from src.utils.datetime import parse_required_datetime
 
 
+def _resolve_phone(pool, args) -> str | None:
+    """Pick the account phone for a dialogs action, printing why it can't run.
+
+    Returns the resolved phone, or ``None`` (after printing an error) when there
+    are no connected accounts or the requested account is not connected.
+    """
+    accounts = sorted(pool.clients.keys())
+    if not accounts:
+        print("No connected accounts.")
+        return None
+    phone = args.phone or accounts[0]
+    if phone not in pool.clients:
+        print(f"Account {phone} not connected.")
+        return None
+    return phone
+
+
+def _parse_message_ids(args) -> list[int] | None:
+    """Parse comma/space-separated ``args.message_ids`` into ints.
+
+    Returns the parsed ids, or ``None`` (after printing an error) when none are
+    valid.
+    """
+    raw_ids: list[str] = []
+    for item in args.message_ids:
+        raw_ids.extend(part.strip() for part in item.split(",") if part.strip())
+    ids = [int(raw) for raw in raw_ids if raw.isdigit()]
+    if not ids:
+        print("No valid message IDs provided.")
+        return None
+    return ids
+
+
+def _confirm_or_abort(args, *lines: str) -> bool:
+    """Show a confirmation preview and read a [y/N] answer unless ``--yes``.
+
+    Returns True to proceed, False (after printing "Aborted.") to stop.
+    """
+    if args.yes:
+        return True
+    for line in lines:
+        print(line)
+    answer = input("Continue? [y/N] ").strip().lower()
+    if answer != "y":
+        print("Aborted.")
+        return False
+    return True
+
+
 def run_with_dependencies(
     args: argparse.Namespace,
     *,
@@ -35,26 +84,16 @@ def run_with_dependencies(
         _, pool = await runtime_mod.init_pool(config, db)
         try:
             if args.dialogs_action == "refresh":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 svc = channel_service_cls(db, pool, None)  # type: ignore[arg-type]
                 dialogs = await svc.get_my_dialogs(phone, refresh=True)
                 print(f"Dialogs refreshed: {len(dialogs)} total.")
 
             elif args.dialogs_action == "list":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 svc = channel_service_cls(db, pool, None)  # type: ignore[arg-type]
                 dialogs = await svc.get_my_dialogs(phone)
@@ -96,13 +135,8 @@ def run_with_dependencies(
                     print(f"Username: @{entity['username']}")
 
             elif args.dialogs_action == "leave":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
 
                 raw_ids: list[str] = []
@@ -147,13 +181,8 @@ def run_with_dependencies(
                 print(f"\nDone: {left} left, {failed} failed.")
 
             elif args.dialogs_action == "join":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
 
                 if not args.yes:
@@ -200,13 +229,8 @@ def run_with_dependencies(
                     )
 
             elif args.dialogs_action == "send":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 recipient = args.recipient
                 text = args.text
@@ -233,27 +257,17 @@ def run_with_dependencies(
                     print(f"Error sending message: {exc}")
 
             elif args.dialogs_action == "forward":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                ids = _parse_message_ids(args)
+                if ids is None:
                     return
-                raw_ids: list[str] = []
-                for item in args.message_ids:
-                    raw_ids.extend(part.strip() for part in item.split(",") if part.strip())
-                ids = [int(raw) for raw in raw_ids if raw.isdigit()]
-                if not ids:
-                    print("No valid message IDs provided.")
+                if not _confirm_or_abort(
+                    args,
+                    f"Forward {len(ids)} message(s) from {args.from_chat} to {args.to_chat}: {ids}",
+                ):
                     return
-                if not args.yes:
-                    print(f"Forward {len(ids)} message(s) from {args.from_chat} to {args.to_chat}: {ids}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
                 try:
                     fwd_result = await TelegramActionService(pool).forward_messages(
                         phone=phone,
@@ -271,22 +285,16 @@ def run_with_dependencies(
                     print(f"Error forwarding messages: {exc}")
 
             elif args.dialogs_action == "edit-message":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                preview = args.text[:200] + ("..." if len(args.text) > 200 else "")
+                if not _confirm_or_abort(
+                    args,
+                    f"Edit message #{args.message_id} in {args.chat_id}:",
+                    f"  {preview}",
+                ):
                     return
-                if not args.yes:
-                    preview = args.text[:200] + ("..." if len(args.text) > 200 else "")
-                    print(f"Edit message #{args.message_id} in {args.chat_id}:")
-                    print(f"  {preview}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
                 try:
                     await TelegramActionService(pool).edit_message(
                         phone=phone,
@@ -301,27 +309,17 @@ def run_with_dependencies(
                     print(f"Error editing message: {exc}")
 
             elif args.dialogs_action == "delete-message":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                ids = _parse_message_ids(args)
+                if ids is None:
                     return
-                raw_ids: list[str] = []
-                for item in args.message_ids:
-                    raw_ids.extend(part.strip() for part in item.split(",") if part.strip())
-                ids = [int(raw) for raw in raw_ids if raw.isdigit()]
-                if not ids:
-                    print("No valid message IDs provided.")
+                if not _confirm_or_abort(
+                    args,
+                    f"Delete {len(ids)} message(s) from {args.chat_id}: {ids}",
+                ):
                     return
-                if not args.yes:
-                    print(f"Delete {len(ids)} message(s) from {args.chat_id}: {ids}")
-                    answer = input("Continue? [y/N] ").strip().lower()
-                    if answer != "y":
-                        print("Aborted.")
-                        return
                 try:
                     await TelegramActionService(pool).delete_messages(
                         phone=phone,
@@ -335,13 +333,8 @@ def run_with_dependencies(
                     print(f"Error deleting messages: {exc}")
 
             elif args.dialogs_action == "react":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 # Surface only a long (non-transient) flood-wait explicitly; a
                 # transient (<=60s) flood is now waited out centrally inside the
@@ -408,13 +401,8 @@ def run_with_dependencies(
                     print(f"Error sending reaction: {type(exc).__name__}: {exc}")
 
             elif args.dialogs_action == "pin-message":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 if not args.yes:
                     print(f"Pin message #{args.message_id} in {args.chat_id}")
@@ -436,13 +424,8 @@ def run_with_dependencies(
                     print(f"Error pinning message: {exc}")
 
             elif args.dialogs_action == "unpin-message":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 if not args.yes:
                     target = f"#{args.message_id}" if args.message_id else "all messages"
@@ -464,13 +447,8 @@ def run_with_dependencies(
                     print(f"Error unpinning message: {exc}")
 
             elif args.dialogs_action == "download-media":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     result = await TelegramActionService(pool).download_media(
@@ -493,13 +471,8 @@ def run_with_dependencies(
                     print(f"Error downloading media: {exc}")
 
             elif args.dialogs_action == "participants":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     result = await TelegramActionService(pool).get_participants(
@@ -531,13 +504,8 @@ def run_with_dependencies(
                     print(f"Error fetching participants: {exc}")
 
             elif args.dialogs_action == "edit-admin":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 if not args.yes:
                     print(f"Edit admin rights for {args.user_id} in {args.chat_id}")
@@ -560,13 +528,8 @@ def run_with_dependencies(
                     print(f"Error editing admin: {exc}")
 
             elif args.dialogs_action == "edit-permissions":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 if not args.yes:
                     print(f"Edit permissions for {args.user_id} in {args.chat_id}")
@@ -604,13 +567,8 @@ def run_with_dependencies(
                     print(f"Error editing permissions: {exc}")
 
             elif args.dialogs_action == "kick":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 if not args.yes:
                     print(f"Kick {args.user_id} from {args.chat_id}")
@@ -631,13 +589,8 @@ def run_with_dependencies(
                     print(f"Error kicking participant: {exc}")
 
             elif args.dialogs_action == "broadcast-stats":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     result = await TelegramActionService(pool).get_broadcast_stats(
@@ -669,13 +622,8 @@ def run_with_dependencies(
                     print(f"Error fetching broadcast stats: {exc}")
 
             elif args.dialogs_action == "archive":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     await TelegramActionService(pool).set_dialog_folder(
@@ -690,13 +638,8 @@ def run_with_dependencies(
                     print(f"Error archiving: {exc}")
 
             elif args.dialogs_action == "unarchive":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     await TelegramActionService(pool).set_dialog_folder(
@@ -711,13 +654,8 @@ def run_with_dependencies(
                     print(f"Error unarchiving: {exc}")
 
             elif args.dialogs_action == "mark-read":
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 try:
                     await TelegramActionService(pool).mark_read(
@@ -743,13 +681,8 @@ def run_with_dependencies(
                     print("Cache cleared for all accounts.")
 
             elif args.dialogs_action in {"create-channel", "create-group"}:
-                accounts = sorted(pool.clients.keys())
-                if not accounts:
-                    print("No connected accounts.")
-                    return
-                phone = args.phone or accounts[0]
-                if phone not in pool.clients:
-                    print(f"Account {phone} not connected.")
+                phone = _resolve_phone(pool, args)
+                if phone is None:
                     return
                 is_group = args.dialogs_action == "create-group"
                 noun = "group" if is_group else "channel"

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -27,12 +27,10 @@ TOTAL_REACTIONS_SQL = (
 )
 # Same sum guarded so it only evaluates for rows holding valid reactions JSON;
 # used inside AVG(...) over arbitrary message rows.
-TOTAL_REACTIONS_GUARDED_SQL = (
-    "CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''\n"
-    "          AND json_valid(m.reactions_json) = 1\n"
-    f"     THEN {TOTAL_REACTIONS_SQL}\n"
-    "     ELSE 0 END"
-)
+TOTAL_REACTIONS_GUARDED_SQL = f"""CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''
+          AND json_valid(m.reactions_json) = 1
+     THEN {TOTAL_REACTIONS_SQL}
+     ELSE 0 END"""
 
 
 def _parse_reactions_json(reactions_json: str) -> list[dict]:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -21,6 +21,19 @@ logger = logging.getLogger(__name__)
 _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _EMBEDDING_DIMENSIONS_SETTING = "semantic_embedding_dimensions"
 
+# Sum of all reaction counts for a single message row (m.reactions_json).
+TOTAL_REACTIONS_SQL = (
+    "(SELECT COALESCE(SUM(json_extract(value, '$.count')), 0) FROM json_each(m.reactions_json))"
+)
+# Same sum guarded so it only evaluates for rows holding valid reactions JSON;
+# used inside AVG(...) over arbitrary message rows.
+TOTAL_REACTIONS_GUARDED_SQL = (
+    "CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''\n"
+    "          AND json_valid(m.reactions_json) = 1\n"
+    f"     THEN {TOTAL_REACTIONS_SQL}\n"
+    "     ELSE 0 END"
+)
+
 
 def _parse_reactions_json(reactions_json: str) -> list[dict]:
     """Parse reactions_json string into a list of {emoji, count} dicts."""
@@ -69,6 +82,23 @@ class MessagesRepository:
             next_day = date.fromisoformat(value) + timedelta(days=1)
             return next_day.isoformat(), "<"
         return value, "<="
+
+    def _append_analytics_date_filter(
+        self,
+        conditions: list[str],
+        params: list,
+        date_from: str | None,
+        date_to: str | None,
+    ) -> None:
+        """Append normalized ``m.date`` bounds to analytics conditions/params in place."""
+        normalized_date_from = self._normalize_date_from(date_from)
+        normalized_date_to, date_to_operator = self._normalize_date_to(date_to)
+        if normalized_date_from:
+            conditions.append("m.date >= ?")
+            params.append(normalized_date_from)
+        if normalized_date_to:
+            conditions.append(f"m.date {date_to_operator} ?")
+            params.append(normalized_date_to)
 
     async def _get_setting(self, key: str) -> str | None:
         cur = await self._db.execute("SELECT value FROM settings WHERE key = ?", (key,))
@@ -1245,21 +1275,13 @@ class MessagesRepository:
             "json_valid(m.reactions_json) = 1",
         ]
         params: list = []
-        normalized_date_from = self._normalize_date_from(date_from)
-        normalized_date_to, date_to_operator = self._normalize_date_to(date_to)
-        if normalized_date_from:
-            conditions.append("m.date >= ?")
-            params.append(normalized_date_from)
-        if normalized_date_to:
-            conditions.append(f"m.date {date_to_operator} ?")
-            params.append(normalized_date_to)
+        self._append_analytics_date_filter(conditions, params, date_from, date_to)
         where = " WHERE " + " AND ".join(conditions)
         cur = await self._db.execute(
             f"""SELECT m.id, m.channel_id, m.message_id, m.text, m.media_type,
                        m.date, m.reactions_json,
                        c.title as channel_title, c.username as channel_username,
-                       (SELECT COALESCE(SUM(json_extract(value, '$.count')), 0)
-                        FROM json_each(m.reactions_json)) as total_reactions
+                       {TOTAL_REACTIONS_SQL} as total_reactions
                 FROM messages m{channel_join}
                 {where}
                 ORDER BY total_reactions DESC
@@ -1278,25 +1300,12 @@ class MessagesRepository:
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
         conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
         params: list = []
-        normalized_date_from = self._normalize_date_from(date_from)
-        normalized_date_to, date_to_operator = self._normalize_date_to(date_to)
-        if normalized_date_from:
-            conditions.append("m.date >= ?")
-            params.append(normalized_date_from)
-        if normalized_date_to:
-            conditions.append(f"m.date {date_to_operator} ?")
-            params.append(normalized_date_to)
+        self._append_analytics_date_filter(conditions, params, date_from, date_to)
         where = " WHERE " + " AND ".join(conditions)
         cur = await self._db.execute(
             f"""SELECT COALESCE(m.media_type, 'text') as content_type,
                        COUNT(*) as message_count,
-                       COALESCE(AVG(
-                           CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''
-                                AND json_valid(m.reactions_json) = 1
-                           THEN (SELECT COALESCE(SUM(json_extract(value, '$.count')), 0)
-                                 FROM json_each(m.reactions_json))
-                           ELSE 0 END
-                       ), 0) as avg_reactions
+                       COALESCE(AVG({TOTAL_REACTIONS_GUARDED_SQL}), 0) as avg_reactions
                 FROM messages m{channel_join}
                 {where}
                 GROUP BY content_type
@@ -1315,25 +1324,12 @@ class MessagesRepository:
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
         conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
         params: list = []
-        normalized_date_from = self._normalize_date_from(date_from)
-        normalized_date_to, date_to_operator = self._normalize_date_to(date_to)
-        if normalized_date_from:
-            conditions.append("m.date >= ?")
-            params.append(normalized_date_from)
-        if normalized_date_to:
-            conditions.append(f"m.date {date_to_operator} ?")
-            params.append(normalized_date_to)
+        self._append_analytics_date_filter(conditions, params, date_from, date_to)
         where = " WHERE " + " AND ".join(conditions)
         cur = await self._db.execute(
             f"""SELECT CAST(strftime('%H', m.date) AS INTEGER) as hour,
                        COUNT(*) as message_count,
-                       COALESCE(AVG(
-                           CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''
-                                AND json_valid(m.reactions_json) = 1
-                           THEN (SELECT COALESCE(SUM(json_extract(value, '$.count')), 0)
-                                 FROM json_each(m.reactions_json))
-                           ELSE 0 END
-                       ), 0) as avg_reactions
+                       COALESCE(AVG({TOTAL_REACTIONS_GUARDED_SQL}), 0) as avg_reactions
                 FROM messages m{channel_join}
                 {where}
                 GROUP BY hour

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -92,6 +92,15 @@ class TelegramSearch:
                 # that contract instead of letting the exception escape `async with`.
                 yield self._error_result(query, exc.info.detail, flood_wait=exc.info)
                 return
+            except Exception as exc:
+                # Non-flood warm-up failures (RPC/network/timeout) were likewise
+                # caught per-method and returned as an error SearchResult on main.
+                logger.exception(
+                    "Telegram dialog cache warm-up failed query_hash=%s",
+                    query_log_fields(query)["query_hash"],
+                )
+                yield self._error_result(query, f"Ошибка поиска в Telegram: {exc}")
+                return
             yield session, phone
         finally:
             await self._pool.release_client(phone)

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -84,7 +84,14 @@ class TelegramSearch:
         session, phone = result
         session = adapt_transport_session(session, disconnect_on_close=False)
         try:
-            await self._warm_dialog_cache_if_needed(session, phone)
+            try:
+                await self._warm_dialog_cache_if_needed(session, phone)
+            except HandledFloodWaitError as exc:
+                # Warm-up flood waits were converted to an error SearchResult by
+                # the per-method try/except before the prelude was extracted; keep
+                # that contract instead of letting the exception escape `async with`.
+                yield self._error_result(query, exc.info.detail, flood_wait=exc.info)
+                return
             yield session, phone
         finally:
             await self._pool.release_client(phone)

--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import logging
 import time
+from contextlib import asynccontextmanager
 from datetime import timezone
 
 from src.models import Channel, Message, SearchResult
@@ -56,6 +57,37 @@ class TelegramSearch:
             result = marker(phone)
             if inspect.isawaitable(result):
                 await result
+
+    @staticmethod
+    def _error_result(query: str, error: str, flood_wait=None) -> SearchResult:
+        """Build an empty SearchResult carrying an error (and optional flood wait)."""
+        return SearchResult(messages=[], total=0, query=query, error=error, flood_wait=flood_wait)
+
+    @asynccontextmanager
+    async def _acquire_search_client(self, query: str):
+        """Yield an adapted (session, phone) for a live search, or an error SearchResult.
+
+        Handles the shared prelude (no pool / no available client / transport
+        adaptation / dialog-cache warm-up) and always releases the client on exit.
+        Consumers must check ``isinstance(acquired, SearchResult)`` to detect the
+        error path before using the tuple.
+        """
+        if not self._pool:
+            yield self._error_result(query, "Нет подключённых Telegram-аккаунтов.")
+            return
+
+        result = await self._pool.get_available_client()
+        if result is None:
+            yield self._error_result(query, "Нет доступных Telegram-аккаунтов. Проверьте подключение.")
+            return
+
+        session, phone = result
+        session = adapt_transport_session(session, disconnect_on_close=False)
+        try:
+            await self._warm_dialog_cache_if_needed(session, phone)
+            yield session, phone
+        finally:
+            await self._pool.release_client(phone)
 
     async def _load_search_quota_with_flood_handling(
         self,
@@ -424,27 +456,10 @@ class TelegramSearch:
         return messages, seen_channels
 
     async def search_my_chats(self, query: str, limit: int = 50) -> SearchResult:
-        if not self._pool:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error="Нет подключённых Telegram-аккаунтов.",
-            )
-
-        result = await self._pool.get_available_client()
-        if result is None:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error="Нет доступных Telegram-аккаунтов. Проверьте подключение.",
-            )
-
-        session, phone = result
-        session = adapt_transport_session(session, disconnect_on_close=False)
-        try:
-            await self._warm_dialog_cache_if_needed(session, phone)
+        async with self._acquire_search_client(query) as acquired:
+            if isinstance(acquired, SearchResult):
+                return acquired
+            session, phone = acquired
 
             async def _collect_my_chats() -> tuple[list[Message], dict[int, Channel]]:
                 collected: list[Message] = []
@@ -466,38 +481,26 @@ class TelegramSearch:
                         )
                 return collected, seen
 
-            messages, seen_channels = await run_with_flood_wait(
-                _collect_my_chats(),
-                operation="search_my_chats",
-                phone=phone,
-                pool=self._pool,
-                logger_=logger,
-                timeout=90.0,
-            )
+            try:
+                messages, seen_channels = await run_with_flood_wait(
+                    _collect_my_chats(),
+                    operation="search_my_chats",
+                    phone=phone,
+                    pool=self._pool,
+                    logger_=logger,
+                    timeout=90.0,
+                )
 
-            messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
-            return SearchResult(messages=messages, total=len(messages), query=query)
-        except HandledFloodWaitError as exc:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error=exc.info.detail,
-                flood_wait=exc.info,
-            )
-        except Exception as exc:
-            logger.exception(
-                "Telegram my_chats search failed query_hash=%s",
-                query_log_fields(query)["query_hash"],
-            )
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error=f"Ошибка поиска в Telegram: {exc}",
-            )
-        finally:
-            await self._pool.release_client(phone)
+                messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
+                return SearchResult(messages=messages, total=len(messages), query=query)
+            except HandledFloodWaitError as exc:
+                return self._error_result(query, exc.info.detail, flood_wait=exc.info)
+            except Exception as exc:
+                logger.exception(
+                    "Telegram my_chats search failed query_hash=%s",
+                    query_log_fields(query)["query_hash"],
+                )
+                return self._error_result(query, f"Ошибка поиска в Telegram: {exc}")
 
     async def search_in_channel(
         self,
@@ -505,136 +508,98 @@ class TelegramSearch:
         query: str,
         limit: int = 50,
     ) -> SearchResult:
-        if not self._pool:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error="Нет подключённых Telegram-аккаунтов.",
-            )
-
-        result = await self._pool.get_available_client()
-        if result is None:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error="Нет доступных Telegram-аккаунтов. Проверьте подключение.",
-            )
-
-        session, phone = result
-        session = adapt_transport_session(session, disconnect_on_close=False)
-        try:
-            await self._warm_dialog_cache_if_needed(session, phone)
-
-            entity = None
-            if channel_id:
-                try:
-                    entity = await run_with_flood_wait(
-                        session.resolve_entity(PeerChannel(channel_id)),
-                        operation="search_in_channel_resolve_entity",
-                        phone=phone,
-                        pool=self._pool,
-                        logger_=logger,
-                        timeout=30.0,
-                    )
-                except HandledFloodWaitError:
-                    raise
-                except Exception:
-                    logger.debug(
-                        "PeerChannel(%s) not in cache, trying username fallback",
-                        channel_id,
-                    )
-                    ch_record = await self._persistence._search.channels.get_channel_by_channel_id(
-                        channel_id
-                    )
-                    username = ch_record.username if ch_record else None
-                    if username:
-                        try:
-                            entity = await self._pool.run_live_username_resolve(
-                                lambda: session.resolve_entity(username),
-                                operation="search_in_channel_resolve_username",
-                                phone=phone,
-                                username=str(username),
-                                logger_=logger,
-                                timeout=30.0,
-                            )
-                        except HandledFloodWaitError:
-                            raise
-                        except Exception as exc2:
-                            logger.warning(
-                                "Cannot resolve channel %s (@%s): %s",
-                                channel_id,
-                                username,
-                                exc2,
-                            )
-                            return SearchResult(
-                                messages=[],
-                                total=0,
-                                query=query,
-                                error=f"Не удалось найти канал {channel_id}: {exc2}",
-                            )
-                    else:
-                        return SearchResult(
-                            messages=[],
-                            total=0,
-                            query=query,
-                            error=(
-                                f"Не удалось найти канал {channel_id}"
-                                " (нет username для fallback)"
-                            ),
+        async with self._acquire_search_client(query) as acquired:
+            if isinstance(acquired, SearchResult):
+                return acquired
+            session, phone = acquired
+            try:
+                entity = None
+                if channel_id:
+                    try:
+                        entity = await run_with_flood_wait(
+                            session.resolve_entity(PeerChannel(channel_id)),
+                            operation="search_in_channel_resolve_entity",
+                            phone=phone,
+                            pool=self._pool,
+                            logger_=logger,
+                            timeout=30.0,
                         )
-
-            async def _collect_in_channel() -> tuple[list[Message], dict[int, Channel]]:
-                collected: list[Message] = []
-                seen: dict[int, Channel] = {}
-                async for msg in session.stream_messages(entity, search=query, limit=limit):
-                    converted = TelegramMessageTransformer.convert_telethon_message(msg)
-                    if converted is None:
+                    except HandledFloodWaitError:
+                        raise
+                    except Exception:
                         logger.debug(
-                            "Skipping message in search_in_channel: id=%s has no chat context",
-                            getattr(msg, "id", None),
+                            "PeerChannel(%s) not in cache, trying username fallback",
+                            channel_id,
                         )
-                        continue
-                    collected.append(converted)
-                    if converted.channel_id not in seen:
-                        seen[converted.channel_id] = Channel(
-                            channel_id=converted.channel_id,
-                            title=converted.channel_title,
-                            username=converted.channel_username,
+                        ch_record = await self._persistence._search.channels.get_channel_by_channel_id(
+                            channel_id
                         )
-                return collected, seen
+                        username = ch_record.username if ch_record else None
+                        if username:
+                            try:
+                                entity = await self._pool.run_live_username_resolve(
+                                    lambda: session.resolve_entity(username),
+                                    operation="search_in_channel_resolve_username",
+                                    phone=phone,
+                                    username=str(username),
+                                    logger_=logger,
+                                    timeout=30.0,
+                                )
+                            except HandledFloodWaitError:
+                                raise
+                            except Exception as exc2:
+                                logger.warning(
+                                    "Cannot resolve channel %s (@%s): %s",
+                                    channel_id,
+                                    username,
+                                    exc2,
+                                )
+                                return self._error_result(
+                                    query, f"Не удалось найти канал {channel_id}: {exc2}"
+                                )
+                        else:
+                            return self._error_result(
+                                query,
+                                f"Не удалось найти канал {channel_id} (нет username для fallback)",
+                            )
 
-            messages, seen_channels = await run_with_flood_wait(
-                _collect_in_channel(),
-                operation="search_in_channel",
-                phone=phone,
-                pool=self._pool,
-                logger_=logger,
-                timeout=90.0,
-            )
+                async def _collect_in_channel() -> tuple[list[Message], dict[int, Channel]]:
+                    collected: list[Message] = []
+                    seen: dict[int, Channel] = {}
+                    async for msg in session.stream_messages(entity, search=query, limit=limit):
+                        converted = TelegramMessageTransformer.convert_telethon_message(msg)
+                        if converted is None:
+                            logger.debug(
+                                "Skipping message in search_in_channel: id=%s has no chat context",
+                                getattr(msg, "id", None),
+                            )
+                            continue
+                        collected.append(converted)
+                        if converted.channel_id not in seen:
+                            seen[converted.channel_id] = Channel(
+                                channel_id=converted.channel_id,
+                                title=converted.channel_title,
+                                username=converted.channel_username,
+                            )
+                    return collected, seen
 
-            messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
-            return SearchResult(messages=messages, total=len(messages), query=query)
-        except HandledFloodWaitError as exc:
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error=exc.info.detail,
-                flood_wait=exc.info,
-            )
-        except Exception as exc:
-            logger.exception(
-                "Telegram channel search failed channel_id=%s query_hash=%s",
-                channel_id,
-                query_log_fields(query)["query_hash"],
-            )
-            return SearchResult(
-                messages=[],
-                total=0,
-                query=query,
-                error=f"Ошибка поиска в Telegram: {exc}",
-            )
-        finally:
-            await self._pool.release_client(phone)
+                messages, seen_channels = await run_with_flood_wait(
+                    _collect_in_channel(),
+                    operation="search_in_channel",
+                    phone=phone,
+                    pool=self._pool,
+                    logger_=logger,
+                    timeout=90.0,
+                )
+
+                messages = await self._persistence.cache_messages_and_channels(seen_channels, messages)
+                return SearchResult(messages=messages, total=len(messages), query=query)
+            except HandledFloodWaitError as exc:
+                return self._error_result(query, exc.info.detail, flood_wait=exc.info)
+            except Exception as exc:
+                logger.exception(
+                    "Telegram channel search failed channel_id=%s query_hash=%s",
+                    channel_id,
+                    query_log_fields(query)["query_hash"],
+                )
+                return self._error_result(query, f"Ошибка поиска в Telegram: {exc}")

--- a/src/search/transformers.py
+++ b/src/search/transformers.py
@@ -32,55 +32,9 @@ class TelegramMessageTransformer:
 
     @staticmethod
     def media_type_from_message(msg) -> str | None:
-        from telethon.tl.types import (
-            DocumentAttributeAnimated,
-            DocumentAttributeAudio,
-            DocumentAttributeSticker,
-            DocumentAttributeVideo,
-            MessageMediaContact,
-            MessageMediaDice,
-            MessageMediaDocument,
-            MessageMediaGame,
-            MessageMediaGeo,
-            MessageMediaGeoLive,
-            MessageMediaPhoto,
-            MessageMediaPoll,
-            MessageMediaWebPage,
-        )
+        from src.telegram.media import get_media_type
 
-        media = msg.media
-        if media is None:
-            return None
-        if isinstance(media, MessageMediaPhoto):
-            return "photo"
-        if isinstance(media, MessageMediaDocument):
-            doc = media.document
-            if doc and hasattr(doc, "attributes"):
-                for attr in doc.attributes:
-                    if isinstance(attr, DocumentAttributeSticker):
-                        return "sticker"
-                    if isinstance(attr, DocumentAttributeVideo):
-                        return "video_note" if getattr(attr, "round_message", False) else "video"
-                    if isinstance(attr, DocumentAttributeAudio):
-                        return "voice" if getattr(attr, "voice", False) else "audio"
-                    if isinstance(attr, DocumentAttributeAnimated):
-                        return "gif"
-            return "document"
-        if isinstance(media, MessageMediaWebPage):
-            return "web_page"
-        if isinstance(media, MessageMediaGeo):
-            return "location"
-        if isinstance(media, MessageMediaGeoLive):
-            return "geo_live"
-        if isinstance(media, MessageMediaContact):
-            return "contact"
-        if isinstance(media, MessageMediaPoll):
-            return "poll"
-        if isinstance(media, MessageMediaDice):
-            return "dice"
-        if isinstance(media, MessageMediaGame):
-            return "game"
-        return "unknown"
+        return get_media_type(msg)
 
     @staticmethod
     def convert_telethon_message(msg) -> Message | None:

--- a/src/services/task_handlers/base.py
+++ b/src/services/task_handlers/base.py
@@ -13,6 +13,7 @@ from src.telegram.collector import Collector
 if TYPE_CHECKING:
     from src.database import Database
     from src.search.engine import SearchEngine
+    from src.services.content_generation_service import ContentGenerationService
     from src.services.image_generation_service import ImageGenerationService
     from src.services.photo_auto_upload_service import PhotoAutoUploadService
     from src.services.photo_task_service import PhotoTaskService
@@ -74,3 +75,31 @@ async def resolve_llm_provider_service(context: TaskHandlerContext) -> object:
     from src.services.provider_service import build_provider_service
 
     return await build_provider_service(context.db, context.config)
+
+
+async def build_content_generation_service(context: TaskHandlerContext) -> "ContentGenerationService":
+    """Assemble a ContentGenerationService with its collaborators from the context.
+
+    Shared by the CONTENT_GENERATE and PIPELINE_RUN task handlers so the wiring
+    (draft notifications + image service + provider/quality services) lives in
+    one place.
+    """
+    from src.services.content_generation_service import ContentGenerationService
+    from src.services.draft_notification_service import DraftNotificationService
+    from src.services.quality_scoring_service import QualityScoringService
+
+    db = context.db
+    notification_service = DraftNotificationService(db, context.notifier)
+    image_service = await build_image_service(context)
+    provider_service = await resolve_llm_provider_service(context)
+    quality_service = QualityScoringService(db, provider_service=provider_service)
+    return ContentGenerationService(
+        db,
+        context.search_engine,
+        config=context.config,
+        image_service=image_service,
+        notification_service=notification_service,
+        quality_service=quality_service,
+        client_pool=context.client_pool,
+        provider_service=provider_service,
+    )

--- a/src/services/task_handlers/content.py
+++ b/src/services/task_handlers/content.py
@@ -9,7 +9,7 @@ from src.models import (
     ContentGenerateTaskPayload,
     ContentPublishTaskPayload,
 )
-from src.services.task_handlers.base import TaskHandlerContext, build_image_service, resolve_llm_provider_service
+from src.services.task_handlers.base import TaskHandlerContext, build_content_generation_service
 
 logger = logging.getLogger(__name__)
 
@@ -52,11 +52,8 @@ class ContentTaskHandler:
         pipeline_id = payload.pipeline_id
         try:
             from src.models import PipelinePublishMode
-            from src.services.content_generation_service import ContentGenerationService
-            from src.services.draft_notification_service import DraftNotificationService
             from src.services.pipeline_service import PipelineService
             from src.services.publish_service import PublishService
-            from src.services.quality_scoring_service import QualityScoringService
 
             svc = PipelineService(ctx.pipeline_bundle)
             pipeline = await svc.get(pipeline_id)
@@ -69,20 +66,7 @@ class ContentTaskHandler:
                 return
 
             db = ctx.db
-            notification_service = DraftNotificationService(db, ctx.notifier)
-            image_service = await build_image_service(ctx)
-            provider_service = await resolve_llm_provider_service(ctx)
-            quality_service = QualityScoringService(db, provider_service=provider_service)
-            gen = ContentGenerationService(
-                db,
-                ctx.search_engine,
-                config=ctx.config,
-                image_service=image_service,
-                notification_service=notification_service,
-                quality_service=quality_service,
-                client_pool=ctx.client_pool,
-                provider_service=provider_service,
-            )
+            gen = await build_content_generation_service(ctx)
             run = await gen.generate(pipeline=pipeline, model=pipeline.llm_model)
 
             effective_mode = (

--- a/src/services/task_handlers/pipeline.py
+++ b/src/services/task_handlers/pipeline.py
@@ -4,7 +4,7 @@ import logging
 import time
 
 from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType, PipelineRunTaskPayload
-from src.services.task_handlers.base import TaskHandlerContext, build_image_service, resolve_llm_provider_service
+from src.services.task_handlers.base import TaskHandlerContext, build_content_generation_service
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +43,7 @@ class PipelineTaskHandler:
         pipeline_id = payload.pipeline_id
         run_id: int | None = None
         try:
-            from src.services.content_generation_service import ContentGenerationService
-            from src.services.draft_notification_service import DraftNotificationService
             from src.services.pipeline_service import PipelineService
-            from src.services.quality_scoring_service import QualityScoringService
 
             svc = PipelineService(ctx.pipeline_bundle)
             pipeline = await svc.get(pipeline_id)
@@ -59,20 +56,7 @@ class PipelineTaskHandler:
                 return
 
             db = ctx.db
-            notification_service = DraftNotificationService(db, ctx.notifier)
-            image_service = await build_image_service(ctx)
-            provider_service = await resolve_llm_provider_service(ctx)
-            quality_service = QualityScoringService(db, provider_service=provider_service)
-            gen = ContentGenerationService(
-                db,
-                ctx.search_engine,
-                config=ctx.config,
-                image_service=image_service,
-                notification_service=notification_service,
-                quality_service=quality_service,
-                client_pool=ctx.client_pool,
-                provider_service=provider_service,
-            )
+            gen = await build_content_generation_service(ctx)
             started_at = time.monotonic()
             try:
                 run = await gen.generate(

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -95,26 +95,35 @@ class TelegramTransportSession:
             report_flood_wait=report_flood_wait,
         )
 
+    async def _translate_flood_wait(self, exc: Exception, operation: str) -> HandledFloodWaitError:
+        """Convert a raw Telethon FloodWaitError into a HandledFloodWaitError.
+
+        Re-raises ``exc`` unchanged when it is not a FloodWaitError or when no
+        phone is bound. Otherwise records the flood wait and returns the wrapped
+        error for the caller to ``raise ... from exc``.
+        """
+        from telethon.errors import FloodWaitError
+
+        if not isinstance(exc, FloodWaitError):
+            raise exc
+        if self._phone is None:
+            raise exc
+        info = await handle_flood_wait(
+            exc,
+            operation=operation,
+            phone=self._phone,
+            pool=self._pool if self._report_flood_wait else None,
+            logger_=self._logger,
+        )
+        return HandledFloodWaitError(info)
+
     async def _run(self, operation: str, awaitable: Any) -> Any:
         try:
             return await awaitable
         except HandledFloodWaitError:
             raise
         except Exception as exc:
-            from telethon.errors import FloodWaitError
-
-            if not isinstance(exc, FloodWaitError):
-                raise
-            if self._phone is None:
-                raise
-            info = await handle_flood_wait(
-                exc,
-                operation=operation,
-                phone=self._phone,
-                pool=self._pool if self._report_flood_wait else None,
-                logger_=self._logger,
-            )
-            raise HandledFloodWaitError(info) from exc
+            raise await self._translate_flood_wait(exc, operation) from exc
 
     async def _stream(self, operation: str, iterator: AsyncIterator[Any]) -> AsyncIterator[Any]:
         try:
@@ -141,20 +150,7 @@ class TelegramTransportSession:
         except HandledFloodWaitError:
             raise
         except Exception as exc:
-            from telethon.errors import FloodWaitError
-
-            if not isinstance(exc, FloodWaitError):
-                raise
-            if self._phone is None:
-                raise
-            info = await handle_flood_wait(
-                exc,
-                operation=operation,
-                phone=self._phone,
-                pool=self._pool if self._report_flood_wait else None,
-                logger_=self._logger,
-            )
-            raise HandledFloodWaitError(info) from exc
+            raise await self._translate_flood_wait(exc, operation) from exc
 
     async def close(self) -> None:
         if self._disconnect_on_close:

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -10,19 +10,6 @@ from inspect import isawaitable
 
 from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import (
-    DocumentAttributeAnimated,
-    DocumentAttributeAudio,
-    DocumentAttributeSticker,
-    DocumentAttributeVideo,
-    MessageMediaContact,
-    MessageMediaDice,
-    MessageMediaDocument,
-    MessageMediaGame,
-    MessageMediaGeo,
-    MessageMediaGeoLive,
-    MessageMediaPhoto,
-    MessageMediaPoll,
-    MessageMediaWebPage,
     PeerChannel,
 )
 
@@ -648,39 +635,9 @@ class Collector:
     @staticmethod
     def _get_media_type(msg) -> str | None:
         """Determine media type from a Telethon message."""
-        media = msg.media
-        if media is None:
-            return None
-        if isinstance(media, MessageMediaPhoto):
-            return "photo"
-        if isinstance(media, MessageMediaDocument):
-            doc = media.document
-            if doc and hasattr(doc, "attributes"):
-                for attr in doc.attributes:
-                    if isinstance(attr, DocumentAttributeSticker):
-                        return "sticker"
-                    if isinstance(attr, DocumentAttributeVideo):
-                        return "video_note" if getattr(attr, "round_message", False) else "video"
-                    if isinstance(attr, DocumentAttributeAudio):
-                        return "voice" if getattr(attr, "voice", False) else "audio"
-                    if isinstance(attr, DocumentAttributeAnimated):
-                        return "gif"
-            return "document"
-        if isinstance(media, MessageMediaWebPage):
-            return "web_page"
-        if isinstance(media, MessageMediaGeo):
-            return "location"
-        if isinstance(media, MessageMediaGeoLive):
-            return "geo_live"
-        if isinstance(media, MessageMediaContact):
-            return "contact"
-        if isinstance(media, MessageMediaPoll):
-            return "poll"
-        if isinstance(media, MessageMediaDice):
-            return "dice"
-        if isinstance(media, MessageMediaGame):
-            return "game"
-        return "unknown"
+        from src.telegram.media import get_media_type
+
+        return get_media_type(msg)
 
     async def _release_collection_client(
         self,

--- a/src/telegram/media.py
+++ b/src/telegram/media.py
@@ -1,0 +1,62 @@
+"""Shared media-type classification for Telethon messages.
+
+Single source of truth used by both the search transformer
+(:class:`~src.search.transformers.TelegramMessageTransformer`) and the
+collector (:class:`~src.telegram.collector.Collector`) so that adding a new
+media type updates classification everywhere at once.
+"""
+
+from __future__ import annotations
+
+
+def get_media_type(msg) -> str | None:
+    """Determine the media type from a Telethon message."""
+    from telethon.tl.types import (
+        DocumentAttributeAnimated,
+        DocumentAttributeAudio,
+        DocumentAttributeSticker,
+        DocumentAttributeVideo,
+        MessageMediaContact,
+        MessageMediaDice,
+        MessageMediaDocument,
+        MessageMediaGame,
+        MessageMediaGeo,
+        MessageMediaGeoLive,
+        MessageMediaPhoto,
+        MessageMediaPoll,
+        MessageMediaWebPage,
+    )
+
+    media = msg.media
+    if media is None:
+        return None
+    if isinstance(media, MessageMediaPhoto):
+        return "photo"
+    if isinstance(media, MessageMediaDocument):
+        doc = media.document
+        if doc and hasattr(doc, "attributes"):
+            for attr in doc.attributes:
+                if isinstance(attr, DocumentAttributeSticker):
+                    return "sticker"
+                if isinstance(attr, DocumentAttributeVideo):
+                    return "video_note" if getattr(attr, "round_message", False) else "video"
+                if isinstance(attr, DocumentAttributeAudio):
+                    return "voice" if getattr(attr, "voice", False) else "audio"
+                if isinstance(attr, DocumentAttributeAnimated):
+                    return "gif"
+        return "document"
+    if isinstance(media, MessageMediaWebPage):
+        return "web_page"
+    if isinstance(media, MessageMediaGeo):
+        return "location"
+    if isinstance(media, MessageMediaGeoLive):
+        return "geo_live"
+    if isinstance(media, MessageMediaContact):
+        return "contact"
+    if isinstance(media, MessageMediaPoll):
+        return "poll"
+    if isinstance(media, MessageMediaDice):
+        return "dice"
+    if isinstance(media, MessageMediaGame):
+        return "game"
+    return "unknown"

--- a/src/web/pipelines/forms.py
+++ b/src/web/pipelines/forms.py
@@ -93,17 +93,7 @@ class PipelineCreateForm(_FrozenForm):
     is_active: bool = False
 
 
-class PipelineEditForm(_FrozenForm):
-    name: str = ""
-    prompt_template: str = ""
-    source_channel_ids: list[int] = Field(default_factory=list)
-    target_refs: list[str] = Field(default_factory=list)
-    llm_model: str = ""
-    image_model: str = ""
-    publish_mode: str = "moderated"
-    generation_backend: str = "chain"
-    generate_interval_minutes: int = 60
-    is_active: bool = False
+class PipelineEditForm(PipelineCreateForm):
     react_emoji: str = ""
     filter_present: str = ""
     filter_message_kinds: list[str] = Field(default_factory=list)

--- a/src/web/pipelines/forms.py
+++ b/src/web/pipelines/forms.py
@@ -80,7 +80,9 @@ class CreateWizardForm(_FrozenForm):
     account_phone: str = ""
 
 
-class PipelineCreateForm(_FrozenForm):
+class _PipelineFormBase(_FrozenForm):
+    """Fields shared by the pipeline create and edit forms."""
+
     name: str = ""
     prompt_template: str = ""
     source_channel_ids: list[int] = Field(default_factory=list)
@@ -93,7 +95,11 @@ class PipelineCreateForm(_FrozenForm):
     is_active: bool = False
 
 
-class PipelineEditForm(PipelineCreateForm):
+class PipelineCreateForm(_PipelineFormBase):
+    pass
+
+
+class PipelineEditForm(_PipelineFormBase):
     react_emoji: str = ""
     filter_present: str = ""
     filter_message_kinds: list[str] = Field(default_factory=list)

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from src.web import deps
 from src.web.search_queries import handlers
-from src.web.search_queries.forms import SearchQueryForm
+from src.web.search_queries.forms import SearchQueryForm, search_query_form
 from src.web.search_queries.responses import search_query_response
 
 router = APIRouter()
@@ -36,27 +36,8 @@ async def search_queries_page(request: Request):
 @router.post("/add")
 async def add_search_query(
     request: Request,
-    query: str = Form(""),
-    interval_minutes: int = Form(60),
-    is_regex: bool = Form(False),
-    is_fts: bool = Form(False),
-    notify_on_collect: bool = Form(False),
-    track_stats: bool = Form(False),
-    exclude_patterns: str = Form(""),
-    max_length: int | None = Form(None),
-    chat_filter: str = Form(""),
+    form: SearchQueryForm = Depends(search_query_form),
 ):
-    form = SearchQueryForm(
-        query=query,
-        interval_minutes=interval_minutes,
-        is_regex=is_regex,
-        is_fts=is_fts,
-        notify_on_collect=notify_on_collect,
-        track_stats=track_stats,
-        exclude_patterns=exclude_patterns,
-        max_length=max_length,
-        chat_filter=chat_filter,
-    )
     return search_query_response(request, await handlers.add_search_query(request, form))
 
 
@@ -69,27 +50,8 @@ async def toggle_search_query(request: Request, sq_id: int):
 async def edit_search_query(
     request: Request,
     sq_id: int,
-    query: str = Form(""),
-    interval_minutes: int = Form(60),
-    is_regex: bool = Form(False),
-    is_fts: bool = Form(False),
-    notify_on_collect: bool = Form(False),
-    track_stats: bool = Form(False),
-    exclude_patterns: str = Form(""),
-    max_length: int | None = Form(None),
-    chat_filter: str = Form(""),
+    form: SearchQueryForm = Depends(search_query_form),
 ):
-    form = SearchQueryForm(
-        query=query,
-        interval_minutes=interval_minutes,
-        is_regex=is_regex,
-        is_fts=is_fts,
-        notify_on_collect=notify_on_collect,
-        track_stats=track_stats,
-        exclude_patterns=exclude_patterns,
-        max_length=max_length,
-        chat_filter=chat_filter,
-    )
     return search_query_response(request, await handlers.edit_search_query(request, sq_id, form))
 
 

--- a/src/web/search_queries/forms.py
+++ b/src/web/search_queries/forms.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from fastapi import Form
+
 
 @dataclass(frozen=True)
 class SearchQueryForm:
@@ -16,3 +18,31 @@ class SearchQueryForm:
     exclude_patterns: str = ""
     max_length: int | None = None
     chat_filter: str = ""
+
+
+def search_query_form(
+    query: str = Form(""),
+    interval_minutes: int = Form(60),
+    is_regex: bool = Form(False),
+    is_fts: bool = Form(False),
+    notify_on_collect: bool = Form(False),
+    track_stats: bool = Form(False),
+    exclude_patterns: str = Form(""),
+    max_length: int | None = Form(None),
+    chat_filter: str = Form(""),
+) -> SearchQueryForm:
+    """FastAPI dependency assembling a SearchQueryForm from posted form fields.
+
+    Shared by the add and edit routes so the nine field declarations live once.
+    """
+    return SearchQueryForm(
+        query=query,
+        interval_minutes=interval_minutes,
+        is_regex=is_regex,
+        is_fts=is_fts,
+        notify_on_collect=notify_on_collect,
+        track_stats=track_stats,
+        exclude_patterns=exclude_patterns,
+        max_length=max_length,
+        chat_filter=chat_filter,
+    )


### PR DESCRIPTION
Закрывает большую часть #807. По одному коммиту на пункт; поведение не менялось, только убраны копии. После каждого пункта — ruff + относящиеся тесты.

## Приоритет 1 — реальные клоны логики
- **п.1** `_get_media_type` → общий `src/telegram/media.py`; `transformers.py` и `collector.py` делегируют (убраны 13 Telethon-импортов из collector).
- **п.2** замыкание `_build_image_service` в `agent/tools/images.py` → импорт `build_image_service` из `_pipeline_runtime`.
- **п.3** сборка `ContentGenerationService` в `task_handlers/content.py` ≡ `pipeline.py` → фабрика `build_content_generation_service` в `base.py`.

## Приоритет 2 — системные паттерны
- **п.10** flood-wait в `backends.py` (`_run`≡`_stream`) → `_translate_flood_wait`.
- **п.9** analytics SQL в `repositories/messages.py` → `_append_analytics_date_filter` + константы `TOTAL_REACTIONS_SQL`/`TOTAL_REACTIONS_GUARDED_SQL` (текст SQL неизменён).
- **п.6** прелюдия клиента в `telegram_search.py` (`search_my_chats`≡`search_in_channel`) → async-contextmanager `_acquire_search_client` + `_error_result` (flood-wait конвертация сохранена).
- **п.7** add/edit search-query роуты → FastAPI-зависимость `search_query_form` через `Depends`; `PipelineEditForm` наследует `PipelineCreateForm`.
- **п.8** CLI `dialogs`: резолв аккаунта (18 копий) + парсинг message_ids + confirm → `_resolve_phone`/`_parse_message_ids`/`_confirm_or_abort`.

## Не вошло
- **п.4** (`SearchParams`) — вынесен в #810: широкий рефакторинг публичного search-API через 6 слоёв, косметическая выгода, высокий риск регрессии.
- **п.5** (facade-прокси) — incidental-пункт; в этом PR код facade-обёрток не затрагивался, отдельных удалений нет.
- photo_loader send/schedule (часть п.7) — общий пролог различается payload'ом, это логика хендлеров, не дубль форм.

## Проверка
- ruff ✓, `lint-imports` ✓ (включая контракт «telegram-entrypoints не импортируют Telethon напрямую» — важно для п.1)
- parallel-сьют: 7738 passed; serial: 853 passed
- 3 предсуществующих `ScopeMismatch`-ошибки в `test_provider_runtime_integration.py` воспроизводятся на чистом `main` — не связаны с этим PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)