### PR TITLE
ci: add advisory jscpd duplication guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,12 @@ jobs:
 
       # Non-blocking duplication guard (#807 dedup round 2). Current level is
       # ~0.6%; threshold 1% leaves headroom while surfacing regressions. Kept
-      # advisory (continue-on-error) so it never reds CI on its own.
+      # advisory (continue-on-error) so it never reds CI on its own. jscpd is
+      # version-pinned so CI never executes an unvetted future npm release
+      # (review #918: @claude/@codex supply-chain note).
       - name: Code duplication guard (advisory)
         continue-on-error: true
-        run: npx -y jscpd --min-tokens 70 --format python --threshold 1 src
+        run: npx -y jscpd@5.0.10 --min-tokens 70 --format python --threshold 1 src
 
       - name: Enforce pytest warnings as errors
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Import architecture contracts
         run: lint-imports --config .importlinter
 
+      # Non-blocking duplication guard (#807 dedup round 2). Current level is
+      # ~0.6%; threshold 1% leaves headroom while surfacing regressions. Kept
+      # advisory (continue-on-error) so it never reds CI on its own.
+      - name: Code duplication guard (advisory)
+        continue-on-error: true
+        run: npx -y jscpd --min-tokens 70 --format python --threshold 1 src
+
       - name: Enforce pytest warnings as errors
         run: |
           python - <<'PY'


### PR DESCRIPTION
## Что

Процессная рекомендация #807 (dedup round 2, related umbrella #879) — non-blocking jscpd-шаг, чтобы дублирование кода не росло незаметно — так и не была реализована. Добавляю.

## Как

В job `lint-and-test`, после import-contracts:
```yaml
- name: Code duplication guard (advisory)
  continue-on-error: true
  run: npx -y jscpd --min-tokens 70 --format python --threshold 1 src
```
`continue-on-error: true` → шаг **никогда не красит CI сам по себе**, только подсвечивает. Текущий уровень ~0.6%, порог 1% даёт запас. Node предустановлен на `ubuntu-latest`.

Включить блокирующий режим (убрать continue-on-error / поднять до --fail-on) можно отдельным решением, когда уровень стабилизируется.