### PR TITLE
refactor(search): introduce SearchParams for message-search signature (#810)

### DIFF
--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -41,6 +41,7 @@ from src.models import (
     PhotoSendMode,
     PipelineSource,
     PipelineTarget,
+    SearchParams,
     SearchQuery,
     SearchQueryDailyStat,
     StatsAllTaskPayload,
@@ -436,31 +437,8 @@ class CollectionBundle:
     ) -> int:
         return await self.messages.insert_messages_batch(messages, premium_search_query)
 
-    async def search_messages(
-        self,
-        query: str = "",
-        channel_id: int | None = None,
-        date_from: str | None = None,
-        date_to: str | None = None,
-        limit: int = 50,
-        offset: int = 0,
-        is_fts: bool = False,
-        min_length: int | None = None,
-        max_length: int | None = None,
-        include_filtered: bool = False,
-    ) -> MessageSearchPage:
-        return await self.messages.search_messages(
-            query=query,
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            limit=limit,
-            offset=offset,
-            is_fts=is_fts,
-            min_length=min_length,
-            max_length=max_length,
-            include_filtered=include_filtered,
-        )
+    async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        return await self.messages.search_messages(params)
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:
         return await self.messages.delete_messages_for_channel(channel_id)
@@ -684,31 +662,8 @@ class SearchBundle:
             numpy_available=numpy_ok,
         )
 
-    async def search_messages(
-        self,
-        query: str = "",
-        channel_id: int | None = None,
-        date_from: str | None = None,
-        date_to: str | None = None,
-        limit: int = 50,
-        offset: int = 0,
-        is_fts: bool = False,
-        min_length: int | None = None,
-        max_length: int | None = None,
-        include_filtered: bool = False,
-    ) -> MessageSearchPage:
-        return await self.messages.search_messages(
-            query=query,
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            limit=limit,
-            offset=offset,
-            is_fts=is_fts,
-            min_length=min_length,
-            max_length=max_length,
-            include_filtered=include_filtered,
-        )
+    async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        return await self.messages.search_messages(params)
 
     async def add_channel(self, channel: Channel) -> int:
         return await self.channels.add_channel(channel)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -44,6 +44,7 @@ from src.models import (
     CollectionTaskStatus,
     Message,
     NotificationBot,
+    SearchParams,
     SearchQuery,
     StatsAllTaskPayload,
 )
@@ -650,17 +651,19 @@ class Database:
     ) -> MessageSearchPage:
         self._require()
         return await self._messages.search_messages(
-            query=query,
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            limit=limit,
-            offset=offset,
-            topic_id=topic_id,
-            is_fts=is_fts,
-            min_length=min_length,
-            max_length=max_length,
-            include_filtered=include_filtered,
+            SearchParams(
+                query=query,
+                channel_id=channel_id,
+                date_from=date_from,
+                date_to=date_to,
+                limit=limit,
+                offset=offset,
+                topic_id=topic_id,
+                is_fts=is_fts,
+                min_length=min_length,
+                max_length=max_length,
+                include_filtered=include_filtered,
+            )
         )
 
     async def search_semantic_messages(

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, AsyncIterator
 
 import aiosqlite
 
-from src.models import Message, SearchQuery
+from src.models import Message, SearchParams, SearchQuery
 from src.telegram.reactions import parse_reactions_json
 from src.utils.datetime import parse_datetime, parse_required_datetime
 from src.utils.search_query_chat_filter import parse_chat_filter
@@ -621,28 +621,18 @@ class MessagesRepository:
         rows = await cur.fetchall()
         return [int(row["id"]) for row in rows]
 
-    async def search_messages(
-        self,
-        query: str = "",
-        channel_id: int | None = None,
-        date_from: str | None = None,
-        date_to: str | None = None,
-        limit: int = 50,
-        offset: int = 0,
-        is_fts: bool = False,
-        min_length: int | None = None,
-        max_length: int | None = None,
-        topic_id: int | None = None,
-        include_filtered: bool = False,
-    ) -> MessageSearchPage:
-        where, params = self._build_message_filters(
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            min_length=min_length,
-            max_length=max_length,
-            topic_id=topic_id,
-            include_filtered=include_filtered,
+    async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        query = params.query
+        limit = params.limit
+        offset = params.offset
+        where, sql_params = self._build_message_filters(
+            channel_id=params.channel_id,
+            date_from=params.date_from,
+            date_to=params.date_to,
+            min_length=params.min_length,
+            max_length=params.max_length,
+            topic_id=params.topic_id,
+            include_filtered=params.include_filtered,
         )
         channel_join = " LEFT JOIN channels c ON m.channel_id = c.channel_id"
 
@@ -652,7 +642,7 @@ class MessagesRepository:
 
         if query:
             if self._fts_available:
-                fts_query = self._build_fts_match(query, is_fts)
+                fts_query = self._build_fts_match(query, params.is_fts)
                 fts_join = (
                     " INNER JOIN (SELECT rowid FROM messages_fts"
                     " WHERE messages_fts MATCH ?) AS fts ON m.id = fts.rowid"
@@ -663,11 +653,11 @@ class MessagesRepository:
                         {where}
                         ORDER BY m.date DESC
                         LIMIT ? OFFSET ?""",
-                    (fts_query, *params, probe_limit, offset),
+                    (fts_query, *sql_params, probe_limit, offset),
                 )
             else:
                 logger.debug("FTS5 unavailable, falling back to LIKE search")
-                params.append(f"%{query}%")
+                sql_params.append(f"%{query}%")
                 like_where = (where + " AND m.text LIKE ?") if where else " WHERE m.text LIKE ?"
 
                 cur = await self._db.execute(
@@ -676,7 +666,7 @@ class MessagesRepository:
                         {like_where}
                         ORDER BY m.date DESC
                         LIMIT ? OFFSET ?""",
-                    (*params, probe_limit, offset),
+                    (*sql_params, probe_limit, offset),
                 )
         else:
             cur = await self._db.execute(
@@ -685,7 +675,7 @@ class MessagesRepository:
                     {where}
                     ORDER BY m.date DESC
                     LIMIT ? OFFSET ?""",
-                (*params, probe_limit, offset),
+                (*sql_params, probe_limit, offset),
             )
 
         rows = await cur.fetchall()

--- a/src/models.py
+++ b/src/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
@@ -7,6 +8,27 @@ from typing import Any
 from pydantic import BaseModel, Field, model_validator
 
 from src.telegram.flood_wait import FloodWaitInfo
+
+
+@dataclass(slots=True)
+class SearchParams:
+    """Single carrier for the message-search filter signature shared across the
+    search stack (repo ↔ bundles ↔ local search). Public entry points
+    (`SearchEngine.*`, `Database.search_messages`) keep their keyword signatures
+    and assemble this object once, so a new search filter is added here + the
+    repo body rather than re-declared at every delegating layer (#810/#807 п.4)."""
+
+    query: str = ""
+    channel_id: int | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    limit: int = 50
+    offset: int = 0
+    is_fts: bool = False
+    min_length: int | None = None
+    max_length: int | None = None
+    topic_id: int | None = None
+    include_filtered: bool = False
 
 
 class Account(BaseModel):

--- a/src/search/ai_search.py
+++ b/src/search/ai_search.py
@@ -6,7 +6,7 @@ import logging
 from src.config import LLMConfig
 from src.database import Database
 from src.database.bundles import SearchBundle
-from src.models import SearchResult
+from src.models import SearchParams, SearchResult
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +49,11 @@ class AISearchEngine:
             try:
                 asyncio.get_running_loop()
                 with concurrent.futures.ThreadPoolExecutor() as executor:
-                    coro = search.search_messages(query, limit=20)
+                    coro = search.search_messages(SearchParams(query=query, limit=20))
                     future = executor.submit(asyncio.run, coro)
                     page = future.result()
             except RuntimeError:
-                page = asyncio.run(search.search_messages(query, limit=20))
+                page = asyncio.run(search.search_messages(SearchParams(query=query, limit=20)))
 
             messages = page.messages
             if not messages:
@@ -86,7 +86,7 @@ class AISearchEngine:
         """Run AI-powered search."""
         if not self._agent:
             # Fallback to basic local search
-            page = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(SearchParams(query=query, limit=20))
             return SearchResult(
                 messages=page.messages,
                 total=page.total,
@@ -100,7 +100,7 @@ class AISearchEngine:
             summary = str(response)
 
             # Also get raw messages for display
-            page = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(SearchParams(query=query, limit=20))
 
             return SearchResult(
                 messages=page.messages,
@@ -111,7 +111,7 @@ class AISearchEngine:
             )
         except Exception as e:
             logger.error("AI search error: %s", e)
-            page = await self._search.search_messages(query, limit=20)
+            page = await self._search.search_messages(SearchParams(query=query, limit=20))
             return SearchResult(
                 messages=page.messages,
                 total=page.total,

--- a/src/search/engine.py
+++ b/src/search/engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from src.database import Database
 from src.database.bundles import SearchBundle
-from src.models import SearchResult
+from src.models import SearchParams, SearchResult
 from src.search.local_search import LocalSearch
 from src.search.persistence import SearchPersistence
 from src.search.telegram_search import TelegramSearch
@@ -77,16 +77,18 @@ class SearchEngine:
         include_filtered: bool = False,
     ) -> SearchResult:
         return await self._local.search(
-            query=query,
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            limit=limit,
-            offset=offset,
-            is_fts=is_fts,
-            min_length=min_length,
-            max_length=max_length,
-            include_filtered=include_filtered,
+            SearchParams(
+                query=query,
+                channel_id=channel_id,
+                date_from=date_from,
+                date_to=date_to,
+                limit=limit,
+                offset=offset,
+                is_fts=is_fts,
+                min_length=min_length,
+                max_length=max_length,
+                include_filtered=include_filtered,
+            )
         )
 
     async def check_search_quota(self, query: str = "") -> dict | None:

--- a/src/search/local_search.py
+++ b/src/search/local_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from src.database.bundles import SearchBundle
-from src.models import SearchResult
+from src.models import SearchParams, SearchResult
 from src.search.numpy_semantic import NumpySemanticIndex
 from src.services.embedding_service import EmbeddingService
 
@@ -20,33 +20,10 @@ class LocalSearch:
         self._numpy_index = None
         self._numpy_index_loaded = False
 
-    async def search(
-        self,
-        query: str,
-        channel_id: int | None = None,
-        date_from: str | None = None,
-        date_to: str | None = None,
-        limit: int = 50,
-        offset: int = 0,
-        is_fts: bool = False,
-        min_length: int | None = None,
-        max_length: int | None = None,
-        include_filtered: bool = False,
-    ) -> SearchResult:
-        page = await self._search.search_messages(
-            query=query,
-            channel_id=channel_id,
-            date_from=date_from,
-            date_to=date_to,
-            limit=limit,
-            offset=offset,
-            is_fts=is_fts,
-            min_length=min_length,
-            max_length=max_length,
-            include_filtered=include_filtered,
-        )
+    async def search(self, params: SearchParams) -> SearchResult:
+        page = await self._search.search_messages(params)
         return SearchResult(
-            messages=page.messages, total=page.total, has_more=page.has_more, query=query
+            messages=page.messages, total=page.total, has_more=page.has_more, query=params.query
         )
 
     async def _ensure_numpy_index(self) -> NumpySemanticIndex:

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -8,7 +8,7 @@ import pytest
 
 from src.database.repositories.channels import ChannelsRepository
 from src.database.repositories.messages import MessagesRepository, _normalize_date_to
-from src.models import Message, SearchQuery
+from src.models import Message, SearchParams, SearchQuery
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ async def test_insert_message_duplicate_ignored(messages_repo):
     assert result is False
 
     # Verify only one message exists
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
     assert total == 1
     assert messages[0].text == "First"
 
@@ -74,7 +74,7 @@ async def test_insert_message_with_all_fields(messages_repo):
     result = await messages_repo.insert_message(msg)
     assert result is True
 
-    messages, _ = await messages_repo.search_messages()
+    messages, _ = await messages_repo.search_messages(SearchParams())
     assert messages[0].sender_id == 12345
     assert messages[0].sender_name == "John Doe"
     assert messages[0].media_type == "photo"
@@ -95,7 +95,7 @@ async def test_insert_message_sender_identity_round_trips(messages_repo):
     )
     assert await messages_repo.insert_message(msg) is True
 
-    messages, _ = await messages_repo.search_messages()
+    messages, _ = await messages_repo.search_messages(SearchParams())
     stored = messages[0]
     assert stored.sender_id == 12345
     assert stored.sender_name == "John Doe"
@@ -121,7 +121,7 @@ async def test_insert_message_with_structured_facets(messages_repo):
     result = await messages_repo.insert_message(msg)
     assert result is True
 
-    messages, _ = await messages_repo.search_messages()
+    messages, _ = await messages_repo.search_messages(SearchParams())
     stored = next(m for m in messages if m.message_id == 101)
     assert stored.message_kind == "service"
     assert stored.service_action_raw == "MessageActionChatJoinedByLink"
@@ -149,7 +149,7 @@ async def test_insert_messages_batch_multiple(messages_repo):
     count = await messages_repo.insert_messages_batch(messages)
     assert count == 3
 
-    _, total = await messages_repo.search_messages()
+    _, total = await messages_repo.search_messages(SearchParams())
     assert total == 3
 
 
@@ -165,7 +165,7 @@ async def test_insert_messages_batch_with_duplicates(messages_repo):
     ]
     await messages_repo.insert_messages_batch(messages)
 
-    messages_list, total = await messages_repo.search_messages()
+    messages_list, total = await messages_repo.search_messages(SearchParams())
     assert total == 2
     texts = {m.text for m in messages_list}
     assert "Original" in texts
@@ -210,7 +210,7 @@ async def test_insert_messages_batch_refreshes_duplicate_stats(messages_repo):
     )
 
     assert count == 0
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
     assert total == 1
     stored = messages[0]
     assert stored.text == "Original"
@@ -252,7 +252,7 @@ async def test_insert_messages_batch_sender_identity_round_trips(messages_repo):
     ]
     assert await messages_repo.insert_messages_batch(messages) == 2
 
-    stored, total = await messages_repo.search_messages()
+    stored, total = await messages_repo.search_messages(SearchParams())
     assert total == 2
     by_id = {message.message_id: message for message in stored}
     assert by_id[110].sender_first_name == "Alice"
@@ -315,7 +315,7 @@ def test_normalize_date_to_module_function():
 
 async def test_search_messages_empty(messages_repo):
     """Test searching when no messages exist."""
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
     assert messages == []
     assert total == 0
 
@@ -329,7 +329,7 @@ async def test_search_messages_all(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
     assert len(messages) == 2
     assert total == 2
 
@@ -344,7 +344,7 @@ async def test_search_messages_by_channel(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(channel_id=1)
+    messages, total = await messages_repo.search_messages(SearchParams(channel_id=1))
     assert len(messages) == 2
     assert total == 2
     assert all(m.channel_id == 1 for m in messages)
@@ -360,7 +360,7 @@ async def test_search_messages_by_topic(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(topic_id=5)
+    messages, total = await messages_repo.search_messages(SearchParams(topic_id=5))
     assert len(messages) == 1
     assert total == 1
     assert messages[0].topic_id == 5
@@ -375,7 +375,7 @@ async def test_search_messages_by_date_from(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(date_from="2026-03-15")
+    messages, total = await messages_repo.search_messages(SearchParams(date_from="2026-03-15"))
     assert len(messages) == 1
     assert messages[0].text == "New"
 
@@ -390,7 +390,7 @@ async def test_search_messages_by_date_to(messages_repo):
     )
 
     # Should include messages up to 2026-03-10
-    messages, total = await messages_repo.search_messages(date_to="2026-03-10")
+    messages, total = await messages_repo.search_messages(SearchParams(date_to="2026-03-10"))
     assert len(messages) == 1
     assert messages[0].text == "Old"
 
@@ -405,7 +405,7 @@ async def test_search_messages_by_date_range(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(date_from="2026-03-08", date_to="2026-03-15")
+    messages, total = await messages_repo.search_messages(SearchParams(date_from="2026-03-08", date_to="2026-03-15"))
     assert len(messages) == 1
     assert messages[0].text == "In range"
 
@@ -419,7 +419,7 @@ async def test_search_messages_by_min_length(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(min_length=10)
+    messages, total = await messages_repo.search_messages(SearchParams(min_length=10))
     assert len(messages) == 1
     assert messages[0].text == "This is a longer message"
 
@@ -433,7 +433,7 @@ async def test_search_messages_by_max_length(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(max_length=10)
+    messages, total = await messages_repo.search_messages(SearchParams(max_length=10))
     assert len(messages) == 1
     assert messages[0].text == "Short"
 
@@ -445,14 +445,14 @@ async def test_search_messages_pagination(messages_repo):
 
     # First page: total is a lower bound (offset + len) since #766, has_more
     # signals the next page instead of an exact COUNT.
-    page = await messages_repo.search_messages(limit=3, offset=0)
+    page = await messages_repo.search_messages(SearchParams(limit=3, offset=0))
     messages = page.messages
     assert len(messages) == 3
     assert page.total == 3
     assert page.has_more is True
 
     # Second page
-    messages2, _ = await messages_repo.search_messages(limit=3, offset=3)
+    messages2, _ = await messages_repo.search_messages(SearchParams(limit=3, offset=3))
     assert len(messages2) == 3
 
     # Verify different messages
@@ -480,7 +480,7 @@ async def test_search_messages_excludes_filtered_channels(messages_repo, channel
         ]
     )
 
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
     assert total == 1
     assert messages[0].channel_id == 1
 
@@ -495,7 +495,7 @@ async def test_search_messages_fts(messages_repo):
         ]
     )
 
-    messages, total = await messages_repo.search_messages(query="hello", is_fts=True)
+    messages, total = await messages_repo.search_messages(SearchParams(query="hello", is_fts=True))
     assert total == 2
     assert all("hello" in m.text.lower() for m in messages)
 
@@ -510,7 +510,7 @@ async def test_search_messages_plain_search(messages_repo):
     )
 
     # Plain search should still work via FTS with quoting
-    messages, total = await messages_repo.search_messages(query="Hello", is_fts=False)
+    messages, total = await messages_repo.search_messages(SearchParams(query="Hello", is_fts=False))
     assert total == 1
 
 
@@ -683,7 +683,7 @@ async def test_delete_messages_for_channel(messages_repo):
     count = await messages_repo.delete_messages_for_channel(1)
     assert count == 2
 
-    _, total = await messages_repo.search_messages()
+    _, total = await messages_repo.search_messages(SearchParams())
     assert total == 1
 
 
@@ -875,7 +875,7 @@ async def test_search_messages_has_more_true_when_results_exceed_limit(messages_
     for i in range(3):
         await messages_repo.insert_message(make_message(1, 100 + i, f"hello {i}"))
 
-    page = await messages_repo.search_messages(limit=2)
+    page = await messages_repo.search_messages(SearchParams(limit=2))
 
     assert len(page.messages) == 2
     assert page.has_more is True
@@ -887,7 +887,7 @@ async def test_search_messages_has_more_false_on_last_page(messages_repo):
     for i in range(3):
         await messages_repo.insert_message(make_message(1, 100 + i, f"hello {i}"))
 
-    page = await messages_repo.search_messages(limit=2, offset=2)
+    page = await messages_repo.search_messages(SearchParams(limit=2, offset=2))
 
     assert len(page.messages) == 1
     assert page.has_more is False
@@ -898,7 +898,7 @@ async def test_search_messages_tuple_unpacking_still_works(messages_repo):
     """Legacy `messages, total = ...` unpacking must keep working (#766)."""
     await messages_repo.insert_message(make_message(1, 100, "hello"))
 
-    messages, total = await messages_repo.search_messages()
+    messages, total = await messages_repo.search_messages(SearchParams())
 
     assert len(messages) == 1
     assert total == 1
@@ -920,10 +920,10 @@ async def test_search_messages_does_not_execute_count(messages_repo, monkeypatch
     monkeypatch.setattr(messages_repo._db, "execute", spy)
 
     if messages_repo._fts_available:
-        await messages_repo.search_messages(query="hello", limit=2)
+        await messages_repo.search_messages(SearchParams(query="hello", limit=2))
     monkeypatch.setattr(messages_repo, "_fts_available", False)
-    await messages_repo.search_messages(query="hello", limit=2)
-    await messages_repo.search_messages(limit=2)
+    await messages_repo.search_messages(SearchParams(query="hello", limit=2))
+    await messages_repo.search_messages(SearchParams(limit=2))
 
     counts = [sql for sql in executed if "count(" in sql.lower()]
     assert not counts, f"COUNT query still executed: {counts}"

--- a/tests/test_agent_threads_moderation_runtime_paths.py
+++ b/tests/test_agent_threads_moderation_runtime_paths.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.database import Database
+from src.models import SearchParams
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -1220,7 +1221,7 @@ async def test_messages_upsert_embedding_json(db):
 
 @pytest.mark.anyio
 async def test_messages_search_no_query(db):
-    msgs, total = await db.repos.messages.search_messages()
+    msgs, total = await db.repos.messages.search_messages(SearchParams())
     assert isinstance(msgs, list)
     assert isinstance(total, int)
 

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -20,6 +20,7 @@ from src.models import (
     CollectionTaskStatus,
     Message,
     NotificationBot,
+    SearchParams,
     SearchQuery,
     StatsAllTaskPayload,
 )
@@ -485,7 +486,7 @@ class TestCollectionBundle:
         b = CollectionBundle.from_database(db)
         await b.channels.add_channel(_channel(channel_id=1012))
         await b.insert_message(_message(channel_id=1012, message_id=1, text="findme"))
-        results, total = await b.search_messages(query="findme")
+        results, total = await b.search_messages(SearchParams(query="findme"))
         assert total >= 1
 
     async def test_delete_messages_for_channel(self, db):
@@ -536,7 +537,7 @@ class TestCollectionBundle:
 class TestSearchBundle:
     async def test_search_messages(self, db):
         b = SearchBundle.from_database(db)
-        results, total = await b.search_messages(query="nope")
+        results, total = await b.search_messages(SearchParams(query="nope"))
         assert total == 0
 
     async def test_add_channel_and_insert(self, db):
@@ -550,7 +551,7 @@ class TestSearchBundle:
         b = SearchBundle.from_database(db)
         await b.add_channel(_channel(channel_id=2002))
         await b.insert_messages_batch([_message(channel_id=2002, message_id=1, text="searchterm")])
-        results, total = await b.search_messages(query="searchterm")
+        results, total = await b.search_messages(SearchParams(query="searchterm"))
         assert total >= 1
 
     async def test_log_and_get_searches(self, db):

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -11,6 +11,7 @@ import aiosqlite
 import pytest
 
 from src.database.repositories.messages import MessageSearchPage
+from src.models import SearchParams
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -757,11 +758,11 @@ async def test_messages_search_with_query_and_date_from(db):
     msg = _make_msg(channel_id=10, message_id=1, text="important news")
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         query="important",
         date_from="2025-01-01",
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
     assert isinstance(total, int)
 
@@ -772,11 +773,11 @@ async def test_messages_search_with_query_and_date_to(db):
     msg = _make_msg(channel_id=11, message_id=2, text="date filter test")
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         query="filter",
         date_to="2025-12-31",
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
 
 
@@ -786,10 +787,10 @@ async def test_messages_search_with_channel_id_filter(db):
     msg = _make_msg(channel_id=42, message_id=3, text="channel specific")
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         channel_id=42,
         limit=10,
-    )
+    ))
     assert all(m.channel_id == 42 for m in msgs)
 
 
@@ -799,11 +800,11 @@ async def test_messages_search_with_min_max_length(db):
     msg = _make_msg(channel_id=50, message_id=4, text="A" * 100)
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         min_length=50,
         max_length=200,
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
 
 
@@ -814,8 +815,8 @@ async def test_messages_search_with_offset(db):
         msg = _make_msg(channel_id=60, message_id=i + 1, text=f"offset test {i}")
         await db.repos.messages.insert_message(msg)
 
-    msgs_all, total_all = await db.repos.messages.search_messages(channel_id=60, limit=10)
-    msgs_offset, _ = await db.repos.messages.search_messages(channel_id=60, limit=10, offset=2)
+    msgs_all, total_all = await db.repos.messages.search_messages(SearchParams(channel_id=60, limit=10))
+    msgs_offset, _ = await db.repos.messages.search_messages(SearchParams(channel_id=60, limit=10, offset=2))
     assert len(msgs_all) - 2 == len(msgs_offset)
 
 
@@ -825,11 +826,11 @@ async def test_messages_search_fts_mode(db):
     msg = _make_msg(channel_id=70, message_id=1, text="fts mode test phrase")
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         query="fts mode test",
         is_fts=True,
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
 
 
@@ -839,11 +840,11 @@ async def test_messages_search_date_to_date_only_normalization(db):
     msg = _make_msg(channel_id=80, message_id=1, text="date norm test")
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         date_from="2025-01-01",
         date_to="2025-01-15",  # date-only → normalized to 2025-01-16 <
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
 
 
@@ -853,7 +854,7 @@ async def test_messages_get_by_id_existing(db):
     msg = _make_msg(channel_id=90, message_id=1, text="by id test")
     await db.repos.messages.insert_message(msg)
 
-    msgs, _ = await db.repos.messages.search_messages(channel_id=90, limit=1)
+    msgs, _ = await db.repos.messages.search_messages(SearchParams(channel_id=90, limit=1))
     assert len(msgs) >= 1
     fetched = await db.repos.messages.get_by_id(msgs[0].id)
     assert fetched is not None
@@ -1000,10 +1001,10 @@ async def test_messages_search_topic_id_filter(db):
     msg.topic_id = 42
     await db.repos.messages.insert_message(msg)
 
-    msgs, total = await db.repos.messages.search_messages(
+    msgs, total = await db.repos.messages.search_messages(SearchParams(
         topic_id=42,
         limit=10,
-    )
+    ))
     assert isinstance(msgs, list)
 
 
@@ -1017,7 +1018,7 @@ async def test_messages_like_fallback_search(db):
 
     # Use the underlying connection directly
     repo_no_fts = MessagesRepository(db._db, fts_available=False)
-    msgs, total = await repo_no_fts.search_messages(query="fallback", limit=10)
+    msgs, total = await repo_no_fts.search_messages(SearchParams(query="fallback", limit=10))
     assert isinstance(msgs, list)
 
 

--- a/tests/test_local_search.py
+++ b/tests/test_local_search.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.database.repositories.messages import MessageSearchPage
-from src.models import Message, SearchResult
+from src.models import Message, SearchParams, SearchResult
 from src.search.local_search import LocalSearch
 
 
@@ -52,7 +52,7 @@ async def test_search_basic(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[msg], total=1)
 
     local_search = LocalSearch(mock_search_bundle)
-    result = await local_search.search(query="test")
+    result = await local_search.search(SearchParams(query="test"))
 
     assert isinstance(result, SearchResult)
     assert result.total == 1
@@ -66,10 +66,10 @@ async def test_search_with_channel_filter(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
-    await local_search.search(query="test", channel_id=123)
+    await local_search.search(SearchParams(query="test", channel_id=123))
 
-    args, kwargs = mock_search_bundle.search_messages.call_args
-    assert kwargs["channel_id"] == 123
+    params = mock_search_bundle.search_messages.call_args.args[0]
+    assert params.channel_id == 123
 
 
 @pytest.mark.anyio
@@ -78,11 +78,11 @@ async def test_search_with_date_range(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
-    await local_search.search(query="test", date_from="2024-01-01", date_to="2024-12-31")
+    await local_search.search(SearchParams(query="test", date_from="2024-01-01", date_to="2024-12-31"))
 
-    args, kwargs = mock_search_bundle.search_messages.call_args
-    assert kwargs["date_from"] == "2024-01-01"
-    assert kwargs["date_to"] == "2024-12-31"
+    params = mock_search_bundle.search_messages.call_args.args[0]
+    assert params.date_from == "2024-01-01"
+    assert params.date_to == "2024-12-31"
 
 
 @pytest.mark.anyio
@@ -91,11 +91,11 @@ async def test_search_with_length_filters(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
-    await local_search.search(query="test", min_length=100, max_length=500)
+    await local_search.search(SearchParams(query="test", min_length=100, max_length=500))
 
-    args, kwargs = mock_search_bundle.search_messages.call_args
-    assert kwargs["min_length"] == 100
-    assert kwargs["max_length"] == 500
+    params = mock_search_bundle.search_messages.call_args.args[0]
+    assert params.min_length == 100
+    assert params.max_length == 500
 
 
 @pytest.mark.anyio
@@ -104,10 +104,10 @@ async def test_search_with_fts_flag(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
-    await local_search.search(query="test", is_fts=True)
+    await local_search.search(SearchParams(query="test", is_fts=True))
 
-    args, kwargs = mock_search_bundle.search_messages.call_args
-    assert kwargs["is_fts"] is True
+    params = mock_search_bundle.search_messages.call_args.args[0]
+    assert params.is_fts is True
 
 
 @pytest.mark.anyio
@@ -116,11 +116,11 @@ async def test_search_with_pagination(mock_search_bundle):
     mock_search_bundle.search_messages.return_value = MessageSearchPage(messages=[], total=0)
 
     local_search = LocalSearch(mock_search_bundle)
-    await local_search.search(query="test", limit=10, offset=20)
+    await local_search.search(SearchParams(query="test", limit=10, offset=20))
 
-    args, kwargs = mock_search_bundle.search_messages.call_args
-    assert kwargs["limit"] == 10
-    assert kwargs["offset"] == 20
+    params = mock_search_bundle.search_messages.call_args.args[0]
+    assert params.limit == 10
+    assert params.offset == 20
 
 
 # === search_semantic tests ===

--- a/tests/test_local_search_semantic_paths.py
+++ b/tests/test_local_search_semantic_paths.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.database.repositories.messages import MessageSearchPage
-from src.models import Message, SearchResult
+from src.models import Message, SearchParams, SearchResult
 from src.search.local_search import LocalSearch
 
 
@@ -38,7 +38,7 @@ def _make_message(msg_id=1, channel_id=100, text="hello", date="2026-01-01T00:00
 async def test_search_basic():
     bundle = _mock_search_bundle()
     ls = LocalSearch(bundle)
-    result = await ls.search("test")
+    result = await ls.search(SearchParams(query="test"))
     assert isinstance(result, SearchResult)
     assert result.total == 0
 
@@ -46,7 +46,7 @@ async def test_search_basic():
 async def test_search_with_channel_filter():
     bundle = _mock_search_bundle()
     ls = LocalSearch(bundle)
-    await ls.search("test", channel_id=100)
+    await ls.search(SearchParams(query="test", channel_id=100))
     bundle.search_messages.assert_called_once()
 
 

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -29,7 +29,7 @@ from src.database.migrations import (
     run_migrations,
 )
 from src.database.repositories.messages import MessageSearchPage
-from src.models import Message
+from src.models import Message, SearchParams
 from src.search.local_search import LocalSearch
 from src.services.provider_service import RuntimeProviderRegistry, build_provider_service
 
@@ -1236,10 +1236,10 @@ async def test_search_semantic_vec_path():
 async def test_search_passes_offset_and_limit(mock_search_bundle_for_local):
     """Covers search with offset parameter."""
     local_search = LocalSearch(mock_search_bundle_for_local)
-    await local_search.search(query="test", offset=10, limit=5)
-    args, kwargs = mock_search_bundle_for_local.search_messages.call_args
-    assert kwargs["offset"] == 10
-    assert kwargs["limit"] == 5
+    await local_search.search(SearchParams(query="test", offset=10, limit=5))
+    params = mock_search_bundle_for_local.search_messages.call_args.args[0]
+    assert params.offset == 10
+    assert params.limit == 5
 
 
 @pytest.fixture


### PR DESCRIPTION
Cluster 4 из #807: 10-полевая сигнатура поиска сообщений (`query, channel_id, date_from/to, limit, offset, is_fts, min/max_length, topic_id, include_filtered`) переобъявлялась на каждом делегирующем слое → новый фильтр = правка ~6 мест синхронно.

## Решение
`SearchParams` (slotted dataclass в `src/models.py`) прокидывается одним объектом через внутреннюю цепочку: `MessagesRepository.search_messages`, `SearchBundle`/`CollectionBundle.search_messages`, `LocalSearch.search`. **Публичные kwargs-точки сохранены** — `SearchEngine.search_local` и `Database.search_messages` оставляют свои kwargs (≈120 вызовов не тронуты) и собирают `SearchParams` один раз. `AISearchEngine` передаёт `SearchParams(...)` в бандл.

## Поведение — идентично
Изменился только внутренний носитель. Тест-вызовы, бьющие во внутренние методы напрямую, обновлены на `SearchParams(...)` (facade-вызовы `db.search_messages` не тронуты).

## Проверка
- `ruff` чист.
- search/repo/bundle/local-search/db: **214 passed**; cli/agent/collector-runtime: **289 passed**.
- Net **−48 строк**.

Closes #810
Part of #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)