### PR TITLE
refactor(collector): drop dead progress_offset + DB-busy flush safety test (#884)

### DIFF
--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -739,7 +739,6 @@ class Collector:
         progress_callback: Callable[[int], Awaitable[None]] | None = None,
         force: bool = False,
         min_subs: int = 0,
-        progress_offset: int = 0,
         cancel_event: asyncio.Event | None = None,
     ) -> int:
         """Collect new messages from a single channel. Returns count."""
@@ -1513,7 +1512,6 @@ class Collector:
                             channel_id,
                         )
                         total_collected += collected_count
-                        progress_offset += collected_count
                         continue
                     capable_at = await self._next_resolve_capable_at()
                     if capable_at is not None:
@@ -1563,7 +1561,6 @@ class Collector:
                     updated = await self._db.get_channel_by_pk(channel.id)
                 if updated:
                     total_collected += collected_count
-                    progress_offset += collected_count
                     channel = updated
                     continue
                 return total_collected + collected_count

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1664,6 +1664,39 @@ async def test_collect_channel_does_not_advance_last_id_when_flush_fails(db):
 
 
 @pytest.mark.anyio
+async def test_collect_channel_db_busy_during_flush_keeps_cursor(db):
+    """Characterization (#884, safety net for #885): a transient DatabaseBusyError
+    raised by insert_messages_batch during flush is swallowed by _flush_batch
+    (returns False) — the cycle stops cleanly, no messages are counted and
+    last_collected_id is left untouched so the batch is re-collected next run."""
+    from src.database import DatabaseBusyError
+
+    ch = Channel(channel_id=-100127, title="Busy", username="busy", last_collected_id=5)
+    await db.add_channel(ch)
+    await db.update_channel_last_id(-100127, 5)
+    stored = next(c for c in await db.get_channels() if c.channel_id == -100127)
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(
+        return_value=_AsyncIterMessages([_make_mock_message(10, text="msg 10")])
+    )
+
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
+
+    db.insert_messages_batch = AsyncMock(  # type: ignore[method-assign]
+        side_effect=DatabaseBusyError("database is locked")
+    )
+
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+    count = await collector._collect_channel(stored)
+
+    updated = next(c for c in await db.get_channels() if c.channel_id == -100127)
+    assert count == 0
+    assert updated.last_collected_id == 5
+
+
+@pytest.mark.anyio
 async def test_full_backfill_does_not_rewind_existing_cursor(db):
     """A full old-history scan must not lower the durable incremental cursor."""
     ch = Channel(channel_id=-100132, title="Backfill", username="backfill", last_collected_id=500)


### PR DESCRIPTION
## Что

Часть umbrella #879 — подготовка collector к разбору (#885) + удаление мёртвого кода. Без изменения поведения сбора.

### Удаление мёртвого кода
`Collector._collect_channel` имел параметр `progress_offset` — write-only: его инкрементировали в двух местах, но никто не передавал и не читал (рабочий progress-callback считает прогресс как `total_collected + collected_count`). Удалён параметр + 2 бесполезных `+=`.

### Safety-тест
Добавлен characterization-тест `test_collect_channel_db_busy_during_flush_keeps_cursor`: фиксирует, что транзиентный `DatabaseBusyError` при flush партии глотается (`_flush_batch` → False), цикл завершается чисто, ничего не засчитывается и `last_collected_id` не сдвигается (партия пересоберётся). Раньше эта ветка (`collector.py` ~881-891) была непокрыта — теперь покрыта. Сеть безопасности для рефактора #885.

## Проверка
- `ruff` чист.
- `pytest tests/test_collector.py` — **104 passed** (103 существующих + новый).
- Подтверждено: ветка DatabaseBusyError-flush ушла из coverage-missing.

Closes #884
Part of #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)
