### PR TITLE
feat(cli): analytics channel-rating command (#967)

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -192,6 +192,7 @@
 | Пиковые часы | `analytics peak-hours` | `GET /analytics/peak-hours` | `get_peak_hours` |
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
 | Аналитика канала | `analytics channel` | `GET /analytics/channels/api/overview` | `get_channel_analytics` |
+| Рейтинг каналов | `analytics channel-rating` | _планируется (#968)_ | _планируется (#969)_ |
 
 ## Dialogs
 

--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -287,6 +287,25 @@ def run(args: argparse.Namespace) -> None:
                         print(f"  {wd_labels[idx]:>3}  " + " ".join(cells))
                 else:
                     print(f"\nNo heatmap data for last {days}d.")
+
+            elif action == "channel-rating":
+                from src.services.channel_analysis_service import ChannelAnalysisService
+
+                svc = ChannelAnalysisService(db)
+                limit = max(1, min(getattr(args, "limit", 50), 1000))
+                ratings = await svc.list_ratings(
+                    useful=getattr(args, "useful", None),
+                    genre=getattr(args, "genre", None),
+                    limit=limit,
+                )
+                if not ratings:
+                    print("No channel ratings found.")
+                    return
+                print(f"{'channel_id':<14} {'useful':<8} {'genre':<11} {'conf':<5} {'title'}")
+                print("-" * 80)
+                for r in ratings:
+                    title = (r.title or r.username or str(r.channel_id))[:30]
+                    print(f"{r.channel_id:<14} {r.useful:<8} {r.genre:<11} {r.confidence:<5.2f} {title}")
         finally:
             await db.close()
 

--- a/src/cli/parser_domains/analytics.py
+++ b/src/cli/parser_domains/analytics.py
@@ -67,3 +67,17 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
     analytics_channel = analytics_sub.add_parser("channel", help="Per-channel statistics overview")
     analytics_channel.add_argument("channel_id", type=int, help="Telegram channel_id (negative int)")
     analytics_channel.add_argument("--days", type=int, default=30, help="Time window in days (default: 30)")
+
+    analytics_rating = analytics_sub.add_parser(
+        "channel-rating", help="Channel ratings (usefulness × genre)"
+    )
+    analytics_rating.add_argument(
+        "--useful", choices=["useful", "useless"], default=None, help="Filter by usefulness axis"
+    )
+    analytics_rating.add_argument(
+        "--genre",
+        choices=["ad", "infobiz", "aggregator", "copy", "original"],
+        default=None,
+        help="Filter by genre axis",
+    )
+    analytics_rating.add_argument("--limit", type=int, default=50, help="Max rows (default: 50)")

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -9,6 +9,7 @@ CLI_REAL_TG_COMMAND_CASES_BY_CATEGORY: dict[str, set[tuple[str, ...]]] = {
         ("agent", "threads"),
         ("analytics", "calendar"),
         ("analytics", "channel"),
+        ("analytics", "channel-rating"),
         ("analytics", "content-types"),
         ("analytics", "daily"),
         ("analytics", "hourly"),

--- a/tests/cli_real_tg_integration/safe_ro/test_analytics_channel_rating.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_analytics_channel_rating.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_analytics_channel_rating(run_cli, assert_cli_ok):
+    result = run_cli("analytics", "channel-rating", "--limit", "5")
+    assert_cli_ok(result)
+    assert result.stdout.strip() or "no" in (result.stdout + result.stderr).lower()

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -1072,6 +1072,45 @@ def test_cli_analytics_channel(cli_db, capsys):
 
 
 @pytest.mark.aiosqlite_serial
+def test_cli_analytics_channel_rating(cli_db, capsys):
+    """End-to-end test for `analytics channel-rating` CLI command (#967)."""
+    from src.cli.commands.analytics import run as analytics_run
+    from src.models import ChannelRating
+
+    async def _seed():
+        await cli_db.repos.channel_ratings.upsert(
+            ChannelRating(
+                channel_id=100777, title="Rated Chan", username="rated",
+                useful="useful", genre="original", confidence=0.91,
+            )
+        )
+        await cli_db.repos.channel_ratings.upsert(
+            ChannelRating(
+                channel_id=100888, title="Spam Chan",
+                useful="useless", genre="infobiz", confidence=0.8,
+            )
+        )
+
+    asyncio.run(_seed())
+    config = AppConfig()
+
+    async def fake_init_db(_config_path):
+        return config, cli_db
+
+    with patch("src.cli.commands.analytics.runtime.init_db", side_effect=fake_init_db):
+        analytics_run(argparse.Namespace(
+            config="config.yaml", analytics_action="channel-rating",
+            useful="useful", genre=None, limit=50,
+        ))
+
+    out = capsys.readouterr().out
+    assert "Rated Chan" in out
+    assert "original" in out
+    # --useful=useful filter excludes the useless channel
+    assert "Spam Chan" not in out
+
+
+@pytest.mark.aiosqlite_serial
 def test_cli_analytics_channel_not_found(cli_db, capsys):
     """CLI analytics channel for nonexistent channel prints not found."""
     from src.cli.commands.analytics import run as analytics_run


### PR DESCRIPTION
Часть #781. CLI-команда `analytics channel-rating` (+parity).

## Что сделано
- `src/cli/commands/analytics.py`: ветка `channel-rating` — список рейтингов через `ChannelAnalysisService.list_ratings` (хранилище из #966), таблица `channel_id / useful / genre / conf / title`.
- `src/cli/parser_domains/analytics.py`: сабпарсер с `--useful` (useful/useless), `--genre` (ad/infobiz/aggregator/copy/original), `--limit`.
- Parity-инварианты: запись в `command_manifest.py` (safe_ro) + safe_ro real-TG тест `safe_ro/test_analytics_channel_rating.py` + строка в `docs/reference/parity.md`.
- Unit-тест `test_cli_analytics_channel_rating` (фильтр по оси).

## Проверка
- `ruff check src/ tests/` — чисто.
- `pytest -k "manifest or parity or real_telegram_policy or cli_main"` — **99 passed**.
- analytics-тесты — 70 passed.
- `/simplify` — чисто (следует паттерну соседних analytics-действий).

> Web (#968) и Agent (#969) части рейтинга — отдельные ишью; в parity помечены как планируемые.

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)