### PR TITLE
refactor(utils): safe_json_dumps/loads → orjson (#956)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "tenacity>=9.1.4",
     "httpx>=0.28.1",
     "beautifulsoup4>=4.14.3",
+    "orjson>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/services/provider_model_compatibility.py
+++ b/src/services/provider_model_compatibility.py
@@ -52,6 +52,10 @@ class ProviderModelCompatibilityMixin:
         *,
         model: str | None = None,
     ) -> str:
+        # NB: this hashes the safe_json_dumps output, so it depends on that
+        # serializer's exact byte format. The orjson migration (#956) made the
+        # output compact, which invalidates fingerprints cached by the old spaced
+        # format once — each provider is simply re-probed on first run, no data loss.
         selected_model = (model or cfg.selected_model).strip()
         spec = provider_spec(cfg.provider)
         if spec is None:

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -43,7 +43,13 @@ def safe_json_dumps(
     - Any truthy ``indent`` pretty-prints with 2 spaces (orjson's sole indent mode).
     - Returns ``str`` (orjson emits ``bytes``; decoded here so callers are unchanged).
     """
-    option = orjson.OPT_PASSTHROUGH_DATETIME  # keep .isoformat() parity via _default
+    option = 0
+    if default is None:
+        # The built-in _default renders datetime/date via .isoformat(); route them
+        # to it for exact parity. With a *custom* default we must NOT force
+        # passthrough — the caller's default may not handle datetime, so let orjson
+        # serialize it natively (RFC 3339) instead (review on #956).
+        option |= orjson.OPT_PASSTHROUGH_DATETIME
     if sort_keys:
         option |= orjson.OPT_SORT_KEYS
     if indent:

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -1,13 +1,32 @@
 """JSON utilities with safe serialization for external data."""
 
-import json
 from datetime import date, datetime
-from typing import Any
+from typing import Any, Callable
+
+import orjson
 
 
-def safe_json_dumps(obj, **kwargs) -> str:
+def _default(o):
+    if isinstance(o, (datetime, date)):
+        return o.isoformat()
+    if isinstance(o, bytes):
+        return o.hex()
+    # Pydantic v2
+    if hasattr(o, "model_dump"):
+        return o.model_dump()
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
+def safe_json_dumps(
+    obj,
+    *,
+    ensure_ascii: bool = False,
+    indent: int | None = None,
+    sort_keys: bool = False,
+    default: Callable[[Any], Any] | None = None,
+) -> str:
     """
-    JSON dumps with fallback for non-serializable types.
+    JSON dumps (orjson-backed) with fallback for non-serializable types.
 
     Handles:
     - datetime, date → .isoformat()
@@ -16,26 +35,28 @@ def safe_json_dumps(obj, **kwargs) -> str:
     - Unknown → raises TypeError (fail-fast)
 
     Use for serializing external/untyped data (Telegram objects, DB payloads, etc.).
-    """
-    def _default(o):
-        if isinstance(o, (datetime, date)):
-            return o.isoformat()
-        if isinstance(o, bytes):
-            return o.hex()
-        # Pydantic v2
-        if hasattr(o, "model_dump"):
-            return o.model_dump()
-        raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
 
-    return json.dumps(obj, default=_default, **kwargs)
+    Notes on the orjson migration (#956):
+    - Output is compact (no spaces after ``:``/``,``) and always UTF-8, so
+      ``ensure_ascii`` is accepted for call-site compatibility but has no effect
+      (orjson never escapes non-ASCII).
+    - Any truthy ``indent`` pretty-prints with 2 spaces (orjson's sole indent mode).
+    - Returns ``str`` (orjson emits ``bytes``; decoded here so callers are unchanged).
+    """
+    option = orjson.OPT_PASSTHROUGH_DATETIME  # keep .isoformat() parity via _default
+    if sort_keys:
+        option |= orjson.OPT_SORT_KEYS
+    if indent:
+        option |= orjson.OPT_INDENT_2
+    return orjson.dumps(obj, default=default or _default, option=option).decode()
 
 
 def safe_json_loads(raw: str | bytes | bytearray | None, default: Any = None) -> Any:
     if not raw:
         return default
     try:
-        return json.loads(raw)
-    except (TypeError, json.JSONDecodeError):
+        return orjson.loads(raw)
+    except (TypeError, ValueError):
         return default
 
 

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -52,7 +52,7 @@ def safe_json_dumps(
         option |= orjson.OPT_PASSTHROUGH_DATETIME
     if sort_keys:
         option |= orjson.OPT_SORT_KEYS
-    if indent:
+    if indent is not None and indent > 0:  # orjson's only indent mode is 2-space
         option |= orjson.OPT_INDENT_2
     return orjson.dumps(obj, default=default or _default, option=option).decode()
 

--- a/tests/repositories/test_collection_tasks_repository.py
+++ b/tests/repositories/test_collection_tasks_repository.py
@@ -67,7 +67,7 @@ def test_serialize_payload_none():
 def test_serialize_payload_dict():
     """Test serializing dict payload."""
     result = CollectionTasksRepository._serialize_payload({"key": "value"})
-    assert result == '{"key": "value"}'
+    assert result == '{"key":"value"}'  # orjson compact output
 
 
 def test_serialize_payload_stats_all():

--- a/tests/routes/test_agent_routes_streaming.py
+++ b/tests/routes/test_agent_routes_streaming.py
@@ -207,7 +207,7 @@ async def test_chat_streaming_keepalive_does_not_cancel_active_stream(client, db
     )
 
     assert resp.status_code == 200
-    assert '"type": "status"' in resp.text
+    assert '"type":"status"' in resp.text
     assert "finished" in resp.text
     assert "Agent response timed out" not in resp.text
     mock_mgr.cancel_stream.assert_not_awaited()
@@ -251,7 +251,7 @@ async def test_chat_streaming_second_message_survives_keepalive_after_first_turn
     assert first_resp.status_code == 200
     assert second_resp.status_code == 200
     assert "first answer" in first_resp.text
-    assert '"type": "status"' in second_resp.text
+    assert '"type":"status"' in second_resp.text
     assert "second answer" in second_resp.text
     assert "Agent response timed out" not in second_resp.text
     assert prompts == ["first prompt", "second prompt"]
@@ -299,7 +299,7 @@ async def test_chat_streaming_client_disconnect_closes_pending_stream(client, db
     ) as resp:
         assert resp.status_code == 200
         async for line in resp.aiter_lines():
-            if '"type": "status"' in line:
+            if '"type":"status"' in line:
                 break
 
     await asyncio.wait_for(closed.wait(), timeout=0.2)

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -2185,7 +2185,7 @@ class TestAgentManagerPermissionGate:
 
         assert captured_tools
         assert captured_tools[-1] == ["send_reaction", "list_channels"]
-        assert any('"done": true' in chunk for chunk in chunks)
+        assert any('"done":true' in chunk for chunk in chunks)
 
     @pytest.mark.anyio
     async def test_noninteractive_permissions_hide_requestable_deepagents_tool(self, db):
@@ -2260,7 +2260,7 @@ class TestAgentManagerPermissionGate:
 
         assert captured_tools
         assert captured_tools[-1] == ["list_channels"]
-        assert any('"done": true' in chunk for chunk in chunks)
+        assert any('"done":true' in chunk for chunk in chunks)
 
 
 class TestAgentManagerCloseAll:

--- a/tests/test_agent_provider_service.py
+++ b/tests/test_agent_provider_service.py
@@ -497,7 +497,7 @@ async def test_agent_manager_prefers_db_provider_configs_over_legacy_env(db, mon
     ):
         chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "hello")]
 
-    assert any('"provider": "openai"' in chunk for chunk in chunks)
+    assert any('"provider":"openai"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -571,7 +571,7 @@ async def test_agent_manager_falls_back_to_legacy_env_when_db_provider_is_unsupp
     assert status.fallback_provider == "anthropic"
     assert "openai" not in seen_providers
     assert "anthropic" in seen_providers
-    assert any('"provider": "anthropic"' in chunk for chunk in chunks)
+    assert any('"provider":"anthropic"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -620,7 +620,7 @@ async def test_agent_manager_fails_over_to_next_provider_on_init_error(db, monke
     ):
         chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "hello")]
 
-    assert any('"provider": "anthropic"' in chunk for chunk in chunks)
+    assert any('"provider":"anthropic"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -669,7 +669,7 @@ async def test_agent_manager_fails_over_to_next_provider_on_run_error(db, monkey
     ):
         chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "hello")]
 
-    assert any('"provider": "groq"' in chunk for chunk in chunks)
+    assert any('"provider":"groq"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -712,7 +712,7 @@ async def test_ollama_cloud_provider_uses_bearer_headers(db, monkeypatch):
     ):
         chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "hello")]
 
-    assert any('"provider": "ollama"' in chunk for chunk in chunks)
+    assert any('"provider":"ollama"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -756,7 +756,7 @@ async def test_ollama_provider_normalizes_api_suffix_for_runtime(db, monkeypatch
     ):
         chunks = [chunk async for chunk in mgr.chat_stream(thread_id, "hello")]
 
-    assert any('"provider": "ollama"' in chunk for chunk in chunks)
+    assert any('"provider":"ollama"' in chunk for chunk in chunks)
 
 
 @pytest.mark.anyio
@@ -860,7 +860,7 @@ async def test_agent_manager_skips_cached_unsupported_provider_and_fails_over(db
 
     assert "openai" not in seen_providers
     assert seen_providers
-    assert any('"provider": "anthropic"' in chunk for chunk in chunks)
+    assert any('"provider":"anthropic"' in chunk for chunk in chunks)
 
 
 # === _fetch_live_models HTTP error handling tests ===

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -13,7 +13,8 @@ class _SampleModel(BaseModel):
 
 
 def test_plain_types():
-    assert safe_json_dumps({"a": 1, "b": "hello"}) == '{"a": 1, "b": "hello"}'
+    # orjson emits compact JSON (no spaces after ':'/',').
+    assert safe_json_dumps({"a": 1, "b": "hello"}) == '{"a":1,"b":"hello"}'
 
 
 def test_datetime_serialization():
@@ -37,8 +38,8 @@ def test_bytes_serialization():
 def test_pydantic_model_serialization():
     m = _SampleModel(name="test", value=42)
     result = safe_json_dumps(m)
-    assert '"name": "test"' in result
-    assert '"value": 42' in result
+    assert '"name":"test"' in result
+    assert '"value":42' in result
 
 
 def test_unknown_type_raises_type_error():
@@ -59,13 +60,18 @@ def test_mixed_types():
     result = safe_json_dumps(payload)
     assert "2026-01-01" in result
     assert "ff" in result
-    assert '"name": "x"' in result
-    assert '"plain": "text"' in result
+    assert '"name":"x"' in result
+    assert '"plain":"text"' in result
 
 
 def test_kwargs_forwarded():
     result = safe_json_dumps({"b": 1, "a": 2}, sort_keys=True)
-    assert result == '{"a": 2, "b": 1}'
+    assert result == '{"a":2,"b":1}'
+
+
+def test_indent_pretty_prints():
+    result = safe_json_dumps({"a": 1}, indent=2)
+    assert result == '{\n  "a": 1\n}'
 
 
 def test_list_of_datetime():

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -69,6 +69,18 @@ def test_kwargs_forwarded():
     assert result == '{"a":2,"b":1}'
 
 
+def test_custom_default_does_not_receive_datetime():
+    # With a custom default, datetime must be serialized natively by orjson, NOT
+    # routed to the caller's default (which may not handle it) — review on #956.
+    def only_bytes(o):
+        if isinstance(o, bytes):
+            return o.hex()
+        raise TypeError("custom default should not be called for datetime")
+
+    out = safe_json_dumps({"ts": datetime(2026, 1, 1)}, default=only_bytes)
+    assert "2026-01-01" in out
+
+
 def test_indent_pretty_prints():
     result = safe_json_dumps({"a": 1}, indent=2)
     assert result == '{\n  "a": 1\n}'

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -781,7 +781,7 @@ async def test_settings_save_agent_providers_preserves_priority_order(client, mo
     assert resp.status_code == 303
     raw = await db.get_setting("agent_deepagents_providers_v1")
     assert raw is not None
-    assert raw.index('"provider": "anthropic"') < raw.index('"provider": "openai"')
+    assert raw.index('"provider":"anthropic"') < raw.index('"provider":"openai"')
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Часть #782. Переводит `src/utils/json.py` с stdlib `json` на `orjson`.

## Что сделано
- `safe_json_dumps`/`safe_json_loads` на `orjson`. Публичный контракт `safe_json_dumps(...) -> str` сохранён → все ~65 call-sites не меняются.
- kwargs транслируются в orjson options: `sort_keys → OPT_SORT_KEYS`, любой truthy `indent → OPT_INDENT_2`. orjson отдаёт `bytes` — декодируется в `str` централизованно.
- `pyproject.toml`: +`orjson>=3.10.0`.

## Изменения поведения (намеренные)
- Вывод теперь **компактный** (без пробелов после `:`/`,`) и всегда UTF-8; `ensure_ascii` принимается ради совместимости, но не действует (orjson не экранирует не-ASCII).
- `OPT_PASSTHROUGH_DATETIME` + `_default` сохраняют точный `.isoformat()` для datetime/date.
- Хранимый в БД JSON и SSE-чанки стали компактными — функционально идентичны при разборе. Fingerprint кэша совместимости провайдеров само-восстанавливается при смене формата.

## Проверка
- `ruff check src/ tests/` — чисто.
- Полный набор: затронутые JSON-ассерты обновлены на компактный формат (utils, repo, agent streaming/runtime, agent_provider, web). Падения вне scope (`langchain-openai` не установлен, `DatabaseBusyError` под параллелью) воспроизводятся на чистом `main`.
- `/simplify` пройден: ленивый `indent` (убран неожиданный `ValueError`); `default`/`ensure_ascii` оставлены осознанно.

## Follow-up (вне scope)
`src/telegram/collector.py:_get_service_action_payload` дублирует `_default` (но с `repr`-fallback) — можно свернуть через новый `default=` параметр в отдельной задаче.

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)