### PR TITLE
feat(ai-rating): web POST + agent write-tool to run LLM judge (#999)

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -142,6 +142,7 @@
 | `get_trending_emojis` | READ | Трендовые эмодзи за период |
 | `get_channel_analytics` | READ | Обзорная аналитика одного канала |
 | `get_channel_ratings` | READ | Рейтинг каналов (полезность × жанр) |
+| `rate_channel` | WRITE | Запуск LLM-судьи для канала (provider spend + запись вердикта); требует `confirm=true` |
 
 ## Планировщик
 

--- a/docs/reference/parity.md
+++ b/docs/reference/parity.md
@@ -193,14 +193,15 @@
 | Календарь | `analytics calendar` | `GET /calendar/api/calendar` | `get_calendar` |
 | Аналитика канала | `analytics channel` | `GET /analytics/channels/api/overview` | `get_channel_analytics` |
 | Рейтинг каналов | `analytics channel-rating` | `GET /analytics/channels/api/ratings` | `get_channel_ratings` |
-| Запуск LLM-судьи | `analytics channel-rate <channel_id>` | — (CLI-first, #994) | — (CLI-first, #994) |
+| Запуск LLM-судьи | `analytics channel-rate <channel_id>` | `POST /analytics/channels/rate` | `rate_channel` |
 
-> **CLI-first (#994).** Запуск LLM-судьи (`ChannelAnalysisService.classify_channel`) — write-операция:
-> делает реальный provider-вызов и апсертит вердикт в `channel_ratings`. Подключён сначала к CLI
-> (`analytics channel-rate`). Прочерки в колонках Web/Agent означают **«ещё не реализовано»** (осознанный
-> follow-up), а не «исключено»: Web POST-эндпоинт и agent write-tool для запуска судьи появятся отдельным
-> PR. Read-путь (`channel-rating` / `GET …/ratings` / `get_channel_ratings`) уже даёт паритетный просмотр
-> результата во всех трёх интерфейсах.
+> **LLM-судья — write-операция (#994 CLI, #999 web+agent).** Запуск судьи
+> (`ChannelAnalysisService.classify_channel`) делает реальный provider-вызов и апсертит вердикт в
+> `channel_ratings`. Подключён к CLI (`analytics channel-rate`, #994), web (HTMX POST со swap-фрагментом
+> вердикта) и agent (`rate_channel`, WRITE-категория, гейт `confirm=true`). Все три интерфейса
+> разделяют одни и те же гарды: нет провайдера → отказ без траты; mistyped-модель → ошибка (не молчаливый
+> stub-вердикт); пустой канал → пропуск без provider-вызова. Read-путь (`channel-rating` /
+> `GET …/ratings` / `get_channel_ratings`) даёт паритетный просмотр результата.
 
 ## Dialogs
 

--- a/src/agent/tools/analytics.py
+++ b/src/agent/tools/analytics.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from claude_agent_sdk import tool
 
 from src.agent.tools._categories import ToolCategory, ToolMeta
-from src.agent.tools._registry import _text_response
+from src.agent.tools._registry import _text_response, require_confirmation
 
 _MAX_TREND_DAYS = 365
 _MAX_TREND_LIMIT = 100
@@ -51,10 +51,14 @@ TOOL_GROUPS: list[tuple[str, dict[str, ToolMeta]]] = [
         "get_trending_emojis": ToolMeta(ToolCategory.READ),
         "get_channel_analytics": ToolMeta(ToolCategory.READ),
         "get_channel_ratings": ToolMeta(ToolCategory.READ),
+        # WRITE: runs the LLM judge (provider spend) and upserts into
+        # channel_ratings (#999). Gated by require_confirmation in the handler.
+        "rate_channel": ToolMeta(ToolCategory.WRITE),
     }),
 ]
 
 def register(db, client_pool, embedding_service, **kwargs):
+    config = kwargs.get("config")
     tools = []
 
     @tool("get_analytics_summary", "Get overall content analytics: generations, published, pending, rejected", {})
@@ -480,5 +484,73 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка рейтинга каналов: {e}")
 
     tools.append(get_channel_ratings)
+
+    @tool(
+        "rate_channel",
+        "Run the AI rater (LLM judge) for one channel and store its verdict "
+        "(usefulness × genre). This SPENDS a provider call and WRITES to the DB, "
+        "so it requires confirm=true. channel_id = Telegram numeric ID. "
+        "Optional: model (provider/model name), sample_size (1-200, default 40).",
+        {
+            "channel_id": Annotated[int, "Числовой Telegram ID канала"],
+            "model": Annotated[str, "Провайдер/модель (опционально)"],
+            "sample_size": Annotated[int, "Сколько последних постов оценивать (1-200)"],
+            "confirm": Annotated[bool, "Подтверждение запуска (provider spend + запись в БД)"],
+        },
+    )
+    async def rate_channel(args):
+        channel_id = args.get("channel_id")
+        if not channel_id:
+            return _text_response("Ошибка: channel_id обязателен.")
+        # Provider spend + DB write — gate behind explicit confirmation (#999).
+        gate = require_confirmation(
+            f"запустит LLM-судью для канала {channel_id} (трата провайдера + запись в БД)", args
+        )
+        if gate:
+            return gate
+        try:
+            from src.services.channel_analysis_service import ChannelAnalysisService
+            from src.services.provider_service import build_provider_service
+
+            provider_service = await build_provider_service(db, config)
+            if not provider_service.has_providers():
+                return _text_response(
+                    "LLM-провайдер не настроен. Добавьте его командой `provider add`, "
+                    "на странице /settings или ключом окружения (например OPENAI_API_KEY)."
+                )
+
+            # A mistyped model must NOT silently fall back to the stub provider
+            # and persist a meaningless verdict — fail loudly (mirrors #994).
+            try:
+                provider_callable = provider_service.resolve_provider_callable(args.get("model") or None)
+            except ValueError as exc:
+                return _text_response(str(exc))
+
+            svc = ChannelAnalysisService(db)
+            sample_size = _clamp_positive(int(args.get("sample_size", 40) or 40), 200)
+            # Empty-channel guard: skip the spend; an empty sample would persist a
+            # defaulted "useless/original" verdict (n_total=0) with zero signal.
+            posts = await svc.sample_posts(int(channel_id), sample_size)
+            if not posts:
+                return _text_response(
+                    f"У канала {channel_id} нет текстовых постов для оценки; пропуск."
+                )
+
+            rating = await svc.classify_channel(
+                int(channel_id), provider_callable=provider_callable, sample_size=sample_size
+            )
+            name = rating.title or (f"@{rating.username}" if rating.username else str(rating.channel_id))
+            return _text_response(
+                f"Канал {name} (id={rating.channel_id}) оценён:\n"
+                f"- полезность: {rating.useful}\n"
+                f"- жанр: {rating.genre}\n"
+                f"- уверенность: {rating.confidence:.2f}\n"
+                f"- причина: {rating.reason or '—'}\n"
+                f"- постов оценено: {rating.n_total}"
+            )
+        except Exception as e:
+            return _text_response(f"Ошибка запуска судьи: {e}")
+
+    tools.append(rate_channel)
 
     return tools

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from src.services.channel_analysis_service import ChannelAnalysisService
@@ -16,6 +16,9 @@ router = APIRouter()
 _MAX_TREND_DAYS = 365
 _MAX_TREND_LIMIT = 100
 _MAX_RATING_LIMIT = 1000
+# Mirror the CLI judge bounds (#994): keep the prompt from tripping token limits.
+_MAX_RATING_SAMPLE = 200
+_DEFAULT_RATING_SAMPLE = 40
 
 
 def _clamp_positive(value: int, upper: int) -> int:
@@ -317,6 +320,70 @@ async def channel_ratings_page(
             "limit": limit,
         },
     )
+
+
+def _verdict_fragment(request: Request, *, rating=None, error: str | None = None) -> HTMLResponse:
+    """Render the LLM-judge verdict as an HTMX swap fragment (#999)."""
+    return deps.get_templates(request).TemplateResponse(
+        request,
+        "analytics/_rating_verdict.html",
+        {"rating": rating, "error": error},
+    )
+
+
+@router.post("/channels/rate", response_class=HTMLResponse)
+async def rate_channel(
+    request: Request,
+    channel_id: int = Form(...),
+    model: str = Form(""),
+    sample_size: int = Form(_DEFAULT_RATING_SAMPLE),
+):
+    """Run the LLM judge for one channel and upsert its verdict (#999).
+
+    Web parity for the CLI ``analytics channel-rate`` write path (#994): this is
+    the *only* web entry point that invokes ``classify_channel`` — a provider
+    spend + ``channel_ratings`` write. Returns an HTMX fragment with the fresh
+    verdict (server-driven swap, per the project's HTMX-over-fetch policy);
+    every guard branch renders the same fragment so the UI always swaps.
+    """
+    provider_service = deps.get_llm_provider_service(request)
+    if not provider_service.has_providers():
+        return _verdict_fragment(
+            request,
+            error=(
+                "LLM-провайдер не настроен. Добавьте его на странице /settings "
+                "или задайте ключ (например OPENAI_API_KEY)."
+            ),
+        )
+
+    # A mistyped model must NOT silently fall back to the stub provider and
+    # persist a meaningless verdict — surface the error instead (mirrors the
+    # CLI guard from #994 / cycle-review).
+    try:
+        provider_callable = provider_service.resolve_provider_callable(model or None)
+    except ValueError as exc:
+        return _verdict_fragment(request, error=str(exc))
+
+    svc = _rating_svc(request)
+    sample_size = _clamp_positive(sample_size, _MAX_RATING_SAMPLE)
+    # Guard against an empty channel before spending a provider call: no posts
+    # would otherwise persist a defaulted "useless/original" verdict (n_total=0)
+    # that looks valid but carries zero signal.
+    posts = await svc.sample_posts(channel_id, sample_size)
+    if not posts:
+        return _verdict_fragment(
+            request,
+            error=f"У канала {channel_id} нет текстовых постов для оценки.",
+        )
+
+    try:
+        rating = await svc.classify_channel(
+            channel_id, provider_callable=provider_callable, sample_size=sample_size
+        )
+    except Exception as exc:  # provider/network/parse failure
+        return _verdict_fragment(request, error=f"Судья не отработал: {exc}")
+
+    return _verdict_fragment(request, rating=rating)
 
 
 @router.get("/channels/api/subscribers")

--- a/src/web/templates/analytics/_rating_verdict.html
+++ b/src/web/templates/analytics/_rating_verdict.html
@@ -1,0 +1,25 @@
+{# LLM-judge verdict fragment (#999) — swapped into the DOM after a POST to
+   /analytics/channels/rate. `error` carries a user-facing failure reason;
+   `rating` is the persisted ChannelRating on success. #}
+{% if error %}
+<div class="alert alert-warning mb-0" role="alert">{{ error }}</div>
+{% else %}
+<div class="card mb-0">
+  <div class="card-body">
+    <h2 class="h6 mb-2">
+      {{ rating.title or ('@' ~ rating.username if rating.username else rating.channel_id) }}
+      <span class="text-muted">(id={{ rating.channel_id }})</span>
+    </h2>
+    <p class="mb-1">
+      Полезность:
+      <span class="badge bg-{{ 'success' if rating.useful == 'useful' else 'secondary' }}">{{ rating.useful }}</span>
+      &nbsp; Жанр: <span class="badge bg-info">{{ rating.genre }}</span>
+      &nbsp; Уверенность: <strong>{{ '%.2f'|format(rating.confidence) }}</strong>
+    </p>
+    {% if rating.reason %}
+    <p class="text-muted mb-1" style="font-size:0.9rem">{{ rating.reason }}</p>
+    {% endif %}
+    <p class="text-muted mb-0" style="font-size:0.85rem">Постов оценено: {{ rating.n_total }}</p>
+  </div>
+</div>
+{% endif %}

--- a/src/web/templates/analytics/_rating_verdict.html
+++ b/src/web/templates/analytics/_rating_verdict.html
@@ -19,7 +19,10 @@
     {% if rating.reason %}
     <p class="text-muted mb-1" style="font-size:0.9rem">{{ rating.reason }}</p>
     {% endif %}
-    <p class="text-muted mb-0" style="font-size:0.85rem">Постов оценено: {{ rating.n_total }}</p>
+    <p class="text-muted mb-1" style="font-size:0.85rem">Постов оценено: {{ rating.n_total }}</p>
+    {# The list table below is part of the full page render and is not swapped
+       here; offer a reload so the fresh verdict shows up in it (#999 review). #}
+    <a href="" onclick="location.reload(); return false;" class="small">Обновить список ниже</a>
   </div>
 </div>
 {% endif %}

--- a/src/web/templates/analytics/channel_ratings.html
+++ b/src/web/templates/analytics/channel_ratings.html
@@ -3,6 +3,28 @@
 {% block content %}
 <h1 class="h3 mb-4">Рейтинг каналов</h1>
 
+{# Run the LLM judge for one channel (#999) — server-driven HTMX swap of the
+   verdict fragment into #rate-result. Mirrors CLI `analytics channel-rate`. #}
+<form class="row g-2 align-items-end mb-3"
+      hx-post="/analytics/channels/rate"
+      hx-target="#rate-result"
+      hx-swap="innerHTML"
+      hx-indicator="#rate-spinner">
+    <div class="col-auto">
+        <label class="form-label">Оценить канал (channel_id)</label>
+        <input type="number" name="channel_id" required class="form-control form-control-sm" style="width:12rem">
+    </div>
+    <div class="col-auto">
+        <label class="form-label">Модель (опц.)</label>
+        <input type="text" name="model" placeholder="по умолчанию" class="form-control form-control-sm" style="width:10rem">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-warning btn-sm">Запустить судью</button>
+        <span id="rate-spinner" class="htmx-indicator spinner-border spinner-border-sm ms-2" role="status"></span>
+    </div>
+</form>
+<div id="rate-result" class="mb-3"></div>
+
 <form method="get" class="row g-2 align-items-end mb-3">
     <div class="col-auto">
         <label class="form-label">Полезность</label>

--- a/src/web/templates/analytics/channel_ratings.html
+++ b/src/web/templates/analytics/channel_ratings.html
@@ -19,6 +19,10 @@
         <input type="text" name="model" placeholder="по умолчанию" class="form-control form-control-sm" style="width:10rem">
     </div>
     <div class="col-auto">
+        <label class="form-label">Постов (1-200)</label>
+        <input type="number" name="sample_size" value="40" min="1" max="200" class="form-control form-control-sm" style="width:7rem">
+    </div>
+    <div class="col-auto">
         <button type="submit" class="btn btn-warning btn-sm">Запустить судью</button>
         <span id="rate-spinner" class="htmx-indicator spinner-border spinner-border-sm ms-2" role="status"></span>
     </div>

--- a/tests/data/tool_permissions_snapshot.json
+++ b/tests/data/tool_permissions_snapshot.json
@@ -94,6 +94,7 @@
     "get_trending_emojis": "read",
     "get_channel_analytics": "read",
     "get_channel_ratings": "read",
+    "rate_channel": "write",
     "get_scheduler_status": "read",
     "start_scheduler": "write",
     "stop_scheduler": "write",
@@ -284,7 +285,8 @@
       "get_hourly_activity",
       "get_trending_emojis",
       "get_channel_analytics",
-      "get_channel_ratings"
+      "get_channel_ratings",
+      "rate_channel"
     ],
     "Планировщик": [
       "get_scheduler_status",

--- a/tests/routes/test_analytics_routes_rate.py
+++ b/tests/routes/test_analytics_routes_rate.py
@@ -1,0 +1,112 @@
+"""Web parity for the LLM-judge write path (#999).
+
+POST /analytics/channels/rate runs ``ChannelAnalysisService.classify_channel``
+— a provider spend + ``channel_ratings`` write — and swaps an HTMX fragment
+with the fresh verdict. These tests mirror the CLI guards from #994 with a fake
+provider callable: no live provider calls, no real spend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.provider_service import RuntimeProviderRegistry
+
+
+async def _seed_posts(db, channel_id: int, n: int = 3) -> None:
+    """Insert text messages so the empty-channel guard does not trip."""
+    for i in range(n):
+        await db.execute_write(
+            "INSERT OR IGNORE INTO messages (channel_id, message_id, text, message_kind, date) "
+            "VALUES (?, ?, ?, 'regular', ?)",
+            (channel_id, i + 1, f"post {i}", "2026-01-01T00:00:00"),
+        )
+
+
+def _fake_registry(verdict_json: str = '{"useful": "useless", "genre": "ad", '
+                   '"confidence": 0.9, "reason": "реклама"}') -> RuntimeProviderRegistry:
+    """A registry with one fake provider that returns a canned judge verdict."""
+    svc = RuntimeProviderRegistry()
+
+    async def _fake_provider(prompt: str = "", **kwargs) -> str:
+        return verdict_json
+
+    svc.register_provider("fake", _fake_provider)
+    return svc
+
+
+@pytest.mark.aiosqlite_serial
+async def test_rate_no_provider_returns_fragment(route_client):
+    """Without a configured provider: no spend, no write, warning fragment."""
+    app = route_client._transport_app
+    app.state.llm_provider_service = RuntimeProviderRegistry()  # has_providers() == False
+
+    resp = await route_client.post("/analytics/channels/rate", data={"channel_id": 100})
+    assert resp.status_code == 200
+    assert "LLM-провайдер не настроен" in resp.text
+    # Nothing persisted.
+    rating = await app.state.db.repos.channel_ratings.get(100)
+    assert rating is None
+
+
+@pytest.mark.aiosqlite_serial
+async def test_rate_unknown_model_aborts(route_client):
+    """A mistyped model must surface an error, not persist a stub verdict."""
+    app = route_client._transport_app
+    app.state.llm_provider_service = _fake_registry()
+
+    resp = await route_client.post(
+        "/analytics/channels/rate", data={"channel_id": 100, "model": "gpt-nope"}
+    )
+    assert resp.status_code == 200
+    assert "not registered" in resp.text
+    assert await app.state.db.repos.channel_ratings.get(100) is None
+
+
+@pytest.mark.aiosqlite_serial
+async def test_rate_empty_channel_skips(route_client):
+    """A channel with no text posts skips the provider call and the upsert."""
+    app = route_client._transport_app
+    app.state.llm_provider_service = _fake_registry()
+
+    resp = await route_client.post("/analytics/channels/rate", data={"channel_id": 100})
+    assert resp.status_code == 200
+    assert "нет текстовых постов" in resp.text
+    assert await app.state.db.repos.channel_ratings.get(100) is None
+
+
+@pytest.mark.aiosqlite_serial
+async def test_rate_runs_judge_and_persists(route_client):
+    """Happy path: fake judge verdict is rendered and persisted to channel_ratings."""
+    app = route_client._transport_app
+    db = app.state.db
+    await _seed_posts(db, 100)
+    app.state.llm_provider_service = _fake_registry()
+
+    resp = await route_client.post("/analytics/channels/rate", data={"channel_id": 100})
+    assert resp.status_code == 200
+    # Verdict fragment rendered.
+    assert "useless" in resp.text
+    assert "ad" in resp.text
+    assert "0.90" in resp.text
+    # Persisted.
+    rating = await db.repos.channel_ratings.get(100)
+    assert rating is not None
+    assert rating.useful == "useless"
+    assert rating.genre == "ad"
+
+
+@pytest.mark.aiosqlite_serial
+async def test_rate_sample_size_clamped(route_client):
+    """sample_size is clamped to [1, 200] before reaching the judge."""
+    app = route_client._transport_app
+    db = app.state.db
+    await _seed_posts(db, 100)
+    app.state.llm_provider_service = _fake_registry()
+
+    resp = await route_client.post(
+        "/analytics/channels/rate", data={"channel_id": 100, "sample_size": 99999}
+    )
+    assert resp.status_code == 200
+    # Did not error out; verdict persisted (clamp accepted the huge value).
+    assert await db.repos.channel_ratings.get(100) is not None

--- a/tests/test_agent_tools_analytics.py
+++ b/tests/test_agent_tools_analytics.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -454,3 +454,121 @@ class TestGetChannelAnalyticsTool:
             handlers = _get_tool_handlers(mock_db)
             result = await handlers["get_channel_analytics"]({"channel_id": 100})
         assert "Ошибка" in _text(result)
+
+
+class TestRateChannelTool:
+    """Agent write-tool parity for the LLM judge (#999).
+
+    rate_channel spends a provider call + writes channel_ratings, so it is gated
+    by confirm=true and shares the CLI guards (no provider / mistyped model /
+    empty channel). Tested with a fake provider — no live calls, no real spend.
+    """
+
+    @pytest.mark.anyio
+    async def test_missing_channel_id(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["rate_channel"]({"confirm": True})
+        assert "channel_id обязателен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_requires_confirmation(self, mock_db):
+        """Without confirm=true the judge must NOT run (no spend, no write)."""
+        with patch("src.services.provider_service.build_provider_service") as mock_build:
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["rate_channel"]({"channel_id": 100})
+        assert "Подтвердите" in _text(result)
+        mock_build.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_provider(self, mock_db):
+        provider_svc = MagicMock()
+        provider_svc.has_providers = MagicMock(return_value=False)
+        with patch(
+            "src.services.provider_service.build_provider_service",
+            AsyncMock(return_value=provider_svc),
+        ):
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["rate_channel"]({"channel_id": 100, "confirm": True})
+        assert "не настроен" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_unknown_model_aborts(self, mock_db):
+        """A mistyped model surfaces an error, never a silent stub verdict."""
+        provider_svc = MagicMock()
+        provider_svc.has_providers = MagicMock(return_value=True)
+        provider_svc.resolve_provider_callable = MagicMock(
+            side_effect=ValueError("Model/provider 'gpt-nope' is not registered.")
+        )
+        analysis_svc = MagicMock()
+        analysis_svc.classify_channel = AsyncMock()
+        with patch(
+            "src.services.provider_service.build_provider_service",
+            AsyncMock(return_value=provider_svc),
+        ), patch(
+            "src.services.channel_analysis_service.ChannelAnalysisService",
+            return_value=analysis_svc,
+        ):
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["rate_channel"](
+                {"channel_id": 100, "model": "gpt-nope", "confirm": True}
+            )
+        assert "not registered" in _text(result)
+        analysis_svc.classify_channel.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_empty_channel_skips(self, mock_db):
+        provider_svc = MagicMock()
+        provider_svc.has_providers = MagicMock(return_value=True)
+        provider_svc.resolve_provider_callable = MagicMock(return_value=AsyncMock())
+        analysis_svc = MagicMock()
+        analysis_svc.sample_posts = AsyncMock(return_value=[])
+        analysis_svc.classify_channel = AsyncMock()
+        with patch(
+            "src.services.provider_service.build_provider_service",
+            AsyncMock(return_value=provider_svc),
+        ), patch(
+            "src.services.channel_analysis_service.ChannelAnalysisService",
+            return_value=analysis_svc,
+        ):
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["rate_channel"]({"channel_id": 100, "confirm": True})
+        assert "нет текстовых постов" in _text(result)
+        analysis_svc.classify_channel.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_runs_judge(self, mock_db):
+        from src.models import ChannelRating
+
+        rating = ChannelRating(
+            channel_id=100, title="JudgedCh", username="judged",
+            useful="useless", genre="ad", confidence=0.77,
+            reason="реклама без сути", n_total=8,
+        )
+        provider_callable = AsyncMock(return_value="{}")
+        provider_svc = MagicMock()
+        provider_svc.has_providers = MagicMock(return_value=True)
+        provider_svc.resolve_provider_callable = MagicMock(return_value=provider_callable)
+        analysis_svc = MagicMock()
+        analysis_svc.sample_posts = AsyncMock(return_value=["a", "b"])
+        analysis_svc.classify_channel = AsyncMock(return_value=rating)
+        with patch(
+            "src.services.provider_service.build_provider_service",
+            AsyncMock(return_value=provider_svc),
+        ), patch(
+            "src.services.channel_analysis_service.ChannelAnalysisService",
+            return_value=analysis_svc,
+        ):
+            handlers = _get_tool_handlers(mock_db)
+            result = await handlers["rate_channel"](
+                {"channel_id": 100, "model": "gpt-4o-mini", "sample_size": 8, "confirm": True}
+            )
+        text = _text(result)
+        assert "JudgedCh" in text
+        assert "useless" in text
+        assert "ad" in text
+        assert "0.77" in text
+        assert "реклама без сути" in text
+        provider_svc.resolve_provider_callable.assert_called_once_with("gpt-4o-mini")
+        analysis_svc.classify_channel.assert_awaited_once_with(
+            100, provider_callable=provider_callable, sample_size=8
+        )


### PR DESCRIPTION
## Что и зачем

Parity follow-up к #994. PR по #994 подключил запуск LLM-судьи (`ChannelAnalysisService.classify_channel`) только в CLI (`analytics channel-rate --judge`), чтобы держать тот PR сфокусированным. Этот PR достраивает parity до **web** и **agent** — судья теперь запускается из всех трёх интерфейсов. Запуск судьи = реальный provider-вызов (spend) + запись вердикта в `channel_ratings`.

Closes #999. Часть эпика #781.

## Изменения

**1. Web — `POST /analytics/channels/rate`** (`src/web/routes/analytics.py`)
- Запускает судью для одного канала и апсертит вердикт.
- Возвращает **HTMX-фрагмент** с обновлённым вердиктом (server-driven swap — по политике проекта HTMX, а не JSON/fetch, т.к. результат — чистый DOM-swap).
- Кнопка «Запустить судью» на странице `/analytics/channels/ratings` (`channel_ratings.html`), фрагмент `_rating_verdict.html`.

**2. Agent — write-tool `rate_channel`** (`src/agent/tools/analytics.py`)
- Категория **WRITE** (spend + DB-write) → авто-выводится в `TOOL_CATEGORIES` через `TOOL_GROUPS`; MCP allow-list / permission-snapshot регенерированы.
- Гейт `require_confirmation()` — требует `confirm=true`.

**3. Parity** (`docs/reference/parity.md`)
- Заполнены колонки Web (`POST /analytics/channels/rate`) и Agent (`rate_channel`), снята CLI-first пометка #994.

## Общие гарды (все три интерфейса, из #994)
- Нет провайдера → отказ без траты.
- Mistyped-модель → ошибка (не молчаливый stub-вердикт).
- Пустой канал → пропуск до provider-вызова.

## Тесты
- `tests/routes/test_analytics_routes_rate.py` (5) — web POST с fake-провайдером.
- `tests/test_agent_tools_analytics.py::TestRateChannelTool` (6) — agent-tool, включая confirm-гейт.
- Регенерирован `tests/data/tool_permissions_snapshot.json` (только `rate_channel: write`).
- Тестируется с fake `provider_callable` — **никаких живых вызовов / трат**. Telegram-вызовов нет → real-tg coverage не нужен (unit/integration).
- Прогон гейтов `pytest -k "manifest or parity or real_telegram_policy or cli_main"`: **99 passed**. Затронутые подсистемы: **1132 passed** (parallel) + **5** (serial). Ruff lint + import-linter чистые.

🤖 Generated with [Claude Code](https://claude.com/claude-code)