### PR TITLE
ci: включить blocking complexity-гейт --fail-on F + radon/vulture в [dev] (#923)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Import architecture contracts
         run: lint-imports --config .importlinter
 
+      # Blocking cyclomatic-complexity gate (#923). After #922/#923 reduced the
+      # last rank-F functions, main is at F:0 — this keeps it there: any function
+      # that grows back to radon rank F (CC ≥ 41) reds CI. radon/vulture ship in
+      # the [dev] extra so `pip install -e ".[dev]"` above already provides them.
+      - name: Cyclomatic-complexity gate (no rank-F functions)
+        run: python scripts/code_health.py --fail-on F
+
       # Non-blocking duplication guard (#807 dedup round 2). Current level is
       # ~0.6%; threshold 1% leaves headroom while surfacing regressions. Kept
       # advisory (continue-on-error) so it never reds CI on its own. jscpd is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.15.14",
     "pytest-cov>=7.1.0",
+    # Code-health tooling: scripts/code_health.py (radon cc/mi + vulture) and the
+    # CI cyclomatic-complexity gate (`--fail-on F`). ruff (above) is the third.
+    "radon>=6.0.1",
+    "vulture>=2.16",
 ]
 docs = ["mkdocs-material>=9.7.6"]
 # Codex SDK image provider + agent backend. Optional: all imports are lazy, so


### PR DESCRIPTION
## Что и зачем

PR-C из #923 (финальный). После #922/#923 каждая функция ранга F снижена до ≤ E — **main на F:0**. Этот PR фиксирует достижение: blocking CI-шаг, который краснит CI, если любая функция снова дорастёт до ранга F (radon CC ≥ 41).

## Изменения

1. **`.github/workflows/ci.yml`** — blocking-шаг (НЕ `continue-on-error`) после import-contracts:
   ```yaml
   - name: Cyclomatic-complexity gate (no rank-F functions)
     run: python scripts/code_health.py --fail-on F
   ```
2. **`pyproject.toml`** — `radon>=6.0.1` и `vulture>=2.16` добавлены в `[dev]`. `code_health.py` требует radon/ruff/vulture; ruff уже был в [dev], radon/vulture — нет (замеры #889 ставили их вручную). Теперь `pip install -e ".[dev]"` (который CI и так выполняет) даёт всё нужное и для гейта, и для локальных прогонов скрипта.

## Проверка

- `code_health.py --fail-on F` — **exit 0** на main (F:0)
- YAML валиден; `pip install -e ".[dev]"` подтягивает radon+vulture

## Связи
Закрывает **#923**. Замер F:0 — в #889. Гейт — blocking при F:0 (как и решено при планировании #922).

🤖 Generated with [Claude Code](https://claude.com/claude-code)