### PR TITLE
test: rename parametrize base_url to configured_base_url (#812)

### DIFF
--- a/tests/test_provider_runtime_integration.py
+++ b/tests/test_provider_runtime_integration.py
@@ -257,8 +257,12 @@ async def test_zai_model_refresh_rejects_legacy_anthropic_models_endpoint(db, mo
     assert "Anthropic-compatible proxy" in entry.error
 
 
+# The param is named configured_base_url (not base_url) because pytest-base-url
+# (pulled in transitively by pytest-playwright) registers a session-scoped
+# fixture `base_url`; shadowing it with a function-scoped param breaks setup
+# with ScopeMismatch (#812).
 @pytest.mark.parametrize(
-    "provider,base_url,model,expected_url",
+    "provider,configured_base_url,model,expected_url",
     [
         # Expected URLs are hardcoded so the test catches changes to the
         # configured endpoint flowing through LangChain.
@@ -287,7 +291,7 @@ async def test_deepagents_chat_runs_real_init_chat_model_and_create_deep_agent(
     db,
     monkeypatch,
     provider,
-    base_url,
+    configured_base_url,
     model,
     expected_url,
 ):
@@ -305,7 +309,7 @@ async def test_deepagents_chat_runs_real_init_chat_model_and_create_deep_agent(
         enabled=True,
         priority=0,
         selected_model=model,
-        plain_fields={"base_url": base_url},
+        plain_fields={"base_url": configured_base_url},
         secret_fields={"api_key": f"{provider}-test-key"},
     )
     await DbProviderConfigService(db, config).save_provider_configs([cfg])


### PR DESCRIPTION
## Проблема (#812)

`tests/test_provider_runtime_integration.py::test_deepagents_chat_runs_real_init_chat_model_and_create_deep_agent` детерминированно падал на setup с тремя `ScopeMismatch` ошибками:

```
ScopeMismatch: You tried to access the function scoped fixture base_url with a
session scoped request object. Requesting fixture stack:
  pytest_base_url/plugin.py:18:  def _verify_url(request, base_url)
```

**Красное состояние зафиксировано на main:**
```
pytest tests/test_provider_runtime_integration.py -p no:cacheprovider -q
→ 8 passed, 1 skipped, 3 errors in 2.48s
```

## Корень

Плагин `pytest-base-url 2.1.0` (транзитивно через `pytest-playwright`) регистрирует session-scoped фикстуру `base_url` и autouse-хук `_verify_url`. Параметр `@pytest.mark.parametrize` с тем же именем перекрывает её function-scoped direct-param фикстурой → ScopeMismatch на setup.

## Фикс

Переименование параметра `base_url` → `configured_base_url` (parametrize, сигнатура, тело) — консистентно с соседним `test_zai_model_refresh_uses_configured_base_url`. Добавлен комментарий, почему имя зарезервировано.

## Проверка

```
pytest tests/test_provider_runtime_integration.py -p no:cacheprovider -q
→ 11 passed, 1 skipped in 4.84s
ruff check src/ tests/ conftest.py → All checks passed!
```

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)