### PR TITLE
fix(agent): hide dead Claude model picker for codex/adk backends (#1002)

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -36,10 +36,8 @@ from claude_agent_sdk import (
 from src.agent.adk_backend import AdkSdkBackend
 from src.agent.codex_backend import CodexSdkBackend
 from src.agent.models import (
-    ADK_MODEL_IDS,
-    CLAUDE_MODEL_IDS,
-    CODEX_MODEL_IDS,
     VALID_AGENT_BACKENDS,
+    model_for_backend,
 )
 from src.agent.prompt_template import (
     AGENT_PROMPT_TEMPLATE_SETTING,
@@ -2211,22 +2209,19 @@ class AgentManager:
             return
         if backend_name == "claude":
             backend = self._claude_backend
-            if model not in CLAUDE_MODEL_IDS:
-                model = None
         elif backend_name == "deepagents":
             backend = self._deepagents_backend
-            model = None
         elif backend_name == "codex":
             backend = self._codex_backend
-            if model not in CODEX_MODEL_IDS:
-                model = None
         elif backend_name == "adk":
             backend = self._adk_backend
-            if model not in ADK_MODEL_IDS:
-                model = None
         else:
             yield _sse({"error": "Ошибка агента: не удалось выбрать backend."})
             return
+        # Drop a model ID that doesn't belong to the selected backend (e.g. a
+        # Claude ID still in the request while codex/adk is active) → backend
+        # default. deepagents always resolves to None (its model is settings-led).
+        model = model_for_backend(backend_name, model)
 
         queue: asyncio.Queue[str | None] = asyncio.Queue()
 

--- a/src/agent/models.py
+++ b/src/agent/models.py
@@ -20,3 +20,24 @@ ADK_MODEL_IDS: frozenset[str] = frozenset({"gemini-2.5-flash", "gemini-2.5-pro"}
 # Valid values for the ``agent_backend_override`` setting. "auto" lets
 # get_runtime_status pick; the rest force a specific backend (dev-mode only).
 VALID_AGENT_BACKENDS: frozenset[str] = frozenset({"auto", "claude", "deepagents", "codex", "adk"})
+
+# Per-backend allow-lists of model IDs accepted from the UI / API. deepagents is
+# absent on purpose: its model comes from saved provider settings, never from the
+# request, so it always resolves to None below.
+_BACKEND_MODEL_IDS: dict[str, frozenset[str]] = {
+    "claude": CLAUDE_MODEL_IDS,
+    "codex": CODEX_MODEL_IDS,
+    "adk": ADK_MODEL_IDS,
+}
+
+
+def model_for_backend(backend_name: str | None, model: str | None) -> str | None:
+    """Return ``model`` only if it is valid for ``backend_name``, else ``None``.
+
+    A model ID submitted for the wrong backend (e.g. a Claude ID left over in the
+    browser while codex/adk is selected) is silently dropped to ``None`` (= auto)
+    so the backend picks its own default. deepagents and unknown backends never
+    accept a request-supplied model and always resolve to ``None`` (#1002).
+    """
+    allowed = _BACKEND_MODEL_IDS.get(backend_name or "")
+    return model if allowed is not None and model in allowed else None

--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -154,9 +154,11 @@ async def agent_threads_fragment(request: Request, thread_id: int | None = None)
     """Lazy fragment: thread list + runtime status panel + composer footer (#949).
 
     Carries `active_thread` so the thread list can mark the open thread and the
-    composer footer (model select vs deepagents hint) renders for the right
-    backend. The skeleton already resolved the active thread via redirect, so the
-    fragment trusts the `thread_id` query param instead of re-running that logic.
+    composer footer (Claude model select vs per-backend hint) renders for the
+    right backend — the picker is Claude-only; codex/adk/deepagents get a hint
+    instead of a dead Claude dropdown (#1002). The skeleton already resolved the
+    active thread via redirect, so the fragment trusts the `thread_id` query
+    param instead of re-running that logic.
     """
     db = deps.get_db(request)
     agent_manager = deps.get_agent_manager(request)

--- a/src/web/templates/agent/_threads.html
+++ b/src/web/templates/agent/_threads.html
@@ -80,17 +80,25 @@
     {% endif %}
 </div>
 
-{# ── OOB: composer footer (subtle hint + model select / deepagents hint) ── #}
+{# ── OOB: composer footer (subtle hint + model select / backend hint) ──
+   The Claude model <select> is the only real UI model picker. Other backends
+   pick their model elsewhere (deepagents from saved settings; codex/adk have a
+   fixed/managed model with no display-name table — see src/agent/models.py), so
+   showing a Claude-labelled dropdown there is a dead control: select_model()
+   only validates Claude IDs and chat_stream drops foreign IDs for those
+   backends. Render the picker for claude only; everyone else gets a hint (#1002). #}
 <span id="composer-subtle-slot" hx-swap-oob="true">
-    {% if agent_status and agent_status.selected_backend == "deepagents" %}
+    {% if agent_status and agent_status.selected_backend == "claude" %}
+    <span class="composer-subtle">Модель Claude можно переключить прямо здесь.</span>
+    {% elif agent_status and agent_status.selected_backend == "deepagents" %}
     <span class="composer-subtle">Runtime управляется настройками deepagents.</span>
     {% else %}
-    <span class="composer-subtle">Модель Claude можно переключить прямо здесь.</span>
+    <span class="composer-subtle">Модель задаётся backend'ом и показана в статусе выше.</span>
     {% endif %}
 </span>
 
 <span id="composer-actions-slot" hx-swap-oob="true">
-    {% if not agent_status or agent_status.selected_backend != "deepagents" %}
+    {% if agent_status and agent_status.selected_backend == "claude" %}
     <div class="composer-caption">Модель Claude</div>
     <select id="model-select" class="form-select model-select">
         <option value="">Авто</option>
@@ -98,10 +106,15 @@
         <option value="{{ value }}">{{ label }}</option>
         {% endfor %}
     </select>
-    {% else %}
+    {% elif agent_status and agent_status.selected_backend == "deepagents" %}
     <div class="composer-hint">
         <strong>Deepagents runtime</strong>
         Модель и provider берутся из сохраненных настроек и показываются в статусе выше.
+    </div>
+    {% elif agent_status and agent_status.selected_backend %}
+    <div class="composer-hint">
+        <strong>{{ agent_status.selected_backend }} runtime</strong>
+        Модель управляется backend'ом — выбор в UI недоступен.
     </div>
     {% endif %}
 </span>

--- a/tests/routes/test_agent_lazyload.py
+++ b/tests/routes/test_agent_lazyload.py
@@ -169,7 +169,7 @@ async def test_fragment_deepagents_hides_model_select(client, db, agent_manager_
 
 @pytest.mark.anyio
 async def test_fragment_claude_shows_model_select(client, db, agent_manager_mock):
-    """For a non-deepagents backend the composer shows the Claude model select."""
+    """The Claude backend is the only one that renders the model select."""
     thread_id = await db.create_agent_thread("Claude")
     runtime = agent_manager_mock.get_runtime_status.return_value
     runtime.selected_backend = "claude"
@@ -178,3 +178,27 @@ async def test_fragment_claude_shows_model_select(client, db, agent_manager_mock
 
     assert resp.status_code == 200
     assert 'id="model-select"' in resp.text
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("backend", ["codex", "adk"])
+async def test_fragment_codex_adk_hide_dead_model_select(client, db, agent_manager_mock, backend):
+    """codex/adk must NOT render the Claude-labelled model select (#1002).
+
+    These backends validate the submitted model against their own ID sets
+    (CODEX_MODEL_IDS / ADK_MODEL_IDS); a Claude-model dropdown there is a dead
+    control whose value is always discarded server-side. The fragment shows a
+    backend hint instead of the picker.
+    """
+    thread_id = await db.create_agent_thread(backend)
+    runtime = agent_manager_mock.get_runtime_status.return_value
+    runtime.selected_backend = backend
+
+    resp = await client.get(f"/agent/fragments/threads?thread_id={thread_id}")
+
+    assert resp.status_code == 200
+    # No dead Claude dropdown and no "Модель Claude" caption for these backends.
+    assert 'id="model-select"' not in resp.text
+    assert "Модель Claude" not in resp.text
+    # A backend-named hint replaces the picker so the slot is not empty.
+    assert f"{backend} runtime" in resp.text

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -419,9 +419,10 @@ async def test_chat_codex_adk_model_survives_validation(client, db, backend):
 
     These backends have no UI model picker; the page no longer renders a Claude
     dropdown for them, but a stale localStorage value could still POST a model.
-    The web handler must accept the request (200) and hand it to chat_stream,
-    which is where the per-backend model allow-list is enforced. We assert via a
-    stream that captures the model kwarg so the request demonstrably reaches it.
+    The web handler must accept the request (200) and forward the model to
+    chat_stream, which is where the per-backend allow-list (model_for_backend)
+    drops a cross-backend ID. We capture the model kwarg and assert the exact
+    value forwarded so a wrong value can't slip past a mere membership check.
     """
     thread_id = await db.create_agent_thread("Chat")
 
@@ -431,7 +432,8 @@ async def test_chat_codex_adk_model_survives_validation(client, db, backend):
     runtime.error = None
     client._transport_app.state.agent_manager.get_runtime_status = AsyncMock(return_value=runtime)
 
-    captured = {}
+    sentinel = object()
+    captured = {"model": sentinel}
 
     async def fake_stream(*args, **kwargs):
         captured["model"] = kwargs.get("model")
@@ -440,6 +442,8 @@ async def test_chat_codex_adk_model_survives_validation(client, db, backend):
     client._transport_app.state.agent_manager.chat_stream = fake_stream
 
     # A stale Claude model id from localStorage must not 500 the codex/adk chat.
+    # select_model() accepts it (a real Claude ID), so the handler forwards it
+    # verbatim; chat_stream is where model_for_backend would then drop it.
     resp = await client.post(
         f"/agent/threads/{thread_id}/chat",
         content=json.dumps({"message": "hi", "model": "claude-sonnet-4-6"}),
@@ -447,7 +451,19 @@ async def test_chat_codex_adk_model_survives_validation(client, db, backend):
     )
 
     assert resp.status_code == 200
-    assert "model" in captured  # reached chat_stream, never crashed mid-validation
+    assert captured["model"] == "claude-sonnet-4-6"  # reached chat_stream, exact value
+
+    # An unknown/garbage model id is coerced to None by the handler's select_model
+    # before chat_stream ever sees it — never a 500.
+    captured["model"] = sentinel
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hi again", "model": "not-a-real-model"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200
+    assert captured["model"] is None
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_agent_routes_threads.py
+++ b/tests/routes/test_agent_routes_threads.py
@@ -413,6 +413,44 @@ async def test_chat_with_model_parameter(client, db):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("backend", ["codex", "adk"])
+async def test_chat_codex_adk_model_survives_validation(client, db, backend):
+    """A submitted model ID must not crash chat for codex/adk backends (#1002).
+
+    These backends have no UI model picker; the page no longer renders a Claude
+    dropdown for them, but a stale localStorage value could still POST a model.
+    The web handler must accept the request (200) and hand it to chat_stream,
+    which is where the per-backend model allow-list is enforced. We assert via a
+    stream that captures the model kwarg so the request demonstrably reaches it.
+    """
+    thread_id = await db.create_agent_thread("Chat")
+
+    runtime = MagicMock()
+    runtime.selected_backend = backend
+    runtime.using_override = False
+    runtime.error = None
+    client._transport_app.state.agent_manager.get_runtime_status = AsyncMock(return_value=runtime)
+
+    captured = {}
+
+    async def fake_stream(*args, **kwargs):
+        captured["model"] = kwargs.get("model")
+        yield 'data: {"done": true, "full_text": "ok"}\n\n'
+
+    client._transport_app.state.agent_manager.chat_stream = fake_stream
+
+    # A stale Claude model id from localStorage must not 500 the codex/adk chat.
+    resp = await client.post(
+        f"/agent/threads/{thread_id}/chat",
+        content=json.dumps({"message": "hi", "model": "claude-sonnet-4-6"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200
+    assert "model" in captured  # reached chat_stream, never crashed mid-validation
+
+
+@pytest.mark.anyio
 async def test_chat_enables_interactive_permissions(client, db):
     """Web chat requests opt into request-scoped PermissionGate prompts."""
     thread_id = await db.create_agent_thread("Chat")

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -1,0 +1,64 @@
+"""Unit tests for per-backend model validation (src/agent/models.py, #1002)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agent.models import (
+    ADK_MODEL_IDS,
+    CLAUDE_MODEL_IDS,
+    CODEX_MODEL_IDS,
+    model_for_backend,
+)
+
+
+@pytest.mark.parametrize(
+    "backend, ids",
+    [
+        ("claude", CLAUDE_MODEL_IDS),
+        ("codex", CODEX_MODEL_IDS),
+        ("adk", ADK_MODEL_IDS),
+    ],
+)
+def test_model_for_backend_accepts_own_ids(backend, ids):
+    """Each backend keeps a model ID drawn from its own allow-list."""
+    for model_id in ids:
+        assert model_for_backend(backend, model_id) == model_id
+
+
+def test_model_for_backend_drops_claude_id_for_codex():
+    """A stale Claude ID submitted while codex is active is coerced to None (#1002)."""
+    claude_id = next(iter(CLAUDE_MODEL_IDS))
+    assert claude_id not in CODEX_MODEL_IDS
+    assert model_for_backend("codex", claude_id) is None
+
+
+def test_model_for_backend_drops_claude_id_for_adk():
+    """A stale Claude ID submitted while adk is active is coerced to None (#1002)."""
+    claude_id = next(iter(CLAUDE_MODEL_IDS))
+    assert claude_id not in ADK_MODEL_IDS
+    assert model_for_backend("adk", claude_id) is None
+
+
+def test_model_for_backend_deepagents_always_none():
+    """deepagents never honours a request model — its model is settings-led."""
+    assert model_for_backend("deepagents", next(iter(CLAUDE_MODEL_IDS))) is None
+    assert model_for_backend("deepagents", None) is None
+
+
+@pytest.mark.parametrize("backend", [None, "", "unknown", "auto"])
+def test_model_for_backend_unknown_backend_none(backend):
+    """An unknown/None backend cannot pin a model — always None."""
+    assert model_for_backend(backend, next(iter(CLAUDE_MODEL_IDS))) is None
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex", "adk", "deepagents", None])
+def test_model_for_backend_none_model_stays_none(backend):
+    """A None model (Авто) is preserved for every backend."""
+    assert model_for_backend(backend, None) is None
+
+
+def test_model_for_backend_unknown_model_dropped():
+    """A model ID in no allow-list is dropped even for a valid backend."""
+    assert model_for_backend("claude", "not-a-real-model") is None
+    assert model_for_backend("codex", "gpt-9.9-imaginary") is None


### PR DESCRIPTION
## Проблема

На странице Agent для `selected_backend` ∈ {`codex`, `adk`} рендерился Claude-селектор `#model-select` с подписью «Модель Claude» и Claude-моделями. Это мёртвый контрол: `select_model()` валидирует только Claude-ID, а `chat_stream()` отбрасывает чужие ID для этих backend — любой выбор пользователя no-op. `src/agent/models.py` уже документирует, что у codex/adk нет UI-picker'а по дизайну.

Найдено при cycle-review PR #998 (предсуществующее поведение, не регрессия).

## Решение — Вариант B (минимальный фикс)

Claude `<select>` — единственный реальный UI-picker модели. Рендерим его **только для backend `claude`**. codex/adk теперь получают per-backend hint (тот же паттерн, что уже используется для deepagents) вместо вводящего в заблуждение dropdown. Никакого нового per-backend хранения выбора — оно для этих backend не востребовано.

## Что изменено

- **`templates/agent/_threads.html`** — селектор только для `claude`; codex/adk/deepagents показывают hint. `agent_status is None` остаётся пустым (graceful, как было).
- **`agent/models.py`** — извлечена `model_for_backend(backend_name, model)`: централизует знание «какие model ID валидны для какого backend», делает это unit-тестируемым. Поведение runtime не меняется.
- **`agent/manager.py`** — `chat_stream` использует `model_for_backend()` вместо четырёх inline-веток валидации.

## Тесты

- Route: codex/adk скрывают Claude-dropdown и показывают backend-hint; stale Claude-model ID, отправленный для codex/adk, переживает серверную валидацию (200, не 500).
- Unit (`tests/test_agent_models.py`): `model_for_backend` для каждого backend — принимает свои ID, отбрасывает чужие, deepagents/unknown → всегда None.

Полный прогон: 8398 параллельных + 893 serial passed, 0 failed. ruff clean.

Связано с per-backend требованием из #949.

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)