### PR TITLE
fix(limits): persist daily cost across restarts (#233)

### DIFF
--- a/src/services/production_limits_service.py
+++ b/src/services/production_limits_service.py
@@ -9,12 +9,18 @@ from typing import TYPE_CHECKING, Awaitable, Callable, TypeVar
 from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt
 from tenacity.wait import wait_exponential_jitter
 
+from src.utils.json import safe_json_dumps, safe_json_loads_dict
+
 if TYPE_CHECKING:
     from src.database import Database
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+# settings key under which the daily cost counter is persisted so it survives restarts (#233)
+_COST_STATE_KEY = "production_limits_daily_cost"
+_DAY_SECONDS = 86400
 
 
 class _AcquireLimitError(RuntimeError):
@@ -154,11 +160,63 @@ class RateLimiter:
 class CostTracker:
     """Track and enforce cost caps for API usage."""
 
-    def __init__(self, config: CostConfig | None = None):
+    def __init__(self, config: CostConfig | None = None, db: "Database | None" = None):
         self._config = config or CostConfig()
         self._daily_cost = 0.0
         self._day_start = time.time()
         self._lock = asyncio.Lock()
+        # When a DB is provided, the daily cost is persisted to the settings table and
+        # restored lazily on first use so a process restart cannot reset the counter and
+        # let usage blow past daily_cost_cap (#233). db=None keeps pure in-memory behaviour.
+        self._db = db
+        self._loaded = False
+
+    async def _ensure_loaded(self) -> None:
+        """Restore the persisted daily cost on first use. Must be called under self._lock."""
+        if self._db is None or self._loaded:
+            return
+        self._loaded = True
+        try:
+            raw = await self._db.get_setting(_COST_STATE_KEY)
+        except Exception:
+            logger.warning("CostTracker: failed to load persisted daily cost", exc_info=True)
+            return
+        state = safe_json_loads_dict(raw)
+        if not state:
+            return
+        try:
+            day_start = float(state["day_start"])
+            daily_cost = float(state["daily_cost"])
+        except (KeyError, TypeError, ValueError):
+            logger.warning("CostTracker: malformed persisted daily cost: %r", raw)
+            return
+        # Only restore if the saved window is still the current day; otherwise start fresh.
+        if time.time() - day_start < _DAY_SECONDS:
+            self._daily_cost = daily_cost
+            self._day_start = day_start
+
+    def _maybe_reset_day(self, now: float) -> bool:
+        """Reset the daily counter when the day window rolls over. Caller holds self._lock.
+
+        Returns True if a reset happened, so callers can decide whether to persist.
+        """
+        if now - self._day_start >= _DAY_SECONDS:
+            self._daily_cost = 0.0
+            self._day_start = now
+            return True
+        return False
+
+    async def _persist(self) -> None:
+        """Persist the current daily cost. Must be called under self._lock."""
+        if self._db is None:
+            return
+        try:
+            await self._db.set_setting(
+                _COST_STATE_KEY,
+                safe_json_dumps({"daily_cost": self._daily_cost, "day_start": self._day_start}),
+            )
+        except Exception:
+            logger.warning("CostTracker: failed to persist daily cost", exc_info=True)
 
     async def estimate_cost(
         self,
@@ -193,10 +251,9 @@ class CostTracker:
             Tuple of (allowed, estimated_cost)
         """
         async with self._lock:
-            now = time.time()
-            if now - self._day_start >= 86400:
-                self._daily_cost = 0.0
-                self._day_start = now
+            await self._ensure_loaded()
+            if self._maybe_reset_day(time.time()):
+                await self._persist()
 
             estimated = await self.estimate_cost(tokens, is_image)
 
@@ -208,13 +265,12 @@ class CostTracker:
     async def record_cost(self, tokens: int = 0, is_image: bool = False) -> float:
         """Record cost for a request after it actually executes."""
         async with self._lock:
-            now = time.time()
-            if now - self._day_start >= 86400:
-                self._daily_cost = 0.0
-                self._day_start = now
+            await self._ensure_loaded()
+            self._maybe_reset_day(time.time())
 
             estimated = await self.estimate_cost(tokens, is_image)
             self._daily_cost += estimated
+            await self._persist()
             return estimated
 
     def get_daily_cost(self) -> float:
@@ -243,7 +299,7 @@ class ProductionLimitsService:
     ):
         self._db = db
         self._rate_limiter = RateLimiter(rate_config)
-        self._cost_tracker = CostTracker(cost_config)
+        self._cost_tracker = CostTracker(cost_config, db=db)
 
     async def acquire(
         self,

--- a/src/services/production_limits_service.py
+++ b/src/services/production_limits_service.py
@@ -175,12 +175,17 @@ class CostTracker:
         """Restore the persisted daily cost on first use. Must be called under self._lock."""
         if self._db is None or self._loaded:
             return
-        self._loaded = True
         try:
             raw = await self._db.get_setting(_COST_STATE_KEY)
         except Exception:
+            # Leave _loaded False so a transient startup error (e.g. SQLite busy) is retried
+            # on the next call instead of silently disabling persistence for the whole
+            # process — which would let a restart reset the counter past daily_cost_cap.
             logger.warning("CostTracker: failed to load persisted daily cost", exc_info=True)
             return
+        # A successful read (even of malformed/empty state) is authoritative — mark loaded so
+        # we don't re-read every call; retrying only helps when the read itself failed.
+        self._loaded = True
         state = safe_json_loads_dict(raw)
         if not state:
             return

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -270,6 +270,29 @@ async def test_cost_tracker_db_error_does_not_break_tracking():
     assert tracker.get_daily_cost() == 2.0
 
 
+@pytest.mark.anyio
+async def test_cost_tracker_transient_load_error_is_retried(db):
+    """A transient load failure must not permanently disable persistence (#813 review)."""
+    cfg = CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0)
+
+    # Seed a persisted value via a healthy tracker.
+    seed = CostTracker(cfg, db=db)
+    await seed.record_cost(tokens=4000)  # 4.0
+    persisted = await db.get_setting("production_limits_daily_cost")
+
+    # Restart with a DB whose first get_setting fails transiently, then recovers.
+    flaky = SimpleNamespace(
+        get_setting=AsyncMock(side_effect=[RuntimeError("busy"), persisted]),
+        set_setting=db.set_setting,
+    )
+
+    tracker = CostTracker(cfg, db=flaky)
+    await tracker.check_cost_cap(tokens=0)  # first load raises -> _loaded stays False
+    assert tracker.get_daily_cost() == 0.0
+    await tracker.check_cost_cap(tokens=0)  # retry succeeds -> restores 4.0
+    assert tracker.get_daily_cost() == 4.0
+
+
 # === ProductionLimitsService tests ===
 
 

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -207,6 +207,69 @@ async def test_cost_tracker_day_reset():
         assert tracker.get_daily_cost() == 0.0
 
 
+# === CostTracker persistence tests (#233) ===
+
+
+@pytest.mark.anyio
+async def test_cost_tracker_persists_across_restart(db):
+    """Daily cost survives a process restart: a fresh tracker on the same DB restores it."""
+    cfg = CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0)
+
+    tracker = CostTracker(cfg, db=db)
+    await tracker.record_cost(tokens=3000)  # 3.0
+    assert tracker.get_daily_cost() == 3.0
+
+    # Simulate a restart: brand-new tracker, same DB, zeroed in-memory state.
+    restarted = CostTracker(cfg, db=db)
+    assert restarted.get_daily_cost() == 0.0  # not loaded yet
+    # check_cost_cap triggers the lazy load.
+    await restarted.check_cost_cap(tokens=0)
+    assert restarted.get_daily_cost() == 3.0
+
+
+@pytest.mark.anyio
+async def test_cost_tracker_stale_day_not_restored(db):
+    """A persisted cost from a previous day is discarded, not carried into the new day."""
+    cfg = CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0)
+
+    fake_time = 5000.0
+    with patch("src.services.production_limits_service.time.time", return_value=fake_time):
+        tracker = CostTracker(cfg, db=db)
+        await tracker.record_cost(tokens=3000)  # persisted with day_start=5000
+
+    # Next day: more than 24h later -> stale state must not be restored.
+    with patch("src.services.production_limits_service.time.time", return_value=fake_time + 86401):
+        restarted = CostTracker(cfg, db=db)
+        await restarted.check_cost_cap(tokens=0)
+        assert restarted.get_daily_cost() == 0.0
+
+
+@pytest.mark.anyio
+async def test_cost_tracker_no_db_is_in_memory():
+    """Without a DB the tracker stays pure in-memory (no persistence, no errors)."""
+    tracker = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0))
+    await tracker.record_cost(tokens=2000)  # 2.0
+
+    # A fresh tracker without DB knows nothing of the previous one.
+    fresh = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0))
+    await fresh.check_cost_cap(tokens=0)
+    assert fresh.get_daily_cost() == 0.0
+
+
+@pytest.mark.anyio
+async def test_cost_tracker_db_error_does_not_break_tracking():
+    """A failing DB degrades gracefully: in-memory tracking continues."""
+    broken_db = SimpleNamespace(
+        get_setting=AsyncMock(side_effect=RuntimeError("db down")),
+        set_setting=AsyncMock(side_effect=RuntimeError("db down")),
+    )
+    tracker = CostTracker(CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0), db=broken_db)
+
+    cost = await tracker.record_cost(tokens=2000)  # load + persist both raise, swallowed
+    assert cost == 2.0
+    assert tracker.get_daily_cost() == 2.0
+
+
 # === ProductionLimitsService tests ===
 
 


### PR DESCRIPTION
## Что и зачем

Аудит #791 («5 закрытых bug-issues без реального фикса») подтвердил, что **#233 был закрыт, но никогда не реализован**. `CostTracker` хранил дневную стоимость только в памяти (`self._daily_cost = 0.0` в `__init__`, сброс по `time.time()`). После рестарта процесса счётчик обнулялся → дневной лимит `daily_cost_cap` можно было превысить кратно, рестартуя воркер во время дорогой генерации изображений/LLM. `db` в сервис передавался, но не использовался.

## Изменения

- `CostTracker.__init__` принимает опциональный `db`; `db=None` сохраняет прежнее чистое in-memory поведение (важно — множество тестов конструируют трекер без БД).
- `_ensure_loaded()` — лениво восстанавливает `{daily_cost, day_start}` из `settings` при первом обращении; протухшее (другие сутки) состояние не восстанавливается.
- `_persist()` — пишет состояние после каждого `record_cost` и при сбросе дня.
- Ошибки БД поглощаются с `logger.warning(exc_info=True)` — трекинг не падает.
- `_maybe_reset_day()` — общий helper для day-reset (устранено дублирование между `check_cost_cap` и `record_cost`).
- `ProductionLimitsService` пробрасывает `db` в трекер.

## Тесты

4 новых теста: persist-across-restart, stale-day-reset, no-db-in-memory, db-error-graceful. Все 28 тестов в файле зелёные с `-W error`, ruff чисто.

## Вне скоупа (follow-up)

`ProductionLimitsService` нигде не вызывается в боевом коде — даже с persistence он не защищает бюджет в проде, пока его не подключат к LLM/image-вызовам. Это отдельная проблема, требует отдельного issue. Также `RateLimiter` (minute/day token counts) не персистится — асимметрично, но вне scope #233.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)