### PR TITLE
feat(cli): filter analyze --quick skips cross-dupe map (#774)

### DIFF
--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -62,7 +62,7 @@ def run(args: argparse.Namespace) -> None:
                 return
 
             if args.filter_action == "analyze":
-                report = await analyzer.analyze_all()
+                report = await analyzer.analyze_all(quick=getattr(args, "quick", False))
                 if not report.results:
                     print("No channels found.")
                     return

--- a/src/cli/parser_domains/filter.py
+++ b/src/cli/parser_domains/filter.py
@@ -6,7 +6,12 @@ import argparse
 def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser | None:
     flt_parser = subparsers.add_parser("filter", help="Channel content filter")
     flt_sub = flt_parser.add_subparsers(dest="filter_action")
-    flt_sub.add_parser("analyze", help="Analyze channels and show report")
+    flt_analyze = flt_sub.add_parser("analyze", help="Analyze channels and show report")
+    flt_analyze.add_argument(
+        "--quick",
+        action="store_true",
+        help="Skip cross-channel duplicate analysis (fast on large DBs)",
+    )
     flt_sub.add_parser("apply", help="Analyze and mark filtered channels")
     flt_reset = flt_sub.add_parser("reset", help="Reset channel filter flag")
     flt_reset.add_argument("--pks", default=None, help="Comma-separated PKs (default: all)")

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -248,7 +248,10 @@ class FilterRepository:
         return await cur.fetchall()
 
     async def fetch_maps_parallel(
-        self, channel_id: int | None = None
+        self,
+        channel_id: int | None = None,
+        *,
+        include_cross_dupe: bool = True,
     ) -> tuple[
         dict[int, tuple[int, int]],  # uniqueness_map
         dict[int, int],               # subscriber_map
@@ -256,7 +259,11 @@ class FilterRepository:
         dict[int, tuple[int, int]],  # cross_dupe_map
         dict[int, tuple[int, int]],  # cyrillic_map
     ]:
-        """Run all 5 map queries in parallel on separate read-only connections."""
+        """Run the map queries in parallel on separate read-only connections.
+
+        include_cross_dupe=False skips the cross-channel duplicate self-join —
+        by far the heaviest query on large DBs (#774) — returning an empty map.
+        """
         # Build parameterised SQL for each query
         u_sql = _SQL_UNIQUENESS + (" AND channel_id = ?" if channel_id is not None else "") + " GROUP BY channel_id"
         u_params: tuple = (channel_id,) if channel_id is not None else ()
@@ -289,14 +296,17 @@ class FilterRepository:
         )
         cy_params: tuple = (channel_id,) if channel_id is not None else ()
 
-        conns = [await self._open_readonly_conn() for _ in range(5)]
+        async def _no_rows() -> list[aiosqlite.Row]:
+            return []
+
+        conns = [await self._open_readonly_conn() for _ in range(4 + int(include_cross_dupe))]
         try:
-            rows_u, rows_s, rows_sm, rows_cd, rows_cy = await asyncio.gather(
+            rows_u, rows_s, rows_sm, rows_cy, rows_cd = await asyncio.gather(
                 self._run_on_conn(conns[0], u_sql, u_params),
                 self._run_on_conn(conns[1], s_sql, s_params),
                 self._run_on_conn(conns[2], sm_sql, sm_params),
-                self._run_on_conn(conns[3], cd_sql, cd_params),
-                self._run_on_conn(conns[4], cy_sql, cy_params),
+                self._run_on_conn(conns[3], cy_sql, cy_params),
+                self._run_on_conn(conns[4], cd_sql, cd_params) if include_cross_dupe else _no_rows(),
             )
         finally:
             for conn in conns:

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -43,7 +43,7 @@ class ChannelAnalyzer:
             logger=logger,
         )
 
-    async def _build_report(self, channel_id: int | None = None) -> FilterReport:
+    async def _build_report(self, channel_id: int | None = None, *, skip_cross_dupe: bool = False) -> FilterReport:
         t0 = time.monotonic()
         channels = await self._repo.fetch_channels_for_analysis(channel_id)
         logger.info("filter/analyze: fetched %d channels in %.1fs", len(channels), time.monotonic() - t0)
@@ -54,7 +54,7 @@ class ChannelAnalyzer:
             logger.info("filter/analyze: all maps — started (parallel)")
             t_map = time.monotonic()
             uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = (
-                await self._repo.fetch_maps_parallel(channel_id)
+                await self._repo.fetch_maps_parallel(channel_id, include_cross_dupe=not skip_cross_dupe)
             )
             logger.info(
                 "filter/analyze: all maps in %.1fs (parallel) — %d channels",
@@ -65,7 +65,11 @@ class ChannelAnalyzer:
             uniqueness_map = await _timed_fetch("uniqueness map", self._repo.fetch_uniqueness_map(channel_id))
             subscriber_map = await _timed_fetch("subscriber map", self._repo.fetch_subscriber_map(channel_id))
             short_map = await _timed_fetch("short-message map", self._repo.fetch_short_message_map(channel_id))
-            cross_dupe_map = await _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id))
+            cross_dupe_map = (
+                {}
+                if skip_cross_dupe
+                else await _timed_fetch("cross-dupe map", self._repo.fetch_cross_dupe_map(channel_id))
+            )
             cyrillic_map = await _timed_fetch("cyrillic map", self._repo.fetch_cyrillic_map(channel_id))
 
         min_subs = await self._load_min_subscribers_filter()
@@ -181,8 +185,9 @@ class ChannelAnalyzer:
             return report.results[0]
         return ChannelFilterResult(channel_id=channel_id)
 
-    async def analyze_all(self) -> FilterReport:
-        return await self._build_report()
+    async def analyze_all(self, quick: bool = False) -> FilterReport:
+        """Analyze all channels; quick=True skips the heavy cross-dupe query (#774)."""
+        return await self._build_report(skip_cross_dupe=quick)
 
     async def apply_filters(self, report: FilterReport) -> int:
         # Dedupe by channel_id (merge flags via set union) to avoid double updates/count inflation.

--- a/tests/cli_real_tg_integration/safe_ro/test_filter_analyze.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_filter_analyze.py
@@ -4,7 +4,16 @@ pytestmark = pytest.mark.real_tg_safe
 
 
 @pytest.mark.timeout(240)
-def test_filter_analyze(run_cli, assert_cli_ok):
-    result = run_cli("filter", "analyze", timeout=180)
+def test_filter_analyze_quick(run_cli, assert_cli_ok):
+    """Smoke: --quick skips the cross-dupe self-join so the command fits the live budget (#774)."""
+    result = run_cli("filter", "analyze", "--quick", timeout=180)
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`filter analyze --quick` produced empty stdout"
+
+
+@pytest.mark.timeout(660)
+def test_filter_analyze_full(run_cli, assert_cli_ok):
+    """Full analysis includes the heavy cross-dupe map — needs a wider budget on live DBs (#774)."""
+    result = run_cli("filter", "analyze", timeout=600)
     assert_cli_ok(result)
     assert result.stdout.strip(), "`filter analyze` produced empty stdout"

--- a/tests/test_cli_filter.py
+++ b/tests/test_cli_filter.py
@@ -94,8 +94,46 @@ def test_filter_analyze(tmp_path, cli_init_patch, capsys):
 
     out = capsys.readouterr().out
     assert "No channels found" in out
-    mock_instance.analyze_all.assert_awaited_once()
+    mock_instance.analyze_all.assert_awaited_once_with(quick=False)
     mock_instance.apply_filters.assert_not_awaited()
+
+
+def test_analyze_quick_skips_cross_dupe(tmp_path, cli_init_patch, capsys):
+    """`filter analyze --quick` requests the analyzer's quick mode (#774)."""
+    db_path = str(tmp_path / "filter_analyze_quick.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    asyncio.run(db.add_account(Account(phone="+100", session_string="sess")))
+    asyncio.run(db.add_channel(Channel(channel_id=1001, title="Test Channel")))
+    with cli_init_patch(db, _FILTER_INIT_DB_TARGET):
+        from src.cli.commands.filter import run
+
+        with patch("src.cli.commands.filter.ChannelAnalyzer") as mock_analyzer:
+            mock_instance = MagicMock()
+            mock_report = MagicMock()
+            mock_report.results = []
+            mock_report.total_channels = 0
+            mock_report.filtered_count = 0
+            mock_instance.analyze_all = AsyncMock(return_value=mock_report)
+            mock_analyzer.return_value = mock_instance
+
+            run(_ns(filter_action="analyze", quick=True))
+
+    out = capsys.readouterr().out
+    assert "No channels found" in out
+    mock_instance.analyze_all.assert_awaited_once_with(quick=True)
+
+
+def test_filter_analyze_parser_accepts_quick_flag():
+    """CLI parser exposes --quick on `filter analyze` (#774)."""
+    from src.cli.parser import build_parser
+
+    args = build_parser().parse_args(["filter", "analyze", "--quick"])
+    assert args.filter_action == "analyze"
+    assert args.quick is True
+
+    args_default = build_parser().parse_args(["filter", "analyze"])
+    assert args_default.quick is False
 
 
 def test_filter_apply(tmp_path, cli_init_patch, capsys):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -151,6 +151,55 @@ class TestAnalyzerCrossChannelDupes:
         assert "cross_channel_spam" in result.flags
 
 
+class TestAnalyzeAllQuickMode:
+    """quick=True skips the cross-dupe map — the heaviest query on live DBs (#774)."""
+
+    async def test_analyze_all_quick_omits_cross_dupe_flags(self, db, raw_db):
+        await _insert_channel(raw_db, 500)
+        await _insert_channel(raw_db, 501, title="Mirror")
+        shared = ["this is a duplicated message across channels"]
+        await _insert_messages(raw_db, 500, shared)
+        await _insert_messages(raw_db, 501, shared)
+        analyzer = ChannelAnalyzer(db)
+
+        full = await analyzer.analyze_all()
+        assert any("cross_channel_spam" in r.flags for r in full.results)
+
+        quick = await analyzer.analyze_all(quick=True)
+        assert quick.results
+        assert all("cross_channel_spam" not in r.flags for r in quick.results)
+        assert all(r.cross_dupe_pct is None for r in quick.results)
+        assert any(r.uniqueness_pct is not None for r in quick.results)
+
+    async def test_analyze_all_quick_parallel_path_skips_cross_dupe(self, tmp_path):
+        from src.database import Database
+
+        file_db = Database(str(tmp_path / "quick.db"))
+        await file_db.initialize()
+        try:
+            conn = file_db.db
+            await _insert_channel(conn, 600)
+            await _insert_channel(conn, 601, title="Mirror")
+            shared = ["duplicated message body across channels"]
+            await _insert_messages(conn, 600, shared)
+            await _insert_messages(conn, 601, shared)
+
+            repo = file_db.filter_repo
+            assert repo._can_parallel()
+
+            *_, full_cross_map, _ = await repo.fetch_maps_parallel(None)
+            assert full_cross_map
+
+            *_, quick_cross_map, _ = await repo.fetch_maps_parallel(None, include_cross_dupe=False)
+            assert quick_cross_map == {}
+
+            quick = await ChannelAnalyzer(file_db).analyze_all(quick=True)
+            assert quick.results
+            assert all("cross_channel_spam" not in r.flags for r in quick.results)
+        finally:
+            await file_db.close()
+
+
 class TestAnalyzerNonCyrillic:
     async def test_cyrillic_channel(self, db, raw_db):
         await _insert_channel(raw_db, 400)


### PR DESCRIPTION
## Проблема (#774)

`filter analyze` на живой БД (7 млн сообщений) не укладывается в бюджет 180с live-теста `safe_ro/test_filter_analyze.py`. После #802 пять map-запросов идут параллельно, но wall-time ограничен самым тяжёлым — cross-channel duplicate self-join (`fetch_cross_dupe_map`).

## Решение: opt-in quick-режим

- `FilterRepository.fetch_maps_parallel(include_cross_dupe=False)` — не открывает 5-е read-only соединение, cross-dupe map пустая;
- `ChannelAnalyzer.analyze_all(quick=True)` — пропуск на обоих путях (параллельном и последовательном); `cross_dupe_pct` остаётся `None`, флаги `cross_channel_spam` не ставятся, остальные метрики считаются как раньше;
- CLI: `filter analyze --quick` (флаг документирован в help как «fast on large DBs»);
- live-suite: smoke-кейс с `--quick` в бюджете 180с + полный анализ отдельным тестом с бюджетом 600с.

Осознанный trade-off: quick-режим не выявляет cross-channel спам — это smoke/diagnostic режим, полный анализ остаётся дефолтом (web-путь не затронут).

## TDD

Красные тесты до фикса (TypeError: unexpected keyword / unrecognized arguments: --quick):
- `tests/test_filters.py::TestAnalyzeAllQuickMode::test_analyze_all_quick_omits_cross_dupe_flags` (последовательная ветка, :memory:)
- `tests/test_filters.py::TestAnalyzeAllQuickMode::test_analyze_all_quick_parallel_path_skips_cross_dupe` (file-backed БД, параллельная ветка + контракт fetch_maps_parallel)
- `tests/test_cli_filter.py::test_analyze_quick_skips_cross_dupe`
- `tests/test_cli_filter.py::test_filter_analyze_parser_accepts_quick_flag`

## Проверка

```
pytest tests/test_filters.py tests/test_cli_filter.py → 61 passed
pytest -k "manifest or parity or real_telegram_policy or cli_main" → 100 passed
полный прогон: 7826 passed (parallel) + 859 passed (serial)
ruff check → All checks passed!
```
Live-прогон safe_ro не запускался (по политике — только с явного согласия).

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)