### PR TITLE
perf(db): configurable cache/mmap + PRAGMA optimize on close (#760)

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -100,6 +100,8 @@ async def init_db(config_path: str):
     db = Database(
         config.database.path,
         session_encryption_secret=resolve_session_encryption_secret(config),
+        cache_size_kb=config.database.cache_size_kb,
+        mmap_size_mb=config.database.mmap_size_mb,
     )
     await db.initialize()
     return config, db

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -59,10 +59,14 @@ class DatabaseConfig(BaseModel):
     read_pool_size: int = 4
     # SQLite page cache per connection in KB (#760). Total committed RAM is roughly
     # cache_size_kb * (read_pool_size + 1); raise for large (multi-GB) databases.
-    cache_size_kb: int = 64000
+    # gt=0: a 0/negative value would make PRAGMA cache_size=-0 silently revert to
+    # the tiny ~8 MB default (review #940).
+    cache_size_kb: int = Field(64000, gt=0)
     # Memory-mapped I/O window in MB (#760). Virtual address space backed by the OS
     # page cache, not per-connection committed RAM — safe to keep large on big DBs.
-    mmap_size_mb: int = 256
+    # ge=0: 0 disables mmap (valid); a negative value would mean "map the whole
+    # file" to SQLite and could exhaust the address space (review #940).
+    mmap_size_mb: int = Field(256, ge=0)
 
 
 class LLMConfig(BaseModel):

--- a/src/config.py
+++ b/src/config.py
@@ -57,6 +57,12 @@ class DatabaseConfig(BaseModel):
     # Number of read connections in the pool (#760). Reads run concurrently across
     # these, so a slow SELECT never blocks navigation. Ignored for :memory:.
     read_pool_size: int = 4
+    # SQLite page cache per connection in KB (#760). Total committed RAM is roughly
+    # cache_size_kb * (read_pool_size + 1); raise for large (multi-GB) databases.
+    cache_size_kb: int = 64000
+    # Memory-mapped I/O window in MB (#760). Virtual address space backed by the OS
+    # page cache, not per-connection committed RAM — safe to keep large on big DBs.
+    mmap_size_mb: int = 256
 
 
 class LLMConfig(BaseModel):

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -26,6 +26,7 @@ class ConnectionTuning:
 
     cache_size_kb: int = 64000  # 64 MB page cache per connection
     mmap_size_mb: int = 256  # 256 MB mmap window (was 30 MB) — issue #760
+    analysis_limit: int = 400  # rows/index PRAGMA optimize samples (SQLite default)
 
 
 DEFAULT_TUNING = ConnectionTuning()
@@ -108,8 +109,8 @@ async def apply_pragmas(
     await conn.execute(f"PRAGMA mmap_size={tuning.mmap_size_mb * 1024 * 1024}")
     # Bound ANALYZE work so `PRAGMA optimize` (run on close) stays fast on
     # million-row tables yet still refreshes stale planner stats (#760, SQLite
-    # recommended value).
-    await conn.execute("PRAGMA analysis_limit=400")
+    # recommended default 400).
+    await conn.execute(f"PRAGMA analysis_limit={tuning.analysis_limit}")
     if role == "write":
         await conn.execute("PRAGMA journal_mode=WAL")
         # WAL hygiene (#766): make the autocheckpoint threshold explicit and
@@ -160,7 +161,10 @@ class DBConnection:
             try:
                 await db.execute("PRAGMA optimize")
             except Exception:
-                logger.debug("PRAGMA optimize on close failed", exc_info=True)
+                # Best-effort (not data-loss — the close below still runs), but
+                # surface it: silently-degrading planner stats are worth an alert
+                # (review #940).
+                logger.warning("PRAGMA optimize on close failed (best-effort)", exc_info=True)
             await db.close()
             self.db = None
 

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import aiosqlite
@@ -10,6 +11,24 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 _PROFILING_ENABLED = os.environ.get("ENV", "PROD").upper() == "DEV"
+
+
+@dataclass(frozen=True)
+class ConnectionTuning:
+    """Per-connection SQLite tuning knobs (#760).
+
+    ``cache_size_kb`` is page cache per connection — total committed RAM is
+    roughly ``cache_size_kb * (read_pool_size + 1)``, so it stays operator-tunable
+    rather than blindly raised. ``mmap_size_mb`` is memory-mapped I/O size; it is
+    virtual address space backed by the shared OS page cache (not per-connection
+    committed RAM), so a larger default helps big databases at little cost.
+    """
+
+    cache_size_kb: int = 64000  # 64 MB page cache per connection
+    mmap_size_mb: int = 256  # 256 MB mmap window (was 30 MB) — issue #760
+
+
+DEFAULT_TUNING = ConnectionTuning()
 
 
 class ProfilingConnection:
@@ -72,7 +91,9 @@ class ProfilingConnection:
             profiler.record_db(time.perf_counter_ns() - t0)
 
 
-async def apply_pragmas(conn: aiosqlite.Connection, *, role: str = "write") -> None:
+async def apply_pragmas(
+    conn: aiosqlite.Connection, *, role: str = "write", tuning: ConnectionTuning = DEFAULT_TUNING
+) -> None:
     """Apply the connection-tuning PRAGMAs shared by every connection (#760).
 
     ``role="write"`` runs the full set including WAL setup/hygiene; ``role="read"``
@@ -82,9 +103,13 @@ async def apply_pragmas(conn: aiosqlite.Connection, *, role: str = "write") -> N
     """
     await conn.execute("PRAGMA synchronous=NORMAL")
     await conn.execute("PRAGMA foreign_keys=ON")
-    await conn.execute("PRAGMA cache_size=-64000")  # 64MB
+    await conn.execute(f"PRAGMA cache_size=-{tuning.cache_size_kb}")
     await conn.execute("PRAGMA temp_store=MEMORY")
-    await conn.execute("PRAGMA mmap_size=30000000")  # 30MB
+    await conn.execute(f"PRAGMA mmap_size={tuning.mmap_size_mb * 1024 * 1024}")
+    # Bound ANALYZE work so `PRAGMA optimize` (run on close) stays fast on
+    # million-row tables yet still refreshes stale planner stats (#760, SQLite
+    # recommended value).
+    await conn.execute("PRAGMA analysis_limit=400")
     if role == "write":
         await conn.execute("PRAGMA journal_mode=WAL")
         # WAL hygiene (#766): make the autocheckpoint threshold explicit and
@@ -101,7 +126,9 @@ def maybe_wrap_profiling(conn: aiosqlite.Connection) -> aiosqlite.Connection:
     return conn
 
 
-async def open_connection(db_path: str, *, role: str = "write") -> aiosqlite.Connection:
+async def open_connection(
+    db_path: str, *, role: str = "write", tuning: ConnectionTuning = DEFAULT_TUNING
+) -> aiosqlite.Connection:
     """Open a single aiosqlite connection with the shared tuning applied.
 
     Used both for the lone write connection and for each reader in the pool (#760).
@@ -110,22 +137,30 @@ async def open_connection(db_path: str, *, role: str = "write") -> aiosqlite.Con
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
     conn = await aiosqlite.connect(db_path, timeout=10.0, isolation_level=None)
     conn.row_factory = aiosqlite.Row
-    await apply_pragmas(conn, role=role)
+    await apply_pragmas(conn, role=role, tuning=tuning)
     return maybe_wrap_profiling(conn)
 
 
 class DBConnection:
-    def __init__(self, db_path: str):
+    def __init__(self, db_path: str, *, tuning: ConnectionTuning = DEFAULT_TUNING):
         self._db_path = db_path
+        self._tuning = tuning
         self.db: aiosqlite.Connection | None = None
 
     async def connect(self) -> aiosqlite.Connection:
-        self.db = await open_connection(self._db_path, role="write")
+        self.db = await open_connection(self._db_path, role="write", tuning=self._tuning)
         return self.db
 
     async def close(self) -> None:
         if self.db:
             db = self.db
+            # Refresh planner statistics for tables that changed enough since the
+            # last run, so the next process start plans queries well on big DBs
+            # (#760). Bounded by PRAGMA analysis_limit; best-effort.
+            try:
+                await db.execute("PRAGMA optimize")
+            except Exception:
+                logger.debug("PRAGMA optimize on close failed", exc_info=True)
             await db.close()
             self.db = None
 

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -11,7 +11,7 @@ from typing import Any
 import aiosqlite
 
 from src.database.bundles import DatabaseRepositories
-from src.database.connection import DBConnection
+from src.database.connection import ConnectionTuning, DBConnection
 from src.database.migrations import run_migrations
 from src.database.pool import BufferedCursor, ReadConnectionPool, ReadPoolProxy
 from src.database.repositories._transactions import begin_immediate
@@ -76,10 +76,13 @@ class Database:
         session_encryption_secret: str | None = None,
         *,
         read_pool_size: int = 4,
+        cache_size_kb: int = 64000,
+        mmap_size_mb: int = 256,
     ):
         self._db_path = db_path
         self._session_encryption_secret = session_encryption_secret
-        self._connection = DBConnection(db_path)
+        self._tuning = ConnectionTuning(cache_size_kb=cache_size_kb, mmap_size_mb=mmap_size_mb)
+        self._connection = DBConnection(db_path, tuning=self._tuning)
         # Lone write connection (`_db`). All DML goes here under `_write_lock` so the
         # "one writer" contract (#569) is preserved. Reads go through `_read_proxy`,
         # backed by a pool of read connections, so a slow SELECT can't block the whole
@@ -128,7 +131,9 @@ class Database:
         # so a slow SELECT only ties up one read connection, never the whole process.
         # For :memory: each connect is a separate empty DB, so the pool degenerates to
         # the single write connection (shared) — tests keep one consistent in-memory DB.
-        self._read_pool = ReadConnectionPool(self._db_path, size=self._read_pool_size)
+        self._read_pool = ReadConnectionPool(
+            self._db_path, size=self._read_pool_size, tuning=self._tuning
+        )
         if self._db_path == ":memory:":
             await self._read_pool.open(shared_conn=self._db)
         else:

--- a/src/database/pool.py
+++ b/src/database/pool.py
@@ -24,7 +24,7 @@ from typing import Any, AsyncIterator
 
 import aiosqlite
 
-from src.database.connection import open_connection
+from src.database.connection import DEFAULT_TUNING, ConnectionTuning, open_connection
 
 
 class BufferedCursor:
@@ -75,9 +75,10 @@ class ReadConnectionPool:
     write connection.
     """
 
-    def __init__(self, db_path: str, *, size: int):
+    def __init__(self, db_path: str, *, size: int, tuning: ConnectionTuning = DEFAULT_TUNING):
         self._db_path = db_path
         self._size = max(1, size)
+        self._tuning = tuning
         self._queue: asyncio.Queue[aiosqlite.Connection] = asyncio.Queue()
         self._all_conns: list[aiosqlite.Connection] = []
         self.owns_conns = True
@@ -91,7 +92,7 @@ class ReadConnectionPool:
             self._queue.put_nowait(shared_conn)
             return
         for _ in range(self._size):
-            conn = await open_connection(self._db_path, role="read")
+            conn = await open_connection(self._db_path, role="read", tuning=self._tuning)
             self._all_conns.append(conn)
             self._queue.put_nowait(conn)
 

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -184,6 +184,8 @@ async def build_container_with_templates(
         config.database.path,
         session_encryption_secret=resolve_session_encryption_secret(config),
         read_pool_size=config.database.read_pool_size,
+        cache_size_kb=config.database.cache_size_kb,
+        mmap_size_mb=config.database.mmap_size_mb,
     )
     if _is_dev:
         t1 = time.monotonic()

--- a/tests/test_connection_tuning.py
+++ b/tests/test_connection_tuning.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import aiosqlite
+import pytest
+from pydantic import ValidationError
 
 from src.config import DatabaseConfig
 from src.database.connection import ConnectionTuning, DBConnection, apply_pragmas
@@ -80,3 +82,21 @@ def test_database_config_tuning_defaults():
     cfg = DatabaseConfig()
     assert cfg.cache_size_kb == 64000
     assert cfg.mmap_size_mb == 256
+
+
+def test_database_config_rejects_invalid_tuning():
+    # cache_size_kb=0 → PRAGMA cache_size=-0 silently reverts to default; reject.
+    for bad in ({"cache_size_kb": 0}, {"cache_size_kb": -5}, {"mmap_size_mb": -1}):
+        with pytest.raises(ValidationError):
+            DatabaseConfig(**bad)
+    # mmap_size_mb=0 disables mmap and is valid.
+    assert DatabaseConfig(mmap_size_mb=0).mmap_size_mb == 0
+
+
+async def test_apply_pragmas_uses_configured_analysis_limit(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"), isolation_level=None)
+    try:
+        await apply_pragmas(conn, role="read", tuning=ConnectionTuning(analysis_limit=1000))
+        assert await _pragma(conn, "analysis_limit") == 1000
+    finally:
+        await conn.close()

--- a/tests/test_connection_tuning.py
+++ b/tests/test_connection_tuning.py
@@ -1,0 +1,82 @@
+"""SQLite connection tuning PRAGMAs for large databases (issue #760)."""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from src.config import DatabaseConfig
+from src.database.connection import ConnectionTuning, DBConnection, apply_pragmas
+from src.database.facade import Database
+
+
+async def _pragma(conn, name: str):
+    cur = await conn.execute(f"PRAGMA {name}")
+    row = await cur.fetchone()
+    return row[0]
+
+
+async def test_apply_pragmas_uses_configured_cache_and_mmap(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"), isolation_level=None)
+    try:
+        await apply_pragmas(conn, role="write", tuning=ConnectionTuning(cache_size_kb=128000, mmap_size_mb=512))
+        assert await _pragma(conn, "cache_size") == -128000
+        assert await _pragma(conn, "mmap_size") == 512 * 1024 * 1024
+        assert await _pragma(conn, "analysis_limit") == 400
+    finally:
+        await conn.close()
+
+
+async def test_apply_pragmas_defaults(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"), isolation_level=None)
+    try:
+        await apply_pragmas(conn, role="write")
+        assert await _pragma(conn, "cache_size") == -64000
+        assert await _pragma(conn, "mmap_size") == 256 * 1024 * 1024  # bumped from 30MB (#760)
+    finally:
+        await conn.close()
+
+
+async def test_read_role_still_tunes_cache_and_mmap(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"), isolation_level=None)
+    try:
+        await apply_pragmas(conn, role="read", tuning=ConnectionTuning(cache_size_kb=70000, mmap_size_mb=128))
+        assert await _pragma(conn, "cache_size") == -70000
+        assert await _pragma(conn, "mmap_size") == 128 * 1024 * 1024
+        assert await _pragma(conn, "analysis_limit") == 400
+    finally:
+        await conn.close()
+
+
+async def test_db_connection_close_runs_optimize(tmp_path):
+    dbc = DBConnection(str(tmp_path / "opt.db"))
+    conn = await dbc.connect()
+    await conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    await conn.execute("INSERT INTO t (v) VALUES ('x')")
+    await dbc.close()  # runs PRAGMA optimize then closes — must not raise
+    assert dbc.db is None
+    # DB remains usable after the optimize-on-close.
+    again = await aiosqlite.connect(str(tmp_path / "opt.db"), isolation_level=None)
+    try:
+        cur = await again.execute("SELECT COUNT(*) FROM t")
+        assert (await cur.fetchone())[0] == 1
+    finally:
+        await again.close()
+
+
+async def test_database_threads_tuning_to_write_and_read_connections(tmp_path):
+    db = Database(str(tmp_path / "facade.db"), cache_size_kb=96000, mmap_size_mb=384)
+    await db.initialize()
+    try:
+        assert await _pragma(db._db, "cache_size") == -96000
+        assert await _pragma(db._db, "mmap_size") == 384 * 1024 * 1024
+        async with db._read_pool.acquire_read() as rconn:
+            assert await _pragma(rconn, "cache_size") == -96000
+            assert await _pragma(rconn, "mmap_size") == 384 * 1024 * 1024
+    finally:
+        await db.close()
+
+
+def test_database_config_tuning_defaults():
+    cfg = DatabaseConfig()
+    assert cfg.cache_size_kb == 64000
+    assert cfg.mmap_size_mb == 256


### PR DESCRIPTION
Частичное решение #760 — безопасный, проверяемый на синтетике подмножество (части, не требующие профилирования на копии прод-базы).

## Что сделано
- **mmap_size** дефолт поднят 30 МБ → **256 МБ** (виртуальное адресное пространство поверх общего OS page cache, не per-connection RAM — безопасно держать большим на больших базах).
- **cache_size** теперь настраивается через `DatabaseConfig.cache_size_kb` (дефолт без изменений — 64 МБ), т.к. он per-connection × размер пула — слепой bump бил бы по памяти всех деплоев.
- **`PRAGMA analysis_limit=400`** на каждом соединении, чтобы `PRAGMA optimize` оставался быстрым на таблицах в миллионы строк, и **`PRAGMA optimize` при закрытии** writer-соединения — освежает устаревшую статистику планировщика (гипотезы #3/#4 из ишью: PRAGMA-тюнинг + ANALYZE).
- Проброшено через `ConnectionTuning` → `open_connection` / `ReadConnectionPool` / `Database`, подключено из config в bootstrap и CLI runtime.

## Отложено (нужна копия 11 GB прод-базы без активного воркера)
Профилирование реальных запросов, аудит пропущенных индексов, перевод `LIKE '%..%'` локального поиска на FTS5. Эти части требуют замеров до/после на реальных данных — без копии базы их нельзя честно сделать.

## Тесты
`tests/test_connection_tuning.py` — настраиваемые cache/mmap применяются к write- и read-соединениям, дефолты (256 МБ mmap), `analysis_limit=400`, `PRAGMA optimize` на закрытии не падает и БД остаётся рабочей, дефолты конфига.

🤖 Generated with [Claude Code](https://claude.com/claude-code)