### PR TITLE
feat(interop): REST /api/tasks create/get/claim/complete/fail (#961)

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -62,6 +62,8 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "payload": "payload TEXT",
         "parent_task_id": "parent_task_id INTEGER",
         "last_progress_at": "last_progress_at TEXT",
+        # Interop tasks (#961): result written back by an external worker.
+        "result_payload": "result_payload TEXT",
     },
     "telegram_commands": {
         "run_after": "run_after TEXT",

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -20,7 +20,7 @@ from src.models import (
     TranslateBatchTaskPayload,
 )
 from src.utils.datetime import parse_datetime
-from src.utils.json import safe_json_dumps
+from src.utils.json import safe_json_dumps, safe_json_loads_dict
 
 _ALLOWED_PAYLOAD_FILTER_KEYS = frozenset({"sq_id", "pipeline_id"})
 
@@ -134,6 +134,11 @@ class CollectionTasksRepository:
             last_progress_at=(
                 parse_datetime(row["last_progress_at"])
                 if "last_progress_at" in row.keys()
+                else None
+            ),
+            result_payload=(
+                safe_json_loads_dict(row["result_payload"])
+                if "result_payload" in row.keys()
                 else None
             ),
         )
@@ -318,7 +323,11 @@ class CollectionTasksRepository:
         error: str | None = None,
         note: str | None = None,
         run_after: datetime | None = None,
-    ) -> None:
+        result_payload: dict[str, Any] | None = None,
+    ) -> int:
+        """Update a task's status (and optional fields). Returns affected rowcount,
+        so callers can tell a real update apart from a no-op (missing id, or a
+        CANCELLED row protected by the guard below)."""
         status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = ?"]
@@ -346,6 +355,9 @@ class CollectionTasksRepository:
         if run_after is not None:
             sets.append("run_after = ?")
             params.append(run_after.astimezone(timezone.utc).isoformat())
+        if result_payload is not None:
+            sets.append("result_payload = ?")
+            params.append(safe_json_dumps(result_payload))
         params.append(task_id)
         # Defense in depth (#633 bug #30): a user-issued CANCELLED is terminal and
         # must not be silently overwritten by a late RUNNING/COMPLETED/FAILED from a
@@ -354,10 +366,11 @@ class CollectionTasksRepository:
         if status_value != CollectionTaskStatus.CANCELLED.value:
             where += " AND status != ?"
             params.append(CollectionTaskStatus.CANCELLED.value)
-        await self._database.execute_write(
+        cur = await self._database.execute_write(
             f"UPDATE collection_tasks SET {', '.join(sets)} {where}",
             tuple(params),
         )
+        return cur.rowcount or 0
 
     async def reschedule_collection_task(
         self,

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -86,7 +86,8 @@ CREATE TABLE IF NOT EXISTS collection_tasks (
     created_at TEXT DEFAULT (datetime('now')),
     started_at TEXT,
     completed_at TEXT,
-    last_progress_at TEXT
+    last_progress_at TEXT,
+    result_payload TEXT
 );
 
 CREATE TABLE IF NOT EXISTS telegram_commands (

--- a/src/models.py
+++ b/src/models.py
@@ -313,6 +313,8 @@ class CollectionTask(BaseModel):
     # When progress (messages_collected) last advanced — used by the scheduler
     # health page to tell a genuinely stuck collection apart from a downed worker.
     last_progress_at: datetime | None = None
+    # Result written back by an external interop worker on completion (#961).
+    result_payload: dict[str, Any] | None = None
 
 
 class ChannelStats(BaseModel):

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -142,6 +142,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.search import router as search_router
     from src.web.routes.search_queries import router as search_queries_router
     from src.web.routes.settings import router as settings_router
+    from src.web.routes.tasks import router as tasks_router
     from src.web.routes.telegram_commands import router as telegram_commands_router
 
     app.include_router(agent_router, prefix="/agent")
@@ -164,6 +165,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(accounts_router, prefix="/settings")
     app.include_router(dialogs_router, prefix="/dialogs")
     app.include_router(telegram_commands_router, prefix="/telegram-commands")
+    app.include_router(tasks_router, prefix="/api/tasks")
     app.include_router(photo_loader_router, prefix="/dialogs/photos")
     app.include_router(debug_router, prefix="/debug")
     app.include_router(images_router, prefix="/images")

--- a/src/web/routes/tasks.py
+++ b/src/web/routes/tasks.py
@@ -1,0 +1,115 @@
+"""Interop task REST API (#961, part of #829).
+
+Lets an external tg_messenger worker create, poll, atomically claim, and report
+back on interop tasks (dm_reply / chat_answer / fetch_dialogs / fetch_history).
+
+Auth: mounted behind the existing web auth middleware (HTTP Basic with WEB_PASS
+for non-browser clients), so no separate gate here.
+
+Gating: only EXTERNAL_INTEROP_TASK_TYPES may be created or claimed through this
+API. The factory's own task types stay internal — an external worker can neither
+inject them nor steal them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from src.models import EXTERNAL_INTEROP_TASK_TYPES, CollectionTaskStatus, CollectionTaskType
+from src.web import deps
+
+router = APIRouter()
+
+_ALLOWED_VALUES = {t.value for t in EXTERNAL_INTEROP_TASK_TYPES}
+
+
+class CreateTaskRequest(BaseModel):
+    type: str
+    payload: dict = Field(default_factory=dict)
+
+
+class ClaimRequest(BaseModel):
+    types: list[str] = Field(default_factory=list)
+
+
+class CompleteRequest(BaseModel):
+    result_payload: dict = Field(default_factory=dict)
+
+
+class FailRequest(BaseModel):
+    error: str
+
+
+def _require_external(type_value: str) -> CollectionTaskType:
+    if type_value not in _ALLOWED_VALUES:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Task type '{type_value}' is not claimable via the interop API",
+        )
+    return CollectionTaskType(type_value)
+
+
+def _task_json(task) -> dict:
+    return task.model_dump(mode="json")
+
+
+@router.post("")
+async def create_task(request: Request, body: CreateTaskRequest):
+    task_type = _require_external(body.type)
+    tasks = deps.get_db(request).repos.tasks
+    task_id = await tasks.create_generic_task(task_type, payload=body.payload)
+    return JSONResponse({"id": task_id}, status_code=201)
+
+
+@router.post("/claim")
+async def claim_task(request: Request, body: ClaimRequest):
+    requested = body.types or list(_ALLOWED_VALUES)
+    for type_value in requested:
+        _require_external(type_value)
+    tasks = deps.get_db(request).repos.tasks
+    # Types are already gated to the external allow-list above; the dispatcher's
+    # HANDLED_TYPES never includes them, so this claim only ever races other
+    # external workers, not the factory's own dispatcher.
+    task = await tasks.claim_next_due_generic_task(datetime.now(timezone.utc), requested)
+    if task is None:
+        return Response(status_code=204)
+    return JSONResponse(_task_json(task))
+
+
+@router.get("/{task_id}")
+async def get_task(request: Request, task_id: int):
+    tasks = deps.get_db(request).repos.tasks
+    task = await tasks.get_collection_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return JSONResponse(_task_json(task))
+
+
+@router.post("/{task_id}/complete")
+async def complete_task(request: Request, task_id: int, body: CompleteRequest):
+    tasks = deps.get_db(request).repos.tasks
+    updated = await tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        result_payload=body.result_payload,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Task not found or not updatable")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/{task_id}/fail")
+async def fail_task(request: Request, task_id: int, body: FailRequest):
+    tasks = deps.get_db(request).repos.tasks
+    updated = await tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.FAILED,
+        error=body.error,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Task not found or not updatable")
+    return JSONResponse({"ok": True})

--- a/tests/routes/test_tasks_api.py
+++ b/tests/routes/test_tasks_api.py
@@ -1,0 +1,84 @@
+"""Interop task REST API route tests (#961). Core happy-path + type gating;
+the full claim-race / concurrency suite lives in #962."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_create_returns_id_and_is_fetchable(route_client):
+    resp = await route_client.post(
+        "/api/tasks", json={"type": "dm_reply", "payload": {"peer": "@bob", "text": "hi"}}
+    )
+    assert resp.status_code == 201
+    task_id = resp.json()["id"]
+    assert task_id > 0
+
+    got = await route_client.get(f"/api/tasks/{task_id}")
+    assert got.status_code == 200
+    body = got.json()
+    assert body["task_type"] == "dm_reply"
+    assert body["status"] == "pending"
+    assert body["payload"]["text"] == "hi"
+
+
+async def test_create_rejects_internal_type(route_client):
+    resp = await route_client.post("/api/tasks", json={"type": "channel_collect", "payload": {}})
+    assert resp.status_code == 403
+
+
+async def test_get_missing_returns_404(route_client):
+    resp = await route_client.get("/api/tasks/999999")
+    assert resp.status_code == 404
+
+
+async def test_claim_returns_204_when_empty(route_client):
+    resp = await route_client.post("/api/tasks/claim", json={"types": ["dm_reply"]})
+    assert resp.status_code == 204
+
+
+async def test_claim_rejects_internal_type(route_client):
+    resp = await route_client.post("/api/tasks/claim", json={"types": ["stats_all"]})
+    assert resp.status_code == 403
+
+
+async def test_full_lifecycle_complete(route_client):
+    created = await route_client.post(
+        "/api/tasks", json={"type": "fetch_dialogs", "payload": {"limit": 10}}
+    )
+    task_id = created.json()["id"]
+
+    claimed = await route_client.post("/api/tasks/claim", json={"types": ["fetch_dialogs"]})
+    assert claimed.status_code == 200
+    assert claimed.json()["id"] == task_id
+    assert claimed.json()["status"] == "running"
+
+    done = await route_client.post(
+        f"/api/tasks/{task_id}/complete", json={"result_payload": {"dialogs": [1, 2, 3]}}
+    )
+    assert done.status_code == 200
+
+    final = await route_client.get(f"/api/tasks/{task_id}")
+    assert final.json()["status"] == "completed"
+    assert final.json()["result_payload"] == {"dialogs": [1, 2, 3]}
+
+
+async def test_full_lifecycle_fail(route_client):
+    created = await route_client.post(
+        "/api/tasks", json={"type": "chat_answer", "payload": {"chat_id": 1, "text": "x"}}
+    )
+    task_id = created.json()["id"]
+
+    failed = await route_client.post(f"/api/tasks/{task_id}/fail", json={"error": "boom"})
+    assert failed.status_code == 200
+
+    final = await route_client.get(f"/api/tasks/{task_id}")
+    assert final.json()["status"] == "failed"
+    assert final.json()["error"] == "boom"
+
+
+async def test_complete_missing_returns_404(route_client):
+    resp = await route_client.post("/api/tasks/999999/complete", json={"result_payload": {}})
+    assert resp.status_code == 404


### PR DESCRIPTION
Часть #829 (интероп tg_messenger). REST-роуты задач.

> ⚠️ **Stacked на #978 (#960).** Base ветки — `feat/960-interop-task-types`. После мёржа #960 в `main` переключу base на `main` (diff схлопнется до изменений #961).

## Что сделано
- `src/web/routes/tasks.py` (новый) за существующей web-авторизацией (HTTP Basic с `WEB_PASS`):
  - `POST /api/tasks` `{type, payload}` → `{id}` (201);
  - `GET /api/tasks/{id}` → задача + status + result_payload;
  - `POST /api/tasks/claim` `{types:[...]}` → атомарный claim или 204;
  - `POST /api/tasks/{id}/complete` `{result_payload}` / `POST /api/tasks/{id}/fail` `{error}`.
- Атомарный claim переиспользует `claim_next_due_generic_task` (`collection_tasks.py`).
- Новая колонка `result_payload` в `collection_tasks` (schema + декларативная миграция + поле модели + `_to_task` с `.keys()`-guard).
- `update_collection_task` теперь также пишет `result_payload` и возвращает rowcount → complete/fail = один защищённый UPDATE (без предварительного GET, без «тихого ok» для CANCELLED).

## Гейтинг и авторизация
- Создавать/клеймить можно **только** `EXTERNAL_INTEROP_TASK_TYPES` — внутренние типы недоступны внешнему воркеру (403 на чужой тип).
- Авторизация — существующий `BasicAuthMiddleware` (`WEB_PASS`). Вопрос отдельного worker-токена вынесен в follow-up (см. комментарий к ишью).

## Проверка
- `ruff check src/ tests/` — чисто.
- `pytest tests/routes/test_tasks_api.py` (lifecycle + гейтинг), репозиторий/диспетчер/очередь — 184 passed суммарно.
- `/simplify` пройден: убран тонкий алиас claim, логика терминального статуса слита в `update_collection_task`, complete/fail свёрнуты в один запрос.

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)