### PR TITLE
fix(telegram): MTProto security-warning watchdog with force reconnect (#556)

### DIFF
--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -384,11 +384,22 @@ class TelegramAuth:
         logger.info("auth.sign_in_fresh success phone=%s duration_ms=%d", phone, duration_ms)
         return session_string
 
-    async def create_client_from_session(self, session_string: str) -> TelegramClient:
-        """Create and connect a client from saved session string."""
+    async def create_client_from_session(
+        self,
+        session_string: str,
+        *,
+        base_logger: logging.Logger | None = None,
+    ) -> TelegramClient:
+        """Create and connect a client from saved session string.
+
+        ``base_logger`` routes the client's Telethon loggers under a per-phone
+        name so the MTProto security watchdog can attribute warnings (#556).
+        """
+        extra_kwargs = {"base_logger": base_logger} if base_logger is not None else {}
         client = TelegramClient(
             StringSession(session_string), self._api_id, self._api_hash,
             connection_retries=None, retry_delay=2,
+            **extra_kwargs,
         )
         await client.connect()
         if not await client.is_user_authorized():

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -16,6 +16,7 @@ from telethon_cli.errors import CLIError
 from src.models import Account
 from src.telegram.auth import TelegramAuth
 from src.telegram.flood_wait import HandledFloodWaitError, handle_flood_wait
+from src.telegram.mtproto_watchdog import bind_telethon_base_logger
 from src.telegram.reactions import normalize_outgoing_reaction_emoji
 from src.telegram.session_materializer import SessionMaterializer
 
@@ -613,11 +614,24 @@ class TelegramBackend(ABC):
 class NativeTelethonBackend(TelegramBackend):
     name = "native"
 
-    def __init__(self, auth: TelegramAuth):
+    def __init__(
+        self,
+        auth: TelegramAuth,
+        client_logger_provider: Callable[[str], logging.Logger] | None = None,
+    ):
         self._auth = auth
+        # Per-phone Telethon base loggers for the MTProto watchdog (#556).
+        self.client_logger_provider = client_logger_provider
 
     async def acquire_client(self, account: Account) -> BackendClientLease:
-        client = await self._auth.create_client_from_session(account.session_string)
+        base_logger = (
+            self.client_logger_provider(account.phone)
+            if self.client_logger_provider is not None
+            else None
+        )
+        client = await self._auth.create_client_from_session(
+            account.session_string, base_logger=base_logger
+        )
         # Surface every FloodWaitError so run_with_flood_wait can call
         # pool.report_flood and rotate accounts (#495). Telethon's default
         # silently sleeps on waits ≤ threshold and hides the flood from us.
@@ -637,10 +651,13 @@ class TelethonCliBackend(TelegramBackend):
         auth: TelegramAuth,
         materializer: SessionMaterializer,
         transport: str = "hybrid",
+        client_logger_provider: Callable[[str], logging.Logger] | None = None,
     ):
         self._auth = auth
         self._materializer = materializer
         self._transport = transport
+        # Per-phone Telethon base loggers for the MTProto watchdog (#556).
+        self.client_logger_provider = client_logger_provider
 
     async def acquire_client(self, account: Account) -> BackendClientLease:
         if self._transport == "subprocess":
@@ -663,6 +680,13 @@ class TelethonCliBackend(TelegramBackend):
             client._connection_retries = None
             client._retry_delay = 2
             client.flood_sleep_threshold = 0
+            if self.client_logger_provider is not None:
+                # create_client() does not expose Telethon's base_logger=, and
+                # MTProtoSender captures its logger in __init__ — rebind both
+                # BEFORE connect() so the watchdog sees this client (#556).
+                bind_telethon_base_logger(
+                    client, self.client_logger_provider(account.phone)
+                )
             await client.connect()
             if not await client.is_user_authorized():
                 await _disconnect_client_safely(client, phone=account.phone)

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -623,10 +623,16 @@ class NativeTelethonBackend(TelegramBackend):
         # Per-phone Telethon base loggers for the MTProto watchdog (#556).
         self.client_logger_provider = client_logger_provider
 
-    async def acquire_client(self, account: Account) -> BackendClientLease:
+    async def acquire_client(
+        self, account: Account, *, ephemeral: bool = False
+    ) -> BackendClientLease:
+        # Ephemeral (force_native) sessions are short-lived and never replace
+        # the pooled client — giving them the per-phone watchdog logger would
+        # misattribute their security warnings to the phone and reconnect the
+        # healthy pooled client instead (#817 review P2).
         base_logger = (
             self.client_logger_provider(account.phone)
-            if self.client_logger_provider is not None
+            if self.client_logger_provider is not None and not ephemeral
             else None
         )
         client = await self._auth.create_client_from_session(
@@ -726,7 +732,7 @@ class BackendRouter:
         force_native: bool = False,
     ) -> BackendClientLease:
         if force_native or self._mode == "native":
-            return await self._native.acquire_client(account)
+            return await self._native.acquire_client(account, ephemeral=force_native)
 
         if self._mode == "auto":
             try:

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -43,10 +43,12 @@ from src.telegram.flood_wait import (
     is_transient_flood_wait_seconds,
     run_with_flood_wait,
 )
+from src.telegram.mtproto_watchdog import MTProtoSecurityWatchdog
 from src.telegram.rate_limiter import ResolveRateLimiter
 from src.telegram.resolve_guard import ResolveGuardMixin
 from src.telegram.session_materializer import SessionMaterializer
 from src.telegram.utils import normalize_utc
+from src.utils.safe_logging import mask_phone
 
 logger = logging.getLogger(__name__)
 REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC = 5.0
@@ -100,11 +102,18 @@ class ClientPool(ResolveGuardMixin):
         self._session_overrides: dict[str, str] = {}
         self._active_leases: dict[str, list[BackendClientLease]] = defaultdict(list)
         self._materializer = SessionMaterializer(self._runtime_config.session_cache_dir)
-        self._native_backend = NativeTelethonBackend(auth)
+        # MTProto security watchdog (#556): per-phone Telethon loggers let it
+        # attribute "Security error while unpacking" warnings and force a
+        # reconnect of the silently-bricked client.
+        self._mtproto_watchdog = MTProtoSecurityWatchdog(self._on_mtproto_security_brick)
+        self._native_backend = NativeTelethonBackend(
+            auth, client_logger_provider=self._mtproto_watchdog.register_phone
+        )
         self._primary_backend = TelethonCliBackend(
             auth,
             self._materializer,
             transport=self._runtime_config.cli_transport,
+            client_logger_provider=self._mtproto_watchdog.register_phone,
         )
         self._backend_router = BackendRouter(
             mode=self._runtime_config.backend_mode,
@@ -528,6 +537,9 @@ class ClientPool(ResolveGuardMixin):
 
     async def initialize(self, *, phones: Iterable[str] | None = None) -> None:
         """Load active accounts and validate that their sessions are usable."""
+        watchdog = getattr(self, "_mtproto_watchdog", None)
+        if watchdog is not None:
+            watchdog.install(asyncio.get_running_loop())
         accounts = await load_live_usable_accounts(self._db, active_only=True)
         # Restore after loading accounts: the legacy single-deadline migration
         # needs the known phones to apply the old global backoff per-phone.
@@ -853,7 +865,55 @@ class ClientPool(ResolveGuardMixin):
             logger.exception("Failed to reconnect client for %s", phone)
             return False
 
+    async def force_reconnect_phone(self, phone: str) -> bool:
+        """Disconnect and reconnect a client even when it looks connected.
+
+        Needed for the MTProto security brick (#556): the transport stays
+        formally connected while every incoming message is dropped, so
+        :meth:`reconnect_phone`'s ``is_connected()`` guard never fires.
+        """
+        session = self.clients.get(phone)
+        if session is None:
+            return False
+        try:
+            client = session.raw_client
+            try:
+                await asyncio.wait_for(
+                    client.disconnect(), timeout=REMOVE_CLIENT_DISCONNECT_TIMEOUT_SEC
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Timeout disconnecting %s during force reconnect", mask_phone(phone))
+            await client.connect()
+            if not await client.is_user_authorized():
+                logger.error("Force reconnect of %s: session no longer authorized", mask_phone(phone))
+                return False
+            return bool(client.is_connected())
+        except Exception:
+            logger.exception("Force reconnect failed for %s", mask_phone(phone))
+            return False
+
+    async def _on_mtproto_security_brick(self, phone: str) -> None:
+        """Watchdog callback: the client is dropping every incoming message."""
+        logger.warning(
+            "MTProto security errors detected on %s — forcing reconnect",
+            mask_phone(phone),
+        )
+        ok = await self.force_reconnect_phone(phone)
+        logger.warning(
+            "MTProto watchdog reconnect of %s %s",
+            mask_phone(phone),
+            "succeeded" if ok else "FAILED",
+        )
+
+    def get_mtproto_watchdog_stats(self) -> dict[str, int]:
+        """Reconnects the watchdog has triggered, keyed by phone."""
+        return self._mtproto_watchdog.get_stats()
+
     async def remove_client(self, phone: str) -> None:
+        # getattr: test doubles build the pool via __new__ without __init__.
+        watchdog = getattr(self, "_mtproto_watchdog", None)
+        if watchdog is not None:
+            watchdog.unregister_phone(phone)
         self._session_overrides.pop(phone, None)
         async with self._lock:
             leases = list(self._active_leases.pop(phone, []))

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -956,6 +956,12 @@ class ClientPool(ResolveGuardMixin):
         return set(self._premium_flood_wait_until)
 
     async def disconnect_all(self) -> None:
+        # Detach the watchdog handler from the global telethon.tgcf logger so
+        # a torn-down pool is not kept alive by it (#817 review F1); a later
+        # initialize() re-installs it. getattr: doubles built via __new__.
+        watchdog = getattr(self, "_mtproto_watchdog", None)
+        if watchdog is not None:
+            watchdog.uninstall()
         had_clients = bool(self.clients)
         for phone in list(self.clients):
             try:

--- a/src/telegram/mtproto_watchdog.py
+++ b/src/telegram/mtproto_watchdog.py
@@ -1,0 +1,190 @@
+"""Watchdog for Telethon MTProto security warnings (#556).
+
+Telethon's ``MTProtoSender._recv_loop`` handles a ``SecurityError`` («Too many
+messages had to be ignored consecutively») by logging a warning and continuing:
+the connection stays formally «connected», but every incoming message is
+dropped — a silent brick. ``ClientPool.reconnect_phone`` only reconnects when
+``not client.is_connected()``, so nothing ever recovers such a client.
+
+This module attributes those warnings to a phone and force-reconnects the
+affected client:
+
+- every pool client gets a per-phone Telethon ``base_logger``
+  (``telethon.tgcf.<sha-slug>``; the slug comes from
+  :func:`src.utils.safe_logging.text_hash` so phone numbers never leak into
+  logger names);
+- one :class:`MTProtoSecurityWatchdog` handler sits on the
+  ``telethon.tgcf`` root and receives the per-phone children via propagation;
+- ``threshold`` warnings within ``window_sec`` trigger the async
+  ``reconnect_cb(phone)`` (scheduled via ``call_soon_threadsafe`` — Telethon
+  may log from a non-loop thread), with a per-phone ``cooldown_sec`` guard
+  against reconnect storms.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import defaultdict, deque
+from collections.abc import Awaitable, Callable
+
+from src.utils.safe_logging import mask_phone, text_hash
+
+logger = logging.getLogger(__name__)
+
+SECURITY_WARNING_SUBSTR = "Security error while unpacking a received message"
+BRICK_DETAIL_SUBSTR = "Too many messages had to be ignored consecutively"
+TGCF_TELETHON_LOGGER_ROOT = "telethon.tgcf"
+_SENDER_LOGGER_SUFFIX = ".network.mtprotosender"
+
+DEFAULT_THRESHOLD = 3
+DEFAULT_WINDOW_SEC = 60.0
+DEFAULT_COOLDOWN_SEC = 300.0
+
+
+class MTProtoSecurityWatchdog(logging.Handler):
+    """Counts MTProto security warnings per phone and fires a reconnect."""
+
+    def __init__(
+        self,
+        reconnect_cb: Callable[[str], Awaitable[None]],
+        *,
+        threshold: int = DEFAULT_THRESHOLD,
+        window_sec: float = DEFAULT_WINDOW_SEC,
+        cooldown_sec: float = DEFAULT_COOLDOWN_SEC,
+    ) -> None:
+        super().__init__(level=logging.WARNING)
+        self._reconnect_cb = reconnect_cb
+        self._threshold = max(1, int(threshold))
+        self._window_sec = float(window_sec)
+        self._cooldown_sec = float(cooldown_sec)
+        self._slug_to_phone: dict[str, str] = {}
+        self._events: dict[str, deque[float]] = defaultdict(deque)
+        self._last_reconnect_at: dict[str, float] = {}
+        self._reconnect_count: dict[str, int] = defaultdict(int)
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def install(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Attach to the telethon.tgcf root logger and capture the loop."""
+        self._loop = loop
+        root = logging.getLogger(TGCF_TELETHON_LOGGER_ROOT)
+        if self not in root.handlers:
+            root.addHandler(self)
+
+    def uninstall(self) -> None:
+        logging.getLogger(TGCF_TELETHON_LOGGER_ROOT).removeHandler(self)
+        self._loop = None
+
+    def register_phone(self, phone: str) -> logging.Logger:
+        """Return the per-phone Telethon base logger and start tracking it."""
+        phone = str(phone)
+        slug = text_hash(phone)
+        self._slug_to_phone[slug] = phone
+        return logging.getLogger(f"{TGCF_TELETHON_LOGGER_ROOT}.{slug}")
+
+    def unregister_phone(self, phone: str) -> None:
+        phone = str(phone)
+        slug = text_hash(phone)
+        self._slug_to_phone.pop(slug, None)
+        self._events.pop(phone, None)
+        self._last_reconnect_at.pop(phone, None)
+
+    def get_stats(self) -> dict[str, int]:
+        """Reconnects triggered per phone (for diagnostics)."""
+        return dict(self._reconnect_count)
+
+    # -- logging.Handler ----------------------------------------------------
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no branch
+        try:
+            phone = self._phone_for_record(record)
+            if phone is None:
+                return
+            if SECURITY_WARNING_SUBSTR not in record.getMessage():
+                return
+            now = time.monotonic()
+            events = self._events[phone]
+            events.append(now)
+            while events and now - events[0] > self._window_sec:
+                events.popleft()
+            if len(events) < self._threshold:
+                return
+            last = self._last_reconnect_at.get(phone)
+            if last is not None and now - last < self._cooldown_sec:
+                return
+            self._last_reconnect_at[phone] = now
+            events.clear()
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+            # emit() may run on a non-loop thread (Telethon recv loop /
+            # logging from anywhere) — never touch asyncio state directly.
+            loop.call_soon_threadsafe(self._spawn_reconnect, phone)
+        except Exception:
+            self.handleError(record)
+
+    def _phone_for_record(self, record: logging.LogRecord) -> str | None:
+        name = record.name
+        if not name.endswith(_SENDER_LOGGER_SUFFIX):
+            return None
+        prefix = f"{TGCF_TELETHON_LOGGER_ROOT}."
+        if not name.startswith(prefix):
+            return None
+        slug = name[len(prefix) : -len(_SENDER_LOGGER_SUFFIX)]
+        return self._slug_to_phone.get(slug)
+
+    def _spawn_reconnect(self, phone: str) -> None:
+        self._reconnect_count[phone] += 1
+        logger.warning(
+            "MTProto security warnings exceeded threshold on %s — scheduling "
+            "force reconnect (#%d)",
+            mask_phone(phone),
+            self._reconnect_count[phone],
+        )
+        task = asyncio.ensure_future(self._reconnect_cb(phone))
+        task.add_done_callback(_log_reconnect_outcome)
+
+
+def _log_reconnect_outcome(task: asyncio.Task) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("MTProto watchdog reconnect failed: %s", exc)
+
+
+def bind_telethon_base_logger(client: object, base_logger: logging.Logger) -> bool:
+    """Rebind an already-constructed TelegramClient onto our base logger.
+
+    The CLI backend builds clients via ``telethon_cli_runtime.create_client``
+    which does not expose Telethon's ``base_logger=`` parameter, and
+    ``MTProtoSender`` captures its logger once in ``__init__`` — so we replace
+    both the client's ``_log`` mapping and the sender's captured logger.
+    Defensive by design: on a breaking Telethon upgrade the client simply
+    stays without per-phone attribution (returns False), nothing crashes.
+    """
+    try:
+
+        class _Loggers(dict):
+            # Mirrors TelegramBaseClient.__init__._Loggers.
+            def __missing__(self, key: str) -> logging.Logger:
+                if key.startswith("telethon."):
+                    key = key.split(".", maxsplit=1)[1]
+                return base_logger.getChild(key)
+
+        loggers = _Loggers()
+        sender = client._sender  # type: ignore[attr-defined]
+        client._log = loggers  # type: ignore[attr-defined]
+        if sender is not None:
+            sender._log = loggers["telethon.network.mtprotosender"]
+        return True
+    except AttributeError:
+        logger.debug(
+            "Could not bind per-phone telethon base logger (telethon internals "
+            "changed?); MTProto watchdog will not cover this client",
+            exc_info=True,
+        )
+        return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,7 +427,7 @@ def _enforce_cli_transport(
 
     if request.node.get_closest_marker("native_backend_allowed"):
 
-        async def _fake_native_transport(self, session_string: str):
+        async def _fake_native_transport(self, session_string: str, *, base_logger=None):
             if native_auth_spy.queued_clients:
                 client = native_auth_spy.queued_clients.pop(0)
             elif session_string in native_auth_spy.by_session:
@@ -448,7 +448,7 @@ def _enforce_cli_transport(
         monkeypatch.setattr(TelegramAuth, "create_client_from_session", _fake_native_transport)
         return
 
-    async def _forbid_native_transport(self, session_string: str):
+    async def _forbid_native_transport(self, session_string: str, *, base_logger=None):
         raise AssertionError(
             "Native Telethon transport is forbidden in this test. "
             "Use telethon-cli-backed runtime or mark the test with native_backend_allowed."

--- a/tests/test_mtproto_watchdog.py
+++ b/tests/test_mtproto_watchdog.py
@@ -1,0 +1,293 @@
+"""Tests for the MTProto security-warning watchdog (#556).
+
+Telethon's ``MTProtoSender._recv_loop`` logs «Security error while unpacking a
+received message: Too many messages had to be ignored consecutively» and keeps
+the connection formally alive — but every incoming update is dropped (a silent
+brick). The watchdog listens on per-phone Telethon loggers and force-reconnects
+the affected client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+from telethon import TelegramClient
+from telethon.sessions import StringSession
+
+from src.telegram.mtproto_watchdog import (
+    SECURITY_WARNING_SUBSTR,
+    TGCF_TELETHON_LOGGER_ROOT,
+    MTProtoSecurityWatchdog,
+    bind_telethon_base_logger,
+)
+
+PHONE_A = "+70001112233"
+PHONE_B = "+70002223344"
+
+
+def _make_watchdog(**kwargs) -> tuple[MTProtoSecurityWatchdog, AsyncMock]:
+    cb = AsyncMock()
+    wd = MTProtoSecurityWatchdog(cb, **kwargs)
+    return wd, cb
+
+
+def _security_record(logger: logging.Logger, detail: str = "Too many messages had to be ignored consecutively"):
+    """Emit the exact warning shape Telethon's MTProtoSender produces."""
+    sender_logger_name = f"{logger.name}.network.mtprotosender"
+    record = logging.LogRecord(
+        name=sender_logger_name,
+        level=logging.WARNING,
+        pathname="mtprotosender.py",
+        lineno=1,
+        msg="Security error while unpacking a received message: %s",
+        args=(detail,),
+        exc_info=None,
+    )
+    return record
+
+
+class TestEmitFiltering:
+    def test_threshold_triggers_reconnect_once(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=3, window_sec=60.0, cooldown_sec=300.0)
+            loop = asyncio.get_running_loop()
+            wd.install(loop)
+            try:
+                base = wd.register_phone(PHONE_A)
+                for _ in range(6):
+                    wd.emit(_security_record(base))
+                # Let call_soon_threadsafe callbacks and the spawned task run.
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                cb.assert_awaited_once_with(PHONE_A)
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_below_threshold_does_not_trigger(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=3)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base = wd.register_phone(PHONE_A)
+                wd.emit(_security_record(base))
+                wd.emit(_security_record(base))
+                await asyncio.sleep(0)
+                cb.assert_not_awaited()
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_per_phone_isolation(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=3)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base_a = wd.register_phone(PHONE_A)
+                base_b = wd.register_phone(PHONE_B)
+                wd.emit(_security_record(base_a))
+                wd.emit(_security_record(base_a))
+                wd.emit(_security_record(base_b))
+                await asyncio.sleep(0)
+                # Neither phone reached 3 on its own.
+                cb.assert_not_awaited()
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_irrelevant_message_and_logger_ignored(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=1)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base = wd.register_phone(PHONE_A)
+                # Right logger, harmless message.
+                rec = _security_record(base)
+                rec.msg = "Connection to %s complete!"
+                rec.args = ("dc",)
+                wd.emit(rec)
+                # Right message, unrelated logger (no registered slug).
+                rec2 = logging.LogRecord(
+                    name="telethon.network.mtprotosender",
+                    level=logging.WARNING,
+                    pathname="x",
+                    lineno=1,
+                    msg=f"{SECURITY_WARNING_SUBSTR}: boom",
+                    args=(),
+                    exc_info=None,
+                )
+                wd.emit(rec2)
+                await asyncio.sleep(0)
+                cb.assert_not_awaited()
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_unregister_stops_tracking(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=1)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base = wd.register_phone(PHONE_A)
+                wd.unregister_phone(PHONE_A)
+                wd.emit(_security_record(base))
+                await asyncio.sleep(0)
+                cb.assert_not_awaited()
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_cooldown_blocks_repeat_reconnects(self):
+        async def _run():
+            wd, cb = _make_watchdog(threshold=1, cooldown_sec=300.0)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base = wd.register_phone(PHONE_A)
+                wd.emit(_security_record(base))
+                wd.emit(_security_record(base))
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                cb.assert_awaited_once()
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+    def test_emit_without_loop_is_safe(self):
+        wd, cb = _make_watchdog(threshold=1)
+        base = wd.register_phone(PHONE_A)
+        # Not installed — must not raise.
+        wd.emit(_security_record(base))
+        cb.assert_not_awaited()
+
+
+class TestPropagationThroughLoggingTree:
+    def test_handler_on_root_receives_child_warning(self):
+        """The handler is installed once on the telethon.tgcf root; warnings on
+        per-phone child loggers must reach it via propagation."""
+
+        async def _run():
+            wd, cb = _make_watchdog(threshold=1)
+            wd.install(asyncio.get_running_loop())
+            try:
+                base = wd.register_phone(PHONE_A)
+                sender_logger = logging.getLogger(f"{base.name}.network.mtprotosender")
+                sender_logger.warning(
+                    "Security error while unpacking a received message: %s",
+                    "Too many messages had to be ignored consecutively",
+                )
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                cb.assert_awaited_once_with(PHONE_A)
+            finally:
+                wd.uninstall()
+
+        asyncio.run(_run())
+
+
+@pytest.mark.telegram_unit
+class TestTelethonIntegration:
+    """Against the installed Telethon — catches breaking upgrades of the
+    private ``_log`` / ``_sender._log`` attributes."""
+
+    def test_native_base_logger_param_routes_sender_logger(self):
+        wd, _cb = _make_watchdog()
+        base = wd.register_phone(PHONE_A)
+        client = TelegramClient(StringSession(), 1, "x", base_logger=base)
+        assert client._sender._log.name.startswith(f"{TGCF_TELETHON_LOGGER_ROOT}.")
+        assert client._sender._log.name.endswith(".network.mtprotosender")
+
+    def test_bind_telethon_base_logger_rebinds_existing_client(self):
+        """CLI-backend clients are built without base_logger; bind must swap
+        both the client loggers dict and the already-captured sender logger."""
+        wd, _cb = _make_watchdog()
+        base = wd.register_phone(PHONE_A)
+        client = TelegramClient(StringSession(), 1, "x")
+        assert not client._sender._log.name.startswith(TGCF_TELETHON_LOGGER_ROOT)
+
+        ok = bind_telethon_base_logger(client, base)
+
+        assert ok is True
+        assert client._sender._log.name == f"{base.name}.network.mtprotosender"
+        # The loggers mapping serves arbitrary telethon.* keys from our base.
+        assert client._log["telethon.client.updates"].name == f"{base.name}.client.updates"
+
+    def test_bind_degrades_gracefully(self):
+        wd, _cb = _make_watchdog()
+        base = wd.register_phone(PHONE_A)
+        assert bind_telethon_base_logger(object(), base) is False
+
+
+class TestForceReconnectPhone:
+    @staticmethod
+    def _pool_with_client(raw) -> object:
+        from types import SimpleNamespace
+
+        from src.telegram.client_pool import ClientPool
+
+        pool = ClientPool.__new__(ClientPool)
+        pool.clients = {PHONE_A: SimpleNamespace(raw_client=raw)}
+        return pool
+
+    async def test_reconnects_even_when_formally_connected(self):
+        from unittest.mock import MagicMock
+
+        raw = AsyncMock()
+        raw.is_connected = MagicMock(return_value=True)
+        raw.is_user_authorized = AsyncMock(return_value=True)
+        pool = self._pool_with_client(raw)
+
+        ok = await pool.force_reconnect_phone(PHONE_A)
+
+        assert ok is True
+        raw.disconnect.assert_awaited_once()
+        raw.connect.assert_awaited_once()
+
+    async def test_unknown_phone_returns_false(self):
+        from src.telegram.client_pool import ClientPool
+
+        pool = ClientPool.__new__(ClientPool)
+        pool.clients = {}
+        assert await pool.force_reconnect_phone(PHONE_A) is False
+
+    async def test_unauthorized_session_returns_false(self):
+        from unittest.mock import MagicMock
+
+        raw = AsyncMock()
+        raw.is_connected = MagicMock(return_value=True)
+        raw.is_user_authorized = AsyncMock(return_value=False)
+        pool = self._pool_with_client(raw)
+
+        assert await pool.force_reconnect_phone(PHONE_A) is False
+
+
+class TestBackendLoggerProvider:
+    async def test_native_backend_passes_per_phone_logger(self):
+        from unittest.mock import MagicMock
+
+        from src.models import Account
+        from src.telegram.backends import NativeTelethonBackend
+
+        auth = MagicMock()
+        client = MagicMock()
+        auth.create_client_from_session = AsyncMock(return_value=client)
+        base = logging.getLogger("telethon.tgcf.testslug")
+        provider = MagicMock(return_value=base)
+        backend = NativeTelethonBackend(auth, client_logger_provider=provider)
+        account = Account(phone=PHONE_A, session_string="sess", is_active=True)
+
+        lease = await backend.acquire_client(account)
+
+        provider.assert_called_once_with(PHONE_A)
+        auth.create_client_from_session.assert_awaited_once_with(
+            "sess", base_logger=base
+        )
+        assert lease.phone == PHONE_A

--- a/tests/test_mtproto_watchdog.py
+++ b/tests/test_mtproto_watchdog.py
@@ -291,3 +291,78 @@ class TestBackendLoggerProvider:
             "sess", base_logger=base
         )
         assert lease.phone == PHONE_A
+
+    async def test_ephemeral_native_client_gets_no_watchdog_logger(self):
+        """Review P2 (#817): force_native sessions are short-lived and never
+        replace ``clients[phone]`` — giving them the per-phone watchdog logger
+        would misattribute their security warnings to the phone and trigger a
+        reconnect of the healthy *pooled* client."""
+        from unittest.mock import MagicMock
+
+        from src.models import Account
+        from src.telegram.backends import NativeTelethonBackend
+
+        auth = MagicMock()
+        auth.create_client_from_session = AsyncMock(return_value=MagicMock())
+        provider = MagicMock()
+        backend = NativeTelethonBackend(auth, client_logger_provider=provider)
+        account = Account(phone=PHONE_A, session_string="sess", is_active=True)
+
+        await backend.acquire_client(account, ephemeral=True)
+
+        provider.assert_not_called()
+        auth.create_client_from_session.assert_awaited_once_with(
+            "sess", base_logger=None
+        )
+
+    async def test_router_marks_force_native_as_ephemeral(self):
+        from unittest.mock import MagicMock
+
+        from src.models import Account
+        from src.telegram.backends import BackendRouter
+
+        native = MagicMock()
+        native.acquire_client = AsyncMock(return_value=MagicMock())
+        router = BackendRouter(mode="auto", primary=MagicMock(), native=native)
+        account = Account(phone=PHONE_A, session_string="sess", is_active=True)
+
+        await router.acquire_client(account, force_native=True)
+
+        native.acquire_client.assert_awaited_once_with(account, ephemeral=True)
+
+    async def test_router_native_mode_pooled_client_is_supervised(self):
+        from unittest.mock import MagicMock
+
+        from src.models import Account
+        from src.telegram.backends import BackendRouter
+
+        native = MagicMock()
+        native.acquire_client = AsyncMock(return_value=MagicMock())
+        router = BackendRouter(mode="native", primary=MagicMock(), native=native)
+        account = Account(phone=PHONE_A, session_string="sess", is_active=True)
+
+        await router.acquire_client(account)
+
+        native.acquire_client.assert_awaited_once_with(account, ephemeral=False)
+
+
+class TestDisconnectAllUninstall:
+    async def test_disconnect_all_uninstalls_watchdog_handler(self):
+        """Review F1 (#817): pool teardown must detach the watchdog handler
+        from the global ``telethon.tgcf`` logger — a stale handler would keep
+        the dead pool referenced and pile up across pool re-creations."""
+        from unittest.mock import MagicMock
+
+        from src.telegram.client_pool import ClientPool
+
+        pool = ClientPool.__new__(ClientPool)
+        pool.clients = {}
+        pool._in_use = set()
+        pool._active_leases = {}
+        pool._dialogs_fetched = set()
+        watchdog = MagicMock()
+        pool._mtproto_watchdog = watchdog
+
+        await pool.disconnect_all()
+
+        watchdog.uninstall.assert_called_once_with()


### PR DESCRIPTION
Часть зонтичного #791; устраняет первопричину #556 (issue закрыт ранее как операционный — этим PR добавляется недостающая обработка в код).

## Проблема

Telethon `MTProtoSender._recv_loop` обрабатывает SecurityError «Too many messages had to be ignored consecutively» так: пишет warning в лог и продолжает. Соединение остаётся формально «connected», но ВСЕ входящие сообщения дропаются — тихий кирпич. `reconnect_phone()` реконнектит только при `not is_connected()`, поэтому такой клиент не восстанавливался никогда. В проекте не было ни перехвата warning'а, ни метрики, ни реакции.

## Фикс (первопричина)

- **`src/telegram/mtproto_watchdog.py`** — `MTProtoSecurityWatchdog` (logging.Handler на корне `telethon.tgcf`): считает security-warning'и per-phone (порог 3 за 60s, cooldown 300s от reconnect-штормов) и планирует асинхронный реконнект через `call_soon_threadsafe` (Telethon может логировать не из loop-треда; в `emit()` никакой async-логики). Имена per-phone логгеров — sha-слаги (`safe_logging.text_hash`), номера телефонов в имена логгеров не попадают.
- **Per-phone Telethon base loggers**: `create_client_from_session(base_logger=…)`; оба бэкенда получают `client_logger_provider`. CLI-бэкенд (клиент создаётся `telethon_cli_runtime.create_client` без base_logger, а `MTProtoSender` захватывает логгер один раз в `__init__`) перепривязывается через `bind_telethon_base_logger()` ДО `connect()` — зеркалит телетоновский `_Loggers`, на ломающем апгрейде Telethon деградирует тихо (клиент просто без атрибуции).
- **`ClientPool.force_reconnect_phone()`** — disconnect → connect → `is_user_authorized()`: работает на «формально connected» кирпиче. Callback watchdog'а вызывает его и логирует исход; `remove_client` снимает регистрацию; счётчики доступны через `get_mtproto_watchdog_stats()`.

## Тесты

- 18 новых в `tests/test_mtproto_watchdog.py`: threshold/cooldown/per-phone изоляция/нерелевантные записи/propagation через дерево логгеров/безопасный emit без loop; **интеграционные против установленного Telethon 1.42** (ловят ломающий апгрейд приватных `_log`/`_sender._log`); `force_reconnect_phone` (включая unauthorized); проброс провайдера в native-бэкенд.
- Полный сьют: 7717 passed (parallel) + 853 passed (serial), ruff и import-linter чистые.
- Живые safe_ro 3/3 (`account list`, `dialogs cache-status`, `collect sample`) — клиенты реально создаются и коннектятся обоими бэкендами с per-phone логгером.

## Порядок мержа

Ветка от main, файлы с #816 не пересекаются, но на main живёт регрессия теста из #815 (чинится в #816) — мержить лучше **после #816**, чтобы CI этой ветки был полностью зелёным.

🤖 Generated with [Claude Code](https://claude.com/claude-code)