### PR TITLE
feat(web): channel ratings JSON endpoint + table (#968)

### DIFF
--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -5,6 +5,7 @@ import dataclasses
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.services.channel_analysis_service import ChannelAnalysisService
 from src.services.channel_analytics_service import ChannelAnalyticsService
 from src.services.content_analytics_service import ContentAnalyticsService
 from src.services.trend_service import TrendService
@@ -14,6 +15,7 @@ router = APIRouter()
 
 _MAX_TREND_DAYS = 365
 _MAX_TREND_LIMIT = 100
+_MAX_RATING_LIMIT = 1000
 
 
 def _clamp_positive(value: int, upper: int) -> int:
@@ -261,6 +263,46 @@ def _svc(request: Request) -> ChannelAnalyticsService:
 async def api_channel_overview(request: Request, channel_id: int, days: int = 30):
     overview = await _svc(request).get_channel_overview(channel_id, days=max(1, days))
     return JSONResponse(dataclasses.asdict(overview))
+
+
+def _rating_svc(request: Request) -> ChannelAnalysisService:
+    return ChannelAnalysisService(deps.get_db(request))
+
+
+@router.get("/channels/api/ratings")
+async def api_channel_ratings(
+    request: Request,
+    useful: str | None = None,
+    genre: str | None = None,
+    limit: int = 100,
+):
+    """Read-only channel ratings (usefulness × genre) as JSON (#968)."""
+    ratings = await _rating_svc(request).list_ratings(
+        useful=useful, genre=genre, limit=_clamp_positive(limit, _MAX_RATING_LIMIT)
+    )
+    return JSONResponse([r.model_dump(mode="json") for r in ratings])
+
+
+@router.get("/channels/ratings", response_class=HTMLResponse)
+async def channel_ratings_page(
+    request: Request,
+    useful: str | None = None,
+    genre: str | None = None,
+    limit: int = 100,
+):
+    """Minimal channel-ratings table (#968). Read-only; full two-axis UI is a follow-up."""
+    limit = _clamp_positive(limit, _MAX_RATING_LIMIT)
+    ratings = await _rating_svc(request).list_ratings(useful=useful, genre=genre, limit=limit)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "analytics/channel_ratings.html",
+        {
+            "ratings": ratings,
+            "selected_useful": useful or "",
+            "selected_genre": genre or "",
+            "limit": limit,
+        },
+    )
 
 
 @router.get("/channels/api/subscribers")

--- a/src/web/templates/analytics/channel_ratings.html
+++ b/src/web/templates/analytics/channel_ratings.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% block title %}Рейтинг каналов — TG Agent{% endblock %}
+{% block content %}
+<h1 class="h3 mb-4">Рейтинг каналов</h1>
+
+<form method="get" class="row g-2 align-items-end mb-3">
+    <div class="col-auto">
+        <label class="form-label">Полезность</label>
+        <select name="useful" class="form-select form-select-sm">
+            <option value="">Все</option>
+            {% for v in ["useful", "useless"] %}
+            <option value="{{ v }}" {{ 'selected' if selected_useful == v else '' }}>{{ v }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <label class="form-label">Жанр</label>
+        <select name="genre" class="form-select form-select-sm">
+            <option value="">Все</option>
+            {% for g in ["ad", "infobiz", "aggregator", "copy", "original"] %}
+            <option value="{{ g }}" {{ 'selected' if selected_genre == g else '' }}>{{ g }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <label class="form-label">Лимит</label>
+        <input type="number" name="limit" value="{{ limit }}" min="1" max="1000" class="form-control form-control-sm" style="width:6rem">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary btn-sm">Фильтр</button>
+    </div>
+</form>
+
+{% if ratings %}
+<div class="table-responsive">
+<table class="tga-table-striped-hover">
+    <thead>
+        <tr>
+            <th>channel_id</th>
+            <th>Название</th>
+            <th>Полезность</th>
+            <th>Жанр</th>
+            <th>Уверенность</th>
+            <th>Причина</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for r in ratings %}
+        <tr>
+            <td class="text-nowrap">{{ r.channel_id }}</td>
+            <td>{{ r.title or ('@' ~ r.username if r.username else '—') }}</td>
+            <td><span class="badge bg-{{ 'success' if r.useful == 'useful' else 'secondary' }}">{{ r.useful }}</span></td>
+            <td>{{ r.genre }}</td>
+            <td>{{ '%.2f'|format(r.confidence) }}</td>
+            <td class="text-muted" style="font-size:0.85rem">{{ (r.reason or '')[:120] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% else %}
+<div class="alert alert-info">Нет рейтингов каналов.</div>
+{% endif %}
+{% endblock %}

--- a/tests/routes/test_analytics_routes_channel_trends.py
+++ b/tests/routes/test_analytics_routes_channel_trends.py
@@ -281,3 +281,46 @@ async def test_api_cross_citations(route_client):
         assert resp.status_code == 200
         data = resp.json()
         assert isinstance(data, list)
+
+
+# ── Channel ratings (#968) ──────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_channel_ratings_api_and_filter(route_client):
+    from src.models import ChannelRating
+
+    db = route_client._transport_app.state.db
+    await db.repos.channel_ratings.upsert(
+        ChannelRating(channel_id=700100, title="Good Chan", useful="useful", genre="original", confidence=0.9)
+    )
+    await db.repos.channel_ratings.upsert(
+        ChannelRating(channel_id=700200, title="Spam Chan", useful="useless", genre="infobiz", confidence=0.8)
+    )
+
+    resp = await route_client.get("/analytics/channels/api/ratings?limit=1000")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert {r["channel_id"] for r in data} >= {700100, 700200}
+
+    only_useful = await route_client.get("/analytics/channels/api/ratings?useful=useful&limit=1000")
+    ids = {r["channel_id"] for r in only_useful.json()}
+    assert 700100 in ids and 700200 not in ids
+
+    only_ad = await route_client.get("/analytics/channels/api/ratings?genre=infobiz&limit=1000")
+    ids2 = {r["channel_id"] for r in only_ad.json()}
+    assert 700200 in ids2 and 700100 not in ids2
+
+
+@pytest.mark.anyio
+async def test_channel_ratings_page_renders(route_client):
+    from src.models import ChannelRating
+
+    db = route_client._transport_app.state.db
+    await db.repos.channel_ratings.upsert(
+        ChannelRating(channel_id=700300, title="Rated Page Chan", useful="useful", genre="original", confidence=0.7)
+    )
+    resp = await route_client.get("/analytics/channels/ratings?limit=1000")
+    assert resp.status_code == 200
+    assert "Rated Page Chan" in resp.text
+    assert "Рейтинг каналов" in resp.text


### PR DESCRIPTION
Часть #781. Web: `GET /analytics/channels/api/ratings`.

## Что сделано
- **`GET /analytics/channels/api/ratings`** — read-only JSON рейтингов (фильтры `useful`/`genre`/`limit`).
- **`GET /analytics/channels/ratings`** — минимальная HTML-таблица + фильтр-форма.
- Оба через `ChannelAnalysisService.list_ratings` (хранилище #966), без записей в БД. Limit — через существующий `_clamp_positive` (cap 1000).
- Полноценный двухосевой UI-дашборд — вне рамок (follow-up), как и указано в ишью.

## Проверка
- `ruff check` — чисто; import-smoke OK (без циклов).
- `pytest tests/routes/test_analytics_routes*` — 52 passed (JSON + фильтры useful/genre + HTML-страница).
- `/simplify` пройден: reuse `_clamp_positive` + константа `_MAX_RATING_LIMIT`, hoist импорта.

> Строка parity для рейтинга сводится в #970 (parity sweep), когда CLI (#967, PR #990) и agent (#969) будут в main — чтобы не плодить cross-branch конфликты.

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)