### PR TITLE
test(e2e): expand PANEL_PATHS with newer full-page routes (#1013)

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -10,9 +10,20 @@ Walks every main web-panel page and asserts that none of them logs a JS error to
 the browser console. A manual one-page pass already found 0 errors (#788); this
 turns that into a repeatable check across all pages so regressions get caught.
 
-Pages walked: `/`, `/channels`, `/channels?view=all`, `/channels/filter/manage`,
-`/search`, `/analytics`, `/analytics/trends`, `/dashboard`, `/agent`,
-`/settings`, `/dialogs`, `/pipelines`.
+Pages walked (kept in lockstep with `PANEL_PATHS` in `console_smoke.py` and the
+`test_panel_paths_match_issue_list` guard): `/`, `/channels`,
+`/channels?view=all`, `/channels/filter/manage`, `/channels/renames`, `/search`,
+`/search-queries`, `/analytics`, `/analytics/trends`, `/analytics/channels`,
+`/analytics/channels/ratings`, `/dashboard`, `/agent`, `/settings`, `/dialogs`,
+`/dialogs/photos`, `/pipelines`, `/jobs`, `/moderation`, `/calendar`, `/images`,
+`/scheduler`.
+
+The list was extended in #1013 (part of #1011) to cover newer full-page routes —
+notably the session features `/jobs` (#965), `/analytics/channels` (#951) and
+`/analytics/channels/ratings` (#968/#999). Only GET full-page routes are walked;
+this is a console-only smoke (it catches JS errors on load). Some of the newer
+pages are lazyload skeletons (#756), so a clean console here does not yet prove
+the deferred fragment loaded — that deeper check is tracked separately.
 
 ### Run it by hand (quickest)
 

--- a/tests/e2e/console_smoke.py
+++ b/tests/e2e/console_smoke.py
@@ -39,21 +39,40 @@ import sys
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
-# The main panel pages to walk, mirroring the list in issue #792. Paths are
-# relative to the base URL; the leading "/" page is the dashboard.
+# The main panel pages to walk. Originally mirrored the list in issue #792;
+# extended in #1013 to cover newer full-page routes (incl. the session features
+# /jobs #965, /analytics/channels #951, /analytics/channels/ratings #968/#999).
+# Only GET full-page routes belong here — no POST endpoints, no /fragments/*
+# routes, and no {id}-parametric pages. Some routes are declared as @get("/")
+# under a non-empty router prefix, so their canonical URL has a trailing slash
+# (e.g. /moderation/, /calendar/); we list them without the slash to match the
+# existing convention — a browser navigation follows the 307 redirect and the
+# bounce-to-/login guard in check_page still holds. Keep this in lockstep with
+# test_panel_paths_match_issue_list (tests/e2e/test_console_smoke_parsing.py)
+# and the "Pages walked" list in tests/e2e/README.md.
 PANEL_PATHS: tuple[str, ...] = (
     "/",
     "/channels",
     "/channels?view=all",
     "/channels/filter/manage",
+    "/channels/renames",
     "/search",
+    "/search-queries",
     "/analytics",
     "/analytics/trends",
+    "/analytics/channels",
+    "/analytics/channels/ratings",
     "/dashboard",
     "/agent",
     "/settings",
     "/dialogs",
+    "/dialogs/photos",
     "/pipelines",
+    "/jobs",
+    "/moderation",
+    "/calendar",
+    "/images",
+    "/scheduler",
 )
 
 # "Total messages: 4 (Errors: 2, Warnings: 1)" — the summary line that

--- a/tests/e2e/test_console_smoke_parsing.py
+++ b/tests/e2e/test_console_smoke_parsing.py
@@ -225,18 +225,30 @@ def test_format_summary_reports_counts_and_errors() -> None:
 
 
 def test_panel_paths_match_issue_list() -> None:
-    # Guard: keep the walked set aligned with the pages enumerated in issue #792.
+    # Guard: keep the walked set aligned with the curated page list. Originally
+    # the #792 set; extended in #1013 with newer full-page routes. Change this
+    # tuple and PANEL_PATHS (console_smoke.py) in the same edit, or CI goes red.
     assert console_smoke.PANEL_PATHS == (
         "/",
         "/channels",
         "/channels?view=all",
         "/channels/filter/manage",
+        "/channels/renames",
         "/search",
+        "/search-queries",
         "/analytics",
         "/analytics/trends",
+        "/analytics/channels",
+        "/analytics/channels/ratings",
         "/dashboard",
         "/agent",
         "/settings",
         "/dialogs",
+        "/dialogs/photos",
         "/pipelines",
+        "/jobs",
+        "/moderation",
+        "/calendar",
+        "/images",
+        "/scheduler",
     )


### PR DESCRIPTION
Part of #1011 (P2 — broaden page coverage). Closes #1013.

## What

Extends `PANEL_PATHS` in the console-smoke walk from 12 → 22 navigable full-page routes (~37% → ~69% of the ~32 routes). Pure list expansion — no new logic — so the smoke now catches load-time JS console errors on the session's newer pages, which previously went entirely unchecked.

New paths added (priority — session features first):
- `/jobs` (#965), `/analytics/channels` (#951), `/analytics/channels/ratings` (#968/#999), `/moderation`
- `/calendar`, `/images`, `/dialogs/photos`, `/search-queries`, `/scheduler`, `/channels/renames`

## Verification

Each new path was checked against `src/web/routes/*` + the `app.include_router` prefixes in `assembly.py` — all are **GET full-page routes returning `HTMLResponse`**. No POST endpoints, no `/fragments/*`, no `{id}`-parametric pages (the smoke just opens the URL and reads the console).

## Lockstep (the trap)

The guard `test_panel_paths_match_issue_list` hard-compares `PANEL_PATHS` against a literal tuple, so a one-sided edit reddens CI. All three sources of truth were changed in the same commit:
- `tests/e2e/console_smoke.py` — `PANEL_PATHS`
- `tests/e2e/test_console_smoke_parsing.py` — the guard tuple
- `tests/e2e/README.md` — the "Pages walked" list

## Notes

- These e2e checks are **opt-in / local** (gate `RUN_E2E_CONSOLE_SMOKE=1` + a live `python -m src.main serve`). No CI workflow touched.
- Several newer pages are lazyload skeletons (#756): a clean console here doesn't yet prove the deferred fragment loaded — that deeper check is P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)