### PR TITLE
refactor(agent): dedup account getter onto _registry._get_accounts

### DIFF
--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from inspect import isawaitable
 from typing import Annotated
 
 from claude_agent_sdk import tool
@@ -11,6 +10,7 @@ from mcp.types import ToolAnnotations
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools._categories import ToolCategory, ToolMeta
 from src.agent.tools._registry import (
+    _get_accounts,
     _text_response,
     account_session_status,
     available_live_read_phones,
@@ -94,19 +94,6 @@ def _diagnostic_lines(accounts: list[object], client_pool: object | None) -> lis
         f"Available phones: {_format_phone_list(available)}.",
         f"Flood-waited phones: {_format_phone_list(flood_waited)}.",
     ]
-
-
-async def _get_account_summaries(db: object) -> list[object]:
-    for getter_name in ("get_account_summaries", "get_accounts"):
-        getter = getattr(db, getter_name, None)
-        if not callable(getter):
-            continue
-        result = getter()
-        if isawaitable(result):
-            result = await result
-        if isinstance(result, (list, tuple)):
-            return list(result)
-    return []
 
 
 async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: object = "") -> str:
@@ -233,7 +220,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if account_id is None:
             return _text_response("Ошибка: account_id обязателен.")
         try:
-            accounts = await _get_account_summaries(db)
+            accounts = await _get_accounts(db)
             acc = next((a for a in accounts if a.id == int(account_id)), None)
             if acc is None:
                 return _text_response(f"Аккаунт id={account_id} не найден.")
@@ -268,7 +255,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if account_id is None:
             return _text_response("Ошибка: account_id обязателен.")
         try:
-            accounts = await _get_account_summaries(db)
+            accounts = await _get_accounts(db)
             acc = next((a for a in accounts if a.id == int(account_id)), None)
             name = acc.phone if acc else f"id={account_id}"
             gate = require_confirmation(f"удалит аккаунт '{name}' из системы", args)
@@ -440,7 +427,7 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            accounts = await _get_account_summaries(db)
+            accounts = await _get_accounts(db)
             acc = next((a for a in accounts if a.phone == phone), None)
             if acc is None:
                 return _text_response(f"Аккаунт {phone} не найден.")

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -17,7 +17,6 @@ import logging
 import time
 from collections import OrderedDict
 from collections.abc import Mapping
-from inspect import isawaitable
 from types import MappingProxyType
 
 from src.agent.tools._categories import (
@@ -26,6 +25,7 @@ from src.agent.tools._categories import (
     ToolCategory,
     ToolMeta,
 )
+from src.agent.tools._registry import _get_accounts
 
 __all__ = [  # noqa: F822 — TOOL_CATEGORIES & co. are served by module __getattr__
     "TOOL_CATEGORIES",
@@ -132,19 +132,6 @@ def __getattr__(name: str):
     if name == "PHONE_BINDED_TOOLS":
         return _phone_binded_tools()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-async def _load_account_records(db) -> list[object]:
-    for getter_name in ("get_account_summaries", "get_accounts"):
-        getter = getattr(db, getter_name, None)
-        if not callable(getter):
-            continue
-        result = getter()
-        if isawaitable(result):
-            result = await result
-        if isinstance(result, (list, tuple)):
-            return list(result)
-    return []
 
 
 
@@ -346,7 +333,7 @@ async def load_tool_permissions(db, phone: str | None = None) -> dict[str, bool]
             phone_known = True
         else:
             if phone is None:
-                accounts = await _load_account_records(db)
+                accounts = await _get_accounts(db)
                 if accounts:
                     primary = next((a for a in accounts if a.is_primary), accounts[0])
                     phone_used = primary.phone


### PR DESCRIPTION
## Что

Дедуп round 2 (продолжение #807, related umbrella #879). jscpd нашёл два байт-идентичных duck-typed геттера аккаунтов:
- `agent/tools/accounts.py::_get_account_summaries`
- `agent/tools/permissions.py::_load_account_records`

Оба — один и тот же цикл (`get_account_summaries`/`get_accounts`, await-если-awaitable, вернуть list).

## Как

В `_registry.py` уже есть `_get_accounts(db, *, active_only=False)` — **надмножество** обеих копий (пробует `getter(active_only=...)`, при `TypeError` падает на `getter()`). Все реальные геттеры имеют сигнатуру `(active_only: bool = False)`, поэтому при дефолте `active_only=False` поведение идентично копиям.

Обе локальные копии удалены, 4 вызова переведены на `_registry._get_accounts`, убраны осиротевшие импорты `isawaitable`. Чистый рефактор.

## Проверка
- `ruff check` — чисто
- `pytest` accounts/permissions/permission-gate/autoderive: 239 passed
- импорт-smoke: без циклов