### PR TITLE
refactor(filters): снизить сложность match_message_filter F(42)→A + safety-тесты (#922)

### DIFF
--- a/src/services/pipeline_filters.py
+++ b/src/services/pipeline_filters.py
@@ -98,6 +98,8 @@ class _MessageAttrs(NamedTuple):
     sender_kind: str | int | bool | None
     sender_id: str | int | bool | None
     sender_name: str | int | bool | None
+    media_type: str | int | bool | None
+    forward_from_channel_id: str | int | bool | None
 
 
 def _extract_message_attributes(message) -> _MessageAttrs:
@@ -110,10 +112,12 @@ def _extract_message_attributes(message) -> _MessageAttrs:
         sender_kind=_safe_scalar(getattr(message, "sender_kind", None)),
         sender_id=_safe_scalar(getattr(message, "sender_id", None)),
         sender_name=_safe_scalar(getattr(message, "sender_name", None)),
+        media_type=_safe_scalar(getattr(message, "media_type", None)),
+        forward_from_channel_id=_safe_scalar(getattr(message, "forward_from_channel_id", None)),
     )
 
 
-def _check_message_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_message_kinds(attrs: _MessageAttrs, config: dict) -> bool:
     if config["message_kinds"] and attrs.message_kind not in config["message_kinds"]:
         if not (
             config["message_kinds"] == ["service"]
@@ -127,7 +131,7 @@ def _check_message_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
     return True
 
 
-def _check_service_actions(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_service_actions(attrs: _MessageAttrs, config: dict) -> bool:
     if config["service_actions"] and attrs.service_action not in config["service_actions"]:
         legacy_aliases = {
             "join": ("joined", "join"),
@@ -150,13 +154,13 @@ def _check_service_actions(message, attrs: _MessageAttrs, config: dict) -> bool:
     return True
 
 
-def _check_media_types(message, attrs: _MessageAttrs, config: dict) -> bool:
-    if config["media_types"] and getattr(message, "media_type", None) not in config["media_types"]:
+def _check_media_types(attrs: _MessageAttrs, config: dict) -> bool:
+    if config["media_types"] and attrs.media_type not in config["media_types"]:
         return False
     return True
 
 
-def _check_sender_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_sender_kinds(attrs: _MessageAttrs, config: dict) -> bool:
     if config["sender_kinds"] and attrs.sender_kind not in config["sender_kinds"]:
         if not (
             attrs.sender_kind is None
@@ -168,16 +172,16 @@ def _check_sender_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
     return True
 
 
-def _check_forwarded(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_forwarded(attrs: _MessageAttrs, config: dict) -> bool:
     expected_forwarded = config.get("forwarded")
     if expected_forwarded is not None:
-        is_forwarded = getattr(message, "forward_from_channel_id", None) is not None
+        is_forwarded = attrs.forward_from_channel_id is not None
         if is_forwarded is not bool(expected_forwarded):
             return False
     return True
 
 
-def _check_has_text(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_has_text(attrs: _MessageAttrs, config: dict) -> bool:
     expected_has_text = config.get("has_text")
     if expected_has_text is not None:
         has_text = bool(attrs.text.strip())
@@ -186,7 +190,7 @@ def _check_has_text(message, attrs: _MessageAttrs, config: dict) -> bool:
     return True
 
 
-def _check_keywords(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_keywords(attrs: _MessageAttrs, config: dict) -> bool:
     keywords = [item.lower() for item in config["keywords"] if item]
     has_keyword_filter = bool(keywords)
     has_link_filter = config["match_links"]
@@ -197,13 +201,13 @@ def _check_keywords(message, attrs: _MessageAttrs, config: dict) -> bool:
     return True
 
 
-def _check_match_links(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_match_links(attrs: _MessageAttrs, config: dict) -> bool:
     if config["match_links"] and not re.search(r"https?://\S+|t\.me/\S+", attrs.text):
         return False
     return True
 
 
-def _check_regex(message, attrs: _MessageAttrs, config: dict) -> bool:
+def _check_regex(attrs: _MessageAttrs, config: dict) -> bool:
     pattern = config["regex"]
     if config.get("_filter_type") == "regex" and not pattern:
         return False
@@ -236,7 +240,7 @@ def match_message_filter(message, raw_config: dict | None) -> bool:
     if config.get("type") != "message_filter":
         return True
     attrs = _extract_message_attributes(message)
-    return all(check(message, attrs, config) for check in _MESSAGE_FILTER_CHECKS)
+    return all(check(attrs, config) for check in _MESSAGE_FILTER_CHECKS)
 
 
 def _safe_scalar(value):

--- a/src/services/pipeline_filters.py
+++ b/src/services/pipeline_filters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from typing import NamedTuple
 
 
 def _empty_message_filter() -> dict:
@@ -87,27 +88,47 @@ def filter_messages(messages: Iterable, raw_config: dict | None) -> list:
     return [message for message in messages if match_message_filter(message, raw_config)]
 
 
-def match_message_filter(message, raw_config: dict | None) -> bool:
-    config = normalize_filter_config(raw_config)
-    if config.get("type") != "message_filter":
-        return True
+class _MessageAttrs(NamedTuple):
+    """Pre-extracted message fields shared across the per-criterion checks."""
 
+    text: str
+    text_lower: str
+    message_kind: str | int | bool | None
+    service_action: str | int | bool | None
+    sender_kind: str | int | bool | None
+    sender_id: str | int | bool | None
+    sender_name: str | int | bool | None
+
+
+def _extract_message_attributes(message) -> _MessageAttrs:
     text = getattr(message, "text", None) or ""
-    text_lower = text.lower()
-    message_kind = _safe_scalar(getattr(message, "message_kind", None))
-    service_action = _safe_scalar(getattr(message, "service_action_semantic", None))
-    sender_kind = _safe_scalar(getattr(message, "sender_kind", None))
-    sender_id = _safe_scalar(getattr(message, "sender_id", None))
-    sender_name = _safe_scalar(getattr(message, "sender_name", None))
+    return _MessageAttrs(
+        text=text,
+        text_lower=text.lower(),
+        message_kind=_safe_scalar(getattr(message, "message_kind", None)),
+        service_action=_safe_scalar(getattr(message, "service_action_semantic", None)),
+        sender_kind=_safe_scalar(getattr(message, "sender_kind", None)),
+        sender_id=_safe_scalar(getattr(message, "sender_id", None)),
+        sender_name=_safe_scalar(getattr(message, "sender_name", None)),
+    )
 
-    if config["message_kinds"] and message_kind not in config["message_kinds"]:
+
+def _check_message_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
+    if config["message_kinds"] and attrs.message_kind not in config["message_kinds"]:
         if not (
             config["message_kinds"] == ["service"]
-            and service_action is None
-            and any(item in text_lower for item in ("join", "left", "pinned", "title", "photo", "migrat", "create"))
+            and attrs.service_action is None
+            and any(
+                item in attrs.text_lower
+                for item in ("join", "left", "pinned", "title", "photo", "migrat", "create")
+            )
         ):
             return False
-    if config["service_actions"] and service_action not in config["service_actions"]:
+    return True
+
+
+def _check_service_actions(message, attrs: _MessageAttrs, config: dict) -> bool:
+    if config["service_actions"] and attrs.service_action not in config["service_actions"]:
         legacy_aliases = {
             "join": ("joined", "join"),
             "leave": ("left", "leave"),
@@ -117,60 +138,105 @@ def match_message_filter(message, raw_config: dict | None) -> bool:
             "migrate": ("migrat",),
             "created": ("create", "created"),
         }
-        if service_action is None:
+        if attrs.service_action is None:
             matched = any(
-                any(alias in text_lower for alias in legacy_aliases.get(expected, (expected,)))
+                any(alias in attrs.text_lower for alias in legacy_aliases.get(expected, (expected,)))
                 for expected in config["service_actions"]
             )
             if not matched:
                 return False
         else:
             return False
+    return True
+
+
+def _check_media_types(message, attrs: _MessageAttrs, config: dict) -> bool:
     if config["media_types"] and getattr(message, "media_type", None) not in config["media_types"]:
         return False
-    if config["sender_kinds"] and sender_kind not in config["sender_kinds"]:
+    return True
+
+
+def _check_sender_kinds(message, attrs: _MessageAttrs, config: dict) -> bool:
+    if config["sender_kinds"] and attrs.sender_kind not in config["sender_kinds"]:
         if not (
-            sender_kind is None
+            attrs.sender_kind is None
             and "anonymous_admin" in config["sender_kinds"]
-            and sender_id is None
-            and sender_name is None
+            and attrs.sender_id is None
+            and attrs.sender_name is None
         ):
             return False
+    return True
 
+
+def _check_forwarded(message, attrs: _MessageAttrs, config: dict) -> bool:
     expected_forwarded = config.get("forwarded")
     if expected_forwarded is not None:
         is_forwarded = getattr(message, "forward_from_channel_id", None) is not None
         if is_forwarded is not bool(expected_forwarded):
             return False
+    return True
 
+
+def _check_has_text(message, attrs: _MessageAttrs, config: dict) -> bool:
     expected_has_text = config.get("has_text")
     if expected_has_text is not None:
-        has_text = bool(text.strip())
+        has_text = bool(attrs.text.strip())
         if has_text is not bool(expected_has_text):
             return False
+    return True
 
+
+def _check_keywords(message, attrs: _MessageAttrs, config: dict) -> bool:
     keywords = [item.lower() for item in config["keywords"] if item]
     has_keyword_filter = bool(keywords)
     has_link_filter = config["match_links"]
     if not has_keyword_filter and not has_link_filter and config.get("_filter_type") == "keywords":
         return False
-    if keywords and not any(item in text_lower for item in keywords):
+    if keywords and not any(item in attrs.text_lower for item in keywords):
         return False
+    return True
 
-    if config["match_links"] and not re.search(r"https?://\S+|t\.me/\S+", text):
+
+def _check_match_links(message, attrs: _MessageAttrs, config: dict) -> bool:
+    if config["match_links"] and not re.search(r"https?://\S+|t\.me/\S+", attrs.text):
         return False
+    return True
 
+
+def _check_regex(message, attrs: _MessageAttrs, config: dict) -> bool:
     pattern = config["regex"]
     if config.get("_filter_type") == "regex" and not pattern:
         return False
     if pattern:
         try:
-            if not re.search(pattern, text, re.IGNORECASE):
+            if not re.search(pattern, attrs.text, re.IGNORECASE):
                 return False
         except re.error:
             return False
-
     return True
+
+
+# Evaluated in order with short-circuit AND semantics — the same precedence as
+# the original linear if-chain. Each predicate returns False to reject.
+_MESSAGE_FILTER_CHECKS = (
+    _check_message_kinds,
+    _check_service_actions,
+    _check_media_types,
+    _check_sender_kinds,
+    _check_forwarded,
+    _check_has_text,
+    _check_keywords,
+    _check_match_links,
+    _check_regex,
+)
+
+
+def match_message_filter(message, raw_config: dict | None) -> bool:
+    config = normalize_filter_config(raw_config)
+    if config.get("type") != "message_filter":
+        return True
+    attrs = _extract_message_attributes(message)
+    return all(check(message, attrs, config) for check in _MESSAGE_FILTER_CHECKS)
 
 
 def _safe_scalar(value):

--- a/tests/test_pipeline_filters.py
+++ b/tests/test_pipeline_filters.py
@@ -1,0 +1,249 @@
+"""Behavior-locking tests for ``match_message_filter`` (#922).
+
+``match_message_filter`` evaluates nine independent filter criteria against a
+message. Before refactoring it from a single rank-F function into
+predicate-per-criterion helpers, these tests pin the exact current behavior of
+each criterion (including the legacy text-fallback paths) so the refactor is
+provably non-behavioral.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.services.pipeline_filters import filter_messages, match_message_filter
+
+
+def _msg(**kwargs):
+    """Build a message stub with the attributes match_message_filter reads."""
+    defaults = {
+        "text": "",
+        "message_kind": None,
+        "service_action_semantic": None,
+        "sender_kind": None,
+        "sender_id": None,
+        "sender_name": None,
+        "media_type": None,
+        "forward_from_channel_id": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _mf(**criteria) -> dict:
+    """Build a raw message_filter config."""
+    return {"type": "message_filter", **criteria}
+
+
+# -- No-op / passthrough ----------------------------------------------------
+
+
+def test_empty_message_filter_passes_everything():
+    assert match_message_filter(_msg(text="anything"), _mf()) is True
+
+
+def test_none_config_normalizes_to_empty_keywords_and_rejects():
+    # A None config normalizes to the default "keywords" filter type with no
+    # keywords, which rejects everything. (filter_messages avoids this by
+    # short-circuiting on a falsy config — see the passthrough test below.)
+    assert match_message_filter(_msg(text="hi"), None) is False
+
+
+def test_filter_messages_passthrough_on_empty_config():
+    msgs = [_msg(text="a"), _msg(text="b")]
+    assert filter_messages(msgs, None) == msgs
+
+
+# -- message_kinds ----------------------------------------------------------
+
+
+def test_message_kinds_match():
+    assert match_message_filter(_msg(message_kind="photo"), _mf(message_kinds=["photo"])) is True
+
+
+def test_message_kinds_mismatch_rejected():
+    assert match_message_filter(_msg(message_kind="text"), _mf(message_kinds=["photo"])) is False
+
+
+def test_message_kinds_service_legacy_text_fallback_passes():
+    # message_kind != "service" but config wants ["service"], no semantic action,
+    # and the text carries a service keyword → legacy fallback lets it through.
+    msg = _msg(message_kind="text", service_action_semantic=None, text="User joined the group")
+    assert match_message_filter(msg, _mf(message_kinds=["service"])) is True
+
+
+def test_message_kinds_service_legacy_text_fallback_no_keyword_rejected():
+    msg = _msg(message_kind="text", service_action_semantic=None, text="hello world")
+    assert match_message_filter(msg, _mf(message_kinds=["service"])) is False
+
+
+# -- service_actions --------------------------------------------------------
+
+
+def test_service_actions_match():
+    msg = _msg(service_action_semantic="join")
+    assert match_message_filter(msg, _mf(service_actions=["join"])) is True
+
+
+def test_service_actions_semantic_mismatch_rejected():
+    msg = _msg(service_action_semantic="leave")
+    assert match_message_filter(msg, _mf(service_actions=["join"])) is False
+
+
+def test_service_actions_legacy_alias_in_text_passes():
+    msg = _msg(service_action_semantic=None, text="Someone joined")
+    assert match_message_filter(msg, _mf(service_actions=["join"])) is True
+
+
+def test_service_actions_legacy_no_alias_rejected():
+    msg = _msg(service_action_semantic=None, text="nothing here")
+    assert match_message_filter(msg, _mf(service_actions=["join"])) is False
+
+
+# -- media_types ------------------------------------------------------------
+
+
+def test_media_types_match():
+    assert match_message_filter(_msg(media_type="photo"), _mf(media_types=["photo"])) is True
+
+
+def test_media_types_mismatch_rejected():
+    assert match_message_filter(_msg(media_type="video"), _mf(media_types=["photo"])) is False
+
+
+# -- sender_kinds -----------------------------------------------------------
+
+
+def test_sender_kinds_match():
+    assert match_message_filter(_msg(sender_kind="user"), _mf(sender_kinds=["user"])) is True
+
+
+def test_sender_kinds_mismatch_rejected():
+    assert match_message_filter(_msg(sender_kind="bot"), _mf(sender_kinds=["user"])) is False
+
+
+def test_sender_kinds_anonymous_admin_inferred_passes():
+    msg = _msg(sender_kind=None, sender_id=None, sender_name=None)
+    assert match_message_filter(msg, _mf(sender_kinds=["anonymous_admin"])) is True
+
+
+def test_sender_kinds_anonymous_admin_with_sender_id_rejected():
+    msg = _msg(sender_kind=None, sender_id=123, sender_name=None)
+    assert match_message_filter(msg, _mf(sender_kinds=["anonymous_admin"])) is False
+
+
+# -- forwarded --------------------------------------------------------------
+
+
+def test_forwarded_true_match():
+    assert match_message_filter(_msg(forward_from_channel_id=42), _mf(forwarded=True)) is True
+
+
+def test_forwarded_true_but_not_forwarded_rejected():
+    assert match_message_filter(_msg(forward_from_channel_id=None), _mf(forwarded=True)) is False
+
+
+def test_forwarded_false_match():
+    assert match_message_filter(_msg(forward_from_channel_id=None), _mf(forwarded=False)) is True
+
+
+def test_forwarded_false_but_forwarded_rejected():
+    assert match_message_filter(_msg(forward_from_channel_id=7), _mf(forwarded=False)) is False
+
+
+# -- has_text ---------------------------------------------------------------
+
+
+def test_has_text_true_match():
+    assert match_message_filter(_msg(text="hello"), _mf(has_text=True)) is True
+
+
+def test_has_text_true_but_blank_rejected():
+    assert match_message_filter(_msg(text="   "), _mf(has_text=True)) is False
+
+
+def test_has_text_false_match():
+    assert match_message_filter(_msg(text=""), _mf(has_text=False)) is True
+
+
+# -- keywords ---------------------------------------------------------------
+
+
+def test_keywords_match_case_insensitive():
+    assert match_message_filter(_msg(text="Hello World"), _mf(keywords=["hello"])) is True
+
+
+def test_keywords_no_match_rejected():
+    assert match_message_filter(_msg(text="bye"), _mf(keywords=["hello"])) is False
+
+
+def test_keywords_filter_type_with_no_keywords_rejected():
+    # The legacy "keywords" filter type with neither keywords nor link matching
+    # rejects everything.
+    assert match_message_filter(_msg(text="anything"), {"type": "keywords", "keywords": []}) is False
+
+
+def test_keywords_filter_type_matches():
+    assert match_message_filter(_msg(text="buy now"), {"type": "keywords", "keywords": ["buy"]}) is True
+
+
+# -- match_links ------------------------------------------------------------
+
+
+def test_match_links_https_passes():
+    assert match_message_filter(_msg(text="see https://example.com"), _mf(match_links=True)) is True
+
+
+def test_match_links_tme_passes():
+    assert match_message_filter(_msg(text="join t.me/channel"), _mf(match_links=True)) is True
+
+
+def test_match_links_no_link_rejected():
+    assert match_message_filter(_msg(text="no link here"), _mf(match_links=True)) is False
+
+
+# -- regex ------------------------------------------------------------------
+
+
+def test_regex_match():
+    assert match_message_filter(_msg(text="order 123"), _mf(regex=r"\d+")) is True
+
+
+def test_regex_no_match_rejected():
+    assert match_message_filter(_msg(text="no digits"), _mf(regex=r"\d+")) is False
+
+
+def test_regex_case_insensitive():
+    assert match_message_filter(_msg(text="HELLO"), _mf(regex=r"hello")) is True
+
+
+def test_regex_invalid_pattern_rejected():
+    assert match_message_filter(_msg(text="anything"), _mf(regex="[")) is False
+
+
+def test_regex_filter_type_empty_pattern_rejected():
+    assert match_message_filter(_msg(text="anything"), {"type": "regex", "pattern": ""}) is False
+
+
+def test_regex_filter_type_matches():
+    assert match_message_filter(_msg(text="order 99"), {"type": "regex", "pattern": r"\d+"}) is True
+
+
+# -- combined criteria (short-circuit / AND semantics) ----------------------
+
+
+def test_combined_all_pass():
+    msg = _msg(message_kind="text", media_type=None, text="buy https://x.io", forward_from_channel_id=None)
+    config = _mf(message_kinds=["text"], keywords=["buy"], match_links=True, forwarded=False)
+    assert match_message_filter(msg, config) is True
+
+
+def test_combined_one_fails_rejected():
+    # keyword present but message_kind mismatches → overall reject.
+    msg = _msg(message_kind="photo", text="buy now")
+    config = _mf(message_kinds=["text"], keywords=["buy"])
+    assert match_message_filter(msg, config) is False
+
+
+def test_anonymous_sender_filter_type_passes_for_anon():
+    msg = _msg(sender_kind=None, sender_id=None, sender_name=None)
+    assert match_message_filter(msg, {"type": "anonymous_sender"}) is True


### PR DESCRIPTION
## Что и зачем

PR-5 из #922 (финальная функция раунда). `match_message_filter` (`src/services/pipeline_filters.py`) была **radon F(42)** — одна функция, оценивающая 9 независимых критериев фильтра линейной if-цепочкой с несколькими legacy text-fallback ветками. Покрытие было слабым (2 непрямых кейса через FilterHandler), поэтому **сначала safety-тесты, потом рефактор**.

## 1. Safety-тесты (написаны против неизменённой функции)

Новый `tests/test_pipeline_filters.py` — **40 кейсов**, фиксирующих каждый критерий (`message_kinds, service_actions, media_types, sender_kinds, forwarded, has_text, keywords, match_links, regex`), legacy text-fallback, нормализацию None-config и комбинированную AND-семантику. Прогон против старого кода — зелёные (зафиксировали реальное поведение; в т.ч. выявили, что `match_message_filter(msg, None)` нормализуется в пустой keywords-фильтр и **отклоняет** всё).

## 2. Рефактор

`_extract_message_attributes` (+ `_MessageAttrs`) + по одному `_check_*`-предикату на критерий. `match_message_filter` стал `all(check(...) for check in _MESSAGE_FILTER_CHECKS)` — порядок предикатов = исходная precedence, поэтому short-circuit/AND поведение идентично.

**radon cc: `match_message_filter` F(42) → A(3)**; самый крупный предикат B(9).

## Проверка

- `ruff check` (src + tests) — clean
- `pytest tests/test_pipeline_filters.py tests/test_pipeline_graph.py` — **64 passed** (40 новых safety + 24 существующих)

Refs #922. Внешнее поведение фильтров без изменений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)