### PR TITLE
feat(cli): analytics channel-rate — connect LLM judge to CLI (#994)

### DIFF
--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -193,6 +193,13 @@
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
 | Аналитика канала | `analytics channel` | `GET /analytics/channels/api/overview` | `get_channel_analytics` |
 | Рейтинг каналов | `analytics channel-rating` | `GET /analytics/channels/api/ratings` | `get_channel_ratings` |
+| Запуск LLM-судьи | `analytics channel-rate <channel_id>` | — (CLI-first, #994) | — (CLI-first, #994) |
+
+> **CLI-first (#994).** Запуск LLM-судьи (`ChannelAnalysisService.classify_channel`) — write-операция:
+> делает реальный provider-вызов и апсертит вердикт в `channel_ratings`. Подключён сначала к CLI
+> (`analytics channel-rate`). Web POST-эндпоинт и agent write-tool — осознанный follow-up: судью можно
+> запустить из любого UI, но read-путь (`channel-rating` / `GET …/ratings` / `get_channel_ratings`)
+> уже даёт паритетный просмотр результата во всех трёх интерфейсах.
 
 ## Dialogs
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -197,9 +197,10 @@
 
 > **CLI-first (#994).** Запуск LLM-судьи (`ChannelAnalysisService.classify_channel`) — write-операция:
 > делает реальный provider-вызов и апсертит вердикт в `channel_ratings`. Подключён сначала к CLI
-> (`analytics channel-rate`). Web POST-эндпоинт и agent write-tool — осознанный follow-up: судью можно
-> запустить из любого UI, но read-путь (`channel-rating` / `GET …/ratings` / `get_channel_ratings`)
-> уже даёт паритетный просмотр результата во всех трёх интерфейсах.
+> (`analytics channel-rate`). Прочерки в колонках Web/Agent означают **«ещё не реализовано»** (осознанный
+> follow-up), а не «исключено»: Web POST-эндпоинт и agent write-tool для запуска судьи появятся отдельным
+> PR. Read-путь (`channel-rating` / `GET …/ratings` / `get_channel_ratings`) уже даёт паритетный просмотр
+> результата во всех трёх интерфейсах.
 
 ## Dialogs
 

--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -320,19 +320,42 @@ def run(args: argparse.Namespace) -> None:
                 await provider_service.load_db_providers()
                 if not provider_service.has_providers():
                     print(
-                        "LLM provider is not configured. Add one in /settings or set an API key "
-                        "env var (e.g. OPENAI_API_KEY)."
+                        "LLM provider is not configured. Add one with `provider add`, in the web "
+                        "/settings page, or set an API key env var (e.g. OPENAI_API_KEY)."
                     )
                     return
 
-                provider_callable = provider_service.get_provider_callable(args.model)
+                # A mistyped --model must NOT silently fall back to the stub
+                # provider and persist a meaningless verdict — fail loudly instead
+                # (cycle-review #994, both reviewers flagged this as the top risk).
+                try:
+                    provider_callable = provider_service.resolve_provider_callable(args.model)
+                except ValueError as exc:
+                    print(str(exc))
+                    return
+
                 svc = ChannelAnalysisService(db)
-                sample_size = max(1, getattr(args, "sample_size", 40))
-                rating = await svc.classify_channel(
-                    channel_id,
-                    provider_callable=provider_callable,
-                    sample_size=sample_size,
-                )
+                # Guard against an empty channel before spending a provider call:
+                # no posts would otherwise persist a defaulted "useless/original"
+                # verdict (n_total=0) that looks valid but carries zero signal.
+                # Cap the sample upper bound so a huge --sample-size can't build a
+                # prompt that trips token limits / OOM.
+                sample_size = min(max(1, getattr(args, "sample_size", 40)), 200)
+                posts = await svc.sample_posts(channel_id, sample_size)
+                if not posts:
+                    print(f"Channel {channel_id} has no text posts to judge; skipping.")
+                    return
+
+                try:
+                    rating = await svc.classify_channel(
+                        channel_id,
+                        provider_callable=provider_callable,
+                        sample_size=sample_size,
+                    )
+                except Exception as exc:  # provider/network/parse failure
+                    print(f"Judge failed for channel {channel_id}: {exc}")
+                    raise SystemExit(1) from exc
+
                 name = rating.title or rating.username or str(rating.channel_id)
                 print(f"Channel {rating.channel_id} ({name}):")
                 print(f"  useful:     {rating.useful}")

--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -8,7 +8,7 @@ from src.cli import runtime
 
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
-        _config, db = await runtime.init_db(args.config)
+        config, db = await runtime.init_db(args.config)
         try:
             action = getattr(args, "analytics_action", None) or "top"
             date_from = getattr(args, "date_from", None)
@@ -306,6 +306,40 @@ def run(args: argparse.Namespace) -> None:
                 for r in ratings:
                     title = (r.title or r.username or str(r.channel_id))[:30]
                     print(f"{r.channel_id:<14} {r.useful:<8} {r.genre:<11} {r.confidence:<5.2f} {title}")
+
+            elif action == "channel-rate":
+                # Write path (#994): run the LLM judge for one channel and upsert
+                # its verdict into channel_ratings. The read-only `channel-rating`
+                # branch above only lists existing verdicts; this is the single
+                # entry point that invokes ChannelAnalysisService.classify_channel.
+                from src.services.channel_analysis_service import ChannelAnalysisService
+                from src.services.provider_service import RuntimeProviderRegistry
+
+                channel_id = args.channel_id
+                provider_service = RuntimeProviderRegistry(db, config)
+                await provider_service.load_db_providers()
+                if not provider_service.has_providers():
+                    print(
+                        "LLM provider is not configured. Add one in /settings or set an API key "
+                        "env var (e.g. OPENAI_API_KEY)."
+                    )
+                    return
+
+                provider_callable = provider_service.get_provider_callable(args.model)
+                svc = ChannelAnalysisService(db)
+                sample_size = max(1, getattr(args, "sample_size", 40))
+                rating = await svc.classify_channel(
+                    channel_id,
+                    provider_callable=provider_callable,
+                    sample_size=sample_size,
+                )
+                name = rating.title or rating.username or str(rating.channel_id)
+                print(f"Channel {rating.channel_id} ({name}):")
+                print(f"  useful:     {rating.useful}")
+                print(f"  genre:      {rating.genre}")
+                print(f"  confidence: {rating.confidence:.2f}")
+                print(f"  reason:     {rating.reason or '-'}")
+                print(f"  posts seen: {rating.n_total}")
         finally:
             await db.close()
 

--- a/src/cli/parser_domains/analytics.py
+++ b/src/cli/parser_domains/analytics.py
@@ -81,3 +81,23 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         help="Filter by genre axis",
     )
     analytics_rating.add_argument("--limit", type=int, default=50, help="Max rows (default: 50)")
+
+    analytics_rate = analytics_sub.add_parser(
+        "channel-rate",
+        help="Run the LLM judge on a channel and upsert its rating (usefulness × genre)",
+    )
+    analytics_rate.add_argument(
+        "channel_id", type=int, help="Telegram channel_id (bare positive int)"
+    )
+    analytics_rate.add_argument(
+        "--model",
+        default=None,
+        help="LLM model/provider name (default: first registered provider)",
+    )
+    analytics_rate.add_argument(
+        "--sample-size",
+        dest="sample_size",
+        type=int,
+        default=40,
+        help="Number of recent posts to sample for the judge (default: 40)",
+    )

--- a/src/services/channel_analysis_service.py
+++ b/src/services/channel_analysis_service.py
@@ -77,6 +77,11 @@ class ChannelAnalysisService:
         return await self._db.repos.channel_ratings.get(channel_id)
 
     # --- classify ---------------------------------------------------------
+    async def sample_posts(self, channel_id: int, sample_size: int = 40) -> list[str]:
+        """Public view of the posts the judge would see — lets callers cheaply
+        pre-check for an empty channel before spending a provider call (#994)."""
+        return await self._sample_posts(channel_id, sample_size)
+
     async def classify_channel(
         self,
         channel_id: int,

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -462,6 +462,26 @@ class RuntimeProviderRegistry:
         logger.warning("Provider %r not registered, falling back to stub default", name)
         return self._registry["default"]
 
+    def resolve_provider_callable(self, name: Optional[str] = None) -> Callable[..., Awaitable[str]]:
+        """Like :meth:`get_provider_callable`, but never silently returns the stub.
+
+        ``get_provider_callable`` degrades to the ``"default"`` stub (which echoes
+        a ``"DRAFT (default provider): ..."`` string) when an explicit ``name`` is
+        given but does not resolve to a real provider. For one-shot operator
+        commands that *persist* the LLM's output (e.g. the channel-rating judge,
+        #994) that silent fallback would write a meaningless verdict that looks
+        successful. Callers that cannot tolerate a stub result should use this
+        method, which raises ``ValueError`` instead of falling back.
+        """
+        callable_ = self.get_provider_callable(name)
+        if name and callable_ is self._registry["default"]:
+            available = sorted(n for n in self._registry if n != "default")
+            raise ValueError(
+                f"Model/provider {name!r} is not registered. "
+                f"Available providers: {', '.join(available) or '(none)'}."
+            )
+        return callable_
+
     def _make_openai_provider(self, api_key: str) -> Callable[..., Awaitable[str]]:
         return self._make_openai_compat_provider(
             os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"),

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -161,6 +161,10 @@ CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS: dict[tuple[str, ...], str] = {
     ("agent", "thread-delete"): "cleanup-only live CLI command; deletes agent thread rows",
     ("agent", "thread-rename"): "local agent-thread mutation",
     ("agent", "thread-stop"): "local agent-stream cancel + last-exchange rollback (DB-only)",
+    ("analytics", "channel-rate"): (
+        "LLM-judge run: provider spend + channel_ratings DB write; no live Telegram. "
+        "Covered by unit/integration tests with a fake provider_callable (#994)"
+    ),
     ("channel", "delete"): "local channel delete mutation",
     ("channel", "import"): "bulk local channel write",
     ("channel", "list-for-import"): "list-only but depends on mutable dialog cache / live dialogs",

--- a/tests/test_channel_analysis_service.py
+++ b/tests/test_channel_analysis_service.py
@@ -82,6 +82,33 @@ async def test_classify_channel_with_fake_provider(db):
     assert stored is not None and stored.genre == "aggregator"
 
 
+async def test_classify_channel_is_idempotent(db):
+    """Re-running the judge on the same channel updates in place — no duplicate
+    rows (#994 cycle-review: idempotency of the write path)."""
+    calls = {"n": 0}
+
+    async def fake_provider(*, prompt, max_tokens=256, temperature=0.0, **kw):
+        calls["n"] += 1
+        # Return a different verdict on the second run to prove update-in-place.
+        if calls["n"] == 1:
+            return '{"useful": "useful", "genre": "original", "confidence": 0.6, "reason": "first"}'
+        return '{"useful": "useless", "genre": "ad", "confidence": 0.3, "reason": "second"}'
+
+    svc = ChannelAnalysisService(db)
+    before = await db.repos.channel_ratings.count()
+
+    await svc.classify_channel(999003, provider_callable=fake_provider, sample_size=5)
+    after_first = await db.repos.channel_ratings.count()
+    assert after_first == before + 1
+
+    await svc.classify_channel(999003, provider_callable=fake_provider, sample_size=5)
+    after_second = await db.repos.channel_ratings.count()
+    assert after_second == after_first  # no duplicate row
+
+    stored = await svc.get_rating(999003)
+    assert stored is not None and stored.useful == "useless" and stored.genre == "ad"
+
+
 async def test_upsert_preserves_flag_count_on_reclassify(db):
     repo = db.repos.channel_ratings
     await repo.upsert(ChannelRating(channel_id=900100, useful="useful", genre="original", flag_count=3))

--- a/tests/test_cli_analytics_commands.py
+++ b/tests/test_cli_analytics_commands.py
@@ -347,3 +347,128 @@ def test_channel_found(capsys):
     out = capsys.readouterr().out
     assert "TestCh" in out
     assert "1000" in out
+
+
+# ---------------------------------------------------------------------------
+# channel-rating (read-only list of stored verdicts)
+# ---------------------------------------------------------------------------
+
+
+def test_channel_rating_empty(capsys):
+    db = make_cli_db()
+    mock_svc = MagicMock()
+    mock_svc.list_ratings = AsyncMock(return_value=[])
+    with _init_patches(db)[0], _init_patches(db)[1], \
+         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=mock_svc):
+        run(_args(analytics_action="channel-rating", useful=None, genre=None, limit=50))
+    assert "No channel ratings" in capsys.readouterr().out
+
+
+def test_channel_rating_with_data(capsys):
+    from src.models import ChannelRating
+
+    db = make_cli_db()
+    rating = ChannelRating(
+        channel_id=100, title="NewsCh", username="newsch",
+        useful="useful", genre="original", confidence=0.91,
+    )
+    mock_svc = MagicMock()
+    mock_svc.list_ratings = AsyncMock(return_value=[rating])
+    with _init_patches(db)[0], _init_patches(db)[1], \
+         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=mock_svc):
+        run(_args(analytics_action="channel-rating", useful="useful", genre=None, limit=50))
+    out = capsys.readouterr().out
+    assert "NewsCh" in out
+    assert "useful" in out
+    assert "original" in out
+    mock_svc.list_ratings.assert_awaited_once_with(useful="useful", genre=None, limit=50)
+
+
+# ---------------------------------------------------------------------------
+# channel-rate (#994: write path — run the LLM judge, upsert the verdict)
+# ---------------------------------------------------------------------------
+
+
+def _rate_args(**overrides):
+    defaults = {
+        "analytics_action": "channel-rate",
+        "channel_id": 100,
+        "model": None,
+        "sample_size": 40,
+    }
+    defaults.update(overrides)
+    return _args(**defaults)
+
+
+def test_channel_rate_no_provider(capsys):
+    """Without a configured provider the judge must not run (no spend, no write)."""
+    db = make_cli_db()
+    provider_svc = MagicMock()
+    provider_svc.load_db_providers = AsyncMock(return_value=0)
+    provider_svc.has_providers = MagicMock(return_value=False)
+    analysis_svc = MagicMock()
+    analysis_svc.classify_channel = AsyncMock()
+    with _init_patches(db)[0], _init_patches(db)[1], \
+         patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
+         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
+        run(_rate_args())
+    out = capsys.readouterr().out
+    assert "LLM provider is not configured" in out
+    analysis_svc.classify_channel.assert_not_awaited()
+
+
+def test_channel_rate_runs_judge(capsys):
+    from src.models import ChannelRating
+
+    db = make_cli_db()
+    provider_callable = AsyncMock(return_value="{}")
+    provider_svc = MagicMock()
+    provider_svc.load_db_providers = AsyncMock(return_value=1)
+    provider_svc.has_providers = MagicMock(return_value=True)
+    provider_svc.get_provider_callable = MagicMock(return_value=provider_callable)
+
+    rating = ChannelRating(
+        channel_id=100, title="JudgedCh", username="judged",
+        useful="useless", genre="ad", confidence=0.77,
+        reason="реклама без сути", n_total=12,
+    )
+    analysis_svc = MagicMock()
+    analysis_svc.classify_channel = AsyncMock(return_value=rating)
+
+    with _init_patches(db)[0], _init_patches(db)[1], \
+         patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
+         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
+        run(_rate_args(model="gpt-4o-mini", sample_size=12))
+
+    out = capsys.readouterr().out
+    assert "JudgedCh" in out
+    assert "useless" in out
+    assert "ad" in out
+    assert "0.77" in out
+    assert "реклама без сути" in out
+    provider_svc.get_provider_callable.assert_called_once_with("gpt-4o-mini")
+    analysis_svc.classify_channel.assert_awaited_once_with(
+        100, provider_callable=provider_callable, sample_size=12
+    )
+
+
+def test_channel_rate_sample_size_floor():
+    """A non-positive --sample-size is clamped to at least 1."""
+    from src.models import ChannelRating
+
+    db = make_cli_db()
+    provider_svc = MagicMock()
+    provider_svc.load_db_providers = AsyncMock(return_value=1)
+    provider_svc.has_providers = MagicMock(return_value=True)
+    provider_svc.get_provider_callable = MagicMock(return_value=AsyncMock())
+    rating = ChannelRating(channel_id=100, useful="useful", genre="original")
+    analysis_svc = MagicMock()
+    analysis_svc.classify_channel = AsyncMock(return_value=rating)
+
+    with _init_patches(db)[0], _init_patches(db)[1], \
+         patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
+         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
+        run(_rate_args(sample_size=0))
+
+    _, kwargs = analysis_svc.classify_channel.await_args
+    assert kwargs["sample_size"] == 1

--- a/tests/test_cli_analytics_commands.py
+++ b/tests/test_cli_analytics_commands.py
@@ -400,21 +400,83 @@ def _rate_args(**overrides):
     return _args(**defaults)
 
 
-def test_channel_rate_no_provider(capsys):
-    """Without a configured provider the judge must not run (no spend, no write)."""
-    db = make_cli_db()
+def _make_provider_svc(*, has_providers=True, resolve=None, resolve_error=None):
     provider_svc = MagicMock()
-    provider_svc.load_db_providers = AsyncMock(return_value=0)
-    provider_svc.has_providers = MagicMock(return_value=False)
+    provider_svc.load_db_providers = AsyncMock(return_value=1 if has_providers else 0)
+    provider_svc.has_providers = MagicMock(return_value=has_providers)
+    if resolve_error is not None:
+        provider_svc.resolve_provider_callable = MagicMock(side_effect=resolve_error)
+    else:
+        provider_svc.resolve_provider_callable = MagicMock(return_value=resolve or AsyncMock())
+    return provider_svc
+
+
+def _make_analysis_svc(*, rating=None, posts=("post",), classify_error=None):
     analysis_svc = MagicMock()
-    analysis_svc.classify_channel = AsyncMock()
+    analysis_svc.sample_posts = AsyncMock(return_value=list(posts))
+    if classify_error is not None:
+        analysis_svc.classify_channel = AsyncMock(side_effect=classify_error)
+    else:
+        analysis_svc.classify_channel = AsyncMock(return_value=rating)
+    return analysis_svc
+
+
+def _run_rate(db, provider_svc, analysis_svc, **arg_overrides):
     with _init_patches(db)[0], _init_patches(db)[1], \
          patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
          patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
-        run(_rate_args())
+        run(_rate_args(**arg_overrides))
+
+
+def test_channel_rate_no_provider(capsys):
+    """Without a configured provider the judge must not run (no spend, no write)."""
+    db = make_cli_db()
+    provider_svc = _make_provider_svc(has_providers=False)
+    analysis_svc = _make_analysis_svc(rating=None)
+    _run_rate(db, provider_svc, analysis_svc)
     out = capsys.readouterr().out
     assert "LLM provider is not configured" in out
     analysis_svc.classify_channel.assert_not_awaited()
+
+
+def test_channel_rate_unknown_model_aborts(capsys):
+    """A mistyped --model must abort loudly, not silently persist a stub verdict."""
+    db = make_cli_db()
+    provider_svc = _make_provider_svc(
+        resolve_error=ValueError("Model/provider 'gpt-nope' is not registered. Available providers: cohere.")
+    )
+    analysis_svc = _make_analysis_svc(rating=None)
+    _run_rate(db, provider_svc, analysis_svc, model="gpt-nope")
+    out = capsys.readouterr().out
+    assert "not registered" in out
+    analysis_svc.classify_channel.assert_not_awaited()
+    analysis_svc.sample_posts.assert_not_awaited()
+
+
+def test_channel_rate_empty_channel_skips(capsys):
+    """A channel with no posts must skip the provider call and the upsert."""
+    db = make_cli_db()
+    provider_svc = _make_provider_svc()
+    analysis_svc = _make_analysis_svc(rating=None, posts=())
+    _run_rate(db, provider_svc, analysis_svc)
+    out = capsys.readouterr().out
+    assert "no text posts to judge" in out
+    analysis_svc.classify_channel.assert_not_awaited()
+
+
+def test_channel_rate_provider_failure_exits_nonzero(capsys):
+    """A provider/network failure surfaces a readable error and exits non-zero."""
+    import pytest
+
+    db = make_cli_db()
+    provider_svc = _make_provider_svc()
+    analysis_svc = _make_analysis_svc(classify_error=RuntimeError("boom: 503 from provider"))
+    with pytest.raises(SystemExit) as excinfo:
+        _run_rate(db, provider_svc, analysis_svc)
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "Judge failed" in out
+    assert "boom: 503" in out
 
 
 def test_channel_rate_runs_judge(capsys):
@@ -422,23 +484,14 @@ def test_channel_rate_runs_judge(capsys):
 
     db = make_cli_db()
     provider_callable = AsyncMock(return_value="{}")
-    provider_svc = MagicMock()
-    provider_svc.load_db_providers = AsyncMock(return_value=1)
-    provider_svc.has_providers = MagicMock(return_value=True)
-    provider_svc.get_provider_callable = MagicMock(return_value=provider_callable)
-
+    provider_svc = _make_provider_svc(resolve=provider_callable)
     rating = ChannelRating(
         channel_id=100, title="JudgedCh", username="judged",
         useful="useless", genre="ad", confidence=0.77,
         reason="реклама без сути", n_total=12,
     )
-    analysis_svc = MagicMock()
-    analysis_svc.classify_channel = AsyncMock(return_value=rating)
-
-    with _init_patches(db)[0], _init_patches(db)[1], \
-         patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
-         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
-        run(_rate_args(model="gpt-4o-mini", sample_size=12))
+    analysis_svc = _make_analysis_svc(rating=rating, posts=("a", "b"))
+    _run_rate(db, provider_svc, analysis_svc, model="gpt-4o-mini", sample_size=12)
 
     out = capsys.readouterr().out
     assert "JudgedCh" in out
@@ -446,29 +499,28 @@ def test_channel_rate_runs_judge(capsys):
     assert "ad" in out
     assert "0.77" in out
     assert "реклама без сути" in out
-    provider_svc.get_provider_callable.assert_called_once_with("gpt-4o-mini")
+    provider_svc.resolve_provider_callable.assert_called_once_with("gpt-4o-mini")
     analysis_svc.classify_channel.assert_awaited_once_with(
         100, provider_callable=provider_callable, sample_size=12
     )
 
 
-def test_channel_rate_sample_size_floor():
-    """A non-positive --sample-size is clamped to at least 1."""
+def test_channel_rate_sample_size_clamped():
+    """--sample-size is clamped to [1, 200]."""
     from src.models import ChannelRating
 
-    db = make_cli_db()
-    provider_svc = MagicMock()
-    provider_svc.load_db_providers = AsyncMock(return_value=1)
-    provider_svc.has_providers = MagicMock(return_value=True)
-    provider_svc.get_provider_callable = MagicMock(return_value=AsyncMock())
     rating = ChannelRating(channel_id=100, useful="useful", genre="original")
-    analysis_svc = MagicMock()
-    analysis_svc.classify_channel = AsyncMock(return_value=rating)
 
-    with _init_patches(db)[0], _init_patches(db)[1], \
-         patch("src.services.provider_service.RuntimeProviderRegistry", return_value=provider_svc), \
-         patch("src.services.channel_analysis_service.ChannelAnalysisService", return_value=analysis_svc):
-        run(_rate_args(sample_size=0))
-
+    # Floor: 0 -> 1
+    db = make_cli_db()
+    analysis_svc = _make_analysis_svc(rating=rating)
+    _run_rate(db, _make_provider_svc(), analysis_svc, sample_size=0)
     _, kwargs = analysis_svc.classify_channel.await_args
     assert kwargs["sample_size"] == 1
+
+    # Ceiling: 10000 -> 200
+    db = make_cli_db()
+    analysis_svc = _make_analysis_svc(rating=rating)
+    _run_rate(db, _make_provider_svc(), analysis_svc, sample_size=10000)
+    _, kwargs = analysis_svc.classify_channel.await_args
+    assert kwargs["sample_size"] == 200

--- a/tests/test_provider_service.py
+++ b/tests/test_provider_service.py
@@ -93,6 +93,47 @@ def test_get_provider_unknown_falls_back_to_default():
     assert "DRAFT" in result
 
 
+def test_resolve_provider_callable_raises_on_unknown_name():
+    """resolve_provider_callable must NOT silently return the stub (#994)."""
+    import pytest
+
+    svc = RuntimeProviderRegistry()
+
+    async def custom_provider(prompt: str = "", **kwargs) -> str:
+        return prompt
+
+    svc.register_provider("cohere", custom_provider)
+
+    with pytest.raises(ValueError) as excinfo:
+        svc.resolve_provider_callable("does-not-exist")
+    # The error must name the registered providers so the operator can recover.
+    assert "cohere" in str(excinfo.value)
+
+
+def test_resolve_provider_callable_returns_registered():
+    """A registered name resolves to the real callable, no error."""
+    svc = RuntimeProviderRegistry()
+
+    async def custom_provider(prompt: str = "", **kwargs) -> str:
+        return f"Custom: {prompt}"
+
+    svc.register_provider("custom", custom_provider)
+    provider = svc.resolve_provider_callable("custom")
+    assert asyncio.run(provider(prompt="x")) == "Custom: x"
+
+
+def test_resolve_provider_callable_no_name_uses_first_real():
+    """With no name, resolve picks the first real provider (no stub error)."""
+    svc = RuntimeProviderRegistry()
+
+    async def custom_provider(prompt: str = "", **kwargs) -> str:
+        return "real"
+
+    svc.register_provider("custom", custom_provider)
+    provider = svc.resolve_provider_callable(None)
+    assert asyncio.run(provider(prompt="x")) == "real"
+
+
 # === OpenAI provider tests ===
 
 


### PR DESCRIPTION
Follow-up из #967 / PR #990. Closes #994.

## Что сделано
Подключён `ChannelAnalysisService.classify_channel` (добавлен в #966, но **нигде не вызывался** — ни в CLI, ни в web, ни в agent) к CLI через новую leaf-команду:

```
analytics channel-rate <channel_id> [--model MODEL] [--sample-size N]
```

Команда:
- получает `provider_callable` через `RuntimeProviderRegistry.get_provider_callable(model)` (прецедент `src/cli/commands/pipeline.py:505`),
- вызывает `classify_channel(channel_id, provider_callable=..., sample_size=...)`,
- печатает вердикт (useful / genre / confidence / reason / posts seen) и апсертит его в `channel_ratings`.

Если провайдер не настроен — судья **не запускается** (нет траты, нет записи).

## Дизайн-решения
- **Отдельная команда, а не `--judge`-флаг.** Запуск судьи — это write (provider-вызов + апсерт в `channel_ratings`). Существующая `analytics channel-rating` остаётся read-only (list). Разделение read/write держит чистым parity и safe_ro real-TG allowlist (read-команда не должна мутировать).
- **CLI-first.** Issue допускает «начать с CLI». Web POST-эндпоинт и agent write-tool — осознанный follow-up, явно задокументирован в `docs/reference/parity.md`. Read-путь (`channel-rating` / `GET …/ratings` / `get_channel_ratings`) уже даёт паритетный просмотр результата во всех трёх интерфейсах.

## Real-TG policy
Команда занесена в `CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS` как excluded (provider spend + DB write, **без живого Telegram**) — по прецеденту `pipeline run`/`generate`. Логика покрыта unit/integration-тестами с fake `provider_callable`.

## Тесты
- 6 новых тестов в `tests/test_cli_analytics_commands.py`: read-ветка `channel-rating` (была без покрытия) + write-ветка `channel-rate` (no-provider guard, успешный запуск судьи, clamp sample-size).
- Parity-инварианты зелёные: `pytest -k "manifest or parity or real_telegram_policy or cli_main"` → **99 passed**.
- `ruff check src tests conftest.py` → clean.

## Заметки про линтеры
В проекте **нет** `[tool.black]`/`ruff format` gate — CI гоняет только `ruff check` (line-length 120). `black .`/`ruff format` с дефолтным 88 переформатировали бы сотни несвязанных строк против конвенции репо, поэтому не применялись. mypy в проекте не настроен и не в CI; новый код повторяет существующий стиль файла (переиспользование `svc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)