### PR TITLE
feat(web): lazyload Analytics Channels selector (#951)

### DIFF
--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -239,16 +239,16 @@ async def api_trending_emojis(request: Request, days: int = 7, limit: int = 15):
 
 @router.get("/channels", response_class=HTMLResponse)
 async def channel_analytics_page(request: Request, channel_id: int = 0, days: int = 30):
-    """Render per-channel analytics dashboard."""
+    """Render the per-channel analytics skeleton.
+
+    The channel selector (``get_active_channels()``) is loaded lazily via an
+    HTMX fragment so the page paints instantly on large databases (#951).
+    """
     days = days if days in (7, 14, 30, 90) else 30
-    db = deps.get_db(request)
-    svc = ChannelAnalyticsService(db)
-    channels = await svc.get_active_channels()
     return deps.get_templates(request).TemplateResponse(
         request,
         "analytics/channels.html",
         {
-            "channels": [dataclasses.asdict(c) for c in channels],
             "selected_channel_id": channel_id,
             "days": days,
         },
@@ -257,6 +257,20 @@ async def channel_analytics_page(request: Request, channel_id: int = 0, days: in
 
 def _svc(request: Request) -> ChannelAnalyticsService:
     return ChannelAnalyticsService(deps.get_db(request))
+
+
+@router.get("/channels/fragments/selector", response_class=HTMLResponse)
+async def fragment_channel_selector(request: Request, channel_id: int = 0):
+    """Channel selector dropdown loaded lazily by the channels page (#951)."""
+    channels = await _svc(request).get_active_channels()
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "analytics/_channel_selector.html",
+        {
+            "channels": [dataclasses.asdict(c) for c in channels],
+            "selected_channel_id": channel_id,
+        },
+    )
 
 
 @router.get("/channels/api/overview")

--- a/src/web/templates/analytics/_channel_selector.html
+++ b/src/web/templates/analytics/_channel_selector.html
@@ -1,0 +1,8 @@
+<select id="channel-select" class="form-select">
+  <option value="">— выберите канал —</option>
+  {% for ch in channels %}
+  <option value="{{ ch.channel_id }}" {% if ch.channel_id == selected_channel_id %}selected{% endif %}>
+    {{ ch.title or ch.username or ch.channel_id }}
+  </option>
+  {% endfor %}
+</select>

--- a/src/web/templates/analytics/channels.html
+++ b/src/web/templates/analytics/channels.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Статистика каналов — TG Agent{% endblock %}
 {% block head_scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
@@ -17,15 +18,10 @@
 {{ analytics_tabs('channels') }}
 
 <div class="row g-3 mb-3">
-  <div class="col-md-5">
-    <select id="channel-select" class="form-select">
-      <option value="">— выберите канал —</option>
-      {% for ch in channels %}
-      <option value="{{ ch.channel_id }}" {% if ch.channel_id == selected_channel_id %}selected{% endif %}>
-        {{ ch.title or ch.username or ch.channel_id }}
-      </option>
-      {% endfor %}
-    </select>
+  <div class="col-md-5"
+       hx-get="/analytics/channels/fragments/selector?channel_id={{ selected_channel_id | default(0) }}"
+       hx-trigger="load" hx-swap="innerHTML">
+    {{ loading() }}
   </div>
   <div class="col-md-3">
     <div class="btn-group btn-group-sm" role="group" id="period-btns">
@@ -394,9 +390,11 @@
     }
   }
 
-  // Channel select
-  document.getElementById('channel-select').addEventListener('change', function() {
-    var val = parseInt(this.value);
+  // Channel select. The dropdown is loaded lazily via an HTMX fragment (#951),
+  // so the listener is delegated on document rather than bound to the element.
+  document.addEventListener('change', function(e) {
+    if (!e.target || e.target.id !== 'channel-select') return;
+    var val = parseInt(e.target.value);
     if (val) {
       channelId = val;
       var url = new URL(window.location);

--- a/tests/routes/test_analytics_routes_channel_trends.py
+++ b/tests/routes/test_analytics_routes_channel_trends.py
@@ -140,6 +140,46 @@ async def test_channel_analytics_page_invalid_days(route_client):
     assert resp.status_code == 200
 
 
+@pytest.mark.anyio
+async def test_channel_page_lazy_loads_selector(route_client):
+    """#951: the channels page paints a skeleton wired to the selector fragment."""
+    resp = await route_client.get("/analytics/channels?channel_id=100")
+    assert resp.status_code == 200
+    assert 'hx-get="/analytics/channels/fragments/selector?channel_id=100"' in resp.text
+    assert 'hx-trigger="load"' in resp.text
+    # The dropdown itself is no longer rendered in the main route.
+    assert 'id="channel-select"' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_channel_selector_fragment_returns_partial(route_client):
+    """#951: selector fragment returns a bare <select>, not a full page."""
+    resp = await route_client.get("/analytics/channels/fragments/selector")
+    assert resp.status_code == 200
+    assert "<html" not in resp.text.lower()
+    assert 'id="channel-select"' in resp.text
+
+
+@pytest.mark.anyio
+async def test_channel_selector_fragment_lists_channels(route_client):
+    """#951: selector fragment renders an <option> per active channel and marks the selected one."""
+    from src.services.channel_analytics_service import ChannelListItem
+
+    channels = [
+        ChannelListItem(channel_id=100, title="Alpha", username="alpha"),
+        ChannelListItem(channel_id=200, title="Beta", username="beta"),
+    ]
+    with patch("src.web.routes.analytics.ChannelAnalyticsService") as mock_svc:
+        instance = mock_svc.return_value
+        instance.get_active_channels = AsyncMock(return_value=channels)
+        resp = await route_client.get("/analytics/channels/fragments/selector?channel_id=100")
+        assert resp.status_code == 200
+        assert "Alpha" in resp.text
+        assert "Beta" in resp.text
+        # The requested channel_id is pre-selected.
+        assert 'value="100" selected' in resp.text
+
+
 # ── Channel API endpoints ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Part of #756 (lazyload heavy analytics pages). Moves the **Analytics: Channels** page (`GET /analytics/channels`) onto the lazyload pattern, following the fragment-route approach from #876.

### Problem
`get_active_channels()` (the channel-selector query) ran in the main page render, blocking TTFB on large databases.

### Changes
- **Main route** now paints a skeleton instantly — no DB query in the request path.
- **Channel selector** extracted to a fragment route `GET /analytics/channels/fragments/selector`, loaded via `hx-trigger="load"` (mirrors the existing `/analytics/fragments/*` routes).
- New partial template `analytics/_channel_selector.html` rendering the `<select>` with active channels and pre-selecting `channel_id`.
- The `change` listener is now **delegated on `document`** instead of bound directly, since the dropdown arrives asynchronously after the HTMX swap. The standalone chart auto-load (driven by `channel_id` in the URL) is unaffected.

### Tests
- `test_channel_page_lazy_loads_selector` — skeleton wires the selector fragment with `hx-trigger="load"`; the dropdown is no longer in the main route.
- `test_channel_selector_fragment_returns_partial` — fragment returns a bare partial (no `<html>`).
- `test_channel_selector_fragment_lists_channels` — fragment renders an `<option>` per active channel and pre-selects the requested one.

## Test plan
- `pytest tests/routes/` — 1020 passed.
- `pytest -m smoke` — green.
- `ruff check src/ tests/` — clean.

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)