### PR TITLE
perf(web): lazyload /dashboard and /channels (#756)

### DIFF
--- a/src/web/channels/handlers.py
+++ b/src/web/channels/handlers.py
@@ -24,6 +24,20 @@ async def _enqueue_channel_command(request: Request, command_type: str, payload:
 
 
 async def channels_list(request: Request) -> ChannelsTemplate:
+    """Skeleton — no heavy queries; the channel table loads via the lazy fragment (#756)."""
+    show_all = request.query_params.get("view") == "all"
+    return ChannelsTemplate(
+        "channels.html",
+        {
+            "error": request.query_params.get("error"),
+            "msg": request.query_params.get("msg"),
+            "show_all": show_all,
+        },
+    )
+
+
+async def channels_list_fragment(request: Request) -> ChannelsTemplate:
+    """Heavy table fragment: channel list with counts + stats (#756)."""
     service = deps.channel_service(request)
     db = deps.get_db(request)
     show_all = request.query_params.get("view") == "all"
@@ -33,13 +47,11 @@ async def channels_list(request: Request) -> ChannelsTemplate:
     active_count = await db.repos.channels.count_channels(active_only=True, include_filtered=False)
     total_count = await db.repos.channels.count_channels()
     return ChannelsTemplate(
-        "channels.html",
+        "channels/_list.html",
         {
             "channels": channels,
             "latest_stats": latest_stats,
             "prev_subscriber_counts": prev_subscriber_counts,
-            "error": request.query_params.get("error"),
-            "msg": request.query_params.get("msg"),
             "show_all": show_all,
             "active_count": active_count,
             "total_count": total_count,

--- a/src/web/channels/handlers.py
+++ b/src/web/channels/handlers.py
@@ -24,16 +24,13 @@ async def _enqueue_channel_command(request: Request, command_type: str, payload:
 
 
 async def channels_list(request: Request) -> ChannelsTemplate:
-    """Skeleton — no heavy queries; the channel table loads via the lazy fragment (#756)."""
+    """Skeleton — no heavy queries; the channel table loads via the lazy fragment (#756).
+
+    Flash msg/error render globally in base.html from the query string, so they are
+    not part of this context (the table template never referenced them).
+    """
     show_all = request.query_params.get("view") == "all"
-    return ChannelsTemplate(
-        "channels.html",
-        {
-            "error": request.query_params.get("error"),
-            "msg": request.query_params.get("msg"),
-            "show_all": show_all,
-        },
-    )
+    return ChannelsTemplate("channels.html", {"show_all": show_all})
 
 
 async def channels_list_fragment(request: Request) -> ChannelsTemplate:

--- a/src/web/routes/channels.py
+++ b/src/web/routes/channels.py
@@ -16,6 +16,11 @@ async def channels_list(request: Request):
     return channels_response(request, await handlers.channels_list(request))
 
 
+@router.get("/fragments/list", response_class=HTMLResponse)
+async def channels_list_fragment(request: Request):
+    return channels_response(request, await handlers.channels_list_fragment(request))
+
+
 @router.post("/add")
 async def add_channel(request: Request, identifier: str = Form("")):
     return channels_response(request, await handlers.add_channel(request, identifier))

--- a/src/web/routes/dashboard.py
+++ b/src/web/routes/dashboard.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.models import AccountSessionStatus
 from src.telegram.flood_wait import is_blocking_flood_wait_until
@@ -30,6 +30,9 @@ def _time_ago(dt: datetime | None) -> str | None:
 
 @router.get("/")
 async def dashboard(request: Request):
+    # Onboarding redirects MUST stay synchronous — they decide whether to render the
+    # page at all (a skeleton 200 would swallow the redirect). The heavy stats
+    # (get_stats does COUNT(*) on millions of messages) load lazily in the fragment (#756).
     auth = deps.get_auth(request)
     if not auth.is_configured:
         return RedirectResponse(url="/settings", status_code=303)
@@ -39,6 +42,13 @@ async def dashboard(request: Request):
     if not accounts:
         return RedirectResponse(url="/settings?msg=no_accounts", status_code=303)
 
+    return deps.get_templates(request).TemplateResponse(request, "dashboard.html", {})
+
+
+@router.get("/fragments/overview", response_class=HTMLResponse)
+async def fragment_overview(request: Request):
+    db = deps.get_db(request)
+    accounts = await db.get_account_summaries(active_only=False)
     stats = await db.get_stats()
     scheduler = deps.get_scheduler(request)
 
@@ -77,7 +87,7 @@ async def dashboard(request: Request):
 
     return deps.get_templates(request).TemplateResponse(
         request,
-        "dashboard.html",
+        "dashboard/_overview.html",
         {
             "stats": stats,
             "scheduler_running": scheduler.is_running,

--- a/src/web/templates/channels.html
+++ b/src/web/templates/channels.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import icon, filter_flags, channel_actions %}
-{% from "_macros_ui.html" import status_dot %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Каналы — TG Agent{% endblock %}
 {% block content %}
 <h1>Каналы</h1>
@@ -23,10 +22,7 @@
     </div>
 </div>
 
-{% if channels or show_all %}
 <div class="d-flex gap-2 align-items-center flex-wrap mb-3">
-    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-primary' }}">Активные ({{ active_count }})</a>
-    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-primary' }}">Все каналы ({{ total_count }})</a>
     <span class="flex-fill"></span>
     <form method="post" action="/channels/stats/all" class="d-inline" data-busy>
         <button type="submit" class="btn btn-outline-primary btn-sm">Обновить статистику</button>
@@ -41,119 +37,13 @@
         </form>
     </span>
 </div>
-<!-- Desktop: table -->
-<div class="table-responsive d-none d-lg-block">
-<table class="tga-table-striped-hover channels-table">
-    <thead>
-        <tr>
-            <th>ID канала</th>
-            <th>Название</th>
-            <th>Username</th>
-            <th>Описание</th>
-            <th>Тип</th>
-            <th>Статус</th>
-            <th>Сообщений</th>
-            <th>Подписчики</th>
-            <th>Просмотры</th>
-            <th>Реакции</th>
-            <th>Репосты</th>
-            <th>Фильтр</th>
-            <th>Действия</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for ch in channels %}
-        {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
-        <tr{% if ch.is_filtered %} class="opacity-50"{% endif %}>
-            <td>{{ ch.channel_id }}</td>
-            <td>{{ ch.title or "—" }}</td>
-            <td>{% if ch.username %}<a href="https://t.me/{{ ch.username }}" target="_blank" rel="noopener">@{{ ch.username }}</a>{% else %}—{% endif %}</td>
-            <td><small>{% if ch.about %}{{ ch.about[:60] }}{% if ch.about|length > 60 %}…{% endif %}{% else %}—{% endif %}</small></td>
-            <td>{% if ch.channel_type == "channel" %}{% if not ch.username %}Канал <span title="Приватный">{{ icon("private") }}</span>{% else %}Канал{% endif %}{% elif ch.channel_type == "supergroup" %}{% if not ch.username %}Супергруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Супергруппа{% endif %}{% elif ch.channel_type == "gigagroup" %}{% if not ch.username %}Гигагруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Гигагруппа{% endif %}{% elif ch.channel_type == "group" %}{% if not ch.username %}Группа <span title="Приватная">{{ icon("private") }}</span>{% else %}Группа{% endif %}{% elif ch.channel_type == "forum" %}{% if not ch.username %}Форум <span title="Приватный">{{ icon("private") }}</span>{% else %}Форум{% endif %}{% elif ch.channel_type == "monoforum" %}Монофорум{% elif ch.channel_type == "restricted" %}<span class="text-danger">Ограничен</span>{% elif ch.channel_type == "scam" %}<span class="text-danger">Скам {{ icon("warning") }}</span>{% elif ch.channel_type == "fake" %}<span class="text-danger">Фейк {{ icon("warning") }}</span>{% elif ch.channel_type == "unavailable" %}<span class="text-muted">Недоступен</span>{% else %}<span class="text-muted">Непроверен</span>{% endif %}{% if ch.has_comments %} <span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}</td>
-            <td>
-              {{ status_dot(ch) }}
-            </td>
-            <td>{{ ch.message_count }}</td>
-            <td>
-                {%- set sub = st.subscriber_count if st and st.subscriber_count is not none else none -%}
-                {%- set prev_sub = prev_subscriber_counts.get(ch.channel_id) if prev_subscriber_counts else none -%}
-                {%- if sub is not none -%}
-                    {{ sub }}
-                    {%- if prev_sub is not none -%}
-                        {%- if sub > prev_sub -%}
-                            <span class="text-success ms-1" title="Рост: +{{ sub - prev_sub }}">{{ icon("trend_up") }}</span>
-                        {%- elif sub < prev_sub -%}
-                            <span class="text-danger ms-1" title="Падение: {{ sub - prev_sub }}">{{ icon("trend_down") }}</span>
-                        {%- else -%}
-                            <span class="text-muted ms-1" title="Без изменений">{{ icon("trend_flat") }}</span>
-                        {%- endif -%}
-                    {%- endif -%}
-                {%- else -%}—{%- endif -%}
-            </td>
-            <td>{{ "%.0f"|format(st.avg_views) if st and st.avg_views is not none else "—" }}</td>
-            <td>{{ "%.0f"|format(st.avg_reactions) if st and st.avg_reactions is not none else "—" }}</td>
-            <td>{{ "%.0f"|format(st.avg_forwards) if st and st.avg_forwards is not none else "—" }}</td>
-            <td>
-                {% if ch.is_filtered %}
-                    {{ filter_flags(ch.filter_flags) }}
-                {% else %}
-                    —
-                {% endif %}
-            </td>
-            <td class="text-nowrap">
-                {{ channel_actions(ch) }}
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-</div>
 
-<!-- Mobile: cards -->
-<div class="d-lg-none mobile-cards">
-    {% for ch in channels %}
-    {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
-    <div class="card mb-2{% if ch.is_filtered %} opacity-50{% endif %}">
-        <div class="card-body">
-            <div class="d-flex justify-content-between align-items-start">
-                <div class="min-w-0 flex-fill">
-                    <div class="d-flex align-items-center gap-1 mb-1">
-                        {{ status_dot(ch) }}
-                        <strong class="text-truncate">{{ ch.title or "—" }}</strong>
-                        {% if ch.has_comments %}<span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}
-                    </div>
-                    {% if ch.about %}<small class="d-block text-muted mb-1" title="{{ ch.about }}">{{ ch.about[:60] }}{% if ch.about|length > 60 %}…{% endif %}</small>{% endif %}
-                    <small class="text-muted">
-                        {% if ch.username %}<a href="https://t.me/{{ ch.username }}" target="_blank" rel="noopener">@{{ ch.username }}</a> &middot; {% endif %}
-                        ID: {{ ch.channel_id }} &middot; {{ ch.message_count }} сообщ.
-                        {%- if st -%}
-                            {%- if st.subscriber_count is not none %}
-                                &middot; {{ st.subscriber_count }}
-                                {%- set prev_sub = prev_subscriber_counts.get(ch.channel_id) if prev_subscriber_counts else none -%}
-                                {%- if prev_sub is not none -%}
-                                    {%- if st.subscriber_count > prev_sub %}<span class="text-success" title="Рост">{{ icon("trend_up") }}</span>
-                                    {%- elif st.subscriber_count < prev_sub %}<span class="text-danger" title="Падение">{{ icon("trend_down") }}</span>
-                                    {%- else %}<span class="text-muted">{{ icon("trend_flat") }}</span>
-                                    {%- endif -%}
-                                {%- endif %} подп.
-                            {%- endif -%}
-                            {%- if st.avg_views is not none %} &middot; {{ icon("view") }} {{ "%.0f"|format(st.avg_views) }}{%- endif -%}
-                            {%- if st.avg_reactions is not none %} &middot; ❤️ {{ "%.0f"|format(st.avg_reactions) }}{%- endif -%}
-                            {%- if st.avg_forwards is not none %} &middot; ↪ {{ "%.0f"|format(st.avg_forwards) }}{%- endif -%}
-                        {%- endif -%}
-                    </small>
-                </div>
-            </div>
-            <div class="card-actions">
-                {{ channel_actions(ch, prefix="m-") }}
-            </div>
-        </div>
-    </div>
-    {% endfor %}
+{# Skeleton paints instantly; the channel table (heavy JOIN+COUNT) loads lazily (#756).
+   Desktop table AND mobile cards live together in the fragment so the per-row collect
+   buttons' OOB targets (-{pk} and -m-{pk}) both exist in the DOM. #}
+<div hx-get="/channels/fragments/list{{ '?view=all' if show_all else '' }}" hx-trigger="load" hx-swap="innerHTML">
+    {{ loading(class="my-4") }}
 </div>
-{% else %}
-<p>Нет добавленных каналов.</p>
-{% endif %}
 
 <div class="modal fade" id="subscriptions-modal" tabindex="-1">
     <div class="modal-dialog modal-lg">

--- a/src/web/templates/channels/_list.html
+++ b/src/web/templates/channels/_list.html
@@ -1,0 +1,120 @@
+{% from "_macros.html" import icon, filter_flags, channel_actions %}
+{% from "_macros_ui.html" import status_dot %}
+{% if channels or show_all %}
+<div class="d-flex gap-2 align-items-center flex-wrap mb-3">
+    <a href="/channels" class="btn btn-sm {{ 'btn-primary' if not show_all else 'btn-outline-primary' }}">Активные ({{ active_count }})</a>
+    <a href="/channels?view=all" class="btn btn-sm {{ 'btn-primary' if show_all else 'btn-outline-primary' }}">Все каналы ({{ total_count }})</a>
+</div>
+<!-- Desktop: table -->
+<div class="table-responsive d-none d-lg-block">
+<table class="tga-table-striped-hover channels-table">
+    <thead>
+        <tr>
+            <th>ID канала</th>
+            <th>Название</th>
+            <th>Username</th>
+            <th>Описание</th>
+            <th>Тип</th>
+            <th>Статус</th>
+            <th>Сообщений</th>
+            <th>Подписчики</th>
+            <th>Просмотры</th>
+            <th>Реакции</th>
+            <th>Репосты</th>
+            <th>Фильтр</th>
+            <th>Действия</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for ch in channels %}
+        {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
+        <tr{% if ch.is_filtered %} class="opacity-50"{% endif %}>
+            <td>{{ ch.channel_id }}</td>
+            <td>{{ ch.title or "—" }}</td>
+            <td>{% if ch.username %}<a href="https://t.me/{{ ch.username }}" target="_blank" rel="noopener">@{{ ch.username }}</a>{% else %}—{% endif %}</td>
+            <td><small>{% if ch.about %}{{ ch.about[:60] }}{% if ch.about|length > 60 %}…{% endif %}{% else %}—{% endif %}</small></td>
+            <td>{% if ch.channel_type == "channel" %}{% if not ch.username %}Канал <span title="Приватный">{{ icon("private") }}</span>{% else %}Канал{% endif %}{% elif ch.channel_type == "supergroup" %}{% if not ch.username %}Супергруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Супергруппа{% endif %}{% elif ch.channel_type == "gigagroup" %}{% if not ch.username %}Гигагруппа <span title="Приватная">{{ icon("private") }}</span>{% else %}Гигагруппа{% endif %}{% elif ch.channel_type == "group" %}{% if not ch.username %}Группа <span title="Приватная">{{ icon("private") }}</span>{% else %}Группа{% endif %}{% elif ch.channel_type == "forum" %}{% if not ch.username %}Форум <span title="Приватный">{{ icon("private") }}</span>{% else %}Форум{% endif %}{% elif ch.channel_type == "monoforum" %}Монофорум{% elif ch.channel_type == "restricted" %}<span class="text-danger">Ограничен</span>{% elif ch.channel_type == "scam" %}<span class="text-danger">Скам {{ icon("warning") }}</span>{% elif ch.channel_type == "fake" %}<span class="text-danger">Фейк {{ icon("warning") }}</span>{% elif ch.channel_type == "unavailable" %}<span class="text-muted">Недоступен</span>{% else %}<span class="text-muted">Непроверен</span>{% endif %}{% if ch.has_comments %} <span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}</td>
+            <td>
+              {{ status_dot(ch) }}
+            </td>
+            <td>{{ ch.message_count }}</td>
+            <td>
+                {%- set sub = st.subscriber_count if st and st.subscriber_count is not none else none -%}
+                {%- set prev_sub = prev_subscriber_counts.get(ch.channel_id) if prev_subscriber_counts else none -%}
+                {%- if sub is not none -%}
+                    {{ sub }}
+                    {%- if prev_sub is not none -%}
+                        {%- if sub > prev_sub -%}
+                            <span class="text-success ms-1" title="Рост: +{{ sub - prev_sub }}">{{ icon("trend_up") }}</span>
+                        {%- elif sub < prev_sub -%}
+                            <span class="text-danger ms-1" title="Падение: {{ sub - prev_sub }}">{{ icon("trend_down") }}</span>
+                        {%- else -%}
+                            <span class="text-muted ms-1" title="Без изменений">{{ icon("trend_flat") }}</span>
+                        {%- endif -%}
+                    {%- endif -%}
+                {%- else -%}—{%- endif -%}
+            </td>
+            <td>{{ "%.0f"|format(st.avg_views) if st and st.avg_views is not none else "—" }}</td>
+            <td>{{ "%.0f"|format(st.avg_reactions) if st and st.avg_reactions is not none else "—" }}</td>
+            <td>{{ "%.0f"|format(st.avg_forwards) if st and st.avg_forwards is not none else "—" }}</td>
+            <td>
+                {% if ch.is_filtered %}
+                    {{ filter_flags(ch.filter_flags) }}
+                {% else %}
+                    —
+                {% endif %}
+            </td>
+            <td class="text-nowrap">
+                {{ channel_actions(ch) }}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Mobile: cards -->
+<div class="d-lg-none mobile-cards">
+    {% for ch in channels %}
+    {% set st = latest_stats.get(ch.channel_id) if latest_stats else None %}
+    <div class="card mb-2{% if ch.is_filtered %} opacity-50{% endif %}">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-start">
+                <div class="min-w-0 flex-fill">
+                    <div class="d-flex align-items-center gap-1 mb-1">
+                        {{ status_dot(ch) }}
+                        <strong class="text-truncate">{{ ch.title or "—" }}</strong>
+                        {% if ch.has_comments %}<span title="Есть комментарии">{{ icon("comments") }}</span>{% endif %}
+                    </div>
+                    {% if ch.about %}<small class="d-block text-muted mb-1" title="{{ ch.about }}">{{ ch.about[:60] }}{% if ch.about|length > 60 %}…{% endif %}</small>{% endif %}
+                    <small class="text-muted">
+                        {% if ch.username %}<a href="https://t.me/{{ ch.username }}" target="_blank" rel="noopener">@{{ ch.username }}</a> &middot; {% endif %}
+                        ID: {{ ch.channel_id }} &middot; {{ ch.message_count }} сообщ.
+                        {%- if st -%}
+                            {%- if st.subscriber_count is not none %}
+                                &middot; {{ st.subscriber_count }}
+                                {%- set prev_sub = prev_subscriber_counts.get(ch.channel_id) if prev_subscriber_counts else none -%}
+                                {%- if prev_sub is not none -%}
+                                    {%- if st.subscriber_count > prev_sub %}<span class="text-success" title="Рост">{{ icon("trend_up") }}</span>
+                                    {%- elif st.subscriber_count < prev_sub %}<span class="text-danger" title="Падение">{{ icon("trend_down") }}</span>
+                                    {%- else %}<span class="text-muted">{{ icon("trend_flat") }}</span>
+                                    {%- endif -%}
+                                {%- endif %} подп.
+                            {%- endif -%}
+                            {%- if st.avg_views is not none %} &middot; {{ icon("view") }} {{ "%.0f"|format(st.avg_views) }}{%- endif -%}
+                            {%- if st.avg_reactions is not none %} &middot; ❤️ {{ "%.0f"|format(st.avg_reactions) }}{%- endif -%}
+                            {%- if st.avg_forwards is not none %} &middot; ↪ {{ "%.0f"|format(st.avg_forwards) }}{%- endif -%}
+                        {%- endif -%}
+                    </small>
+                </div>
+            </div>
+            <div class="card-actions">
+                {{ channel_actions(ch, prefix="m-") }}
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<p>Нет добавленных каналов.</p>
+{% endif %}

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -1,78 +1,11 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Панель — TG Agent{% endblock %}
 {% block content %}
 <h1>Панель</h1>
 
-<div class="row g-3 mb-4">
-    <div class="col-6 col-md-3">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Аккаунты</h6>
-                <p class="mb-1"><strong>{{ stats.get('accounts', 0) }}</strong> в базе</p>
-                <p class="mb-1"><strong>{{ accounts_connected }}</strong> подключено</p>
-                {% if accounts_flood_wait %}<p class="mb-0 text-warning"><strong>{{ accounts_flood_wait }}</strong> в flood-wait</p>{% endif %}
-                {% if collector_attention %}<p class="mb-0 small"><a href="/scheduler">Коллектор ограничен, открыть диагностику</a></p>{% endif %}
-            </div>
-            <div class="card-footer"><a href="/settings">Управление</a></div>
-        </div>
-    </div>
-    <div class="col-6 col-md-3">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Каналы</h6>
-                <p class="mb-0">В базе: <strong>{{ stats.get('channels', 0) }}</strong></p>
-                <p class="mb-0">Отфильтровано: <strong>{{ stats.get('channels_filtered', 0) }}</strong></p>
-                <p class="mb-0">Отслеживается: <strong>{{ stats.get('channels_tracked', 0) }}</strong></p>
-            </div>
-            <div class="card-footer"><a href="/channels">Управление</a></div>
-        </div>
-    </div>
-    <div class="col-6 col-md-3">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Сообщения</h6>
-                <p class="mb-1"><strong>{{ stats.get('messages', 0) }}</strong> всего</p>
-                {% if stats.get('messages_today', 0) %}<p class="mb-1">+<strong>{{ stats.get('messages_today', 0) }}</strong> за 24ч</p>{% endif %}
-                {% if last_collect_ago %}<p class="mb-1 text-muted small">последний сбор: {{ last_collect_ago }}</p>{% endif %}
-                {% if active_tasks %}<p class="mb-0"><strong>{{ active_tasks }}</strong> задач в очереди</p>{% endif %}
-            </div>
-            <div class="card-footer"><a href="/search">Поиск</a></div>
-        </div>
-    </div>
-    <div class="col-6 col-md-3">
-        <div class="card h-100">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Поиск + Планировщик</h6>
-                <p class="mb-1"><strong>{{ stats.get('search_queries', 0) }}</strong> запросов</p>
-                <p class="mb-1">Интервал: <strong>{{ scheduler_interval }} мин</strong></p>
-                <p class="mb-0">Статус: <strong>{{ "Запущен" if scheduler_running else "Остановлен" }}</strong></p>
-            </div>
-            <div class="card-footer"><a href="/search-queries">Поиск</a> · <a href="/scheduler">Планировщик</a></div>
-        </div>
-    </div>
+{# Skeleton paints instantly; the heavy stats (COUNT over millions of messages) load lazily (#756). #}
+<div hx-get="/dashboard/fragments/overview" hx-trigger="load" hx-swap="innerHTML">
+    {{ loading(class="my-4") }}
 </div>
-
-{% if pipelines_total or content_published %}
-<div class="card mb-4">
-    <div class="card-header fw-semibold">Контент</div>
-    <div class="card-body">
-        <div class="row g-3">
-            <div class="col-6 col-md-3">
-                <p class="text-muted mb-1 small">Пайплайны</p>
-                <p class="mb-0"><strong>{{ pipelines_active }}</strong> / {{ pipelines_total }} активных</p>
-            </div>
-            <div class="col-6 col-md-3">
-                <p class="text-muted mb-1 small">На модерации</p>
-                <p class="mb-0"><strong>{{ content_pending + content_approved }}</strong></p>
-            </div>
-            <div class="col-6 col-md-3">
-                <p class="text-muted mb-1 small">Опубликовано</p>
-                <p class="mb-0"><strong>{{ content_published }}</strong></p>
-            </div>
-        </div>
-    </div>
-    <div class="card-footer"><a href="/pipelines">Управление</a> · <a href="/calendar">Календарь</a></div>
-</div>
-{% endif %}
-
 {% endblock %}

--- a/src/web/templates/dashboard/_overview.html
+++ b/src/web/templates/dashboard/_overview.html
@@ -1,0 +1,71 @@
+<div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Аккаунты</h6>
+                <p class="mb-1"><strong>{{ stats.get('accounts', 0) }}</strong> в базе</p>
+                <p class="mb-1"><strong>{{ accounts_connected }}</strong> подключено</p>
+                {% if accounts_flood_wait %}<p class="mb-0 text-warning"><strong>{{ accounts_flood_wait }}</strong> в flood-wait</p>{% endif %}
+                {% if collector_attention %}<p class="mb-0 small"><a href="/scheduler">Коллектор ограничен, открыть диагностику</a></p>{% endif %}
+            </div>
+            <div class="card-footer"><a href="/settings">Управление</a></div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Каналы</h6>
+                <p class="mb-0">В базе: <strong>{{ stats.get('channels', 0) }}</strong></p>
+                <p class="mb-0">Отфильтровано: <strong>{{ stats.get('channels_filtered', 0) }}</strong></p>
+                <p class="mb-0">Отслеживается: <strong>{{ stats.get('channels_tracked', 0) }}</strong></p>
+            </div>
+            <div class="card-footer"><a href="/channels">Управление</a></div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Сообщения</h6>
+                <p class="mb-1"><strong>{{ stats.get('messages', 0) }}</strong> всего</p>
+                {% if stats.get('messages_today', 0) %}<p class="mb-1">+<strong>{{ stats.get('messages_today', 0) }}</strong> за 24ч</p>{% endif %}
+                {% if last_collect_ago %}<p class="mb-1 text-muted small">последний сбор: {{ last_collect_ago }}</p>{% endif %}
+                {% if active_tasks %}<p class="mb-0"><strong>{{ active_tasks }}</strong> задач в очереди</p>{% endif %}
+            </div>
+            <div class="card-footer"><a href="/search">Поиск</a></div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Поиск + Планировщик</h6>
+                <p class="mb-1"><strong>{{ stats.get('search_queries', 0) }}</strong> запросов</p>
+                <p class="mb-1">Интервал: <strong>{{ scheduler_interval }} мин</strong></p>
+                <p class="mb-0">Статус: <strong>{{ "Запущен" if scheduler_running else "Остановлен" }}</strong></p>
+            </div>
+            <div class="card-footer"><a href="/search-queries">Поиск</a> · <a href="/scheduler">Планировщик</a></div>
+        </div>
+    </div>
+</div>
+
+{% if pipelines_total or content_published %}
+<div class="card mb-4">
+    <div class="card-header fw-semibold">Контент</div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-6 col-md-3">
+                <p class="text-muted mb-1 small">Пайплайны</p>
+                <p class="mb-0"><strong>{{ pipelines_active }}</strong> / {{ pipelines_total }} активных</p>
+            </div>
+            <div class="col-6 col-md-3">
+                <p class="text-muted mb-1 small">На модерации</p>
+                <p class="mb-0"><strong>{{ content_pending + content_approved }}</strong></p>
+            </div>
+            <div class="col-6 col-md-3">
+                <p class="text-muted mb-1 small">Опубликовано</p>
+                <p class="mb-0"><strong>{{ content_published }}</strong></p>
+            </div>
+        </div>
+    </div>
+    <div class="card-footer"><a href="/pipelines">Управление</a> · <a href="/calendar">Календарь</a></div>
+</div>
+{% endif %}

--- a/tests/routes/test_channels_routes.py
+++ b/tests/routes/test_channels_routes.py
@@ -341,3 +341,34 @@ async def test_review_confirm_missing_channel(route_client):
     resp = await route_client.post("/channels/99999/review-confirm", follow_redirects=False)
     assert resp.status_code == 303
     assert "error=resolve" in resp.headers["location"]
+
+
+@pytest.mark.anyio
+async def test_channels_page_lazy_loads_list(route_client):
+    """#756: the channels page paints a skeleton wired to the HTMX list fragment."""
+    resp = await route_client.get("/channels/")
+    assert resp.status_code == 200
+    assert 'hx-get="/channels/fragments/list' in resp.text
+    assert 'hx-trigger="load"' in resp.text
+    # The collect-all button (independent OOB target) stays in the skeleton.
+    assert 'id="collect-all-btn"' in resp.text
+
+
+@pytest.mark.anyio
+async def test_channels_fragment_is_bare_partial_with_both_oob_copies(route_client, db):
+    """#756: the list fragment is a bare partial and renders BOTH per-row collect
+    button copies (desktop -{pk} and mobile -m-{pk}) so OOB swaps resolve."""
+    from src.models import Channel
+
+    await db.add_channel(
+        Channel(channel_id=-100777, title="OOB Chan", username="oobchan", channel_type="channel")
+    )
+    pk = (await db.get_channel_by_channel_id(-100777)).id
+
+    resp = await route_client.get("/channels/fragments/list")
+    assert resp.status_code == 200
+    assert "<html" not in resp.text.lower()
+    assert "OOB Chan" in resp.text
+    # Both OOB copies present (collect-btn-{pk} and collect-btn-m-{pk}).
+    assert f"collect-btn-{pk}" in resp.text
+    assert f"collect-btn-m-{pk}" in resp.text

--- a/tests/routes/test_dashboard_routes.py
+++ b/tests/routes/test_dashboard_routes.py
@@ -10,13 +10,17 @@ import pytest
 async def test_dashboard_renders_with_data(route_client, base_app):
     """Dashboard renders with stats cards when auth configured and accounts exist."""
     app, db, pool = base_app
-    # base_app already adds an account, so dashboard should render
+    # base_app already adds an account, so dashboard should render the skeleton
     resp = await route_client.get("/dashboard/")
     assert resp.status_code == 200
     assert "Панель" in resp.text
-    # Required dashboard cards
-    assert "Аккаунты" in resp.text
-    assert "Каналы" in resp.text
+    assert 'hx-get="/dashboard/fragments/overview"' in resp.text
+    assert 'hx-trigger="load"' in resp.text
+    # The stats cards now render in the lazy-loaded overview fragment (#756).
+    frag = await route_client.get("/dashboard/fragments/overview")
+    assert frag.status_code == 200
+    assert "Аккаунты" in frag.text
+    assert "Каналы" in frag.text
 
 
 @pytest.mark.anyio
@@ -61,10 +65,9 @@ async def test_dashboard_contains_stats(route_client, base_app):
     # db.get_stats() must expose the counters the template depends on.
     for key in ("accounts", "channels", "channels_filtered", "channels_tracked"):
         assert key in stats
-    resp = await route_client.get("/dashboard/")
+    # Stats numbers now render in the lazy overview fragment (#756).
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
-    # The template renders the raw numbers from stats — check at least the
-    # accounts and channels counters appear in the rendered HTML.
     assert f"<strong>{stats['accounts']}</strong> в базе" in resp.text
     assert f"В базе: <strong>{stats['channels']}</strong>" in resp.text
 
@@ -170,9 +173,9 @@ async def test_dashboard_with_active_flood_wait(route_client, base_app):
     for acc in accounts:
         await db.update_account_flood(acc.phone, future_time)
 
-    resp = await route_client.get("/dashboard/")
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
-    # Template renders an explicit flood-wait warning when >0 accounts are flooded.
+    # Flood-wait warning now lives in the overview fragment (#756).
     assert "flood-wait" in resp.text
 
 
@@ -185,7 +188,7 @@ async def test_dashboard_with_expired_flood_wait(route_client, base_app):
     for acc in accounts:
         await db.update_account_flood(acc.phone, past_time)
 
-    resp = await route_client.get("/dashboard/")
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
     # Expired flood wait must not surface as an active warning.
     assert "flood-wait" not in resp.text
@@ -200,9 +203,9 @@ async def test_dashboard_all_connected_flooded(route_client, base_app):
     for acc in accounts:
         await db.update_account_flood(acc.phone, future_time)
 
-    resp = await route_client.get("/dashboard/")
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
-    # Template only renders this link when collector_attention is truthy.
+    # collector_attention link now lives in the overview fragment (#756).
     assert "Коллектор ограничен" in resp.text
 
 
@@ -215,7 +218,7 @@ async def test_dashboard_ignores_transient_flood_wait(route_client, base_app):
     for acc in accounts:
         await db.update_account_flood(acc.phone, future_time)
 
-    resp = await route_client.get("/dashboard/")
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
     assert "Коллектор ограничен" not in resp.text
     assert "flood-wait" not in resp.text
@@ -247,7 +250,16 @@ async def test_dashboard_no_connected_clients(route_client, base_app):
 
 @pytest.mark.anyio
 async def test_dashboard_with_pipeline_data(route_client, base_app):
-    """Dashboard renders with pipeline statistics."""
+    """Dashboard renders with pipeline statistics (now in the overview fragment, #756)."""
     app, db, pool = base_app
-    resp = await route_client.get("/dashboard/")
+    resp = await route_client.get("/dashboard/fragments/overview")
     assert resp.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_dashboard_overview_fragment_is_bare_partial(route_client, base_app):
+    """#756: the overview fragment returns a bare partial, not a full page."""
+    resp = await route_client.get("/dashboard/fragments/overview")
+    assert resp.status_code == 200
+    assert "<html" not in resp.text.lower()
+    assert "Аккаунты" in resp.text

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -223,7 +223,8 @@ class TestChannelCRUD:
         ch = Channel(channel_id=-100999, title="Visible Channel")
         await test_db.add_channel(ch)
 
-        resp = await auth_client.get("/channels/")
+        # The channel list renders in the lazy-loaded fragment (#756).
+        resp = await auth_client.get("/channels/fragments/list")
         assert resp.status_code == 200
         assert "Visible Channel" in resp.text
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2264,8 +2264,8 @@ async def test_add_bulk(client):
         data={"channel_ids": ["-100111", "-100222"]},
     )
     assert resp.status_code == 200
-    # Verify channels page shows added channels
-    resp = await client.get("/channels/")
+    # Added channels show in the lazy-loaded list fragment (#756).
+    resp = await client.get("/channels/fragments/list")
     assert "Dialog Chan 1" in resp.text
     assert "Dialog Chan 2" in resp.text
 
@@ -2351,7 +2351,8 @@ async def test_channel_type_displayed(client):
     await client._transport.app.state.db.add_channel(
         Channel(channel_id=-100123, title="Test", username="testchan", channel_type="channel")
     )
-    resp = await client.get("/channels/")
+    # The channel table now renders in the lazy-loaded fragment (#756).
+    resp = await client.get("/channels/fragments/list")
     assert resp.status_code == 200
     assert "Канал" in resp.text
     assert "Тип" in resp.text


### PR DESCRIPTION
## Summary

Continues the lazyload work (#756, after #876) for the two slowest **non-analytics** pages measured on the 45 GB prod DB. Both now paint a skeleton instantly and load their heavy data via HTMX fragments — same pattern as `/analytics`.

### `/dashboard/`
`get_stats()` runs `COUNT(*)` over millions of messages (+ calendar/task/pipeline queries) — all moved to `GET /dashboard/fragments/overview`.
**Onboarding redirects** (no auth → `/settings`; no accounts → `/settings?msg=no_accounts`) stay synchronous, so a skeleton 200 can't swallow them.

### `/channels/` (0.6–9.8 s cold)
`list_channels_with_counts` (JOIN channels+stats) + `get_latest_and_previous_stats` + 2× `count_channels` → `GET /channels/fragments/list`.

**OOB-button care (non-trivial):** the per-row collect buttons swap OOB into both `collect-btn-{pk}` (desktop) and `collect-btn-m-{pk}` (mobile) copies, so **desktop table AND mobile cards live together in the one fragment** — splitting them would break the OOB swap. The independent `collect-all-btn` stays in the skeleton.

## Test plan
- Redirected table-data assertions to the fragment endpoints (`/dashboard/fragments/overview`, `/channels/fragments/list`).
- Added: skeleton has `hx-get` + `hx-trigger="load"` markers; dashboard onboarding redirect preserved; fragments return bare partials; **channels fragment renders both OOB copies**.
- Full parallel-safe suite green; `ruff` clean.

## Scope
This is **wave 1 (part 1)** of the slow-page lazyload. `/scheduler/` and `/dialogs/` (also slow, but with non-trivial gather-context split / existing-HTMX retargeting) follow in a separate PR. `/settings/` is excluded (only ~0.4 s; `settings.js` re-init risk not worth it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)