### PR TITLE
refactor(cli): снизить сложность GraphBuilder.build F(44)→A (#922)

### DIFF
--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -14,6 +14,7 @@ hints, applying auto-wiring rules:
 """
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any
 
 from src.cli.node_dsl import NodeSpec, generate_node_id
@@ -30,6 +31,32 @@ class GraphBuilderError(ValueError):
 
 
 _AUTO_INSERT_TYPES = {PipelineNodeType.FETCH_MESSAGES}
+
+
+@dataclass
+class _BuildState:
+    """Mutable accumulator threaded through the ``GraphBuilder.build`` phases.
+
+    Holds the nodes/edges under construction plus the auto-wiring bookkeeping
+    (id counters, the resolved source/fetch ids, the ordered user-node ids).
+    Split out of ``build`` so each phase is a small method instead of one
+    rank-F function (#922).
+    """
+
+    nodes: list[PipelineNode] = field(default_factory=list)
+    edges: list[PipelineEdge] = field(default_factory=list)
+    type_counters: dict[str, int] = field(default_factory=dict)
+    source_node_id: str | None = None
+    fetch_node_id: str | None = None
+    user_node_ids: list[str] = field(default_factory=list)
+
+    def next_id(self, spec: NodeSpec) -> str:
+        if spec.id is not None:
+            return spec.id
+        key = spec.type.value
+        idx = self.type_counters.get(key, 0)
+        self.type_counters[key] = idx + 1
+        return generate_node_id(spec.type, idx)
 
 
 class GraphBuilder:
@@ -64,28 +91,24 @@ class GraphBuilder:
         if not self._node_specs and not self._source_channel_ids:
             raise GraphBuilderError("Cannot build an empty graph. Add --node specs or --source.")
 
-        nodes: list[PipelineNode] = []
-        edges: list[PipelineEdge] = []
-        type_counters: dict[str, int] = {}
+        state = _BuildState()
+        self._build_source_and_user_nodes(state)
+        self._auto_insert_fetch(state)
+        self._auto_publish_and_targets(state)
+        self._build_edges(state)
+        self._apply_overrides_and_validate(state)
+        return PipelineGraph(nodes=state.nodes, edges=state.edges)
 
-        def _next_id(spec: NodeSpec) -> str:
-            if spec.id is not None:
-                return spec.id
-            key = spec.type.value
-            idx = type_counters.get(key, 0)
-            type_counters[key] = idx + 1
-            return generate_node_id(spec.type, idx)
-
+    def _build_source_and_user_nodes(self, state: _BuildState) -> None:
         # -- 1. Resolve source --------------------------------------------------
         has_user_source = any(s.type == PipelineNodeType.SOURCE for s in self._node_specs)
-        source_node_id: str | None = None
 
         if self._source_channel_ids and not has_user_source:
             # Auto-create source node (channel_ids injection into user source happens at step 2)
             source_id = "source_0"
-            type_counters["source"] = 1
-            source_node_id = source_id
-            nodes.append(PipelineNode(
+            state.type_counters["source"] = 1
+            state.source_node_id = source_id
+            state.nodes.append(PipelineNode(
                 id=source_id,
                 type=PipelineNodeType.SOURCE,
                 name="source",
@@ -94,9 +117,8 @@ class GraphBuilder:
             ))
 
         # -- 2. Process user node specs ------------------------------------------
-        user_node_ids: list[str] = []
         for spec in self._node_specs:
-            nid = _next_id(spec)
+            nid = state.next_id(spec)
             config = dict(spec.config)
 
             # Inject channel_ids into user source node
@@ -116,104 +138,106 @@ class GraphBuilder:
                 name=spec.type.value,
                 config=config,
             )
-            nodes.append(node)
-            user_node_ids.append(nid)
+            state.nodes.append(node)
+            state.user_node_ids.append(nid)
 
-            if spec.type == PipelineNodeType.SOURCE and source_node_id is None:
-                source_node_id = nid
+            if spec.type == PipelineNodeType.SOURCE and state.source_node_id is None:
+                state.source_node_id = nid
 
+    def _auto_insert_fetch(self, state: _BuildState) -> None:
         # -- 3. Auto-insert fetch_messages after source --------------------------
         need_fetch = (
-            source_node_id is not None
+            state.source_node_id is not None
             and not any(
                 s.type in _AUTO_INSERT_TYPES for s in self._node_specs
             )
-            and (len(user_node_ids) > 0 or self._target_refs)
+            and (len(state.user_node_ids) > 0 or self._target_refs)
         )
-        fetch_node_id: str | None = None
-        if need_fetch:
-            fetch_id = "fetch_messages_0"
-            type_counters["fetch_messages"] = 1
-            fetch_node_id = fetch_id
-            # Insert after source
-            source_idx = next(
-                (i for i, n in enumerate(nodes) if n.id == source_node_id), -1
-            )
-            fetch_node = PipelineNode(
-                id=fetch_id,
-                type=PipelineNodeType.FETCH_MESSAGES,
-                name="fetch_messages",
-                config={},
-                position={"x": float(source_idx + 1) * 200, "y": 0.0},
-            )
-            nodes.insert(source_idx + 1, fetch_node)
+        if not need_fetch:
+            return
+        fetch_id = "fetch_messages_0"
+        state.type_counters["fetch_messages"] = 1
+        state.fetch_node_id = fetch_id
+        # Insert after source
+        source_idx = next(
+            (i for i, n in enumerate(state.nodes) if n.id == state.source_node_id), -1
+        )
+        fetch_node = PipelineNode(
+            id=fetch_id,
+            type=PipelineNodeType.FETCH_MESSAGES,
+            name="fetch_messages",
+            config={},
+            position={"x": float(source_idx + 1) * 200, "y": 0.0},
+        )
+        state.nodes.insert(source_idx + 1, fetch_node)
 
+    def _auto_publish_and_targets(self, state: _BuildState) -> None:
         # -- 4. Auto-publish from targets ----------------------------------------
         has_publish_or_forward = any(
             n.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD)
-            for n in nodes
+            for n in state.nodes
         )
         if self._target_refs and not has_publish_or_forward:
             pub_id = "publish_0"
-            type_counters["publish"] = 1
+            state.type_counters["publish"] = 1
             pub_node = PipelineNode(
                 id=pub_id,
                 type=PipelineNodeType.PUBLISH,
                 name="publish",
                 config={"targets": self._target_refs},
             )
-            nodes.append(pub_node)
-            user_node_ids.append(pub_id)
+            state.nodes.append(pub_node)
+            state.user_node_ids.append(pub_id)
 
         # -- 5. Inject targets into first publish/forward ------------------------
         if self._target_refs:
-            for node in nodes:
+            for node in state.nodes:
                 if node.type in (PipelineNodeType.PUBLISH, PipelineNodeType.FORWARD):
                     if not node.config.get("targets"):
                         node.config["targets"] = self._target_refs
                     break
 
+    def _build_edges(self, state: _BuildState) -> None:
         # -- 6. Build linear edges -----------------------------------------------
         # Chain: source -> [fetch] -> user_0 -> user_1 -> ...
         chain: list[str] = []
-        if source_node_id:
-            chain.append(source_node_id)
-        if fetch_node_id:
-            chain.append(fetch_node_id)
-        chain.extend(nid for nid in user_node_ids if nid not in chain)
+        if state.source_node_id:
+            chain.append(state.source_node_id)
+        if state.fetch_node_id:
+            chain.append(state.fetch_node_id)
+        chain.extend(nid for nid in state.user_node_ids if nid not in chain)
 
         for i in range(len(chain) - 1):
-            edges.append(PipelineEdge(from_node=chain[i], to_node=chain[i + 1]))
+            state.edges.append(PipelineEdge(from_node=chain[i], to_node=chain[i + 1]))
 
         # -- 7. Explicit edges ---------------------------------------------------
-        node_ids = {n.id for n in nodes}
-        existing = {(e.from_node, e.to_node) for e in edges}
+        node_ids = {n.id for n in state.nodes}
+        existing = {(e.from_node, e.to_node) for e in state.edges}
         for from_id, to_id in self._explicit_edges:
             if from_id not in node_ids or to_id not in node_ids:
                 raise GraphBuilderError(
                     f"Edge references non-existent node: {from_id} -> {to_id}"
                 )
             if (from_id, to_id) not in existing:
-                edges.append(PipelineEdge(from_node=from_id, to_node=to_id))
+                state.edges.append(PipelineEdge(from_node=from_id, to_node=to_id))
 
+    def _apply_overrides_and_validate(self, state: _BuildState) -> None:
         # -- 8. Apply node config overrides --------------------------------------
-        node_by_id = {n.id: n for n in nodes}
+        node_by_id = {n.id: n for n in state.nodes}
         for nid, override in self._node_config_overrides.items():
             node = node_by_id.get(nid)
             if node is not None:
                 node.config.update(override)
 
         # -- 9. Assign positions --------------------------------------------------
-        _assign_positions(nodes)
+        _assign_positions(state.nodes)
 
         # -- 10. Validate: no duplicate IDs --------------------------------------
         seen_ids: set[str] = set()
-        for n in nodes:
+        for n in state.nodes:
             if n.id in seen_ids:
                 raise GraphBuilderError(f"Duplicate node ID: {n.id}")
             seen_ids.add(n.id)
-
-        return PipelineGraph(nodes=nodes, edges=edges)
 
 
 def _assign_positions(nodes: list[PipelineNode]) -> None:


### PR DESCRIPTION
## Что и зачем

PR-3 из #922. `GraphBuilder.build` (`src/cli/graph_builder.py`) была **radon F(44)** — один метод, выполняющий все 10 фаз авто-разводки графа inline, протягивая 6 мутабельных локалов (`nodes, edges, type_counters, source_node_id, fetch_node_id, user_node_ids`) + closure `_next_id`.

## Подход

Состояние сборки вынесено в dataclass `_BuildState` (туда же переехал `_next_id` → `_BuildState.next_id` с идентичной семантикой счётчиков), фазы — в сфокусированные методы:

| Метод | Фазы | CC |
|---|---|---|
| `_build_source_and_user_nodes` | 1–2 (резолв source + user-specs) | C(12) |
| `_auto_insert_fetch` | 3 (вставка fetch_messages) | B(8) |
| `_auto_publish_and_targets` | 4–5 (auto-publish + инъекция targets) | B(8) |
| `_build_edges` | 6–7 (линейная цепочка + явные рёбра) | C(12) |
| `_apply_overrides_and_validate` | 8–10 (overrides, позиции, dup-id) | B(6) |

`build()` теперь тонкий оркестратор из 5 вызовов. **radon cc: `build` F(44) → A(3)**; `_BuildState` A(3).

## Поведение не меняется

Тот же порядок построения nodes/edges и валидаций, та же логика инъекции channel_ids/targets, те же тексты ошибок `GraphBuilderError`.

## Проверка

- `ruff check src/cli/graph_builder.py` — clean
- `pytest tests/test_cli_graph_builder.py` — **18 passed** (единственный потребитель GraphBuilder в тестах)

Refs #922. Внешнее поведение CLI без изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)