### PR TITLE
refactor(web): dedup lazyload spinner + search error-wrapping (#1009)

### DIFF
--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -167,7 +167,7 @@ async def _safe_search(
     coro: Awaitable[SearchResult],
     *,
     log_msg: str,
-    log_args: tuple = (),
+    log_args: tuple[object, ...] = (),
     error_text: str,
     error_query: str,
 ) -> SearchResult:

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Awaitable
 from dataclasses import dataclass, field
 
 from fastapi import Request
@@ -160,6 +161,30 @@ async def _telegram_search_via_worker(
             "Задача могла ещё выполняться в Telegram-worker; проверьте логи."
         ),
     )
+
+
+async def _safe_search(
+    coro: Awaitable[SearchResult],
+    *,
+    log_msg: str,
+    log_args: tuple = (),
+    error_text: str,
+    error_query: str,
+) -> SearchResult:
+    """Await a search coroutine, converting any failure into an error
+    ``SearchResult`` so the fragment renders a message instead of a 500.
+
+    Centralises the ``try/except logger.exception → fallback SearchResult``
+    boilerplate that the three search branches in :func:`render_search_results`
+    each repeated verbatim (#1009). ``error_text`` is formatted with the caught
+    exception (it must contain a single ``{exc}`` placeholder); ``log_msg`` and
+    ``log_args`` are passed straight to ``logger.exception``.
+    """
+    try:
+        return await coro
+    except Exception as exc:
+        logger.exception(log_msg, *log_args)
+        return SearchResult(messages=[], total=0, query=error_query, error=error_text.format(exc=exc))
 
 
 async def root_page(request: Request) -> SearchRedirect:
@@ -328,8 +353,8 @@ async def render_search_results(
 
     # Browse mode: channel_id without query shows latest messages from that channel
     if not q and channel_id_int and mode in _DB_SEARCH_MODES:
-        try:
-            result = await service.search(
+        result = await _safe_search(
+            service.search(
                 mode="local",
                 query="",
                 limit=limit,
@@ -339,31 +364,29 @@ async def render_search_results(
                 offset=offset,
                 is_fts=False,
                 include_filtered=include_filtered,
-            )
-        except Exception as exc:
-            logger.exception("Browse mode failed: channel_id=%s", channel_id_int)
-            result = SearchResult(
-                messages=[], total=0, query="", error=f"Ошибка загрузки сообщений: {exc}"
-            )
+            ),
+            log_msg="Browse mode failed: channel_id=%s",
+            log_args=(channel_id_int,),
+            error_text="Ошибка загрузки сообщений: {exc}",
+            error_query="",
+        )
     elif q:
         if ctx.channel_id_error and mode in _DB_SEARCH_MODES | {"channel"}:
             result = SearchResult(messages=[], total=0, query=q, error=ctx.channel_id_error)
         elif mode in _TELEGRAM_SEARCH_MODES and ctx.runtime_mode == "web":
             # Web container has no live ClientPool — run it on the worker (#643).
-            try:
-                result = await _telegram_search_via_worker(
+            result = await _safe_search(
+                _telegram_search_via_worker(
                     request, mode=mode, query=ctx.fts_query, limit=limit, channel_id=channel_id_int
-                )
-            except Exception as exc:
-                logger.exception(
-                    "Worker search proxy failed: mode=%s query_hash=%s",
-                    mode,
-                    query_log_fields(q)["query_hash"],
-                )
-                result = SearchResult(messages=[], total=0, query=q, error=f"Ошибка поиска: {exc}")
+                ),
+                log_msg="Worker search proxy failed: mode=%s query_hash=%s",
+                log_args=(mode, query_log_fields(q)["query_hash"]),
+                error_text="Ошибка поиска: {exc}",
+                error_query=q,
+            )
         else:
-            try:
-                result = await service.search(
+            result = await _safe_search(
+                service.search(
                     mode=mode,
                     query=ctx.fts_query,
                     limit=limit,
@@ -375,14 +398,12 @@ async def render_search_results(
                     min_length=ctx.min_length,
                     max_length=ctx.max_length,
                     include_filtered=include_filtered,
-                )
-            except Exception as exc:
-                logger.exception(
-                    "Search request failed: mode=%s query_hash=%s",
-                    mode,
-                    query_log_fields(q)["query_hash"],
-                )
-                result = SearchResult(messages=[], total=0, query=q, error=f"Ошибка поиска: {exc}")
+                ),
+                log_msg="Search request failed: mode=%s query_hash=%s",
+                log_args=(mode, query_log_fields(q)["query_hash"]),
+                error_text="Ошибка поиска: {exc}",
+                error_query=q,
+            )
 
     # Page-based navigation without an exact total (#766): «Далее» is shown when
     # the LIMIT N+1 probe saw another page. Semantic/hybrid/telegram modes still

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -8,6 +8,6 @@
      hx-get="/channels/filter/manage/fragments/table?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    {{ loading('Загрузка отфильтрованных каналов…') }}
+    {{ loading('Загрузка отфильтрованных каналов…', class="my-4") }}
 </div>
 {% endblock %}

--- a/src/web/templates/filter_manage.html
+++ b/src/web/templates/filter_manage.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Очистка — TG Agent{% endblock %}
 {% block content %}
 {# Lazyload (#952): the filtered-channels table (get_channels_with_counts) loads
@@ -7,9 +8,6 @@
      hx-get="/channels/filter/manage/fragments/table?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    <div class="text-center text-muted py-5">
-        <span class="spinner-border" role="status"></span>
-        <div class="mt-2">Загрузка отфильтрованных каналов…</div>
-    </div>
+    {{ loading('Загрузка отфильтрованных каналов…') }}
 </div>
 {% endblock %}

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -10,6 +10,6 @@
      hx-get="/moderation/fragments/table?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    {{ loading('Загрузка очереди модерации…') }}
+    {{ loading('Загрузка очереди модерации…', class="my-4") }}
 </div>
 {% endblock %}

--- a/src/web/templates/moderation.html
+++ b/src/web/templates/moderation.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 
 {% block title %}Очередь модерации{% endblock %}
 
@@ -9,9 +10,6 @@
      hx-get="/moderation/fragments/table?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    <div class="text-center text-muted py-5">
-        <span class="spinner-border" role="status"></span>
-        <div class="mt-2">Загрузка очереди модерации…</div>
-    </div>
+    {{ loading('Загрузка очереди модерации…') }}
 </div>
 {% endblock %}

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Photo Loader — TG Agent{% endblock %}
 {% block content %}
 {# Lazyload (#950): the dialog list (1000+ chats from the Telegram cache) loads
@@ -7,9 +8,6 @@
      hx-get="/dialogs/photos/fragments/dialogs?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    <div class="text-center text-muted py-5">
-        <span class="spinner-border" role="status"></span>
-        <div class="mt-2">Загрузка диалогов…</div>
-    </div>
+    {{ loading('Загрузка диалогов…') }}
 </div>
 {% endblock %}

--- a/src/web/templates/photo_loader.html
+++ b/src/web/templates/photo_loader.html
@@ -8,6 +8,6 @@
      hx-get="/dialogs/photos/fragments/dialogs?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    {{ loading('Загрузка диалогов…') }}
+    {{ loading('Загрузка диалогов…', class="my-4") }}
 </div>
 {% endblock %}

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -8,6 +8,6 @@
      hx-get="/pipelines/fragments/list?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    {{ loading('Загрузка пайплайнов…') }}
+    {{ loading('Загрузка пайплайнов…', class="my-4") }}
 </div>
 {% endblock %}

--- a/src/web/templates/pipelines.html
+++ b/src/web/templates/pipelines.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros_ui.html" import loading %}
 {% block title %}Пайплайны — TG Agent{% endblock %}
 {% block content %}
 {# Lazyload (#947): the page shell renders instantly; the pipeline list and its
@@ -7,9 +8,6 @@
      hx-get="/pipelines/fragments/list?{{ request.url.query }}"
      hx-trigger="load"
      hx-swap="innerHTML">
-    <div class="text-center text-muted py-5">
-        <span class="spinner-border" role="status"></span>
-        <div class="mt-2">Загрузка пайплайнов…</div>
-    </div>
+    {{ loading('Загрузка пайплайнов…') }}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Что

Реализованы обе находки read-only аудита техдолга дельты сессии из #1009 (PR #990–#1004 и окружение). Чистый рефакторинг **без смены поведения** — существующие тесты остаются зелёными.

### Находка #1 — несогласованность lazyload-обёртки (S, low)
`photo_loader.html`, `filter_manage.html`, `moderation.html`, `pipelines.html` дублировали ручной spinner-блок `<div class="text-center py-5"><span class="spinner-border">…`, тогда как остальная часть приложения (`jobs.html`, `agent.html` + 7 шаблонов) уже использует общий макрос `loading(text)` из `_macros_ui.html`. Эти 4 страницы просто не были переведены — заменено на `{{ loading('…') }}`. Тексты плейсхолдеров сохранены.

### Находка #2 — повтор error-wrapping ×3 (S, med)
`render_search_results` повторял `try: await … except Exception: log + fallback SearchResult` в трёх ветках (browse / telegram-via-worker / generic), что давало функции цикломатику **D(23)**. Вынесен хелпер:

```python
async def _safe_search(coro, *, log_msg, log_args, error_text, error_query) -> SearchResult
```

Три блока схлопнуты в три вызова. Цикломатика **D(23)→C(20)** (подтверждено radon). Log-сообщения, тексты ошибок и значения `query` в fallback сохранены дословно — отрендеренный вывод идентичен.

### Находка #3 (опциональная) — пропущена
Дедуп инициализации OpenAI/Together image-адаптеров — пропущена согласно собственной пометке аудита о низком ROI.

## Проверка
- `ruff check src tests conftest.py` — чисто (CI-линтер)
- `pytest tests/routes/test_search_routes.py tests/test_web.py` — 233 passed
- route-тесты 4 lazyload-страниц (pipelines/moderation/dialogs/photo/filter) — 278 passed
- `pytest -m smoke` — 11 passed
- error-ветки поиска покрыты существующими `test_search_error_rendered` / browse-error тестами (упражняют `_safe_search` except-путь)
- `lint-imports` — контракты целы

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)