### PR TITLE
feat(web): navigation progress bar for immediate load feedback (#756)

### DIFF
--- a/src/web/static/js/nav-progress.js
+++ b/src/web/static/js/nav-progress.js
@@ -1,0 +1,81 @@
+// Lightweight top progress bar so navigation gives immediate feedback instead
+// of "nothing happens" while a slow page/request loads (issue #756). No deps.
+(function () {
+  "use strict";
+
+  var bar = document.getElementById("app-progress");
+  if (!bar) return;
+
+  var timer = null;
+  var visible = false;
+
+  function set(pct) {
+    bar.style.width = pct + "%";
+  }
+
+  function start() {
+    if (visible) return;
+    visible = true;
+    bar.classList.add("is-active");
+    set(8);
+    var pct = 8;
+    // Trickle towards (but never reaching) 100% so the bar keeps moving while
+    // we wait on the server.
+    timer = window.setInterval(function () {
+      pct += Math.max(0.5, (90 - pct) * 0.08);
+      if (pct > 90) pct = 90;
+      set(pct);
+    }, 200);
+  }
+
+  function done() {
+    if (timer) {
+      window.clearInterval(timer);
+      timer = null;
+    }
+    if (!visible) return;
+    set(100);
+    window.setTimeout(function () {
+      bar.classList.remove("is-active");
+      set(0);
+      visible = false;
+    }, 250);
+  }
+
+  // --- Full-page navigation (sidebar links, forms) ---
+  function isProgressLink(a) {
+    if (!a || a.target === "_blank" || a.hasAttribute("download")) return false;
+    if (a.dataset.noProgress !== undefined) return false;
+    var href = a.getAttribute("href");
+    if (!href || href.charAt(0) === "#" || href.indexOf("javascript:") === 0) return false;
+    if (a.hasAttribute("hx-get") || a.hasAttribute("hx-post")) return false; // HTMX handles its own
+    // Same-origin only.
+    return a.origin === window.location.origin;
+  }
+
+  document.addEventListener("click", function (e) {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    var a = e.target.closest && e.target.closest("a");
+    if (a && isProgressLink(a)) start();
+  });
+
+  document.addEventListener("submit", function (e) {
+    var form = e.target;
+    if (form && form.tagName === "FORM" && !form.hasAttribute("hx-post") && !form.hasAttribute("hx-get")) {
+      start();
+    }
+  });
+
+  // The new document finishes loading → complete the bar; bfcache restore resets it.
+  window.addEventListener("load", done);
+  window.addEventListener("pageshow", function (e) {
+    if (e.persisted) done();
+  });
+  window.addEventListener("beforeunload", start);
+
+  // --- HTMX requests (partial swaps) ---
+  document.body.addEventListener("htmx:beforeRequest", start);
+  document.body.addEventListener("htmx:afterRequest", done);
+  document.body.addEventListener("htmx:responseError", done);
+  document.body.addEventListener("htmx:sendError", done);
+})();

--- a/src/web/static/js/nav-progress.js
+++ b/src/web/static/js/nav-progress.js
@@ -7,6 +7,7 @@
   if (!bar) return;
 
   var timer = null;
+  var safety = null;
   var visible = false;
 
   function set(pct) {
@@ -26,12 +27,20 @@
       if (pct > 90) pct = 90;
       set(pct);
     }, 200);
+    // Safety net: if navigation is aborted (Esc, blocked, cancelled submit) and
+    // no done() fires, auto-clear so the bar can't freeze and lock out future
+    // triggers via the `if (visible) return` guard (review #941).
+    safety = window.setTimeout(done, 20000);
   }
 
   function done() {
     if (timer) {
       window.clearInterval(timer);
       timer = null;
+    }
+    if (safety) {
+      window.clearTimeout(safety);
+      safety = null;
     }
     if (!visible) return;
     set(100);
@@ -60,17 +69,28 @@
   });
 
   document.addEventListener("submit", function (e) {
+    // Skip submissions cancelled by another handler (AJAX/confirm flows) and
+    // new-tab forms — neither navigates the current page (review #941).
+    if (e.defaultPrevented) return;
     var form = e.target;
-    if (form && form.tagName === "FORM" && !form.hasAttribute("hx-post") && !form.hasAttribute("hx-get")) {
+    if (
+      form &&
+      form.tagName === "FORM" &&
+      form.target !== "_blank" &&
+      !form.hasAttribute("hx-post") &&
+      !form.hasAttribute("hx-get")
+    ) {
       start();
     }
   });
 
-  // The new document finishes loading → complete the bar; bfcache restore resets it.
+  // The new document finishes loading → complete the bar; bfcache restore resets
+  // it; pagehide covers aborted/cancelled navigations.
   window.addEventListener("load", done);
   window.addEventListener("pageshow", function (e) {
     if (e.persisted) done();
   });
+  window.addEventListener("pagehide", done);
   window.addEventListener("beforeunload", start);
 
   // --- HTMX requests (partial swaps) ---

--- a/src/web/static/style.css
+++ b/src/web/static/style.css
@@ -572,3 +572,21 @@ label:first-child .hint::before { left: 0.5em; transform: none; }
 .wizard-type-card input[type="radio"] {
     display: none;
 }
+
+/* Navigation progress bar (#756) — immediate feedback during slow page loads. */
+.app-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 0;
+    height: 3px;
+    background: var(--bs-primary, #0d6efd);
+    box-shadow: 0 0 8px rgba(13, 110, 253, 0.5);
+    opacity: 0;
+    z-index: 2000;
+    transition: width 0.2s ease, opacity 0.25s ease;
+    pointer-events: none;
+}
+.app-progress.is-active {
+    opacity: 1;
+}

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -13,6 +13,7 @@
     {% block head_scripts %}{% endblock %}
 </head>
 <body class="app-body d-flex flex-column min-vh-100">
+    <div id="app-progress" class="app-progress" role="presentation" aria-hidden="true"></div>
     {% block nav %}
     {% set nav_items = [
         ("/agent", "Агент", "robot"),
@@ -89,6 +90,7 @@
     </footer>
     {% endblock %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="/static/js/nav-progress.js?v={{ app_version }}-layout"></script>
 <script src="/static/_busy_button.js"></script>
 <script src="/static/js/searchable-picker.js"></script>
 <script>

--- a/tests/routes/test_nav_progress.py
+++ b/tests/routes/test_nav_progress.py
@@ -1,0 +1,15 @@
+"""Navigation progress bar is wired into the base layout (issue #756)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_base_layout_includes_progress_bar(route_client):
+    resp = await route_client.get("/channels/")
+    assert resp.status_code == 200
+    html = resp.text
+    # The bar element and its driver script must be present on every page.
+    assert 'id="app-progress"' in html
+    assert "/static/js/nav-progress.js" in html


### PR DESCRIPTION
Закрывает #756 — «любой эндпоинт грузится — ничего не происходит».

## Проблема
Клик по ссылке сайдбара / сабмит формы не давали никакой обратной связи, пока медленная страница грузится — выглядит как зависание.

## Решение
Лёгкий top-progress-bar (без зависимостей), который стартует на полной навигации, сабмите форм и HTMX-запросах и завершается на `load` / HTMX-ответе.

- `src/web/static/js/nav-progress.js` — управляет `#app-progress` из кликов по ссылкам, сабмитов форм, `beforeunload`, `window load/pageshow` и `htmx:beforeRequest/afterRequest/responseError/sendError`. Игнорирует new-tab / download / hash / HTMX-ссылки и клики с модификаторами.
- `base.html` — элемент `#app-progress` + подключение скрипта.
- `style.css` — фиксированный бар 3px сверху с анимацией width/opacity.

## Тест
`tests/routes/test_nav_progress.py` — бар и драйвер-скрипт присутствуют в base-лейауте.

Примечание: это UX-фидбэк на медленную загрузку; корневую перф-деградацию на больших базах закрывает отдельно #760 (PR #940).

🤖 Generated with [Claude Code](https://claude.com/claude-code)