### PR TITLE
test: rename remaining base_url parametrize param missed by #812 fix

### DIFF
--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -1366,8 +1366,12 @@ def test_zai_provider_spec_uses_openai_package_hint():
     assert spec.package_name == "langchain-openai"
 
 
+# The param is named default_base_url (not base_url) because pytest-base-url
+# (pulled in transitively by pytest-playwright) registers a session-scoped
+# fixture `base_url`; shadowing it with a function-scoped param breaks setup
+# with ScopeMismatch (#812).
 @pytest.mark.parametrize(
-    ("provider", "base_url"),
+    ("provider", "default_base_url"),
     [
         ("openai", "https://api.openai.com/v1"),
         ("groq", "https://api.groq.com/openai/v1"),
@@ -1379,14 +1383,14 @@ def test_zai_provider_spec_uses_openai_package_hint():
         ("mistralai", "https://api.mistral.ai/v1"),
     ],
 )
-def test_openai_compatible_provider_specs_expose_default_base_urls(provider, base_url):
+def test_openai_compatible_provider_specs_expose_default_base_urls(provider, default_base_url):
     spec = provider_spec(provider)
 
     assert spec is not None
     assert spec.openai_compatible is True
     assert spec.supports_lightweight_adapter is True
-    assert spec.default_base_url == base_url
-    assert default_base_url_for(provider) == base_url
+    assert spec.default_base_url == default_base_url
+    assert default_base_url_for(provider) == default_base_url
 
 
 def test_registry_normalization_helpers_keep_zai_and_ollama_policy():


### PR DESCRIPTION
## Контекст

Хвост #812 (PR #819): полный локальный прогон после мержа #819 показал ещё **8 ScopeMismatch errors** в `tests/test_agent_provider_service.py::test_openai_compatible_provider_specs_expose_default_base_urls` — тот же конфликт параметра `base_url` с session-scoped фикстурой плагина `pytest-base-url` (транзитивно через локально установленный `pytest-playwright`; в CI плагина нет, поэтому CI зелёный).

Это было единственное оставшееся вхождение — проверено грепом по всем `parametrize` в tests/.

## Фикс

Переименование параметра `base_url` → `default_base_url` (соответствует сути проверки `spec.default_base_url == default_base_url` и неймингу в соседнем `test_provider_service_db_load.py`).

## Проверка

```
До:    pytest tests/test_agent_provider_service.py → 48 passed, 8 errors
После: pytest tests/test_agent_provider_service.py → 56 passed
ruff check → All checks passed!
```

Ref #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)