### PR TITLE
fix(photo): cancel scheduled posts, per-file progress, batch status (835#3,#4,#14, 837#11)

### DIFF
--- a/src/services/photo_auto_upload_service.py
+++ b/src/services/photo_auto_upload_service.py
@@ -76,6 +76,12 @@ class PhotoAutoUploadService:
             send_mode = job.send_mode
             if send_mode == PhotoSendMode.ALBUM and len(files) < 2:
                 send_mode = PhotoSendMode.SEPARATE
+
+            async def _mark_sent(file_path: str, _ids: list[int], _jid: int = job.id or 0) -> None:
+                # Mark each file the moment it is published so a mid-batch failure
+                # doesn't re-send already-sent files next cycle (audit #835/4).
+                await self._bundle.mark_auto_file_sent(_jid, file_path)
+
             await self._publish.send_now(
                 phone=job.phone,
                 target_dialog_id=job.target_dialog_id,
@@ -83,9 +89,8 @@ class PhotoAutoUploadService:
                 file_paths=files,
                 send_mode=send_mode,
                 caption=job.caption,
+                on_file_sent=_mark_sent,
             )
-            for file_path in files:
-                await self._bundle.mark_auto_file_sent(job.id or 0, file_path)
             await self._bundle.update_auto_job(
                 job.id or 0,
                 error="",

--- a/src/services/photo_publish_service.py
+++ b/src/services/photo_publish_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 
 from src.models import PhotoSendMode
@@ -26,6 +27,7 @@ class PhotoPublishService:
         send_mode: PhotoSendMode,
         caption: str | None = None,
         schedule_at: datetime | None = None,
+        on_file_sent: Callable[[str, list[int]], Awaitable[None]] | None = None,
     ) -> list[int]:
         result = await self._pool.get_client_by_phone(phone, wait_for_flood=True)
         if result is None:
@@ -56,7 +58,12 @@ class PhotoPublishService:
                     pool=self._pool,
                     logger_=logger,
                 )
-                return [int(msg.id) for msg in sent]
+                album_ids = [int(msg.id) for msg in sent]
+                if on_file_sent is not None:
+                    # Atomic album send — record all files only after it succeeds.
+                    for path in file_paths:
+                        await on_file_sent(path, album_ids)
+                return album_ids
 
             message_ids: list[int] = []
             for path in file_paths:
@@ -72,7 +79,44 @@ class PhotoPublishService:
                     pool=self._pool,
                     logger_=logger,
                 )
-                message_ids.append(int(sent.id))
+                msg_id = int(sent.id)
+                message_ids.append(msg_id)
+                # Record progress per file so a mid-batch failure doesn't cause the
+                # already-sent files to be re-sent next cycle (audit #835/4).
+                if on_file_sent is not None:
+                    await on_file_sent(path, [msg_id])
             return message_ids
+        finally:
+            await self._pool.release_client(acquired_phone)
+
+    async def unschedule(
+        self,
+        *,
+        phone: str,
+        target_dialog_id: int,
+        target_type: str | None = None,
+        message_ids: list[int],
+    ) -> None:
+        """Cancel previously server-scheduled messages on Telegram (audit #835/3)."""
+        if not message_ids:
+            return
+        result = await self._pool.get_client_by_phone(phone, wait_for_flood=True)
+        if result is None:
+            raise RuntimeError("no_client")
+        session, acquired_phone = result
+        session = adapt_transport_session(session, disconnect_on_close=False)
+        try:
+            entity = target_dialog_id
+            resolver = getattr(self._pool, "resolve_dialog_entity", None)
+            if callable(resolver):
+                resolved = resolver(session, acquired_phone, target_dialog_id, target_type)
+                entity = await resolved if inspect.isawaitable(resolved) else resolved
+            await run_with_flood_wait(
+                session.delete_scheduled_messages(entity, message_ids),
+                operation="photo_unschedule",
+                phone=acquired_phone,
+                pool=self._pool,
+                logger_=logger,
+            )
         finally:
             await self._pool.release_client(acquired_phone)

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -11,6 +12,8 @@ from src.database.bundles import PhotoLoaderBundle
 from src.models import PhotoBatch, PhotoBatchItem, PhotoBatchStatus, PhotoSendMode
 from src.services.photo_publish_service import PhotoPublishService
 from src.utils.datetime import parse_required_schedule_datetime
+
+logger = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
 
@@ -291,7 +294,31 @@ class PhotoTaskService:
                 )
 
     async def cancel_item(self, item_id: int) -> bool:
-        return await self._bundle.cancel_item(item_id)
+        item = await self._bundle.get_item(item_id)
+        # A SCHEDULED item is already queued server-side on Telegram; cancel it
+        # there too, otherwise the post still goes out at its scheduled time
+        # (audit #835/3). Guard the RPC so the DB cancellation proceeds even if it
+        # fails (e.g. flood/network).
+        if (
+            item is not None
+            and item.status == PhotoBatchStatus.SCHEDULED
+            and item.telegram_message_ids
+        ):
+            try:
+                await self._publish.unschedule(
+                    phone=item.phone,
+                    target_dialog_id=item.target_dialog_id,
+                    target_type=item.target_type,
+                    message_ids=item.telegram_message_ids,
+                )
+            except Exception:
+                logger.warning(
+                    "cancel_item: failed to unschedule item %s on Telegram", item_id, exc_info=True
+                )
+        cancelled = await self._bundle.cancel_item(item_id)
+        if cancelled and item is not None and item.batch_id:
+            await self._sync_batch_status(item.batch_id, last_run_at=datetime.now(timezone.utc))
+        return cancelled
 
     async def recover_running(self) -> int:
         return await self._bundle.requeue_running_items_on_startup(datetime.now(timezone.utc))
@@ -305,30 +332,40 @@ class PhotoTaskService:
     ) -> None:
         items = await self._bundle.list_items_for_batch(batch_id)
         statuses = {item.status for item in items}
-        if statuses <= {PhotoBatchStatus.COMPLETED}:
-            await self._bundle.update_batch(
-                batch_id,
-                status=PhotoBatchStatus.COMPLETED,
-                last_run_at=last_run_at,
-            )
-            return
-        terminal_pending = {
+        # SCHEDULED is a server-side in-flight state; PENDING/RUNNING are local
+        # in-flight. While any item is in-flight the batch is not terminal.
+        in_flight = {
             PhotoBatchStatus.PENDING,
             PhotoBatchStatus.RUNNING,
+            PhotoBatchStatus.SCHEDULED,
         }
-        if PhotoBatchStatus.FAILED in statuses and statuses.isdisjoint(terminal_pending):
+        if statuses & in_flight:
+            # All-SCHEDULED batches surface as SCHEDULED, otherwise RUNNING.
+            status = (
+                PhotoBatchStatus.SCHEDULED
+                if statuses <= {PhotoBatchStatus.SCHEDULED}
+                else PhotoBatchStatus.RUNNING
+            )
+            await self._bundle.update_batch(batch_id, status=status, last_run_at=last_run_at)
+            return
+        # Every item is terminal (COMPLETED / FAILED / CANCELLED). Recognise
+        # CANCELLED so a COMPLETED+CANCELLED mix doesn't get stuck RUNNING
+        # (audit #837/11).
+        if PhotoBatchStatus.FAILED in statuses:
             await self._bundle.update_batch(
                 batch_id,
                 status=PhotoBatchStatus.FAILED,
                 error=fallback_error,
                 last_run_at=last_run_at,
             )
-            return
-        await self._bundle.update_batch(
-            batch_id,
-            status=PhotoBatchStatus.RUNNING,
-            last_run_at=last_run_at,
-        )
+        elif statuses <= {PhotoBatchStatus.CANCELLED}:
+            await self._bundle.update_batch(
+                batch_id, status=PhotoBatchStatus.CANCELLED, last_run_at=last_run_at
+            )
+        else:
+            await self._bundle.update_batch(
+                batch_id, status=PhotoBatchStatus.COMPLETED, last_run_at=last_run_at
+            )
 
     def load_manifest(self, manifest_path: str) -> list[dict]:
         path = Path(manifest_path)

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -204,6 +204,13 @@ class PhotoTaskService:
                 # SCHEDULED with their ids so cancel_item can still unschedule
                 # them. Never lose the cancel handle — record the error but leave
                 # the item (and batch) in-flight so the post stays cancellable.
+                #
+                # This is a *partial success*, not a failed operation: do NOT
+                # raise. Raising would make the command dispatcher / CLI / agent
+                # report the schedule as FAILED, so the user retries and schedules
+                # a SECOND copy while the first stays queued (duplicate publish).
+                # Fall through to return the durably-created, cancellable item;
+                # the recorded error surfaces the partial failure (#864 review).
                 await self._bundle.update_item(
                     item_id,
                     status=PhotoBatchStatus.SCHEDULED,
@@ -211,7 +218,8 @@ class PhotoTaskService:
                     error=f"partial schedule failure: {exc}",
                 )
             else:
-                # Nothing was scheduled — failing with no ids is correct.
+                # Nothing was scheduled — failing with no ids is correct; raise so
+                # the caller/dispatcher reports a genuine failure.
                 await self._bundle.update_item(
                     item_id,
                     status=PhotoBatchStatus.FAILED,
@@ -222,7 +230,7 @@ class PhotoTaskService:
                     status=PhotoBatchStatus.FAILED,
                     error=str(exc),
                 )
-            raise
+                raise
         item = await self._bundle.get_item(item_id)
         assert item is not None
         return item

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -295,10 +295,13 @@ class PhotoTaskService:
 
     async def cancel_item(self, item_id: int) -> bool:
         item = await self._bundle.get_item(item_id)
-        # A SCHEDULED item is already queued server-side on Telegram; cancel it
-        # there too, otherwise the post still goes out at its scheduled time
-        # (audit #835/3). Guard the RPC so the DB cancellation proceeds even if it
-        # fails (e.g. flood/network).
+        # A SCHEDULED item is already queued server-side on Telegram; it MUST be
+        # cancelled there too, otherwise the post still goes out at its scheduled
+        # time (audit #835/3). Server-side unschedule is a PRECONDITION for marking
+        # such an item CANCELLED: if the RPC fails (flood/network/missing client),
+        # do NOT mark it cancelled — that would report success while Telegram still
+        # publishes the post, and lose the telegram_message_ids retry target. Leave
+        # it SCHEDULED with the error recorded so cancellation can be retried.
         if (
             item is not None
             and item.status == PhotoBatchStatus.SCHEDULED
@@ -311,10 +314,15 @@ class PhotoTaskService:
                     target_type=item.target_type,
                     message_ids=item.telegram_message_ids,
                 )
-            except Exception:
+            except Exception as exc:
                 logger.warning(
-                    "cancel_item: failed to unschedule item %s on Telegram", item_id, exc_info=True
+                    "cancel_item: failed to unschedule item %s on Telegram; "
+                    "leaving it SCHEDULED so the post can still be cancelled",
+                    item_id,
+                    exc_info=True,
                 )
+                await self._bundle.update_item(item_id, error=f"unschedule failed: {exc}")
+                return False
         cancelled = await self._bundle.cancel_item(item_id)
         if cancelled and item is not None and item.batch_id:
             await self._sync_batch_status(item.batch_id, last_run_at=datetime.now(timezone.utc))

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -162,6 +162,26 @@ class PhotoTaskService:
                 status=PhotoBatchStatus.SCHEDULED,
             )
         )
+        # Accumulate server-scheduled message ids progressively. In SEPARATE mode
+        # send_now schedules files one-by-one; if a later file fails, the earlier
+        # ones are already queued on Telegram. Persisting their ids onto the item
+        # as a still-SCHEDULED (cancellable) state means a partial failure never
+        # strands an already-scheduled post without a cancel handle — the same
+        # ghost-publish class this PR fixes (audit #835/3,4).
+        accumulated: list[int] = []
+
+        async def _record_scheduled(_path: str, ids: list[int]) -> None:
+            # ALBUM fires the callback once per path sharing the same id set, so
+            # de-dupe to store the album's ids exactly once.
+            for mid in ids:
+                if mid not in accumulated:
+                    accumulated.append(mid)
+            await self._bundle.update_item(
+                item_id,
+                status=PhotoBatchStatus.SCHEDULED,
+                telegram_message_ids=list(accumulated),
+            )
+
         try:
             message_ids = await self._publish.send_now(
                 phone=phone,
@@ -171,6 +191,7 @@ class PhotoTaskService:
                 send_mode=send_mode,
                 caption=caption,
                 schedule_at=schedule_at,
+                on_file_sent=_record_scheduled,
             )
             await self._bundle.update_item(
                 item_id,
@@ -178,16 +199,29 @@ class PhotoTaskService:
                 telegram_message_ids=message_ids,
             )
         except Exception as exc:
-            await self._bundle.update_item(
-                item_id,
-                status=PhotoBatchStatus.FAILED,
-                error=str(exc),
-            )
-            await self._bundle.update_batch(
-                batch_id,
-                status=PhotoBatchStatus.FAILED,
-                error=str(exc),
-            )
+            if accumulated:
+                # Some files were already scheduled server-side: keep the item
+                # SCHEDULED with their ids so cancel_item can still unschedule
+                # them. Never lose the cancel handle — record the error but leave
+                # the item (and batch) in-flight so the post stays cancellable.
+                await self._bundle.update_item(
+                    item_id,
+                    status=PhotoBatchStatus.SCHEDULED,
+                    telegram_message_ids=list(accumulated),
+                    error=f"partial schedule failure: {exc}",
+                )
+            else:
+                # Nothing was scheduled — failing with no ids is correct.
+                await self._bundle.update_item(
+                    item_id,
+                    status=PhotoBatchStatus.FAILED,
+                    error=str(exc),
+                )
+                await self._bundle.update_batch(
+                    batch_id,
+                    status=PhotoBatchStatus.FAILED,
+                    error=str(exc),
+                )
             raise
         item = await self._bundle.get_item(item_id)
         assert item is not None

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -85,6 +85,25 @@ class PhotoTaskService:
                 started_at=datetime.now(timezone.utc),
             )
         )
+        # Accumulate ids of files already published live on Telegram. In SEPARATE
+        # mode send_now publishes file-by-file immediately, so if a later file
+        # fails the earlier ones are irreversibly live. Without this, the item is
+        # marked FAILED with no ids → the CLI/agent/UI report failure → the user
+        # reruns the command → file 1 is published a SECOND time (#864 review).
+        accumulated: list[int] = []
+
+        async def _record_sent(_path: str, ids: list[int]) -> None:
+            # ALBUM fires the callback once per path sharing the same id set, so
+            # de-dupe to store the album's ids exactly once.
+            for mid in ids:
+                if mid not in accumulated:
+                    accumulated.append(mid)
+            await self._bundle.update_item(
+                item_id,
+                status=PhotoBatchStatus.RUNNING,
+                telegram_message_ids=list(accumulated),
+            )
+
         try:
             message_ids = await self._publish.send_now(
                 phone=phone,
@@ -93,6 +112,7 @@ class PhotoTaskService:
                 file_paths=files,
                 send_mode=send_mode,
                 caption=caption,
+                on_file_sent=_record_sent,
             )
             now = datetime.now(timezone.utc)
             await self._bundle.update_item(
@@ -108,19 +128,42 @@ class PhotoTaskService:
             )
         except Exception as exc:
             now = datetime.now(timezone.utc)
-            await self._bundle.update_item(
-                item_id,
-                status=PhotoBatchStatus.FAILED,
-                error=str(exc),
-                completed_at=now,
-            )
-            await self._bundle.update_batch(
-                batch_id,
-                status=PhotoBatchStatus.FAILED,
-                error=str(exc),
-                last_run_at=now,
-            )
-            raise
+            if accumulated:
+                # Some files are already published live (irreversible — there is no
+                # unschedule handle for an immediate send). Persist their ids so the
+                # live posts are tied to the record for audit/cleanup, and mark the
+                # item COMPLETED-with-error rather than FAILED. Do NOT raise: a
+                # FAILED report makes callers tell the user it failed, the user
+                # reruns, and the published files are duplicated (#864 review).
+                await self._bundle.update_item(
+                    item_id,
+                    status=PhotoBatchStatus.COMPLETED,
+                    telegram_message_ids=list(accumulated),
+                    error=f"partial send failure: {exc}",
+                    completed_at=now,
+                )
+                await self._bundle.update_batch(
+                    batch_id,
+                    status=PhotoBatchStatus.COMPLETED,
+                    error=f"partial send failure: {exc}",
+                    last_run_at=now,
+                )
+            else:
+                # Nothing was published — failing with no ids is correct; raise so
+                # the caller/dispatcher reports a genuine failure.
+                await self._bundle.update_item(
+                    item_id,
+                    status=PhotoBatchStatus.FAILED,
+                    error=str(exc),
+                    completed_at=now,
+                )
+                await self._bundle.update_batch(
+                    batch_id,
+                    status=PhotoBatchStatus.FAILED,
+                    error=str(exc),
+                    last_run_at=now,
+                )
+                raise
         item = await self._bundle.get_item(item_id)
         assert item is not None
         return item
@@ -304,6 +347,11 @@ class PhotoTaskService:
 
     async def _run_claimed_item(self, item: PhotoBatchItem) -> None:
         now = datetime.now(timezone.utc)
+        # NB: this due-execution path intentionally omits on_file_sent. A FAILED due
+        # item is terminal — claim_next_due_item only claims status='pending' and no
+        # verb resets FAILED→PENDING — so it is never re-run and cannot double-publish.
+        # If a retry/requeue-failed verb is ever added, wire on_file_sent here (mirror
+        # send_now) AND add skip-already-sent logic, or partial sends will duplicate.
         try:
             message_ids = await self._publish.send_now(
                 phone=item.phone,

--- a/src/telegram/backends.py
+++ b/src/telegram/backends.py
@@ -263,6 +263,18 @@ class TelegramTransportSession:
             self._client.delete_messages(entity, message_ids),
         )
 
+    async def delete_scheduled_messages(self, entity: Any, message_ids: list[int]) -> Any:
+        """Cancel server-side scheduled messages (Telethon raw API)."""
+        try:
+            from telethon.tl.functions.messages import DeleteScheduledMessagesRequest
+        except ImportError:
+            # Telethon not available (e.g. test env with stub backend).
+            return None
+        return await self._run(
+            "telegram_delete_scheduled_messages",
+            self._client(DeleteScheduledMessagesRequest(peer=entity, id=list(message_ids))),
+        )
+
     async def send_reaction(self, entity: Any, message_id: int, emoji: str | None) -> Any:
         """Set or clear a reaction to a message using the Telethon raw API."""
         try:

--- a/tests/test_photo_auto_upload_service.py
+++ b/tests/test_photo_auto_upload_service.py
@@ -194,6 +194,17 @@ async def test_run_job_sends_files(service, bundle, tmp_path):
     bundle.get_auto_job.return_value = job
     bundle.has_sent_auto_file.return_value = False
 
+    # send_now now records progress per file via the on_file_sent callback
+    # (audit #835/4) — simulate that so the dedup marks are exercised.
+    async def _fake_send_now(**kwargs):
+        cb = kwargs.get("on_file_sent")
+        if cb is not None:
+            for path in kwargs["file_paths"]:
+                await cb(path, [1])
+        return [1] * len(kwargs["file_paths"])
+
+    service._publish.send_now = AsyncMock(side_effect=_fake_send_now)
+
     # Create test images
     (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff")
     (tmp_path / "img2.png").write_bytes(b"\x89PNG")

--- a/tests/test_photo_task_lifecycle.py
+++ b/tests/test_photo_task_lifecycle.py
@@ -114,6 +114,37 @@ async def test_cancel_pending_item_does_not_unschedule():
     publish.unschedule.assert_not_awaited()
 
 
+@pytest.mark.anyio
+async def test_cancel_scheduled_item_not_marked_when_unschedule_fails():
+    """Regression (#864 review): if the server-side unschedule fails for a SCHEDULED item
+    with telegram_message_ids, the item must NOT be marked CANCELLED — otherwise the UI
+    reports success while Telegram still publishes the post. cancel_item returns False and
+    records the error; the item stays SCHEDULED so cancellation can be retried."""
+    item = SimpleNamespace(
+        id=5,
+        status=PhotoBatchStatus.SCHEDULED,
+        telegram_message_ids=[101, 102],
+        phone="+7",
+        target_dialog_id=-100,
+        target_type="channel",
+        batch_id=9,
+    )
+    bundle = MagicMock()
+    bundle.get_item = AsyncMock(return_value=item)
+    bundle.cancel_item = AsyncMock(return_value=True)
+    bundle.update_item = AsyncMock()
+    publish = MagicMock()
+    publish.unschedule = AsyncMock(side_effect=RuntimeError("flood wait"))
+
+    svc = PhotoTaskService(bundle, publish)
+    result = await svc.cancel_item(5)
+
+    assert result is False, "cancel must report failure when the server-side unschedule fails"
+    bundle.cancel_item.assert_not_awaited()  # item NOT marked CANCELLED
+    bundle.update_item.assert_awaited_once()  # error recorded
+    assert "unschedule failed" in bundle.update_item.await_args.kwargs["error"]
+
+
 # ── 835#4: per-file progress callback ─────────────────────────────────────────
 
 

--- a/tests/test_photo_task_lifecycle.py
+++ b/tests/test_photo_task_lifecycle.py
@@ -1,0 +1,157 @@
+"""Tests for photo task cancellation, batch status and per-file progress.
+
+Covers audit #835/3 (cancel a server-scheduled item), #837/11 (batch terminal
+status with CANCELLED), and #835/4 (per-file send progress).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models import PhotoBatchStatus, PhotoSendMode
+from src.services.photo_publish_service import PhotoPublishService
+from src.services.photo_task_service import PhotoTaskService
+from tests.helpers import FakeCliTelethonClient
+
+_NOW = datetime.now(timezone.utc)
+
+
+# ── 837#11: _sync_batch_status terminal handling ──────────────────────────────
+
+
+async def _run_sync(item_statuses: list[PhotoBatchStatus]) -> PhotoBatchStatus:
+    bundle = MagicMock()
+    bundle.list_items_for_batch = AsyncMock(
+        return_value=[SimpleNamespace(status=s) for s in item_statuses]
+    )
+    bundle.update_batch = AsyncMock()
+    svc = PhotoTaskService(bundle, MagicMock())
+    await svc._sync_batch_status(1, last_run_at=_NOW)
+    return bundle.update_batch.await_args.kwargs["status"]
+
+
+@pytest.mark.anyio
+async def test_sync_batch_completed_plus_cancelled_is_completed():
+    status = await _run_sync([PhotoBatchStatus.COMPLETED, PhotoBatchStatus.CANCELLED])
+    assert status == PhotoBatchStatus.COMPLETED  # not stuck RUNNING (#837/11)
+
+
+@pytest.mark.anyio
+async def test_sync_batch_all_cancelled_is_cancelled():
+    status = await _run_sync([PhotoBatchStatus.CANCELLED, PhotoBatchStatus.CANCELLED])
+    assert status == PhotoBatchStatus.CANCELLED
+
+
+@pytest.mark.anyio
+async def test_sync_batch_any_failed_is_failed():
+    status = await _run_sync([PhotoBatchStatus.COMPLETED, PhotoBatchStatus.FAILED])
+    assert status == PhotoBatchStatus.FAILED
+
+
+@pytest.mark.anyio
+async def test_sync_batch_with_pending_stays_running():
+    status = await _run_sync([PhotoBatchStatus.COMPLETED, PhotoBatchStatus.PENDING])
+    assert status == PhotoBatchStatus.RUNNING
+
+
+# ── 835#3: cancel_item unschedules a server-scheduled item ────────────────────
+
+
+@pytest.mark.anyio
+async def test_cancel_scheduled_item_unschedules_on_telegram():
+    item = SimpleNamespace(
+        id=5,
+        status=PhotoBatchStatus.SCHEDULED,
+        telegram_message_ids=[101, 102],
+        phone="+7",
+        target_dialog_id=-100,
+        target_type="channel",
+        batch_id=9,
+    )
+    bundle = MagicMock()
+    bundle.get_item = AsyncMock(return_value=item)
+    bundle.cancel_item = AsyncMock(return_value=True)
+    bundle.list_items_for_batch = AsyncMock(
+        return_value=[SimpleNamespace(status=PhotoBatchStatus.CANCELLED)]
+    )
+    bundle.update_batch = AsyncMock()
+    publish = MagicMock()
+    publish.unschedule = AsyncMock()
+
+    svc = PhotoTaskService(bundle, publish)
+    result = await svc.cancel_item(5)
+
+    assert result is True
+    publish.unschedule.assert_awaited_once()
+    assert publish.unschedule.await_args.kwargs["message_ids"] == [101, 102]
+
+
+@pytest.mark.anyio
+async def test_cancel_pending_item_does_not_unschedule():
+    item = SimpleNamespace(
+        id=5,
+        status=PhotoBatchStatus.PENDING,
+        telegram_message_ids=None,
+        phone="+7",
+        target_dialog_id=-100,
+        target_type="channel",
+        batch_id=None,
+    )
+    bundle = MagicMock()
+    bundle.get_item = AsyncMock(return_value=item)
+    bundle.cancel_item = AsyncMock(return_value=True)
+    publish = MagicMock()
+    publish.unschedule = AsyncMock()
+
+    svc = PhotoTaskService(bundle, publish)
+    result = await svc.cancel_item(5)
+
+    assert result is True
+    publish.unschedule.assert_not_awaited()
+
+
+# ── 835#4: per-file progress callback ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_send_now_separate_marks_each_file_via_callback(real_pool_harness_factory):
+    harness = real_pool_harness_factory()
+    counter = {"n": 0}
+
+    def _send_file(*args, **kwargs):
+        counter["n"] += 1
+        return SimpleNamespace(id=200 + counter["n"])
+
+    harness.queue_cli_client(
+        phone="+7000",
+        client=FakeCliTelethonClient(
+            input_entity_resolver=lambda peer: SimpleNamespace(
+                id=getattr(peer, "channel_id", getattr(peer, "user_id", peer))
+            ),
+            send_file_side_effect=_send_file,
+        ),
+    )
+    await harness.add_account("+7000", session_string="s", is_primary=True)
+    await harness.initialize_connected_accounts()
+
+    marked: list[tuple[str, list[int]]] = []
+
+    async def _on_file_sent(path: str, ids: list[int]) -> None:
+        marked.append((path, ids))
+
+    service = PhotoPublishService(harness.pool)
+    result = await service.send_now(
+        phone="+7000",
+        target_dialog_id=-1001,
+        target_type="channel",
+        file_paths=["/a.jpg", "/b.jpg"],
+        send_mode=PhotoSendMode.SEPARATE,
+        on_file_sent=_on_file_sent,
+    )
+
+    assert result == [201, 202]
+    assert marked == [("/a.jpg", [201]), ("/b.jpg", [202])]

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -1313,6 +1313,53 @@ class TestPhotoTaskServiceScheduleSend:
                 schedule_at=datetime.now(timezone.utc),
             )
 
+    @pytest.mark.anyio
+    async def test_schedule_send_separate_partial_failure_keeps_scheduled_with_ids(self, tmp_path):
+        """Regression (#864 review): in SEPARATE mode, if file 1 is scheduled server-side
+        and file 2 fails, the item must stay SCHEDULED with file 1's id (cancellable) — never
+        FAILED-with-no-ids, which would strand a queued post with no cancel handle (ghost publish)."""
+        from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        img2 = tmp_path / "photo2.jpg"
+        img2.write_bytes(b"\xff\xd8\xff")
+
+        bundle = MagicMock()
+        bundle.create_batch = AsyncMock(return_value=5)
+        bundle.create_item = AsyncMock(return_value=50)
+        bundle.update_item = AsyncMock()
+        bundle.update_batch = AsyncMock()
+
+        # send_now schedules file 1 (fires on_file_sent) then fails on file 2, mirroring the
+        # real SEPARATE loop where earlier files are already queued before a later one raises.
+        async def _send_now(*, file_paths, on_file_sent=None, **_kwargs):
+            if on_file_sent is not None:
+                await on_file_sent(file_paths[0], [100])
+            raise RuntimeError("file 2 failed")
+
+        publish = MagicMock()
+        publish.send_now = AsyncMock(side_effect=_send_now)
+
+        svc = PhotoTaskService(bundle, publish)
+        target = PhotoTarget(dialog_id=300)
+        with pytest.raises(RuntimeError, match="file 2 failed"):
+            await svc.schedule_send(
+                phone="+3",
+                target=target,
+                file_paths=[str(img), str(img2)],
+                mode="separate",
+                schedule_at=datetime.now(timezone.utc),
+            )
+
+        # Last update_item must keep the item SCHEDULED with file 1's id — the cancel handle.
+        last = bundle.update_item.call_args_list[-1].kwargs
+        assert last.get("status") == PhotoBatchStatus.SCHEDULED
+        assert last.get("telegram_message_ids") == [100]
+        # The batch must NOT be force-marked FAILED while a post is still scheduled & cancellable.
+        for call in bundle.update_batch.call_args_list:
+            assert call.kwargs.get("status") != PhotoBatchStatus.FAILED
+
 
 class TestPhotoTaskServiceCancelItem:
     @pytest.mark.anyio

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -1421,9 +1421,19 @@ class TestPhotoTaskServiceScheduleSend:
 class TestPhotoTaskServiceCancelItem:
     @pytest.mark.anyio
     async def test_cancel_delegates_to_bundle(self):
+        from types import SimpleNamespace
+
+        from src.models import PhotoBatchStatus
         from src.services.photo_task_service import PhotoTaskService
 
         bundle = MagicMock()
+        # A non-SCHEDULED item with no batch: cancel_item skips the Telegram
+        # unschedule precondition and the batch-status sync, delegating straight
+        # to the repository (#864 changed cancel_item to look up the item first).
+        item = SimpleNamespace(
+            status=PhotoBatchStatus.PENDING, telegram_message_ids=None, batch_id=None
+        )
+        bundle.get_item = AsyncMock(return_value=item)
         bundle.cancel_item = AsyncMock(return_value=True)
         svc = PhotoTaskService(bundle, MagicMock())
         result = await svc.cancel_item(99)
@@ -1435,6 +1445,7 @@ class TestPhotoTaskServiceCancelItem:
         from src.services.photo_task_service import PhotoTaskService
 
         bundle = MagicMock()
+        bundle.get_item = AsyncMock(return_value=None)
         bundle.cancel_item = AsyncMock(return_value=False)
         svc = PhotoTaskService(bundle, MagicMock())
         result = await svc.cancel_item(123)

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -1251,6 +1251,56 @@ class TestPhotoTaskServiceSendNow:
         assert call_kwargs.kwargs.get("status") == PhotoBatchStatus.FAILED or \
                (call_kwargs.args and PhotoBatchStatus.FAILED in str(call_kwargs))
 
+    @pytest.mark.anyio
+    async def test_send_now_separate_partial_failure_keeps_published_ids(self, tmp_path):
+        """Regression (#864 review): an immediate SEPARATE send that publishes file 1 then fails
+        on file 2 must persist file 1's id and NOT raise. Raising makes the CLI/agent/UI report
+        failure, the user reruns, and file 1 is published a second time (duplicate)."""
+        from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        img2 = tmp_path / "photo2.jpg"
+        img2.write_bytes(b"\xff\xd8\xff")
+
+        bundle = MagicMock()
+        bundle.create_batch = AsyncMock(return_value=6)
+        bundle.create_item = AsyncMock(return_value=60)
+        bundle.update_item = AsyncMock()
+        bundle.update_batch = AsyncMock()
+        returned_item = MagicMock()
+        returned_item.id = 60
+        bundle.get_item = AsyncMock(return_value=returned_item)
+
+        # send_now publishes file 1 (fires on_file_sent immediately) then fails on file 2.
+        async def _send_now(*, file_paths, on_file_sent=None, **_kwargs):
+            if on_file_sent is not None:
+                await on_file_sent(file_paths[0], [42])
+            raise RuntimeError("file 2 failed")
+
+        publish = MagicMock()
+        publish.send_now = AsyncMock(side_effect=_send_now)
+
+        svc = PhotoTaskService(bundle, publish)
+        target = PhotoTarget(dialog_id=100)
+        # Partial publish returns the item (file 1 is live, irreversible) — it does NOT raise.
+        item = await svc.send_now(
+            phone="+1",
+            target=target,
+            file_paths=[str(img), str(img2)],
+            mode="separate",
+        )
+        assert item is returned_item
+
+        # Last update_item must record the published id and mark the item COMPLETED (not FAILED).
+        last = bundle.update_item.call_args_list[-1].kwargs
+        assert last.get("status") == PhotoBatchStatus.COMPLETED
+        assert last.get("telegram_message_ids") == [42]
+        assert "partial send failure" in (last.get("error") or "")
+        # The batch must NOT be marked FAILED — that would prompt a duplicate retry.
+        for call in bundle.update_batch.call_args_list:
+            assert call.kwargs.get("status") != PhotoBatchStatus.FAILED
+
 
 class TestPhotoTaskServiceScheduleSend:
     @pytest.mark.anyio

--- a/tests/test_settings_scheduler_pipeline_search_paths.py
+++ b/tests/test_settings_scheduler_pipeline_search_paths.py
@@ -1315,9 +1315,11 @@ class TestPhotoTaskServiceScheduleSend:
 
     @pytest.mark.anyio
     async def test_schedule_send_separate_partial_failure_keeps_scheduled_with_ids(self, tmp_path):
-        """Regression (#864 review): in SEPARATE mode, if file 1 is scheduled server-side
-        and file 2 fails, the item must stay SCHEDULED with file 1's id (cancellable) — never
-        FAILED-with-no-ids, which would strand a queued post with no cancel handle (ghost publish)."""
+        """Regression (#864 review): in SEPARATE mode, if file 1 is scheduled server-side and
+        file 2 fails, the item must stay SCHEDULED with file 1's id (cancellable) — never
+        FAILED-with-no-ids, which would strand a queued post with no cancel handle (ghost publish).
+        And partial success must NOT raise: raising makes the dispatcher/CLI report the schedule as
+        FAILED, so the user retries and schedules a duplicate while the first stays queued."""
         from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 
         img = tmp_path / "photo.jpg"
@@ -1330,6 +1332,9 @@ class TestPhotoTaskServiceScheduleSend:
         bundle.create_item = AsyncMock(return_value=50)
         bundle.update_item = AsyncMock()
         bundle.update_batch = AsyncMock()
+        returned_item = MagicMock()
+        returned_item.id = 50
+        bundle.get_item = AsyncMock(return_value=returned_item)
 
         # send_now schedules file 1 (fires on_file_sent) then fails on file 2, mirroring the
         # real SEPARATE loop where earlier files are already queued before a later one raises.
@@ -1343,19 +1348,21 @@ class TestPhotoTaskServiceScheduleSend:
 
         svc = PhotoTaskService(bundle, publish)
         target = PhotoTarget(dialog_id=300)
-        with pytest.raises(RuntimeError, match="file 2 failed"):
-            await svc.schedule_send(
-                phone="+3",
-                target=target,
-                file_paths=[str(img), str(img2)],
-                mode="separate",
-                schedule_at=datetime.now(timezone.utc),
-            )
+        # Partial success returns the durable, cancellable item — it does NOT raise.
+        item = await svc.schedule_send(
+            phone="+3",
+            target=target,
+            file_paths=[str(img), str(img2)],
+            mode="separate",
+            schedule_at=datetime.now(timezone.utc),
+        )
+        assert item is returned_item
 
         # Last update_item must keep the item SCHEDULED with file 1's id — the cancel handle.
         last = bundle.update_item.call_args_list[-1].kwargs
         assert last.get("status") == PhotoBatchStatus.SCHEDULED
         assert last.get("telegram_message_ids") == [100]
+        assert "partial schedule failure" in (last.get("error") or "")
         # The batch must NOT be force-marked FAILED while a post is still scheduled & cancellable.
         for call in bundle.update_batch.call_args_list:
             assert call.kwargs.get("status") != PhotoBatchStatus.FAILED


### PR DESCRIPTION
## Что
- **835#3** (HIGH) Отмена запланированного фото теперь шлёт `DeleteScheduledMessages` в Telegram (transport-обёртка + `PhotoPublishService.unschedule`), `cancel_item` отменяет серверно (guarded) + sync batch.
- **835#4** (HIGH) `send_now` получил `on_file_sent` — авто-загрузка помечает файлы прогрессивно, нет дублей после частичного сбоя.
- **837#11** (LOW) `_sync_batch_status` знает CANCELLED/SCHEDULED → batch не застревает RUNNING.
- **835#14** (LOW) согласовано с 835#3: SCHEDULED — корректное отменяемое состояние; batch SCHEDULED-aware.

## Тесты (TDD)
`test_photo_task_lifecycle.py` (cancel/unschedule, batch status, per-file progress). 90 passed (test_photo_loader пропущен — отсутствует optional `jieba` в окружении, не связано). ruff чисто.

Closes #863 · Part of #835, #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)