### PR TITLE
ci: e2e job — реально запускает console-smoke на каждом PR (#1012)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
   # "Assert the smoke test really ran" step.
   e2e:
     runs-on: ubuntu-latest
+    # Bound the whole job so a hung browser/server can't burn the 6h default.
+    # Each playwright-cli call also has its own 120s timeout (console_smoke._run_cli).
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
@@ -197,6 +200,9 @@ jobs:
           RUN_E2E_CONSOLE_SMOKE: "1"
           E2E_BASE_URL: http://localhost:8080
           WEB_PASS: ci-secret
+          # Wait briefly after each page load so console errors fired async
+          # shortly after load are still captured before the one-shot read.
+          E2E_SETTLE: "0.5"
         run: pytest tests/e2e/test_console_smoke.py -m e2e -rs --junitxml=e2e-results.xml
 
       # Guard against the "silent zero": prove the smoke actually executed as

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,113 @@ jobs:
       - name: Pytest (aiosqlite serial)
         if: ${{ !cancelled() }}
         run: pytest tests -q -m aiosqlite_serial
+
+  # Browser console-smoke (issue #1012, part of #1011). Its own job so it never
+  # slows or flaps the main `lint-and-test` run. It REALLY drives the panel:
+  # installs the `playwright-cli` binary + a Chromium build, boots the web server
+  # in the background, waits for /health, then runs `tests/e2e -m e2e`.
+  #
+  # No secrets needed — console_smoke only walks the web UI, and `--no-worker`
+  # means no Telegram/LLM connections are opened (the only required setting is
+  # the panel password, supplied via --web-pass; confirmed safe in #1011).
+  #
+  # The "silent zero" trap: if `playwright-cli` is missing the pytest wrapper
+  # `skip`s and the job would go green having checked nothing
+  # (tests/e2e/test_console_smoke.py:62). So we (a) install the binary + browser
+  # so the skip branch can't fire, and (b) emit a JUnit report and assert the
+  # smoke test actually ran as `passed` (zero skipped/errors) — see the final
+  # "Assert the smoke test really ran" step.
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      # `console_smoke` shells out to the `playwright-cli` binary from the
+      # `@playwright/cli` npm package — it is NOT `pytest-playwright` (migrating
+      # to that is the separate, larger P1b task; this keeps the already-tested
+      # redaction/auth logic). Pin the version (supply-chain hygiene, mirroring
+      # the pinned `jscpd` above) so CI never runs an unvetted future release.
+      - name: Install playwright-cli
+        run: npm install -g @playwright/cli@0.1.11
+
+      # Install the Chromium build for the EXACT playwright-core that ships
+      # inside @playwright/cli (it pins its own alpha build), so the browser
+      # version always matches the binary that drives it. `--with-deps` pulls in
+      # the OS libraries Chromium needs on the runner.
+      - name: Install Chromium for playwright-cli
+        run: node "$(npm root -g)/@playwright/cli/node_modules/playwright-core/cli.js" install --with-deps chromium
+
+      # Boot the panel in the background. `--no-worker` keeps it web-only (no
+      # Telegram connections). Logs go to a file so a failed boot is debuggable
+      # in the "show server log" step below.
+      - name: Start web server (background)
+        run: |
+          WEB_PASS=ci-secret python -m src.main serve --web-pass ci-secret --no-worker > server.log 2>&1 &
+
+      # Wait for readiness via /health (retry ~30s). Fail loudly if it never
+      # comes up rather than letting pytest hit a dead server.
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null; then
+              echo "server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::web server did not become healthy within 30s"
+          exit 1
+
+      # Run ONLY the console smoke (not test_collection_flow.py — that ASGI e2e
+      # already runs in the main job). `-rs` reports skip reasons; the JUnit XML
+      # is the machine-checkable proof for the guard step.
+      - name: Run console smoke
+        env:
+          RUN_E2E_CONSOLE_SMOKE: "1"
+          E2E_BASE_URL: http://localhost:8080
+          WEB_PASS: ci-secret
+        run: pytest tests/e2e/test_console_smoke.py -m e2e -rs --junitxml=e2e-results.xml
+
+      # Guard against the "silent zero": prove the smoke actually executed as
+      # `passed`. A skipped/errored/empty report fails the job even if pytest
+      # itself exited 0 (an all-skipped run does). This is what makes the job
+      # meaningful — green here means the browser really walked the panel.
+      - name: Assert the smoke test really ran
+        if: ${{ !cancelled() }}
+        run: |
+          python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          tree = ET.parse("e2e-results.xml")
+          cases = tree.getroot().iter("testcase")
+          target = "test_no_console_errors_on_any_page"
+          matches = [c for c in cases if c.get("name") == target]
+          if not matches:
+              sys.exit(f"FAIL: {target!r} not found in JUnit report — did collection break?")
+          for case in matches:
+              status = "passed"
+              for child in case:
+                  if child.tag in ("skipped", "failure", "error"):
+                      status = child.tag
+                      break
+              if status != "passed":
+                  sys.exit(f"FAIL: {target!r} was {status}, not passed — the smoke did not really run")
+          print(f"OK: {target!r} ran and passed ({len(matches)} case(s))")
+          PY
+
+      - name: Show server log on failure
+        if: ${{ failure() }}
+        run: cat server.log || true


### PR DESCRIPTION
## Что и зачем

Часть #1011 · **P1a — корень**. Closes #1012.

До этого PR browser-smoke (`tests/e2e/console_smoke.py`) **не запускался ни в одном workflow** — `e2e` был лишь маркером в `pyproject.toml`. Любая регрессия в UI/консоли не ловилась CI автоматически. Этот PR добавляет отдельный job `e2e` в `.github/workflows/ci.yml`, который **реально** прогоняет smoke на каждом PR.

## Что делает job

- `checkout@v4` + `setup-python@v5` (3.11, cache pip) + `pip install -e ".[dev]"`.
- Ставит бинарь `playwright-cli` (npm-пакет `@playwright/cli@0.1.11`, запинено — supply-chain гигиена, как `jscpd@5.0.10`).
- Ставит Chromium для **той же** версии `playwright-core`, что внутри `@playwright/cli` (через его вложенный `cli.js install --with-deps chromium`), чтобы версия браузера всегда совпадала с бинарём.
- Поднимает сервер в фоне: `serve --web-pass ci-secret --no-worker` → лог в файл.
- Ждёт готовности по `/health` (retry ~30с), фейлит громко если сервер не встал.
- Гоняет `pytest tests/e2e/test_console_smoke.py -m e2e` с env `RUN_E2E_CONSOLE_SMOKE=1 / E2E_BASE_URL / WEB_PASS`.

## Гард против «тихого ноля» 🛡️

Главный подводный камень: если `playwright-cli` не установлен, pytest-обёртка `skip`-ает и job стал бы зелёным, **ничего не проверив** (`tests/e2e/test_console_smoke.py:62`). Защита двойная:
1. Job ставит бинарь + браузер — ветка skip не может сработать.
2. Финальный шаг парсит JUnit-XML и **утверждает**, что `test_no_console_errors_on_any_page` отработал как `passed` (ноль skipped/errors). Это и делает job осмысленным: all-skipped прогон pytest всё равно выходит с кодом 0, поэтому одного exit-кода мало.

Проверено локально на всех 4 сценариях JUnit (passed→0, skipped→1, error→1, missing→1).

## Решения по scope

- **Минимальный первый шаг** (#1012): оставлен текущий shell-out на `playwright-cli`. Миграция на `pytest-playwright` — отдельная задача P1b (крупнее, теряет уже протестированную логику redaction/auth).
- **Отдельный job**, не внутри `lint-and-test` — чтобы не тормозить и не флапать основной прогон.
- **`test_collection_flow.py` не тронут** — он (ASGI-e2e) уже идёт в основном прогоне через `-m "not aiosqlite_serial"`. Новый job только для `console_smoke`.
- **Секреты не нужны** — `console_smoke` ходит только по web-UI; `--no-worker` не открывает Telegram/LLM-соединений (подтверждено в #1011).

## Локальная верификация

Сервер поднялся без секретов (`{"status":"healthy","db":true}`), smoke реально прогнал браузер по 12 страницам: **2 passed за ~40с**, гард подтвердил `passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)