### PR TITLE
refactor(agent): extract _dispatch_stream_message from chat_stream (#900)

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -113,6 +113,158 @@ async def _emit_error(queue: asyncio.Queue, message: str, details: str | None = 
     await queue.put(None)
 
 
+class _ChatStreamState:
+    """Mutable accumulator for one `chat_stream` run, threaded through
+    `_dispatch_stream_message` so per-message handlers update the running
+    assistant text in place instead of mutating `chat_stream` closure locals."""
+
+    __slots__ = ("full_text", "streamed")
+
+    def __init__(self) -> None:
+        self.full_text = ""
+        self.streamed = False
+
+
+async def _dispatch_stream_message(
+    msg,
+    *,
+    tracker: _ToolTracker,
+    queue: asyncio.Queue,
+    state: _ChatStreamState,
+    last_activity: list[float],
+    last_rate_limit: list[str],
+    thread_id: int,
+) -> None:
+    """Handle one SDK stream message: emit its SSE frames, drive the tool
+    tracker, and accumulate assistant text on `state`. Raises CLIConnectionError
+    / ClaudeSDKError for API stream-error events (the caller's retry loop owns
+    them); asyncio.CancelledError propagates for the caller's draining handling."""
+    if isinstance(msg, RateLimitEvent):
+        info = msg.rate_limit_info
+        rl_status = info.status if info else "unknown"
+        resets = info.resets_at if info else None
+        utilization = info.utilization if info else None
+        logger.warning(
+            "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
+            thread_id, rl_status, resets, utilization,
+        )
+        rl_parts = [rl_status]
+        if utilization is not None:
+            rl_parts.append(f"{utilization:.0%}")
+        rl_summary = ", ".join(rl_parts)
+        rl_text = f"Rate limit: {rl_summary}"
+        last_rate_limit[0] = rl_summary
+        if rl_status == "rejected":
+            # Hard reject — surface as warning, not just status
+            await queue.put(_sse({"type": "warning", "text": f"⛔ {rl_text}. API отклоняет запросы."}))
+        else:
+            await tracker.on_status(rl_text)
+    elif isinstance(msg, StreamEvent):
+        event = msg.event
+        event_type = event.get("type")
+        await tracker.on_first_event()
+
+        if event_type == "content_block_start":
+            block = event.get("content_block", {})
+            block_type = block.get("type")
+            if block_type == "tool_use":
+                last_activity[0] = time.monotonic()
+                await tracker.on_tool_start(
+                    block.get("name", "unknown"),
+                    event.get("index", 0),
+                    tool_use_id=block.get("id", ""),
+                )
+            else:
+                logger.debug(
+                    "content_block_start type=%s (thread %d)",
+                    block_type, thread_id,
+                )
+
+        elif event_type == "content_block_delta":
+            delta = event.get("delta", {})
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                text_chunk = delta.get("text", "")
+                if text_chunk:
+                    last_activity[0] = time.monotonic()
+                    state.full_text += text_chunk
+                    state.streamed = True
+                    await queue.put(_sse({"text": text_chunk}))
+                    await asyncio.sleep(0)
+            elif delta_type == "input_json_delta":
+                last_activity[0] = time.monotonic()
+                tracker.accumulate_input(delta.get("partial_json", ""))
+
+        elif event_type == "content_block_stop":
+            last_activity[0] = time.monotonic()
+            await tracker.on_block_stop(event.get("index", 0))
+
+        elif event_type == "error":
+            error_info = event.get("error", {})
+            api_error_type = error_info.get("type", "unknown")
+            api_error_msg = error_info.get("message", str(error_info))
+            logger.warning(
+                "API stream error event (thread %d): type=%s message=%s",
+                thread_id, api_error_type, api_error_msg,
+            )
+            if api_error_type == "overloaded_error":
+                raise CLIConnectionError(f"API overloaded: {api_error_msg}")
+            raise ClaudeSDKError(f"{api_error_type}: {api_error_msg}")
+
+    elif isinstance(msg, AssistantMessage):
+        last_activity[0] = time.monotonic()
+        for _idx, block in enumerate(msg.content):
+            if isinstance(block, TextBlock) and not state.streamed:
+                state.full_text += block.text
+                await queue.put(_sse({"text": block.text}))
+            elif isinstance(block, ToolUseBlock):
+                # SDK delivers tool calls via AssistantMessage (not
+                # StreamEvent content_block_start), so we must
+                # manually emit tool_start / tool_end events here.
+                await tracker.on_tool_start(
+                    block.name, _idx, tool_use_id=block.id
+                )
+                tracker.accumulate_input(
+                    safe_json_dumps(block.input or {}, ensure_ascii=False)
+                )
+                await tracker.on_block_stop(_idx)
+            elif isinstance(block, ToolResultBlock):
+                content = block.content if isinstance(block.content, str) else ""
+                await tracker.on_tool_result(
+                    block.tool_use_id, content, bool(block.is_error)
+                )
+    elif isinstance(msg, UserMessage):
+        # Tool results sent back to Claude — real progress.
+        last_activity[0] = time.monotonic()
+    elif isinstance(msg, ResultMessage):
+        done_data: dict = {
+            "done": True,
+            "full_text": state.full_text,
+            "backend": "claude",
+        }
+        _usage = getattr(msg, "usage", None)
+        if isinstance(_usage, dict):
+            done_data["usage"] = _usage
+        _model_usage = getattr(msg, "model_usage", None)
+        if isinstance(_model_usage, dict):
+            done_data["model_usage"] = _model_usage
+        _cost = getattr(msg, "total_cost_usd", None)
+        if isinstance(_cost, (int, float)):
+            done_data["total_cost_usd"] = _cost
+        _turns = getattr(msg, "num_turns", None)
+        if isinstance(_turns, int) and _turns > 0:
+            done_data["num_turns"] = _turns
+        _sid = getattr(msg, "session_id", None)
+        if isinstance(_sid, str) and _sid:
+            done_data["session_id"] = _sid
+        await queue.put(_sse(done_data))
+    else:
+        logger.warning(
+            "Unhandled SDK message type: %s (thread %d)",
+            type(msg).__name__, thread_id,
+        )
+
+
 def _diagnose_connection(cli_path: str | None, stderr_lines: list[str]) -> str:
     """Build a concrete diagnostic message by checking environment and stderr."""
     problems: list[str] = []
@@ -634,8 +786,7 @@ class ClaudeSdkBackend:
                 await tracker_retry.on_status("Повтор подключения к Claude...")
             tracker = _ToolTracker(queue=queue)
             draining = False
-            full_text = ""
-            streamed = False
+            stream_state = _ChatStreamState()
             t0 = time.monotonic()
             first_event_logged = False
             _api_request_count[0] = 0
@@ -705,141 +856,15 @@ class ClaudeSdkBackend:
                     if draining:
                         continue
                     try:
-                        if isinstance(msg, RateLimitEvent):
-                            info = msg.rate_limit_info
-                            rl_status = info.status if info else "unknown"
-                            resets = info.resets_at if info else None
-                            utilization = info.utilization if info else None
-                            logger.warning(
-                                "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
-                                thread_id, rl_status, resets, utilization,
-                            )
-                            rl_parts = [rl_status]
-                            if utilization is not None:
-                                rl_parts.append(f"{utilization:.0%}")
-                            rl_summary = ", ".join(rl_parts)
-                            rl_text = f"Rate limit: {rl_summary}"
-                            _last_rate_limit[0] = rl_summary
-                            if rl_status == "rejected":
-                                # Hard reject — surface as warning, not just status
-                                warn_payload = safe_json_dumps(
-                                    {"type": "warning", "text": f"⛔ {rl_text}. API отклоняет запросы."},
-                                    ensure_ascii=False,
-                                )
-                                await queue.put(f"data: {warn_payload}\n\n")
-                            else:
-                                await tracker.on_status(rl_text)
-                        elif isinstance(msg, StreamEvent):
-                            event = msg.event
-                            event_type = event.get("type")
-                            await tracker.on_first_event()
-
-                            if event_type == "content_block_start":
-                                block = event.get("content_block", {})
-                                block_type = block.get("type")
-                                if block_type == "tool_use":
-                                    _last_activity[0] = time.monotonic()
-                                    await tracker.on_tool_start(
-                                        block.get("name", "unknown"),
-                                        event.get("index", 0),
-                                        tool_use_id=block.get("id", ""),
-                                    )
-                                else:
-                                    logger.debug(
-                                        "content_block_start type=%s (thread %d)",
-                                        block_type, thread_id,
-                                    )
-
-                            elif event_type == "content_block_delta":
-                                delta = event.get("delta", {})
-                                delta_type = delta.get("type")
-                                if delta_type == "text_delta":
-                                    text_chunk = delta.get("text", "")
-                                    if text_chunk:
-                                        _last_activity[0] = time.monotonic()
-                                        full_text += text_chunk
-                                        streamed = True
-                                        chunk_payload = safe_json_dumps(
-                                            {"text": text_chunk}, ensure_ascii=False
-                                        )
-                                        await queue.put(f"data: {chunk_payload}\n\n")
-                                        await asyncio.sleep(0)
-                                elif delta_type == "input_json_delta":
-                                    _last_activity[0] = time.monotonic()
-                                    tracker.accumulate_input(delta.get("partial_json", ""))
-
-                            elif event_type == "content_block_stop":
-                                _last_activity[0] = time.monotonic()
-                                await tracker.on_block_stop(event.get("index", 0))
-
-                            elif event_type == "error":
-                                error_info = event.get("error", {})
-                                api_error_type = error_info.get("type", "unknown")
-                                api_error_msg = error_info.get("message", str(error_info))
-                                logger.warning(
-                                    "API stream error event (thread %d): type=%s message=%s",
-                                    thread_id, api_error_type, api_error_msg,
-                                )
-                                if api_error_type == "overloaded_error":
-                                    raise CLIConnectionError(f"API overloaded: {api_error_msg}")
-                                raise ClaudeSDKError(f"{api_error_type}: {api_error_msg}")
-
-                        elif isinstance(msg, AssistantMessage):
-                            _last_activity[0] = time.monotonic()
-                            for _idx, block in enumerate(msg.content):
-                                if isinstance(block, TextBlock) and not streamed:
-                                    full_text += block.text
-                                    chunk_payload = safe_json_dumps(
-                                        {"text": block.text}, ensure_ascii=False
-                                    )
-                                    await queue.put(f"data: {chunk_payload}\n\n")
-                                elif isinstance(block, ToolUseBlock):
-                                    # SDK delivers tool calls via AssistantMessage (not
-                                    # StreamEvent content_block_start), so we must
-                                    # manually emit tool_start / tool_end events here.
-                                    await tracker.on_tool_start(
-                                        block.name, _idx, tool_use_id=block.id
-                                    )
-                                    tracker.accumulate_input(
-                                        safe_json_dumps(block.input or {}, ensure_ascii=False)
-                                    )
-                                    await tracker.on_block_stop(_idx)
-                                elif isinstance(block, ToolResultBlock):
-                                    content = block.content if isinstance(block.content, str) else ""
-                                    await tracker.on_tool_result(
-                                        block.tool_use_id, content, bool(block.is_error)
-                                    )
-                        elif isinstance(msg, UserMessage):
-                            # Tool results sent back to Claude — real progress.
-                            _last_activity[0] = time.monotonic()
-                        elif isinstance(msg, ResultMessage):
-                            done_data: dict = {
-                                "done": True,
-                                "full_text": full_text,
-                                "backend": "claude",
-                            }
-                            _usage = getattr(msg, "usage", None)
-                            if isinstance(_usage, dict):
-                                done_data["usage"] = _usage
-                            _model_usage = getattr(msg, "model_usage", None)
-                            if isinstance(_model_usage, dict):
-                                done_data["model_usage"] = _model_usage
-                            _cost = getattr(msg, "total_cost_usd", None)
-                            if isinstance(_cost, (int, float)):
-                                done_data["total_cost_usd"] = _cost
-                            _turns = getattr(msg, "num_turns", None)
-                            if isinstance(_turns, int) and _turns > 0:
-                                done_data["num_turns"] = _turns
-                            _sid = getattr(msg, "session_id", None)
-                            if isinstance(_sid, str) and _sid:
-                                done_data["session_id"] = _sid
-                            done_payload = safe_json_dumps(done_data, ensure_ascii=False)
-                            await queue.put(f"data: {done_payload}\n\n")
-                        else:
-                            logger.warning(
-                                "Unhandled SDK message type: %s (thread %d)",
-                                type(msg).__name__, thread_id,
-                            )
+                        await _dispatch_stream_message(
+                            msg,
+                            tracker=tracker,
+                            queue=queue,
+                            state=stream_state,
+                            last_activity=_last_activity,
+                            last_rate_limit=_last_rate_limit,
+                            thread_id=thread_id,
+                        )
                     except asyncio.CancelledError:
                         draining = True
                 finally:


### PR DESCRIPTION
Цепочка диспетчеризации одного сообщения (RateLimitEvent / StreamEvent / AssistantMessage / UserMessage / ResultMessage) из `async for`-цикла `ClaudeSdkBackend.chat_stream` вынесена в module-функцию `_dispatch_stream_message(...)` (она не использует `self`).

## Faithful-сохранение
- Реассайн-локали dispatch (`full_text` аккумуляция, `streamed` флаг) перенесены на маленький mutable `_ChatStreamState`, пишутся in place → персистят между сообщениями как раньше closure-локали.
- `_last_activity` / `_last_rate_limit` уже были 1-элементными list-cells → передаются как есть.
- Гард `except asyncio.CancelledError: draining = True` остался на месте вызова; API stream-error по-прежнему raise CLIConnectionError/ClaudeSDKError в retry-цикл.
- Payload'ы идут через `_sse` helper (#899).

## Эффект
- `ClaudeSdkBackend.chat_stream`: **F(91) → F(58)**
- `_dispatch_stream_message`: E(34)

## Проверка
SSE-вывод байт-в-байт — **226 тестов** (`test_agent.py` + `test_agent_manager_runtime_paths.py`) зелёные; `ruff` чист.

Closes #900
Part of #887, #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)