### PR TITLE
feat(web): lazyload the Search page (#946)

### DIFF
--- a/src/web/routes/search.py
+++ b/src/web/routes/search.py
@@ -77,6 +77,34 @@ async def search_page(
     )
 
 
+@router.get("/search/fragments/results", response_class=HTMLResponse)
+async def search_results_fragment(
+    request: Request,
+    q: str = Query(""),
+    channel_id: str = Query(""),
+    date_from: str = Query(""),
+    date_to: str = Query(""),
+    mode: str = Query("local"),
+    is_fts: bool = Query(False),
+    include_filtered: bool = Query(False),
+    page: int = Query(1),
+):
+    return search_response(
+        request,
+        await handlers.render_search_results(
+            request=request,
+            q=q,
+            channel_id=channel_id,
+            date_from=date_from,
+            date_to=date_to,
+            mode=mode,
+            is_fts=is_fts,
+            include_filtered=include_filtered,
+            page=page,
+        ),
+    )
+
+
 @router.post("/search/purge-cache")
 async def purge_premium_search_cache_endpoint(request: Request):
     return search_response(request, await handlers.purge_premium_search_cache(request))

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from dataclasses import dataclass, field
 
 from fastapi import Request
 from pydantic import ValidationError
@@ -167,33 +168,47 @@ async def root_page(request: Request) -> SearchRedirect:
     return SearchRedirect(url="/search")
 
 
-async def render_search_page(
-    request: Request,
-    q: str = "",
-    channel_id: str = "",
-    date_from: str = "",
-    date_to: str = "",
-    mode: str = "local",
-    is_fts: bool = False,
-    include_filtered: bool = False,
-    page: int = 1,
-) -> SearchTemplate | SearchRedirect:
+@dataclass
+class _SearchContext:
+    """Shared search setup — everything needed to render the form *and* run the
+    search, minus the search itself. Built once and used by both the page
+    skeleton (#946 lazyload) and the results fragment."""
+
+    redirect: SearchRedirect | None = None
+    db: object = None
+    service: object = None
+    channels: list = field(default_factory=list)
+    channel_id_int: int | None = None
+    channel_id_error: str | None = None
+    mode: str = "local"
+    fts_query: str = ""
+    min_length: int | None = None
+    max_length: int | None = None
+    available_modes: set = field(default_factory=set)
+    runtime_mode: str = "web"
+    limit: int = 50
+    offset: int = 0
+
+
+async def _build_search_context(
+    request: Request, *, q: str, channel_id: str, mode: str, page: int
+) -> _SearchContext:
+    limit = 50
+    offset = (page - 1) * limit
     # Onboarding: redirect if no accounts configured
     auth = deps.get_auth(request)
     if not auth.is_configured:
-        return SearchRedirect(url="/settings")
+        return _SearchContext(redirect=SearchRedirect(url="/settings"))
     db = deps.get_db(request)
     if not await db.get_account_summaries(active_only=False):
-        return SearchRedirect(url="/settings?msg=no_accounts")
+        return _SearchContext(redirect=SearchRedirect(url="/settings?msg=no_accounts"))
 
-    result = None
-    limit = 50
-    offset = (page - 1) * limit
     channel_id_int, channel_id_error = parse_channel_id(channel_id)
-
-    fts_query, _length_lo, _length_hi = extract_length(q)
-
+    fts_query, length_lo, length_hi = extract_length(q)
     service = deps.search_service(request)
+    # Loaded eagerly for the page's channel <select>; the results fragment reuses
+    # it only for the browse-mode selected_channel lookup. It's a light bounded
+    # query (channel list, not messages), so loading it on both calls is cheap.
     channels = await db.repos.channels.get_channels()
     runtime_mode = getattr(request.app.state, "runtime_mode", "web")
 
@@ -224,7 +239,92 @@ async def render_search_page(
 
     # Length filters (e.g. "foo:50") only apply to local-DB modes; resolve them
     # against the *normalised* mode so a fallback to local keeps/drops them correctly.
-    min_length, max_length = (_length_lo, _length_hi) if mode in _DB_SEARCH_MODES else (None, None)
+    min_length, max_length = (length_lo, length_hi) if mode in _DB_SEARCH_MODES else (None, None)
+
+    return _SearchContext(
+        db=db,
+        service=service,
+        channels=channels,
+        channel_id_int=channel_id_int,
+        channel_id_error=channel_id_error,
+        mode=mode,
+        fts_query=fts_query,
+        min_length=min_length,
+        max_length=max_length,
+        available_modes=available_modes,
+        runtime_mode=runtime_mode,
+        limit=limit,
+        offset=offset,
+    )
+
+
+async def render_search_page(
+    request: Request,
+    q: str = "",
+    channel_id: str = "",
+    date_from: str = "",
+    date_to: str = "",
+    mode: str = "local",
+    is_fts: bool = False,
+    include_filtered: bool = False,
+    page: int = 1,
+) -> SearchTemplate | SearchRedirect:
+    """Lazyload skeleton (#946): render the form only; the heavy search runs in
+    the ``/search/fragments/results`` fragment, triggered by HTMX on load."""
+    ctx = await _build_search_context(request, q=q, channel_id=channel_id, mode=mode, page=page)
+    if ctx.redirect is not None:
+        return ctx.redirect
+
+    try:
+        search_quota = await ctx.service.check_quota()
+    except Exception:
+        logger.exception("Failed to load search quota")
+        search_quota = None
+
+    browse_mode = bool(not q and ctx.channel_id_int and ctx.mode in _DB_SEARCH_MODES)
+    return SearchTemplate(
+        "search.html",
+        {
+            "channels": ctx.channels,
+            "q": q,
+            "channel_id": ctx.channel_id_int,
+            "date_from": date_from,
+            "date_to": date_to,
+            "mode": ctx.mode,
+            "is_fts": is_fts,
+            "include_filtered": include_filtered,
+            "page": page,
+            "available_modes": ctx.available_modes,
+            "search_quota": search_quota,
+            # Only fetch results when there's actually something to search/browse.
+            "trigger_search": bool(q) or browse_mode,
+        },
+    )
+
+
+async def render_search_results(
+    request: Request,
+    q: str = "",
+    channel_id: str = "",
+    date_from: str = "",
+    date_to: str = "",
+    mode: str = "local",
+    is_fts: bool = False,
+    include_filtered: bool = False,
+    page: int = 1,
+) -> SearchTemplate | SearchRedirect:
+    """Heavy search, rendered as an HTMX fragment (#946)."""
+    ctx = await _build_search_context(request, q=q, channel_id=channel_id, mode=mode, page=page)
+    if ctx.redirect is not None:
+        # Onboarding race (accounts removed between page load and fragment): the
+        # full-page handler already redirects, so the fragment just shows nothing.
+        return SearchTemplate("search_results.html", {"result": None})
+
+    service = ctx.service
+    channel_id_int = ctx.channel_id_int
+    mode = ctx.mode
+    limit, offset = ctx.limit, ctx.offset
+    result = None
 
     # Browse mode: channel_id without query shows latest messages from that channel
     if not q and channel_id_int and mode in _DB_SEARCH_MODES:
@@ -243,19 +343,16 @@ async def render_search_page(
         except Exception as exc:
             logger.exception("Browse mode failed: channel_id=%s", channel_id_int)
             result = SearchResult(
-                messages=[],
-                total=0,
-                query="",
-                error=f"Ошибка загрузки сообщений: {exc}",
+                messages=[], total=0, query="", error=f"Ошибка загрузки сообщений: {exc}"
             )
     elif q:
-        if channel_id_error and mode in _DB_SEARCH_MODES | {"channel"}:
-            result = SearchResult(messages=[], total=0, query=q, error=channel_id_error)
-        elif mode in _TELEGRAM_SEARCH_MODES and runtime_mode == "web":
+        if ctx.channel_id_error and mode in _DB_SEARCH_MODES | {"channel"}:
+            result = SearchResult(messages=[], total=0, query=q, error=ctx.channel_id_error)
+        elif mode in _TELEGRAM_SEARCH_MODES and ctx.runtime_mode == "web":
             # Web container has no live ClientPool — run it on the worker (#643).
             try:
                 result = await _telegram_search_via_worker(
-                    request, mode=mode, query=fts_query, limit=limit, channel_id=channel_id_int
+                    request, mode=mode, query=ctx.fts_query, limit=limit, channel_id=channel_id_int
                 )
             except Exception as exc:
                 logger.exception(
@@ -268,15 +365,15 @@ async def render_search_page(
             try:
                 result = await service.search(
                     mode=mode,
-                    query=fts_query,
+                    query=ctx.fts_query,
                     limit=limit,
                     channel_id=channel_id_int,
                     date_from=date_from or None,
                     date_to=date_to or None,
                     offset=offset,
                     is_fts=is_fts,
-                    min_length=min_length,
-                    max_length=max_length,
+                    min_length=ctx.min_length,
+                    max_length=ctx.max_length,
                     include_filtered=include_filtered,
                 )
             except Exception as exc:
@@ -285,18 +382,7 @@ async def render_search_page(
                     mode,
                     query_log_fields(q)["query_hash"],
                 )
-                result = SearchResult(
-                    messages=[],
-                    total=0,
-                    query=q,
-                    error=f"Ошибка поиска: {exc}",
-                )
-
-    try:
-        search_quota = await service.check_quota()
-    except Exception:
-        logger.exception("Failed to load search quota")
-        search_quota = None
+                result = SearchResult(messages=[], total=0, query=q, error=f"Ошибка поиска: {exc}")
 
     # Page-based navigation without an exact total (#766): «Далее» is shown when
     # the LIMIT N+1 probe saw another page. Semantic/hybrid/telegram modes still
@@ -304,17 +390,17 @@ async def render_search_page(
     # there so their deeper pages stay reachable (review on #824).
     has_more = bool(result and (result.has_more or result.total > page * limit))
 
-    # Browse mode: viewing channel messages without search query
     browse_mode = bool(not q and channel_id_int and mode in _DB_SEARCH_MODES)
     selected_channel = None
     if browse_mode and channel_id_int:
-        selected_channel = next((ch for ch in channels if ch.channel_id == channel_id_int), None)
+        selected_channel = next(
+            (ch for ch in ctx.channels if ch.channel_id == channel_id_int), None
+        )
 
     return SearchTemplate(
-        "search.html",
+        "search_results.html",
         {
             "result": result,
-            "channels": channels,
             "q": q,
             "channel_id": channel_id_int,
             "date_from": date_from,
@@ -324,8 +410,6 @@ async def render_search_page(
             "include_filtered": include_filtered,
             "page": page,
             "has_more": has_more,
-            "available_modes": available_modes,
-            "search_quota": search_quota,
             "browse_mode": browse_mode,
             "selected_channel": selected_channel,
         },

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% from "_macros.html" import icon %}
 {% block title %}Поиск — TG Agent{% endblock %}
 {% block content %}
 <h1>Поиск по постам</h1>
@@ -88,125 +87,14 @@
     </div>
 </form>
 
-{% if result %}
+{% if trigger_search %}
 <hr>
-
-{% if result.error %}
-<div class="alert alert-danger">
-    <strong>Ошибка:</strong> {{ result.error }}
+<div id="search-results"
+     hx-get="/search/fragments/results?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page }}"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+    <div class="text-center text-muted py-4"><span class="spinner-border spinner-border-sm"></span> Поиск…</div>
 </div>
-{% endif %}
-
-{% if result.ai_summary %}
-<div class="card mb-3">
-    <div class="card-header fw-semibold">AI-анализ</div>
-    <div class="card-body"><p class="mb-0">{{ result.ai_summary }}</p></div>
-</div>
-{% endif %}
-
-{% if not result.error %}
-{% if browse_mode and selected_channel %}
-<p>Сообщения из канала <strong>{{ selected_channel.title or selected_channel.username or selected_channel.channel_id }}</strong>: {{ result.total }}{% if result.has_more %}+{% endif %}</p>
-{% else %}
-<p>Найдено: <strong>{{ result.total }}{% if result.has_more %}+{% endif %}</strong> сообщений по запросу «{{ result.query }}»</p>
-{% endif %}
-{% endif %}
-
-{% if result.messages %}
-<!-- Desktop: table -->
-<div class="table-responsive d-none d-md-block">
-<table class="tga-table-striped-hover">
-    <thead>
-        <tr>
-            <th>Дата</th>
-            <th>Канал</th>
-            <th>Отправитель</th>
-            <th>Медиа</th>
-            <th>Текст</th>
-            <th>Охват</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for msg in result.messages %}
-        <tr>
-            <td class="text-nowrap">{{ msg.date|local_dt }}</td>
-            <td>{{ msg.channel_title or msg.channel_username or msg.channel_id }}</td>
-            <td>{{ msg.sender_name or "—" }}</td>
-            <td>{{ msg.media_type or "—" }}</td>
-            <td>
-                {% if msg.detected_lang %}<span class="badge bg-secondary me-1" style="font-size:0.65rem">{{ msg.detected_lang }}</span>{% endif %}
-                <span>{{ msg.text[:300] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 300 else "" }}</span>
-                {% if msg.translation_en %}
-                <div class="text-muted mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:300] }}{{ "..." if msg.translation_en|length > 300 else "" }}</div>
-                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
-                <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
-                <div class="translation-result text-muted mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></div>
-                {% endif %}
-            </td>
-            <td class="text-nowrap text-muted" style="font-size:0.8rem">
-                {%- if msg.views is not none %}👁 {{ msg.views }}{% endif %}
-                {%- if msg.forwards is not none %} ↗ {{ msg.forwards }}{% endif %}
-                {%- if msg.reply_count is not none %} {{ icon("comments") }} {{ msg.reply_count }}{% endif %}
-                {%- if msg.views is none and msg.forwards is none and msg.reply_count is none %}—{% endif %}
-            </td>
-            <td>{% if msg.channel_username %}<a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener" title="Открыть в Telegram">{{ icon("link") }}</a>{% else %}<a href="https://t.me/c/{{ msg.channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener" title="Открыть в Telegram">{{ icon("link") }}</a>{% endif %}</td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-</div>
-
-<!-- Mobile: cards -->
-<div class="d-md-none mobile-cards">
-    {% for msg in result.messages %}
-    <div class="card mb-2">
-        <div class="card-body">
-            <div class="d-flex justify-content-between align-items-center mb-1">
-                <strong class="text-truncate">{{ msg.channel_title or msg.channel_username or msg.channel_id }}</strong>
-                {% if msg.channel_username %}<a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>{% else %}<a href="https://t.me/c/{{ msg.channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>{% endif %}
-            </div>
-            <small class="text-muted">{{ msg.date|local_dt }}{% if msg.sender_name %} &middot; {{ msg.sender_name }}{% endif %}{% if msg.media_type %} &middot; {{ msg.media_type }}{% endif %}</small>
-            <p class="mb-0 mt-1" style="font-size:0.85rem">
-                {% if msg.detected_lang %}<span class="badge bg-secondary me-1" style="font-size:0.6rem">{{ msg.detected_lang }}</span>{% endif %}
-                {{ msg.text[:200] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 200 else "" }}
-                {% if msg.translation_en %}
-                <span class="text-muted d-block mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:200] }}{{ "..." if msg.translation_en|length > 200 else "" }}</span>
-                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
-                <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
-                <span class="translation-result text-muted d-block mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></span>
-                {% endif %}
-            </p>
-            {%- if msg.views is not none or msg.forwards is not none or msg.reply_count is not none %}
-            <small class="text-muted">
-                {%- if msg.views is not none %}👁 {{ msg.views }}{% endif %}
-                {%- if msg.forwards is not none %} ↗ {{ msg.forwards }}{% endif %}
-                {%- if msg.reply_count is not none %} {{ icon("comments") }} {{ msg.reply_count }}{% endif %}
-            </small>
-            {%- endif %}
-        </div>
-    </div>
-    {% endfor %}
-</div>
-
-{% if page > 1 or has_more %}
-<nav>
-    <ul class="pagination justify-content-center">
-        {% if page > 1 %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page - 1 }}">Назад</a></li>
-        {% endif %}
-        <li class="page-item disabled"><span class="page-link">Страница {{ page }}</span></li>
-        {% if has_more %}
-        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page + 1 }}">Далее</a></li>
-        {% endif %}
-    </ul>
-</nav>
-{% endif %}
-
-{% else %}
-<p>Ничего не найдено.</p>
-{% endif %}
-
 {% endif %}
 
 <script>

--- a/src/web/templates/search.html
+++ b/src/web/templates/search.html
@@ -90,7 +90,7 @@
 {% if trigger_search %}
 <hr>
 <div id="search-results"
-     hx-get="/search/fragments/results?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page }}"
+     hx-get="/search/fragments/results?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
     <div class="text-center text-muted py-4"><span class="spinner-border spinner-border-sm"></span> Поиск…</div>

--- a/src/web/templates/search_results.html
+++ b/src/web/templates/search_results.html
@@ -1,0 +1,121 @@
+{# Search results fragment (#946): rendered by GET /search/fragments/results
+   and swapped into the #search-results container on the lazyloaded search page. #}
+{% from "_macros.html" import icon %}
+{% if result %}
+{% if result.error %}
+<div class="alert alert-danger">
+    <strong>Ошибка:</strong> {{ result.error }}
+</div>
+{% endif %}
+
+{% if result.ai_summary %}
+<div class="card mb-3">
+    <div class="card-header fw-semibold">AI-анализ</div>
+    <div class="card-body"><p class="mb-0">{{ result.ai_summary }}</p></div>
+</div>
+{% endif %}
+
+{% if not result.error %}
+{% if browse_mode and selected_channel %}
+<p>Сообщения из канала <strong>{{ selected_channel.title or selected_channel.username or selected_channel.channel_id }}</strong>: {{ result.total }}{% if result.has_more %}+{% endif %}</p>
+{% else %}
+<p>Найдено: <strong>{{ result.total }}{% if result.has_more %}+{% endif %}</strong> сообщений по запросу «{{ result.query }}»</p>
+{% endif %}
+{% endif %}
+
+{% if result.messages %}
+<!-- Desktop: table -->
+<div class="table-responsive d-none d-md-block">
+<table class="tga-table-striped-hover">
+    <thead>
+        <tr>
+            <th>Дата</th>
+            <th>Канал</th>
+            <th>Отправитель</th>
+            <th>Медиа</th>
+            <th>Текст</th>
+            <th>Охват</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for msg in result.messages %}
+        <tr>
+            <td class="text-nowrap">{{ msg.date|local_dt }}</td>
+            <td>{{ msg.channel_title or msg.channel_username or msg.channel_id }}</td>
+            <td>{{ msg.sender_name or "—" }}</td>
+            <td>{{ msg.media_type or "—" }}</td>
+            <td>
+                {% if msg.detected_lang %}<span class="badge bg-secondary me-1" style="font-size:0.65rem">{{ msg.detected_lang }}</span>{% endif %}
+                <span>{{ msg.text[:300] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 300 else "" }}</span>
+                {% if msg.translation_en %}
+                <div class="text-muted mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:300] }}{{ "..." if msg.translation_en|length > 300 else "" }}</div>
+                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
+                <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
+                <div class="translation-result text-muted mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></div>
+                {% endif %}
+            </td>
+            <td class="text-nowrap text-muted" style="font-size:0.8rem">
+                {%- if msg.views is not none %}👁 {{ msg.views }}{% endif %}
+                {%- if msg.forwards is not none %} ↗ {{ msg.forwards }}{% endif %}
+                {%- if msg.reply_count is not none %} {{ icon("comments") }} {{ msg.reply_count }}{% endif %}
+                {%- if msg.views is none and msg.forwards is none and msg.reply_count is none %}—{% endif %}
+            </td>
+            <td>{% if msg.channel_username %}<a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener" title="Открыть в Telegram">{{ icon("link") }}</a>{% else %}<a href="https://t.me/c/{{ msg.channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener" title="Открыть в Telegram">{{ icon("link") }}</a>{% endif %}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+
+<!-- Mobile: cards -->
+<div class="d-md-none mobile-cards">
+    {% for msg in result.messages %}
+    <div class="card mb-2">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <strong class="text-truncate">{{ msg.channel_title or msg.channel_username or msg.channel_id }}</strong>
+                {% if msg.channel_username %}<a href="https://t.me/{{ msg.channel_username }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>{% else %}<a href="https://t.me/c/{{ msg.channel_id }}/{{ msg.message_id }}" target="_blank" rel="noopener">{{ icon("link") }}</a>{% endif %}
+            </div>
+            <small class="text-muted">{{ msg.date|local_dt }}{% if msg.sender_name %} &middot; {{ msg.sender_name }}{% endif %}{% if msg.media_type %} &middot; {{ msg.media_type }}{% endif %}</small>
+            <p class="mb-0 mt-1" style="font-size:0.85rem">
+                {% if msg.detected_lang %}<span class="badge bg-secondary me-1" style="font-size:0.6rem">{{ msg.detected_lang }}</span>{% endif %}
+                {{ msg.text[:200] if msg.text else "—" }}{{ "..." if msg.text and msg.text|length > 200 else "" }}
+                {% if msg.translation_en %}
+                <span class="text-muted d-block mt-1" style="font-size:0.8rem"><i class="bi bi-translate me-1"></i>{{ msg.translation_en[:200] }}{{ "..." if msg.translation_en|length > 200 else "" }}</span>
+                {% elif msg.id is not none and msg.text and msg.detected_lang and msg.detected_lang != 'en' %}
+                <button class="btn btn-link btn-sm p-0 ms-1 translate-btn" data-msg-id="{{ msg.id }}" title="Перевести"><i class="bi bi-translate"></i></button>
+                <span class="translation-result text-muted d-block mt-1" style="font-size:0.8rem;display:none" data-target="translation-{{ msg.id }}"></span>
+                {% endif %}
+            </p>
+            {%- if msg.views is not none or msg.forwards is not none or msg.reply_count is not none %}
+            <small class="text-muted">
+                {%- if msg.views is not none %}👁 {{ msg.views }}{% endif %}
+                {%- if msg.forwards is not none %} ↗ {{ msg.forwards }}{% endif %}
+                {%- if msg.reply_count is not none %} {{ icon("comments") }} {{ msg.reply_count }}{% endif %}
+            </small>
+            {%- endif %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+
+{% if page > 1 or has_more %}
+<nav>
+    <ul class="pagination justify-content-center">
+        {% if page > 1 %}
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page - 1 }}">Назад</a></li>
+        {% endif %}
+        <li class="page-item disabled"><span class="page-link">Страница {{ page }}</span></li>
+        {% if has_more %}
+        <li class="page-item"><a class="page-link" href="/search?q={{ q|urlencode }}&channel_id={{ channel_id or '' }}&date_from={{ date_from }}&date_to={{ date_to }}&mode={{ mode }}&is_fts={{ 1 if is_fts else 0 }}&include_filtered={{ 1 if include_filtered else 0 }}&page={{ page + 1 }}">Далее</a></li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}
+
+{% else %}
+<p>Ничего не найдено.</p>
+{% endif %}
+
+{% endif %}

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -72,6 +72,22 @@ async def test_search_page_with_message(route_client):
 
 
 @pytest.mark.anyio
+async def test_search_page_is_skeleton_and_defers_search(route_client, monkeypatch):
+    """Lazyload (#946): GET /search with a query returns the skeleton with an
+    hx-get trigger to the results fragment, and does NOT run the search itself."""
+    mock_svc = MagicMock()
+    mock_svc.search = AsyncMock(return_value=SearchResult(messages=[], total=0, query="test"))
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr("src.web.search.handlers.deps.search_service", lambda r: mock_svc)
+
+    resp = await route_client.get("/search?q=test")
+    assert resp.status_code == 200
+    assert "/search/fragments/results?q=test" in resp.text
+    assert 'hx-trigger="load"' in resp.text
+    mock_svc.search.assert_not_called()
+
+
+@pytest.mark.anyio
 async def test_search_with_query(route_client, monkeypatch):
     """Test search with query executes search."""
     mock_result = SearchResult(messages=[], total=0, query="test")
@@ -83,7 +99,7 @@ async def test_search_with_query(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test")
+    resp = await route_client.get("/search/fragments/results?q=test")
     assert resp.status_code == 200
     mock_svc.search.assert_called_once()
 
@@ -113,7 +129,7 @@ async def test_search_result_does_not_render_translate_button_without_db_id(rout
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=привет")
+    resp = await route_client.get("/search/fragments/results?q=привет")
 
     assert resp.status_code == 200
     assert 'data-msg-id="None"' not in resp.text
@@ -144,7 +160,7 @@ async def test_search_result_renders_translate_button_with_db_id(route_client, m
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=привет")
+    resp = await route_client.get("/search/fragments/results?q=привет")
 
     assert resp.status_code == 200
     assert 'data-msg-id="123"' in resp.text
@@ -164,7 +180,7 @@ async def test_search_invalid_channel_id(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&channel_id=bad")
+    resp = await route_client.get("/search/fragments/results?q=test&channel_id=bad")
     assert resp.status_code == 200
     assert "Некорректный ID" in resp.text or "invalid" in resp.text.lower()
 
@@ -181,7 +197,7 @@ async def test_search_pagination(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&page=2")
+    resp = await route_client.get("/search/fragments/results?q=test&page=2")
     assert resp.status_code == 200
 
 
@@ -197,7 +213,7 @@ async def test_search_fts_mode(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&is_fts=true")
+    resp = await route_client.get("/search/fragments/results?q=test&is_fts=true")
     assert resp.status_code == 200
 
 
@@ -213,7 +229,7 @@ async def test_search_hybrid_mode(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&mode=hybrid")
+    resp = await route_client.get("/search/fragments/results?q=test&mode=hybrid")
     assert resp.status_code == 200
 
 
@@ -228,7 +244,7 @@ async def test_search_error_rendered(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test")
+    resp = await route_client.get("/search/fragments/results?q=test")
     assert resp.status_code == 200
     assert "ошибка" in resp.text.lower() or "error" in resp.text.lower()
 
@@ -246,7 +262,7 @@ async def test_search_date_filters(route_client, monkeypatch):
     )
 
     resp = await route_client.get(
-        "/search?q=test&date_from=2024-01-01&date_to=2024-12-31"
+        "/search/fragments/results?q=test&date_from=2024-01-01&date_to=2024-12-31"
     )
     assert resp.status_code == 200
 
@@ -263,7 +279,7 @@ async def test_search_length_filter(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test%20len%3C500&mode=local")
+    resp = await route_client.get("/search/fragments/results?q=test%20len%3C500&mode=local")
     assert resp.status_code == 200
 
 
@@ -288,7 +304,7 @@ async def test_browse_mode_with_channel_id(route_client, monkeypatch, base_app):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?channel_id=200&mode=local")
+    resp = await route_client.get("/search/fragments/results?channel_id=200&mode=local")
     assert resp.status_code == 200
     # Should call search with mode="local" (browse forces local mode)
     mock_svc.search.assert_called_once()
@@ -326,7 +342,7 @@ async def test_browse_mode_with_query(route_client, monkeypatch, base_app):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&channel_id=200&mode=local")
+    resp = await route_client.get("/search/fragments/results?q=test&channel_id=200&mode=local")
     assert resp.status_code == 200
     # Should call search normally (not browse mode)
     mock_svc.search.assert_called_once()
@@ -447,7 +463,7 @@ async def test_search_quota_failure(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test")
+    resp = await route_client.get("/search/fragments/results?q=test")
     assert resp.status_code == 200
 
 
@@ -679,7 +695,7 @@ async def test_search_page_shows_plus_when_has_more(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test")
+    resp = await route_client.get("/search/fragments/results?q=test")
 
     assert resp.status_code == 200
     # #766: the result counter renders «N+» and the next-page link appears.
@@ -708,7 +724,7 @@ async def test_search_page_no_next_when_no_more(route_client, monkeypatch):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test")
+    resp = await route_client.get("/search/fragments/results?q=test")
 
     assert resp.status_code == 200
     # #766: the result counter renders the exact total with no lower-bound «+»,
@@ -762,7 +778,7 @@ async def test_search_page_next_link_for_exact_total_modes(route_client, monkeyp
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?q=test&mode=semantic")
+    resp = await route_client.get("/search/fragments/results?q=test&mode=semantic")
 
     assert resp.status_code == 200
     assert "Далее" in resp.text

--- a/tests/routes/test_search_routes.py
+++ b/tests/routes/test_search_routes.py
@@ -88,6 +88,20 @@ async def test_search_page_is_skeleton_and_defers_search(route_client, monkeypat
 
 
 @pytest.mark.anyio
+async def test_skeleton_forwards_raw_channel_id_to_fragment(route_client, monkeypatch):
+    """Lazyload (#946) review: the skeleton must forward the raw query string so a
+    hand-crafted ?channel_id=bad reaches the fragment and gets validated there,
+    instead of being parsed to None and silently searching all channels."""
+    mock_svc = MagicMock()
+    mock_svc.check_quota = AsyncMock(return_value=None)
+    monkeypatch.setattr("src.web.search.handlers.deps.search_service", lambda r: mock_svc)
+
+    resp = await route_client.get("/search?q=test&channel_id=bad")
+    assert resp.status_code == 200
+    assert "channel_id=bad" in resp.text  # forwarded verbatim to the fragment hx-get
+
+
+@pytest.mark.anyio
 async def test_search_with_query(route_client, monkeypatch):
     """Test search with query executes search."""
     mock_result = SearchResult(messages=[], total=0, query="test")
@@ -364,9 +378,10 @@ async def test_browse_mode_error_handling(route_client, monkeypatch, base_app):
         lambda r: mock_svc,
     )
 
-    resp = await route_client.get("/search?channel_id=300&mode=local")
+    # The browse search runs in the fragment (lazyload #946); the skeleton page
+    # never calls service.search, so hit the fragment to exercise the error path.
+    resp = await route_client.get("/search/fragments/results?channel_id=300&mode=local")
     assert resp.status_code == 200
-    # Error should be rendered on page
     assert "error" in resp.text.lower() or "ошибка" in resp.text.lower()
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -315,7 +315,7 @@ class TestSearchModes:
         ]
         await test_db.insert_messages_batch(msgs)
 
-        resp = await auth_client.get("/search?q=Bitcoin&mode=local")
+        resp = await auth_client.get("/search/fragments/results?q=Bitcoin&mode=local")
         assert resp.status_code == 200
         assert "Bitcoin" in resp.text
 
@@ -540,12 +540,12 @@ class TestSearchPagination:
         await test_db.insert_messages_batch(msgs)
 
         # Page 1 (limit=50 by default)
-        resp1 = await auth_client.get("/search?q=Crypto&mode=local&page=1")
+        resp1 = await auth_client.get("/search/fragments/results?q=Crypto&mode=local&page=1")
         assert resp1.status_code == 200
         assert "Crypto" in resp1.text
 
         # Page 2
-        resp2 = await auth_client.get("/search?q=Crypto&mode=local&page=2")
+        resp2 = await auth_client.get("/search/fragments/results?q=Crypto&mode=local&page=2")
         assert resp2.status_code == 200
 
     @pytest.mark.anyio

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1487,14 +1487,14 @@ async def test_scheduler_limit_preserved_in_links(client):
 
 @pytest.mark.anyio
 async def test_search_with_query(client):
-    resp = await client.get("/search?q=test&mode=local")
+    resp = await client.get("/search/fragments/results?q=test&mode=local")
     assert resp.status_code == 200
     assert "test" in resp.text
 
 
 @pytest.mark.anyio
 async def test_search_with_invalid_channel_id_returns_error(client):
-    resp = await client.get("/search?q=test&mode=channel&channel_id=abc")
+    resp = await client.get("/search/fragments/results?q=test&mode=channel&channel_id=abc")
     assert resp.status_code == 200
     assert "Некорректный ID канала: abc" in resp.text
 
@@ -1538,7 +1538,7 @@ async def test_search_semantic_unavailable_falls_back_to_local(client):
         vec_available=False, numpy_available=False
     )
 
-    resp = await client.get("/search?q=paris&mode=semantic")
+    resp = await client.get("/search/fragments/results?q=paris&mode=semantic")
     assert resp.status_code == 200
     # No semantic-unavailable banner — the mode was normalised away before searching.
     assert "Семантический поиск недоступен" not in resp.text
@@ -1579,11 +1579,12 @@ async def test_search_with_semantic_mode(client, monkeypatch):
         AsyncMock(return_value=[1.0, 0.0]),
     )
 
-    resp = await client.get("/search?q=bitcoin&mode=semantic")
+    resp = await client.get("/search/fragments/results?q=bitcoin&mode=semantic")
 
     assert resp.status_code == 200
     assert "Bitcoin rebounds strongly" in resp.text
-    assert "Семантический" in resp.text
+    # The "Семантический" radio is a form element on the page skeleton, not the
+    # results fragment; its availability is covered by the search-route tests.
 
 
 @pytest.mark.anyio
@@ -1601,7 +1602,7 @@ async def test_search_runtime_error_is_rendered(client, monkeypatch):
 
     # mode=local goes through service.search directly (telegram modes are now
     # proxied to the worker in web runtime, see #643).
-    resp = await client.get("/search?q=test&mode=local")
+    resp = await client.get("/search/fragments/results?q=test&mode=local")
 
     assert resp.status_code == 200
     assert "Ошибка поиска: boom" in resp.text
@@ -1613,7 +1614,7 @@ async def test_search_telegram_proxy_when_worker_down(client, monkeypatch):
     monkeypatch.setattr("src.web.routes.scheduler._is_worker_alive", AsyncMock(return_value=False))
     _connect_pool(client)
 
-    resp = await client.get("/search?q=test&mode=telegram")
+    resp = await client.get("/search/fragments/results?q=test&mode=telegram")
 
     assert resp.status_code == 200
     assert "Telegram-worker не запущен" in resp.text
@@ -1628,7 +1629,7 @@ async def test_search_telegram_proxied_in_web_even_with_empty_snapshot_pool(clie
     app.state.pool = SimpleNamespace(clients={})  # empty snapshot — no clients visible
     monkeypatch.setattr("src.web.routes.scheduler._is_worker_alive", AsyncMock(return_value=False))
 
-    resp = await client.get("/search?q=test&mode=telegram")
+    resp = await client.get("/search/fragments/results?q=test&mode=telegram")
 
     assert resp.status_code == 200
     # Reached the worker-proxy branch (which reports the worker is down), NOT a local search.
@@ -1661,7 +1662,7 @@ async def test_search_telegram_proxy_renders_worker_result(client, monkeypatch):
     )
     monkeypatch.setattr(deps, "telegram_command_service", lambda request: fake_cmd_service)
 
-    resp = await client.get("/search?q=test&mode=telegram")
+    resp = await client.get("/search/fragments/results?q=test&mode=telegram")
 
     assert resp.status_code == 200
     assert "proxied premium hit" in resp.text
@@ -1701,7 +1702,7 @@ async def test_search_telegram_proxy_timeout_logs_command_context(client, monkey
     )
     monkeypatch.setattr(deps, "telegram_command_service", lambda request: fake_cmd_service)
 
-    resp = await client.get("/search?q=test&mode=telegram")
+    resp = await client.get("/search/fragments/results?q=test&mode=telegram")
 
     assert resp.status_code == 200
     assert "command_id=123" in resp.text
@@ -2841,7 +2842,7 @@ async def test_search_results_have_tg_links(client):
     )
     await db.insert_message(msg)
 
-    resp = await client.get("/search?q=Hello&mode=local")
+    resp = await client.get("/search/fragments/results?q=Hello&mode=local")
     assert resp.status_code == 200
     assert "t.me/testchan/42" in resp.text
     assert "bi-link-45deg" in resp.text
@@ -2865,7 +2866,7 @@ async def test_search_results_private_channel_link(client):
     )
     await db.insert_message(msg)
 
-    resp = await client.get("/search?q=Secret&mode=local")
+    resp = await client.get("/search/fragments/results?q=Secret&mode=local")
     assert resp.status_code == 200
     assert "t.me/c/-100999/7" in resp.text
 


### PR DESCRIPTION
Часть #756 (lazyload). Переводит страницу **Search** (`GET /search`) на lazyload-паттерн.

## Проблема
Полный поиск по ~6 млн сообщений выполнялся прямо в рендере страницы → страница висела 10+ сек до первого байта контента.

## Что сделано
- `GET /search` теперь отдаёт **только skeleton**: форма + плейсхолдер результатов с `hx-get="/search/fragments/results?…" hx-trigger="load"` (триггерится только когда есть запрос/browse).
- Новый fragment-роут **`GET /search/fragments/results`** выполняет тяжёлый поиск и рендерит шаблон только результатов.
- Общая настройка (онбординг, каналы, нормализация режима, length-фильтры, quota-входы) вынесена в `_build_search_context`, который зовут **оба** handler'а — без дублирования логики.
- `search.html` → форма + контейнер; `search_results.html` (новый) — блок результатов, перенесён 1-в-1.
- Эталон: `/dashboard` (`templates/dashboard.html` skeleton → `dashboard.py:GET /fragments/overview`).

## Проверка
- `ruff check src/ tests/` — чисто.
- `pytest tests/routes/ tests/test_integration.py tests/test_web.py -k search` — зелёно; полный `tests/routes/` — **992 passed**.
- Result-ассерты тестов перенесены на fragment-роут; добавлен тест, что `/search` **откладывает** поиск (search не вызывается) и содержит hx-get-триггер — это и есть acceptance-проверка lazyload через реальное ASGI-приложение.
- `/simplify` пройден: удалён мёртвый импорт макроса, добавлен поясняющий комментарий.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)