### PR TITLE
fix(telegram): per-account resolve_username backoff with rotation (#790)

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -18,6 +18,17 @@ def _pending_key(phone: str) -> str:
     return f"auth_pending:{phone}"
 
 
+async def _load_resolve_backoffs(db, *, now: datetime) -> dict[str, datetime]:
+    """Read active per-phone resolve_username backoff deadlines from settings (#790)."""
+    from src.telegram.resolve_guard import (
+        RESOLVE_BACKOFF_BY_PHONE_SETTING,
+        parse_resolve_backoff_setting,
+    )
+
+    raw = await db.get_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING)
+    return parse_resolve_backoff_setting(raw, now=now)
+
+
 async def _resolve_credentials(args: argparse.Namespace, config, db) -> tuple[int, str]:
     api_id = getattr(args, "api_id", None) or config.telegram.api_id
     api_hash = getattr(args, "api_hash", None) or config.telegram.api_hash
@@ -202,9 +213,10 @@ def run(args: argparse.Namespace) -> None:
                     print("No accounts found.")
                     return
                 now = datetime.now(timezone.utc)
-                fmt = "{:<16} {:<28} {:<14}"
-                print(fmt.format("Phone", "Flood wait until", "Remaining"))
-                print("-" * 60)
+                resolve_backoffs = await _load_resolve_backoffs(db, now=now)
+                fmt = "{:<16} {:<28} {:<14} {:<18}"
+                print(fmt.format("Phone", "Flood wait until", "Remaining", "Resolve backoff"))
+                print("-" * 78)
                 for acc in accounts:
                     if acc.flood_wait_until is None:
                         until_str = "OK"
@@ -220,7 +232,12 @@ def run(args: argparse.Namespace) -> None:
                         else:
                             until_str = "OK (expired)"
                             remaining_str = ""
-                    print(fmt.format(acc.phone, until_str, remaining_str))
+                    resolve_until = resolve_backoffs.get(acc.phone)
+                    if resolve_until is None:
+                        resolve_str = ""
+                    else:
+                        resolve_str = f"{int((resolve_until - now).total_seconds())}s"
+                    print(fmt.format(acc.phone, until_str, remaining_str, resolve_str))
             elif args.account_action == "flood-clear":
                 accounts = await db.get_account_summaries(active_only=False)
                 acc = next((a for a in accounts if a.phone == args.phone), None)

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -20,6 +20,7 @@ from src.services.channel_service import ChannelService
 from src.telegram.backends import adapt_transport_session
 from src.telegram.collector import (
     RESOLVE_USERNAME_BACKOFF_BUFFER_SEC,
+    AllCollectionClientsFloodedError,
     Collector,
     UsernameResolveFloodWaitDeferredError,
     UsernameResolveRateLimitedError,
@@ -518,6 +519,18 @@ def run(args: argparse.Namespace) -> None:
                     print(
                         "Collection deferred: resolve_username rate-limited "
                         f"on {exc.phone} until {run_after.astimezone().isoformat()}"
+                    )
+                except AllCollectionClientsFloodedError as exc:
+                    run_after = exc.next_available_at
+                    note = (
+                        "Отложено: все аккаунты в Flood Wait до "
+                        f"{run_after.astimezone().isoformat()}"
+                    )
+                    await db.reschedule_collection_task(task_id, run_after=run_after, note=note)
+                    print(
+                        "Collection deferred: all accounts flood-waited until "
+                        f"{run_after.astimezone().isoformat()} "
+                        f"(retry in {exc.retry_after_sec}s)"
                     )
                 except Exception as exc:
                     await db.update_collection_task(

--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -9,10 +9,36 @@ from src.database.bundles import ChannelBundle
 from src.services.collection_service import CollectionService
 from src.services.task_enqueuer import TaskEnqueuer
 from src.telegram.collector import (
+    AllCollectionClientsFloodedError,
     Collector,
     UsernameResolveFloodWaitDeferredError,
     UsernameResolveRateLimitedError,
 )
+
+
+def print_resolve_backoff_warning(pool) -> None:
+    """Print active per-account resolve_username backoffs, if any (#790)."""
+    get_remaining = getattr(pool, "get_resolve_username_backoff_remaining_sec", None)
+    if not callable(get_remaining):
+        return
+    active: dict[str, int] = {}
+    for phone in getattr(pool, "clients", {}) or {}:
+        try:
+            remaining = int(get_remaining(phone))
+        except TypeError:
+            return
+        except ValueError:
+            continue
+        if remaining > 0:
+            active[str(phone)] = remaining
+    if not active:
+        return
+    parts = ", ".join(f"{phone} ({sec}s left)" for phone, sec in sorted(active.items()))
+    print(
+        f"Warning: resolve_username Flood Wait active on: {parts}. "
+        "Username channels are rotated to free accounts; if every account is "
+        "blocked they are deferred."
+    )
 
 
 def run(args: argparse.Namespace) -> None:
@@ -57,6 +83,13 @@ def run(args: argparse.Namespace) -> None:
                         f"on {exc.phone}; deferred until {retry_at}."
                     )
                     return
+                except AllCollectionClientsFloodedError as exc:
+                    retry_at = exc.next_available_at.astimezone().isoformat()
+                    print(
+                        f"All accounts are flood-waited until {retry_at} "
+                        f"(retry in {exc.retry_after_sec}s); try again later."
+                    )
+                    return
                 print(f"Collected {count} messages from channel {args.channel_id}")
             else:
                 channel_bundle = ChannelBundle.from_database(db)
@@ -73,6 +106,7 @@ def run(args: argparse.Namespace) -> None:
                     f"total {result.total_candidates}). "
                     f"Run 'serve' to execute tasks."
                 )
+                print_resolve_backoff_warning(pool)
         finally:
             await pool.disconnect_all()
             await db.close()

--- a/src/cli/commands/scheduler.py
+++ b/src/cli/commands/scheduler.py
@@ -11,21 +11,30 @@ from src.services.collection_service import CollectionService
 from src.services.task_enqueuer import TaskEnqueuer
 from src.telegram.collector import Collector
 
+# Only these actions actually talk to Telegram; everything else is a pure DB
+# operation and must not pay (or risk) a full multi-account pool connect.
+_POOL_REQUIRED_ACTIONS = frozenset({"start", "trigger"})
+
 
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         config, db = await runtime.init_db(args.config)
-        _, pool = await runtime.init_pool(config, db)
+        pool = None
+        collection_service = None
+        task_enqueuer = None
 
         try:
-            if not pool.clients:
-                logging.error("No connected accounts.")
-                return
-
-            collector = Collector(pool, db, config.scheduler)
-            channel_bundle = ChannelBundle.from_database(db)
-            collection_service = CollectionService(channel_bundle, collector, collection_queue=None)
-            task_enqueuer = TaskEnqueuer(db, collection_service)
+            if args.scheduler_action in _POOL_REQUIRED_ACTIONS:
+                _, pool = await runtime.init_pool(config, db)
+                if not pool.clients:
+                    logging.error("No connected accounts.")
+                    return
+                collector = Collector(pool, db, config.scheduler)
+                channel_bundle = ChannelBundle.from_database(db)
+                collection_service = CollectionService(
+                    channel_bundle, collector, collection_queue=None
+                )
+                task_enqueuer = TaskEnqueuer(db, collection_service)
 
             if args.scheduler_action == "start":
                 manager = SchedulerManager(
@@ -119,7 +128,8 @@ def run(args: argparse.Namespace) -> None:
                 await db.set_setting("collection_queue_paused", "0")
                 print("Collection queue resumed.")
         finally:
-            await pool.disconnect_all()
+            if pool is not None:
+                await pool.disconnect_all()
             await db.close()
 
     asyncio.run(_run())

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -92,6 +92,17 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
     elif callable(getattr(type(container.pool), "is_warming", None)):
         is_warming_method = getattr(container.pool, "is_warming")
     is_warming = bool(is_warming_method()) if callable(is_warming_method) else False
+    # Per-phone live-resolve backoff deadlines (#790) — surfaced for web parity.
+    resolve_backoffs: dict[str, str] = {}
+    get_backoff_until = getattr(container.pool, "get_resolve_username_backoff_until", None)
+    if callable(get_backoff_until):
+        for phone in connected_phones:
+            try:
+                until = get_backoff_until(phone)
+            except TypeError:
+                break
+            if isinstance(until, datetime):
+                resolve_backoffs[phone] = until.isoformat()
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="worker_heartbeat",
@@ -106,6 +117,7 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 "connected_count": len(connected_phones),
                 "available_phones": sorted(available_phones),
                 "flood_waits": flood_waits,
+                "resolve_backoffs": resolve_backoffs,
                 "is_warming": is_warming,
                 "timestamp": now.isoformat(),
             },

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -121,9 +121,9 @@ class ClientPool(ResolveGuardMixin):
         self._dialog_refresh_tasks: dict[tuple[str, str], asyncio.Task[list[dict]]] = {}
         self._premium_flood_wait_until: dict[str, datetime] = {}
         self._resolve_rate_limiter = ResolveRateLimiter()
-        self._resolve_username_backoff_until_utc: datetime | None = None
-        self._resolve_ramp_up_until_utc: datetime | None = None
-        self._resolve_ramp_up_last_call_utc: datetime | None = None
+        self._resolve_username_backoff_until_utc: dict[str, datetime] = {}
+        self._resolve_ramp_up_until_utc: dict[str, datetime] = {}
+        self._resolve_ramp_up_last_call_utc: dict[str, datetime] = {}
         self._resolve_ramp_up_min_interval_sec: float = 5.0
 
     def is_dialogs_fetched(self, phone: str) -> bool:
@@ -528,8 +528,12 @@ class ClientPool(ResolveGuardMixin):
 
     async def initialize(self, *, phones: Iterable[str] | None = None) -> None:
         """Load active accounts and validate that their sessions are usable."""
-        await self.restore_resolve_username_backoff(self._db)
         accounts = await load_live_usable_accounts(self._db, active_only=True)
+        # Restore after loading accounts: the legacy single-deadline migration
+        # needs the known phones to apply the old global backoff per-phone.
+        await self.restore_resolve_username_backoff(
+            self._db, phones=[acc.phone for acc in accounts]
+        )
         if phones is not None:
             allowed_phones = {str(phone) for phone in phones if str(phone)}
             accounts = [acc for acc in accounts if acc.phone in allowed_phones]
@@ -583,10 +587,20 @@ class ClientPool(ResolveGuardMixin):
                         pass
                     del self.clients[phone]
 
-    async def get_available_client(self) -> tuple[TelegramTransportSession, str] | None:
-        """Get first available client not in flood wait. Returns (client, phone) or None."""
+    async def get_available_client(
+        self, *, exclude_phones: set[str] | frozenset[str] = frozenset()
+    ) -> tuple[TelegramTransportSession, str] | None:
+        """Get first available client not in flood wait. Returns (client, phone) or None.
+
+        ``exclude_phones`` skips specific accounts — used by the collector to
+        rotate a username resolve away from accounts already in resolve
+        backoff (#790).
+        """
         for _ in range(max(1, len(self.clients))):
-            lease = await self._lease_pool.acquire_available(self._connected_phones())
+            candidates = self._connected_phones() - set(exclude_phones)
+            if not candidates:
+                return None
+            lease = await self._lease_pool.acquire_available(candidates)
             if lease is None:
                 return None
             result = await self._acquire_from_lease(lease)

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -608,6 +608,31 @@ class ClientPool(ResolveGuardMixin):
                 return result
         return None
 
+    async def has_rotatable_resolve_phone(
+        self, exclude: set[str] | frozenset[str] = frozenset()
+    ) -> bool:
+        """True if some connected account outside ``exclude`` can run a live
+        username resolve right now (#790).
+
+        Stricter than the sync :meth:`has_resolve_capable_phone`, which only
+        knows the resolve-backoff map: this also rejects accounts in a *generic*
+        flood wait (``accounts.flood_wait_until``, known only to the DB) and
+        accounts already leased out. The collector uses it to decide whether
+        rotating a channel to another account can actually succeed — avoiding a
+        rotate-into-dead-end that would otherwise abort the whole run.
+        """
+        excluded = {str(p) for p in exclude}
+        # First narrow to phones that are not in resolve backoff (sync), then
+        # let the lease pool reject generic-flooded / in-use ones (async).
+        candidates = {
+            phone
+            for phone in self._connected_phones() - excluded
+            if self.get_resolve_username_backoff_remaining_sec(phone) == 0
+        }
+        if not candidates:
+            return False
+        return await self._lease_pool.available_exclusive_count(candidates) > 0
+
     async def available_stats_client_count(self) -> int:
         return await self._lease_pool.available_exclusive_count(self._connected_phones())
 

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -633,6 +633,43 @@ class ClientPool(ResolveGuardMixin):
             return False
         return await self._lease_pool.available_exclusive_count(candidates) > 0
 
+    async def next_resolve_capable_at(self) -> datetime | None:
+        """Earliest UTC moment any connected account can run a live username
+        resolve again (#790).
+
+        Per phone the readiness is ``max(resolve backoff, generic
+        accounts.flood_wait_until)``; the result is the minimum across
+        connected phones. Returns ``None`` when some account is capable right
+        now (even if transiently leased) or when nothing is connected — the
+        caller then falls back to its own deadline.
+        """
+        connected = self._connected_phones()
+        if not connected:
+            return None
+        now = datetime.now(timezone.utc)
+        accounts = await load_live_usable_accounts(self._db, active_only=True)
+        generic: dict[str, datetime] = {}
+        for account in accounts:
+            until = normalize_utc(getattr(account, "flood_wait_until", None))
+            if until is not None:
+                generic[account.phone] = until
+        earliest: datetime | None = None
+        for phone in connected:
+            deadlines = [
+                until
+                for until in (
+                    self.get_resolve_username_backoff_until(phone),
+                    generic.get(phone),
+                )
+                if until is not None and until > now
+            ]
+            if not deadlines:
+                return None
+            ready = max(deadlines)
+            if earliest is None or ready < earliest:
+                earliest = ready
+        return earliest
+
     async def available_stats_client_count(self) -> int:
         return await self._lease_pool.available_exclusive_count(self._connected_phones())
 

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -168,6 +168,23 @@ class Collector:
             return False
         return bool(has_capable(exclude=attempted_phones))
 
+    async def _next_resolve_capable_at(self) -> datetime | None:
+        """Earliest moment any connected account can live-resolve again (#790).
+
+        Prefers the async pool method, which also accounts for *generic*
+        flood waits — in the mixed state (this phone resolve-blocked for
+        hours, another phone generically flooded for minutes) the channel
+        must retry when the generic flood clears. Falls back to the
+        resolve-backoff-only aggregate for doubles lacking the async method.
+        """
+        getter = getattr(self._pool, "next_resolve_capable_at", None)
+        if callable(getter):
+            result = getter()
+            if isawaitable(result):
+                result = await result
+            return result
+        return self._pool.get_resolve_username_backoff_until()
+
     async def get_collection_availability(self):
         availability_fn = getattr(self._pool, "get_stats_availability", None)
         if callable(availability_fn):
@@ -935,15 +952,18 @@ class Collector:
                                 mask_phone(phone),
                             )
                             continue
-                        # Every account is in resolve backoff — defer the channel
-                        # for the moment the *first* account frees up (pool-wide
-                        # aggregate), not for this arbitrary phone's window (#790 F2).
-                        aggregate_until = self._pool.get_resolve_username_backoff_until()
-                        if aggregate_until is not None:
+                        # No account can live-resolve right now — defer the
+                        # channel for the moment the *first* account becomes
+                        # capable again, combining per-phone resolve backoff
+                        # with generic flood waits; this phone's own (possibly
+                        # hours-long) window must not dictate the retry when
+                        # another account frees up sooner (#790 review P2).
+                        capable_at = await self._next_resolve_capable_at()
+                        if capable_at is not None:
                             now = datetime.now(timezone.utc)
                             raise UsernameResolveRateLimitedError(
                                 phone,
-                                (aggregate_until - now).total_seconds(),
+                                (capable_at - now).total_seconds(),
                                 now=now,
                             )
                         raise
@@ -1476,9 +1496,9 @@ class Collector:
                         total_collected += collected_count
                         progress_offset += collected_count
                         continue
-                    aggregate_until = self._pool.get_resolve_username_backoff_until()
-                    if aggregate_until is not None:
-                        next_available_at = aggregate_until
+                    capable_at = await self._next_resolve_capable_at()
+                    if capable_at is not None:
+                        next_available_at = capable_at
                     logger.warning(
                         "%s got FloodWait %ss on %s; pausing username resolves on "
                         "that account until %s (no free account to rotate to)",

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1493,8 +1493,20 @@ class Collector:
                             f"channel {channel_id} — pausing username resolves on "
                             f"this account until {next_available_at.isoformat()}"
                         )
+                    # wait_seconds must describe the same deadline as
+                    # next_available_at (the aggregate min across accounts may
+                    # be earlier than this phone's own flood) — callers and the
+                    # stats path surface both, so they cannot diverge.
+                    defer_wait_sec = max(
+                        0,
+                        int(
+                            (
+                                next_available_at - datetime.now(timezone.utc)
+                            ).total_seconds()
+                        ),
+                    )
                     raise UsernameResolveFloodWaitDeferredError(
-                        wait_seconds=flood_wait_sec,
+                        wait_seconds=defer_wait_sec,
                         next_available_at=next_available_at,
                     )
 

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -147,21 +147,22 @@ class Collector:
         # pool-wide aggregate (0 while any connected account is free, #790).
         return self._pool.get_resolve_username_backoff_remaining_sec(phone)
 
-    def _raise_resolve_username_deferred(self) -> None:
-        remaining = self._get_resolve_username_backoff_remaining_sec()
-        if remaining <= 0:
-            return
-        next_available_at = self._pool.get_resolve_username_backoff_until() or (
-            datetime.now(timezone.utc) + timedelta(seconds=remaining)
-        )
-        raise UsernameResolveFloodWaitDeferredError(
-            wait_seconds=remaining,
-            next_available_at=next_available_at,
-        )
-
-    def _can_rotate_resolve(self, attempted_phones: set[str]) -> bool:
+    async def _can_rotate_resolve(self, attempted_phones: set[str]) -> bool:
         """True if another connected account outside ``attempted_phones`` can
-        run a live username resolve right now (#790)."""
+        run a live username resolve right now (#790).
+
+        Prefers the async ``has_rotatable_resolve_phone`` which also rejects
+        accounts in a *generic* flood wait (only the DB knows that, so the
+        check has to be async). Falls back to the sync resolve-backoff-only
+        ``has_resolve_capable_phone`` for test doubles that lack the async
+        method.
+        """
+        has_rotatable = getattr(self._pool, "has_rotatable_resolve_phone", None)
+        if callable(has_rotatable):
+            result = has_rotatable(exclude=attempted_phones)
+            if isawaitable(result):
+                result = await result
+            return bool(result)
         has_capable = getattr(self._pool, "has_resolve_capable_phone", None)
         if not callable(has_capable):
             return False
@@ -925,7 +926,7 @@ class Collector:
                         # defer the channel only when every account is blocked
                         # (#790). The outer finally releases the client.
                         attempted_resolve_phones.add(phone)
-                        if self._can_rotate_resolve(attempted_resolve_phones):
+                        if await self._can_rotate_resolve(attempted_resolve_phones):
                             logger.warning(
                                 "Channel %d (%s): live resolve unavailable on %s; "
                                 "rotating to another account",
@@ -934,6 +935,17 @@ class Collector:
                                 mask_phone(phone),
                             )
                             continue
+                        # Every account is in resolve backoff — defer the channel
+                        # for the moment the *first* account frees up (pool-wide
+                        # aggregate), not for this arbitrary phone's window (#790 F2).
+                        aggregate_until = self._pool.get_resolve_username_backoff_until()
+                        if aggregate_until is not None:
+                            now = datetime.now(timezone.utc)
+                            raise UsernameResolveRateLimitedError(
+                                phone,
+                                (aggregate_until - now).total_seconds(),
+                                now=now,
+                            )
                         raise
                     except (ValueError, UsernameNotOccupiedError, UsernameInvalidError):
                         logger.warning(
@@ -1451,7 +1463,7 @@ class Collector:
                     # when one exists; defer only when every account is in
                     # backoff (#790).
                     attempted_resolve_phones.add(phone)
-                    if self._can_rotate_resolve(attempted_resolve_phones):
+                    if await self._can_rotate_resolve(attempted_resolve_phones):
                         logger.warning(
                             "%s got FloodWait %ss on %s; backoff on that account "
                             "until %s — rotating channel %d to another account",

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -141,9 +141,11 @@ class Collector:
         self._stats_all_lock = asyncio.Lock()
         self._last_unavailability_log: tuple[str, str | int | None, datetime | None] | None = None
 
-    def _get_resolve_username_backoff_remaining_sec(self) -> int:
-        # The pool owns the single source of truth for the resolve backoff (#785).
-        return self._pool.get_resolve_username_backoff_remaining_sec()
+    def _get_resolve_username_backoff_remaining_sec(self, phone: str | None = None) -> int:
+        # The pool owns the single source of truth for the resolve backoff
+        # (#785). With ``phone`` — that account's window; without — the
+        # pool-wide aggregate (0 while any connected account is free, #790).
+        return self._pool.get_resolve_username_backoff_remaining_sec(phone)
 
     def _raise_resolve_username_deferred(self) -> None:
         remaining = self._get_resolve_username_backoff_remaining_sec()
@@ -156,6 +158,14 @@ class Collector:
             wait_seconds=remaining,
             next_available_at=next_available_at,
         )
+
+    def _can_rotate_resolve(self, attempted_phones: set[str]) -> bool:
+        """True if another connected account outside ``attempted_phones`` can
+        run a live username resolve right now (#790)."""
+        has_capable = getattr(self._pool, "has_resolve_capable_phone", None)
+        if not callable(has_capable):
+            return False
+        return bool(has_capable(exclude=attempted_phones))
 
     async def get_collection_availability(self):
         availability_fn = getattr(self._pool, "get_stats_availability", None)
@@ -493,10 +503,11 @@ class Collector:
             return cached
 
         if cache_only:
-            # Global resolve backoff (#552): the cache missed and we must not hit
-            # the live API on any account. Defer this channel for the run.
+            # Resolve backoff on this account (#552/#790): the cache missed and
+            # we must not hit the live API on this phone. The caller decides
+            # whether to rotate to another account or defer the channel.
             raise UsernameResolveRateLimitedError(
-                phone, self._get_resolve_username_backoff_remaining_sec()
+                phone, self._get_resolve_username_backoff_remaining_sec(phone)
             )
 
         raw_client = None
@@ -698,6 +709,11 @@ class Collector:
     ) -> int:
         """Collect new messages from a single channel. Returns count."""
         total_collected = 0
+        # Accounts that already failed a live resolve for this channel in this
+        # pass (resolve backoff / limiter / fresh long flood). Used to rotate
+        # the channel to a different account instead of deferring it while a
+        # free account exists (#790).
+        attempted_resolve_phones: set[str] = set()
 
         while True:
             if self._is_collection_cancelled(cancel_event):
@@ -705,25 +721,6 @@ class Collector:
 
             channel_id = channel.channel_id
             min_id = channel.last_collected_id
-
-            # Global resolve backoff (#552): while a long flood is in effect we
-            # do NOT abort the whole run. Instead this channel runs in cache-only
-            # mode — if its InputPeer is cached the collection proceeds, otherwise
-            # it is deferred and the run continues to the next channel (which may
-            # well be cache-resolvable).
-            resolve_cache_only = False
-            if channel.username:
-                backoff_remaining_sec = self._get_resolve_username_backoff_remaining_sec()
-                if backoff_remaining_sec > 0:
-                    resolve_cache_only = True
-                    logger.warning(
-                        "Channel %d (%s): %s global backoff active for %ss — "
-                        "cache-only resolve",
-                        channel_id,
-                        channel.username,
-                        RESOLVE_USERNAME_OPERATION,
-                        backoff_remaining_sec,
-                    )
 
             # For private groups (no username):
             #   1. preferred_phone from DB (persists across restarts)
@@ -741,6 +738,10 @@ class Collector:
                     result = await self._pool.get_client_by_phone(preferred)
                 else:
                     result = await self._pool.get_available_client()
+            elif attempted_resolve_phones:
+                result = await self._pool.get_available_client(
+                    exclude_phones=set(attempted_resolve_phones)
+                )
             else:
                 result = await self._pool.get_available_client()
 
@@ -753,6 +754,27 @@ class Collector:
             session, phone = result
             self._reset_collection_unavailability_log()
             session = adapt_transport_session(session, disconnect_on_close=False)
+
+            # Per-account resolve backoff (#552/#790): while this phone is in a
+            # flood backoff the channel runs in cache-only mode on it — a cached
+            # InputPeer still collects for free, a cache miss rotates to another
+            # account or defers the channel (handled at the resolve call site).
+            resolve_cache_only = False
+            if channel.username:
+                backoff_remaining_sec = self._get_resolve_username_backoff_remaining_sec(
+                    phone
+                )
+                if backoff_remaining_sec > 0:
+                    resolve_cache_only = True
+                    logger.warning(
+                        "Channel %d (%s): %s backoff active on %s for %ss — "
+                        "cache-only resolve",
+                        channel_id,
+                        channel.username,
+                        RESOLVE_USERNAME_OPERATION,
+                        mask_phone(phone),
+                        backoff_remaining_sec,
+                    )
             # Populate entity cache when using PeerChannel
             # (StringSession loses cache between restarts).
             # Only needed once per process lifetime per phone —
@@ -896,6 +918,22 @@ class Collector:
                     except HandledFloodWaitError as exc:
                         flood_wait_sec = exc.info.wait_seconds
                         flood_wait_operation = RESOLVE_USERNAME_OPERATION
+                        raise
+                    except UsernameResolveRateLimitedError:
+                        # This phone cannot resolve live right now (backoff or
+                        # limiter). Rotate to a free account when one exists;
+                        # defer the channel only when every account is blocked
+                        # (#790). The outer finally releases the client.
+                        attempted_resolve_phones.add(phone)
+                        if self._can_rotate_resolve(attempted_resolve_phones):
+                            logger.warning(
+                                "Channel %d (%s): live resolve unavailable on %s; "
+                                "rotating to another account",
+                                channel_id,
+                                channel.username,
+                                mask_phone(phone),
+                            )
+                            continue
                         raise
                     except (ValueError, UsernameNotOccupiedError, UsernameInvalidError):
                         logger.warning(
@@ -1370,52 +1408,78 @@ class Collector:
                             logger_=logger,
                         )
                         continue
-                    # Only a *long* resolve flood freezes live resolves for every
-                    # account (#552). A medium resolve flood skips just this
-                    # channel so one blip does not stall the whole pool.
+                    # Only a *long* resolve flood freezes live resolves — and
+                    # only for the flooded account (#552/#790). A medium resolve
+                    # flood skips just this channel so one blip does not stall
+                    # the whole pool.
                     if flood_wait_sec <= GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC:
                         logger.warning(
                             "%s short FloodWait %ss on %s; skipping channel %d "
-                            "(no global backoff)",
+                            "(no backoff)",
                             RESOLVE_USERNAME_OPERATION,
                             flood_wait_sec,
                             phone,
                             channel_id,
                         )
                         return total_collected + collected_count
-                    # The pool already recorded this long flood inside
-                    # run_live_username_resolve (>300s threshold); read back the
-                    # active deadline rather than re-setting a second window (#785).
-                    next_available_at = self._pool.get_resolve_username_backoff_until()
+                    # The pool already recorded this long flood for the phone
+                    # inside run_live_username_resolve (>300s threshold); read
+                    # back the active deadline rather than re-setting a second
+                    # window (#785).
+                    next_available_at = self._pool.get_resolve_username_backoff_until(phone)
                     if next_available_at is None and flood_wait_sec > GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC:
-                        next_available_at = self._pool.set_resolve_username_backoff(flood_wait_sec)
+                        next_available_at = self._pool.set_resolve_username_backoff(
+                            flood_wait_sec, phone=phone
+                        )
                         persist_backoff = getattr(self._pool, "persist_resolve_username_backoff", None)
                         if callable(persist_backoff):
                             maybe_awaitable = persist_backoff()
                             if isawaitable(maybe_awaitable):
                                 await maybe_awaitable
                         logger.warning(
-                            "%s: defensive backoff set to %s (was None, flood_wait_sec=%d)",
+                            "%s: defensive backoff set to %s on %s (was None, flood_wait_sec=%d)",
                             RESOLVE_USERNAME_OPERATION,
                             next_available_at.isoformat(),
+                            mask_phone(phone),
                             flood_wait_sec,
                         )
                     if next_available_at is None:
                         next_available_at = datetime.now(timezone.utc) + timedelta(
                             seconds=flood_wait_sec
                         )
+                    # Rotate the channel to a free account within the same pass
+                    # when one exists; defer only when every account is in
+                    # backoff (#790).
+                    attempted_resolve_phones.add(phone)
+                    if self._can_rotate_resolve(attempted_resolve_phones):
+                        logger.warning(
+                            "%s got FloodWait %ss on %s; backoff on that account "
+                            "until %s — rotating channel %d to another account",
+                            RESOLVE_USERNAME_OPERATION,
+                            flood_wait_sec,
+                            mask_phone(phone),
+                            next_available_at.isoformat(),
+                            channel_id,
+                        )
+                        total_collected += collected_count
+                        progress_offset += collected_count
+                        continue
+                    aggregate_until = self._pool.get_resolve_username_backoff_until()
+                    if aggregate_until is not None:
+                        next_available_at = aggregate_until
                     logger.warning(
-                        "%s got FloodWait %ss on %s; pausing ALL username resolves until %s",
+                        "%s got FloodWait %ss on %s; pausing username resolves on "
+                        "that account until %s (no free account to rotate to)",
                         RESOLVE_USERNAME_OPERATION,
                         flood_wait_sec,
-                        phone,
+                        mask_phone(phone),
                         next_available_at.isoformat(),
                     )
                     if self._notifier:
                         await self._notifier.notify(
                             f"FloodWait {flood_wait_sec}s on {phone}, "
-                            f"channel {channel_id} — pausing username resolves until "
-                            f"{next_available_at.isoformat()}"
+                            f"channel {channel_id} — pausing username resolves on "
+                            f"this account until {next_available_at.isoformat()}"
                         )
                     raise UsernameResolveFloodWaitDeferredError(
                         wait_seconds=flood_wait_sec,
@@ -1721,6 +1785,16 @@ class Collector:
                                     channel.channel_id,
                                 )
                             return None
+                        except Exception:
+                            # Transient failure (timeout, connection drop, …):
+                            # skip this run WITHOUT deactivating the channel
+                            # (#815 review follow-up).
+                            logger.warning(
+                                "Stats: channel %d entity lookup failed transiently, skipping",
+                                channel.channel_id,
+                                exc_info=True,
+                            )
+                            return None
                         new_username = getattr(entity, "username", None)
                         new_title = (
                             getattr(entity, "title", None)
@@ -1764,6 +1838,16 @@ class Collector:
                                 "Stats: cannot deactivate channel %d -- no DB pk",
                                 channel.channel_id,
                             )
+                        return None
+                    except Exception:
+                        # Transient failure (timeout, connection drop, …): skip
+                        # this run WITHOUT deactivating the channel (#815
+                        # review follow-up).
+                        logger.warning(
+                            "Stats: channel %d entity lookup failed transiently, skipping",
+                            channel.channel_id,
+                            exc_info=True,
+                        )
                         return None
 
                 # Guard: entity resolved as a User/Bot (no ``title``) — not a channel.

--- a/src/telegram/resolve_guard.py
+++ b/src/telegram/resolve_guard.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime, timedelta, timezone
 
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
@@ -13,24 +14,65 @@ from src.telegram.rate_limiter import (
 
 logger = logging.getLogger(__name__)
 
+RESOLVE_BACKOFF_BY_PHONE_SETTING = "resolve_username_backoff_by_phone"
+RESOLVE_BACKOFF_LEGACY_SETTING = "resolve_username_backoff_until_utc"
+
+
+def parse_resolve_backoff_setting(
+    raw: str | None, *, now: datetime | None = None
+) -> dict[str, datetime]:
+    """Parse the per-phone backoff DB setting, keeping only active deadlines.
+
+    Shared by CLI ``account flood-status`` and the web settings page, which
+    read the persisted state directly instead of holding a live pool (#790).
+    """
+    if not raw:
+        return {}
+    try:
+        entries = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(entries, dict):
+        return {}
+    now = now or datetime.now(timezone.utc)
+    result: dict[str, datetime] = {}
+    for phone, raw_until in entries.items():
+        try:
+            until = datetime.fromisoformat(str(raw_until))
+        except (ValueError, TypeError):
+            continue
+        if until.tzinfo is None:
+            until = until.replace(tzinfo=timezone.utc)
+        if until > now:
+            result[str(phone)] = until
+    return result
+
 
 class ResolveGuardMixin:
-    """Shared live-username-resolve FloodWait guard (#785).
+    """Shared live-username-resolve FloodWait guard (#785, #790).
 
-    Owns the single source of truth for the per-account resolve rate limiter and
-    the global cross-account backoff window. Every runtime path that performs a
-    live ``auth.resolveUsername`` (collection, stats, search fallback, agent
-    tools) routes through :meth:`run_live_username_resolve` so they share one
-    budget and one flood-wait policy.
+    Owns the single source of truth for the per-account resolve rate limiter
+    and the per-account FloodWait backoff windows. Every runtime path that
+    performs a live ``auth.resolveUsername`` (collection, stats, search
+    fallback, agent tools) routes through :meth:`run_live_username_resolve`
+    so they share one budget and one flood-wait policy.
 
-    Concrete pools must initialise ``self._resolve_rate_limiter`` and
-    ``self._resolve_username_backoff_until_utc`` in their ``__init__``.
+    Since #790 the backoff is **per phone**: a long resolve flood on one
+    account freezes live resolves only for that account, while the other
+    connected accounts keep resolving. Callers that need the old pool-wide
+    view (collection queue deferral, CLI status) use the no-argument
+    aggregate getters, which report "blocked" only when *every* connected
+    account is in backoff.
+
+    Concrete pools must initialise ``self._resolve_rate_limiter`` and the
+    per-phone dicts in their ``__init__`` (the mixin lazily repairs missing
+    or legacy-scalar attributes for test doubles).
     """
 
     _resolve_rate_limiter: ResolveRateLimiter
-    _resolve_username_backoff_until_utc: datetime | None
-    _resolve_ramp_up_until_utc: datetime | None
-    _resolve_ramp_up_last_call_utc: datetime | None
+    _resolve_username_backoff_until_utc: dict[str, datetime]
+    _resolve_ramp_up_until_utc: dict[str, datetime]
+    _resolve_ramp_up_last_call_utc: dict[str, datetime]
     _resolve_ramp_up_min_interval_sec: float
 
     def _get_resolve_rate_limiter(self) -> ResolveRateLimiter:
@@ -40,120 +82,226 @@ class ResolveGuardMixin:
             self._resolve_rate_limiter = limiter
         return limiter
 
-    def get_resolve_username_backoff_remaining_sec(self) -> int:
-        """Return global live username-resolve backoff remaining seconds."""
-        backoff_until = getattr(self, "_resolve_username_backoff_until_utc", None)
-        if backoff_until is None:
-            return 0
-        remaining = (backoff_until - datetime.now(timezone.utc)).total_seconds()
-        if remaining <= 0:
-            self._resolve_username_backoff_until_utc = None
-            return 0
-        return int(remaining)
+    def _resolve_guard_dict(self, attr: str) -> dict[str, datetime]:
+        """Return the per-phone state dict, repairing non-dict legacy values."""
+        value = getattr(self, attr, None)
+        if not isinstance(value, dict):
+            value = {}
+            setattr(self, attr, value)
+        return value
 
-    def get_resolve_username_backoff_until(self) -> datetime | None:
-        """Return the active backoff deadline, clearing it once elapsed."""
-        backoff_until = getattr(self, "_resolve_username_backoff_until_utc", None)
-        if backoff_until is None:
-            return None
-        if (backoff_until - datetime.now(timezone.utc)).total_seconds() <= 0:
-            self._resolve_username_backoff_until_utc = None
-            return None
-        return backoff_until
+    def _resolve_backoff_map(self) -> dict[str, datetime]:
+        return self._resolve_guard_dict("_resolve_username_backoff_until_utc")
 
-    def is_resolve_ramp_up_active(self) -> bool:
-        ramp = getattr(self, "_resolve_ramp_up_until_utc", None)
-        if ramp is None:
+    def _resolve_capable_phones(self) -> set[str]:
+        """Phones eligible for live resolves — the pool's connected clients."""
+        clients = getattr(self, "clients", None) or {}
+        return {str(phone) for phone in clients}
+
+    def _prune_resolve_backoff(self) -> dict[str, datetime]:
+        backoff = self._resolve_backoff_map()
+        now = datetime.now(timezone.utc)
+        for phone in [p for p, until in backoff.items() if until <= now]:
+            del backoff[phone]
+        return backoff
+
+    def get_resolve_username_backoff_remaining_sec(self, phone: str | None = None) -> int:
+        """Remaining live-resolve backoff seconds.
+
+        With ``phone`` — the remaining window for that account only. Without —
+        the pool-wide aggregate: ``0`` while at least one connected account is
+        free, otherwise the smallest remaining window (the moment the first
+        account becomes usable again).
+        """
+        backoff = self._prune_resolve_backoff()
+        now = datetime.now(timezone.utc)
+        if phone is not None:
+            until = backoff.get(str(phone))
+            if until is None:
+                return 0
+            return int((until - now).total_seconds())
+        if not backoff:
+            return 0
+        phones = self._resolve_capable_phones()
+        if phones:
+            if any(p not in backoff for p in phones):
+                return 0
+            candidates = [backoff[p] for p in phones]
+        else:
+            candidates = list(backoff.values())
+        return int((min(candidates) - now).total_seconds())
+
+    def get_resolve_username_backoff_until(self, phone: str | None = None) -> datetime | None:
+        """Backoff deadline — per-phone, or the aggregate min across the pool."""
+        backoff = self._prune_resolve_backoff()
+        if phone is not None:
+            return backoff.get(str(phone))
+        if not backoff:
+            return None
+        phones = self._resolve_capable_phones()
+        if phones:
+            if any(p not in backoff for p in phones):
+                return None
+            return min(backoff[p] for p in phones)
+        return min(backoff.values())
+
+    def has_resolve_capable_phone(self, exclude: set[str] | None = None) -> bool:
+        """True if a connected account outside ``exclude`` can resolve live now."""
+        excluded = {str(p) for p in (exclude or set())}
+        return any(
+            phone not in excluded
+            and self.get_resolve_username_backoff_remaining_sec(phone) == 0
+            for phone in self._resolve_capable_phones()
+        )
+
+    def is_resolve_ramp_up_active(self, phone: str) -> bool:
+        ramp = self._resolve_guard_dict("_resolve_ramp_up_until_utc")
+        until = ramp.get(str(phone))
+        if until is None:
             return False
-        if (ramp - datetime.now(timezone.utc)).total_seconds() <= 0:
-            self._resolve_ramp_up_until_utc = None
+        if (until - datetime.now(timezone.utc)).total_seconds() <= 0:
+            del ramp[str(phone)]
             return False
         return True
 
-    def set_resolve_username_backoff(self, wait_seconds: int) -> datetime:
+    def set_resolve_username_backoff(self, wait_seconds: int, *, phone: str) -> datetime:
+        phone = str(phone)
         new_until = datetime.now(timezone.utc) + timedelta(
             seconds=max(0, int(wait_seconds))
         )
-        existing = getattr(self, "_resolve_username_backoff_until_utc", None)
+        backoff = self._resolve_backoff_map()
+        existing = backoff.get(phone)
         if existing is not None and existing > new_until:
             logger.warning(
-                "resolve backoff: keeping existing %s (new would be %s for wait_seconds=%d)",
+                "resolve backoff [%s]: keeping existing %s (new would be %s for wait_seconds=%d)",
+                phone,
                 existing.isoformat(),
                 new_until.isoformat(),
                 wait_seconds,
             )
             return existing
-        self._resolve_username_backoff_until_utc = new_until
+        backoff[phone] = new_until
         # Ramp-up: 10% of flood wait, max 1h
         ramp_duration = min(wait_seconds * 0.1, 3600)
-        self._resolve_ramp_up_until_utc = new_until + timedelta(seconds=ramp_duration)
+        ramp = self._resolve_guard_dict("_resolve_ramp_up_until_utc")
+        ramp[phone] = new_until + timedelta(seconds=ramp_duration)
         logger.warning(
-            "resolve backoff: set until %s (wait_seconds=%d, ramp-up until %s)",
+            "resolve backoff [%s]: set until %s (wait_seconds=%d, ramp-up until %s)",
+            phone,
             new_until.isoformat(),
             wait_seconds,
-            (self._resolve_ramp_up_until_utc or new_until).isoformat(),
+            ramp[phone].isoformat(),
         )
         return new_until
 
     async def persist_resolve_username_backoff(self) -> None:
-        """Persist the backoff deadline to DB settings before the caller exits."""
-        backoff_until = self._resolve_username_backoff_until_utc
+        """Persist the per-phone backoff deadlines to DB settings."""
         db = getattr(self, "_db", None)
         if db is None:
             return
-
+        backoff = self._prune_resolve_backoff()
+        payload = json.dumps(
+            {phone: until.isoformat() for phone, until in backoff.items()}
+        )
         try:
-            if backoff_until is not None:
-                await db.set_setting(
-                    "resolve_username_backoff_until_utc",
-                    backoff_until.isoformat(),
-                )
-            else:
-                await db.set_setting("resolve_username_backoff_until_utc", "")
+            await db.set_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING, payload)
         except Exception:
             logger.debug("Failed to persist resolve_username backoff", exc_info=True)
 
-    async def restore_resolve_username_backoff(self, db: object) -> None:
-        """Restore backoff from DB on startup. Call once during pool init."""
+    def _restore_resolve_backoff_entry(self, phone: str, until: datetime) -> None:
+        remaining = (until - datetime.now(timezone.utc)).total_seconds()
+        if remaining <= 0:
+            return
+        self._resolve_backoff_map()[phone] = until
+        # Also restore ramp-up: 10% of remaining, max 1h
+        ramp_duration = min(remaining * 0.1, 3600)
+        self._resolve_guard_dict("_resolve_ramp_up_until_utc")[phone] = until + timedelta(
+            seconds=ramp_duration
+        )
+        logger.warning(
+            "resolve backoff [%s]: restored from DB until %s (%.0fs remaining)",
+            phone,
+            until.isoformat(),
+            remaining,
+        )
+
+    @staticmethod
+    def _parse_backoff_deadline(value: object) -> datetime | None:
         try:
-            value = await db.get_setting("resolve_username_backoff_until_utc")
+            restored = datetime.fromisoformat(str(value))
+        except (ValueError, TypeError):
+            return None
+        if restored.tzinfo is None:
+            restored = restored.replace(tzinfo=timezone.utc)
+        return restored
+
+    async def restore_resolve_username_backoff(
+        self, db: object, *, phones: Iterable[str] | None = None
+    ) -> None:
+        """Restore backoff from DB on startup. Call once during pool init.
+
+        ``phones`` (known account phones) is only needed for the one-time
+        migration of the legacy single-deadline setting: an active legacy
+        backoff is conservatively applied to every known phone, re-persisted
+        in the per-phone format, and the legacy key is cleared.
+        """
+        try:
+            value = await db.get_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING)
         except Exception:
             return
-        if not value:
-            return
+        if value:
+            try:
+                entries = json.loads(value)
+            except (ValueError, TypeError):
+                entries = None
+            if isinstance(entries, dict):
+                for phone, raw_until in entries.items():
+                    until = self._parse_backoff_deadline(raw_until)
+                    if until is not None:
+                        self._restore_resolve_backoff_entry(str(phone), until)
+                return
+        # Legacy single-deadline migration (pre-#790).
         try:
-            restored = datetime.fromisoformat(value)
-            if restored.tzinfo is None:
-                restored = restored.replace(tzinfo=timezone.utc)
-            remaining = (restored - datetime.now(timezone.utc)).total_seconds()
-            if remaining > 0:
-                self._resolve_username_backoff_until_utc = restored
-                # Also restore ramp-up: 10% of remaining, max 1h
-                ramp_duration = min(remaining * 0.1, 3600)
-                self._resolve_ramp_up_until_utc = restored + timedelta(seconds=ramp_duration)
-                logger.warning(
-                    "resolve backoff: restored from DB until %s (%.0fs remaining)",
-                    restored.isoformat(),
-                    remaining,
-                )
-        except (ValueError, TypeError):
-            pass
+            legacy_value = await db.get_setting(RESOLVE_BACKOFF_LEGACY_SETTING)
+        except Exception:
+            return
+        if not legacy_value:
+            return
+        until = self._parse_backoff_deadline(legacy_value)
+        if until is None or (until - datetime.now(timezone.utc)).total_seconds() <= 0:
+            return
+        phone_list = [str(p) for p in (phones or []) if str(p)]
+        if not phone_list:
+            # No known accounts yet — leave the legacy key for the next start.
+            return
+        for phone in phone_list:
+            self._restore_resolve_backoff_entry(phone, until)
+        try:
+            await db.set_setting(
+                RESOLVE_BACKOFF_BY_PHONE_SETTING,
+                json.dumps({phone: until.isoformat() for phone in phone_list}),
+            )
+            await db.set_setting(RESOLVE_BACKOFF_LEGACY_SETTING, "")
+        except Exception:
+            logger.debug("Failed to migrate legacy resolve backoff", exc_info=True)
 
     def reserve_resolve_username_call(self, phone: str) -> float:
-        remaining = self.get_resolve_username_backoff_remaining_sec()
+        phone = str(phone or "unknown")
+        remaining = self.get_resolve_username_backoff_remaining_sec(phone)
         if remaining > 0:
             return float(remaining)
-        if self.is_resolve_ramp_up_active():
+        if self.is_resolve_ramp_up_active(phone):
             min_interval = getattr(self, "_resolve_ramp_up_min_interval_sec", 5.0)
-            last = getattr(self, "_resolve_ramp_up_last_call_utc", None)
+            last_map = self._resolve_guard_dict("_resolve_ramp_up_last_call_utc")
+            last = last_map.get(phone)
             now = datetime.now(timezone.utc)
             if last is not None:
                 elapsed = (now - last).total_seconds()
                 if elapsed < min_interval:
                     return min_interval - elapsed
-            self._resolve_ramp_up_last_call_utc = now
+            last_map[phone] = now
             return 0.0
-        return self._get_resolve_rate_limiter().try_acquire(str(phone or "unknown"))
+        return self._get_resolve_rate_limiter().try_acquire(phone)
 
     @staticmethod
     def _is_live_username_peer(peer: object) -> bool:
@@ -164,10 +312,10 @@ class ResolveGuardMixin:
             return False
         return not value.lstrip("-").isdigit()
 
-    def _record_resolve_username_flood(self, wait_seconds: int) -> datetime | None:
+    def _record_resolve_username_flood(self, wait_seconds: int, *, phone: str) -> datetime | None:
         if wait_seconds <= GLOBAL_RESOLVE_BACKOFF_THRESHOLD_SEC:
             return None
-        return self.set_resolve_username_backoff(wait_seconds)
+        return self.set_resolve_username_backoff(wait_seconds, phone=phone)
 
     async def run_live_username_resolve(
         self,
@@ -193,16 +341,19 @@ class ResolveGuardMixin:
                 timeout=timeout,
             )
         except HandledFloodWaitError as exc:
-            next_available_at = self._record_resolve_username_flood(exc.info.wait_seconds)
+            next_available_at = self._record_resolve_username_flood(
+                exc.info.wait_seconds, phone=phone
+            )
             if next_available_at is not None:
                 await self.persist_resolve_username_backoff()
                 (logger_ or logger).warning(
                     "%s got FloodWait %ss on %s while resolving %s; "
-                    "pausing live username resolves until %s",
+                    "pausing live username resolves on %s until %s",
                     operation,
                     exc.info.wait_seconds,
                     phone,
                     username,
+                    phone,
                     next_available_at.isoformat(),
                 )
             raise

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -50,6 +50,10 @@ from src.services.telegram_command_dispatcher import (
 )
 from src.settings_utils import parse_float_setting, parse_int_setting
 from src.telegram.flood_wait import is_blocking_flood_wait_until
+from src.telegram.resolve_guard import (
+    RESOLVE_BACKOFF_BY_PHONE_SETTING,
+    parse_resolve_backoff_setting,
+)
 from src.utils.datetime import parse_datetime
 from src.web import deps
 from src.web.settings.forms import (
@@ -494,6 +498,9 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
                 await db.update_account_flood(account.phone, None)
                 account.flood_wait_until = None
     connected_phones = set(pool.clients.keys())
+    resolve_backoffs = parse_resolve_backoff_setting(
+        await db.repos.settings.get_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING), now=now
+    )
     account_status: dict[str, dict[str, object]] = {}
     flooded_connected = []
     for account in accounts:
@@ -569,6 +576,7 @@ async def handle_settings_page(request: Request) -> SettingsTemplate:
         "account_status": account_status,
         "account_phones": [acc.phone for acc in accounts],
         "connected_phones": connected_phones,
+        "resolve_backoffs": resolve_backoffs,
         "all_accounts_flooded": all_accounts_flooded,
         "next_available_at": next_available_at,
         "notification_target": notification_target,

--- a/src/web/templates/settings/_accounts.html
+++ b/src/web/templates/settings/_accounts.html
@@ -42,6 +42,9 @@
                 {% if acc.flood_wait_until and account_status[acc.phone].state == 'flood' %}
                 {{ acc.flood_wait_until|local_dt("time") }}
                 <br><small class="text-muted">ещё {{ account_status[acc.phone].remaining_minutes }} мин</small>
+                {% elif resolve_backoffs and resolve_backoffs.get(acc.phone) %}
+                <span class="badge text-bg-warning" title="Live-резолв username приостановлен на этом аккаунте">Resolve</span>
+                <small class="text-muted">до {{ resolve_backoffs[acc.phone]|local_dt("time") }}</small>
                 {% else %}
                 <span class="text-muted">—</span>
                 {% endif %}
@@ -93,6 +96,7 @@
                 {% if account_status[acc.phone].state == 'available' %}&middot; Доступен{% endif %}
                 {% if account_status[acc.phone].state == 'disconnected' %}&middot; Не подключён{% endif %}
                 {% if account_status[acc.phone].state == 'flood' %}&middot; Flood до {{ acc.flood_wait_until|local_dt("time") }} ({{ account_status[acc.phone].remaining_minutes }} мин){% endif %}
+                {% if resolve_backoffs and resolve_backoffs.get(acc.phone) %}&middot; Resolve-backoff до {{ resolve_backoffs[acc.phone]|local_dt("time") }}{% endif %}
                 {% if account_status[acc.phone].state == 'session_unavailable' %}&middot; {{ session_status_label(acc.session_status) }}{% endif %}
                 {% if acc.created_at %}&middot; {{ acc.created_at|local_dt("date") }}{% endif %}
             </small>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -455,9 +455,9 @@ class FakeClientPool(ResolveGuardMixin, MagicMock):
     def __init__(self, **kwargs):
         super().__init__()
         self._resolve_rate_limiter = ResolveRateLimiter()
-        self._resolve_username_backoff_until_utc = None
-        self._resolve_ramp_up_until_utc = None
-        self._resolve_ramp_up_last_call_utc = None
+        self._resolve_username_backoff_until_utc = {}
+        self._resolve_ramp_up_until_utc = {}
+        self._resolve_ramp_up_last_call_utc = {}
         self._resolve_ramp_up_min_interval_sec = 5.0
         self.clients = kwargs.pop("clients", {})
         self.release_client = kwargs.pop("release_client", AsyncMock())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -498,6 +498,20 @@ class FakeClientPool(ResolveGuardMixin, MagicMock):
         # flood-wait semantics override this attribute explicitly.
         return self.has_resolve_capable_phone(exclude=set(exclude))
 
+    async def next_resolve_capable_at(self):
+        # Resolve-backoff-only approximation of the production method (the
+        # fake has no DB-backed generic flood deadlines). Tests exercising
+        # the mixed state override this attribute explicitly.
+        now = datetime.now(timezone.utc)
+        earliest = None
+        for phone in self.connected_phones():
+            until = self.get_resolve_username_backoff_until(phone)
+            if until is None or until <= now:
+                return None
+            if earliest is None or until < earliest:
+                earliest = until
+        return earliest
+
 
 def make_mock_reactions(items: list[tuple[str, int]]) -> SimpleNamespace:
     """Create a mock MessageReactions object.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -491,6 +491,13 @@ class FakeClientPool(ResolveGuardMixin, MagicMock):
 
         return await ClientPool.resolve_entity_with_warm(self, session, phone, peer, **kwargs)
 
+    async def has_rotatable_resolve_phone(self, exclude=frozenset()):
+        # Mirror production rotation eligibility (#790). Without a real lease
+        # pool the fake only knows the resolve-backoff map, so reuse the sync
+        # ``has_resolve_capable_phone`` from the mixin. Tests that need generic
+        # flood-wait semantics override this attribute explicitly.
+        return self.has_resolve_capable_phone(exclude=set(exclude))
+
 
 def make_mock_reactions(items: list[tuple[str, int]]) -> SimpleNamespace:
     """Create a mock MessageReactions object.

--- a/tests/test_cli_commands_edge_cases.py
+++ b/tests/test_cli_commands_edge_cases.py
@@ -775,22 +775,29 @@ class TestSchedulerClearPending:
 
 
 class TestSchedulerNoAccounts:
-    def test_status_no_accounts(self, capsys):
+    def test_status_works_without_accounts(self, capsys):
+        """`scheduler status` is a DB-only read: it must print the config even
+        when no Telegram account is connected (it no longer inits the pool)."""
         from src.cli.commands.scheduler import run
 
         db = MagicMock()
         db.close = AsyncMock()
+        db.get_setting = AsyncMock(return_value="0")
+        db.repos.settings.list_all = AsyncMock(return_value=[])
 
         config = MagicMock()
-        pool = MagicMock()
-        pool.clients = {}
-        pool.disconnect_all = AsyncMock()
+        config.scheduler.collect_interval_minutes = 60
+
+        async def _no_pool(config, db):
+            raise AssertionError("init_pool must not be called for `scheduler status`")
 
         with patch("src.cli.commands.scheduler.runtime.init_db", side_effect=_make_coro((config, db))), \
-             patch("src.cli.commands.scheduler.runtime.init_pool", side_effect=_make_coro((MagicMock(), pool))):
+             patch("src.cli.commands.scheduler.runtime.init_pool", side_effect=_no_pool):
             run(cli_ns(scheduler_action="status"))
 
-        # No crash; command exits silently after logging error
+        out = capsys.readouterr().out
+        assert "Scheduler config:" in out
+        assert "Interval: 60 min" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_dialogs_notifications_scheduler.py
+++ b/tests/test_cli_dialogs_notifications_scheduler.py
@@ -785,6 +785,43 @@ class TestSchedulerCommandRW:
         assert _sched_read_setting(db_path, "collection_queue_paused") == "0"
         assert "Collection queue resumed" in capsys.readouterr().out
 
+    def test_db_only_actions_do_not_init_pool(self, tmp_path, cli_init_patch, capsys):
+        """DB-only scheduler subcommands must not connect the Telegram pool.
+
+        Each `scheduler task-cancel` used to spin up a full ClientPool (every
+        account connecting to Telegram) just to flip one DB row — which made
+        per-task cleanup in the live heavy suite take 30s+ per call and blow
+        the test timeout, and needlessly hammered Telegram with connects.
+        """
+
+        async def _explode(config, db):
+            raise AssertionError(
+                "init_pool must not be called for DB-only scheduler actions"
+            )
+
+        db_path = str(tmp_path / "sched_no_pool.db")
+        seed = Database(db_path)
+        asyncio.run(seed.initialize())
+        try:
+            task_id = _sched_seed_collection_task(seed, channel_id=222_020)
+        finally:
+            asyncio.run(seed.close())
+
+        with patch("src.cli.runtime.init_pool", side_effect=_explode):
+            for ns in (
+                _ns(scheduler_action="task-cancel", task_id=task_id),
+                _ns(scheduler_action="clear-pending"),
+                _ns(scheduler_action="status"),
+                _ns(scheduler_action="stop"),
+                _ns(scheduler_action="job-toggle", job_id="collect_all"),
+                _ns(scheduler_action="set-interval", job_id="collect_all", minutes=30),
+                _ns(scheduler_action="queue-pause"),
+                _ns(scheduler_action="queue-resume"),
+            ):
+                _sched_run_with_db(db_path, cli_init_patch, ns)
+
+        assert _sched_read_task_status(db_path, task_id) == "cancelled"
+
 
 # ---------------------------------------------------------------------------
 # serve command
@@ -1000,6 +1037,62 @@ class TestCollectCommand:
         out = capsys.readouterr().out
         assert "resolve_username rate-limited" in out
         assert "Collected" not in out
+
+    def test_collect_single_channel_all_clients_flooded(self, cli_env_with_pool, capsys):
+        """A pool-wide collection FloodWait must print a CLI message with the
+        retry deadline, not dump a traceback."""
+        from datetime import datetime, timedelta, timezone
+
+        from src.telegram.collector import AllCollectionClientsFloodedError, Collector
+
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+70001112233": AsyncMock()}
+        _add_channel(cli_env, channel_id=102, title="Flooded Channel")
+
+        next_at = datetime.now(timezone.utc) + timedelta(seconds=120)
+        exc = AllCollectionClientsFloodedError(120, next_at)
+        with patch.object(Collector, "collect_single_channel", new_callable=AsyncMock, side_effect=exc):
+            from src.cli.commands.collect import run
+
+            run(_ns(channel_id=102, full=False))
+
+        out = capsys.readouterr().out
+        assert "flood-waited until" in out
+        assert "120s" in out
+        assert "Collected" not in out
+
+    def test_collect_enqueue_warns_about_active_resolve_backoff(
+        self, cli_env_with_pool, capsys
+    ):
+        """#790: bare `collect` must surface active per-account resolve
+        backoffs instead of silently enqueueing as if nothing is wrong."""
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+7001": AsyncMock(), "+7002": AsyncMock()}
+        fake_pool.get_resolve_username_backoff_remaining_sec = MagicMock(
+            side_effect=lambda phone=None: 600 if phone == "+7001" else 0
+        )
+
+        from src.cli.commands.collect import run
+
+        run(_ns(channel_id=None, full=False))
+
+        out = capsys.readouterr().out
+        assert "enqueued" in out.lower()
+        assert "resolve_username Flood Wait active" in out
+        assert "+7001" in out
+        assert "+7002" not in out.split("Flood Wait active")[-1]
+
+    def test_collect_enqueue_no_backoff_no_warning(self, cli_env_with_pool, capsys):
+        cli_env, fake_pool = cli_env_with_pool
+        fake_pool.clients = {"+7001": AsyncMock()}
+
+        from src.cli.commands.collect import run
+
+        run(_ns(channel_id=None, full=False))
+
+        out = capsys.readouterr().out
+        assert "enqueued" in out.lower()
+        assert "Flood Wait active" not in out
 
 
 def _add_channel(db: Database, channel_id: int = 100, title: str = "TestCh") -> int:

--- a/tests/test_client_pool_resolve_guard.py
+++ b/tests/test_client_pool_resolve_guard.py
@@ -179,6 +179,60 @@ class TestHasResolveCapablePhone:
         assert pool.has_resolve_capable_phone(exclude={"+7001", "+7002"}) is False
 
 
+class TestHasRotatableResolvePhone:
+    """#790 F1: rotation eligibility must also reject *generic* flood-waited
+    accounts, not just resolve-backoff ones — that knowledge lives in the lease
+    pool (DB-backed), so the check is async and delegates the flood/in-use
+    filter to ``available_exclusive_count``."""
+
+    def _pool(self, clients, available_count):
+        pool = ClientPool.__new__(ClientPool)
+        pool._resolve_rate_limiter = ResolveRateLimiter()
+        pool._resolve_username_backoff_until_utc = {}
+        pool._resolve_ramp_up_until_utc = {}
+        pool._resolve_ramp_up_last_call_utc = {}
+        pool._resolve_ramp_up_min_interval_sec = 5.0
+        pool.clients = clients
+        # available_exclusive_count is the async lease-pool filter for generic
+        # flood wait + in-use; capture the candidate set it is asked about.
+        pool._lease_pool = SimpleNamespace(
+            available_exclusive_count=AsyncMock(side_effect=available_count)
+        )
+        return pool
+
+    @pytest.mark.anyio
+    async def test_false_when_only_free_phone_is_generically_flooded(self):
+        # +7001 in resolve backoff; +7002 free of backoff but the lease pool
+        # reports zero available (it is generically flooded) → not rotatable.
+        seen = {}
+
+        async def _count(candidates):
+            seen["candidates"] = set(candidates)
+            return 0
+
+        pool = self._pool({"+7001": object(), "+7002": object()}, _count)
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert await pool.has_rotatable_resolve_phone(exclude={"+7001"}) is False
+        # The backoff phone must be narrowed out before hitting the lease pool.
+        assert seen["candidates"] == {"+7002"}
+
+    @pytest.mark.anyio
+    async def test_true_when_free_phone_is_available(self):
+        pool = self._pool({"+7001": object(), "+7002": object()}, lambda c: 1)
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert await pool.has_rotatable_resolve_phone(exclude={"+7001"}) is True
+
+    @pytest.mark.anyio
+    async def test_false_when_all_phones_in_resolve_backoff(self):
+        # No candidate survives the sync backoff filter → lease pool not queried.
+        count = AsyncMock(return_value=5)
+        pool = self._pool({"+7001": object(), "+7002": object()}, count)
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        pool.set_resolve_username_backoff(600, phone="+7002")
+        assert await pool.has_rotatable_resolve_phone() is False
+        count.assert_not_awaited()
+
+
 class TestRampUpMode:
     def test_ramp_up_active_after_backoff_set(self):
         pool = _make_pool()

--- a/tests/test_client_pool_resolve_guard.py
+++ b/tests/test_client_pool_resolve_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -10,14 +11,17 @@ from telethon.errors import FloodWaitError
 from src.telegram.client_pool import ClientPool
 from src.telegram.flood_wait import HandledFloodWaitError
 from src.telegram.rate_limiter import ResolveRateLimiter, UsernameResolveRateLimitedError
-from src.telegram.resolve_guard import ResolveGuardMixin
+from src.telegram.resolve_guard import (
+    RESOLVE_BACKOFF_BY_PHONE_SETTING,
+    RESOLVE_BACKOFF_LEGACY_SETTING,
+    ResolveGuardMixin,
+)
 
 
 @pytest.mark.anyio
 async def test_live_username_resolve_uses_shared_rate_limiter():
     pool = ClientPool.__new__(ClientPool)
     pool.report_flood = AsyncMock()
-    pool._resolve_username_backoff_until_utc = None
     pool._resolve_rate_limiter = ResolveRateLimiter(
         max_calls=1,
         window_sec=60.0,
@@ -42,12 +46,13 @@ async def test_live_username_resolve_uses_shared_rate_limiter():
 
 
 @pytest.mark.anyio
-async def test_live_username_resolve_records_full_long_flood_backoff():
+async def test_live_username_resolve_records_per_phone_long_flood_backoff():
+    """#790: a long flood on one phone freezes only that phone, not the pool."""
     pool = ClientPool.__new__(ClientPool)
     pool.report_flood = AsyncMock()
     pool._db = SimpleNamespace(set_setting=AsyncMock())
-    pool._resolve_username_backoff_until_utc = None
-    pool._resolve_rate_limiter = ResolveRateLimiter(max_calls=1, jitter_sec=0.0)
+    pool.clients = {"+7001": object(), "+7002": object()}
+    pool._resolve_rate_limiter = ResolveRateLimiter(jitter_sec=0.0)
 
     async def _flood():
         raise FloodWaitError(request=None, capture=7200)
@@ -61,66 +66,241 @@ async def test_live_username_resolve_records_full_long_flood_backoff():
         )
 
     pool.report_flood.assert_awaited_once_with("+7001", 7200)
-    remaining = pool.get_resolve_username_backoff_remaining_sec()
-    assert 7100 < remaining <= 7200
+    remaining_a = pool.get_resolve_username_backoff_remaining_sec("+7001")
+    assert 7100 < remaining_a <= 7200
+    # The other connected phone is untouched...
+    assert pool.get_resolve_username_backoff_remaining_sec("+7002") == 0
+    # ...so the pool-level aggregate reports "a free phone exists".
+    assert pool.get_resolve_username_backoff_remaining_sec() == 0
     pool._db.set_setting.assert_awaited_once()
     key, value = pool._db.set_setting.await_args.args
-    assert key == "resolve_username_backoff_until_utc"
-    assert datetime.fromisoformat(value) == pool.get_resolve_username_backoff_until()
+    assert key == RESOLVE_BACKOFF_BY_PHONE_SETTING
+    stored = json.loads(value)
+    assert set(stored) == {"+7001"}
+    assert datetime.fromisoformat(stored["+7001"]) == pool.get_resolve_username_backoff_until(
+        "+7001"
+    )
 
 
-def _make_pool():
+def _make_pool(clients: dict | None = None):
     class FakePool(ResolveGuardMixin):
         def __init__(self):
             self._resolve_rate_limiter = None
-            self._resolve_username_backoff_until_utc = None
-            self._resolve_ramp_up_until_utc = None
-            self._resolve_ramp_up_last_call_utc = None
+            self._resolve_username_backoff_until_utc = {}
+            self._resolve_ramp_up_until_utc = {}
+            self._resolve_ramp_up_last_call_utc = {}
             self._resolve_ramp_up_min_interval_sec = 5.0
+            self.clients = clients or {}
 
     return FakePool()
 
 
+class TestPerPhoneBackoffIsolation:
+    def test_backoff_on_one_phone_does_not_block_other(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert pool.get_resolve_username_backoff_remaining_sec("+7001") > 500
+        assert pool.get_resolve_username_backoff_remaining_sec("+7002") == 0
+        # reserve on the free phone passes the backoff layer entirely
+        assert pool.reserve_resolve_username_call("+7002") == 0.0
+        # reserve on the backoff phone is deferred for its own remaining window
+        assert pool.reserve_resolve_username_call("+7001") > 500
+
+    def test_until_is_per_phone(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        deadline = pool.set_resolve_username_backoff(600, phone="+7001")
+        assert pool.get_resolve_username_backoff_until("+7001") == deadline
+        assert pool.get_resolve_username_backoff_until("+7002") is None
+
+
 class TestBackoffNeverShortens:
-    def test_keeps_longer_backoff(self):
+    def test_keeps_longer_backoff_same_phone(self):
         pool = _make_pool()
-        first = pool.set_resolve_username_backoff(10000)
-        second = pool.set_resolve_username_backoff(100)
+        first = pool.set_resolve_username_backoff(10000, phone="+7001")
+        second = pool.set_resolve_username_backoff(100, phone="+7001")
         assert second == first
-        assert pool.get_resolve_username_backoff_remaining_sec() > 9000
+        assert pool.get_resolve_username_backoff_remaining_sec("+7001") > 9000
 
-    def test_replaces_shorter_backoff(self):
+    def test_replaces_shorter_backoff_same_phone(self):
         pool = _make_pool()
-        pool.set_resolve_username_backoff(100)
-        pool.set_resolve_username_backoff(10000)
-        assert pool.get_resolve_username_backoff_remaining_sec() > 9000
+        pool.set_resolve_username_backoff(100, phone="+7001")
+        pool.set_resolve_username_backoff(10000, phone="+7001")
+        assert pool.get_resolve_username_backoff_remaining_sec("+7001") > 9000
 
-    def test_sets_backoff_when_none_active(self):
+    def test_other_phone_unaffected_by_never_shorten(self):
         pool = _make_pool()
-        pool.set_resolve_username_backoff(5000)
-        assert pool.get_resolve_username_backoff_remaining_sec() > 4000
+        pool.set_resolve_username_backoff(10000, phone="+7001")
+        pool.set_resolve_username_backoff(100, phone="+7002")
+        assert pool.get_resolve_username_backoff_remaining_sec("+7002") <= 100
+
+
+class TestAggregateBackoff:
+    def test_aggregate_zero_when_one_connected_phone_free(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert pool.get_resolve_username_backoff_remaining_sec() == 0
+        assert pool.get_resolve_username_backoff_until() is None
+
+    def test_aggregate_min_when_all_connected_phones_blocked(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        until_b = pool.set_resolve_username_backoff(300, phone="+7002")
+        remaining = pool.get_resolve_username_backoff_remaining_sec()
+        assert 200 < remaining <= 300
+        assert pool.get_resolve_username_backoff_until() == until_b
+
+    def test_aggregate_without_clients_uses_backoff_entries(self):
+        pool = _make_pool()
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        remaining = pool.get_resolve_username_backoff_remaining_sec()
+        assert 500 < remaining <= 600
+
+    def test_aggregate_zero_when_no_backoff(self):
+        pool = _make_pool(clients={"+7001": object()})
+        assert pool.get_resolve_username_backoff_remaining_sec() == 0
+
+
+class TestHasResolveCapablePhone:
+    def test_free_phone_is_capable(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert pool.has_resolve_capable_phone() is True
+        assert pool.has_resolve_capable_phone(exclude={"+7002"}) is False
+
+    def test_all_blocked_not_capable(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        pool.set_resolve_username_backoff(600, phone="+7002")
+        assert pool.has_resolve_capable_phone() is False
+
+    def test_exclude_respected(self):
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        assert pool.has_resolve_capable_phone(exclude={"+7001"}) is True
+        assert pool.has_resolve_capable_phone(exclude={"+7001", "+7002"}) is False
 
 
 class TestRampUpMode:
     def test_ramp_up_active_after_backoff_set(self):
         pool = _make_pool()
-        pool.set_resolve_username_backoff(600)
-        assert pool.is_resolve_ramp_up_active()
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        assert pool.is_resolve_ramp_up_active("+7001")
+        assert not pool.is_resolve_ramp_up_active("+7002")
 
-    def test_ramp_up_rate_limits(self):
+    def test_ramp_up_rate_limits_only_its_phone(self):
         pool = _make_pool()
-        pool._resolve_username_backoff_until_utc = datetime.now(timezone.utc) - timedelta(seconds=1)
-        pool._resolve_ramp_up_until_utc = datetime.now(timezone.utc) + timedelta(seconds=300)
+        now = datetime.now(timezone.utc)
+        pool._resolve_ramp_up_until_utc["+7001"] = now + timedelta(seconds=300)
         pool._resolve_ramp_up_min_interval_sec = 5.0
-        pool._resolve_ramp_up_last_call_utc = datetime.now(timezone.utc)
-        retry_after = pool.reserve_resolve_username_call("+1234567890")
-        assert retry_after > 0
+        pool._resolve_ramp_up_last_call_utc["+7001"] = now
+        assert pool.reserve_resolve_username_call("+7001") > 0
+        # The other phone has no ramp-up and an empty limiter window.
+        pool._resolve_rate_limiter = ResolveRateLimiter(jitter_sec=0.0)
+        assert pool.reserve_resolve_username_call("+7002") == 0.0
 
     def test_ramp_up_allows_slow_calls(self):
         pool = _make_pool()
-        pool._resolve_username_backoff_until_utc = datetime.now(timezone.utc) - timedelta(seconds=1)
-        pool._resolve_ramp_up_until_utc = datetime.now(timezone.utc) + timedelta(seconds=300)
+        now = datetime.now(timezone.utc)
+        pool._resolve_ramp_up_until_utc["+7001"] = now + timedelta(seconds=300)
         pool._resolve_ramp_up_min_interval_sec = 0.01
-        pool._resolve_ramp_up_last_call_utc = datetime.now(timezone.utc) - timedelta(seconds=1)
-        retry_after = pool.reserve_resolve_username_call("+1234567890")
-        assert retry_after == 0.0
+        pool._resolve_ramp_up_last_call_utc["+7001"] = now - timedelta(seconds=1)
+        assert pool.reserve_resolve_username_call("+7001") == 0.0
+
+
+class TestPersistence:
+    @pytest.mark.anyio
+    async def test_persist_writes_pruned_json_map(self):
+        pool = _make_pool()
+        pool._db = SimpleNamespace(set_setting=AsyncMock())
+        until = pool.set_resolve_username_backoff(600, phone="+7001")
+        # Expired entry must be pruned out of the persisted payload.
+        pool._resolve_username_backoff_until_utc["+7002"] = datetime.now(
+            timezone.utc
+        ) - timedelta(seconds=10)
+
+        await pool.persist_resolve_username_backoff()
+
+        key, value = pool._db.set_setting.await_args.args
+        assert key == RESOLVE_BACKOFF_BY_PHONE_SETTING
+        stored = json.loads(value)
+        assert set(stored) == {"+7001"}
+        assert datetime.fromisoformat(stored["+7001"]) == until
+
+    @pytest.mark.anyio
+    async def test_restore_round_trip(self):
+        until = datetime.now(timezone.utc) + timedelta(seconds=900)
+        payload = json.dumps({"+7001": until.isoformat()})
+
+        async def get_setting(key):
+            return payload if key == RESOLVE_BACKOFF_BY_PHONE_SETTING else None
+
+        pool = _make_pool(clients={"+7001": object(), "+7002": object()})
+        await pool.restore_resolve_username_backoff(
+            SimpleNamespace(get_setting=get_setting, set_setting=AsyncMock())
+        )
+
+        assert pool.get_resolve_username_backoff_until("+7001") == until
+        assert pool.get_resolve_username_backoff_remaining_sec("+7002") == 0
+        # Ramp-up restored for the blocked phone only.
+        assert pool.is_resolve_ramp_up_active("+7001")
+        assert not pool.is_resolve_ramp_up_active("+7002")
+
+    @pytest.mark.anyio
+    async def test_restore_skips_expired_entries(self):
+        until = datetime.now(timezone.utc) - timedelta(seconds=10)
+        payload = json.dumps({"+7001": until.isoformat()})
+
+        async def get_setting(key):
+            return payload if key == RESOLVE_BACKOFF_BY_PHONE_SETTING else None
+
+        pool = _make_pool()
+        await pool.restore_resolve_username_backoff(
+            SimpleNamespace(get_setting=get_setting, set_setting=AsyncMock())
+        )
+        assert pool.get_resolve_username_backoff_remaining_sec("+7001") == 0
+
+    @pytest.mark.anyio
+    async def test_legacy_global_value_migrates_to_all_known_phones(self):
+        """Upgrade mid-flood: the legacy single deadline conservatively applies
+        to every known phone, is re-persisted in the new format, and the legacy
+        key is cleared."""
+        legacy_until = datetime.now(timezone.utc) + timedelta(seconds=1800)
+
+        async def get_setting(key):
+            if key == RESOLVE_BACKOFF_BY_PHONE_SETTING:
+                return None
+            if key == RESOLVE_BACKOFF_LEGACY_SETTING:
+                return legacy_until.isoformat()
+            return None
+
+        set_setting = AsyncMock()
+        pool = _make_pool()
+        pool._db = SimpleNamespace(get_setting=get_setting, set_setting=set_setting)
+        await pool.restore_resolve_username_backoff(
+            pool._db, phones=["+7001", "+7002"]
+        )
+
+        assert pool.get_resolve_username_backoff_until("+7001") == legacy_until
+        assert pool.get_resolve_username_backoff_until("+7002") == legacy_until
+        written = {call.args[0]: call.args[1] for call in set_setting.await_args_list}
+        assert RESOLVE_BACKOFF_LEGACY_SETTING in written
+        assert written[RESOLVE_BACKOFF_LEGACY_SETTING] == ""
+        stored = json.loads(written[RESOLVE_BACKOFF_BY_PHONE_SETTING])
+        assert set(stored) == {"+7001", "+7002"}
+
+    @pytest.mark.anyio
+    async def test_legacy_migration_without_phones_is_skipped(self):
+        legacy_until = datetime.now(timezone.utc) + timedelta(seconds=1800)
+
+        async def get_setting(key):
+            if key == RESOLVE_BACKOFF_LEGACY_SETTING:
+                return legacy_until.isoformat()
+            return None
+
+        set_setting = AsyncMock()
+        pool = _make_pool()
+        await pool.restore_resolve_username_backoff(
+            SimpleNamespace(get_setting=get_setting, set_setting=set_setting)
+        )
+        # Nothing restored, legacy key left intact for the next start.
+        assert pool.get_resolve_username_backoff_remaining_sec() == 0
+        set_setting.assert_not_awaited()

--- a/tests/test_client_pool_resolve_guard.py
+++ b/tests/test_client_pool_resolve_guard.py
@@ -233,6 +233,93 @@ class TestHasRotatableResolvePhone:
         count.assert_not_awaited()
 
 
+class TestNextResolveCapableAt:
+    """#790 review P2: the defer deadline must combine the per-phone resolve
+    backoff with *generic* flood waits (``accounts.flood_wait_until``) — in the
+    mixed state (this phone resolve-blocked for hours, the other phone only
+    generically flooded for minutes) the channel must retry when the generic
+    flood clears, not after the hours-long resolve window."""
+
+    def _pool(self, clients, accounts, monkeypatch):
+        pool = ClientPool.__new__(ClientPool)
+        pool._resolve_rate_limiter = ResolveRateLimiter()
+        pool._resolve_username_backoff_until_utc = {}
+        pool._resolve_ramp_up_until_utc = {}
+        pool._resolve_ramp_up_last_call_utc = {}
+        pool._resolve_ramp_up_min_interval_sec = 5.0
+        pool.clients = clients
+        pool._db = SimpleNamespace()
+        monkeypatch.setattr(
+            "src.telegram.client_pool.load_live_usable_accounts",
+            AsyncMock(return_value=accounts),
+        )
+        return pool
+
+    @pytest.mark.anyio
+    async def test_mixed_state_uses_generic_flood_deadline(self, monkeypatch):
+        now = datetime.now(timezone.utc)
+        accounts = [
+            SimpleNamespace(phone="+7001", flood_wait_until=None),
+            SimpleNamespace(phone="+7002", flood_wait_until=now + timedelta(seconds=600)),
+        ]
+        pool = self._pool({"+7001": object(), "+7002": object()}, accounts, monkeypatch)
+        pool.set_resolve_username_backoff(7200, phone="+7001")
+
+        capable_at = await pool.next_resolve_capable_at()
+
+        assert capable_at is not None
+        remaining = (capable_at - now).total_seconds()
+        assert 590 < remaining <= 600
+
+    @pytest.mark.anyio
+    async def test_none_when_some_phone_is_capable_now(self, monkeypatch):
+        accounts = [
+            SimpleNamespace(phone="+7001", flood_wait_until=None),
+            SimpleNamespace(phone="+7002", flood_wait_until=None),
+        ]
+        pool = self._pool({"+7001": object(), "+7002": object()}, accounts, monkeypatch)
+        pool.set_resolve_username_backoff(7200, phone="+7001")
+        assert await pool.next_resolve_capable_at() is None
+
+    @pytest.mark.anyio
+    async def test_all_resolve_backoff_matches_aggregate(self, monkeypatch):
+        accounts = [
+            SimpleNamespace(phone="+7001", flood_wait_until=None),
+            SimpleNamespace(phone="+7002", flood_wait_until=None),
+        ]
+        pool = self._pool({"+7001": object(), "+7002": object()}, accounts, monkeypatch)
+        pool.set_resolve_username_backoff(7200, phone="+7001")
+        pool.set_resolve_username_backoff(400, phone="+7002")
+
+        capable_at = await pool.next_resolve_capable_at()
+
+        assert capable_at == pool.get_resolve_username_backoff_until()
+
+    @pytest.mark.anyio
+    async def test_per_phone_max_of_resolve_and_generic(self, monkeypatch):
+        # +7001: resolve 600s AND generic 1200s → ready at 1200s.
+        # +7002: resolve 3600s only → ready at 3600s. Earliest = 1200s.
+        now = datetime.now(timezone.utc)
+        accounts = [
+            SimpleNamespace(phone="+7001", flood_wait_until=now + timedelta(seconds=1200)),
+            SimpleNamespace(phone="+7002", flood_wait_until=None),
+        ]
+        pool = self._pool({"+7001": object(), "+7002": object()}, accounts, monkeypatch)
+        pool.set_resolve_username_backoff(600, phone="+7001")
+        pool.set_resolve_username_backoff(3600, phone="+7002")
+
+        capable_at = await pool.next_resolve_capable_at()
+
+        assert capable_at is not None
+        remaining = (capable_at - now).total_seconds()
+        assert 1190 < remaining <= 1200
+
+    @pytest.mark.anyio
+    async def test_none_when_no_clients_connected(self, monkeypatch):
+        pool = self._pool({}, [], monkeypatch)
+        assert await pool.next_resolve_capable_at() is None
+
+
 class TestRampUpMode:
     def test_ramp_up_active_after_backoff_set(self):
         pool = _make_pool()

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -686,6 +686,50 @@ async def test_deferred_error_wait_seconds_matches_aggregate_deadline(db):
 
 
 @pytest.mark.anyio
+async def test_rate_limited_defer_uses_pool_capable_deadline_in_mixed_state(db):
+    """#790 review P2: this phone is in an hours-long resolve backoff while the
+    only alternative is blocked by a *generic* flood that clears much earlier —
+    the deferred error must carry the pool-wide capable-again deadline, not
+    this phone's own resolve window."""
+    ch_id = await db.add_channel(
+        Channel(channel_id=1970788997, title="Mixed Defer", username="mixed_defer")
+    )
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    # +7001 sits in a long resolve backoff → its resolves run cache-only and
+    # the cache miss raises UsernameResolveRateLimitedError (hours).
+    pool.set_resolve_username_backoff(7200, phone="+7001")
+    # +7002 is free of resolve backoff but generically flooded: rotation is
+    # impossible, yet the pool knows it becomes capable again in ~600s.
+    capable_at = datetime.now(timezone.utc) + timedelta(seconds=600)
+
+    async def _no_rotation(exclude=frozenset()):
+        return False
+
+    async def _capable():
+        return capable_at
+
+    pool.has_rotatable_resolve_phone = _no_rotation
+    pool.next_resolve_capable_at = _capable
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    pool.get_available_client = AsyncMock(return_value=(s1, "+7001"))
+    collector = Collector(
+        pool, db, SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10)
+    )
+
+    with pytest.raises(UsernameResolveRateLimitedError) as exc_info:
+        await collector._collect_channel(stored)
+
+    exc = exc_info.value
+    assert abs((exc.next_available_at - capable_at).total_seconds()) <= 2
+    # The ~600s generic window must win over the 7200s resolve backoff.
+    assert exc.retry_after_sec <= 600
+
+
+@pytest.mark.anyio
 async def test_collect_channel_defensive_backoff_when_guard_returns_none(db):
     """#785: if the pool's backoff is None after a long resolve FloodWait, the
     collector sets it defensively rather than letting all subsequent channels

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -651,6 +651,41 @@ async def test_collect_all_channels_rotates_flooded_channel_mid_run(db):
 
 
 @pytest.mark.anyio
+async def test_deferred_error_wait_seconds_matches_aggregate_deadline(db):
+    """#790 review follow-up: when rotation is exhausted, the deferred error's
+    ``wait_seconds`` must describe the same deadline as ``next_available_at``
+    (the aggregate min across accounts), not the triggering phone's own flood —
+    the stats path and ``str(exc)`` surface both fields."""
+    ch_id = await db.add_channel(
+        Channel(channel_id=1970788996, title="Agg Defer", username="agg_defer")
+    )
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    flood_err = FloodWaitError(request=None, capture=7200)
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    # The would-be rotation target already sits in a much shorter backoff —
+    # the aggregate deadline is +7002's ~400s, not +7001's fresh 7200s flood.
+    pool.set_resolve_username_backoff(400, phone="+7002")
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    pool.get_available_client = AsyncMock(return_value=(s1, "+7001"))
+    collector = Collector(
+        pool, db, SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10)
+    )
+
+    with pytest.raises(UsernameResolveFloodWaitDeferredError) as exc_info:
+        await collector._collect_channel(stored)
+
+    exc = exc_info.value
+    assert exc.next_available_at == pool.get_resolve_username_backoff_until()
+    expected_sec = (exc.next_available_at - datetime.now(timezone.utc)).total_seconds()
+    assert abs(exc.wait_seconds - expected_sec) <= 2
+    # The aggregate (free in ~400s) must win over the triggering 7200s flood.
+    assert exc.wait_seconds <= 400
+
+
+@pytest.mark.anyio
 async def test_collect_channel_defensive_backoff_when_guard_returns_none(db):
     """#785: if the pool's backoff is None after a long resolve FloodWait, the
     collector sets it defensively rather than letting all subsequent channels

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -465,6 +465,79 @@ async def test_collect_channel_rotates_on_cache_miss_during_backoff(db):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_defers_when_only_other_account_is_flooded(db):
+    """#790 F1: the serving phone is in resolve backoff and the cache misses,
+    and the only other connected account is in a *generic* flood wait — so it
+    is NOT a valid rotation target. The channel must defer (raise), not abort
+    the run by rotating into a dead end.
+    """
+    ch = Channel(
+        channel_id=1970788987,
+        title="Flooded Neighbor",
+        username="flooded_neighbor",
+        last_collected_id=5,
+    )
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    # +7001 serves the channel (resolve backoff → cache-only). +7002 is the only
+    # other account but it is generically flooded, so get_available_client with
+    # +7001 excluded yields nothing and rotation is not possible.
+    pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), None])
+    pool.set_resolve_username_backoff(600, phone="+7001")
+    # +7002 is free of resolve backoff but in a generic flood wait: rotation
+    # must report it as not capable.
+    pool.has_rotatable_resolve_phone = AsyncMock(return_value=False)
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+
+    with pytest.raises(UsernameResolveRateLimitedError):
+        await collector._collect_channel(stored)
+
+    raw1.get_input_entity.assert_not_awaited()
+    pool.report_flood.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_collect_channel_defer_uses_aggregate_backoff_window(db):
+    """#790 F2: when every account is in resolve backoff with different windows,
+    the deferral the channel raises must carry the *pool-wide minimum* remaining
+    (the moment the first account frees up), not the serving phone's own longer
+    window.
+    """
+    ch = Channel(
+        channel_id=1970788988,
+        title="Aggregate Defer",
+        username="aggregate_defer",
+        last_collected_id=5,
+    )
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    pool.get_available_client = AsyncMock(return_value=(s1, "+7001"))
+    # Serving phone has the long window; the other a much shorter one. Both in
+    # backoff → no rotation target → defer for the shorter (aggregate) window.
+    pool.set_resolve_username_backoff(7000, phone="+7001")
+    pool.set_resolve_username_backoff(100, phone="+7002")
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+
+    with pytest.raises(UsernameResolveRateLimitedError) as exc_info:
+        await collector._collect_channel(stored)
+
+    # Deferral window reflects +7002's ~100s, not +7001's ~7000s.
+    assert exc_info.value.retry_after_seconds <= 110
+    raw1.get_input_entity.assert_not_awaited()
+    pool.report_flood.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_collect_all_channels_continues_cache_only_during_backoff(db):
     """#552: a global resolve backoff no longer aborts the whole run. Channels
     that miss the cache are deferred while the run continues — cache-resolvable

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -206,7 +207,9 @@ async def test_collect_positive_id_end_to_end(db):
 
 
 @pytest.mark.anyio
-async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_rotation(db):
+async def test_collect_channel_long_resolve_flood_rotates_to_free_account(db):
+    """#790: a long resolve flood backs off only the flooded phone; the channel
+    is retried within the same pass on another connected account."""
     ch = Channel(
         channel_id=1970788984,
         title="Long Username Flood",
@@ -220,7 +223,7 @@ async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_
     flood_err = FloodWaitError(request=None, capture=7200)
     raw_client1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
     raw_client2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
-    pool = make_mock_pool()
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
     session1 = TelegramTransportSession(
         raw_client1,
         disconnect_on_close=False,
@@ -245,15 +248,58 @@ async def test_collect_channel_long_username_resolve_flood_sets_backoff_without_
         SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
     )
 
+    result = await collector._collect_channel(stored)
+
+    assert result == 0
+    pool.report_flood.assert_awaited_once_with("+7001", 7200)
+    # The channel was retried on the second, free account in the same pass.
+    assert pool.get_available_client.await_count == 2
+    raw_client2.get_input_entity.assert_awaited()
+    # The second acquisition excluded the flooded phone.
+    second_call = pool.get_available_client.await_args_list[1]
+    assert second_call.kwargs.get("exclude_phones") == {"+7001"}
+    # Backoff is per-phone: full window on the flooded phone, none on the other.
+    remaining = collector._get_resolve_username_backoff_remaining_sec("+7001")
+    assert 7100 < remaining <= 7200
+    assert collector._get_resolve_username_backoff_remaining_sec("+7002") == 0
+
+
+@pytest.mark.anyio
+async def test_collect_channel_long_resolve_flood_defers_when_no_other_account(db):
+    """#790: with a single connected account, a long resolve flood still defers
+    the channel for the full window — there is nobody to rotate to."""
+    ch = Channel(
+        channel_id=1970788984,
+        title="Long Username Flood Single",
+        username="long_flood_single",
+        last_collected_id=5,
+    )
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    flood_err = FloodWaitError(request=None, capture=7200)
+    raw_client1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
+    pool = make_mock_pool(clients={"+7001": object()})
+    session1 = TelegramTransportSession(
+        raw_client1,
+        disconnect_on_close=False,
+        phone="+7001",
+        pool=pool,
+    )
+    pool.get_available_client = AsyncMock(return_value=(session1, "+7001"))
+    collector = Collector(
+        pool,
+        db,
+        SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10),
+    )
+
     with pytest.raises(UsernameResolveFloodWaitDeferredError):
         await collector._collect_channel(stored)
 
     pool.report_flood.assert_awaited_once_with("+7001", 7200)
     pool.get_available_client.assert_awaited_once()
-    raw_client2.get_input_entity.assert_not_awaited()
-    # Long resolve floods are honored for Telegram's full window so the worker
-    # does not retry before the account is usable again.
-    remaining = collector._get_resolve_username_backoff_remaining_sec()
+    remaining = collector._get_resolve_username_backoff_remaining_sec("+7001")
     assert 7100 < remaining <= 7200
 
 
@@ -354,9 +400,9 @@ async def test_collect_channel_defers_when_resolve_rate_limited(db):
 
 @pytest.mark.anyio
 async def test_collect_channel_cache_only_defers_on_backoff_miss(db):
-    """#552: while a global resolve backoff is active, a channel whose InputPeer
-    is not cached runs in cache-only mode — it raises a defer signal without
-    ever calling the live resolve API."""
+    """#552/#790: while the serving phone is in resolve backoff and no other
+    account is free, a channel whose InputPeer is not cached runs in cache-only
+    mode — it raises a defer signal without ever calling the live resolve API."""
     ch = Channel(
         channel_id=1970788986,
         title="Backoff Active",
@@ -368,19 +414,53 @@ async def test_collect_channel_cache_only_defers_on_backoff_miss(db):
     assert stored is not None
 
     raw_client = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
-    pool = make_mock_pool()
+    pool = make_mock_pool(clients={"+7001": object()})
     session = TelegramTransportSession(
         raw_client, disconnect_on_close=False, phone="+7001", pool=pool
     )
     pool.get_available_client = AsyncMock(return_value=(session, "+7001"))
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
-    pool.set_resolve_username_backoff(600)
+    pool.set_resolve_username_backoff(600, phone="+7001")
 
     with pytest.raises(UsernameResolveRateLimitedError) as exc_info:
         await collector._collect_channel(stored)
 
     assert exc_info.value.phone == "+7001"
     raw_client.get_input_entity.assert_not_awaited()
+    pool.report_flood.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_collect_channel_rotates_on_cache_miss_during_backoff(db):
+    """#790: the serving phone is in resolve backoff and the cache misses, but
+    another connected account is free — the channel rotates to it and resolves
+    live instead of being deferred."""
+    ch = Channel(
+        channel_id=1970788986,
+        title="Backoff Rotate",
+        username="backoff_rotate",
+        last_collected_id=5,
+    )
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
+    pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+    pool.set_resolve_username_backoff(600, phone="+7001")
+
+    result = await collector._collect_channel(stored)
+
+    assert result == 0
+    # The backoff phone never fired a live resolve; the free phone did.
+    raw1.get_input_entity.assert_not_awaited()
+    raw2.get_input_entity.assert_awaited()
+    assert pool.get_available_client.await_count == 2
     pool.report_flood.assert_not_awaited()
 
 
@@ -398,12 +478,14 @@ async def test_collect_all_channels_continues_cache_only_during_backoff(db):
 
     raw1 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
     raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
-    pool = make_mock_pool()
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
     s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
     s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
     pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
     collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
-    pool.set_resolve_username_backoff(600)
+    # #790: every connected account is in backoff — nothing to rotate to.
+    pool.set_resolve_username_backoff(600, phone="+7001")
+    pool.set_resolve_username_backoff(600, phone="+7002")
 
     stats = await collector.collect_all_channels()
 
@@ -417,11 +499,9 @@ async def test_collect_all_channels_continues_cache_only_during_backoff(db):
 
 @pytest.mark.anyio
 async def test_collect_all_channels_continues_after_mid_run_resolve_flood(db):
-    """#552: when the FIRST channel of a run triggers a long resolve flood mid-run,
-    the run must NOT abort — the backoff it just set makes every subsequent channel
-    resolve cache-only, so the run continues instead of bricking on the triggering
-    channel. Regression guard for the break→continue fix (the pre-set-backoff test
-    never reaches this path)."""
+    """#552/#790: when the FIRST channel of a run triggers a long resolve flood
+    mid-run, the run must NOT abort. The backoff applies only to the flooded
+    phone, so subsequent channels served by other accounts keep resolving live."""
     await db.add_channel(
         Channel(channel_id=1970788991, title="Trigger Flood", username="trigger_flood")
     )
@@ -429,14 +509,14 @@ async def test_collect_all_channels_continues_after_mid_run_resolve_flood(db):
         Channel(channel_id=1970788992, title="After Flood", username="after_flood")
     )
 
-    # Channel 1's live resolve raises a 7200s flood (> 300s threshold) → sets the
-    # global backoff and raises UsernameResolveFloodWaitDeferredError mid-run.
+    # Channel 1's live resolve raises a 7200s flood (> 300s threshold) → sets a
+    # per-phone backoff and raises UsernameResolveFloodWaitDeferredError mid-run
+    # (the flooded phone is the only connected account — nothing to rotate to).
     flood_err = FloodWaitError(request=None, capture=7200)
     raw1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
-    # Channel 2 would resolve fine live, but the active backoff routes it cache-only,
-    # so its live get_input_entity must never be awaited.
+    # Channel 2 is served by a different, non-backoff phone — it resolves live.
     raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
-    pool = make_mock_pool()
+    pool = make_mock_pool(clients={"+7001": object()})
     s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
     s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
     pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
@@ -451,15 +531,50 @@ async def test_collect_all_channels_continues_after_mid_run_resolve_flood(db):
     assert pool.get_available_client.await_count == 2
     # The triggering channel is counted as deferred, not as an error.
     assert stats["errors"] == 0
-    assert stats.get("deferred", 0) >= 1
-    # Backoff is active for Telegram's full FloodWait window.
-    remaining = collector._get_resolve_username_backoff_remaining_sec()
+    assert stats.get("deferred", 0) == 1
+    # Backoff is active for Telegram's full FloodWait window — on the flooded
+    # phone only (#790).
+    remaining = collector._get_resolve_username_backoff_remaining_sec("+7001")
     assert 7100 < remaining <= 7200
+    assert collector._get_resolve_username_backoff_remaining_sec("+7002") == 0
     # Single source of truth (#785): the collector reads the pool's backoff, no
     # separate collector-local copy.
-    assert remaining == pool.get_resolve_username_backoff_remaining_sec()
-    # Channel 2 was routed cache-only — no live resolve fired.
-    raw2.get_input_entity.assert_not_awaited()
+    assert remaining == pool.get_resolve_username_backoff_remaining_sec("+7001")
+    # Channel 2 was served by a free phone — its live resolve fired and the
+    # channel collected normally instead of being routed cache-only.
+    raw2.get_input_entity.assert_awaited()
+    assert stats["channels"] == 1
+
+
+@pytest.mark.anyio
+async def test_collect_all_channels_rotates_flooded_channel_mid_run(db):
+    """#790: with a second free account connected, the channel that just
+    triggered a long resolve flood is retried on the free account within the
+    same run instead of being deferred."""
+    await db.add_channel(
+        Channel(channel_id=1970788993, title="Rotate Flood", username="rotate_flood")
+    )
+
+    flood_err = FloodWaitError(request=None, capture=7200)
+    raw1 = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
+    raw2 = FakeTelethonClient(entity_resolver=lambda _arg: SimpleNamespace())
+    pool = make_mock_pool(clients={"+7001": object(), "+7002": object()})
+    s1 = TelegramTransportSession(raw1, disconnect_on_close=False, phone="+7001", pool=pool)
+    s2 = TelegramTransportSession(raw2, disconnect_on_close=False, phone="+7002", pool=pool)
+    pool.get_available_client = AsyncMock(side_effect=[(s1, "+7001"), (s2, "+7002")])
+    collector = Collector(
+        pool, db, SchedulerConfig(delay_between_requests_sec=0, max_flood_wait_sec=10)
+    )
+
+    stats = await collector.collect_all_channels()
+
+    assert stats["errors"] == 0
+    assert stats.get("deferred", 0) == 0
+    assert stats["channels"] == 1
+    raw2.get_input_entity.assert_awaited()
+    remaining = collector._get_resolve_username_backoff_remaining_sec("+7001")
+    assert 7100 < remaining <= 7200
+    assert collector._get_resolve_username_backoff_remaining_sec("+7002") == 0
 
 
 @pytest.mark.anyio
@@ -481,12 +596,7 @@ async def test_collect_channel_defensive_backoff_when_guard_returns_none(db):
 
     flood_err = FloodWaitError(request=None, capture=55919)
     raw_client = FakeTelethonClient(entity_resolver=lambda _arg: flood_err)
-    pool = make_mock_pool()
-    # Initialise all ResolveGuardMixin state so MagicMock auto-fabrication
-    # does not interfere with the mixin's datetime comparisons.
-    pool._resolve_ramp_up_until_utc = None
-    pool._resolve_ramp_up_last_call_utc = None
-    pool._resolve_ramp_up_min_interval_sec = 5.0
+    pool = make_mock_pool(clients={"+7001": object()})
     pool._db = SimpleNamespace(set_setting=AsyncMock())
     session = TelegramTransportSession(
         raw_client,
@@ -499,7 +609,7 @@ async def test_collect_channel_defensive_backoff_when_guard_returns_none(db):
     # Simulate the pool having lost its backoff: get_resolve_username_backoff_until
     # always returns None even though a long flood was just raised. The collector
     # must call set_resolve_username_backoff defensively.
-    pool.get_resolve_username_backoff_until = lambda: None
+    pool.get_resolve_username_backoff_until = lambda phone=None: None
 
     collector = Collector(
         pool,
@@ -511,19 +621,18 @@ async def test_collect_channel_defensive_backoff_when_guard_returns_none(db):
         await collector._collect_channel(stored)
 
     # The defensive set_resolve_username_backoff call must have been made with
-    # the flood_wait_sec value (55919 > 300 threshold). Verify by reading the
-    # raw internal state (get_resolve_username_backoff_until is overridden to
-    # always return None, so we read _resolve_username_backoff_until_utc directly).
-    assert pool._resolve_username_backoff_until_utc is not None
-    remaining = (
-        pool._resolve_username_backoff_until_utc - datetime.now(timezone.utc)
-    ).total_seconds()
+    # the flood_wait_sec value (55919 > 300 threshold) for the flooded phone.
+    # Verify by reading the raw internal state (get_resolve_username_backoff_until
+    # is overridden to always return None, so we read the dict directly).
+    backoff_until = pool._resolve_username_backoff_until_utc.get("+7001")
+    assert backoff_until is not None
+    remaining = (backoff_until - datetime.now(timezone.utc)).total_seconds()
     assert remaining > 0, "defensive backoff must be active"
     assert remaining <= 55919
     assert pool._db.set_setting.await_count >= 1
     key, value = pool._db.set_setting.await_args.args
-    assert key == "resolve_username_backoff_until_utc"
-    assert datetime.fromisoformat(value) == pool._resolve_username_backoff_until_utc
+    assert key == "resolve_username_backoff_by_phone"
+    assert datetime.fromisoformat(json.loads(value)["+7001"]) == backoff_until
 
 
 @pytest.mark.anyio

--- a/tests/test_collector_runtime.py
+++ b/tests/test_collector_runtime.py
@@ -392,3 +392,39 @@ async def test_collect_channel_stats_deactivates_on_username_fallback_failure(
 
     saved = await db.get_channel_stats(-100555)
     assert len(saved) == 0
+
+
+@pytest.mark.anyio
+async def test_collect_channel_stats_transient_error_skips_without_deactivation(
+    db,
+    real_pool_harness_factory,
+):
+    """A transient failure (timeout, connection drop — anything that is not a
+    ValueError/TypeError entity miss) must skip the stats run WITHOUT
+    deactivating the channel (#815 review follow-up): the channel is valid,
+    only this attempt failed.
+    """
+    await db.add_channel(Channel(channel_id=-100777, title="Flaky"))
+    channel = (await db.get_channels())[0]
+
+    def _resolver(_peer):
+        raise RuntimeError("connection reset mid-request")
+
+    harness = real_pool_harness_factory()
+    harness.queue_cli_client(
+        phone="+7000",
+        client=FakeCliTelethonClient(entity_resolver=_resolver),
+    )
+    await harness.add_account("+7000", session_string="session-flaky", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    collector = Collector(harness.pool, db, SchedulerConfig())
+    result = await collector.collect_channel_stats(channel)
+
+    assert result is None
+
+    updated = (await db.get_channels())[0]
+    assert updated.is_active is True
+
+    saved = await db.get_channel_stats(-100777)
+    assert len(saved) == 0


### PR DESCRIPTION
Closes #790. Часть зонтичного #791.

## Проблема

`_resolve_username_backoff_until_utc` — один скаляр на весь `ClientPool`: длинный resolve-FloodWait (>300s) на ОДНОМ аккаунте замораживал live-резолвы username для ВСЕХ аккаунтов. Per-account rate limiter (#647) уже существовал — глобальным оставался только backoff.

## Фикс (первопричина)

- **Per-phone backoff/ramp-up** в `ResolveGuardMixin` (`dict[phone → deadline]`). Геттеры без аргумента возвращают агрегат: 0, пока хоть один connected-аккаунт свободен, иначе min remaining — все 4 существующих потребителя (queue/scheduler/CLI) получают «defer только когда заблокированы все».
- **Ротация в Collector**: cache-miss на backoff-аккаунте или свежий длинный flood ретраят канал на свободном аккаунте в том же проходе (`get_available_client(exclude_phones=…)`, `has_resolve_capable_phone`). Канал откладывается только когда исчерпаны все аккаунты. InputPeer аккаунт-специфичен, поэтому ротация = повторный заход цикла с новым клиентом.
- **Persistence**: новый ключ `resolve_username_backoff_by_phone` (JSON, prune истёкших); одноразовая консервативная миграция легаси-значения на все известные аккаунты с очисткой старого ключа.
- **Отображение**: колонка «Resolve backoff» в `account flood-status`, `resolve_backoffs` в worker-снапшоте `accounts_status`, бейдж на странице настроек web (CLI/Web parity).

## Drive-by фиксы (найдены живой heavy-верификацией)

1. **DB-only подкоманды `scheduler` поднимали полный Telegram-пул** (коннект всех аккаунтов ради одной DB-записи). Из-за этого per-task cleanup в heavy-сьюте занимал 30s+ на вызов, валил тест по таймауту и утёк 152 pending-задачами в живую БД (прибрано). Теперь пул только для `start`/`trigger`. Heavy-тест: таймаут 360s → проходит за 214s.
2. **Вывод flood-ошибок**: `AllCollectionClientsFloodedError` в `collect --channel-id`/`channel collect` печатал traceback — теперь дедлайн ретрая + reschedule; bare `collect` предупреждает об активных resolve-backoff по аккаунтам.
3. **Регрессия #815 на main**: сужение `except` в stats-пути уронило `test_collect_stats_username_fallback_fails` — transient-ошибки снова дают skip, но БЕЗ деактивации канала (+ регрессионный тест).

## Осознанный trade-off

Если Telegram эскалирует resolve-floods на уровне IP/DC, отказ от глобального backoff может ре-триггерить flood на соседних аккаунтах. Митигации: per-account limiter (20/60s) сохранён, per-phone ramp-up сохранён, flooded-аккаунт и так исключён через `report_flood`/`accounts.flood_wait_until`, ротация срабатывает только на cache-miss.

## Тесты

- TDD: переписан `test_client_pool_resolve_guard.py` (per-phone изоляция, never-shorten, агрегаты, persist/restore, легаси-миграция, prune); новые тесты ротации в `test_collector.py`; тест «DB-only scheduler-команды не поднимают пул»; тесты flood-вывода CLI.
- Полный сьют: 7769+857 passed, ruff/lint-imports чистые, parity-инварианты 100 passed.
- Живые: safe_ro 5/5 (flood-status, collect sample, channel stats ×2, dialogs resolve), heavy 2/2 (`channel collect first`, `collect default all`). Единственные ошибки окружения — известный #812 (ScopeMismatch pytest-base-url).

🤖 Generated with [Claude Code](https://claude.com/claude-code)