### PR TITLE
fix(db): remove exact COUNT(*) from search_messages — LIMIT N+1 / has_more (#766)

### DIFF
--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -44,11 +44,14 @@ def register(db, client_pool, embedding_service, **kwargs):
         total: int,
         empty_prefix: str,
         found_prefix: str,
+        has_more: bool = False,
     ) -> str:
         if not messages:
             return f"{empty_prefix}: {query!r}"
+        # total is a lower bound when has_more is set (#766) — show "N+".
+        total_display = f"{total}+" if has_more else str(total)
         lines = [
-            f"{found_prefix} {total} сообщений для '{query}'. "
+            f"{found_prefix} {total_display} сообщений для '{query}'. "
             f"Показаны первые {len(messages)}:"
         ]
         for message in messages:
@@ -86,7 +89,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         min_length = args.get("min_length")
         max_length = args.get("max_length")
         try:
-            messages, total = await db.search_messages(
+            page = await db.search_messages(
                 query=query,
                 channel_id=int(channel_id) if channel_id else None,
                 date_from=date_from,
@@ -97,10 +100,11 @@ def register(db, client_pool, embedding_service, **kwargs):
             )
             text = _render_search_result(
                 query=query,
-                messages=messages,
-                total=total,
+                messages=page.messages,
+                total=page.total,
                 empty_prefix="Ничего не найдено по запросу",
                 found_prefix="Найдено",
+                has_more=page.has_more,
             )
         except Exception as e:
             text = f"Ошибка поиска сообщений: {e}"

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -186,6 +186,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             total=result.total,
             empty_prefix="Ничего не найдено по запросу",
             found_prefix="Найдено",
+            has_more=getattr(result, "has_more", False),
         )
 
     # ------------------------------------------------------------------

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -20,7 +20,7 @@ from src.telegram.reactions import (
 )
 
 
-def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
+def _print_messages(messages: list[Message], fmt: str, total: int, has_more: bool = False) -> None:
     if fmt == "json":
         items = []
         for msg in messages:
@@ -49,7 +49,9 @@ def _print_messages(messages: list[Message], fmt: str, total: int) -> None:
             ])
         print(buf.getvalue(), end="")
     else:
-        print(f"Total: {total} messages (showing {len(messages)})\n")
+        # total is a lower bound when has_more is set (#766) — show "N+".
+        total_display = f"{total}+" if has_more else str(total)
+        print(f"Total: {total_display} messages (showing {len(messages)})\n")
         for msg in messages:
             date_str = str(msg.date)[:19] if msg.date else "—"
             text = (msg.text or "").strip()
@@ -194,7 +196,7 @@ def run(args: argparse.Namespace) -> None:
                             "Use --live to read directly from Telegram."
                         )
                         return
-                    messages, total = await db.search_messages(
+                    page = await db.search_messages(
                         query=args.query,
                         channel_id=ch.channel_id,
                         date_from=args.date_from,
@@ -202,10 +204,11 @@ def run(args: argparse.Namespace) -> None:
                         limit=args.limit,
                         topic_id=args.topic_id,
                     )
+                    messages = page.messages
                     if not messages:
                         print("No messages found.")
                         return
-                    _print_messages(messages, args.output_format, total)
+                    _print_messages(messages, args.output_format, page.total, has_more=page.has_more)
         finally:
             if pool:
                 await pool.disconnect_all()

--- a/src/cli/commands/search.py
+++ b/src/cli/commands/search.py
@@ -82,7 +82,8 @@ def run(args: argparse.Namespace) -> None:
                     include_filtered=include_filtered,
                 )
 
-            print(f"Found {result.total} results for '{result.query}':\n")
+            total_display = f"{result.total}+" if result.has_more else str(result.total)
+            print(f"Found {total_display} results for '{result.query}':\n")
             for msg in result.messages:
                 text_preview = (msg.text or "")[:200]
                 print(f"[{msg.date}] Channel {msg.channel_id}: {text_preview}")

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -363,8 +363,9 @@ async def _check_notification_queries(db) -> CheckResult:
 
 async def _check_local_search(db) -> CheckResult:
     try:
-        messages, total = await db.search_messages("test", limit=5)
-        return CheckResult("local_search", Status.PASS, f"Query OK ({total} results)")
+        page = await db.search_messages("test", limit=5)
+        total_display = f"{page.total}+" if page.has_more else str(page.total)
+        return CheckResult("local_search", Status.PASS, f"Query OK ({total_display} results)")
     except Exception as exc:
         return CheckResult("local_search", Status.FAIL, str(exc))
 

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -13,7 +13,7 @@ from src.database.repositories.dialog_cache import DialogCacheRepository
 from src.database.repositories.filters import FilterRepository
 from src.database.repositories.generated_images import GeneratedImagesRepository
 from src.database.repositories.generation_runs import GenerationRunsRepository
-from src.database.repositories.messages import MessagesRepository
+from src.database.repositories.messages import MessageSearchPage, MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.database.repositories.photo_loader import PhotoLoaderRepository
 from src.database.repositories.pipeline_action_log import PipelineActionLogRepository
@@ -446,7 +446,7 @@ class CollectionBundle:
         min_length: int | None = None,
         max_length: int | None = None,
         include_filtered: bool = False,
-    ) -> tuple[list[Message], int]:
+    ) -> MessageSearchPage:
         return await self.messages.search_messages(
             query=query,
             channel_id=channel_id,
@@ -694,7 +694,7 @@ class SearchBundle:
         min_length: int | None = None,
         max_length: int | None = None,
         include_filtered: bool = False,
-    ) -> tuple[list[Message], int]:
+    ) -> MessageSearchPage:
         return await self.messages.search_messages(
             query=query,
             channel_id=channel_id,

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -88,6 +88,11 @@ class DBConnection:
         await self.db.execute("PRAGMA cache_size=-64000")  # 64MB
         await self.db.execute("PRAGMA temp_store=MEMORY")
         await self.db.execute("PRAGMA mmap_size=30000000")  # 30MB
+        # WAL hygiene (#766): make the autocheckpoint threshold explicit and
+        # trim a WAL grown by a previous run. PASSIVE never blocks other
+        # connections — it simply does nothing while readers hold snapshots.
+        await self.db.execute("PRAGMA wal_autocheckpoint=1000")
+        await self.db.execute("PRAGMA wal_checkpoint(PASSIVE)")
         if _PROFILING_ENABLED:
             self.db = ProfilingConnection(self.db)  # type: ignore[assignment]
         return self.db

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -23,7 +23,7 @@ from src.database.repositories.dialog_cache import DialogCacheRepository
 from src.database.repositories.filters import FilterRepository
 from src.database.repositories.generated_images import GeneratedImagesRepository
 from src.database.repositories.generation_runs import GenerationRunsRepository
-from src.database.repositories.messages import MessagesRepository
+from src.database.repositories.messages import MessageSearchPage, MessagesRepository
 from src.database.repositories.notification_bots import NotificationBotsRepository
 from src.database.repositories.photo_loader import PhotoLoaderRepository
 from src.database.repositories.pipeline_action_log import PipelineActionLogRepository
@@ -628,7 +628,7 @@ class Database:
         min_length: int | None = None,
         max_length: int | None = None,
         include_filtered: bool = False,
-    ) -> tuple[list[Message], int]:
+    ) -> MessageSearchPage:
         self._require()
         return await self._messages.search_messages(
             query=query,

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import struct
+from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
@@ -20,6 +21,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _EMBEDDING_DIMENSIONS_SETTING = "semantic_embedding_dimensions"
+
+
+@dataclass(frozen=True)
+class MessageSearchPage:
+    """One page of search results without an exact total (#766).
+
+    ``total`` is a lower bound — ``offset + len(messages)`` — exact only when
+    ``has_more`` is False. The exact ``COUNT(*)`` it replaced took 2-19s (FTS)
+    to 72s (LIKE full scan) on a 7M-row DB and starved WAL checkpoints, which
+    cascaded into "database is locked" across background loops.
+
+    ``__iter__`` keeps the legacy ``messages, total = ...`` unpacking working.
+    """
+
+    messages: list[Message]
+    total: int
+    has_more: bool = False
+
+    def __iter__(self):
+        yield self.messages
+        yield self.total
 
 # Sum of all reaction counts for a single message row (m.reactions_json).
 TOTAL_REACTIONS_SQL = (
@@ -605,7 +627,7 @@ class MessagesRepository:
         max_length: int | None = None,
         topic_id: int | None = None,
         include_filtered: bool = False,
-    ) -> tuple[list[Message], int]:
+    ) -> MessageSearchPage:
         where, params = self._build_message_filters(
             channel_id=channel_id,
             date_from=date_from,
@@ -617,6 +639,10 @@ class MessagesRepository:
         )
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
 
+        # LIMIT limit+1 probes for a next page instead of an exact COUNT(*) —
+        # see MessageSearchPage for why the COUNT had to go (#766).
+        probe_limit = limit + 1
+
         if query:
             if self._fts_available:
                 fts_query = self._build_fts_match(query, is_fts)
@@ -624,32 +650,18 @@ class MessagesRepository:
                     " INNER JOIN (SELECT rowid FROM messages_fts"
                     " WHERE messages_fts MATCH ?) AS fts ON m.id = fts.rowid"
                 )
-                count_cur = await self._db.execute(
-                    f"SELECT COUNT(*) as cnt FROM messages m{fts_join}{channel_join}{where}",
-                    (fts_query, *params),
-                )
-                row = await count_cur.fetchone()
-                total = row["cnt"] if row else 0
-
                 cur = await self._db.execute(
                     f"""SELECT m.*, c.title as channel_title, c.username as channel_username
                         FROM messages m{fts_join}{channel_join}
                         {where}
                         ORDER BY m.date DESC
                         LIMIT ? OFFSET ?""",
-                    (fts_query, *params, limit, offset),
+                    (fts_query, *params, probe_limit, offset),
                 )
             else:
                 logger.debug("FTS5 unavailable, falling back to LIKE search")
                 params.append(f"%{query}%")
                 like_where = (where + " AND m.text LIKE ?") if where else " WHERE m.text LIKE ?"
-
-                count_cur = await self._db.execute(
-                    f"SELECT COUNT(*) as cnt FROM messages m{channel_join}{like_where}",
-                    tuple(params),
-                )
-                row = await count_cur.fetchone()
-                total = row["cnt"] if row else 0
 
                 cur = await self._db.execute(
                     f"""SELECT m.*, c.title as channel_title, c.username as channel_username
@@ -657,26 +669,26 @@ class MessagesRepository:
                         {like_where}
                         ORDER BY m.date DESC
                         LIMIT ? OFFSET ?""",
-                    (*params, limit, offset),
+                    (*params, probe_limit, offset),
                 )
         else:
-            count_cur = await self._db.execute(
-                f"SELECT COUNT(*) as cnt FROM messages m{channel_join}{where}", tuple(params)
-            )
-            row = await count_cur.fetchone()
-            total = row["cnt"] if row else 0
-
             cur = await self._db.execute(
                 f"""SELECT m.*, c.title as channel_title, c.username as channel_username
                     FROM messages m{channel_join}
                     {where}
                     ORDER BY m.date DESC
                     LIMIT ? OFFSET ?""",
-                (*params, limit, offset),
+                (*params, probe_limit, offset),
             )
 
         rows = await cur.fetchall()
-        return self._rows_to_messages(rows), total
+        has_more = len(rows) > limit
+        messages = self._rows_to_messages(rows[:limit])
+        return MessageSearchPage(
+            messages=messages,
+            total=offset + len(messages),
+            has_more=has_more,
+        )
 
     async def _search_semantic_candidates(
         self,

--- a/src/models.py
+++ b/src/models.py
@@ -397,7 +397,10 @@ class SearchQueryDailyStat(BaseModel):
 
 class SearchResult(BaseModel):
     messages: list[Message]
+    # Lower bound for local DB search since #766 (offset + page size; exact only
+    # when has_more is False); other modes keep their own semantics.
     total: int
+    has_more: bool = False
     query: str
     ai_summary: str | None = None
     error: str | None = None

--- a/src/search/ai_search.py
+++ b/src/search/ai_search.py
@@ -51,14 +51,18 @@ class AISearchEngine:
                 with concurrent.futures.ThreadPoolExecutor() as executor:
                     coro = search.search_messages(query, limit=20)
                     future = executor.submit(asyncio.run, coro)
-                    messages, total = future.result()
+                    page = future.result()
             except RuntimeError:
-                messages, total = asyncio.run(search.search_messages(query, limit=20))
+                page = asyncio.run(search.search_messages(query, limit=20))
 
+            messages = page.messages
             if not messages:
                 return f"No results found for: {query}"
 
-            lines = [f"Found {total} results for '{query}'. Top results:"]
+            # total is a lower bound when has_more is set (#766) — keep the
+            # volume signal for the LLM so it knows the query is broad.
+            total_display = f"{page.total}+" if page.has_more else str(page.total)
+            lines = [f"Found {total_display} results for '{query}'. Top results:"]
             for m in messages:
                 text_preview = (m.text or "")[:200]
                 lines.append(f"- [{m.date}] Channel {m.channel_id}: {text_preview}")
@@ -82,10 +86,11 @@ class AISearchEngine:
         """Run AI-powered search."""
         if not self._agent:
             # Fallback to basic local search
-            messages, total = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(query, limit=20)
             return SearchResult(
-                messages=messages,
-                total=total,
+                messages=page.messages,
+                total=page.total,
+                has_more=page.has_more,
                 query=query,
                 ai_summary="AI search is not available. Showing local results.",
             )
@@ -95,20 +100,22 @@ class AISearchEngine:
             summary = str(response)
 
             # Also get raw messages for display
-            messages, total = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(query, limit=20)
 
             return SearchResult(
-                messages=messages,
-                total=total,
+                messages=page.messages,
+                total=page.total,
+                has_more=page.has_more,
                 query=query,
                 ai_summary=summary,
             )
         except Exception as e:
             logger.error("AI search error: %s", e)
-            messages, total = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(query, limit=20)
             return SearchResult(
-                messages=messages,
-                total=total,
+                messages=page.messages,
+                total=page.total,
+                has_more=page.has_more,
                 query=query,
                 ai_summary=f"AI search error: {e}. Showing local results.",
             )

--- a/src/search/local_search.py
+++ b/src/search/local_search.py
@@ -33,7 +33,7 @@ class LocalSearch:
         max_length: int | None = None,
         include_filtered: bool = False,
     ) -> SearchResult:
-        messages, total = await self._search.search_messages(
+        page = await self._search.search_messages(
             query=query,
             channel_id=channel_id,
             date_from=date_from,
@@ -45,7 +45,9 @@ class LocalSearch:
             max_length=max_length,
             include_filtered=include_filtered,
         )
-        return SearchResult(messages=messages, total=total, query=query)
+        return SearchResult(
+            messages=page.messages, total=page.total, has_more=page.has_more, query=query
+        )
 
     async def _ensure_numpy_index(self) -> NumpySemanticIndex:
         """Lazily load and build the numpy in-memory index from the JSON table."""

--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -27,7 +27,7 @@ async def read_messages(
     if ch is None:
         return JSONResponse({"error": "channel_not_found"}, status_code=404)
     limit = max(1, min(limit, 500))
-    messages, total = await db.search_messages(
+    result = await db.search_messages(
         query=query,
         channel_id=ch.channel_id,
         date_from=date_from or None,
@@ -37,8 +37,10 @@ async def read_messages(
     )
     return JSONResponse({
         "channel_id": ch.channel_id,
-        "total": total,
-        "messages": [m.model_dump(mode="json") for m in messages],
+        # Lower bound (#766) — exact only when has_more is false.
+        "total": result.total,
+        "has_more": result.has_more,
+        "messages": [m.model_dump(mode="json") for m in result.messages],
     })
 
 

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -271,9 +271,9 @@ async def render_search_page(
         logger.exception("Failed to load search quota")
         search_quota = None
 
-    total_pages = 0
-    if result and result.total > 0:
-        total_pages = (result.total + limit - 1) // limit
+    # Page-based navigation without an exact total (#766): «Далее» is shown when
+    # the LIMIT N+1 probe saw another page, «Назад» — when we're past page 1.
+    has_more = bool(result and getattr(result, "has_more", False))
 
     # Browse mode: viewing channel messages without search query
     browse_mode = bool(not q and channel_id_int and mode in {"local", "semantic", "hybrid"})
@@ -294,7 +294,7 @@ async def render_search_page(
             "is_fts": is_fts,
             "include_filtered": include_filtered,
             "page": page,
-            "total_pages": total_pages,
+            "has_more": has_more,
             "semantic_available": semantic_available,
             "telegram_available": telegram_available,
             "ai_enabled": ai_enabled,

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -272,8 +272,10 @@ async def render_search_page(
         search_quota = None
 
     # Page-based navigation without an exact total (#766): «Далее» is shown when
-    # the LIMIT N+1 probe saw another page, «Назад» — when we're past page 1.
-    has_more = bool(result and getattr(result, "has_more", False))
+    # the LIMIT N+1 probe saw another page. Semantic/hybrid/telegram modes still
+    # return an exact total without setting has_more — derive it from the total
+    # there so their deeper pages stay reachable (review on #824).
+    has_more = bool(result and (result.has_more or result.total > page * limit))
 
     # Browse mode: viewing channel messages without search query
     browse_mode = bool(not q and channel_id_int and mode in {"local", "semantic", "hybrid"})

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -102,9 +102,9 @@
 
 {% if not result.error %}
 {% if browse_mode and selected_channel %}
-<p>Сообщения из канала <strong>{{ selected_channel.title or selected_channel.username or selected_channel.channel_id }}</strong>: {{ result.total }}</p>
+<p>Сообщения из канала <strong>{{ selected_channel.title or selected_channel.username or selected_channel.channel_id }}</strong>: {{ result.total }}{% if result.has_more %}+{% endif %}</p>
 {% else %}
-<p>Найдено: <strong>{{ result.total }}</strong> сообщений по запросу «{{ result.query }}»</p>
+<p>Найдено: <strong>{{ result.total }}{% if result.has_more %}+{% endif %}</strong> сообщений по запросу «{{ result.query }}»</p>
 {% endif %}
 {% endif %}
 
@@ -185,14 +185,14 @@
     {% endfor %}
 </div>
 
-{% if total_pages > 1 %}
+{% if page > 1 or has_more %}
 <nav>
     <ul class="pagination justify-content-center">
         {% if page > 1 %}
         <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page - 1 }}">Назад</a></li>
         {% endif %}
-        <li class="page-item disabled"><span class="page-link">Страница {{ page }} из {{ total_pages }}</span></li>
-        {% if page < total_pages %}
+        <li class="page-item disabled"><span class="page-link">Страница {{ page }}</span></li>
+        {% if has_more %}
         <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page + 1 }}">Далее</a></li>
         {% endif %}
     </ul>

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -443,10 +443,13 @@ async def test_search_messages_pagination(messages_repo):
     for i in range(10):
         await messages_repo.insert_message(make_message(1, 100 + i, f"Message {i}"))
 
-    # First page
-    messages, total = await messages_repo.search_messages(limit=3, offset=0)
+    # First page: total is a lower bound (offset + len) since #766, has_more
+    # signals the next page instead of an exact COUNT.
+    page = await messages_repo.search_messages(limit=3, offset=0)
+    messages = page.messages
     assert len(messages) == 3
-    assert total == 10
+    assert page.total == 3
+    assert page.has_more is True
 
     # Second page
     messages2, _ = await messages_repo.search_messages(limit=3, offset=3)
@@ -862,3 +865,65 @@ async def test_delete_premium_search_results_no_match_returns_zero(messages_repo
     assert await messages_repo.delete_premium_search_results("nothing") == 0
     cur = await messages_repo._db.execute("SELECT COUNT(*) FROM messages")
     assert (await cur.fetchone())[0] == 1
+
+
+# search_messages page contract (#766): no exact COUNT, LIMIT N+1 / has_more
+
+
+async def test_search_messages_has_more_true_when_results_exceed_limit(messages_repo):
+    """LIMIT N+1 probe: more rows than the limit → has_more=True, total is a lower bound."""
+    for i in range(3):
+        await messages_repo.insert_message(make_message(1, 100 + i, f"hello {i}"))
+
+    page = await messages_repo.search_messages(limit=2)
+
+    assert len(page.messages) == 2
+    assert page.has_more is True
+    assert page.total == 2  # offset + len(messages): lower bound, not an exact COUNT
+
+
+async def test_search_messages_has_more_false_on_last_page(messages_repo):
+    """On the last page total == offset + len(messages) is exact."""
+    for i in range(3):
+        await messages_repo.insert_message(make_message(1, 100 + i, f"hello {i}"))
+
+    page = await messages_repo.search_messages(limit=2, offset=2)
+
+    assert len(page.messages) == 1
+    assert page.has_more is False
+    assert page.total == 3
+
+
+async def test_search_messages_tuple_unpacking_still_works(messages_repo):
+    """Legacy `messages, total = ...` unpacking must keep working (#766)."""
+    await messages_repo.insert_message(make_message(1, 100, "hello"))
+
+    messages, total = await messages_repo.search_messages()
+
+    assert len(messages) == 1
+    assert total == 1
+
+
+async def test_search_messages_does_not_execute_count(messages_repo, monkeypatch):
+    """The expensive COUNT(*) is gone from all three branches (#766):
+    FTS, LIKE fallback and the empty-query browse."""
+    for i in range(3):
+        await messages_repo.insert_message(make_message(1, 100 + i, f"hello {i}"))
+
+    executed: list[str] = []
+    orig_execute = messages_repo._db.execute
+
+    async def spy(sql, *args, **kwargs):
+        executed.append(sql)
+        return await orig_execute(sql, *args, **kwargs)
+
+    monkeypatch.setattr(messages_repo._db, "execute", spy)
+
+    if messages_repo._fts_available:
+        await messages_repo.search_messages(query="hello", limit=2)
+    monkeypatch.setattr(messages_repo, "_fts_available", False)
+    await messages_repo.search_messages(query="hello", limit=2)
+    await messages_repo.search_messages(limit=2)
+
+    counts = [sql for sql in executed if "count(" in sql.lower()]
+    assert not counts, f"COUNT query still executed: {counts}"

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -733,3 +733,29 @@ async def test_read_messages_json_includes_has_more(route_client):
     data_all = resp_all.json()
     assert data_all["has_more"] is False
     assert data_all["total"] == 3
+
+
+@pytest.mark.anyio
+async def test_search_page_next_link_for_exact_total_modes(route_client, monkeypatch):
+    """Semantic/hybrid modes return an exact total without has_more — «Далее»
+    must still appear when total exceeds the current page (review on #824)."""
+    msg = Message(
+        id=1,
+        channel_id=100,
+        message_id=1,
+        text="hit",
+        date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+    mock_result = SearchResult(messages=[msg], total=120, has_more=False, query="test")
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=mock_result)
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "src.web.search.handlers.deps.search_service",
+        lambda r: mock_svc,
+    )
+
+    resp = await route_client.get("/search?q=test&mode=semantic")
+
+    assert resp.status_code == 200
+    assert "Далее" in resp.text

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -643,7 +643,9 @@ async def test_read_messages_route_returns_json(route_client):
 async def test_read_messages_route_clamps_limit(route_client, monkeypatch):
     db = route_client._transport_app.state.db
     await db.add_channel(Channel(channel_id=778, title="ClampChan", username="clampchan"))
-    search_messages = AsyncMock(return_value=([], 0))
+    from src.database.repositories.messages import MessageSearchPage
+
+    search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     monkeypatch.setattr(db, "search_messages", search_messages)
 
     resp = await route_client.get("/messages/clampchan?limit=100000")
@@ -656,3 +658,78 @@ async def test_read_messages_route_clamps_limit(route_client, monkeypatch):
 async def test_read_messages_route_channel_not_found(route_client):
     resp = await route_client.get("/messages/nonexistent_channel")
     assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_search_page_shows_plus_when_has_more(route_client, monkeypatch):
+    """With has_more the counter renders «N+» and the next-page link appears (#766)."""
+    msg = Message(
+        id=1,
+        channel_id=100,
+        message_id=1,
+        text="hit",
+        date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+    mock_result = SearchResult(messages=[msg], total=50, has_more=True, query="test")
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=mock_result)
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "src.web.search.handlers.deps.search_service",
+        lambda r: mock_svc,
+    )
+
+    resp = await route_client.get("/search?q=test")
+
+    assert resp.status_code == 200
+    assert "50+" in resp.text
+    assert "Далее" in resp.text
+
+
+@pytest.mark.anyio
+async def test_search_page_no_next_when_no_more(route_client, monkeypatch):
+    """Without has_more there is no «Далее» link and no «+» on the counter (#766)."""
+    msg = Message(
+        id=1,
+        channel_id=100,
+        message_id=1,
+        text="hit",
+        date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+    mock_result = SearchResult(messages=[msg], total=1, has_more=False, query="test")
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=mock_result)
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "src.web.search.handlers.deps.search_service",
+        lambda r: mock_svc,
+    )
+
+    resp = await route_client.get("/search?q=test")
+
+    assert resp.status_code == 200
+    assert "1+" not in resp.text
+    assert "Далее" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_read_messages_json_includes_has_more(route_client):
+    """GET /messages/{identifier} exposes has_more next to the lower-bound total (#766)."""
+    db = route_client._transport_app.state.db
+    await db.add_channel(Channel(channel_id=779, title="MoreChan", username="morechan"))
+    await db.insert_messages_batch([
+        Message(channel_id=779, message_id=i, text=f"msg {i}", date=datetime(2024, 6, 1, tzinfo=timezone.utc))
+        for i in range(1, 4)
+    ])
+
+    resp = await route_client.get("/messages/morechan?limit=2")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["has_more"] is True
+    assert len(data["messages"]) == 2
+
+    resp_all = await route_client.get("/messages/morechan?limit=50")
+    data_all = resp_all.json()
+    assert data_all["has_more"] is False
+    assert data_all["total"] == 3

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.database import Database
+from src.database.repositories.messages import MessageSearchPage
 
 
 @pytest.fixture
@@ -51,7 +52,7 @@ class TestSearchMessagesTool:
 
     @pytest.mark.anyio
     async def test_empty_result(self, mock_db):
-        mock_db.search_messages = AsyncMock(return_value=([], 0))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "nonexistent", "limit": 20})
@@ -81,7 +82,7 @@ class TestSearchMessagesTool:
                 date="2025-01-02",
             ),
         ]
-        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 2))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=mock_messages, total=2))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "test", "limit": 10})
@@ -105,7 +106,7 @@ class TestSearchMessagesTool:
                 date="2025-01-01",
             ),
         ]
-        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=mock_messages, total=1))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "label", "limit": 10})
@@ -127,7 +128,7 @@ class TestSearchMessagesTool:
                 date="2025-01-01",
             ),
         ]
-        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=mock_messages, total=1))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "fallback", "limit": 10})
@@ -143,7 +144,7 @@ class TestSearchMessagesTool:
         mock_messages = [
             SimpleNamespace(channel_id=100, message_id=1, text=long_text, date="2025-01-01"),
         ]
-        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=mock_messages, total=1))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "x", "limit": 20})
@@ -159,7 +160,7 @@ class TestSearchMessagesTool:
         mock_messages = [
             SimpleNamespace(channel_id=100, message_id=1, text=None, date="2025-01-01"),
         ]
-        mock_db.search_messages = AsyncMock(return_value=(mock_messages, 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=mock_messages, total=1))
         handlers = _get_tool_handlers(mock_db)
 
         result = await handlers["search_messages"]({"query": "test", "limit": 20})
@@ -170,7 +171,7 @@ class TestSearchMessagesTool:
     @pytest.mark.anyio
     async def test_default_limit(self, mock_db):
         """Tool applies default limit=20 when not provided."""
-        mock_db.search_messages = AsyncMock(return_value=([], 0))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         handlers = _get_tool_handlers(mock_db)
 
         await handlers["search_messages"]({"query": "test"})
@@ -179,7 +180,7 @@ class TestSearchMessagesTool:
 
     @pytest.mark.anyio
     async def test_custom_limit(self, mock_db):
-        mock_db.search_messages = AsyncMock(return_value=([], 0))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         handlers = _get_tool_handlers(mock_db)
 
         await handlers["search_messages"]({"query": "test", "limit": 50})

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.database.repositories.messages import MessageSearchPage
 from src.filters.models import ChannelFilterResult
 from src.models import NotificationBot
 
@@ -408,7 +409,7 @@ class TestDeepagentsSyncSearchMessages:
             text="Labeled message",
             date="2025-01-01",
         )
-        mock_db.search_messages = AsyncMock(return_value=([msg], 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
 
@@ -428,7 +429,7 @@ class TestDeepagentsSyncSearchMessages:
             text="Fallback message",
             date="2025-01-01",
         )
-        mock_db.search_messages = AsyncMock(return_value=([msg], 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         tools = build_deepagents_tools(mock_db)
         tool_map = {t.__name__: t for t in tools}
 

--- a/tests/test_ai_search.py
+++ b/tests/test_ai_search.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.config import LLMConfig
+from src.database.repositories.messages import MessageSearchPage
 from src.models import Message
 from src.search.ai_search import AISearchEngine
 
@@ -18,7 +19,7 @@ def llm_config():
 @pytest.fixture
 def mock_search_bundle():
     bundle = MagicMock()
-    bundle.search_messages = AsyncMock(return_value=([], 0))
+    bundle.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     return bundle
 
 
@@ -81,9 +82,9 @@ async def test_ai_search_run_success(llm_config, mock_search_bundle, fake_deepag
     mock_agent = MagicMock()
     mock_agent.run.return_value = "AI Summary Result"
 
-    mock_search_bundle.search_messages.return_value = (
-        [Message(channel_id=1, message_id=1, text="hello", date=datetime.now())],
-        1,
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(
+        messages=[Message(channel_id=1, message_id=1, text="hello", date=datetime.now())],
+        total=1,
     )
 
     fake_deepagents.return_value = mock_agent
@@ -111,9 +112,9 @@ async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagen
 @pytest.mark.anyio
 async def test_search_posts_tool_logic(llm_config, mock_search_bundle, fake_deepagents):
     # This tests the tool function defined inside initialize
-    mock_search_bundle.search_messages.return_value = (
-        [Message(channel_id=1, message_id=1, text="content", date=datetime.now())],
-        1,
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(
+        messages=[Message(channel_id=1, message_id=1, text="content", date=datetime.now())],
+        total=1,
     )
 
     engine = AISearchEngine(llm_config, mock_search_bundle)
@@ -132,7 +133,7 @@ async def test_search_posts_tool_logic(llm_config, mock_search_bundle, fake_deep
 
 @pytest.mark.anyio
 async def test_search_posts_tool_no_results(llm_config, mock_search_bundle, fake_deepagents):
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     engine = AISearchEngine(llm_config, mock_search_bundle)
     engine.initialize()

--- a/tests/test_cli_commands_edge_cases.py
+++ b/tests/test_cli_commands_edge_cases.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from src.cli.commands.filter import _build_deletion_service, _parse_pks, _print_result
 from src.cli.commands.messages import _print_live_messages, _print_messages
 from src.cli.commands.search_query import _chat_filter_warning
+from src.database.repositories.messages import MessageSearchPage
 from src.models import Account, Channel, Message, SearchQuery, SearchQueryDailyStat
 from tests.helpers import AsyncIterMessages, cli_ns
 
@@ -1595,7 +1596,7 @@ class TestMessagesReadDbMode:
         ch = Channel(id=1, channel_id=100, title="TestCh", username="testch")
         db = MagicMock()
         db.get_channels = AsyncMock(return_value=[ch])
-        db.search_messages = AsyncMock(return_value=([], 0))
+        db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         db.close = AsyncMock()
 
         with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))):
@@ -1626,7 +1627,7 @@ class TestMessagesReadDbMode:
         )
         db = MagicMock()
         db.get_channels = AsyncMock(return_value=[ch])
-        db.search_messages = AsyncMock(return_value=([msg], 1))
+        db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         db.close = AsyncMock()
 
         with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))):
@@ -1657,7 +1658,7 @@ class TestMessagesReadDbMode:
         )
         db = MagicMock()
         db.get_channels = AsyncMock(return_value=[ch])
-        db.search_messages = AsyncMock(return_value=([msg], 1))
+        db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         db.close = AsyncMock()
 
         with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))):
@@ -1689,7 +1690,7 @@ class TestMessagesReadDbMode:
         )
         db = MagicMock()
         db.get_channels = AsyncMock(return_value=[ch])
-        db.search_messages = AsyncMock(return_value=([msg], 1))
+        db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         db.close = AsyncMock()
 
         with patch("src.cli.commands.messages.runtime.init_db", side_effect=_make_coro((MagicMock(), db))):

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiosqlite
 import pytest
 
+from src.database.repositories.messages import MessageSearchPage
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -409,7 +411,7 @@ class TestCLITestRunEntry:
         fake_db.get_accounts = AsyncMock(return_value=[])
         fake_db.get_channels_with_counts = AsyncMock(return_value=[])
         fake_db.get_notification_queries = AsyncMock(return_value=[])
-        fake_db.search_messages = AsyncMock(return_value=([], 0))
+        fake_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         fake_db.get_collection_tasks = AsyncMock(return_value=[])
         fake_db.get_recent_searches = AsyncMock(return_value=[])
         fake_db.repos = MagicMock()
@@ -439,7 +441,7 @@ class TestCLITestRunEntry:
         fake_db.get_accounts = AsyncMock(return_value=[])
         fake_db.get_channels_with_counts = AsyncMock(return_value=[])
         fake_db.get_notification_queries = AsyncMock(return_value=[])
-        fake_db.search_messages = AsyncMock(return_value=([], 0))
+        fake_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         fake_db.get_collection_tasks = AsyncMock(return_value=[])
         fake_db.get_recent_searches = AsyncMock(return_value=[])
         fake_db.repos = MagicMock()

--- a/tests/test_cli_test_commands.py
+++ b/tests/test_cli_test_commands.py
@@ -35,6 +35,7 @@ from src.cli.commands.test import (
     _run_benchmark_step,
     _skip_remaining_tg_checks,
 )
+from src.database.repositories.messages import MessageSearchPage
 
 # ---------------------------------------------------------------------------
 # Status enum
@@ -328,7 +329,7 @@ class TestCheckLocalSearch:
     @pytest.mark.anyio
     async def test_pass(self):
         db = MagicMock()
-        db.search_messages = AsyncMock(return_value=([], 0))
+        db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         result = await _check_local_search(db)
         assert result.status == Status.PASS
         assert "0 results" in result.detail

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.database import Database
+from src.database.repositories.messages import MessageSearchPage
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,14 +56,14 @@ def _text(result: dict) -> str:
 
 class TestDeepagentsSyncSearchMessages:
     def test_no_results(self, mock_db):
-        mock_db.search_messages = AsyncMock(return_value=([], 0))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["search_messages"]("test query")
         assert "Ничего не найдено" in result
 
     def test_with_results(self, mock_db):
         msg = SimpleNamespace(date="2026-01-01", channel_id=10, text="hello world")
-        mock_db.search_messages = AsyncMock(return_value=([msg], 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["search_messages"]("hello")
         assert "hello world" in result
@@ -77,7 +78,7 @@ class TestDeepagentsSyncSearchMessages:
     def test_long_message_truncated(self, mock_db):
         long_text = "x" * 500
         msg = SimpleNamespace(date="2026-01-01", channel_id=5, text=long_text)
-        mock_db.search_messages = AsyncMock(return_value=([msg], 1))
+        mock_db.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[msg], total=1))
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["search_messages"]("x")
         # Preview capped at 200 chars + surrounding

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -567,8 +567,11 @@ class TestSearchPagination:
 
         assert len(page1.messages) == 5
         assert len(page2.messages) == 5
-        assert page1.total == 20
-        assert page2.total == 20
+        # total is a lower bound since #766; has_more marks remaining pages.
+        assert page1.total == 5
+        assert page1.has_more is True
+        assert page2.total == 10
+        assert page2.has_more is True
 
         # Pages should contain different messages
         ids_page1 = {m.message_id for m in page1.messages}

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.database.repositories.messages import MessageSearchPage
 from src.models import Message, SearchResult
 from src.search.local_search import LocalSearch
 
@@ -14,10 +15,10 @@ from src.search.local_search import LocalSearch
 def mock_search_bundle():
     """Mock SearchBundle."""
     bundle = MagicMock()
-    bundle.search_messages = AsyncMock(return_value=([], 0))
+    bundle.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     bundle.messages = MagicMock()
-    bundle.messages.search_semantic_messages = AsyncMock(return_value=([], 0))
-    bundle.messages.search_hybrid_messages = AsyncMock(return_value=([], 0))
+    bundle.messages.search_semantic_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
+    bundle.messages.search_hybrid_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     return bundle
 
 
@@ -48,7 +49,7 @@ def make_message(**kwargs) -> Message:
 async def test_search_basic(mock_search_bundle):
     """Basic search returns SearchResult."""
     msg = make_message(text="test message", channel_id=1, message_id=1)
-    mock_search_bundle.search_messages.return_value = ([msg], 1)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[msg], total=1)
 
     local_search = LocalSearch(mock_search_bundle)
     result = await local_search.search(query="test")
@@ -62,7 +63,7 @@ async def test_search_basic(mock_search_bundle):
 @pytest.mark.anyio
 async def test_search_with_channel_filter(mock_search_bundle):
     """Search with channel_id filter."""
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
     await local_search.search(query="test", channel_id=123)
@@ -74,7 +75,7 @@ async def test_search_with_channel_filter(mock_search_bundle):
 @pytest.mark.anyio
 async def test_search_with_date_range(mock_search_bundle):
     """Search with date range."""
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
     await local_search.search(query="test", date_from="2024-01-01", date_to="2024-12-31")
@@ -87,7 +88,7 @@ async def test_search_with_date_range(mock_search_bundle):
 @pytest.mark.anyio
 async def test_search_with_length_filters(mock_search_bundle):
     """Search with min/max length filters."""
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
     await local_search.search(query="test", min_length=100, max_length=500)
@@ -100,7 +101,7 @@ async def test_search_with_length_filters(mock_search_bundle):
 @pytest.mark.anyio
 async def test_search_with_fts_flag(mock_search_bundle):
     """Search with FTS flag."""
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
     await local_search.search(query="test", is_fts=True)
@@ -112,7 +113,7 @@ async def test_search_with_fts_flag(mock_search_bundle):
 @pytest.mark.anyio
 async def test_search_with_pagination(mock_search_bundle):
     """Search with limit and offset."""
-    mock_search_bundle.search_messages.return_value = ([], 0)
+    mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
     await local_search.search(query="test", limit=10, offset=20)

--- a/tests/test_local_search_semantic_paths.py
+++ b/tests/test_local_search_semantic_paths.py
@@ -5,13 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.database.repositories.messages import MessageSearchPage
 from src.models import Message, SearchResult
 from src.search.local_search import LocalSearch
 
 
 def _mock_search_bundle(**overrides):
     bundle = MagicMock()
-    bundle.search_messages = AsyncMock(return_value=([], 0))
+    bundle.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     bundle.vec_available = overrides.get("vec_available", False)
     bundle.numpy_available = overrides.get("numpy_available", True)
     return bundle
@@ -60,7 +61,7 @@ async def test_search_semantic_with_vec():
     bundle = _mock_search_bundle(vec_available=True)
     embedding = _mock_embedding_service()
     bundle.messages = MagicMock()
-    bundle.messages.search_semantic_messages = AsyncMock(return_value=([], 0))
+    bundle.messages.search_semantic_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     ls = LocalSearch(bundle, embedding_service=embedding)
     result = await ls.search_semantic("test")
     assert result.total == 0
@@ -121,7 +122,7 @@ async def test_search_hybrid_with_embedding():
     bundle = _mock_search_bundle()
     embedding = _mock_embedding_service()
     bundle.messages = MagicMock()
-    bundle.messages.search_hybrid_messages = AsyncMock(return_value=([], 0))
+    bundle.messages.search_hybrid_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     ls = LocalSearch(bundle, embedding_service=embedding)
     result = await ls.search_hybrid("test")
     assert result.total == 0
@@ -131,7 +132,7 @@ async def test_search_hybrid_with_filters():
     bundle = _mock_search_bundle()
     embedding = _mock_embedding_service()
     bundle.messages = MagicMock()
-    bundle.messages.search_hybrid_messages = AsyncMock(return_value=([], 0))
+    bundle.messages.search_hybrid_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     ls = LocalSearch(bundle, embedding_service=embedding)
     result = await ls.search_hybrid(
         "test", channel_id=1, date_from="2026-01-01", date_to="2026-12-31",

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -28,6 +28,7 @@ from src.database.migrations import (
     _migrate_vec_to_portable,
     run_migrations,
 )
+from src.database.repositories.messages import MessageSearchPage
 from src.models import Message
 from src.search.local_search import LocalSearch
 from src.services.provider_service import RuntimeProviderRegistry, build_provider_service
@@ -1245,10 +1246,10 @@ async def test_search_passes_offset_and_limit(mock_search_bundle_for_local):
 def mock_search_bundle_for_local():
     """Mock SearchBundle for local search tests."""
     bundle = MagicMock()
-    bundle.search_messages = AsyncMock(return_value=([], 0))
+    bundle.search_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     bundle.messages = MagicMock()
-    bundle.messages.search_semantic_messages = AsyncMock(return_value=([], 0))
-    bundle.messages.search_hybrid_messages = AsyncMock(return_value=([], 0))
+    bundle.messages.search_semantic_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
+    bundle.messages.search_hybrid_messages = AsyncMock(return_value=MessageSearchPage(messages=[], total=0))
     return bundle
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -66,7 +66,15 @@ async def test_search_local_pagination(db):
     engine = SearchEngine(db)
     result = await engine.search_local("Test", limit=5, offset=0)
     assert len(result.messages) == 5
-    assert result.total == 20
+    # total is a lower bound since #766 (offset + page size), has_more marks
+    # the remaining pages instead of an exact COUNT.
+    assert result.total == 5
+    assert result.has_more is True
+
+    last_page = await engine.search_local("Test", limit=5, offset=15)
+    assert len(last_page.messages) == 5
+    assert last_page.has_more is False
+    assert last_page.total == 20
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Проблема (#766)

Каждый `/search` помимо страницы результатов выполнял точный `SELECT COUNT(*)`: ~2–19с через FTS-join (холодный кэш) и ~72с на LIKE-фолбэке (full scan) на проде с 7 млн сообщений. Долгий read-снапшот не давал WAL-checkpoint усечь WAL → параллельные записи упирались в busy_timeout → каскад `database is locked` по collector/dispatcher/snapshot-циклам. Это корень, смягчения были в #767.

## Фикс (коммит 1)

`search_messages` возвращает `MessageSearchPage(messages, total, has_more)`:
- выборка `LIMIT limit+1`; `has_more` = пришла лишняя строка; `total = offset + len(messages)` — нижняя граница, точная когда `has_more=False`;
- `COUNT(*)` удалён из всех трёх веток (FTS, LIKE-фолбэк, пустой query) — регрессионный тест шпионит за каждым выполненным SQL и запрещает `COUNT(`;
- `MessageSearchPage.__iter__` сохраняет legacy-распаковку `messages, total = ...` у ~10 потребителей и 60+ тестовых вызовов;
- `SearchResult.has_more`; UI: «Найдено: **N+**», пагинация «Страница X» (без «из Y»), «Далее» по `has_more`; JSON `/messages/{id}` отдаёт `has_more`; agent tool и CLI `search` показывают «N+».
- Семантический/Telegram-режимы поиска не тронуты (свой total).

## Коммит 2 (отделимый): WAL-гигиена

`PRAGMA wal_autocheckpoint=1000` (явно) + однократный `PRAGMA wal_checkpoint(PASSIVE)` при connect — усечение WAL, оставшегося от прошлого запуска; PASSIVE не блокирует параллельные соединения.

## TDD

Красные до фикса:
- `test_search_messages_has_more_true_when_results_exceed_limit`, `..._has_more_false_on_last_page`, `..._does_not_execute_count` (шпион SQL, 3 ветки), `..._tuple_unpacking_still_works`;
- `test_search_page_shows_plus_when_has_more` («50+», «Далее»), `test_search_page_no_next_when_no_more`, `test_read_messages_json_includes_has_more`.

Обновлены под нижнюю границу total: `test_search_messages_pagination`, `test_search_local_pagination`, `test_search_engine_pagination_offsets` + tuple-моки в 6 тестовых файлах.

## Проверка

```
полный прогон: 7841 passed (parallel) + 859 passed (serial), 0 failed
ruff check → All checks passed!
```

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)