### PR TITLE
feat(interop): dm_reply/chat_answer/fetch_* task types + payloads (#960)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -252,11 +252,16 @@ class ExportTaskPayload(BaseModel):
 # tg_messenger worker. ``v`` is the payload schema version so the worker can
 # evolve independently; ``task_kind`` mirrors the enum value for self-describing
 # rows.
+#
+# By design these are NOT added to CollectionTasksRepository._deserialize_payload
+# / create_generic_task's typed union: the factory only produces them (the REST
+# API stores the request body as an opaque JSON dict) and never executes them, so
+# it never needs typed read access — the external worker owns validation/execution.
 class DmReplyTaskPayload(BaseModel):
     v: int = 1
     task_kind: str = CollectionTaskType.DM_REPLY.value
-    peer: str  # @username or numeric user id of the DM peer
-    text: str
+    peer: str = Field(min_length=1)  # @username or numeric user id of the DM peer
+    text: str = Field(min_length=1)
     reply_to_message_id: int | None = None
 
 
@@ -264,7 +269,7 @@ class ChatAnswerTaskPayload(BaseModel):
     v: int = 1
     task_kind: str = CollectionTaskType.CHAT_ANSWER.value
     chat_id: int
-    text: str
+    text: str = Field(min_length=1)
     reply_to_message_id: int | None = None
 
 
@@ -278,7 +283,7 @@ class FetchDialogsTaskPayload(BaseModel):
 class FetchHistoryTaskPayload(BaseModel):
     v: int = 1
     task_kind: str = CollectionTaskType.FETCH_HISTORY.value
-    peer: str  # @username or numeric chat/channel id
+    peer: str = Field(min_length=1)  # @username or numeric chat/channel id
     limit: int = 100
     offset_id: int = 0
 

--- a/src/models.py
+++ b/src/models.py
@@ -144,6 +144,27 @@ class CollectionTaskType(StrEnum):
     CONTENT_PUBLISH = "content_publish"
     TRANSLATE_BATCH = "translate_batch"
     EXPORT = "export"
+    # Interop types (#960): produced by tg_content_factory, executed by an
+    # external tg_messenger worker via the /api/tasks REST claim API (#961).
+    # The factory's own workers (UnifiedDispatcher, CollectionQueue) never claim
+    # these — they are absent from HANDLED_TYPES and from the CHANNEL_COLLECT
+    # pull — so they sit PENDING until the external worker claims them.
+    DM_REPLY = "dm_reply"
+    CHAT_ANSWER = "chat_answer"
+    FETCH_DIALOGS = "fetch_dialogs"
+    FETCH_HISTORY = "fetch_history"
+
+
+# Task types executed by an external interop worker (tg_messenger), never by the
+# factory's internal dispatchers. See #829 / #960.
+EXTERNAL_INTEROP_TASK_TYPES: frozenset[CollectionTaskType] = frozenset(
+    {
+        CollectionTaskType.DM_REPLY,
+        CollectionTaskType.CHAT_ANSWER,
+        CollectionTaskType.FETCH_DIALOGS,
+        CollectionTaskType.FETCH_HISTORY,
+    }
+)
 
 
 class TelegramCommandStatus(StrEnum):
@@ -225,6 +246,41 @@ class ExportTaskPayload(BaseModel):
     limit: int = 5000
     out_dir: str | None = None
     requested_by: str | None = None
+
+
+# Interop payloads (#960). Produced by the factory, consumed by an external
+# tg_messenger worker. ``v`` is the payload schema version so the worker can
+# evolve independently; ``task_kind`` mirrors the enum value for self-describing
+# rows.
+class DmReplyTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.DM_REPLY.value
+    peer: str  # @username or numeric user id of the DM peer
+    text: str
+    reply_to_message_id: int | None = None
+
+
+class ChatAnswerTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.CHAT_ANSWER.value
+    chat_id: int
+    text: str
+    reply_to_message_id: int | None = None
+
+
+class FetchDialogsTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.FETCH_DIALOGS.value
+    limit: int = 100
+    archived: bool = False
+
+
+class FetchHistoryTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.FETCH_HISTORY.value
+    peer: str  # @username or numeric chat/channel id
+    limit: int = 100
+    offset_id: int = 0
 
 
 class CollectionTask(BaseModel):

--- a/tests/test_interop_task_types.py
+++ b/tests/test_interop_task_types.py
@@ -52,3 +52,17 @@ def test_payload_models_default_to_v1(model, kwargs, kind):
     payload = model(**kwargs)
     assert payload.v == 1
     assert payload.task_kind == kind
+
+
+def test_interop_payloads_reject_empty_peer_and_text():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DmReplyTaskPayload(peer="", text="hi")
+    with pytest.raises(ValidationError):
+        DmReplyTaskPayload(peer="@bob", text="")
+    with pytest.raises(ValidationError):
+        ChatAnswerTaskPayload(chat_id=1, text="")
+    with pytest.raises(ValidationError):
+        FetchHistoryTaskPayload(peer="")

--- a/tests/test_interop_task_types.py
+++ b/tests/test_interop_task_types.py
@@ -1,0 +1,54 @@
+"""Interop task types (#960): external dm_reply/chat_answer/fetch_* must exist
+as enum values + payload models, and must NOT be claimable by the factory's own
+internal workers (they are executed by an external tg_messenger worker)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models import (
+    EXTERNAL_INTEROP_TASK_TYPES,
+    ChatAnswerTaskPayload,
+    CollectionTaskType,
+    DmReplyTaskPayload,
+    FetchDialogsTaskPayload,
+    FetchHistoryTaskPayload,
+)
+
+
+def test_external_interop_types_are_defined():
+    assert {t.value for t in EXTERNAL_INTEROP_TASK_TYPES} == {
+        "dm_reply",
+        "chat_answer",
+        "fetch_dialogs",
+        "fetch_history",
+    }
+
+
+def test_external_types_absent_from_unified_dispatcher_pool():
+    # HANDLED_TYPES drives claim_next_due_generic_task; if an external type leaked
+    # in, the factory worker would steal a task meant for tg_messenger.
+    from src.services.unified_dispatcher import HANDLED_TYPES
+
+    for task_type in EXTERNAL_INTEROP_TASK_TYPES:
+        assert task_type.value not in HANDLED_TYPES
+
+
+def test_channel_collect_pull_is_unaffected():
+    # CollectionQueue only pulls CHANNEL_COLLECT, so external types never enter it.
+    assert CollectionTaskType.CHANNEL_COLLECT not in EXTERNAL_INTEROP_TASK_TYPES
+
+
+@pytest.mark.parametrize(
+    "model, kwargs, kind",
+    [
+        (DmReplyTaskPayload, {"peer": "@bob", "text": "hi"}, "dm_reply"),
+        (ChatAnswerTaskPayload, {"chat_id": 42, "text": "hi"}, "chat_answer"),
+        (FetchDialogsTaskPayload, {}, "fetch_dialogs"),
+        (FetchHistoryTaskPayload, {"peer": "@chan"}, "fetch_history"),
+    ],
+)
+def test_payload_models_default_to_v1(model, kwargs, kind):
+    payload = model(**kwargs)
+    assert payload.v == 1
+    assert payload.task_kind == kind


### PR DESCRIPTION
Часть #829 (интероп tg_messenger). Добавляет новые типы задач + payload-модели.

## Что сделано
- `CollectionTaskType`: +`dm_reply`, `chat_answer`, `fetch_dialogs`, `fetch_history`.
- Констант `EXTERNAL_INTEROP_TASK_TYPES` (frozenset) — типы, исполняемые внешним tg_messenger-воркером.
- Pydantic payload-модели с `v=1` (версия схемы) и `task_kind`-дискриминатором: `DmReplyTaskPayload`, `ChatAnswerTaskPayload`, `FetchDialogsTaskPayload`, `FetchHistoryTaskPayload`.

## Фильтрация внешних типов
Отдельный исключающий код не нужен — оба внутренних пула воркеров построены как **позитивные allow-list**:
- `UnifiedDispatcher` клеймит только `HANDLED_TYPES` (производный от классов-обработчиков; у внешних типов обработчиков нет);
- `CollectionQueue` тянет только `CHANNEL_COLLECT` (`get_pending_channel_tasks`).

Поэтому внешние задачи остаются `PENDING`, пока их не заберёт внешний воркер через `/api/tasks/claim` (#961). Регрессионный тест фиксирует инвариант (типы отсутствуют в `HANDLED_TYPES`).

## Проверка
- `ruff check` — чисто.
- `pytest tests/test_interop_task_types.py tests/test_task_handlers_registry.py tests/test_unified_dispatcher*.py` — 84 passed.
- `/simplify` пройден: код признан чистым (базовый класс для `v` отклонён ради консистентности с соседними payload-моделями).

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)