### PR TITLE
refactor(collector): extract _resolve_stats_entity_or_deactivate

### DIFF
--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -1966,6 +1966,60 @@ class Collector:
     async def collect_channel_stats_unlocked(self, channel: Channel) -> ChannelStats | None:
         return await self._collect_channel_stats(channel)
 
+    async def _resolve_stats_entity_or_deactivate(
+        self,
+        session: object,
+        phone: str,
+        channel: Channel,
+        operation: str,
+    ) -> object | None:
+        """Resolve a channel entity by numeric ID for the stats path.
+
+        Returns the resolved entity, or ``None`` when the caller should stop
+        and return ``None`` itself: either the channel was deactivated after a
+        permanent lookup failure (``ValueError``/``TypeError``) or the run is
+        skipped after a transient failure (timeout/connection drop, #815).
+        Re-raises :class:`HandledFloodWaitError` so flood handling propagates.
+        """
+        try:
+            return await self._pool.resolve_entity_with_warm(
+                session,
+                phone,
+                PeerChannel(channel.channel_id),
+                operation=operation,
+            )
+        except HandledFloodWaitError:
+            raise
+        except (ValueError, TypeError):
+            logger.warning(
+                "Stats: channel %d all entity lookups failed, deactivating",
+                channel.channel_id,
+            )
+            if channel.id:
+                try:
+                    await self._db.set_channel_active(channel.id, False)
+                except Exception:
+                    logger.debug(
+                        "Stats: failed to deactivate channel %d",
+                        channel.channel_id,
+                        exc_info=True,
+                    )
+            else:
+                logger.warning(
+                    "Stats: cannot deactivate channel %d -- no DB pk",
+                    channel.channel_id,
+                )
+            return None
+        except Exception:
+            # Transient failure (timeout, connection drop, …): skip this run
+            # WITHOUT deactivating the channel (#815 review follow-up).
+            logger.warning(
+                "Stats: channel %d entity lookup failed transiently, skipping",
+                channel.channel_id,
+                exc_info=True,
+            )
+            return None
+
     async def _collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
         while True:
             result = await self._pool.get_available_client()
@@ -2008,44 +2062,13 @@ class Collector:
                             channel.channel_id,
                             channel.username,
                         )
-                        try:
-                            entity = await self._pool.resolve_entity_with_warm(
-                                session,
-                                phone,
-                                PeerChannel(channel.channel_id),
-                                operation="collect_channel_stats_resolve_channel_id_fallback",
-                            )
-                        except HandledFloodWaitError:
-                            raise
-                        except (ValueError, TypeError):
-                            logger.warning(
-                                "Stats: channel %d all entity lookups failed, deactivating",
-                                channel.channel_id,
-                            )
-                            if channel.id:
-                                try:
-                                    await self._db.set_channel_active(channel.id, False)
-                                except Exception:
-                                    logger.debug(
-                                        "Stats: failed to deactivate channel %d",
-                                        channel.channel_id,
-                                        exc_info=True,
-                                    )
-                            else:
-                                logger.warning(
-                                    "Stats: cannot deactivate channel %d -- no DB pk",
-                                    channel.channel_id,
-                                )
-                            return None
-                        except Exception:
-                            # Transient failure (timeout, connection drop, …):
-                            # skip this run WITHOUT deactivating the channel
-                            # (#815 review follow-up).
-                            logger.warning(
-                                "Stats: channel %d entity lookup failed transiently, skipping",
-                                channel.channel_id,
-                                exc_info=True,
-                            )
+                        entity = await self._resolve_stats_entity_or_deactivate(
+                            session,
+                            phone,
+                            channel,
+                            operation="collect_channel_stats_resolve_channel_id_fallback",
+                        )
+                        if entity is None:
                             return None
                         new_username = getattr(entity, "username", None)
                         new_title = (
@@ -2066,44 +2089,13 @@ class Collector:
                         return None
                 else:
                     # Warm cache for numeric-id channels; bare resolve loops forever (#794).
-                    try:
-                        entity = await self._pool.resolve_entity_with_warm(
-                            session,
-                            phone,
-                            PeerChannel(channel.channel_id),
-                            operation="collect_channel_stats_resolve_channel_id",
-                        )
-                    except HandledFloodWaitError:
-                        raise
-                    except (ValueError, TypeError):
-                        logger.warning(
-                            "Stats: channel %d all entity lookups failed, deactivating",
-                            channel.channel_id,
-                        )
-                        if channel.id:
-                            try:
-                                await self._db.set_channel_active(channel.id, False)
-                            except Exception:
-                                logger.debug(
-                                    "Stats: failed to deactivate channel %d",
-                                    channel.channel_id,
-                                    exc_info=True,
-                                )
-                        else:
-                            logger.warning(
-                                "Stats: cannot deactivate channel %d -- no DB pk",
-                                channel.channel_id,
-                            )
-                        return None
-                    except Exception:
-                        # Transient failure (timeout, connection drop, …): skip
-                        # this run WITHOUT deactivating the channel (#815
-                        # review follow-up).
-                        logger.warning(
-                            "Stats: channel %d entity lookup failed transiently, skipping",
-                            channel.channel_id,
-                            exc_info=True,
-                        )
+                    entity = await self._resolve_stats_entity_or_deactivate(
+                        session,
+                        phone,
+                        channel,
+                        operation="collect_channel_stats_resolve_channel_id",
+                    )
+                    if entity is None:
                         return None
 
                 # Guard: entity resolved as a User/Bot (no ``title``) — not a channel.


### PR DESCRIPTION
## Что

Дедуп round 2 (продолжение #807, related umbrella #879). Свежий прогон jscpd по `main` нашёл реальный клон логики в `src/telegram/collector.py`.

Блок resolve-entity по numeric-id + обработка ошибок (деактивация при `ValueError/TypeError`, пропуск при transient-сбое, re-raise `HandledFloodWaitError`) был **продублирован 1:1** между веткой username-fallback и numeric-id в `_collect_channel_stats` — 25 строк, которые молча разошлись бы при изменении политики деактивации только в одной ветке.

## Как

Вынесен один приватный метод `_resolve_stats_entity_or_deactivate(session, phone, channel, operation)`, возвращающий entity или `None` (когда вызывающему нужно вернуть `None` — деактивация/transient skip). Чистый рефактор: поведение и per-branch `operation`-метки сохранены.

## Проверка

- `ruff check src/telegram/collector.py` — чисто
- `pytest tests/test_collector.py tests/test_collector_extended.py tests/test_collector_runtime.py` — 130 passed
- jscpd: целевой 25-строчный клон устранён (collector duplicated lines: was 25 → теперь 0 для этого блока)

Внешнее поведение CLI/Web/Agent не меняется (acceptance #879).