### PR TITLE
test(search): assert rendered counter element, not bare substring (#883)

### DIFF
--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -682,7 +682,10 @@ async def test_search_page_shows_plus_when_has_more(route_client, monkeypatch):
     resp = await route_client.get("/search?q=test")
 
     assert resp.status_code == 200
-    assert "50+" in resp.text
+    # #766: the result counter renders «N+» and the next-page link appears.
+    # Assert the rendered counter element directly rather than a bare "50+"
+    # substring so an incidental match elsewhere in the page can't flake it (#883).
+    assert "<strong>50+</strong>" in resp.text
     assert "Далее" in resp.text
 
 
@@ -708,7 +711,12 @@ async def test_search_page_no_next_when_no_more(route_client, monkeypatch):
     resp = await route_client.get("/search?q=test")
 
     assert resp.status_code == 200
-    assert "1+" not in resp.text
+    # #766: the result counter renders the exact total with no lower-bound «+»,
+    # and there is no next-page link. Assert the rendered counter element
+    # directly: a bare `"1+" not in resp.text` substring check flaked under
+    # xdist on an incidental "1+" elsewhere in the fully-rendered page (#883).
+    assert "<strong>1</strong>" in resp.text
+    assert "<strong>1+</strong>" not in resp.text
     assert "Далее" not in resp.text
 
 

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -683,9 +683,9 @@ async def test_search_page_shows_plus_when_has_more(route_client, monkeypatch):
 
     assert resp.status_code == 200
     # #766: the result counter renders «N+» and the next-page link appears.
-    # Assert the rendered counter element directly rather than a bare "50+"
-    # substring so an incidental match elsewhere in the page can't flake it (#883).
-    assert "<strong>50+</strong>" in resp.text
+    # Assert the full rendered counter phrase rather than a bare "50+" substring
+    # so an incidental match elsewhere in the page can't flake it (#883, #920).
+    assert "<strong>50+</strong> сообщений" in resp.text
     assert "Далее" in resp.text
 
 
@@ -712,11 +712,10 @@ async def test_search_page_no_next_when_no_more(route_client, monkeypatch):
 
     assert resp.status_code == 200
     # #766: the result counter renders the exact total with no lower-bound «+»,
-    # and there is no next-page link. Assert the rendered counter element
-    # directly: a bare `"1+" not in resp.text` substring check flaked under
-    # xdist on an incidental "1+" elsewhere in the fully-rendered page (#883).
-    assert "<strong>1</strong>" in resp.text
-    assert "<strong>1+</strong>" not in resp.text
+    # and there is no next-page link. Assert the full rendered counter phrase
+    # (`</strong> сообщений`) so neither an incidental "1+" elsewhere (#883) nor
+    # a stray "+" adjacent to the counter (Codex review #920) can pass unnoticed.
+    assert "<strong>1</strong> сообщений" in resp.text
     assert "Далее" not in resp.text
 
 


### PR DESCRIPTION
## Что

Чинит изоляционный флак из **#883**, который заблокировал CI #918: `tests/routes/test_search_routes.py::test_search_page_no_next_when_no_more` падал под xdist на `assert "1+" not in resp.text`.

## Корень

Ассерт — широкий substring-матч по **всей** отрендеренной странице поиска. Для `mode=local` мок `search_service` применяется всегда (хендлер зовёт `deps.search_service(request)` — патч-таргет совпадает), поэтому сам счётчик детерминированно «1». Флак — именно из-за того, что `"1+"` инцидентально встречался где-то ещё в большом HTML при определённом порядке тестов на воркере. Не баг продакшена — фрагильный ассерт.

## Как

Проверяем **конкретный элемент счётчика**, а не глобальную подстроку:
- no-more: `assert "<strong>1</strong>" in resp.text` + `assert "<strong>1+</strong>" not in resp.text`
- has-more (симметрично): `assert "<strong>50+</strong>" in resp.text`

Поведение под тестом не меняется; ассерты стали герметичными.

## Проверка
- `ruff check` — чисто
- `pytest tests/routes/test_search_routes.py` — 38 passed
- оба counter-теста проходят (подтверждают точный рендер `<strong>1</strong>` / `<strong>50+</strong>`)

## Scope
Чинит **именно** этот изоляционный флак. Детерминизация timing-тестов `test_runtime_worker.py` (sleep→Event) — отдельная часть #883, не входит сюда. Разблокирует мёрж #918.