### PR TITLE
feat(web): lazyload the Moderation page (#948)

### DIFF
--- a/src/web/routes/moderation.py
+++ b/src/web/routes/moderation.py
@@ -19,7 +19,14 @@ def _moderation_redirect(code: str, *, error: bool = False) -> RedirectResponse:
 
 
 @router.get("/", response_class=HTMLResponse)
-async def moderation_queue_page(
+async def moderation_queue_page(request: Request):
+    # Lazyload skeleton (#948): the heavy queue (pending-moderation table +
+    # pipeline relations) loads via the /moderation/fragments/table fragment.
+    return deps.get_templates(request).TemplateResponse(request, "moderation.html", {})
+
+
+@router.get("/fragments/table", response_class=HTMLResponse)
+async def moderation_table_fragment(
     request: Request,
     pipeline_id: str | None = None,
     limit: str | None = None,
@@ -43,7 +50,7 @@ async def moderation_queue_page(
 
     return deps.get_templates(request).TemplateResponse(
         request,
-        "moderation.html",
+        "moderation_content.html",
         {
             "pending_runs": pending_runs,
             "pipelines": pipelines,

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -3,115 +3,15 @@
 {% block title %}Очередь модерации{% endblock %}
 
 {% block content %}
-<div class="container-fluid">
-    <h1 class="h3 mb-4">Очередь модерации</h1>
-
-    <div class="card mb-4">
-        <div class="card-body">
-            <form method="get" class="row g-3">
-                <div class="col-md-4">
-                    <label class="form-label">Пайплайн</label>
-                    <select name="pipeline_id" class="form-select">
-                        <option value="">Все пайплайны</option>
-                        {% for item in pipelines %}
-                        <option value="{{ item.pipeline.id }}" {% if selected_pipeline_id == item.pipeline.id %}selected{% endif %}>
-                            {{ item.pipeline.name }}
-                        </option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div class="col-md-2">
-                    <label class="form-label">Лимит</label>
-                    <input type="number" name="limit" value="{{ limit }}" class="form-control" min="1" max="200">
-                </div>
-                <div class="col-md-2 d-flex align-items-end">
-                    <button type="submit" class="btn btn-primary">Фильтр</button>
-                </div>
-            </form>
-        </div>
+{# Lazyload (#948): the pending-moderation table (list_pending_moderation +
+   pipeline relations) loads via the fragment on load, not in the page render. #}
+<div id="moderation-content"
+     hx-get="/moderation/fragments/table?{{ request.url.query }}"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+    <div class="text-center text-muted py-5">
+        <span class="spinner-border" role="status"></span>
+        <div class="mt-2">Загрузка очереди модерации…</div>
     </div>
-
-    {% if pending_runs %}
-    <form method="post" action="/moderation/bulk-approve" data-busy>
-        <div class="mb-3">
-            <button type="submit" class="btn btn-success btn-sm">Одобрить выбранные</button>
-            <button type="submit" formaction="/moderation/bulk-reject" class="btn btn-danger btn-sm">Отклонить выбранные</button>
-        </div>
-
-        <div class="table-responsive">
-            <table class="tga-table tga-table-hover tga-table-lg">
-                <thead>
-                    <tr>
-                        <th><input type="checkbox" id="select-all"></th>
-                        <th>ID</th>
-                        <th>Пайплайн</th>
-                        <th>Статус</th>
-                        <th>Создан</th>
-                        <th>Превью</th>
-                        <th>Действия</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for run in pending_runs %}
-                    <tr>
-                        <td>
-                            <input type="checkbox" name="run_ids" value="{{ run.id }}" class="run-checkbox">
-                        </td>
-                        <td>{{ run.id }}</td>
-                        <td>{{ run.pipeline_id }}</td>
-                        <td>
-                            <span class="badge bg-{% if run.moderation_status == 'pending' %}secondary{% elif run.moderation_status == 'approved' %}success{% elif run.moderation_status == 'rejected' %}danger{% else %}primary{% endif %}">
-                                {{ run.moderation_status }}
-                            </span>
-                        </td>
-                        <td>{{ run.created_at|local_dt }}</td>
-                        <td>
-                            {% if run.generated_text %}
-                            <span class="text-muted">{{ run.generated_text[:100] }}{% if run.generated_text|length > 100 %}...{% endif %}</span>
-                            {% else %}
-                            <span class="text-muted">Нет текста</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div class="btn-group btn-group-sm">
-                                <a href="/moderation/{{ run.id }}/view" class="btn btn-outline-primary">Просмотр</a>
-                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/approve" class="btn btn-outline-success">Одобрить</button>
-                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/reject" class="btn btn-outline-danger">Отклонить</button>
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </form>
-
-    <nav>
-        <ul class="pagination">
-            {% if offset > 0 %}
-            <li class="page-item">
-                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ [offset - limit, 0] | max }}">Назад</a>
-            </li>
-            {% endif %}
-            {% if pending_runs|length == limit %}
-            <li class="page-item">
-                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ offset + limit }}">Вперёд</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
-    {% else %}
-    <div class="alert alert-info">Нет черновиков на модерации.</div>
-    {% endif %}
 </div>
-
-<script>
-const selectAll = document.getElementById('select-all');
-if (selectAll) {
-    selectAll.addEventListener('change', function() {
-        const checkboxes = document.querySelectorAll('.run-checkbox');
-        checkboxes.forEach(cb => cb.checked = this.checked);
-    });
-}
-</script>
 {% endblock %}

--- a/src/web/templates/moderation_content.html
+++ b/src/web/templates/moderation_content.html
@@ -1,0 +1,111 @@
+<div class="container-fluid">
+    <h1 class="h3 mb-4">Очередь модерации</h1>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <form method="get" class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">Пайплайн</label>
+                    <select name="pipeline_id" class="form-select">
+                        <option value="">Все пайплайны</option>
+                        {% for item in pipelines %}
+                        <option value="{{ item.pipeline.id }}" {% if selected_pipeline_id == item.pipeline.id %}selected{% endif %}>
+                            {{ item.pipeline.name }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">Лимит</label>
+                    <input type="number" name="limit" value="{{ limit }}" class="form-control" min="1" max="200">
+                </div>
+                <div class="col-md-2 d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary">Фильтр</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {% if pending_runs %}
+    <form method="post" action="/moderation/bulk-approve" data-busy>
+        <div class="mb-3">
+            <button type="submit" class="btn btn-success btn-sm">Одобрить выбранные</button>
+            <button type="submit" formaction="/moderation/bulk-reject" class="btn btn-danger btn-sm">Отклонить выбранные</button>
+        </div>
+
+        <div class="table-responsive">
+            <table class="tga-table tga-table-hover tga-table-lg">
+                <thead>
+                    <tr>
+                        <th><input type="checkbox" id="select-all"></th>
+                        <th>ID</th>
+                        <th>Пайплайн</th>
+                        <th>Статус</th>
+                        <th>Создан</th>
+                        <th>Превью</th>
+                        <th>Действия</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for run in pending_runs %}
+                    <tr>
+                        <td>
+                            <input type="checkbox" name="run_ids" value="{{ run.id }}" class="run-checkbox">
+                        </td>
+                        <td>{{ run.id }}</td>
+                        <td>{{ run.pipeline_id }}</td>
+                        <td>
+                            <span class="badge bg-{% if run.moderation_status == 'pending' %}secondary{% elif run.moderation_status == 'approved' %}success{% elif run.moderation_status == 'rejected' %}danger{% else %}primary{% endif %}">
+                                {{ run.moderation_status }}
+                            </span>
+                        </td>
+                        <td>{{ run.created_at|local_dt }}</td>
+                        <td>
+                            {% if run.generated_text %}
+                            <span class="text-muted">{{ run.generated_text[:100] }}{% if run.generated_text|length > 100 %}...{% endif %}</span>
+                            {% else %}
+                            <span class="text-muted">Нет текста</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <a href="/moderation/{{ run.id }}/view" class="btn btn-outline-primary">Просмотр</a>
+                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/approve" class="btn btn-outline-success">Одобрить</button>
+                                <button type="submit" name="run_id" value="{{ run.id }}" formaction="/moderation/{{ run.id }}/reject" class="btn btn-outline-danger">Отклонить</button>
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </form>
+
+    <nav>
+        <ul class="pagination">
+            {% if offset > 0 %}
+            <li class="page-item">
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ [offset - limit, 0] | max }}">Назад</a>
+            </li>
+            {% endif %}
+            {% if pending_runs|length == limit %}
+            <li class="page-item">
+                <a class="page-link" href="?pipeline_id={{ selected_pipeline_id or '' }}&limit={{ limit }}&offset={{ offset + limit }}">Вперёд</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% else %}
+    <div class="alert alert-info">Нет черновиков на модерации.</div>
+    {% endif %}
+</div>
+
+<script>
+const selectAll = document.getElementById('select-all');
+if (selectAll) {
+    selectAll.addEventListener('change', function() {
+        const checkboxes = document.querySelectorAll('.run-checkbox');
+        checkboxes.forEach(cb => cb.checked = this.checked);
+    });
+}
+</script>

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -62,10 +62,19 @@ async def _create_pipeline(db: Database, *, publish_mode: PipelinePublishMode) -
 
 @pytest.mark.anyio
 async def test_moderation_page_renders_empty_queue(client):
-    resp = await client.get("/moderation/")
+    resp = await client.get("/moderation/fragments/table")
     assert resp.status_code == 200
     assert "Нет черновиков на модерации." in resp.text
     assert "request.query_params.get" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_moderation_page_is_skeleton(client):
+    """Lazyload (#948): the page shell defers the queue table to the fragment."""
+    resp = await client.get("/moderation/")
+    assert resp.status_code == 200
+    assert "/moderation/fragments/table" in resp.text
+    assert 'hx-trigger="load"' in resp.text
 
 
 @pytest.mark.anyio
@@ -235,14 +244,14 @@ async def test_bulk_approve_empty(client):
 @pytest.mark.anyio
 async def test_moderation_page_with_pipeline_filter(client):
     """Test moderation page with pipeline filter."""
-    resp = await client.get("/moderation/?pipeline_id=1")
+    resp = await client.get("/moderation/fragments/table?pipeline_id=1")
     assert resp.status_code == 200
 
 
 @pytest.mark.anyio
 async def test_moderation_page_empty_filter_params_return_200(client):
     """The filter form submits ?pipeline_id= (empty option value) — must not 422 (#779)."""
-    resp = await client.get("/moderation/?pipeline_id=&limit=&offset=")
+    resp = await client.get("/moderation/fragments/table?pipeline_id=&limit=&offset=")
     assert resp.status_code == 200
     assert "Очередь модерации" in resp.text
 
@@ -250,7 +259,7 @@ async def test_moderation_page_empty_filter_params_return_200(client):
 @pytest.mark.anyio
 async def test_moderation_page_pipeline_id_none_string_returns_200(client):
     """Pagination links render pipeline_id=None when no pipeline selected — must not 422 (#779)."""
-    resp = await client.get("/moderation/?pipeline_id=None&limit=50&offset=50")
+    resp = await client.get("/moderation/fragments/table?pipeline_id=None&limit=50&offset=50")
     assert resp.status_code == 200
 
 
@@ -260,7 +269,7 @@ async def test_moderation_page_empty_pipeline_id_shows_all_runs(client):
     db = client._transport_app.state.db
     _, run_id = await _create_pipeline_and_run(db)
 
-    resp = await client.get("/moderation/?pipeline_id=")
+    resp = await client.get("/moderation/fragments/table?pipeline_id=")
     assert resp.status_code == 200
     assert "Generated content" in resp.text
     assert f"/moderation/{run_id}/view" in resp.text
@@ -269,5 +278,5 @@ async def test_moderation_page_empty_pipeline_id_shows_all_runs(client):
 @pytest.mark.anyio
 async def test_moderation_page_clamps_out_of_range_limit_and_offset(client):
     """limit is clamped to [1, 200] and offset to >= 0 instead of erroring (#779)."""
-    resp = await client.get("/moderation/?limit=100000&offset=-5")
+    resp = await client.get("/moderation/fragments/table?limit=100000&offset=-5")
     assert resp.status_code == 200


### PR DESCRIPTION
Часть #756 (lazyload). Переводит страницу **Moderation** (`GET /moderation/`) на lazyload-паттерн.

## Проблема
Таблица `list_pending_moderation` (+ `get_with_relations` для фильтра) рендерилась в основном запросе страницы.

## Что сделано
- `GET /moderation/` отдаёт **skeleton** с `hx-get="/moderation/fragments/table?{{ request.url.query }}" hx-trigger="load"`.
- Новый **`GET /moderation/fragments/table`** строит `pending_runs`+`pipelines` и рендерит таблицу — перенесено 1-в-1 в `moderation_content.html`.
- Фильтр-форма (GET без action) и относительные ссылки пагинации (`href="?..."`) резолвятся относительно URL документа `/moderation/`, поэтому фильтр/пагинация работают как раньше (полный reload → skeleton → fragment).

## Проверка
- `ruff check` — чисто.
- `pytest tests/routes/test_moderation_routes.py` — **18 passed**. Контент-ассерты перенесены на fragment; добавлен тест skeleton.
- `/simplify` пройден: перенос (не копия) подтверждён, мёртвого кода/импортов нет; флаг ревью про «standalone-фрагмент при фильтре» — false positive (резолв относительно URL документа), регресса нет.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)