### PR TITLE
fix(web): moderation filter 422 on empty pipeline_id/limit/offset (#779)

### DIFF
--- a/src/web/query_params.py
+++ b/src/web/query_params.py
@@ -1,0 +1,27 @@
+"""Lenient parsing for optional query parameters.
+
+HTML GET forms submit empty selects/inputs as empty strings (``?pipeline_id=``),
+and Jinja renders ``None`` into handcrafted pagination links. FastAPI rejects
+both with 422 when the parameter is annotated as ``int | None``, so routes that
+back such forms accept ``str | None`` and parse with these helpers (#779).
+"""
+
+from __future__ import annotations
+
+
+def parse_optional_int(value: str | None, default: int | None = None) -> int | None:
+    """Return ``int(value)`` or *default* when the value is empty or not a number."""
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def parse_clamped_int(value: str | None, default: int, minimum: int, maximum: int) -> int:
+    """Parse like :func:`parse_optional_int` and clamp the result to [minimum, maximum]."""
+    parsed = parse_optional_int(value, default)
+    if parsed is None:
+        parsed = default
+    return max(minimum, min(parsed, maximum))

--- a/src/web/routes/calendar.py
+++ b/src/web/routes/calendar.py
@@ -5,17 +5,9 @@ from fastapi.responses import HTMLResponse, JSONResponse
 
 from src.services.content_calendar_service import ContentCalendarService
 from src.web import deps
+from src.web.query_params import parse_optional_int
 
 router = APIRouter()
-
-
-def _parse_pipeline_id(value: str | None) -> int | None:
-    if value is None or value.strip() == "":
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -27,7 +19,7 @@ async def calendar_page(
     """Render content calendar page."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
-    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
+    selected_pipeline_id = parse_optional_int(pipeline_id)
 
     calendar_days = await calendar.get_calendar(days=days, pipeline_id=selected_pipeline_id)
     stats = await calendar.get_stats()
@@ -58,7 +50,7 @@ async def api_calendar(
     """Get calendar data as JSON."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
-    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
+    selected_pipeline_id = parse_optional_int(pipeline_id)
 
     calendar_days = await calendar.get_calendar(days=days, pipeline_id=selected_pipeline_id)
 
@@ -91,7 +83,7 @@ async def api_upcoming(
     """Get upcoming events as JSON."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
-    selected_pipeline_id = _parse_pipeline_id(pipeline_id)
+    selected_pipeline_id = parse_optional_int(pipeline_id)
 
     events = await calendar.get_upcoming(limit=limit, pipeline_id=selected_pipeline_id)
 

--- a/src/web/routes/moderation.py
+++ b/src/web/routes/moderation.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.services.publish_service import PublishService  # noqa: F401
 from src.web import deps
+from src.web.query_params import parse_clamped_int, parse_optional_int
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -20,15 +21,21 @@ def _moderation_redirect(code: str, *, error: bool = False) -> RedirectResponse:
 @router.get("/", response_class=HTMLResponse)
 async def moderation_queue_page(
     request: Request,
-    pipeline_id: int | None = None,
-    limit: int = 50,
-    offset: int = 0,
+    pipeline_id: str | None = None,
+    limit: str | None = None,
+    offset: str | None = None,
 ):
+    # The filter form submits empty values (?pipeline_id=) and pagination links
+    # may carry "None" — parse leniently instead of letting FastAPI 422 (#779).
+    parsed_pipeline_id = parse_optional_int(pipeline_id)
+    parsed_limit = parse_clamped_int(limit, default=50, minimum=1, maximum=200)
+    parsed_offset = max(0, parse_optional_int(offset, 0) or 0)
+
     db = deps.get_db(request)
     pending_runs = await db.repos.generation_runs.list_pending_moderation(
-        pipeline_id=pipeline_id,
-        limit=limit,
-        offset=offset,
+        pipeline_id=parsed_pipeline_id,
+        limit=parsed_limit,
+        offset=parsed_offset,
     )
 
     pipelines_svc = deps.pipeline_service(request)
@@ -40,9 +47,9 @@ async def moderation_queue_page(
         {
             "pending_runs": pending_runs,
             "pipelines": pipelines,
-            "selected_pipeline_id": pipeline_id,
-            "limit": limit,
-            "offset": offset,
+            "selected_pipeline_id": parsed_pipeline_id,
+            "limit": parsed_limit,
+            "offset": parsed_offset,
         },
     )
 

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -90,12 +90,12 @@
         <ul class="pagination">
             {% if offset > 0 %}
             <li class="page-item">
-                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id }}&limit={{ limit }}&offset={{ offset - limit }}">Назад</a>
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ [offset - limit, 0] | max }}">Назад</a>
             </li>
             {% endif %}
             {% if pending_runs|length == limit %}
             <li class="page-item">
-                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id }}&limit={{ limit }}&offset={{ offset + limit }}">Вперёд</a>
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ offset + limit }}">Вперёд</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -237,3 +237,37 @@ async def test_moderation_page_with_pipeline_filter(client):
     """Test moderation page with pipeline filter."""
     resp = await client.get("/moderation/?pipeline_id=1")
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_moderation_page_empty_filter_params_return_200(client):
+    """The filter form submits ?pipeline_id= (empty option value) — must not 422 (#779)."""
+    resp = await client.get("/moderation/?pipeline_id=&limit=&offset=")
+    assert resp.status_code == 200
+    assert "Очередь модерации" in resp.text
+
+
+@pytest.mark.anyio
+async def test_moderation_page_pipeline_id_none_string_returns_200(client):
+    """Pagination links render pipeline_id=None when no pipeline selected — must not 422 (#779)."""
+    resp = await client.get("/moderation/?pipeline_id=None&limit=50&offset=50")
+    assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_moderation_page_empty_pipeline_id_shows_all_runs(client):
+    """Empty pipeline_id means 'all pipelines' — pending runs stay visible (#779)."""
+    db = client._transport_app.state.db
+    _, run_id = await _create_pipeline_and_run(db)
+
+    resp = await client.get("/moderation/?pipeline_id=")
+    assert resp.status_code == 200
+    assert "Generated content" in resp.text
+    assert f"/moderation/{run_id}/view" in resp.text
+
+
+@pytest.mark.anyio
+async def test_moderation_page_clamps_out_of_range_limit_and_offset(client):
+    """limit is clamped to [1, 200] and offset to >= 0 instead of erroring (#779)."""
+    resp = await client.get("/moderation/?limit=100000&offset=-5")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Проблема (#779)

На `/moderation/` кнопка «Фильтр» выдавала окно с ошибкой вместо результата.

**Корень.** Форма фильтра — `method=get` с `<option value="">Все пайплайны</option>`, поэтому сабмит идёт как `?pipeline_id=` (пустая строка). Роут объявлял `pipeline_id: int | None`, а FastAPI/Pydantic v2 не коэрсит `""` → `None` и возвращает **422 Unprocessable Entity**. Вторая мина там же: пагинационные ссылки рендерили `?pipeline_id=None` при невыбранном пайплайне — тоже 422. Пустой `limit` из очищенного input давал тот же эффект.

**TDD.** Красные тесты воспроизводят баг на main (3 падения с `assert 422 == 200`):
- `test_moderation_page_empty_filter_params_return_200`
- `test_moderation_page_pipeline_id_none_string_returns_200`
- `test_moderation_page_empty_pipeline_id_shows_all_runs`
- `test_moderation_page_clamps_out_of_range_limit_and_offset` (регрессионный)

## Фикс

- Новый модуль `src/web/query_params.py`: `parse_optional_int()` (пустое/мусор → default) и `parse_clamped_int()` (то же + зажим в диапазон). Паттерн уже существовал локально в `calendar.py::_parse_pipeline_id` — вынесен в общее место.
- `src/web/routes/moderation.py`: параметры приняты как `str | None`, парсятся хелперами; `limit` зажат в [1, 200], `offset` ≥ 0.
- `src/web/routes/calendar.py`: локальный `_parse_pipeline_id` заменён общим `parse_optional_int` (поведение 1:1).
- `src/web/templates/moderation.html`: пагинация рендерит `{{ selected_pipeline_id or '' }}` вместо `None`, «Назад» не уводит offset в минус.

## Аналогичные мины вне скоупа

Тот же класс проблемы (int-параметры + потенциальные пустые значения) есть в `src/web/routes/rss.py:39,95`, `src/web/routes/analytics.py:93,113,285`, `src/web/agent/handlers.py:81` — но они не репродуцируются из текущего UI (JS не шлёт пустые строки), поэтому не трогались.

## Проверка

```
pytest tests/routes/test_moderation_routes.py tests/routes/test_calendar_routes.py -q → 29 passed
ruff check src/ tests/ conftest.py → All checks passed!
полный прогон: 7824 passed, 136 skipped, 8 errors*
```
\* 8 errors — pre-existing хвост #812 в `tests/test_agent_provider_service.py` (есть только при локально установленном pytest-playwright), чинится отдельным PR.

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)