### PR TITLE
fix(channels): don't deactivate live channel on stale @username (#858 follow-up)

### DIFF
--- a/src/agent/tools/channels.py
+++ b/src/agent/tools/channels.py
@@ -270,7 +270,11 @@ def register(db, client_pool, embedding_service, **kwargs):
                     # signal_gone=True so a *definitive* not-found deactivates the channel
                     # (parity with the CLI/worker refresh-types, audit #835/8). The old
                     # `if info is False` branch was dead — resolve_channel returns dict|None.
-                    info = await client_pool.resolve_channel(identifier, signal_gone=True)
+                    # numeric_fallback so a stale @username doesn't deactivate a live
+                    # channel — gone is retried by numeric id first (#858 review).
+                    info = await client_pool.resolve_channel(
+                        identifier, signal_gone=True, numeric_fallback=str(ch.channel_id)
+                    )
                 except Exception:
                     info = None
                 if info and info.get("gone"):

--- a/src/cli/commands/channel.py
+++ b/src/cli/commands/channel.py
@@ -303,7 +303,11 @@ def run(args: argparse.Namespace) -> None:
                 for ch in channels:
                     identifier = ch.username or str(ch.channel_id)
                     try:
-                        info = await pool.resolve_channel(identifier, signal_gone=True)
+                        # numeric_fallback so a stale @username doesn't deactivate a
+                        # live channel — gone is retried by numeric id first (#858 review).
+                        info = await pool.resolve_channel(
+                            identifier, signal_gone=True, numeric_fallback=str(ch.channel_id)
+                        )
                     except Exception as e:
                         logging.warning("Failed to resolve %s: %s", identifier, e)
                         info = None

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -873,7 +873,11 @@ class TelegramCommandDispatcher:
         for ch in channels:
             identifier = ch.username or str(ch.channel_id)
             try:
-                info = await self._pool.resolve_channel(identifier, signal_gone=True)
+                # numeric_fallback so a stale @username doesn't deactivate a live
+                # channel — gone is retried by numeric id first (#858 review).
+                info = await self._pool.resolve_channel(
+                    identifier, signal_gone=True, numeric_fallback=str(ch.channel_id)
+                )
             except Exception:
                 info = None
             # Definitive not-found → deactivate; transient None → skip and leave

--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -1236,7 +1236,13 @@ class ClientPool(ResolveGuardMixin):
         result.sort(key=lambda u: (not u.is_primary, u.phone))
         return result
 
-    async def resolve_channel(self, identifier: str, *, signal_gone: bool = False) -> dict | None:
+    async def resolve_channel(
+        self,
+        identifier: str,
+        *,
+        signal_gone: bool = False,
+        numeric_fallback: str | None = None,
+    ) -> dict | None:
         """Resolve channel by @username or t.me/ link. Returns dict with channel info.
 
         When ``signal_gone`` is True, a *definitive* not-found (username no longer
@@ -1244,6 +1250,16 @@ class ClientPool(ResolveGuardMixin):
         so callers like ``channel refresh-types`` can deactivate the channel — while
         a *transient* failure (timeout / flood / no client) still returns None and
         the channel is left active (audit #835/8).
+
+        ``numeric_fallback`` guards against deactivating a *live* channel whose stored
+        @username merely went stale: a ``UsernameNotOccupiedError`` only proves the
+        username is no longer occupied, not that the channel row is dead — the channel
+        keeps a stable numeric id and may have just renamed/dropped its @username. When
+        the primary (username) resolution returns the gone sentinel and a distinct
+        ``numeric_fallback`` is given, resolution is retried by that numeric id; only a
+        *second* definitive not-found yields ``{"gone": True}``. A successful numeric
+        resolution returns the live channel dict, so refresh-types leaves it active
+        (#858 review).
 
         ChannelForbidden is NOT treated as gone: it is an access/permission error
         (the *resolving* account is not a member of a private/restricted channel),
@@ -1255,6 +1271,20 @@ class ClientPool(ResolveGuardMixin):
         Raises:
             RuntimeError("no_client") — no connected/available Telegram accounts.
         """
+        result = await self._resolve_channel_once(identifier, signal_gone=signal_gone)
+        # Stale-username guard: a gone-by-username verdict is not proof the channel is
+        # dead — retry by the stable numeric id before signalling gone (#858 review).
+        if (
+            signal_gone
+            and isinstance(result, dict)
+            and result.get("gone")
+            and numeric_fallback
+            and numeric_fallback != identifier
+        ):
+            return await self._resolve_channel_once(numeric_fallback, signal_gone=signal_gone)
+        return result
+
+    async def _resolve_channel_once(self, identifier: str, *, signal_gone: bool = False) -> dict | None:
         gone: dict | None = {"gone": True} if signal_gone else None
         # Normalize post links: https://t.me/channel/123 → https://t.me/channel
         identifier = re.sub(r"(t\.me/[^/\s]+)/\d+$", r"\1", identifier)

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -1181,6 +1181,72 @@ async def test_resolve_channel_username_invalid_is_gone_with_signal_gone(pool):
 
 
 @pytest.mark.anyio
+async def test_resolve_channel_stale_username_falls_back_to_numeric_id(pool):
+    """#858 review: a live channel that dropped/renamed its @username must NOT be
+    deactivated. When username resolution is gone but the numeric id resolves to a
+    live entity, the live dict is returned (refresh-types leaves the channel active)."""
+    client = AsyncMock()
+    live = SimpleNamespace(id=123, title="Renamed", broadcast=True, megagroup=False,
+                           gigagroup=False, forum=False, monoforum=False, scam=False,
+                           fake=False, restricted=False)
+
+    async def fake_get_entity(peer, *a, **kw):
+        # username peer raises gone; numeric PeerChannel resolves to the live entity
+        if isinstance(peer, str):
+            raise UsernameNotOccupiedError("nope")
+        return live
+
+    client.get_entity = AsyncMock(side_effect=fake_get_entity)
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+
+    with patch.object(pool, "get_available_client", return_value=(
+        TelegramTransportSession(client, disconnect_on_close=False), "+7001"
+    )):
+        result = await pool.resolve_channel(
+            "@oldname", signal_gone=True, numeric_fallback="-100123"
+        )
+    assert result is not None
+    assert result.get("gone") is None
+    assert result["channel_id"] == 123
+
+
+@pytest.mark.anyio
+async def test_resolve_channel_gone_by_both_username_and_numeric_is_gone(pool):
+    """Only a *second* definitive not-found (numeric id also gone) yields the gone
+    sentinel — so a truly deleted channel still gets deactivated (#858 review)."""
+    client = AsyncMock()
+    client.get_entity = AsyncMock(side_effect=UsernameNotOccupiedError("nope"))
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+
+    with patch.object(pool, "get_available_client", return_value=(
+        TelegramTransportSession(client, disconnect_on_close=False), "+7001"
+    )):
+        result = await pool.resolve_channel(
+            "@oldname", signal_gone=True, numeric_fallback="-100123"
+        )
+    assert result == {"gone": True}
+
+
+@pytest.mark.anyio
+async def test_resolve_channel_no_fallback_when_identifier_is_already_numeric(pool):
+    """When the channel has no username the identifier already IS the numeric id, so a
+    gone verdict needs no retry (fallback == identifier → skipped) and stays gone."""
+    client = AsyncMock()
+    client.get_entity = AsyncMock(side_effect=UsernameInvalidError("inv"))
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+
+    with patch.object(pool, "get_available_client", return_value=(
+        TelegramTransportSession(client, disconnect_on_close=False), "+7001"
+    )):
+        result = await pool.resolve_channel(
+            "-100123", signal_gone=True, numeric_fallback="-100123"
+        )
+    assert result == {"gone": True}
+    # identifier == fallback → resolved exactly once, no redundant retry
+    assert client.get_entity.await_count == 1
+
+
+@pytest.mark.anyio
 async def test_resolve_channel_numeric_id(pool):
     client = AsyncMock()
     entity = SimpleNamespace(id=123, title="Ch", broadcast=True, megagroup=False, gigagroup=False,

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -1372,7 +1372,29 @@ async def test_channels_refresh_types_no_username():
     d = _dispatcher(db=db, pool=pool)
     r = await d._handle_channels_refresh_types({})
     assert r["updated"] == 1
-    pool.resolve_channel.assert_awaited_once_with("-100", signal_gone=True)
+    pool.resolve_channel.assert_awaited_once_with(
+        "-100", signal_gone=True, numeric_fallback="-100"
+    )
+
+
+# --- _handle_channels_refresh_types: stale @username must not deactivate a live channel ---
+
+
+async def test_channels_refresh_types_passes_numeric_fallback():
+    """#858 review: refresh-types resolves by @username but must pass the numeric
+    channel_id as fallback so a stale username can't deactivate a live channel."""
+    from src.models import Channel
+
+    db = _mock_db()
+    pool = _mock_pool()
+    db.get_channels.return_value = [Channel(id=1, channel_id=-100, title="T", username="oldname")]
+    pool.resolve_channel.return_value = {"channel_id": -100, "channel_type": "channel"}
+    d = _dispatcher(db=db, pool=pool)
+    r = await d._handle_channels_refresh_types({})
+    assert r["updated"] == 1
+    pool.resolve_channel.assert_awaited_once_with(
+        "oldname", signal_gone=True, numeric_fallback="-100"
+    )
 
 
 # --- _handle_channels_refresh_types: resolve returns info with None channel_type ---


### PR DESCRIPTION
## Что
Follow-up к уже смёрженному **#858**. Локальное ревью (Claude subagent + Codex companion) нашло **data-loss баг**, попавший в main вместе с #858.

`channel refresh-types` (worker-dispatcher, agent-tool, CLI) резолвит канал по `ch.username or str(ch.channel_id)` — т.е. **по @username, если он есть**. После #858 `resolve_channel(signal_gone=True)` превращает `UsernameNotOccupiedError`/`UsernameInvalidError` в `{"gone": True}` → канал деактивируется (`set_channel_active(False)` + type `unavailable`).

Но освободившийся @username доказывает лишь, что **username** больше не занят, а **не** что канал мёртв: публичный канал со стабильным числовым `channel_id`, который **переименовался или убрал @username**, по-прежнему жив. До #858 деактивации не было вовсе (ветка `if info is False` была мёртвой), так что #858 этот регресс и ввёл.

## Фикс
`resolve_channel` получает новый параметр `numeric_fallback: str | None`:
- основной резолв идёт по `identifier` (username);
- если он вернул gone-sentinel и задан **отличный** `numeric_fallback` — резолв повторяется по числовому id;
- `{"gone": True}` возвращается **только** если и числовой id даёт definitive not-found.

Логика инкапсулирована в pool (`_resolve_channel_once` + обёртка), все 3 call-site refresh-types передают `numeric_fallback=str(ch.channel_id)`. Поведение для реально удалённых каналов (оба резолва gone) и для транзиентных ошибок (None → skip) не меняется.

## Тесты (TDD)
- `resolve_channel`: stale-username → numeric fallback возвращает живой канал (НЕ gone); оба gone → gone; identifier==fallback → ровно один резолв, без лишнего retry.
- dispatcher refresh-types: проверка передачи `numeric_fallback`.
- ruff чисто, затронутые suites зелёные.

Закрывает находку ревью #858; см. https://github.com/axisrow/tg_content_factory/pull/858#issuecomment-4714762389

🤖 Generated with [Claude Code](https://claude.com/claude-code)