### PR TITLE
test(runtime-worker): убрать timing-флак в EmbeddedWorker тестах (#883)

### DIFF
--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -264,21 +264,23 @@ async def test_embedded_worker_stop_suppresses_cancelled_snapshot_publish():
 
     container = MagicMock()
     worker = EmbeddedWorker(AppConfig())
+    publish_started = asyncio.Event()
+
+    async def cancelled_publish(_container, *, stop_event=None):
+        # Signal that the publish step actually ran before it raises, so the test
+        # can await a deterministic event instead of polling with a fixed yield
+        # budget that flakes under coverage/xdist (#883).
+        publish_started.set()
+        raise asyncio.CancelledError
 
     with (
         patch("src.web.embedded_worker.build_worker_container", AsyncMock(return_value=container)),
         patch("src.web.embedded_worker.start_container", AsyncMock()),
         patch("src.web.embedded_worker.stop_container", AsyncMock()) as stop_container,
-        patch(
-            "src.web.embedded_worker._publish_snapshots",
-            AsyncMock(side_effect=asyncio.CancelledError),
-        ) as publish_snapshots,
+        patch("src.web.embedded_worker._publish_snapshots", new=cancelled_publish),
     ):
         await worker.start()
-        for _ in range(10):
-            if publish_snapshots.await_count:
-                break
-            await asyncio.sleep(0)
+        await asyncio.wait_for(publish_started.wait(), timeout=2.0)
 
         stop_container.assert_not_awaited()
         await worker.stop(timeout=1.0)
@@ -296,13 +298,18 @@ async def test_embedded_worker_retries_after_hanging_snapshot_publish():
     config = AppConfig()
     config.scheduler.snapshot_publish_timeout_sec = 0.01
     worker = EmbeddedWorker(config)
-    publish_started = asyncio.Event()
     publish_calls = 0
+    second_publish = asyncio.Event()
 
     async def hanging_publish(_container, *, stop_event=None):
         nonlocal publish_calls
         publish_calls += 1
-        publish_started.set()
+        # The first publish hangs and is killed by the per-publish timeout; the
+        # loop must retry. Fire on the second invocation so the test can await
+        # the retry deterministically instead of sleeping a fixed window and
+        # hoping two cycles elapsed (#883).
+        if publish_calls >= 2:
+            second_publish.set()
         await asyncio.Event().wait()
 
     with (
@@ -314,11 +321,10 @@ async def test_embedded_worker_retries_after_hanging_snapshot_publish():
     ):
         await worker.start()
         try:
-            await asyncio.wait_for(publish_started.wait(), timeout=0.05)
-            await asyncio.sleep(0.05)
+            await asyncio.wait_for(second_publish.wait(), timeout=2.0)
             assert publish_calls >= 2
         finally:
-            await worker.stop(timeout=0.01)
+            await worker.stop(timeout=1.0)
 
     stop_container.assert_awaited_once_with(container)
 


### PR DESCRIPTION
## Что и зачем

Закрывает оставшийся timing-флак из #883 в `tests/test_runtime_worker.py`. Два теста `EmbeddedWorker` зависели от настенных таймингов и флакали под coverage/xdist:

- **`test_embedded_worker_stop_suppresses_cancelled_snapshot_publish`** — опрашивал `range(10)` + `asyncio.sleep(0)` в ожидании первого publish. Под нагрузкой воркер-таску могло не хватить 10 yield'ов, чтобы дойти до шага publish.
- **`test_embedded_worker_retries_after_hanging_snapshot_publish`** — спал фиксированные 50 мс и затем проверял `publish_calls >= 2`. Два цикла ретрая (publish-timeout 0.01s + heartbeat 0.001s) не гарантированно укладываются в 50 мс при инструментировании покрытием.

## Как

«Sleep-и-надейся» заменён на детерминированные сигналы `asyncio.Event`, которые заглушка publish выставляет ровно на границе нужного шага, а тест ждёт через `asyncio.wait_for(..., timeout=2.0)` с запасом (а не «впритык»):

- стоп-тест: `cancelled_publish` ставит `publish_started` перед тем как поднять `CancelledError` → ждём событие вместо polling-цикла;
- ретрай-тест: `hanging_publish` ставит `second_publish` на **втором** вызове → ждём именно факт ретрая, а не фиксированное окно.

Тестируемые продакшен-пути (ретрай после таймаута, подавление `CancelledError` при stop) не меняются — маленькие publish/heartbeat таймауты по-прежнему гонят ретрай; меняется только ожидание: edge-triggered вместо time-boxed.

## Проверка

- `ruff check tests/test_runtime_worker.py` — clean
- `pytest tests/test_runtime_worker.py` — 18 passed
- 5× прогон обоих тестов под `--cov=src.web.embedded_worker` — стабильно passed
- полный файл под `-n auto` и 3× под `--cov=src` — стабильно 18 passed

Refs #883. Внешнее поведение CLI/Web/Agent не меняется (только тесты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)