### PR TITLE
test(parity): fix false-red FastAPI parity guard via OpenAPI (#882)

### DIFF
--- a/tests/test_cli_agent_parity.py
+++ b/tests/test_cli_agent_parity.py
@@ -100,8 +100,12 @@ def _paths_match(actual_path: str, documented_path: str) -> bool:
     documented_parts = documented_path.strip("/").split("/") if documented_path.strip("/") else []
     if len(actual_parts) != len(documented_parts):
         return False
+    # A segment matches only when it is literally equal, or BOTH sides are path
+    # params. Treating a single param segment as a wildcard (e.g. documented
+    # {id} vs actual static "notifications") would let an unrelated static
+    # sibling satisfy a removed dynamic route, false-greening the guard.
     return all(
-        actual == documented or _is_path_param(actual) or _is_path_param(documented)
+        actual == documented or (_is_path_param(actual) and _is_path_param(documented))
         for actual, documented in zip(actual_parts, documented_parts, strict=True)
     )
 
@@ -132,6 +136,22 @@ def test_documented_web_endpoints_exist_in_app_routes():
         if not _route_exists(actual_routes, method, path)
     ]
     assert missing_routes == []
+
+
+def test_path_param_does_not_match_unrelated_static_sibling():
+    """A documented dynamic route must NOT be satisfied by an unrelated static
+    sibling of the same shape. If POST /settings/{account_id}/delete regresses,
+    the guard must fail rather than false-green against POST
+    /settings/notifications/delete (param-vs-static segment is not a match)."""
+    documented_dynamic = "/settings/{id}/delete"
+    static_sibling_only = {("POST", "/settings/notifications/delete")}
+
+    # The real dynamic endpoint is gone -> the guard must report it missing.
+    assert not _route_exists(static_sibling_only, "POST", documented_dynamic)
+
+    # A genuine param-to-param route still matches (different param name is fine).
+    real_dynamic = {("POST", "/settings/{account_id}/delete")}
+    assert _route_exists(real_dynamic, "POST", documented_dynamic)
 
 
 def test_configure_app_tolerates_unnamed_included_routers():

--- a/tests/test_cli_agent_parity.py
+++ b/tests/test_cli_agent_parity.py
@@ -46,15 +46,16 @@ def _parity_rows() -> list[tuple[str, str, list[str]]]:
 
 
 def _actual_web_routes() -> set[tuple[str, str]]:
+    # Introspect via OpenAPI instead of app.routes: newer Starlette nests
+    # feature routes inside an unnamed _IncludedRouter per include_router(), so a
+    # flat walk of app.routes misses them. app.openapi()["paths"] expands every
+    # included router, exposing the documented (in-schema) endpoints with methods.
     from src.web.app import create_app
 
     routes: set[tuple[str, str]] = set()
-    for route in create_app().routes:
-        path = getattr(route, "path", "")
-        methods = getattr(route, "methods", set()) or set()
-        for method in methods:
-            if method not in {"HEAD", "OPTIONS"}:
-                routes.add((method, path))
+    for path, operations in create_app().openapi().get("paths", {}).items():
+        for method in operations:
+            routes.add((method.upper(), path))
     return routes
 
 


### PR DESCRIPTION
## Что

Чинит false-red parity-guard. `tests/test_cli_agent_parity.py::_actual_web_routes()` перебирал `create_app().routes`, но новый Starlette на каждый `include_router()` кладёт в `app.routes` безымянный `_IncludedRouter`, чьи feature-routes не видны при плоском обходе → `test_documented_web_endpoints_exist_in_app_routes` ложно показывал документированные маршруты как «missing».

## Решение

`_actual_web_routes()` теперь читает `create_app().openapi()["paths"]` — OpenAPI разворачивает все включённые роутеры. Возвращаемый тип `set[tuple[str, str]]` сохранён.

Дополнительно (по итогам local-ревью, нашёл Codex): ужесточён `_paths_match` — сегмент совпадает только при буквальном равенстве ИЛИ param-to-param. Раньше одиночный path-параметр трактовался как wildcard, поэтому документированный `POST /settings/{id}/delete` ложно совпадал со статическим братом `POST /settings/notifications/delete` → guard зазеленел бы при регрессии destructive-эндпоинта. Добавлен регрессионный тест `test_path_param_does_not_match_unrelated_static_sibling`. Все 192 документированных маршрута по-прежнему находятся (0 missing).

## Проверка
- `ruff` чист; `pytest tests/test_cli_agent_parity.py` — 5 passed.

## История

Заменяет #891 (был автоматически закрыт GitHub при squash-мерже #890, т.к. его base-ветка `refactor/881-remove-legacy-compat` удалена; переоткрытие/ретаргет закрытого PR с удалённой базой GitHub блокирует). Ветка ребейзнута на `main` (изменения #890 уже в main), diff = ровно один файл. Ревью-история — в #891.

Closes #882
Part of #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)