### PR TITLE
feat(export): worker EXPORT task — media download end-to-end (#834, PR 3/3)

### DIFF
--- a/src/cli/commands/export.py
+++ b/src/cli/commands/export.py
@@ -66,7 +66,7 @@ def run(args: argparse.Namespace) -> None:
 
 
 async def _run_telegram(db, args: argparse.Namespace) -> None:
-    from src.services.export_service import resolve_max_file_size_mb, run_offline_export
+    from src.services.export_service import run_offline_export
 
     channel_id = getattr(args, "channel_id", None)
     if not channel_id:
@@ -74,14 +74,10 @@ async def _run_telegram(db, args: argparse.Namespace) -> None:
         return
 
     if args.with_media:
-        # Media download needs the live worker (PR-3); the offline CLI path
-        # still produces a faithful tree with "not included" placeholders.
-        max_mb = await resolve_max_file_size_mb(db, args.max_file_size)
-        print(
-            "Note: --with-media requires a running worker to fetch files; "
-            f"this offline export marks media as not included (skip threshold {max_mb} MB).",
-            file=sys.stderr,
-        )
+        # Media download needs the live worker (owns the ClientPool); enqueue an
+        # EXPORT task and optionally wait for it.
+        await _enqueue_media_export(db, args, int(channel_id))
+        return
 
     summary = await run_offline_export(
         db,
@@ -106,6 +102,53 @@ async def _run_telegram(db, args: argparse.Namespace) -> None:
             f"{summary.message_count} (raise --limit to include more).",
             file=sys.stderr,
         )
+
+
+async def _enqueue_media_export(db, args: argparse.Namespace, channel_id: int) -> None:
+    from src.models import CollectionTaskType, ExportTaskPayload
+
+    payload = ExportTaskPayload(
+        channel_id=channel_id,
+        fmt=args.export_format,
+        with_media=True,
+        max_file_size_mb=args.max_file_size,
+        date_from=args.date_from,
+        date_to=args.date_to,
+        limit=int(args.limit),
+        out_dir=args.output,
+        requested_by="cli",
+    )
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.EXPORT, title=f"export channel {channel_id} (media)", payload=payload
+    )
+    print(
+        f"Enqueued media export task #{task_id}; the worker will download media and build the tree.",
+        file=sys.stderr,
+    )
+    if args.wait:
+        await _poll_export_task(db, task_id)
+
+
+async def _poll_export_task(db, task_id: int, *, timeout: float = 600.0, interval: float = 2.0) -> None:
+    from src.models import CollectionTaskStatus
+
+    terminal = {CollectionTaskStatus.COMPLETED, CollectionTaskStatus.FAILED, CollectionTaskStatus.CANCELLED}
+    waited = 0.0
+    while waited < timeout:
+        task = await db.repos.tasks.get_collection_task(task_id)
+        if task and task.status in terminal:
+            if task.status == CollectionTaskStatus.COMPLETED:
+                print(f"Export task #{task_id} completed: {task.note or ''}", file=sys.stderr)
+            else:
+                detail = task.error or task.note or ""
+                print(f"Export task #{task_id} {task.status.value}: {detail}", file=sys.stderr)
+            return
+        await asyncio.sleep(interval)
+        waited += interval
+    print(
+        f"Export task #{task_id} still pending after {int(timeout)}s — is the worker running?",
+        file=sys.stderr,
+    )
 
 
 def _export_json(messages) -> str:

--- a/src/cli/commands/export.py
+++ b/src/cli/commands/export.py
@@ -139,10 +139,11 @@ async def _poll_export_task(db, task_id: int, *, timeout: float = 600.0, interva
         if task and task.status in terminal:
             if task.status == CollectionTaskStatus.COMPLETED:
                 print(f"Export task #{task_id} completed: {task.note or ''}", file=sys.stderr)
-            else:
-                detail = task.error or task.note or ""
-                print(f"Export task #{task_id} {task.status.value}: {detail}", file=sys.stderr)
-            return
+                return
+            detail = task.error or task.note or ""
+            print(f"Export task #{task_id} {task.status.value}: {detail}", file=sys.stderr)
+            # Non-zero exit so scripts using --wait can detect failure (#939 review).
+            sys.exit(1)
         await asyncio.sleep(interval)
         waited += interval
     print(

--- a/src/cli/commands/export.py
+++ b/src/cli/commands/export.py
@@ -150,6 +150,9 @@ async def _poll_export_task(db, task_id: int, *, timeout: float = 600.0, interva
         f"Export task #{task_id} still pending after {int(timeout)}s — is the worker running?",
         file=sys.stderr,
     )
+    # Distinct exit code so scripts can tell a timeout apart from a task failure
+    # (exit 1) and from success (exit 0) — #939 review.
+    sys.exit(2)
 
 
 def _export_json(messages) -> str:

--- a/src/cli/parser_domains/export.py
+++ b/src/cli/parser_domains/export.py
@@ -21,7 +21,9 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     tg.add_argument("--format", choices=["json", "html", "both"], default="json",
                     dest="export_format", help="Output format (default: json)")
     tg.add_argument("--with-media", action="store_true", default=False, dest="with_media",
-                    help="Download media artifacts (requires running worker)")
+                    help="Download media artifacts (enqueues a worker task)")
+    tg.add_argument("--wait", action="store_true", default=False,
+                    help="With --with-media: poll the enqueued task until it finishes")
     tg.add_argument("--max-file-size", type=int, default=None, dest="max_file_size",
                     help="Skip files larger than N MB (default: from settings or 3)")
     tg.add_argument("--date-from", default=None, dest="date_from", help="Start date YYYY-MM-DD")

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -12,6 +12,7 @@ from src.models import (
     CollectionTaskType,
     ContentGenerateTaskPayload,
     ContentPublishTaskPayload,
+    ExportTaskPayload,
     FilterAnalyzeTaskPayload,
     PipelineRunTaskPayload,
     SqStatsTaskPayload,
@@ -76,6 +77,8 @@ class CollectionTasksRepository:
             return ContentPublishTaskPayload.model_validate(parsed)
         if task_kind == CollectionTaskType.TRANSLATE_BATCH.value:
             return TranslateBatchTaskPayload.model_validate(parsed)
+        if task_kind == CollectionTaskType.EXPORT.value:
+            return ExportTaskPayload.model_validate(parsed)
         return parsed
 
     @staticmethod
@@ -104,6 +107,7 @@ class CollectionTasksRepository:
                 ContentGenerateTaskPayload,
                 ContentPublishTaskPayload,
                 TranslateBatchTaskPayload,
+                ExportTaskPayload,
             ),
         ):
             return payload.model_dump_json()
@@ -614,6 +618,7 @@ class CollectionTasksRepository:
             | ContentGenerateTaskPayload
             | ContentPublishTaskPayload
             | TranslateBatchTaskPayload
+            | ExportTaskPayload
             | None
         ) = None,
         run_after: datetime | None = None,

--- a/src/models.py
+++ b/src/models.py
@@ -143,6 +143,7 @@ class CollectionTaskType(StrEnum):
     CONTENT_GENERATE = "content_generate"
     CONTENT_PUBLISH = "content_publish"
     TRANSLATE_BATCH = "translate_batch"
+    EXPORT = "export"
 
 
 class TelegramCommandStatus(StrEnum):
@@ -213,6 +214,19 @@ class TranslateBatchTaskPayload(BaseModel):
     last_processed_id: int = 0
 
 
+class ExportTaskPayload(BaseModel):
+    task_kind: str = CollectionTaskType.EXPORT.value
+    channel_id: int
+    fmt: str = "json"  # json | html | both
+    with_media: bool = False
+    max_file_size_mb: int | None = None
+    date_from: str | None = None
+    date_to: str | None = None
+    limit: int = 5000
+    out_dir: str | None = None
+    requested_by: str | None = None
+
+
 class CollectionTask(BaseModel):
     id: int | None = None
     channel_id: int | None = None
@@ -233,6 +247,7 @@ class CollectionTask(BaseModel):
         | ContentGenerateTaskPayload
         | ContentPublishTaskPayload
         | TranslateBatchTaskPayload
+        | ExportTaskPayload
         | None
     ) = None
     parent_task_id: int | None = None

--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -217,7 +217,7 @@ class TranslateBatchTaskPayload(BaseModel):
 class ExportTaskPayload(BaseModel):
     task_kind: str = CollectionTaskType.EXPORT.value
     channel_id: int
-    fmt: str = "json"  # json | html | both
+    fmt: Literal["json", "html", "both"] = "json"
     with_media: bool = False
     max_file_size_mb: int | None = None
     date_from: str | None = None

--- a/src/services/task_handlers/__init__.py
+++ b/src/services/task_handlers/__init__.py
@@ -1,5 +1,6 @@
 from src.services.task_handlers.base import TaskHandler, TaskHandlerContext
 from src.services.task_handlers.content import ContentTaskHandler
+from src.services.task_handlers.export import ExportTaskHandler
 from src.services.task_handlers.filter_analyze import FilterAnalyzeTaskHandler
 from src.services.task_handlers.photo import PhotoTaskHandler
 from src.services.task_handlers.pipeline import PipelineTaskHandler
@@ -8,6 +9,7 @@ from src.services.task_handlers.translation import TranslationTaskHandler
 
 __all__ = [
     "ContentTaskHandler",
+    "ExportTaskHandler",
     "FilterAnalyzeTaskHandler",
     "PhotoTaskHandler",
     "PipelineTaskHandler",

--- a/src/services/task_handlers/export.py
+++ b/src/services/task_handlers/export.py
@@ -114,14 +114,23 @@ class ExportTaskHandler:
 
         svc = TelegramActionService(ctx.client_pool)
         max_size_bytes = await resolve_max_file_size_mb(ctx.db, payload.max_file_size_mb) * 1024 * 1024
+        # Prefer the @username for public channels: the numeric PeerChannel path
+        # cannot resolve without a cached access hash on the chosen account, while
+        # the username always resolves (Codex review on #939).
+        chat_identity = channel.username or channel.channel_id
+        logger.info("EXPORT media download for channel %s via %s", channel.channel_id, phone)
         artifacts: dict[int, MediaArtifact] = {}
         for message in messages:
+            if ctx.stop_event.is_set():
+                # Honour graceful shutdown — build the export from what we have.
+                logger.info("EXPORT media download interrupted by stop_event")
+                break
             if not message.media_type:
                 continue
             try:
                 outcome = await svc.download_media_sized(
                     phone=phone,
-                    chat_id=channel.channel_id,
+                    chat_id=chat_identity,
                     message_id=message.message_id,
                     output_dir=target,
                     max_size_bytes=max_size_bytes,

--- a/src/services/task_handlers/export.py
+++ b/src/services/task_handlers/export.py
@@ -1,0 +1,153 @@
+"""Worker task handler for Telegram-Desktop export with media (#834, PR-3).
+
+Runs in the worker container (which owns the live ClientPool). For with_media
+exports it downloads each message's media via TelegramActionService (size-skip
+from PR-2), then feeds the resulting artifacts to the TelegramExportBuilder
+(PR-1). Without media it produces the same offline "not included" tree the CLI/
+web inline path does.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType, ExportTaskPayload
+from src.services.export_service import (
+    default_export_dir,
+    gather_channel_messages,
+    resolve_html_page_size,
+    resolve_max_file_size_mb,
+)
+from src.services.task_handlers.base import TaskHandlerContext
+from src.services.telegram_export_builder import (
+    MediaArtifact,
+    TelegramExportBuilder,
+    offline_media_resolver,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ExportTaskHandler:
+    task_types = (CollectionTaskType.EXPORT,)
+
+    def __init__(self, context: TaskHandlerContext):
+        self._context = context
+
+    async def handle(self, task: CollectionTask) -> None:
+        ctx = self._context
+        if task.id is None:
+            return
+        payload = task.payload
+        if not isinstance(payload, ExportTaskPayload):
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Invalid EXPORT payload"
+            )
+            return
+        if ctx.db is None:
+            await ctx.tasks.update_collection_task(
+                task.id, CollectionTaskStatus.FAILED, error="Export environment not configured"
+            )
+            return
+
+        try:
+            channel = await ctx.db.get_channel_by_channel_id(payload.channel_id)
+            if channel is None:
+                await ctx.tasks.update_collection_task(
+                    task.id, CollectionTaskStatus.COMPLETED, note=f"Channel {payload.channel_id} not found"
+                )
+                return
+            messages, truncated = await gather_channel_messages(
+                ctx.db,
+                payload.channel_id,
+                date_from=payload.date_from,
+                date_to=payload.date_to,
+                limit=payload.limit,
+            )
+            if not messages:
+                await ctx.tasks.update_collection_task(
+                    task.id, CollectionTaskStatus.COMPLETED, note="No messages to export"
+                )
+                return
+
+            target = payload.out_dir or str(default_export_dir(payload.channel_id))
+            page_size = await resolve_html_page_size(ctx.db)
+
+            resolver = offline_media_resolver
+            media_note = "media not requested"
+            if payload.with_media:
+                resolver, media_note = await self._build_media_resolver(channel, messages, payload, target)
+
+            summary = await TelegramExportBuilder().write_export(
+                target,
+                channel,
+                messages,
+                fmt=payload.fmt,
+                media_resolver=resolver,
+                page_size=page_size,
+                truncated=truncated,
+            )
+            await ctx.tasks.update_collection_task_progress(task.id, summary.message_count)
+            note = (
+                f"Exported {summary.message_count} msgs to {summary.out_dir} "
+                f"(media: {summary.media_included} ok / {summary.media_skipped} skipped; {media_note}"
+                f"{'; truncated' if truncated else ''})"
+            )
+            await ctx.tasks.update_collection_task(task.id, CollectionTaskStatus.COMPLETED, note=note)
+        except Exception as exc:  # noqa: BLE001 — surface any failure on the task row
+            logger.exception("EXPORT task %s failed", task.id)
+            await ctx.tasks.update_collection_task(task.id, CollectionTaskStatus.FAILED, error=str(exc))
+
+    async def _build_media_resolver(self, channel, messages, payload: ExportTaskPayload, target: str):
+        """Pre-download media into the export tree, return a sync resolver + note.
+
+        The builder's resolver is synchronous, so all downloads happen here up
+        front and the resolver just looks artifacts up by message_id.
+        """
+        ctx = self._context
+        phone = self._resolve_phone(channel)
+        if ctx.client_pool is None or phone is None:
+            # No live account available — fall back to the offline representation.
+            return offline_media_resolver, "no account for media download"
+
+        from src.services.telegram_actions import TelegramActionService
+
+        svc = TelegramActionService(ctx.client_pool)
+        max_size_bytes = await resolve_max_file_size_mb(ctx.db, payload.max_file_size_mb) * 1024 * 1024
+        artifacts: dict[int, MediaArtifact] = {}
+        for message in messages:
+            if not message.media_type:
+                continue
+            try:
+                outcome = await svc.download_media_sized(
+                    phone=phone,
+                    chat_id=channel.channel_id,
+                    message_id=message.message_id,
+                    output_dir=target,
+                    max_size_bytes=max_size_bytes,
+                )
+            except Exception:
+                logger.warning("media download failed for msg %s; marking not included", message.message_id)
+                artifacts[message.message_id] = MediaArtifact(
+                    kind="file", skipped=True, reason="download_failed"
+                )
+                continue
+            if outcome.skipped:
+                artifacts[message.message_id] = MediaArtifact(
+                    kind=outcome.kind, skipped=True, reason=outcome.reason, size_bytes=outcome.size_bytes
+                )
+            else:
+                artifacts[message.message_id] = MediaArtifact(
+                    kind=outcome.kind, rel_path=outcome.rel_path, size_bytes=outcome.size_bytes
+                )
+
+        def resolver(message):
+            return artifacts.get(message.message_id)
+
+        return resolver, f"downloaded via {phone}"
+
+    def _resolve_phone(self, channel) -> str | None:
+        if getattr(channel, "preferred_phone", None):
+            return channel.preferred_phone
+        clients = getattr(self._context.client_pool, "clients", None) or {}
+        return next(iter(clients), None)

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -12,6 +12,7 @@ from src.live_runtime_pause import LiveRuntimePauseGate
 from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType
 from src.services.task_handlers import (
     ContentTaskHandler,
+    ExportTaskHandler,
     FilterAnalyzeTaskHandler,
     PhotoTaskHandler,
     PipelineTaskHandler,
@@ -41,6 +42,7 @@ _HANDLER_CLASSES = (
     PipelineTaskHandler,
     ContentTaskHandler,
     TranslationTaskHandler,
+    ExportTaskHandler,
 )
 
 HANDLED_TYPES = [
@@ -265,6 +267,7 @@ class UnifiedDispatcher:
                 CollectionTaskType.CONTENT_GENERATE: self._handle_content_generate,
                 CollectionTaskType.CONTENT_PUBLISH: self._handle_content_publish,
                 CollectionTaskType.TRANSLATE_BATCH: self._handle_translate_batch,
+                CollectionTaskType.EXPORT: self._handle_export,
             }
             return self.__handler_map
 
@@ -305,3 +308,6 @@ class UnifiedDispatcher:
 
     async def _handle_translate_batch(self, task: CollectionTask) -> None:
         await self._handler(TranslationTaskHandler).handle_translate_batch(task)
+
+    async def _handle_export(self, task: CollectionTask) -> None:
+        await self._handler(ExportTaskHandler).handle(task)

--- a/src/web/routes/export.py
+++ b/src/web/routes/export.py
@@ -1,9 +1,9 @@
 """Telegram-Desktop export route (issue #834).
 
 Per the operator's choice the export tree is written under ``data/exports/`` on
-the server and the response returns the path + summary (no file download). The
-heavy media-download path runs in the worker (PR-3); this route does the offline
-text/metadata export inline.
+the server and the response returns the path + summary (no file download). A
+text-only export runs inline; a ``with_media`` export is enqueued as a worker
+EXPORT task (the worker owns the live Telegram clients needed to fetch media).
 """
 
 from __future__ import annotations
@@ -13,7 +13,8 @@ import logging
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import JSONResponse
 
-from src.services.export_service import resolve_max_file_size_mb, run_offline_export
+from src.models import CollectionTaskType, ExportTaskPayload
+from src.services.export_service import run_offline_export
 from src.web import deps
 
 logger = logging.getLogger(__name__)
@@ -33,18 +34,26 @@ async def export_channel(
 ) -> JSONResponse:
     fmt = format if format in ("json", "html", "both") else "json"
     # Cap the inline export so a single web request can't pull a 100k-message
-    # channel into the event loop (Claude review on #937). Larger exports should
-    # go through the worker EXPORT task (PR-3).
+    # channel into the event loop (Claude review on #937).
     limit = max(1, min(limit, 10_000))
     db = deps.get_db(request)
 
-    note = None
     if with_media:
-        max_mb = await resolve_max_file_size_mb(db, max_file_size)
-        note = (
-            "Скачивание медиа выполняется worker'ом; офлайн-экспорт помечает медиа как "
-            f"«не включено» (порог пропуска {max_mb} МБ)."
+        # Media download needs the worker's live ClientPool — enqueue a task.
+        payload = ExportTaskPayload(
+            channel_id=channel_id,
+            fmt=fmt,
+            with_media=True,
+            max_file_size_mb=max_file_size,
+            date_from=date_from or None,
+            date_to=date_to or None,
+            limit=limit,
+            requested_by="web",
         )
+        task_id = await db.repos.tasks.create_generic_task(
+            CollectionTaskType.EXPORT, title=f"export channel {channel_id} (media)", payload=payload
+        )
+        return JSONResponse({"task_id": task_id, "status": "enqueued", "with_media": True})
 
     try:
         summary = await run_offline_export(
@@ -71,6 +80,5 @@ async def export_channel(
             "media_included": summary.media_included,
             "media_skipped": summary.media_skipped,
             "skipped_files": summary.skipped,
-            "note": note,
         }
     )

--- a/tests/routes/test_export_routes.py
+++ b/tests/routes/test_export_routes.py
@@ -48,11 +48,17 @@ async def test_export_channel_no_messages_returns_404(route_client, base_app, tm
 
 
 @pytest.mark.anyio
-async def test_export_channel_with_media_note(route_client, base_app, tmp_path, monkeypatch):
+async def test_export_channel_with_media_enqueues_task(route_client, base_app, tmp_path, monkeypatch):
     _, db, _ = base_app
     monkeypatch.setattr("src.services.export_service.EXPORT_ROOT", tmp_path)
     await _seed_messages(db)
 
+    # with_media needs the worker's live clients → the route enqueues a task.
     resp = await route_client.post("/channels/100/export", data={"format": "json", "with_media": "true"})
     assert resp.status_code == 200
-    assert resp.json()["note"] is not None
+    body = resp.json()
+    assert body["status"] == "enqueued"
+    assert body["with_media"] is True
+    assert isinstance(body["task_id"], int)
+    task = await db.repos.tasks.get_collection_task(body["task_id"])
+    assert task is not None and task.payload.with_media is True

--- a/tests/test_export_task_handler.py
+++ b/tests/test_export_task_handler.py
@@ -8,6 +8,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+from pydantic import ValidationError
+
 from src.models import (
     Channel,
     CollectionTaskStatus,
@@ -19,9 +22,9 @@ from src.services.task_handlers.base import TaskHandlerContext
 from src.services.task_handlers.export import ExportTaskHandler
 
 
-async def _seed(db, channel_id=900, *, with_media_msg=False, **channel_kw):
+async def _seed(db, channel_id=900, *, with_media_msg=False, username="chan", **channel_kw):
     await db.repos.channels.add_channel(
-        Channel(channel_id=channel_id, title="Chan", username="chan", channel_type="channel", **channel_kw)
+        Channel(channel_id=channel_id, title="Chan", username=username, channel_type="channel", **channel_kw)
     )
     for mid in (1, 2):
         await db.repos.messages.insert_message(
@@ -140,6 +143,76 @@ async def test_handle_with_media_downloads_via_action_service(db, tmp_path, monk
     data = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
     media_msg = next(m for m in data["messages"] if m["id"] == 3)
     assert media_msg["photo"] == "photos/3.jpg"  # downloaded, linked relative path
+
+
+def test_export_payload_rejects_invalid_fmt():
+    with pytest.raises(ValidationError):
+        ExportTaskPayload(channel_id=1, fmt="pdf")
+
+
+async def test_handle_with_media_uses_username_for_resolve(db, tmp_path, monkeypatch):
+    await _seed(db, 905, with_media_msg=True, username="publicchan")
+
+    from src.services.telegram_actions import MediaDownloadOutcome
+
+    captured = {}
+
+    class FakeActionService:
+        def __init__(self, pool):
+            pass
+
+        async def download_media_sized(self, *, phone, chat_id, message_id, output_dir, max_size_bytes):
+            captured["chat_id"] = chat_id
+            return MediaDownloadOutcome(
+                phone=phone, kind="photo", subdir="photos",
+                rel_path=f"photos/{message_id}.jpg", size_bytes=100,
+            )
+
+    monkeypatch.setattr("src.services.telegram_actions.TelegramActionService", FakeActionService)
+    pool = MagicMock()
+    pool.clients = {"+1": object()}
+    task = await _make_task(db, ExportTaskPayload(channel_id=905, with_media=True, out_dir=str(tmp_path)))
+    await ExportTaskHandler(_context(db, client_pool=pool)).handle(task)
+    # Public channel → resolve by @username, not the bare numeric id.
+    assert captured["chat_id"] == "publicchan"
+
+
+async def test_handle_with_media_stops_on_stop_event(db, tmp_path, monkeypatch):
+    await _seed(db, 906, with_media_msg=True)
+
+    called = {"n": 0}
+
+    class FakeActionService:
+        def __init__(self, pool):
+            pass
+
+        async def download_media_sized(self, **kw):
+            called["n"] += 1
+            raise AssertionError("should not download after stop_event")
+
+    monkeypatch.setattr("src.services.telegram_actions.TelegramActionService", FakeActionService)
+    pool = MagicMock()
+    pool.clients = {"+1": object()}
+    ctx = _context(db, client_pool=pool)
+    ctx.stop_event.set()  # request shutdown before downloads start
+
+    task = await _make_task(db, ExportTaskPayload(channel_id=906, with_media=True, out_dir=str(tmp_path)))
+    await ExportTaskHandler(ctx).handle(task)
+    refreshed = await db.repos.tasks.get_collection_task(task.id)
+    assert refreshed.status == CollectionTaskStatus.COMPLETED
+    assert called["n"] == 0  # no downloads attempted
+
+
+async def test_poll_export_task_exits_nonzero_on_failure(db):
+    from src.cli.commands.export import _poll_export_task
+
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.EXPORT, title="x", payload=ExportTaskPayload(channel_id=1)
+    )
+    await db.repos.tasks.update_collection_task(task_id, CollectionTaskStatus.FAILED, error="boom")
+    with pytest.raises(SystemExit) as exc:
+        await _poll_export_task(db, task_id, timeout=1.0, interval=0.01)
+    assert exc.value.code == 1
 
 
 async def test_handle_with_media_skips_oversized_and_records(db, tmp_path, monkeypatch):

--- a/tests/test_export_task_handler.py
+++ b/tests/test_export_task_handler.py
@@ -1,0 +1,176 @@
+"""Worker EXPORT task handler + payload wiring (issue #834, PR-3)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.models import (
+    Channel,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    ExportTaskPayload,
+    Message,
+)
+from src.services.task_handlers.base import TaskHandlerContext
+from src.services.task_handlers.export import ExportTaskHandler
+
+
+async def _seed(db, channel_id=900, *, with_media_msg=False, **channel_kw):
+    await db.repos.channels.add_channel(
+        Channel(channel_id=channel_id, title="Chan", username="chan", channel_type="channel", **channel_kw)
+    )
+    for mid in (1, 2):
+        await db.repos.messages.insert_message(
+            Message(channel_id=channel_id, message_id=mid, text=f"m{mid}",
+                    date=datetime(2026, 6, 12, 12, mid, tzinfo=timezone.utc))
+        )
+    if with_media_msg:
+        await db.repos.messages.insert_message(
+            Message(channel_id=channel_id, message_id=3, text="pic", media_type="photo",
+                    date=datetime(2026, 6, 12, 12, 3, tzinfo=timezone.utc))
+        )
+
+
+def _context(db, *, client_pool=None) -> TaskHandlerContext:
+    return TaskHandlerContext(
+        collector=MagicMock(),
+        channel_bundle=MagicMock(),
+        tasks=db.repos.tasks,
+        stop_event=asyncio.Event(),
+        db=db,
+        client_pool=client_pool,
+    )
+
+
+async def _make_task(db, payload: ExportTaskPayload):
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.EXPORT, title="export", payload=payload
+    )
+    return await db.repos.tasks.get_collection_task(task_id)
+
+
+# ── payload wiring ─────────────────────────────────────────────────────────
+
+
+async def test_export_payload_roundtrips_through_repo(db):
+    payload = ExportTaskPayload(channel_id=42, fmt="both", with_media=True, max_file_size_mb=7, limit=99)
+    task = await _make_task(db, payload)
+    assert isinstance(task.payload, ExportTaskPayload)
+    assert task.payload.channel_id == 42
+    assert task.payload.fmt == "both"
+    assert task.payload.with_media is True
+    assert task.payload.max_file_size_mb == 7
+    assert task.payload.limit == 99
+
+
+# ── handler ────────────────────────────────────────────────────────────────
+
+
+async def test_handle_offline_writes_tree_and_completes(db, tmp_path):
+    await _seed(db, 900)
+    task = await _make_task(db, ExportTaskPayload(channel_id=900, fmt="both", out_dir=str(tmp_path)))
+    await ExportTaskHandler(_context(db)).handle(task)
+
+    refreshed = await db.repos.tasks.get_collection_task(task.id)
+    assert refreshed.status == CollectionTaskStatus.COMPLETED
+    names = {p.name for p in tmp_path.iterdir()}
+    assert {"result.json", "messages.html", "export_manifest.json"} <= names
+
+
+async def test_handle_invalid_payload_fails(db):
+    # A non-export payload (plain dict) under an EXPORT task → FAILED.
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.EXPORT, title="bad", payload={"task_kind": "nope"}
+    )
+    task = await db.repos.tasks.get_collection_task(task_id)
+    await ExportTaskHandler(_context(db)).handle(task)
+    refreshed = await db.repos.tasks.get_collection_task(task_id)
+    assert refreshed.status == CollectionTaskStatus.FAILED
+
+
+async def test_handle_unknown_channel_completes_with_note(db, tmp_path):
+    task = await _make_task(db, ExportTaskPayload(channel_id=12345, out_dir=str(tmp_path)))
+    await ExportTaskHandler(_context(db)).handle(task)
+    refreshed = await db.repos.tasks.get_collection_task(task.id)
+    assert refreshed.status == CollectionTaskStatus.COMPLETED
+    assert "not found" in (refreshed.note or "")
+
+
+async def test_handle_with_media_no_pool_falls_back_offline(db, tmp_path):
+    await _seed(db, 901, with_media_msg=True)
+    task = await _make_task(db, ExportTaskPayload(channel_id=901, with_media=True, out_dir=str(tmp_path)))
+    await ExportTaskHandler(_context(db, client_pool=None)).handle(task)
+    refreshed = await db.repos.tasks.get_collection_task(task.id)
+    assert refreshed.status == CollectionTaskStatus.COMPLETED
+    data = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    media_msg = next(m for m in data["messages"] if m["id"] == 3)
+    # No account → media represented as "not included", not a broken link.
+    assert "not included" in media_msg["photo"].lower()
+
+
+async def test_handle_with_media_downloads_via_action_service(db, tmp_path, monkeypatch):
+    await _seed(db, 902, with_media_msg=True)
+
+    from src.services.telegram_actions import MediaDownloadOutcome
+
+    class FakeActionService:
+        def __init__(self, pool):
+            self._pool = pool
+
+        async def download_media_sized(self, *, phone, chat_id, message_id, output_dir, max_size_bytes):
+            return MediaDownloadOutcome(
+                phone=phone, kind="photo", subdir="photos",
+                path=str(Path(output_dir) / "photos" / f"{message_id}.jpg"),
+                rel_path=f"photos/{message_id}.jpg", size_bytes=100,
+            )
+
+    monkeypatch.setattr("src.services.telegram_actions.TelegramActionService", FakeActionService)
+    pool = MagicMock()
+    pool.clients = {"+15550001111": object()}
+
+    task = await _make_task(db, ExportTaskPayload(channel_id=902, with_media=True, out_dir=str(tmp_path)))
+    await ExportTaskHandler(_context(db, client_pool=pool)).handle(task)
+
+    refreshed = await db.repos.tasks.get_collection_task(task.id)
+    assert refreshed.status == CollectionTaskStatus.COMPLETED
+    data = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    media_msg = next(m for m in data["messages"] if m["id"] == 3)
+    assert media_msg["photo"] == "photos/3.jpg"  # downloaded, linked relative path
+
+
+async def test_handle_with_media_skips_oversized_and_records(db, tmp_path, monkeypatch):
+    await _seed(db, 903, with_media_msg=True)
+
+    from src.services.telegram_actions import MediaDownloadOutcome
+
+    class FakeActionService:
+        def __init__(self, pool):
+            pass
+
+        async def download_media_sized(self, *, phone, chat_id, message_id, output_dir, max_size_bytes):
+            return MediaDownloadOutcome(
+                phone=phone, kind="photo", subdir="photos",
+                size_bytes=9_000_000, skipped=True, reason="exceeds_max_size",
+            )
+
+    monkeypatch.setattr("src.services.telegram_actions.TelegramActionService", FakeActionService)
+    pool = MagicMock()
+    pool.clients = {"+15550001111": object()}
+
+    task = await _make_task(
+        db, ExportTaskPayload(channel_id=903, with_media=True, max_file_size_mb=3, out_dir=str(tmp_path))
+    )
+    await ExportTaskHandler(_context(db, client_pool=pool)).handle(task)
+
+    manifest = json.loads((tmp_path / "export_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["media_skipped"] == 1
+    entry = manifest["skipped_files"][0]
+    assert entry["reason"] == "exceeds_max_size"
+    assert entry["original_size_bytes"] == 9_000_000
+    data = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    media_msg = next(m for m in data["messages"] if m["id"] == 3)
+    assert "exceeds maximum size" in media_msg["photo"].lower()

--- a/tests/test_export_task_handler.py
+++ b/tests/test_export_task_handler.py
@@ -215,6 +215,18 @@ async def test_poll_export_task_exits_nonzero_on_failure(db):
     assert exc.value.code == 1
 
 
+async def test_poll_export_task_times_out_with_exit_2(db):
+    from src.cli.commands.export import _poll_export_task
+
+    # Task stays PENDING (no worker) → --wait should time out with a distinct code.
+    task_id = await db.repos.tasks.create_generic_task(
+        CollectionTaskType.EXPORT, title="x", payload=ExportTaskPayload(channel_id=1)
+    )
+    with pytest.raises(SystemExit) as exc:
+        await _poll_export_task(db, task_id, timeout=0.05, interval=0.01)
+    assert exc.value.code == 2
+
+
 async def test_handle_with_media_skips_oversized_and_records(db, tmp_path, monkeypatch):
     await _seed(db, 903, with_media_msg=True)
 

--- a/tests/test_task_handlers_registry.py
+++ b/tests/test_task_handlers_registry.py
@@ -7,6 +7,7 @@ import pytest
 from src.models import CollectionTask, CollectionTaskStatus, CollectionTaskType
 from src.services.task_handlers import (
     ContentTaskHandler,
+    ExportTaskHandler,
     FilterAnalyzeTaskHandler,
     PhotoTaskHandler,
     PipelineTaskHandler,
@@ -42,6 +43,7 @@ def test_handled_types_are_derived_from_task_handlers():
             PipelineTaskHandler,
             ContentTaskHandler,
             TranslationTaskHandler,
+            ExportTaskHandler,
         )
         for task_type in handler_cls.task_types
     ]
@@ -70,6 +72,7 @@ async def test_dispatcher_routes_each_handled_type_to_compatibility_shim():
         (CollectionTaskType.CONTENT_GENERATE, "_handle_content_generate"),
         (CollectionTaskType.CONTENT_PUBLISH, "_handle_content_publish"),
         (CollectionTaskType.TRANSLATE_BATCH, "_handle_translate_batch"),
+        (CollectionTaskType.EXPORT, "_handle_export"),
     ):
         async def shim(task, task_type=task_type):
             called.append(task_type)
@@ -95,6 +98,7 @@ def test_task_handler_metadata_covers_only_supported_task_types():
         PipelineTaskHandler(context),
         ContentTaskHandler(context),
         TranslationTaskHandler(context),
+        ExportTaskHandler(context),
     ]
 
     handled = [task_type for handler in handlers for task_type in handler.task_types]


### PR DESCRIPTION
PR **3 of 3** (финальный) для #834 — экспорт в формат Telegram Desktop. Зависимости (#937 PR-1 билдер, #938 PR-2 size-aware скачивание) уже в main.

## Что в этом PR
Связывает билдер (PR-1) и size-aware загрузчик (PR-2) в worker-задачу, чтобы `with_media`-экспорт реально качал фото/файлы (worker владеет живым ClientPool — web/CLI Telegram-соединений не открывают).

- **`CollectionTaskType.EXPORT` + `ExportTaskPayload`** (channel_id, fmt, with_media, max_file_size_mb, даты, limit, out_dir). Подключено в (де)сериализацию payload `collection_tasks` и union `CollectionTask`.
- **`ExportTaskHandler`** (`src/services/task_handlers/export.py`): читает сообщения (oldest-first), для `with_media` предзагружает медиа каждого сообщения через `TelegramActionService.download_media_sized` → `MediaArtifact`, затем отдаёт синхронный resolver в `TelegramExportBuilder.write_export`. При отсутствии аккаунта откатывается к офлайн-представлению «не включено». Зарегистрирован в `UnifiedDispatcher` (`_HANDLER_CLASSES` + handler-map).
- **CLI**: `export telegram --with-media [--wait]` — ставит EXPORT-задачу (и при `--wait` поллит до завершения) вместо инлайн-экспорта.
- **Web**: `POST /channels/{id}/export` с `with_media` — enqueue задачи, возвращает `{task_id, status}`; текстовый экспорт остаётся инлайн.

## Тесты
- Worker-хендлер (`tests/test_export_task_handler.py`): roundtrip payload через репозиторий, офлайн-завершение, невалидный payload → FAILED, неизвестный канал, `with_media` без аккаунта → fallback, `with_media` качает и линкует медиа относительным путём, файл сверх порога → пропущен и зафиксирован в манифесте.
- Обновлён web route-тест: `with_media` теперь enqueue'ит задачу.

ruff + import-linter зелёные; contract/policy/levels-сьюты проходят; 147 смежных тестов зелёные локально.

После мёржа #834 закрывается полностью (формат-выбор json/html/both, default json, HTML-пагинация, медиа on/off, size-skip default 3MB настраиваемый, фиксация пропущенных файлов).

🤖 Generated with [Claude Code](https://claude.com/claude-code)