### PR TITLE
feat(jobs): unified jobs read API + table fragment (#964)

### DIFF
--- a/src/services/jobs_read_model.py
+++ b/src/services/jobs_read_model.py
@@ -33,6 +33,7 @@ from src.models import (
     TelegramCommand,
     TelegramCommandStatus,
 )
+from src.utils.datetime import normalize_utc
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -57,6 +58,10 @@ _PHOTO_ITEM_STATE = {
     PhotoBatchStatus.FAILED: JobRuntimeState.FAILED,
     PhotoBatchStatus.CANCELLED: JobRuntimeState.CANCELLED,
 }
+
+# UTC-aware floor for jobs without a timestamp (e.g. scheduler jobs) so they sort
+# last; kept aware to match ``normalize_utc`` keys in the sort below.
+_NO_TIMESTAMP_SENTINEL = datetime.min.replace(tzinfo=timezone.utc)
 
 
 def _future(dt: datetime | None, now: datetime) -> bool:
@@ -111,7 +116,10 @@ class JobsReadModel:
             jobs = [j for j in jobs if j.runtime_state in wanted_states]
 
         # Newest activity first; jobs without timestamps (scheduler) sort last.
-        jobs.sort(key=lambda j: (j.created_at or datetime.min.replace(tzinfo=timezone.utc)), reverse=True)
+        # ``created_at`` mixes naive (SQLite ``datetime('now')``) and aware values
+        # across sources; normalise every key to UTC-aware so ``sort`` never raises
+        # ``TypeError`` on a naive-vs-aware comparison (the ``None``-sentinel is aware).
+        jobs.sort(key=lambda j: (normalize_utc(j.created_at) or _NO_TIMESTAMP_SENTINEL), reverse=True)
         # ``limit`` is the unified cap; each source is also fetched with it as a
         # per-source bound, so the final slice honours the documented contract.
         return jobs[:limit]

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -134,6 +134,7 @@ def register_routes(app: FastAPI) -> None:
     from src.web.routes.filter import router as filter_router
     from src.web.routes.images import router as images_router
     from src.web.routes.import_channels import router as import_router
+    from src.web.routes.jobs import router as jobs_router
     from src.web.routes.moderation import router as moderation_router
     from src.web.routes.photo_loader import router as photo_loader_router
     from src.web.routes.pipelines import router as pipelines_router
@@ -166,6 +167,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(dialogs_router, prefix="/dialogs")
     app.include_router(telegram_commands_router, prefix="/telegram-commands")
     app.include_router(tasks_router, prefix="/api/tasks")
+    app.include_router(jobs_router, prefix="/jobs")
     app.include_router(photo_loader_router, prefix="/dialogs/photos")
     app.include_router(debug_router, prefix="/debug")
     app.include_router(images_router, prefix="/images")

--- a/src/web/routes/jobs.py
+++ b/src/web/routes/jobs.py
@@ -1,0 +1,76 @@
+"""Unified background-jobs read API + fragment (#964).
+
+Read-only views over JobsReadModel (the #963 unified read-model): a JSON list and
+an HTML table fragment, both filterable by source / runtime-state. No DB writes
+and no Telegram API calls — purely reads collection_tasks/telegram_commands/
+photo_* tables plus the runtime snapshots.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from src.models import JobRuntimeState, JobSource
+from src.web import deps
+
+router = APIRouter()
+
+_MAX_JOBS_LIMIT = 500
+
+
+def _jobs_model(request: Request):
+    from src.services.jobs_read_model import JobsReadModel
+
+    return JobsReadModel(deps.get_db(request))
+
+
+def _parse_enum_csv(raw: str | None, enum_cls):
+    """Parse a comma-separated query value into enum members, dropping unknown
+    tokens (so a bogus filter degrades to 'no filter', never a 422/500)."""
+    if not raw:
+        return None
+    valid = {e.value for e in enum_cls}
+    return [enum_cls(s) for s in raw.split(",") if s in valid] or None
+
+
+async def _list(request: Request, source: str | None, status: str | None, limit: int):
+    return await _jobs_model(request).list_jobs(
+        sources=_parse_enum_csv(source, JobSource),
+        statuses=_parse_enum_csv(status, JobRuntimeState),
+        limit=max(1, min(limit, _MAX_JOBS_LIMIT)),
+    )
+
+
+@router.get("/api/list")
+async def api_jobs_list(
+    request: Request,
+    source: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+):
+    """Unified jobs as JSON (filters: comma-separated source / status)."""
+    jobs = await _list(request, source, status, limit)
+    return JSONResponse([j.model_dump(mode="json") for j in jobs])
+
+
+@router.get("/fragments/list", response_class=HTMLResponse)
+async def jobs_table_fragment(
+    request: Request,
+    source: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+):
+    """Unified jobs table fragment (consumed by the lazyloaded dashboard, #965)."""
+    jobs = await _list(request, source, status, limit)
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "jobs_table.html",
+        {
+            "jobs": jobs,
+            "sources": [s.value for s in JobSource],
+            "states": [s.value for s in JobRuntimeState],
+            "selected_source": source or "",
+            "selected_status": status or "",
+        },
+    )

--- a/src/web/templates/jobs_table.html
+++ b/src/web/templates/jobs_table.html
@@ -1,0 +1,57 @@
+{# Unified jobs table fragment (#964). Rendered by GET /jobs/fragments/list and
+   swapped into the dashboard (#965). Filter form reloads the same fragment. #}
+<form method="get" class="row g-2 align-items-end mb-3"
+      hx-get="/jobs/fragments/list" hx-target="#jobs-table" hx-swap="innerHTML">
+    <div class="col-auto">
+        <label class="form-label">Источник</label>
+        <select name="source" class="form-select form-select-sm">
+            <option value="">Все</option>
+            {% for s in sources %}
+            <option value="{{ s }}" {{ 'selected' if selected_source == s else '' }}>{{ s }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <label class="form-label">Статус</label>
+        <select name="status" class="form-select form-select-sm">
+            <option value="">Все</option>
+            {% for st in states %}
+            <option value="{{ st }}" {{ 'selected' if selected_status == st else '' }}>{{ st }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary btn-sm">Фильтр</button>
+    </div>
+</form>
+
+{% if jobs %}
+<div class="table-responsive">
+<table class="tga-table-striped-hover">
+    <thead>
+        <tr>
+            <th>Источник</th>
+            <th>Тип</th>
+            <th>Состояние</th>
+            <th>Описание</th>
+            <th>Создано</th>
+            <th>Ошибка</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for j in jobs %}
+        <tr>
+            <td class="text-nowrap">{{ j.source }}</td>
+            <td>{{ j.job_type }}</td>
+            <td><span class="badge bg-{% if j.runtime_state in ['failed'] %}danger{% elif j.runtime_state in ['running'] %}primary{% elif j.runtime_state in ['completed'] %}success{% elif j.runtime_state in ['pause_gate','flood_wait'] %}warning{% else %}secondary{% endif %}">{{ j.runtime_state }}</span></td>
+            <td>{{ (j.summary or '')[:60] }}</td>
+            <td class="text-nowrap text-muted" style="font-size:0.8rem">{{ j.created_at|local_dt if j.created_at else '—' }}</td>
+            <td class="text-danger" style="font-size:0.8rem">{{ (j.error or '')[:60] }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% else %}
+<div class="alert alert-info">Нет фоновых задач.</div>
+{% endif %}

--- a/tests/routes/test_jobs_routes.py
+++ b/tests/routes/test_jobs_routes.py
@@ -1,0 +1,62 @@
+"""Tests for the unified jobs read API + fragment (#964)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def _seed_jobs(db):
+    # One collection task (PENDING) + one telegram command (succeeded).
+    await db.repos.tasks.create_collection_task(700900, "Jobs Chan")
+    from src.models import TelegramCommand, TelegramCommandStatus
+
+    await db.repos.telegram_commands.create_command(
+        TelegramCommand(command_type="get_profile", status=TelegramCommandStatus.SUCCEEDED)
+    )
+
+
+async def test_jobs_api_list_returns_all_sources(route_client):
+    db = route_client._transport_app.state.db
+    await _seed_jobs(db)
+    resp = await route_client.get("/jobs/api/list")
+    assert resp.status_code == 200
+    data = resp.json()
+    sources = {j["source"] for j in data}
+    assert "collection_task" in sources
+    assert "telegram_command" in sources
+
+
+async def test_jobs_api_filters_by_source(route_client):
+    db = route_client._transport_app.state.db
+    await _seed_jobs(db)
+    resp = await route_client.get("/jobs/api/list?source=telegram_command")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data and all(j["source"] == "telegram_command" for j in data)
+
+
+async def test_jobs_api_filters_by_status(route_client):
+    db = route_client._transport_app.state.db
+    await _seed_jobs(db)
+    resp = await route_client.get("/jobs/api/list?status=pending")
+    assert resp.status_code == 200
+    assert all(j["runtime_state"] == "pending" for j in resp.json())
+
+
+async def test_jobs_api_ignores_unknown_filter_tokens(route_client):
+    db = route_client._transport_app.state.db
+    await _seed_jobs(db)
+    # Unknown source token → treated as no filter, returns 200 (not 422/500).
+    resp = await route_client.get("/jobs/api/list?source=bogus")
+    assert resp.status_code == 200
+
+
+async def test_jobs_fragment_renders(route_client):
+    db = route_client._transport_app.state.db
+    await _seed_jobs(db)
+    resp = await route_client.get("/jobs/fragments/list")
+    assert resp.status_code == 200
+    assert "Jobs Chan" in resp.text
+    assert 'hx-target="#jobs-table"' in resp.text

--- a/tests/routes/test_jobs_routes.py
+++ b/tests/routes/test_jobs_routes.py
@@ -60,3 +60,22 @@ async def test_jobs_fragment_renders(route_client):
     assert resp.status_code == 200
     assert "Jobs Chan" in resp.text
     assert 'hx-target="#jobs-table"' in resp.text
+
+
+async def test_jobs_api_sorts_mixed_null_and_naive_timestamps(route_client):
+    # Regression: the sort key mixed a tz-aware None-sentinel with the naive
+    # ``created_at`` values SQLite stores, so a job with ``created_at IS NULL``
+    # next to one with a real timestamp raised ``TypeError: can't compare
+    # offset-naive and offset-aware datetimes`` → HTTP 500. One NULL + one naive
+    # row must now sort cleanly.
+    db = route_client._transport_app.state.db
+    await db.repos.tasks.create_collection_task(700901, "Has Timestamp")
+    await db.repos.tasks.create_collection_task(700902, "Null Timestamp")
+    await db.execute_write(
+        "UPDATE collection_tasks SET created_at = NULL WHERE channel_id = ?", (700902,)
+    )
+    resp = await route_client.get("/jobs/api/list")
+    assert resp.status_code == 200
+    # channel_title surfaces via the JobView ``summary`` field.
+    summaries = {j["summary"] for j in resp.json()}
+    assert {"Has Timestamp", "Null Timestamp"} <= summaries


### PR DESCRIPTION
Часть #769. Unified API / fragment-роут с фильтрами поверх read-модели.

## Что сделано
- `src/web/routes/jobs.py`:
  - `GET /jobs/api/list` — JSON всех фоновых задач (фильтры `source`/`status`, CSV).
  - `GET /jobs/fragments/list` — HTML-таблица + фильтр-форма (hx-get на себя, target `#jobs-table`).
  - Оба через `JobsReadModel.list_jobs` (#963), фильтры source/runtime-state; неизвестные токены игнорируются (деградация в «без фильтра», не 422/500).
- ⚠️ Только чтение БД/снапшотов — **никаких** новых Telegram-вызовов (acceptance-критерий).
- Регистрация роутера в `assembly.py` (prefix `/jobs`).
- `templates/jobs_table.html` (fragment).

## Проверка
- `ruff check src/ tests/` — чисто; import/registration smoke OK.
- `pytest tests/routes/test_jobs_routes.py` — 5 passed (все источники, фильтры source/status, игнор неизвестных токенов, fragment-рендер).
- `/simplify`: парсеры обобщены в `_parse_enum_csv`.

> UI-дашборд, хостящий фрагмент (обёртка `#jobs-table`), — #965.

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)