### PR TITLE
feat(agent): get_channel_ratings read tool (#969)

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -141,6 +141,7 @@
 | `get_hourly_activity` | READ | Почасовая активность |
 | `get_trending_emojis` | READ | Трендовые эмодзи за период |
 | `get_channel_analytics` | READ | Обзорная аналитика одного канала |
+| `get_channel_ratings` | READ | Рейтинг каналов (полезность × жанр) |
 
 ## Планировщик
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -192,7 +192,7 @@
 | Пиковые часы | `analytics peak-hours` | `GET /analytics/peak-hours` | `get_peak_hours` |
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
 | Аналитика канала | `analytics channel` | `GET /analytics/channels/api/overview` | `get_channel_analytics` |
-| Рейтинг каналов | `analytics channel-rating` | _планируется (#968)_ | _планируется (#969)_ |
+| Рейтинг каналов | `analytics channel-rating` | `GET /analytics/channels/api/ratings` | `get_channel_ratings` |
 
 ## Dialogs
 

--- a/src/agent/tools/__init__.py
+++ b/src/agent/tools/__init__.py
@@ -185,6 +185,7 @@ _PIPELINE_SAFE_TOOLS: frozenset[str] = frozenset({
     "get_pipeline_stats",
     "get_trending_topics",
     "get_trending_channels",
+    "get_channel_ratings",
     "get_message_velocity",
     "get_peak_hours",
     "get_calendar",

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -25,6 +25,9 @@ def _clamp_positive(value: int, upper: int) -> int:
     return max(1, min(value, upper))
 
 
+_MAX_RATING_LIMIT = 1000
+
+
 
 
 # Permission metadata for this module's tools (#245). Single source of
@@ -47,6 +50,7 @@ TOOL_GROUPS: list[tuple[str, dict[str, ToolMeta]]] = [
         "get_hourly_activity": ToolMeta(ToolCategory.READ),
         "get_trending_emojis": ToolMeta(ToolCategory.READ),
         "get_channel_analytics": ToolMeta(ToolCategory.READ),
+        "get_channel_ratings": ToolMeta(ToolCategory.READ),
     }),
 ]
 
@@ -440,5 +444,41 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка аналитики канала: {e}")
 
     tools.append(get_channel_analytics)
+
+    @tool(
+        "get_channel_ratings",
+        "List channel ratings (usefulness × genre) produced by the AI rater. "
+        "Optional filters: useful (useful|useless), genre "
+        "(ad|infobiz|aggregator|copy|original).",
+        {
+            "useful": Annotated[str, "Фильтр по оси полезности: useful или useless"],
+            "genre": Annotated[str, "Фильтр по жанру: ad/infobiz/aggregator/copy/original"],
+            "limit": Annotated[int, "Сколько строк (по умолчанию 50)"],
+        },
+    )
+    async def get_channel_ratings(args):
+        try:
+            from src.services.channel_analysis_service import ChannelAnalysisService
+
+            limit = _clamp_positive(int(args.get("limit", 50) or 50), _MAX_RATING_LIMIT)
+            ratings = await ChannelAnalysisService(db).list_ratings(
+                useful=args.get("useful") or None,
+                genre=args.get("genre") or None,
+                limit=limit,
+            )
+            if not ratings:
+                return _text_response("Рейтингов каналов не найдено.")
+            lines = ["Рейтинг каналов (полезность × жанр):"]
+            for r in ratings:
+                name = r.title or (f"@{r.username}" if r.username else str(r.channel_id))
+                lines.append(
+                    f"- {name} (id={r.channel_id}): {r.useful} / {r.genre} "
+                    f"(conf {r.confidence:.2f})"
+                )
+            return _text_response("\n".join(lines))
+        except Exception as e:
+            return _text_response(f"Ошибка рейтинга каналов: {e}")
+
+    tools.append(get_channel_ratings)
 
     return tools

--- a/tests/data/tool_permissions_snapshot.json
+++ b/tests/data/tool_permissions_snapshot.json
@@ -93,6 +93,7 @@
     "get_hourly_activity": "read",
     "get_trending_emojis": "read",
     "get_channel_analytics": "read",
+    "get_channel_ratings": "read",
     "get_scheduler_status": "read",
     "start_scheduler": "write",
     "stop_scheduler": "write",
@@ -282,7 +283,8 @@
       "get_content_type_stats",
       "get_hourly_activity",
       "get_trending_emojis",
-      "get_channel_analytics"
+      "get_channel_analytics",
+      "get_channel_ratings"
     ],
     "Планировщик": [
       "get_scheduler_status",


### PR DESCRIPTION
Часть #781. Agent-tool `get_channel_ratings` (read, pipeline-safe).

## Что сделано
- Новый read-only тул `get_channel_ratings` в `src/agent/tools/analytics.py` (группа `TOOL_GROUPS["Аналитика"]`, `ToolCategory.READ`) — список рейтингов через `ChannelAnalysisService.list_ratings`, фильтры `useful`/`genre`/`limit`.
- Регистрация в `_PIPELINE_SAFE_TOOLS` (`src/agent/tools/__init__.py`).
- Обновлены: golden-snapshot прав (`tests/data/tool_permissions_snapshot.json`), `docs/reference/agent-tools.md`, строка parity (Agent-колонка; CLI #967 / Web #968 помечены планируемыми — сведутся в #970 sweep).

## Проверка
- `ruff check` — чисто.
- gate-тесты прав/контракта/parity: `test_agent_tools_permissions`, `test_tool_permissions_autoderive`, `test_agent_tool_smoke_contract`, `test_cli_agent_parity` — зелёные; общий agent_tool/parity срез — 1058 passed.
- `/simplify`: добавлена константа `_MAX_RATING_LIMIT` (консистентность).

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)