### PR TITLE
refactor(web): session.py → itsdangerous.Signer (#953)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "tenacity>=9.1.4",
     "httpx>=0.28.1",
     "beautifulsoup4>=4.14.3",
+    "itsdangerous>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/web/session.py
+++ b/src/web/session.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import hmac
 import json
 import time
+from functools import lru_cache
+
+from itsdangerous import BadSignature, Signer
 
 COOKIE_NAME = "session"
 COOKIE_MAX_AGE = 30 * 24 * 3600  # 30 days
@@ -21,33 +23,32 @@ def _b64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s)
 
 
-def _sign(payload_b64: str, secret: str) -> str:
-    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
-    return _b64url_encode(sig)
+@lru_cache(maxsize=4)
+def _signer(secret: str) -> Signer:
+    # SHA256 HMAC keeps parity with the previous hand-rolled signer; the "."
+    # separator preserves the historical ``payload.sig`` token shape.
+    # Cached per secret: ``Signer`` runs key derivation on construction, and
+    # ``verify_session_token`` is on the authenticated-request hot path.
+    #
+    # ``exp`` is kept in the payload (rather than itsdangerous' TimestampSigner)
+    # so the per-token ``ttl`` contract and the ``payload.sig`` shape survive.
+    return Signer(secret, sep=".", digest_method=hashlib.sha256)
 
 
 def create_session_token(username: str, secret: str, ttl: int = COOKIE_MAX_AGE) -> str:
     payload = json.dumps({"user": username, "exp": int(time.time()) + ttl})
     payload_b64 = _b64url_encode(payload.encode())
-    sig_b64 = _sign(payload_b64, secret)
-    return f"{payload_b64}.{sig_b64}"
+    return _signer(secret).sign(payload_b64).decode()
 
 
 def verify_session_token(token: str, secret: str) -> str | None:
-    parts = token.split(".")
-    if len(parts) != 2:
-        return None
-    payload_b64, sig_b64 = parts
-    # hmac.compare_digest raises TypeError on a non-ASCII str, so a tampered
-    # cookie with non-ASCII bytes in the signature segment must be rejected first.
-    if not sig_b64.isascii():
-        return None
-    expected_sig = _sign(payload_b64, secret)
-    if not hmac.compare_digest(sig_b64, expected_sig):
+    try:
+        payload_b64 = _signer(secret).unsign(token).decode()
+    except (BadSignature, UnicodeDecodeError):
         return None
     try:
         payload = json.loads(_b64url_decode(payload_b64))
-    except (json.JSONDecodeError, Exception):
+    except Exception:
         return None
     # A validly-signed but non-object JSON payload (null/int/list/str) has no
     # .get(); guard before treating it as a dict.

--- a/src/web/session.py
+++ b/src/web/session.py
@@ -25,14 +25,17 @@ def _b64url_decode(s: str) -> bytes:
 
 @lru_cache(maxsize=4)
 def _signer(secret: str) -> Signer:
-    # SHA256 HMAC keeps parity with the previous hand-rolled signer; the "."
-    # separator preserves the historical ``payload.sig`` token shape.
-    # Cached per secret: ``Signer`` runs key derivation on construction, and
-    # ``verify_session_token`` is on the authenticated-request hot path.
+    # ``key_derivation="none"`` makes the HMAC key the raw secret (no salt/derived
+    # key), so the signature is byte-for-byte the old hand-rolled
+    # ``base64url(HMAC-SHA256(secret, payload))``. This keeps existing 30-day
+    # ``session`` cookies valid across the deploy instead of logging everyone out
+    # (review on #953). The "." separator preserves the ``payload.sig`` token shape.
+    # Cached per secret: ``verify_session_token`` is on the authenticated-request
+    # hot path.
     #
     # ``exp`` is kept in the payload (rather than itsdangerous' TimestampSigner)
     # so the per-token ``ttl`` contract and the ``payload.sig`` shape survive.
-    return Signer(secret, sep=".", digest_method=hashlib.sha256)
+    return Signer(secret, sep=".", key_derivation="none", digest_method=hashlib.sha256)
 
 
 def create_session_token(username: str, secret: str, ttl: int = COOKIE_MAX_AGE) -> str:

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -6768,22 +6768,20 @@ class TestWebSessionCoverage:
         # Create a token with TTL=0 (immediately expired)
         import json
 
-        from src.web.session import _b64url_encode, _sign, verify_session_token
+        from src.web.session import _b64url_encode, _signer, verify_session_token
 
         payload = json.dumps({"user": "admin", "exp": 0})
         payload_b64 = _b64url_encode(payload.encode())
-        sig_b64 = _sign(payload_b64, "secret")
-        token = f"{payload_b64}.{sig_b64}"
+        token = _signer("secret").sign(payload_b64).decode()
         result = verify_session_token(token, "secret")
         assert result is None
 
     def test_verify_token_invalid_json(self):
         """Lines 46-47: invalid JSON payload."""
-        from src.web.session import _b64url_encode, _sign, verify_session_token
+        from src.web.session import _b64url_encode, _signer, verify_session_token
 
         payload_b64 = _b64url_encode(b"not_json{{{")
-        sig_b64 = _sign(payload_b64, "secret")
-        token = f"{payload_b64}.{sig_b64}"
+        token = _signer("secret").sign(payload_b64).decode()
         result = verify_session_token(token, "secret")
         assert result is None
 

--- a/tests/test_session_tokens.py
+++ b/tests/test_session_tokens.py
@@ -22,6 +22,19 @@ def test_round_trip_valid_token():
     assert verify_session_token(tok, "secret") == "admin"
 
 
+def test_legacy_bare_hmac_token_still_verifies():
+    # Cookies issued by the pre-#953 hand-rolled signer
+    # (base64url(HMAC-SHA256(secret, payload))) must keep working across the
+    # deploy — the itsdangerous Signer uses key_derivation="none" to match.
+    import hashlib
+    import hmac
+
+    payload_b64 = _b64url_encode(json.dumps({"user": "admin", "exp": 9999999999}).encode())
+    sig = hmac.new(b"secret", payload_b64.encode(), hashlib.sha256).digest()
+    legacy_token = f"{payload_b64}.{base64.urlsafe_b64encode(sig).rstrip(b'=').decode()}"
+    assert verify_session_token(legacy_token, "secret") == "admin"
+
+
 def test_wrong_secret_rejected():
     tok = create_session_token("admin", "secret")
     assert verify_session_token(tok, "other-secret") is None

--- a/tests/test_session_tokens.py
+++ b/tests/test_session_tokens.py
@@ -1,15 +1,20 @@
-"""Regression tests for src/web/session.py token verification (#971)."""
+"""Regression tests for src/web/session.py token verification (#971, #953)."""
 
 from __future__ import annotations
 
 import base64
 import json
 
-from src.web.session import _sign, create_session_token, verify_session_token
+from src.web.session import _b64url_encode, _signer, create_session_token, verify_session_token
 
 
 def _b64url(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _signed(value, secret: str = "secret") -> str:
+    """Produce a validly-signed token wrapping an arbitrary JSON value."""
+    return _signer(secret).sign(_b64url_encode(json.dumps(value).encode())).decode()
 
 
 def test_round_trip_valid_token():
@@ -17,9 +22,25 @@ def test_round_trip_valid_token():
     assert verify_session_token(tok, "secret") == "admin"
 
 
+def test_wrong_secret_rejected():
+    tok = create_session_token("admin", "secret")
+    assert verify_session_token(tok, "other-secret") is None
+
+
+def test_tampered_signature_rejected():
+    tok = create_session_token("admin", "secret")
+    payload_b64, _sig = tok.rsplit(".", 1)
+    assert verify_session_token(f"{payload_b64}.deadbeef", "secret") is None
+
+
+def test_expired_token_rejected():
+    tok = create_session_token("admin", "secret", ttl=-1)
+    assert verify_session_token(tok, "secret") is None
+
+
 def test_non_ascii_signature_returns_none_not_raises():
-    # hmac.compare_digest raises TypeError on a non-ASCII str; a tampered cookie
-    # with non-ASCII in the signature segment must be rejected, not crash.
+    # A tampered cookie with non-ASCII bytes in the signature segment must be
+    # rejected, not crash.
     payload_b64 = _b64url(json.dumps({"user": "x", "exp": 9999999999}).encode())
     assert verify_session_token(f"{payload_b64}.bad✓sig", "secret") is None
 
@@ -28,6 +49,4 @@ def test_signed_non_object_payload_returns_none_not_raises():
     # A correctly-signed but non-object JSON payload (null/int/list/str) has no
     # .get(); verify must return None instead of raising AttributeError.
     for value in (None, 5, "hello", [1, 2, 3]):
-        payload_b64 = _b64url(json.dumps(value).encode())
-        token = f"{payload_b64}.{_sign(payload_b64, 'secret')}"
-        assert verify_session_token(token, "secret") is None
+        assert verify_session_token(_signed(value), "secret") is None


### PR DESCRIPTION
Часть #782. Заменяет самописный HMAC-SHA256 signer session-токенов на `itsdangerous.Signer`.

## Что сделано
- `src/web/session.py`: `_sign`/`hmac` → `itsdangerous.Signer` (SHA256, sep="."). Удалён ручной `hmac.compare_digest`/проверка ascii — `unsign` обрабатывает подделку/не-ascii сам.
- `exp` остаётся в payload (а не `TimestampSigner`), чтобы сохранить контракт `create_session_token(ttl)` и формат токена `payload.sig`.
- `_signer` кэшируется per-secret (`lru_cache`) — `verify_session_token` на горячем auth-пути.
- `pyproject.toml`: +`itsdangerous>=2.2.0`.
- Тесты: убран импорт удалённого `_sign`; добавлены кейсы tamper/expiry/wrong-secret.

## Проверка
- `ruff check` — чисто.
- `pytest` session-токены + web auth: 35 passed.
- `/simplify` пройден перед PR (кэш `_signer` + комментарий; b64-обёртка сохранена намеренно ради формата токена).

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)