### PR TITLE
feat(jobs): unified jobs dashboard page + lazyload table (#965)

### DIFF
--- a/src/web/routes/jobs.py
+++ b/src/web/routes/jobs.py
@@ -1,9 +1,10 @@
-"""Unified background-jobs read API + fragment (#964).
+"""Unified background-jobs read API + fragment (#964) + dashboard page (#965).
 
 Read-only views over JobsReadModel (the #963 unified read-model): a JSON list and
-an HTML table fragment, both filterable by source / runtime-state. No DB writes
-and no Telegram API calls — purely reads collection_tasks/telegram_commands/
-photo_* tables plus the runtime snapshots.
+an HTML table fragment, both filterable by source / runtime-state, plus the
+lazyloaded dashboard page that hosts the fragment. No DB writes and no Telegram
+API calls — purely reads collection_tasks/telegram_commands/photo_* tables plus
+the runtime snapshots.
 """
 
 from __future__ import annotations

--- a/src/web/routes/jobs.py
+++ b/src/web/routes/jobs.py
@@ -42,6 +42,17 @@ async def _list(request: Request, source: str | None, status: str | None, limit:
     )
 
 
+@router.get("", response_class=HTMLResponse)
+async def jobs_page(request: Request):
+    """Unified jobs dashboard (#965).
+
+    Paints the page shell instantly (no DB query); the filterable table is loaded
+    lazily via the ``/jobs/fragments/list`` fragment with ``hx-trigger="load"``
+    (the #756 lazyload pattern), so TTFB stays flat on large databases.
+    """
+    return deps.get_templates(request).TemplateResponse(request, "jobs.html", {})
+
+
 @router.get("/api/list")
 async def api_jobs_list(
     request: Request,

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -32,6 +32,7 @@
         ("/calendar", "Календарь", "calendar-event"),
         ("/dialogs", "Диалоги", "chat-dots"),
         ("/scheduler", "Планировщик", "clock-history"),
+        ("/jobs", "Задачи", "list-task"),
         ("/debug", "Дебаг", "bug")
     ] %}
     <div class="app-sidebar-backdrop" data-sidebar-backdrop></div>

--- a/src/web/templates/jobs.html
+++ b/src/web/templates/jobs.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
+{% block title %}Задачи — TG Agent{% endblock %}
+{% block content %}
+<h1 class="h3 mb-3">Фоновые задачи</h1>
+<p class="text-muted">
+  Единая таблица всех agent/runtime задач: что выполняется сейчас, что ждёт из-за
+  pause-gate, что отложено flood-wait, pending и failed. Фильтры по источнику и статусу.
+</p>
+
+{# The table (and its filter form) paints lazily via an HTMX fragment so the page
+   shell loads instantly on large databases (#756 lazyload pattern, #965). The
+   fragment route renders the filter form too, so filtering re-swaps in place. #}
+<div id="jobs-table"
+     hx-get="/jobs/fragments/list"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  {{ loading() }}
+</div>
+{% endblock %}

--- a/tests/routes/test_jobs_routes.py
+++ b/tests/routes/test_jobs_routes.py
@@ -71,6 +71,7 @@ async def test_jobs_page_renders_lazyload_shell(route_client):
     assert 'id="jobs-table"' in body
     assert 'hx-get="/jobs/fragments/list"' in body
     assert 'hx-trigger="load"' in body
+    assert 'hx-swap="innerHTML"' in body
 
 
 async def test_jobs_page_omits_table_data(route_client):

--- a/tests/routes/test_jobs_routes.py
+++ b/tests/routes/test_jobs_routes.py
@@ -62,6 +62,50 @@ async def test_jobs_fragment_renders(route_client):
     assert 'hx-target="#jobs-table"' in resp.text
 
 
+async def test_jobs_page_renders_lazyload_shell(route_client):
+    # The dashboard page (#965) must paint instantly without querying the DB and
+    # defer the table to the fragment via hx-trigger="load" (the #756 pattern).
+    resp = await route_client.get("/jobs")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'id="jobs-table"' in body
+    assert 'hx-get="/jobs/fragments/list"' in body
+    assert 'hx-trigger="load"' in body
+
+
+async def test_jobs_page_omits_table_data(route_client):
+    # The shell must not contain the fragment's table — it's loaded lazily, so a
+    # seeded job must NOT appear in the page response itself (only in the fragment).
+    db = route_client._transport_app.state.db
+    await db.repos.tasks.create_collection_task(700903, "Lazy Only In Fragment")
+    resp = await route_client.get("/jobs")
+    assert "Lazy Only In Fragment" not in resp.text
+
+
+async def test_jobs_fragment_shows_pause_gate_state(route_client):
+    # A PENDING collection task while the queue is paused must surface as
+    # pause_gate in the fragment with the warning badge (#770 LiveRuntimePauseGate).
+    from datetime import datetime, timezone
+
+    from src.models import RuntimeSnapshot
+
+    db = route_client._transport_app.state.db
+    await db.repos.tasks.create_collection_task(700904, "Held By Pause Gate")
+    await db.repos.runtime_snapshots.upsert_snapshot(
+        RuntimeSnapshot(
+            snapshot_type="collection_queue_status",
+            payload={"paused": True, "active_task_ids": []},
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+    resp = await route_client.get("/jobs/fragments/list")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Held By Pause Gate" in body
+    assert "pause_gate" in body
+    assert "bg-warning" in body
+
+
 async def test_jobs_api_sorts_mixed_null_and_naive_timestamps(route_client):
     # Regression: the sort key mixed a tz-aware None-sentinel with the naive
     # ``created_at`` values SQLite stores, so a job with ``created_at IS NULL``
@@ -71,9 +115,7 @@ async def test_jobs_api_sorts_mixed_null_and_naive_timestamps(route_client):
     db = route_client._transport_app.state.db
     await db.repos.tasks.create_collection_task(700901, "Has Timestamp")
     await db.repos.tasks.create_collection_task(700902, "Null Timestamp")
-    await db.execute_write(
-        "UPDATE collection_tasks SET created_at = NULL WHERE channel_id = ?", (700902,)
-    )
+    await db.execute_write("UPDATE collection_tasks SET created_at = NULL WHERE channel_id = ?", (700902,))
     resp = await route_client.get("/jobs/api/list")
     assert resp.status_code == 200
     # channel_title surfaces via the JobView ``summary`` field.


### PR DESCRIPTION
## Что сделано

Часть #769. UI dashboard единой таблицы фоновых задач — страница, на которой живёт fragment из #964.

Единая вкладка **«Задачи»** в боковом меню веб-панели показывает все фоновые agent/runtime jobs из read-модели #963 в одной таблице:

- что **выполняется** сейчас (`running`),
- что **ждёт из-за pause-gate** (`pause_gate`, удерживается `LiveRuntimePauseGate` #770),
- что **отложено flood-wait** (`flood_wait`),
- `pending` / `scheduled` / `failed` / `cancelled` / `inactive`,

с фильтрами по **источнику** и **статусу** и сортировкой (новейшие сверху — обеспечивается read-моделью).

## Lazyload (#756)

Роут `GET /jobs` рисует скелет страницы **без единого DB-запроса** и догружает таблицу фрагментом `GET /jobs/fragments/list` через `hx-trigger="load"` — TTFB не зависит от объёма БД. Форма фильтров находится **внутри** фрагмента, поэтому повторная фильтрация переотрисовывает таблицу на месте, не оставляя stale-контролов вне swap-цели (грабли #756).

Эталон паттерна — `templates/analytics/` (свежий #951: `_channel_selector.html` + fragment-роут).

## Изменения

- **Роут**: новый `GET /jobs` (только shell) в `src/web/routes/jobs.py`.
- **Навигация**: пункт «Задачи» (`list-task`) в `base.html`.
- **Шаблон**: `templates/jobs.html` — оборачивает существующий fragment `jobs_table.html`.
- **Тесты** (`tests/routes/test_jobs_routes.py`): обвязка lazyload-shell, shell-не-содержит-данных-таблицы, рендер pause-gate состояния (paused queue → warning badge).

Backend (#963 read-модель, #964 API/fragment-роут) уже смержен — здесь только UI поверх него, без изменений API.

## Проверки

- `ruff check src tests conftest.py` — чисто.
- `pytest tests/routes/` — 1023 passed (включая 9 jobs-тестов и проверку отсутствия регрессий навигации).

Closes #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)