### PR TITLE
feat(agent): lazyload Agent page thread list + runtime status (#949)

### DIFF
--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import sqlite3
+from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, Request
 
@@ -14,6 +15,9 @@ from src.utils.json import safe_json_dumps
 from src.web import deps
 from src.web.agent.forms import select_model
 from src.web.agent.responses import AgentJson, AgentRedirect, AgentStream, AgentTemplate
+
+if TYPE_CHECKING:
+    from src.agent.manager import AgentManager
 
 logger = logging.getLogger(__name__)
 
@@ -78,30 +82,42 @@ def _agent_unavailable_result(runtime_state: deps.AgentRuntimeState) -> AgentJso
     )
 
 
+async def _agent_status_dict(agent_manager: AgentManager | None) -> dict | None:
+    """Probe the agent backend and map its runtime status to a template dict.
+
+    This is the heavy bit (`refresh_settings_cache` + per-backend availability
+    probes); kept out of the skeleton route so it only runs when the lazy
+    threads fragment loads (#949 / part of #756).
+    """
+    if agent_manager is None:
+        return None
+    runtime_status = await agent_manager.get_runtime_status()
+    return {
+        "claude_available": runtime_status.claude_available,
+        "deepagents_available": runtime_status.deepagents_available,
+        "codex_available": runtime_status.codex_available,
+        "adk_available": runtime_status.adk_available,
+        "dev_mode_enabled": runtime_status.dev_mode_enabled,
+        "backend_override": runtime_status.backend_override,
+        "selected_backend": runtime_status.selected_backend,
+        "fallback_model": runtime_status.fallback_model,
+        "fallback_provider": runtime_status.fallback_provider,
+        "using_override": runtime_status.using_override,
+        "error": runtime_status.error,
+    }
+
+
 async def agent_page(request: Request, thread_id: int | None = None):
+    # Onboarding/redirect logic MUST stay synchronous — it decides which thread the
+    # page renders (a skeleton 200 would swallow the redirect, mirroring dashboard.py).
+    # The runtime-status probe (refresh_settings_cache + backend availability) is the
+    # heavy per-load cost; it loads lazily in the threads fragment (#949).
     db = deps.get_db(request)
     agent_runtime_state = deps.get_agent_runtime_state(request)
-    agent_manager = agent_runtime_state.manager
     threads = await db.get_agent_threads()
-    agent_status = None
     agent_disabled_title = None
     agent_disabled_reason = None
-    if agent_manager is not None:
-        runtime_status = await agent_manager.get_runtime_status()
-        agent_status = {
-            "claude_available": runtime_status.claude_available,
-            "deepagents_available": runtime_status.deepagents_available,
-            "codex_available": runtime_status.codex_available,
-            "adk_available": runtime_status.adk_available,
-            "dev_mode_enabled": runtime_status.dev_mode_enabled,
-            "backend_override": runtime_status.backend_override,
-            "selected_backend": runtime_status.selected_backend,
-            "fallback_model": runtime_status.fallback_model,
-            "fallback_provider": runtime_status.fallback_provider,
-            "using_override": runtime_status.using_override,
-            "error": runtime_status.error,
-        }
-    else:
+    if agent_runtime_state.manager is None:
         agent_disabled_title, agent_disabled_reason = _agent_unavailable_copy(agent_runtime_state)
 
     messages = []
@@ -125,13 +141,34 @@ async def agent_page(request: Request, thread_id: int | None = None):
     return AgentTemplate(
         "agent.html",
         {
-            "threads": threads,
             "active_thread": active_thread,
             "messages": messages,
-            "agent_status": agent_status,
             "agent_runtime_state": agent_runtime_state.state,
             "agent_disabled_title": agent_disabled_title,
             "agent_disabled_reason": agent_disabled_reason,
+        },
+    )
+
+
+async def agent_threads_fragment(request: Request, thread_id: int | None = None) -> AgentTemplate:
+    """Lazy fragment: thread list + runtime status panel + composer footer (#949).
+
+    Carries `active_thread` so the thread list can mark the open thread and the
+    composer footer (model select vs deepagents hint) renders for the right
+    backend. The skeleton already resolved the active thread via redirect, so the
+    fragment trusts the `thread_id` query param instead of re-running that logic.
+    """
+    db = deps.get_db(request)
+    agent_manager = deps.get_agent_manager(request)
+    threads = await db.get_agent_threads()
+    active_thread = await db.get_agent_thread(thread_id) if thread_id is not None else None
+    agent_status = await _agent_status_dict(agent_manager)
+    return AgentTemplate(
+        "agent/_threads.html",
+        {
+            "threads": threads,
+            "active_thread": active_thread,
+            "agent_status": agent_status,
             "model_options": CLAUDE_MODELS,
         },
     )

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -21,12 +21,21 @@ async def get_thread_messages(request: Request, thread_id: int):
     if thread is None:
         return JSONResponse({"error": "thread_not_found"}, status_code=404)
     messages = await db.get_agent_messages(thread_id)
-    return JSONResponse({"thread_id": thread_id, "title": thread.get("title"), "messages": messages})
+    return JSONResponse(
+        {"thread_id": thread_id, "title": thread.get("title"), "messages": messages}
+    )
 
 
 @router.get("", response_class=HTMLResponse)
 async def agent_page(request: Request, thread_id: int | None = None):
     return agent_response(request, await handlers.agent_page(request, thread_id))
+
+
+@router.get("/fragments/threads", response_class=HTMLResponse)
+async def agent_threads_fragment(request: Request, thread_id: int | None = None):
+    return agent_response(
+        request, await handlers.agent_threads_fragment(request, thread_id)
+    )
 
 
 @router.post("/threads", response_class=HTMLResponse)
@@ -61,7 +70,9 @@ async def inject_context(request: Request, thread_id: int):
 
 @router.post("/threads/{thread_id}/permission/{request_id}")
 async def resolve_permission(request: Request, thread_id: int, request_id: str):
-    return agent_response(request, await handlers.resolve_permission(request, thread_id, request_id))
+    return agent_response(
+        request, await handlers.resolve_permission(request, thread_id, request_id)
+    )
 
 
 @router.post("/threads/{thread_id}/stop")

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% from "_macros.html" import icon %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Агент — TG Agent{% endblock %}
 
 {% block head_scripts %}
@@ -569,17 +570,10 @@
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
     </div>
     <div class="offcanvas-body d-flex flex-column gap-2">
-        {% for thread in threads %}
-        <a class="thread-item {% if active_thread and active_thread.id == thread.id %}active{% endif %}"
-           href="/agent?thread_id={{ thread.id }}">
-            <span class="thread-title" title="{{ thread.title }}">{{ thread.title }}</span>
-            <button class="thread-delete-btn"
-                    onclick="deleteThread(event, {{ thread.id }})"
-                    title="Удалить тред">{{ icon("close") }}</button>
-        </a>
-        {% else %}
-        <p class="small text-muted">Тредов пока нет</p>
-        {% endfor %}
+        {# Thread list loads lazily via the threads fragment (OOB-swapped, #949). #}
+        <div id="offcanvas-threads">
+            {{ loading() }}
+        </div>
         <form method="post" action="/agent/threads" style="margin-top:auto" data-busy>
             <button type="submit" class="btn btn-outline-primary btn-sm w-100">+ Новый тред</button>
         </form>
@@ -611,18 +605,14 @@
     <div class="agent-sidebar">
         <h3 class="text-muted text-uppercase small">Треды</h3>
 
-        {% for thread in threads %}
-        <a class="thread-item {% if active_thread and active_thread.id == thread.id %}active{% endif %}"
-           href="/agent?thread_id={{ thread.id }}"
-           data-thread-id="{{ thread.id }}">
-            <span class="thread-title" title="{{ thread.title }}">{{ thread.title }}</span>
-            <button class="thread-delete-btn"
-                    onclick="deleteThread(event, {{ thread.id }})"
-                    title="Удалить тред">{{ icon("close") }}</button>
-        </a>
-        {% else %}
-        <p class="small text-muted">Тредов пока нет</p>
-        {% endfor %}
+        {# Thread list + runtime status + composer footer load lazily here; the fragment
+           also OOB-swaps the offcanvas list, runtime panel and composer footer (#949). #}
+        <div id="sidebar-threads"
+             hx-get="/agent/fragments/threads{{ '?thread_id=' ~ active_thread.id if active_thread else '' }}"
+             hx-trigger="load"
+             hx-swap="innerHTML">
+            {{ loading() }}
+        </div>
 
         <form method="post" action="/agent/threads" style="margin-top:auto" data-busy>
             <button type="submit" class="btn btn-outline-primary btn-sm w-100 mt-2">+ Новый тред</button>
@@ -632,50 +622,12 @@
     <!-- Main chat area -->
     <div class="agent-chat">
         {% if active_thread %}
-        <div class="chat-status-panel">
+        {# Runtime chips/badges depend on the lazily-probed backend; the threads
+           fragment OOB-swaps this slot once it knows the runtime status (#949). #}
+        <div class="chat-status-panel" id="chat-runtime-slot">
             <div class="chat-header">
                 <div class="chat-header-title">{{ active_thread.title }}</div>
-                <div class="chat-header-badges">
-                    {% if agent_status and agent_status.selected_backend %}
-                    <span class="badge text-bg-secondary">{{ agent_status.selected_backend }}</span>
-                    {% endif %}
-                    {% if agent_status and agent_status.using_override %}
-                    <span class="badge text-bg-warning">dev override</span>
-                    {% endif %}
-                </div>
             </div>
-
-            {% if agent_status %}
-            <div class="chat-runtime">
-                <span class="runtime-chip {{ 'runtime-chip-on' if agent_status.selected_backend == 'claude' else 'runtime-chip-off' }}">
-                    Claude
-                    <strong>{{ "on" if agent_status.selected_backend == "claude" else "off" }}</strong>
-                </span>
-                <span class="runtime-chip {{ 'runtime-chip-on' if agent_status.selected_backend == 'deepagents' else 'runtime-chip-off' }}">
-                    deepagents
-                    <strong>{{ "on" if agent_status.selected_backend == "deepagents" else "off" }}</strong>
-                </span>
-                {% if agent_status.selected_backend == "adk" %}
-                <span class="runtime-chip runtime-chip-on">
-                    google-adk
-                    <strong>on</strong>
-                </span>
-                {% endif %}
-                {% if agent_status.selected_backend == "deepagents" and agent_status.fallback_model %}
-                <span class="runtime-chip runtime-chip-accent">
-                    provider
-                    <code>{{ agent_status.fallback_provider or "unknown" }}</code>
-                </span>
-                <span class="runtime-chip runtime-chip-accent">
-                    model
-                    <code>{{ agent_status.fallback_model }}</code>
-                </span>
-                {% endif %}
-            </div>
-            {% if agent_status.error %}
-            <div class="alert alert-warning py-2 mb-0">{{ agent_status.error }}</div>
-            {% endif %}
-            {% endif %}
         </div>
 
         <div class="chat-stage">
@@ -697,31 +649,17 @@
             <div class="chat-composer">
                 <div class="chat-composer-meta">
                     <span class="composer-caption">Сообщение отправится в текущий тред.</span>
-                    {% if agent_status and agent_status.selected_backend == "deepagents" %}
-                    <span class="composer-subtle">Runtime управляется настройками deepagents.</span>
-                    {% else %}
-                    <span class="composer-subtle">Модель Claude можно переключить прямо здесь.</span>
-                    {% endif %}
+                    {# composer-subtle hint depends on the lazy backend; OOB-filled (#949). #}
+                    <span id="composer-subtle-slot"></span>
                 </div>
                 <div class="chat-input-area">
                     <textarea id="chat-input" class="form-control"
                               placeholder="Введите сообщение… (Enter — отправить, Shift+Enter — перенос строки)"
                               ></textarea>
                     <div class="composer-actions">
-                        {% if not agent_status or agent_status.selected_backend != "deepagents" %}
-                        <div class="composer-caption">Модель Claude</div>
-                        <select id="model-select" class="form-select model-select">
-                            <option value="">Авто</option>
-                            {% for value, label in model_options %}
-                            <option value="{{ value }}">{{ label }}</option>
-                            {% endfor %}
-                        </select>
-                        {% else %}
-                        <div class="composer-hint">
-                            <strong>Deepagents runtime</strong>
-                            Модель и provider берутся из сохраненных настроек и показываются в статусе выше.
-                        </div>
-                        {% endif %}
+                        {# Model select vs deepagents hint depends on the lazy backend; the
+                           threads fragment OOB-swaps this slot (#949). #}
+                        <span id="composer-actions-slot"></span>
                         <button class="btn btn-primary chat-send-btn" id="send-btn"
                                 onclick="sendMessage()">Отправить</button>
                     </div>
@@ -759,15 +697,22 @@
     var sending = false;
     var abortController = null;
 
-    // Model selector: persist in localStorage
-    var modelSelect = document.getElementById('model-select');
-    if (modelSelect) {
-        var savedModel = localStorage.getItem('agent_model') || '';
-        modelSelect.value = savedModel;
-        modelSelect.addEventListener('change', function() {
-            localStorage.setItem('agent_model', this.value);
-        });
+    // Model selector: persist in localStorage. The <select> loads lazily via the
+    // threads fragment (OOB swap, #949), so restore its saved value whenever it
+    // (re)appears and delegate the change handler off the document.
+    function restoreModelSelect() {
+        var modelSelect = document.getElementById('model-select');
+        if (modelSelect) modelSelect.value = localStorage.getItem('agent_model') || '';
     }
+    restoreModelSelect();
+    document.addEventListener('change', function(e) {
+        if (e.target && e.target.id === 'model-select') {
+            localStorage.setItem('agent_model', e.target.value);
+        }
+    });
+    document.body.addEventListener('htmx:afterSwap', function(e) {
+        if (e.target && e.target.id === 'sidebar-threads') restoreModelSelect();
+    });
 
     // Configure marked
     marked.setOptions({breaks: true, gfm: true});

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -718,11 +718,14 @@
             localStorage.setItem('agent_model', e.target.value);
         }
     });
-    // Re-seed on ANY swap once the select is present — the select arrives via an
-    // OOB swap into #composer-actions-slot, not the primary #sidebar-threads target,
-    // so gating on a specific target id would couple correctness to HTMX's
-    // OOB-vs-primary event ordering. restoreModelSelect() is idempotent and
-    // self-guards on the element, so a broad listener is safe (#949).
+    // Re-seed on ANY swap once the select is present. The select arrives via an
+    // OOB swap into #composer-actions-slot (not the primary #sidebar-threads
+    // target), and the base-layout #rename-badge polls on `every 60s`, so its
+    // afterSwap keeps bubbling to document.body — gating on a specific target id
+    // would couple correctness to HTMX's event order and miss the OOB insertion.
+    // restoreModelSelect() is idempotent, self-guards on the element, and only
+    // ever writes back the localStorage value the change-handler already persisted,
+    // so a broad listener can't clobber an in-session pick (#949).
     document.body.addEventListener('htmx:afterSwap', restoreModelSelect);
 
     // Configure marked

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -704,6 +704,14 @@
         var modelSelect = document.getElementById('model-select');
         if (modelSelect) modelSelect.value = localStorage.getItem('agent_model') || '';
     }
+    // localStorage is the source of truth for the chosen model — read it (not the
+    // possibly-not-yet-loaded <select>) at send time so a message sent before the
+    // lazy composer fragment lands still carries the user's saved model (#949).
+    function selectedModel() {
+        var modelSelect = document.getElementById('model-select');
+        if (modelSelect) return modelSelect.value || '';
+        return localStorage.getItem('agent_model') || '';
+    }
     restoreModelSelect();
     document.addEventListener('change', function(e) {
         if (e.target && e.target.id === 'model-select') {
@@ -1091,7 +1099,7 @@
             var resp = await fetch('/agent/threads/' + threadId + '/chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({message: text, model: (document.getElementById('model-select') || {}).value || ''}),
+                body: JSON.stringify({message: text, model: selectedModel()}),
                 signal: abortController.signal
             });
 

--- a/src/web/templates/agent.html
+++ b/src/web/templates/agent.html
@@ -718,9 +718,12 @@
             localStorage.setItem('agent_model', e.target.value);
         }
     });
-    document.body.addEventListener('htmx:afterSwap', function(e) {
-        if (e.target && e.target.id === 'sidebar-threads') restoreModelSelect();
-    });
+    // Re-seed on ANY swap once the select is present — the select arrives via an
+    // OOB swap into #composer-actions-slot, not the primary #sidebar-threads target,
+    // so gating on a specific target id would couple correctness to HTMX's
+    // OOB-vs-primary event ordering. restoreModelSelect() is idempotent and
+    // self-guards on the element, so a broad listener is safe (#949).
+    document.body.addEventListener('htmx:afterSwap', restoreModelSelect);
 
     // Configure marked
     marked.setOptions({breaks: true, gfm: true});

--- a/src/web/templates/agent/_threads.html
+++ b/src/web/templates/agent/_threads.html
@@ -1,0 +1,107 @@
+{% from "_macros.html" import icon %}
+{#
+  Lazy fragment for the Agent page (#949). Primary swap target is the desktop
+  sidebar (#sidebar-threads, innerHTML). Everything else is filled via HTMX
+  out-of-band swaps in one round-trip:
+    - #offcanvas-threads   mobile thread list
+    - #chat-runtime-slot   backend chips/badges (runtime status)
+    - #composer-subtle-slot / #composer-actions-slot  composer footer
+  The skeleton already resolved the active thread; we just mark it here.
+#}
+
+{# ── macro: a single thread list (shared by sidebar + offcanvas) ── #}
+{% macro thread_list() %}
+    {% for thread in threads %}
+    <a class="thread-item {% if active_thread and active_thread.id == thread.id %}active{% endif %}"
+       href="/agent?thread_id={{ thread.id }}"
+       data-thread-id="{{ thread.id }}">
+        <span class="thread-title" title="{{ thread.title }}">{{ thread.title }}</span>
+        <button class="thread-delete-btn"
+                onclick="deleteThread(event, {{ thread.id }})"
+                title="Удалить тред">{{ icon("close") }}</button>
+    </a>
+    {% else %}
+    <p class="small text-muted">Тредов пока нет</p>
+    {% endfor %}
+{% endmacro %}
+
+{# ── primary swap: desktop sidebar thread list ── #}
+{{ thread_list() }}
+
+{# ── OOB: mobile offcanvas thread list ── #}
+<div id="offcanvas-threads" hx-swap-oob="true">
+    {{ thread_list() }}
+</div>
+
+{# ── OOB: runtime status panel ── #}
+<div class="chat-status-panel" id="chat-runtime-slot" hx-swap-oob="true">
+    <div class="chat-header">
+        <div class="chat-header-title">{{ active_thread.title if active_thread else "" }}</div>
+        <div class="chat-header-badges">
+            {% if agent_status and agent_status.selected_backend %}
+            <span class="badge text-bg-secondary">{{ agent_status.selected_backend }}</span>
+            {% endif %}
+            {% if agent_status and agent_status.using_override %}
+            <span class="badge text-bg-warning">dev override</span>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if agent_status %}
+    <div class="chat-runtime">
+        <span class="runtime-chip {{ 'runtime-chip-on' if agent_status.selected_backend == 'claude' else 'runtime-chip-off' }}">
+            Claude
+            <strong>{{ "on" if agent_status.selected_backend == "claude" else "off" }}</strong>
+        </span>
+        <span class="runtime-chip {{ 'runtime-chip-on' if agent_status.selected_backend == 'deepagents' else 'runtime-chip-off' }}">
+            deepagents
+            <strong>{{ "on" if agent_status.selected_backend == "deepagents" else "off" }}</strong>
+        </span>
+        {% if agent_status.selected_backend == "adk" %}
+        <span class="runtime-chip runtime-chip-on">
+            google-adk
+            <strong>on</strong>
+        </span>
+        {% endif %}
+        {% if agent_status.selected_backend == "deepagents" and agent_status.fallback_model %}
+        <span class="runtime-chip runtime-chip-accent">
+            provider
+            <code>{{ agent_status.fallback_provider or "unknown" }}</code>
+        </span>
+        <span class="runtime-chip runtime-chip-accent">
+            model
+            <code>{{ agent_status.fallback_model }}</code>
+        </span>
+        {% endif %}
+    </div>
+    {% if agent_status.error %}
+    <div class="alert alert-warning py-2 mb-0">{{ agent_status.error }}</div>
+    {% endif %}
+    {% endif %}
+</div>
+
+{# ── OOB: composer footer (subtle hint + model select / deepagents hint) ── #}
+<span id="composer-subtle-slot" hx-swap-oob="true">
+    {% if agent_status and agent_status.selected_backend == "deepagents" %}
+    <span class="composer-subtle">Runtime управляется настройками deepagents.</span>
+    {% else %}
+    <span class="composer-subtle">Модель Claude можно переключить прямо здесь.</span>
+    {% endif %}
+</span>
+
+<span id="composer-actions-slot" hx-swap-oob="true">
+    {% if not agent_status or agent_status.selected_backend != "deepagents" %}
+    <div class="composer-caption">Модель Claude</div>
+    <select id="model-select" class="form-select model-select">
+        <option value="">Авто</option>
+        {% for value, label in model_options %}
+        <option value="{{ value }}">{{ label }}</option>
+        {% endfor %}
+    </select>
+    {% else %}
+    <div class="composer-hint">
+        <strong>Deepagents runtime</strong>
+        Модель и provider берутся из сохраненных настроек и показываются в статусе выше.
+    </div>
+    {% endif %}
+</span>

--- a/tests/routes/test_agent_lazyload.py
+++ b/tests/routes/test_agent_lazyload.py
@@ -1,0 +1,159 @@
+"""Lazyload split for the Agent page (#949, part of #756).
+
+The skeleton route (`GET /agent`) must render instantly without probing the
+agent backend runtime status; the thread list + runtime chips + composer footer
+load lazily from `GET /agent/fragments/threads`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+async def client(route_client, agent_manager_mock):
+    """Client with the agent_manager_mock wired into app.state."""
+    client = route_client
+    client._transport_app.state.agent_manager = agent_manager_mock
+    yield client
+
+
+@pytest.fixture
+async def db(base_app):
+    _, db, _ = base_app
+    return db
+
+
+@pytest.mark.anyio
+async def test_skeleton_does_not_probe_runtime_status(client, db, agent_manager_mock):
+    """The skeleton route must NOT call get_runtime_status (it's the heavy bit)."""
+    thread_id = await db.create_agent_thread("Skeleton Thread")
+    agent_manager_mock.get_runtime_status.reset_mock()
+
+    resp = await client.get(f"/agent?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    agent_manager_mock.get_runtime_status.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_skeleton_has_lazy_fragment_trigger(client, db):
+    """Skeleton wires the lazy fragment with hx-trigger=load + active thread id."""
+    thread_id = await db.create_agent_thread("Lazy Thread")
+
+    resp = await client.get(f"/agent?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    assert f"/agent/fragments/threads?thread_id={thread_id}" in resp.text
+    assert 'hx-trigger="load"' in resp.text
+    # The active thread title still renders synchronously (chat header) so the
+    # page is recognisable before the fragment lands.
+    assert "Lazy Thread" in resp.text
+
+
+@pytest.mark.anyio
+async def test_skeleton_defers_runtime_chips(client, db):
+    """Runtime chips/model-select are NOT in the skeleton — they OOB-load later."""
+    thread_id = await db.create_agent_thread("Chips Thread")
+
+    resp = await client.get(f"/agent?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    # The OOB target slots exist (empty) but their runtime-dependent content does not.
+    assert 'id="chat-runtime-slot"' in resp.text
+    assert 'id="composer-actions-slot"' in resp.text
+    # No rendered chip spans and no model select — only the CSS rules for the
+    # chip classes live in <head>, never the `<span class="runtime-chip ...">`
+    # markup or the OOB swaps (those are fragment-only).
+    assert '<span class="runtime-chip' not in resp.text
+    assert "hx-swap-oob" not in resp.text
+    assert 'id="model-select"' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_fragment_probes_runtime_and_renders_threads(
+    client, db, agent_manager_mock
+):
+    """The fragment probes runtime status and renders the thread list + chips."""
+    thread_id = await db.create_agent_thread("Fragment Thread")
+    agent_manager_mock.get_runtime_status.reset_mock()
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    agent_manager_mock.get_runtime_status.assert_awaited_once()
+    # Thread list (primary swap) + runtime chips (OOB) + composer (OOB).
+    assert "Fragment Thread" in resp.text
+    assert '<span class="runtime-chip' in resp.text
+    assert f'data-thread-id="{thread_id}"' in resp.text
+
+
+@pytest.mark.anyio
+async def test_fragment_oob_targets_match_skeleton_slots(client, db):
+    """Fragment OOB swaps must target the slot ids the skeleton renders."""
+    thread_id = await db.create_agent_thread("OOB Thread")
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    for slot in ("offcanvas-threads", "chat-runtime-slot", "composer-actions-slot"):
+        assert f'id="{slot}"' in resp.text
+        assert 'hx-swap-oob="true"' in resp.text
+
+
+@pytest.mark.anyio
+async def test_fragment_marks_active_thread(client, db):
+    """The open thread is highlighted via the active class in the fragment."""
+    other = await db.create_agent_thread("Other")
+    active = await db.create_agent_thread("Active")
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={active}")
+
+    assert resp.status_code == 200
+    # The active thread row carries the `active` class; the other one does not.
+    assert 'class="thread-item active"' in resp.text
+    assert f'href="/agent?thread_id={active}"' in resp.text
+    assert f'data-thread-id="{other}"' in resp.text
+    # Exactly one row is marked active (the open thread), not the other.
+    assert resp.text.count('class="thread-item active"') == 2  # sidebar + offcanvas
+
+
+@pytest.mark.anyio
+async def test_fragment_without_agent_manager(client, db):
+    """Fragment degrades gracefully when no agent manager is configured."""
+    client._transport_app.state.agent_manager = None
+    thread_id = await db.create_agent_thread("No Manager")
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    # Threads still render; runtime chips are absent (no status to show).
+    assert "No Manager" in resp.text
+    assert '<span class="runtime-chip' not in resp.text
+
+
+@pytest.mark.anyio
+async def test_fragment_deepagents_hides_model_select(client, db, agent_manager_mock):
+    """For the deepagents backend the composer shows the hint, not the model select."""
+    thread_id = await db.create_agent_thread("Deepagents")
+    runtime = agent_manager_mock.get_runtime_status.return_value
+    runtime.selected_backend = "deepagents"
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    assert 'id="model-select"' not in resp.text
+    assert "Deepagents runtime" in resp.text
+
+
+@pytest.mark.anyio
+async def test_fragment_claude_shows_model_select(client, db, agent_manager_mock):
+    """For a non-deepagents backend the composer shows the Claude model select."""
+    thread_id = await db.create_agent_thread("Claude")
+    runtime = agent_manager_mock.get_runtime_status.return_value
+    runtime.selected_backend = "claude"
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    assert 'id="model-select"' in resp.text

--- a/tests/routes/test_agent_lazyload.py
+++ b/tests/routes/test_agent_lazyload.py
@@ -71,6 +71,27 @@ async def test_skeleton_defers_runtime_chips(client, db):
 
 
 @pytest.mark.anyio
+async def test_skeleton_send_reads_saved_model_before_fragment_loads(client, db):
+    """A message sent before the lazy composer fragment lands keeps the saved model.
+
+    Regression guard (#949): the composer's <select> now loads lazily, so the
+    send-time read MUST fall back to localStorage (via selectedModel()) instead of
+    reading the not-yet-present #model-select directly — otherwise the user's saved
+    model choice is silently dropped (sent as ''/Авто) during the load window.
+    """
+    thread_id = await db.create_agent_thread("Race Thread")
+
+    resp = await client.get(f"/agent?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    # The chat POST body uses the localStorage-backed helper, never the raw element.
+    assert "model: selectedModel()" in resp.text
+    assert "localStorage.getItem('agent_model')" in resp.text
+    # The old direct-read pattern (drops the saved model pre-fragment) must be gone.
+    assert "(document.getElementById('model-select') || {}).value" not in resp.text
+
+
+@pytest.mark.anyio
 async def test_fragment_probes_runtime_and_renders_threads(
     client, db, agent_manager_mock
 ):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3455,7 +3455,7 @@ class TestWebAgent:
         assert str(resp.url).endswith("?thread_id=1")
 
     @pytest.mark.anyio
-    async def test_agent_page_shows_deepagents_status_and_hides_claude_model_select(self, client):
+    async def test_agent_fragment_shows_deepagents_status_and_hides_claude_model_select(self, client):
         db = client._transport.app.state.db
         await db.create_agent_thread("First")
         client._transport.app.state.agent_manager = AsyncMock()
@@ -3475,7 +3475,9 @@ class TestWebAgent:
             )
         )
 
-        resp = await client.get("/agent?thread_id=1")
+        # Runtime status + the composer's model-select/hint moved into the lazy
+        # threads fragment (#949); the skeleton route no longer renders them.
+        resp = await client.get("/agent/fragments/threads?thread_id=1")
 
         assert resp.status_code == 200
         assert "deepagents" in resp.text


### PR DESCRIPTION
## Что и зачем

Часть #756 (lazyload). Страница **Agent** (`GET /`) на каждую загрузку выполняла `get_agent_threads()` **плюс** полный зонд бэкенда `get_runtime_status()` (`refresh_settings_cache` + проверка доступности каждого бэкенда), что блокировало первую отрисовку.

Перевёл страницу на lazyload-паттерн — эталоны #877 (`/channels`) и `/dashboard`.

## Изменения

- **`GET /agent`** теперь рендерит skeleton. Логика редиректов/онбординга остаётся синхронной (она решает, какой тред показывать — skeleton-200 проглотил бы редирект, как в `dashboard.py`), но тяжёлый зонд runtime status отложен.
- **Новый `GET /agent/fragments/threads`** (`hx-trigger="load"`) рендерит список тредов, runtime-чипы/бейджи статуса и низ composer'а (выбор Claude-модели vs deepagents-подсказка), вызывая зонд бэкенда один раз. Список тредов (сайдбар + offcanvas), панель runtime и слоты composer'а заполняются за один round-trip через HTMX **out-of-band swaps**.
- `#model-select` теперь грузится лениво: восстановление сохранённого значения перевешано на `htmx:afterSwap`, а обработчик `change` делегирован на `document`.

## Тесты

- Новый `tests/routes/test_agent_lazyload.py`: skeleton не зондирует runtime status; проводка ленивого триггера; зонд + OOB-цели фрагмента; маркировка активного треда; рендер composer'а под каждый бэкенд.
- В `test_web.py` перенаправил ассерт перенесённого контента (`deepagents`/`dev override`/`model-select`) на fragment-роут.

Локально: `pytest tests/routes/ tests/test_web.py` — **1219 passed**; ruff clean; import-contracts kept.

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)