### PR TITLE
fix(limits): подключить ProductionLimitsService к рантайму + атомарный персист стоимости (#814)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -87,6 +87,22 @@ class TelegramRuntimeConfig(BaseModel):
     session_cache_dir: str = "data/telegram_sessions"
 
 
+class ProductionLimitsConfig(BaseModel):
+    """Opt-in rate-limit + daily cost cap for paid LLM/image generation (#814).
+
+    ``enabled`` defaults to False so existing deployments keep their current
+    (unlimited) behavior; the limits only apply when an operator turns them on.
+    """
+
+    enabled: bool = False
+    requests_per_minute: int = 60
+    tokens_per_minute: int = 100000
+    tokens_per_day: int = 1000000
+    cost_per_1k_tokens: float = 0.002
+    cost_per_image: float = 0.02
+    daily_cost_cap: float = 10.0
+
+
 class AppConfig(BaseModel):
     telegram: TelegramConfig = TelegramConfig()
     telegram_runtime: TelegramRuntimeConfig = TelegramRuntimeConfig()
@@ -97,6 +113,7 @@ class AppConfig(BaseModel):
     llm: LLMConfig = LLMConfig()
     agent: AgentConfig = AgentConfig()
     security: SecurityConfig = SecurityConfig()
+    production_limits: ProductionLimitsConfig = ProductionLimitsConfig()
 
 
 _ENV_PATTERN = re.compile(r"\$\{(\w+)\}")

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
+    from src.services.production_limits_service import ProductionLimitsService
     from src.services.provider_adapters import ImageAdapter
     from src.services.s3_store import S3Store
 
@@ -67,10 +68,18 @@ class ImageGenerationService:
     first available adapter is used as fallback.
     """
 
-    def __init__(self, adapters: dict[str, "ImageAdapter"] | None = None) -> None:
+    def __init__(
+        self,
+        adapters: dict[str, "ImageAdapter"] | None = None,
+        limits: "ProductionLimitsService | None" = None,
+    ) -> None:
         self._adapters: dict[str, ImageAdapter] = {}
         self._s3: S3Store | None = None
         self._last_failure: ImageGenerationFailure | None = None
+        # Optional opt-in rate-limit / daily cost cap (#814). None = unlimited
+        # (the default), so generation behaves exactly as before unless an
+        # operator enables production_limits in config.
+        self._limits = limits
         if adapters is not None:
             self._adapters = dict(adapters)
         else:
@@ -96,6 +105,19 @@ class ImageGenerationService:
                 retryable=False,
             )
             return None
+        limits = getattr(self, "_limits", None)
+        if limits is not None:
+            allowed, error = await limits.acquire(is_image=True)
+            if not allowed:
+                logger.warning("Image generation blocked by production limits (model=%s): %s", model, error)
+                self._last_failure = ImageGenerationFailure(
+                    kind="rate_limited",
+                    provider=provider_name,
+                    model=model,
+                    message=error or "production limit exceeded",
+                    retryable=True,
+                )
+                return None
         try:
             result = await adapter(text, model_id)
         except TimeoutError as exc:
@@ -115,6 +137,9 @@ class ImageGenerationService:
                 kind="error", provider=provider_name, model=model, message=str(exc),
             )
             return None
+        # The paid generation succeeded → record its cost against the daily cap.
+        if limits is not None and result:
+            await limits.record_cost(is_image=True)
         s3 = getattr(self, "_s3", None)
         if result and s3 is not None:
             if result.startswith("http"):

--- a/src/services/production_limits_service.py
+++ b/src/services/production_limits_service.py
@@ -223,6 +223,74 @@ class CostTracker:
         except Exception:
             logger.warning("CostTracker: failed to persist daily cost", exc_info=True)
 
+    @staticmethod
+    def _parse_state(state: dict | None, now: float) -> tuple[float, float]:
+        """(day_start, daily_cost) from persisted state, or a fresh day on garbage."""
+        if state:
+            try:
+                return float(state["day_start"]), float(state["daily_cost"])
+            except (KeyError, TypeError, ValueError):
+                logger.warning("CostTracker: malformed persisted daily cost: %r", state)
+        return now, 0.0
+
+    async def _read_persisted_cost(self, now: float) -> float:
+        """Read the authoritative daily cost from the DB, applying day-rollover.
+
+        Updates ``self._day_start`` so a subsequent write keeps the same window.
+        On read failure, falls back to the in-memory value (fail-open read; the
+        cap check below still guards with whatever total we have).
+        """
+        try:
+            raw = await self._db.get_setting(_COST_STATE_KEY)
+        except Exception:
+            logger.warning("CostTracker: failed to read persisted daily cost", exc_info=True)
+            return self._daily_cost
+        day_start, daily_cost = self._parse_state(safe_json_loads_dict(raw), now)
+        if now - day_start >= _DAY_SECONDS:
+            self._day_start = now
+            return 0.0
+        self._day_start = day_start
+        return daily_cost
+
+    async def _atomic_increment(self, delta: float) -> float:
+        """Read-increment-write the persisted daily cost atomically. Caller holds
+        self._lock.
+
+        Uses the connection-wide write transaction (BEGIN IMMEDIATE) so two
+        instances sharing the SQLite file accumulate into the same total instead
+        of clobbering each other (the multi-instance bug from #814). On any DB
+        error, falls back to an in-memory increment so a transient failure never
+        crashes the caller (matching the previous best-effort persist).
+        """
+        now = time.time()
+        try:
+            async with self._db.transaction() as conn:
+                cur = await conn.execute(
+                    "SELECT value FROM settings WHERE key = ?", (_COST_STATE_KEY,)
+                )
+                row = await cur.fetchone()
+                day_start, daily_cost = self._parse_state(
+                    safe_json_loads_dict(row[0] if row else None), now
+                )
+                if now - day_start >= _DAY_SECONDS:
+                    day_start, daily_cost = now, 0.0
+                daily_cost += delta
+                self._day_start = day_start
+                await conn.execute(
+                    "INSERT INTO settings (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (
+                        _COST_STATE_KEY,
+                        safe_json_dumps({"daily_cost": daily_cost, "day_start": day_start}),
+                    ),
+                )
+            return daily_cost
+        except Exception:
+            logger.warning("CostTracker: atomic cost increment failed; counting in-memory", exc_info=True)
+            self._maybe_reset_day(now)
+            self._daily_cost += delta
+            return self._daily_cost
+
     async def estimate_cost(
         self,
         tokens: int = 0,
@@ -256,9 +324,16 @@ class CostTracker:
             Tuple of (allowed, estimated_cost)
         """
         async with self._lock:
-            await self._ensure_loaded()
-            if self._maybe_reset_day(time.time()):
-                await self._persist()
+            now = time.time()
+            if self._db is not None:
+                # Re-read the authoritative total so a sibling instance's spend is
+                # seen before we approve another call against the shared cap (#814).
+                self._daily_cost = await self._read_persisted_cost(now)
+                self._loaded = True
+            else:
+                await self._ensure_loaded()
+                if self._maybe_reset_day(now):
+                    await self._persist()
 
             estimated = await self.estimate_cost(tokens, is_image)
 
@@ -270,12 +345,14 @@ class CostTracker:
     async def record_cost(self, tokens: int = 0, is_image: bool = False) -> float:
         """Record cost for a request after it actually executes."""
         async with self._lock:
-            await self._ensure_loaded()
-            self._maybe_reset_day(time.time())
-
             estimated = await self.estimate_cost(tokens, is_image)
-            self._daily_cost += estimated
-            await self._persist()
+            if self._db is None:
+                self._maybe_reset_day(time.time())
+                self._daily_cost += estimated
+                return estimated
+            # DB-authoritative atomic accumulation across instances (#814).
+            self._daily_cost = await self._atomic_increment(estimated)
+            self._loaded = True
             return estimated
 
     def get_daily_cost(self) -> float:
@@ -305,6 +382,26 @@ class ProductionLimitsService:
         self._db = db
         self._rate_limiter = RateLimiter(rate_config)
         self._cost_tracker = CostTracker(cost_config, db=db)
+
+    @classmethod
+    def from_config(cls, db: Database, config) -> "ProductionLimitsService | None":
+        """Build from ``AppConfig.production_limits``; ``None`` when disabled (#814)."""
+        pl = getattr(config, "production_limits", None)
+        if pl is None or not pl.enabled:
+            return None
+        return cls(
+            db,
+            RateLimitConfig(
+                requests_per_minute=pl.requests_per_minute,
+                tokens_per_minute=pl.tokens_per_minute,
+                tokens_per_day=pl.tokens_per_day,
+            ),
+            CostConfig(
+                cost_per_1k_tokens=pl.cost_per_1k_tokens,
+                cost_per_image=pl.cost_per_image,
+                daily_cost_cap=pl.daily_cost_cap,
+            ),
+        )
 
     async def acquire(
         self,
@@ -337,6 +434,15 @@ class ProductionLimitsService:
             return False, "Rate limit timeout"
 
         return True, None
+
+    async def record_cost(self, tokens: int = 0, is_image: bool = False) -> float:
+        """Record the actual cost of a completed call against the daily cap.
+
+        Pair with ``acquire`` for call sites that don't use ``execute_with_retry``
+        (e.g. image generation): ``acquire`` reserves the rate slot and checks the
+        cap, ``record_cost`` books the spend once the paid call has succeeded.
+        """
+        return await self._cost_tracker.record_cost(tokens, is_image)
 
     async def execute_with_retry(
         self,

--- a/src/services/task_handlers/base.py
+++ b/src/services/task_handlers/base.py
@@ -66,7 +66,14 @@ async def build_image_service(context: TaskHandlerContext) -> "ImageGenerationSe
         except Exception:
             logger.warning("Failed to load image provider configs from DB", exc_info=True)
             adapters = {}
-    return ImageGenerationService(adapters=adapters)
+    # Opt-in production rate-limit / daily cost cap (#814); None unless the
+    # operator enabled production_limits, so default behavior is unchanged.
+    limits = None
+    if context.db and context.config:
+        from src.services.production_limits_service import ProductionLimitsService
+
+        limits = ProductionLimitsService.from_config(context.db, context.config)
+    return ImageGenerationService(adapters=adapters, limits=limits)
 
 
 async def resolve_llm_provider_service(context: TaskHandlerContext) -> object:

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -856,3 +856,71 @@ async def test_local_path_uploaded_via_upload_file():
     result = await svc.generate("hf:m", "x")
     assert result == "https://s3.example.com/presigned"
     s3.upload_file.assert_awaited_once()
+
+
+# ── production limits enforcement (#814) ──
+
+
+@pytest.mark.anyio
+async def test_generate_blocked_when_cost_cap_exceeded():
+    """With production limits enabled and the cap already exceeded, generate is
+    blocked BEFORE the (paid) adapter runs (#814)."""
+    from src.services.production_limits_service import (
+        CostConfig,
+        ProductionLimitsService,
+        RateLimitConfig,
+    )
+
+    db = MagicMock()
+    db.get_setting = AsyncMock(return_value=None)
+    # cost_per_image (10) already exceeds the cap (5) on the very first image.
+    limits = ProductionLimitsService(
+        db, RateLimitConfig(), CostConfig(cost_per_image=10.0, daily_cost_cap=5.0)
+    )
+    called = False
+
+    async def fake(text, model_id):
+        nonlocal called
+        called = True
+        return "http://img"
+
+    svc = ImageGenerationService.__new__(ImageGenerationService)
+    svc._adapters = {"together": fake}
+    svc._s3 = None
+    svc._last_failure = None
+    svc._limits = limits
+
+    result = await svc.generate("together:flux", "a cat")
+    assert result is None
+    assert called is False  # the paid adapter never ran
+    assert svc._last_failure is not None
+    assert svc._last_failure.kind == "rate_limited"
+
+
+@pytest.mark.anyio
+async def test_generate_records_cost_when_allowed():
+    """When within limits, generate proceeds and records the image cost (#814)."""
+    from src.services.production_limits_service import (
+        CostConfig,
+        ProductionLimitsService,
+        RateLimitConfig,
+    )
+
+    db = MagicMock()
+    db.get_setting = AsyncMock(return_value=None)
+    limits = ProductionLimitsService(
+        db, RateLimitConfig(), CostConfig(cost_per_image=1.0, daily_cost_cap=100.0)
+    )
+
+    async def fake(text, model_id):
+        return "http://img/result.png"
+
+    svc = ImageGenerationService.__new__(ImageGenerationService)
+    svc._adapters = {"together": fake}
+    svc._s3 = None
+    svc._last_failure = None
+    svc._limits = limits
+
+    result = await svc.generate("together:flux", "a cat")
+    assert result == "http://img/result.png"
+    assert limits._cost_tracker.get_daily_cost() == pytest.approx(1.0)

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -492,3 +492,57 @@ async def test_execute_with_retry_rate_limit_raises():
     service.acquire = AsyncMock(return_value=(False, "Rate limit timeout"))
     with pytest.raises(RuntimeError, match="Rate limit"):
         await service.execute_with_retry(func=AsyncMock(return_value="x"), tokens=10)
+
+
+# === #814: atomic cost accumulation + config gating ===
+
+
+@pytest.mark.anyio
+async def test_cost_tracker_atomic_across_instances(db):
+    """Two trackers sharing one DB accumulate into the same persisted total
+    instead of clobbering each other's write (multi-instance bug, #814)."""
+    import json
+
+    cfg = CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=100.0)
+    a = CostTracker(cfg, db=db)
+    b = CostTracker(cfg, db=db)
+
+    await a.record_cost(tokens=1000)  # +1.0
+    await b.record_cost(tokens=2000)  # +2.0 — must see a's spend, not overwrite it
+
+    assert b.get_daily_cost() == pytest.approx(3.0)
+    # The persisted authoritative total is the accumulation, not the last writer.
+    raw = await db.get_setting("production_limits_daily_cost")
+    assert json.loads(raw)["daily_cost"] == pytest.approx(3.0)
+    # A fresh instance sees the shared total when checking the cap.
+    fresh = CostTracker(cfg, db=db)
+    await fresh.check_cost_cap(tokens=0)
+    assert fresh.get_daily_cost() == pytest.approx(3.0)
+
+
+@pytest.mark.anyio
+async def test_cost_cap_blocks_using_other_instances_spend(db):
+    """The cap is enforced against the shared persisted total: one instance can be
+    blocked by spend another instance recorded (#814)."""
+    cfg = CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=2.5)
+    a = CostTracker(cfg, db=db)
+    b = CostTracker(cfg, db=db)
+    await a.record_cost(tokens=2000)  # 2.0 of the 2.5 cap
+    allowed, _ = await b.check_cost_cap(tokens=1000)  # would push to 3.0 > 2.5
+    assert allowed is False
+
+
+def test_from_config_disabled_returns_none():
+    from src.config import AppConfig
+
+    cfg = AppConfig()  # production_limits.enabled defaults to False
+    assert ProductionLimitsService.from_config(MagicMock(), cfg) is None
+
+
+def test_from_config_enabled_builds_service():
+    from src.config import AppConfig, ProductionLimitsConfig
+
+    cfg = AppConfig(production_limits=ProductionLimitsConfig(enabled=True, daily_cost_cap=5.0))
+    svc = ProductionLimitsService.from_config(MagicMock(), cfg)
+    assert svc is not None
+    assert svc._cost_tracker._config.daily_cost_cap == 5.0


### PR DESCRIPTION
## Баг

`ProductionLimitsService` был «осиротевшим» — инстанцировался только в тестах, ни на одном рантайм-пути не вызывался. Плюс персист дневной стоимости был read-modify-write, который затирал тоталы других инстансов (multi-instance на общем SQLite-файле).

## Фикс

**Подключаем и делаем стоимость durable:**

- **`ProductionLimitsConfig`** (config.py) — opt-in, **`enabled=False` по умолчанию**: существующие деплои сохраняют текущее (без лимитов) поведение; caps применяются только если оператор включит.
- **Атомарный персист стоимости**: `CostTracker.record_cost` теперь делает read-increment-write под connection-wide `BEGIN IMMEDIATE` (БД — источник истины), а `check_cost_cap` перечитывает тотал — два инстанса **аккумулируют в один общий тотал**, а не затирают друг друга. При ошибке БД — fallback на in-memory инкремент (broken-db/restart тесты сохранены).
- **`ProductionLimitsService.from_config()`** — строит сервис из конфига (None если disabled); публичный `record_cost()` для не-retry call-site'ов.
- **Подключено в image generation** (`build_image_service` → `ImageGenerationService`): при `enabled` `generate()` делает `acquire()` перед платным вызовом адаптера и `record_cost()` при успехе; при disabled (`limits=None`) путь **байт-в-байт как раньше**.

Image generation — конкретный enforced рантайм-путь; распространение того же `acquire()/record_cost()` паттерна на text-LLM и translate — инкрементальный follow-up (конфиг, атомарный ledger и wiring уже на месте).

## Проверка

- `ruff` (src+tests) — clean
- Тесты: атомарная cross-instance аккумуляция + cap против общего тотала, `from_config` gating, gated image-gen enforcement (блок при cap / запись стоимости при allowed). **383 связанных теста проходят.**

Closes #814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)