### PR TITLE
perf(analytics): aggregate message_reactions instead of json_each-scanning messages (#826)

### DIFF
--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -43,18 +43,6 @@ class MessageSearchPage:
         yield self.messages
         yield self.total
 
-# Sum of all reaction counts for a single message row (m.reactions_json).
-TOTAL_REACTIONS_SQL = (
-    "(SELECT COALESCE(SUM(json_extract(value, '$.count')), 0) FROM json_each(m.reactions_json))"
-)
-# Same sum guarded so it only evaluates for rows holding valid reactions JSON;
-# used inside AVG(...) over arbitrary message rows.
-TOTAL_REACTIONS_GUARDED_SQL = f"""CASE WHEN m.reactions_json IS NOT NULL AND m.reactions_json != ''
-          AND json_valid(m.reactions_json) = 1
-     THEN {TOTAL_REACTIONS_SQL}
-     ELSE 0 END"""
-
-
 def _parse_reactions_json(reactions_json: str) -> list[dict]:
     """Parse reactions_json string into a list of {emoji, count} dicts."""
     return parse_reactions_json(reactions_json)
@@ -1276,30 +1264,99 @@ class MessagesRepository:
         date_from: str | None = None,
         date_to: str | None = None,
     ) -> list[dict]:
-        """Return top messages sorted by total reaction count."""
-        channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
-        conditions: list[str] = [
-            "(c.is_filtered IS NULL OR c.is_filtered = 0)",
-            "m.reactions_json IS NOT NULL",
-            "m.reactions_json != ''",
-            "json_valid(m.reactions_json) = 1",
-        ]
+        """Return top messages sorted by total reaction count.
+
+        Aggregates the normalized message_reactions table instead of running
+        json_each over reactions_json of every messages row — the latter is a
+        full-table scan that times out on multi-million-row databases (#826).
+        """
+        inner_conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
         params: list = []
-        self._append_analytics_date_filter(conditions, params, date_from, date_to)
-        where = " WHERE " + " AND ".join(conditions)
+        date_conditions: list[str] = []
+        self._append_analytics_date_filter(date_conditions, params, date_from, date_to)
+        # Date bounds live on messages; join it inside the aggregate only when
+        # a date filter is requested — the no-filter path stays index-only.
+        messages_join = ""
+        if date_conditions:
+            messages_join = (
+                " JOIN messages m ON m.channel_id = mr.channel_id AND m.message_id = mr.message_id"
+            )
+            inner_conditions.extend(date_conditions)
+        where = " WHERE " + " AND ".join(inner_conditions)
         cur = await self._db.execute(
             f"""SELECT m.id, m.channel_id, m.message_id, m.text, m.media_type,
                        m.date, m.reactions_json,
                        c.title as channel_title, c.username as channel_username,
-                       {TOTAL_REACTIONS_SQL} as total_reactions
-                FROM messages m{channel_join}
-                {where}
-                ORDER BY total_reactions DESC
-                LIMIT ?""",
+                       t.total_reactions
+                FROM (SELECT mr.channel_id, mr.message_id, SUM(mr.count) AS total_reactions
+                      FROM message_reactions mr{messages_join}
+                      LEFT JOIN channels c ON mr.channel_id = c.channel_id
+                      {where}
+                      GROUP BY mr.channel_id, mr.message_id
+                      ORDER BY total_reactions DESC
+                      LIMIT ?) t
+                JOIN messages m ON m.channel_id = t.channel_id AND m.message_id = t.message_id
+                LEFT JOIN channels c ON m.channel_id = c.channel_id
+                ORDER BY t.total_reactions DESC""",
             (*params, limit),
         )
         rows = await cur.fetchall()
         return [dict(r) for r in rows]
+
+    _REACTIONS_PER_MESSAGE_SQL = """(SELECT channel_id, message_id, SUM(count) AS total_reactions
+                       FROM message_reactions GROUP BY channel_id, message_id)"""
+
+    async def _get_engagement_rows(
+        self,
+        group_expr: str,
+        group_alias: str,
+        order_by: str,
+        date_from: str | None,
+        date_to: str | None,
+    ) -> list[dict]:
+        """Group messages by *group_expr*, averaging reactions over ALL messages
+        of the group (zero-reaction messages included in the denominator).
+
+        Runs two cheap aggregates — a plain COUNT over messages and a reaction
+        sum over the normalized message_reactions table — instead of a
+        json_each scan of every reactions_json (#826).
+        """
+        conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
+        params: list = []
+        self._append_analytics_date_filter(conditions, params, date_from, date_to)
+        where = " WHERE " + " AND ".join(conditions)
+        count_cur = await self._db.execute(
+            f"""SELECT {group_expr} as {group_alias}, COUNT(*) as message_count
+                FROM messages m
+                LEFT JOIN channels c ON m.channel_id = c.channel_id
+                {where}
+                GROUP BY {group_alias}
+                ORDER BY {order_by}""",
+            tuple(params),
+        )
+        counts = await count_cur.fetchall()
+        sum_cur = await self._db.execute(
+            f"""SELECT {group_expr} as {group_alias}, SUM(t.total_reactions) as reactions_sum
+                FROM {self._REACTIONS_PER_MESSAGE_SQL} t
+                JOIN messages m ON m.channel_id = t.channel_id AND m.message_id = t.message_id
+                LEFT JOIN channels c ON m.channel_id = c.channel_id
+                {where}
+                GROUP BY {group_alias}""",
+            tuple(params),
+        )
+        sums = {row[group_alias]: row["reactions_sum"] or 0 for row in await sum_cur.fetchall()}
+        return [
+            {
+                group_alias: row[group_alias],
+                "message_count": row["message_count"],
+                "avg_reactions": (
+                    sums.get(row[group_alias], 0) / row["message_count"]
+                    if row["message_count"]
+                    else 0.0
+                ),
+            }
+            for row in counts
+        ]
 
     async def get_engagement_by_media_type(
         self,
@@ -1307,23 +1364,13 @@ class MessagesRepository:
         date_to: str | None = None,
     ) -> list[dict]:
         """Return message count and avg reactions per content type."""
-        channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
-        conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
-        params: list = []
-        self._append_analytics_date_filter(conditions, params, date_from, date_to)
-        where = " WHERE " + " AND ".join(conditions)
-        cur = await self._db.execute(
-            f"""SELECT COALESCE(m.media_type, 'text') as content_type,
-                       COUNT(*) as message_count,
-                       COALESCE(AVG({TOTAL_REACTIONS_GUARDED_SQL}), 0) as avg_reactions
-                FROM messages m{channel_join}
-                {where}
-                GROUP BY content_type
-                ORDER BY message_count DESC""",
-            tuple(params),
+        return await self._get_engagement_rows(
+            group_expr="COALESCE(m.media_type, 'text')",
+            group_alias="content_type",
+            order_by="message_count DESC",
+            date_from=date_from,
+            date_to=date_to,
         )
-        rows = await cur.fetchall()
-        return [dict(r) for r in rows]
 
     async def get_hourly_activity(
         self,
@@ -1331,23 +1378,13 @@ class MessagesRepository:
         date_to: str | None = None,
     ) -> list[dict]:
         """Return message count and avg reactions per hour of day (0-23)."""
-        channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
-        conditions: list[str] = ["(c.is_filtered IS NULL OR c.is_filtered = 0)"]
-        params: list = []
-        self._append_analytics_date_filter(conditions, params, date_from, date_to)
-        where = " WHERE " + " AND ".join(conditions)
-        cur = await self._db.execute(
-            f"""SELECT CAST(strftime('%H', m.date) AS INTEGER) as hour,
-                       COUNT(*) as message_count,
-                       COALESCE(AVG({TOTAL_REACTIONS_GUARDED_SQL}), 0) as avg_reactions
-                FROM messages m{channel_join}
-                {where}
-                GROUP BY hour
-                ORDER BY hour""",
-            tuple(params),
+        return await self._get_engagement_rows(
+            group_expr="CAST(strftime('%H', m.date) AS INTEGER)",
+            group_alias="hour",
+            order_by="hour",
+            date_from=date_from,
+            date_to=date_to,
         )
-        rows = await cur.fetchall()
-        return [dict(r) for r in rows]
 
     async def get_message_by_id(self, message_db_id: int) -> Message | None:
         """Get a single message by its DB primary key (id)."""

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -218,17 +218,26 @@ class MessagesRepository:
     async def _upsert_reactions(
         self, channel_id: int, message_id: int, reactions_json: str
     ) -> None:
-        """Parse reactions_json and upsert rows into message_reactions."""
+        """Replace message_reactions rows for the message with reactions_json contents.
+
+        Delete-then-insert (not bare INSERT OR REPLACE) so emoji that vanished
+        from the refreshed JSON don't linger and inflate the analytics
+        aggregates built on this table (#826/#827 review).
+        """
         items = _parse_reactions_json(reactions_json)
-        if not items:
-            return
         data = [(channel_id, message_id, r["emoji"], r.get("count", 0)) for r in items]
         try:
-            await self._database.executemany_write(
-                """INSERT OR REPLACE INTO message_reactions
-                   (channel_id, message_id, emoji, count) VALUES (?, ?, ?, ?)""",
-                data,
-            )
+            async with self._database.transaction() as conn:
+                await conn.execute(
+                    "DELETE FROM message_reactions WHERE channel_id = ? AND message_id = ?",
+                    (channel_id, message_id),
+                )
+                if data:
+                    await conn.executemany(
+                        """INSERT OR REPLACE INTO message_reactions
+                           (channel_id, message_id, emoji, count) VALUES (?, ?, ?, ?)""",
+                        data,
+                    )
         except Exception:
             logger.exception(
                 "Failed to upsert reactions for channel_id=%s message_id=%s",
@@ -315,19 +324,29 @@ class MessagesRepository:
                     clear_premium_search_query=premium_search_query is None,
                 )
 
+        # Replace, not append: drop the messages' old rows first so emoji that
+        # vanished from a refreshed reactions_json don't linger and inflate the
+        # analytics aggregates built on this table (#826/#827 review).
+        reaction_keys = list({(m.channel_id, m.message_id) for m in messages if m.reactions_json})
         reactions_data = [
             (m.channel_id, m.message_id, r["emoji"], r.get("count", 0))
             for m in messages
             if m.reactions_json
             for r in _parse_reactions_json(m.reactions_json)
         ]
-        if reactions_data:
+        if reaction_keys:
             try:
-                await self._database.executemany_write(
-                    """INSERT OR REPLACE INTO message_reactions
-                       (channel_id, message_id, emoji, count) VALUES (?, ?, ?, ?)""",
-                    reactions_data,
-                )
+                async with self._database.transaction() as conn:
+                    await conn.executemany(
+                        "DELETE FROM message_reactions WHERE channel_id = ? AND message_id = ?",
+                        reaction_keys,
+                    )
+                    if reactions_data:
+                        await conn.executemany(
+                            """INSERT OR REPLACE INTO message_reactions
+                               (channel_id, message_id, emoji, count) VALUES (?, ?, ?, ?)""",
+                            reactions_data,
+                        )
             except Exception as exc:
                 logger.error("Failed to upsert reactions for batch: %s", exc)
 

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -371,6 +371,9 @@ CREATE INDEX IF NOT EXISTS idx_message_reactions_channel_msg
 CREATE INDEX IF NOT EXISTS idx_message_reactions_emoji
     ON message_reactions(emoji);
 CREATE INDEX IF NOT EXISTS idx_messages_collected_at ON messages(collected_at);
+-- Covering index for analytics GROUP BY media_type with the is_filtered
+-- channel join: without it the count query full-scans the messages table (#826).
+CREATE INDEX IF NOT EXISTS idx_messages_media_type ON messages(media_type, channel_id);
 
 -- NOTE: the legacy denormalized `pipelines` table (schema v1, with JSON
 -- `source_channel_ids`/`targets` columns) was superseded by the normalized

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1731,6 +1731,69 @@ async def test_get_top_messages_excludes_filtered_channels(db):
     assert [r["channel_id"] for r in result] == [-100507]
 
 
+@pytest.mark.anyio
+async def test_reaction_refresh_removes_stale_emoji_rows(db):
+    """Re-collecting a message with fewer reactions must drop vanished emoji rows
+    from message_reactions so analytics mirror the current reactions_json."""
+    await db.add_channel(Channel(channel_id=-100509, title="StaleSingle"))
+    base = dict(channel_id=-100509, message_id=1, text="msg", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    await db.insert_message(
+        Message(**base, reactions_json='[{"emoji": "👍", "count": 5}, {"emoji": "🔥", "count": 2}]')
+    )
+    # Same Telegram message re-collected after the 🔥 reactions were removed
+    await db.insert_message(Message(**base, reactions_json='[{"emoji": "👍", "count": 3}]'))
+
+    result = await db.get_top_messages(limit=10)
+    assert len(result) == 1
+    assert result[0]["total_reactions"] == 3  # not 3 + stale 🔥=2
+
+    cur = await db.execute(
+        "SELECT emoji, count FROM message_reactions WHERE channel_id = ? AND message_id = ?",
+        (-100509, 1),
+    )
+    rows = await cur.fetchall()
+    assert [(r["emoji"], r["count"]) for r in rows] == [("👍", 3)]
+
+
+@pytest.mark.anyio
+async def test_reaction_refresh_batch_removes_stale_emoji_rows(db):
+    """insert_messages_batch refresh path must also drop vanished emoji rows."""
+    await db.add_channel(Channel(channel_id=-100510, title="StaleBatch"))
+    base = dict(channel_id=-100510, message_id=1, text="msg", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    await db.insert_messages_batch(
+        [Message(**base, reactions_json='[{"emoji": "👍", "count": 5}, {"emoji": "🔥", "count": 2}]')]
+    )
+    await db.insert_messages_batch([Message(**base, reactions_json='[{"emoji": "👍", "count": 3}]')])
+
+    result = await db.get_top_messages(limit=10)
+    assert len(result) == 1
+    assert result[0]["total_reactions"] == 3
+
+    cur = await db.execute(
+        "SELECT emoji, count FROM message_reactions WHERE channel_id = ? AND message_id = ?",
+        (-100510, 1),
+    )
+    rows = await cur.fetchall()
+    assert [(r["emoji"], r["count"]) for r in rows] == [("👍", 3)]
+
+
+@pytest.mark.anyio
+async def test_reaction_refresh_with_empty_list_clears_rows(db):
+    """An explicit empty reactions list ('[]') clears message_reactions for the message."""
+    await db.add_channel(Channel(channel_id=-100511, title="StaleEmpty"))
+    base = dict(channel_id=-100511, message_id=1, text="msg", date=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    await db.insert_message(Message(**base, reactions_json='[{"emoji": "👍", "count": 5}]'))
+    await db.insert_message(Message(**base, reactions_json="[]"))
+
+    assert await db.get_top_messages(limit=10) == []
+    cur = await db.execute(
+        "SELECT COUNT(*) AS cnt FROM message_reactions WHERE channel_id = ? AND message_id = ?",
+        (-100511, 1),
+    )
+    row = await cur.fetchone()
+    assert row["cnt"] == 0
+
+
 @pytest.mark.aiosqlite_serial
 @pytest.mark.anyio
 async def test_migration_creates_message_reactions_without_backfill(tmp_path):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1588,6 +1588,149 @@ async def test_get_hourly_activity(db):
     assert hours[20]["message_count"] == 1
 
 
+class _SQLRecorder:
+    """Proxy around the raw connection that records every executed SQL string."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.statements: list[str] = []
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    async def execute(self, sql, parameters=()):
+        self.statements.append(sql)
+        return await self._inner.execute(sql, parameters)
+
+
+@pytest.mark.anyio
+async def test_analytics_queries_do_not_scan_reactions_json(db):
+    """top/content-types/hourly must aggregate message_reactions, not json_each
+    over every messages row — a full json_each scan times out on 18M-row DBs (#826)."""
+    await db.add_channel(Channel(channel_id=-100504, title="NoScan"))
+    await db.insert_message(
+        Message(
+            channel_id=-100504,
+            message_id=1,
+            text="msg",
+            reactions_json='[{"emoji": "👍", "count": 3}]',
+            date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+
+    recorder = _SQLRecorder(db._messages._db)
+    db._messages._db = recorder
+    try:
+        await db.get_top_messages(limit=5)
+        await db.get_top_messages(limit=5, date_from="2025-01-01", date_to="2025-12-31")
+        await db.get_engagement_by_media_type()
+        await db.get_engagement_by_media_type(date_from="2025-01-01")
+        await db.get_hourly_activity()
+        await db.get_hourly_activity(date_to="2025-12-31")
+    finally:
+        db._messages._db = recorder._inner
+
+    offenders = [sql for sql in recorder.statements if "json_each" in sql]
+    assert not offenders, f"analytics queries still scan reactions_json via json_each: {offenders}"
+
+
+@pytest.mark.anyio
+async def test_get_engagement_avg_counts_zero_reaction_messages(db):
+    """avg_reactions denominator is ALL messages of the type, including ones without reactions."""
+    await db.add_channel(Channel(channel_id=-100505, title="AvgSemantics"))
+    msgs = [
+        Message(
+            channel_id=-100505,
+            message_id=1,
+            text="text with reactions",
+            media_type=None,
+            reactions_json='[{"emoji": "👍", "count": 4}]',
+            date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        ),
+        Message(
+            channel_id=-100505,
+            message_id=2,
+            text="text without reactions",
+            media_type=None,
+            date=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        ),
+        Message(
+            channel_id=-100505,
+            message_id=3,
+            text="photo",
+            media_type="photo",
+            reactions_json='[{"emoji": "❤️", "count": 6}]',
+            date=datetime(2025, 1, 3, tzinfo=timezone.utc),
+        ),
+    ]
+    for m in msgs:
+        await db.insert_message(m)
+
+    result = await db.get_engagement_by_media_type()
+    by_type = {r["content_type"]: r for r in result}
+    assert by_type["text"]["avg_reactions"] == pytest.approx(2.0)  # (4 + 0) / 2
+    assert by_type["photo"]["avg_reactions"] == pytest.approx(6.0)
+    # ordered by message_count descending
+    assert [r["content_type"] for r in result] == ["text", "photo"]
+
+
+@pytest.mark.anyio
+async def test_get_hourly_activity_avg_counts_zero_reaction_messages(db):
+    """hourly avg_reactions averages over all messages in the hour, zeros included."""
+    await db.add_channel(Channel(channel_id=-100506, title="HourlyAvg"))
+    msgs = [
+        Message(
+            channel_id=-100506,
+            message_id=1,
+            text="reacted",
+            reactions_json='[{"emoji": "👍", "count": 3}]',
+            date=datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+        ),
+        Message(
+            channel_id=-100506,
+            message_id=2,
+            text="silent",
+            date=datetime(2025, 1, 2, 9, 30, tzinfo=timezone.utc),
+        ),
+    ]
+    for m in msgs:
+        await db.insert_message(m)
+
+    result = await db.get_hourly_activity()
+    hours = {r["hour"]: r for r in result}
+    assert hours[9]["message_count"] == 2
+    assert hours[9]["avg_reactions"] == pytest.approx(1.5)  # (3 + 0) / 2
+
+
+@pytest.mark.anyio
+async def test_get_top_messages_excludes_filtered_channels(db):
+    """Messages from is_filtered channels never reach the top list."""
+    await db.add_channel(Channel(channel_id=-100507, title="Visible"))
+    await db.add_channel(Channel(channel_id=-100508, title="Filtered"))
+    await db.set_channels_filtered_bulk([(-100508, "low_uniqueness")])
+    await db.insert_message(
+        Message(
+            channel_id=-100507,
+            message_id=1,
+            text="visible",
+            reactions_json='[{"emoji": "👍", "count": 2}]',
+            date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+    await db.insert_message(
+        Message(
+            channel_id=-100508,
+            message_id=1,
+            text="hidden",
+            reactions_json='[{"emoji": "🔥", "count": 100}]',
+            date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+    )
+
+    result = await db.get_top_messages(limit=10)
+    assert [r["channel_id"] for r in result] == [-100507]
+
+
 @pytest.mark.aiosqlite_serial
 @pytest.mark.anyio
 async def test_migration_creates_message_reactions_without_backfill(tmp_path):


### PR DESCRIPTION
Closes #826

## Корень

`get_top_messages` / `get_engagement_by_media_type` / `get_hourly_activity` считали реакции коррелированным подзапросом `json_each(m.reactions_json)` на **каждую** строку `messages`. На живой БД (32 ГБ, 18,8 млн строк) это полный скан с JSON-парсингом: `analytics top` >60с (timeout), `analytics content-types` >120с (timeout), `analytics hourly` — на грани.

## Фикс

Все три метода переведены на агрегацию нормализованной таблицы `message_reactions` (индекс `idx_message_reactions_channel_msg`, прецедент — `get_top_reacted_messages`, `get_err_data`):

- **top** — агрегат `SUM(mr.count)` GROUP BY (channel_id, message_id) с фильтром каналов внутри, JOIN `messages` только для топ-N строк; JOIN messages в агрегате добавляется только при date-фильтре;
- **content-types / hourly** — общий хелпер `_get_engagement_rows`: плоский COUNT по `messages` (без JSON) + сумма реакций через mr-агрегат, merge в Python; `avg = sum/count`, семантика прежняя (сообщения без реакций — в знаменателе);
- новый covering-индекс `idx_messages_media_type(media_type, channel_id)` — убирает оставшийся 103-секундный full scan COUNT GROUP BY media_type (схема выполняется при старте с `IF NOT EXISTS`; одноразовое построение на живой БД займёт ~1–3 мин при первом запуске);
- `TOTAL_REACTIONS_SQL` / `TOTAL_REACTIONS_GUARDED_SQL` удалены — потребителей не осталось.

## Покрытие данных (проверено на живой БД read-only)

`message_reactions` полностью покрывает `reactions_json`: 1 869 601 уникальных сообщений против 1 850 653 с reactions_json (чуть полнее — устаревшие реакции из неё не удаляются). Backfill не нужен. Таблица заполняется в `insert_message` / `insert_messages_batch` / `_refresh_existing_messages`.

## Бенчмарки на живой БД (18,8 млн строк)

| Запрос | До | После |
|---|---|---|
| top-5 (без дат) | >60с (timeout) | **1,8с** |
| top-5 (date_from 30д) | — | 29,1с |
| content-types: суммы реакций по mr | >120с (timeout) | **15,5с** |
| content-types: COUNT GROUP BY media_type | 103,3с (full scan) | ~15с с новым covering-индексом |
| hourly: COUNT GROUP BY hour | — | 14,8с (covering `idx_messages_channel_date`) |
| hourly: суммы реакций | — | 14,2с |

## TDD

Красный тест `test_analytics_queries_do_not_scan_reactions_json` (шпион на SQL: запросы трёх методов не содержат `json_each`) — красный до фикса, зелёный после. Семантика avg и исключение фильтрованных каналов зафиксированы новыми тестами `test_get_engagement_avg_counts_zero_reaction_messages`, `test_get_hourly_activity_avg_counts_zero_reaction_messages`, `test_get_top_messages_excludes_filtered_channels`. Существующие analytics-тесты не менялись и зелёные.

Прогон: 7856 passed (parallel) + 863 passed (serial), ruff чисто.

## Вне scope

- #825 — точный COUNT(*) с FTS-join в `search_messages_for_query/_since` (notification scheduler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)