### PR TITLE
test(interop): claim-race + dispatcher-gating for /api/tasks (#962)

### DIFF
--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -62,6 +62,8 @@ SCHEMA_REPAIR_COLUMNS: Mapping[str, ColumnSpec] = {
         "payload": "payload TEXT",
         "parent_task_id": "parent_task_id INTEGER",
         "last_progress_at": "last_progress_at TEXT",
+        # Interop tasks (#961): result written back by an external worker.
+        "result_payload": "result_payload TEXT",
     },
     "telegram_commands": {
         "run_after": "run_after TEXT",

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -20,7 +20,7 @@ from src.models import (
     TranslateBatchTaskPayload,
 )
 from src.utils.datetime import parse_datetime
-from src.utils.json import safe_json_dumps
+from src.utils.json import safe_json_dumps, safe_json_loads_dict
 
 _ALLOWED_PAYLOAD_FILTER_KEYS = frozenset({"sq_id", "pipeline_id"})
 
@@ -134,6 +134,11 @@ class CollectionTasksRepository:
             last_progress_at=(
                 parse_datetime(row["last_progress_at"])
                 if "last_progress_at" in row.keys()
+                else None
+            ),
+            result_payload=(
+                safe_json_loads_dict(row["result_payload"])
+                if "result_payload" in row.keys()
                 else None
             ),
         )
@@ -318,7 +323,11 @@ class CollectionTasksRepository:
         error: str | None = None,
         note: str | None = None,
         run_after: datetime | None = None,
-    ) -> None:
+        result_payload: dict[str, Any] | None = None,
+    ) -> int:
+        """Update a task's status (and optional fields). Returns affected rowcount,
+        so callers can tell a real update apart from a no-op (missing id, or a
+        CANCELLED row protected by the guard below)."""
         status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = ?"]
@@ -346,6 +355,9 @@ class CollectionTasksRepository:
         if run_after is not None:
             sets.append("run_after = ?")
             params.append(run_after.astimezone(timezone.utc).isoformat())
+        if result_payload is not None:
+            sets.append("result_payload = ?")
+            params.append(safe_json_dumps(result_payload))
         params.append(task_id)
         # Defense in depth (#633 bug #30): a user-issued CANCELLED is terminal and
         # must not be silently overwritten by a late RUNNING/COMPLETED/FAILED from a
@@ -354,10 +366,11 @@ class CollectionTasksRepository:
         if status_value != CollectionTaskStatus.CANCELLED.value:
             where += " AND status != ?"
             params.append(CollectionTaskStatus.CANCELLED.value)
-        await self._database.execute_write(
+        cur = await self._database.execute_write(
             f"UPDATE collection_tasks SET {', '.join(sets)} {where}",
             tuple(params),
         )
+        return cur.rowcount or 0
 
     async def reschedule_collection_task(
         self,

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -86,7 +86,8 @@ CREATE TABLE IF NOT EXISTS collection_tasks (
     created_at TEXT DEFAULT (datetime('now')),
     started_at TEXT,
     completed_at TEXT,
-    last_progress_at TEXT
+    last_progress_at TEXT,
+    result_payload TEXT
 );
 
 CREATE TABLE IF NOT EXISTS telegram_commands (

--- a/src/models.py
+++ b/src/models.py
@@ -313,6 +313,8 @@ class CollectionTask(BaseModel):
     # When progress (messages_collected) last advanced — used by the scheduler
     # health page to tell a genuinely stuck collection apart from a downed worker.
     last_progress_at: datetime | None = None
+    # Result written back by an external interop worker on completion (#961).
+    result_payload: dict[str, Any] | None = None
 
 
 class ChannelStats(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -144,6 +144,27 @@ class CollectionTaskType(StrEnum):
     CONTENT_PUBLISH = "content_publish"
     TRANSLATE_BATCH = "translate_batch"
     EXPORT = "export"
+    # Interop types (#960): produced by tg_content_factory, executed by an
+    # external tg_messenger worker via the /api/tasks REST claim API (#961).
+    # The factory's own workers (UnifiedDispatcher, CollectionQueue) never claim
+    # these — they are absent from HANDLED_TYPES and from the CHANNEL_COLLECT
+    # pull — so they sit PENDING until the external worker claims them.
+    DM_REPLY = "dm_reply"
+    CHAT_ANSWER = "chat_answer"
+    FETCH_DIALOGS = "fetch_dialogs"
+    FETCH_HISTORY = "fetch_history"
+
+
+# Task types executed by an external interop worker (tg_messenger), never by the
+# factory's internal dispatchers. See #829 / #960.
+EXTERNAL_INTEROP_TASK_TYPES: frozenset[CollectionTaskType] = frozenset(
+    {
+        CollectionTaskType.DM_REPLY,
+        CollectionTaskType.CHAT_ANSWER,
+        CollectionTaskType.FETCH_DIALOGS,
+        CollectionTaskType.FETCH_HISTORY,
+    }
+)
 
 
 class TelegramCommandStatus(StrEnum):
@@ -225,6 +246,41 @@ class ExportTaskPayload(BaseModel):
     limit: int = 5000
     out_dir: str | None = None
     requested_by: str | None = None
+
+
+# Interop payloads (#960). Produced by the factory, consumed by an external
+# tg_messenger worker. ``v`` is the payload schema version so the worker can
+# evolve independently; ``task_kind`` mirrors the enum value for self-describing
+# rows.
+class DmReplyTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.DM_REPLY.value
+    peer: str  # @username or numeric user id of the DM peer
+    text: str
+    reply_to_message_id: int | None = None
+
+
+class ChatAnswerTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.CHAT_ANSWER.value
+    chat_id: int
+    text: str
+    reply_to_message_id: int | None = None
+
+
+class FetchDialogsTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.FETCH_DIALOGS.value
+    limit: int = 100
+    archived: bool = False
+
+
+class FetchHistoryTaskPayload(BaseModel):
+    v: int = 1
+    task_kind: str = CollectionTaskType.FETCH_HISTORY.value
+    peer: str  # @username or numeric chat/channel id
+    limit: int = 100
+    offset_id: int = 0
 
 
 class CollectionTask(BaseModel):

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -142,6 +142,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.search import router as search_router
     from src.web.routes.search_queries import router as search_queries_router
     from src.web.routes.settings import router as settings_router
+    from src.web.routes.tasks import router as tasks_router
     from src.web.routes.telegram_commands import router as telegram_commands_router
 
     app.include_router(agent_router, prefix="/agent")
@@ -164,6 +165,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(accounts_router, prefix="/settings")
     app.include_router(dialogs_router, prefix="/dialogs")
     app.include_router(telegram_commands_router, prefix="/telegram-commands")
+    app.include_router(tasks_router, prefix="/api/tasks")
     app.include_router(photo_loader_router, prefix="/dialogs/photos")
     app.include_router(debug_router, prefix="/debug")
     app.include_router(images_router, prefix="/images")

--- a/src/web/routes/tasks.py
+++ b/src/web/routes/tasks.py
@@ -1,0 +1,115 @@
+"""Interop task REST API (#961, part of #829).
+
+Lets an external tg_messenger worker create, poll, atomically claim, and report
+back on interop tasks (dm_reply / chat_answer / fetch_dialogs / fetch_history).
+
+Auth: mounted behind the existing web auth middleware (HTTP Basic with WEB_PASS
+for non-browser clients), so no separate gate here.
+
+Gating: only EXTERNAL_INTEROP_TASK_TYPES may be created or claimed through this
+API. The factory's own task types stay internal — an external worker can neither
+inject them nor steal them.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from src.models import EXTERNAL_INTEROP_TASK_TYPES, CollectionTaskStatus, CollectionTaskType
+from src.web import deps
+
+router = APIRouter()
+
+_ALLOWED_VALUES = {t.value for t in EXTERNAL_INTEROP_TASK_TYPES}
+
+
+class CreateTaskRequest(BaseModel):
+    type: str
+    payload: dict = Field(default_factory=dict)
+
+
+class ClaimRequest(BaseModel):
+    types: list[str] = Field(default_factory=list)
+
+
+class CompleteRequest(BaseModel):
+    result_payload: dict = Field(default_factory=dict)
+
+
+class FailRequest(BaseModel):
+    error: str
+
+
+def _require_external(type_value: str) -> CollectionTaskType:
+    if type_value not in _ALLOWED_VALUES:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Task type '{type_value}' is not claimable via the interop API",
+        )
+    return CollectionTaskType(type_value)
+
+
+def _task_json(task) -> dict:
+    return task.model_dump(mode="json")
+
+
+@router.post("")
+async def create_task(request: Request, body: CreateTaskRequest):
+    task_type = _require_external(body.type)
+    tasks = deps.get_db(request).repos.tasks
+    task_id = await tasks.create_generic_task(task_type, payload=body.payload)
+    return JSONResponse({"id": task_id}, status_code=201)
+
+
+@router.post("/claim")
+async def claim_task(request: Request, body: ClaimRequest):
+    requested = body.types or list(_ALLOWED_VALUES)
+    for type_value in requested:
+        _require_external(type_value)
+    tasks = deps.get_db(request).repos.tasks
+    # Types are already gated to the external allow-list above; the dispatcher's
+    # HANDLED_TYPES never includes them, so this claim only ever races other
+    # external workers, not the factory's own dispatcher.
+    task = await tasks.claim_next_due_generic_task(datetime.now(timezone.utc), requested)
+    if task is None:
+        return Response(status_code=204)
+    return JSONResponse(_task_json(task))
+
+
+@router.get("/{task_id}")
+async def get_task(request: Request, task_id: int):
+    tasks = deps.get_db(request).repos.tasks
+    task = await tasks.get_collection_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return JSONResponse(_task_json(task))
+
+
+@router.post("/{task_id}/complete")
+async def complete_task(request: Request, task_id: int, body: CompleteRequest):
+    tasks = deps.get_db(request).repos.tasks
+    updated = await tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.COMPLETED,
+        result_payload=body.result_payload,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Task not found or not updatable")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/{task_id}/fail")
+async def fail_task(request: Request, task_id: int, body: FailRequest):
+    tasks = deps.get_db(request).repos.tasks
+    updated = await tasks.update_collection_task(
+        task_id,
+        CollectionTaskStatus.FAILED,
+        error=body.error,
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Task not found or not updatable")
+    return JSONResponse({"ok": True})

--- a/tests/routes/test_tasks_api.py
+++ b/tests/routes/test_tasks_api.py
@@ -1,0 +1,84 @@
+"""Interop task REST API route tests (#961). Core happy-path + type gating;
+the full claim-race / concurrency suite lives in #962."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_create_returns_id_and_is_fetchable(route_client):
+    resp = await route_client.post(
+        "/api/tasks", json={"type": "dm_reply", "payload": {"peer": "@bob", "text": "hi"}}
+    )
+    assert resp.status_code == 201
+    task_id = resp.json()["id"]
+    assert task_id > 0
+
+    got = await route_client.get(f"/api/tasks/{task_id}")
+    assert got.status_code == 200
+    body = got.json()
+    assert body["task_type"] == "dm_reply"
+    assert body["status"] == "pending"
+    assert body["payload"]["text"] == "hi"
+
+
+async def test_create_rejects_internal_type(route_client):
+    resp = await route_client.post("/api/tasks", json={"type": "channel_collect", "payload": {}})
+    assert resp.status_code == 403
+
+
+async def test_get_missing_returns_404(route_client):
+    resp = await route_client.get("/api/tasks/999999")
+    assert resp.status_code == 404
+
+
+async def test_claim_returns_204_when_empty(route_client):
+    resp = await route_client.post("/api/tasks/claim", json={"types": ["dm_reply"]})
+    assert resp.status_code == 204
+
+
+async def test_claim_rejects_internal_type(route_client):
+    resp = await route_client.post("/api/tasks/claim", json={"types": ["stats_all"]})
+    assert resp.status_code == 403
+
+
+async def test_full_lifecycle_complete(route_client):
+    created = await route_client.post(
+        "/api/tasks", json={"type": "fetch_dialogs", "payload": {"limit": 10}}
+    )
+    task_id = created.json()["id"]
+
+    claimed = await route_client.post("/api/tasks/claim", json={"types": ["fetch_dialogs"]})
+    assert claimed.status_code == 200
+    assert claimed.json()["id"] == task_id
+    assert claimed.json()["status"] == "running"
+
+    done = await route_client.post(
+        f"/api/tasks/{task_id}/complete", json={"result_payload": {"dialogs": [1, 2, 3]}}
+    )
+    assert done.status_code == 200
+
+    final = await route_client.get(f"/api/tasks/{task_id}")
+    assert final.json()["status"] == "completed"
+    assert final.json()["result_payload"] == {"dialogs": [1, 2, 3]}
+
+
+async def test_full_lifecycle_fail(route_client):
+    created = await route_client.post(
+        "/api/tasks", json={"type": "chat_answer", "payload": {"chat_id": 1, "text": "x"}}
+    )
+    task_id = created.json()["id"]
+
+    failed = await route_client.post(f"/api/tasks/{task_id}/fail", json={"error": "boom"})
+    assert failed.status_code == 200
+
+    final = await route_client.get(f"/api/tasks/{task_id}")
+    assert final.json()["status"] == "failed"
+    assert final.json()["error"] == "boom"
+
+
+async def test_complete_missing_returns_404(route_client):
+    resp = await route_client.post("/api/tasks/999999/complete", json={"result_payload": {}})
+    assert resp.status_code == 404

--- a/tests/routes/test_tasks_api_concurrency.py
+++ b/tests/routes/test_tasks_api_concurrency.py
@@ -1,0 +1,70 @@
+"""Interop task API claim-race + dispatcher-gating tests (#962).
+
+Complements tests/routes/test_tasks_api.py (lifecycle/gating) with the
+concurrency invariant: a task is claimed by exactly one caller, and the
+factory's own dispatcher never claims an external interop task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from src.services.unified_dispatcher import HANDLED_TYPES
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_concurrent_claims_yield_the_task_to_exactly_one(route_client):
+    created = await route_client.post(
+        "/api/tasks", json={"type": "dm_reply", "payload": {"peer": "@bob", "text": "hi"}}
+    )
+    task_id = created.json()["id"]
+
+    # Fire many claims at once; only one may win the single pending task.
+    responses = await asyncio.gather(
+        *[route_client.post("/api/tasks/claim", json={"types": ["dm_reply"]}) for _ in range(8)]
+    )
+
+    won = [r for r in responses if r.status_code == 200]
+    empty = [r for r in responses if r.status_code == 204]
+    assert len(won) == 1, f"expected exactly one winner, got {len(won)}"
+    assert len(empty) == 7
+    assert won[0].json()["id"] == task_id
+    assert won[0].json()["status"] == "running"
+
+
+async def test_claim_distributes_distinct_tasks(route_client):
+    # Two pending tasks, many concurrent claimers → two distinct winners, no
+    # task handed out twice.
+    ids = set()
+    for _ in range(2):
+        r = await route_client.post("/api/tasks", json={"type": "fetch_dialogs", "payload": {}})
+        ids.add(r.json()["id"])
+
+    responses = await asyncio.gather(
+        *[route_client.post("/api/tasks/claim", json={"types": ["fetch_dialogs"]}) for _ in range(6)]
+    )
+    won_ids = [r.json()["id"] for r in responses if r.status_code == 200]
+    assert sorted(won_ids) == sorted(ids)  # each task claimed exactly once
+    assert len(won_ids) == len(set(won_ids))
+
+
+async def test_internal_dispatcher_never_claims_external_task(route_client):
+    # An external task created via the API must stay PENDING when the factory's
+    # own dispatcher runs its claim over HANDLED_TYPES.
+    created = await route_client.post(
+        "/api/tasks", json={"type": "chat_answer", "payload": {"chat_id": 1, "text": "x"}}
+    )
+    task_id = created.json()["id"]
+
+    db = route_client._transport_app.state.db
+    claimed = await db.repos.tasks.claim_next_due_generic_task(
+        datetime.now(timezone.utc), HANDLED_TYPES
+    )
+    assert claimed is None
+
+    still = await route_client.get(f"/api/tasks/{task_id}")
+    assert still.json()["status"] == "pending"

--- a/tests/test_interop_task_types.py
+++ b/tests/test_interop_task_types.py
@@ -1,0 +1,54 @@
+"""Interop task types (#960): external dm_reply/chat_answer/fetch_* must exist
+as enum values + payload models, and must NOT be claimable by the factory's own
+internal workers (they are executed by an external tg_messenger worker)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models import (
+    EXTERNAL_INTEROP_TASK_TYPES,
+    ChatAnswerTaskPayload,
+    CollectionTaskType,
+    DmReplyTaskPayload,
+    FetchDialogsTaskPayload,
+    FetchHistoryTaskPayload,
+)
+
+
+def test_external_interop_types_are_defined():
+    assert {t.value for t in EXTERNAL_INTEROP_TASK_TYPES} == {
+        "dm_reply",
+        "chat_answer",
+        "fetch_dialogs",
+        "fetch_history",
+    }
+
+
+def test_external_types_absent_from_unified_dispatcher_pool():
+    # HANDLED_TYPES drives claim_next_due_generic_task; if an external type leaked
+    # in, the factory worker would steal a task meant for tg_messenger.
+    from src.services.unified_dispatcher import HANDLED_TYPES
+
+    for task_type in EXTERNAL_INTEROP_TASK_TYPES:
+        assert task_type.value not in HANDLED_TYPES
+
+
+def test_channel_collect_pull_is_unaffected():
+    # CollectionQueue only pulls CHANNEL_COLLECT, so external types never enter it.
+    assert CollectionTaskType.CHANNEL_COLLECT not in EXTERNAL_INTEROP_TASK_TYPES
+
+
+@pytest.mark.parametrize(
+    "model, kwargs, kind",
+    [
+        (DmReplyTaskPayload, {"peer": "@bob", "text": "hi"}, "dm_reply"),
+        (ChatAnswerTaskPayload, {"chat_id": 42, "text": "hi"}, "chat_answer"),
+        (FetchDialogsTaskPayload, {}, "fetch_dialogs"),
+        (FetchHistoryTaskPayload, {"peer": "@chan"}, "fetch_history"),
+    ],
+)
+def test_payload_models_default_to_v1(model, kwargs, kind):
+    payload = model(**kwargs)
+    assert payload.v == 1
+    assert payload.task_kind == kind


### PR DESCRIPTION
Часть #829 (интероп tg_messenger). Тесты + claim-гонка.

> ⚠️ **Stacked на #979 (#961) → #978 (#960).** После мёржа нижних PR переключу base на `main`.

## Что сделано
- **Атомарность claim:** 8 параллельных `POST /api/tasks/claim` на одну PENDING-задачу → ровно один 200 (running), семь 204.
- **Распределение:** 2 PENDING-задачи + 6 конкурентных claim → две различные задачи, ни одна не выдана дважды.
- **Гейтинг диспетчера:** внешняя задача, созданная через API, не подхватывается внутренним диспетчером (`claim_next_due_generic_task` по `HANDLED_TYPES` → None), остаётся PENDING.

Полный lifecycle PENDING→RUNNING→COMPLETED/→FAILED покрыт в #961 (`test_tasks_api.py`).

## Проверка
- `ruff check` — чисто.
- `pytest tests/routes/test_tasks_api_concurrency.py` — 3 passed.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)