### PR TITLE
test(e2e): migrate console-smoke to the Playwright Python API (#1014)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,16 @@ dev = [
     # CI cyclomatic-complexity gate (`--fail-on F`). ruff (above) is the third.
     "radon>=6.0.1",
     "vulture>=2.16",
+    # Console-error e2e smoke (issue #1014): the opt-in browser walk in
+    # tests/e2e/console_smoke.py drives the Playwright Python API directly
+    # instead of shelling out to an undeclared `playwright-cli` binary. The
+    # browser binaries are installed separately with
+    # `playwright install --with-deps chromium`; pytest-playwright pulls in the
+    # `playwright` package and the e2e fixtures. The smoke test is gated behind
+    # RUN_E2E_CONSOLE_SMOKE=1, runs locally against a `python -m src.main serve`
+    # panel, and never runs in the default suite or in CI.
+    "playwright>=1.59.0",
+    "pytest-playwright>=0.8.0",
 ]
 docs = ["mkdocs-material>=9.7.6"]
 # Codex SDK image provider + agent backend. Optional: all imports are lazy, so

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,13 +2,20 @@
 
 End-to-end checks that drive a real browser / the full server surface. They are
 **opt-in** — skipped in normal CI because they need a live server (and, for the
-console smoke check, the `playwright-cli` binary).
+console smoke check, the Playwright Chromium build).
 
-## Console-error smoke test (issue #792)
+## Console-error smoke test (issues #792, #1014)
 
 Walks every main web-panel page and asserts that none of them logs a JS error to
 the browser console. A manual one-page pass already found 0 errors (#788); this
 turns that into a repeatable check across all pages so regressions get caught.
+
+Since #1014 the check drives the **Playwright Python API** (a declared `[dev]`
+dependency) directly — `page.goto` + `page.on("console")` / `page.on("pageerror")`
+— instead of shelling out to the external `playwright-cli` binary and parsing its
+text output. That removes the undeclared external dependency and the brittle CLI
+parsing while keeping the same guards (password redaction, the `/login` bounce
+guard, and a loud failure on a dead server).
 
 Pages walked (kept in lockstep with `PANEL_PATHS` in `console_smoke.py` and the
 `test_panel_paths_match_issue_list` guard): `/`, `/channels`,
@@ -25,6 +32,16 @@ this is a console-only smoke (it catches JS errors on load). Some of the newer
 pages are lazyload skeletons (#756), so a clean console here does not yet prove
 the deferred fragment loaded — that deeper check is tracked separately.
 
+### Setup (once)
+
+The Playwright packages come from the `[dev]` extra; the browser binaries are a
+separate one-time download:
+
+```bash
+pip install -e ".[dev]"
+playwright install --with-deps chromium
+```
+
 ### Run it by hand (quickest)
 
 ```bash
@@ -37,10 +54,7 @@ python -m tests.e2e.console_smoke --base-url http://localhost:8080 --web-pass se
 
 It prints a per-page summary (✓ clean / ✗ N errors) and exits non-zero if any
 page logged an error. Drop `--web-pass` if the panel runs without a password.
-
-Add `--settle N` (or `E2E_SETTLE=N`) to wait N seconds after each page load
-before reading the console — useful when a page logs errors asynchronously a
-moment after load (the default reads the console immediately).
+Add `--headed` to watch the run in a visible browser window (default: headless).
 
 **Auth note:** when a password is set, the script logs in through the real
 `/login` form (which sets a session cookie) rather than embedding credentials in
@@ -48,7 +62,9 @@ the URL — `BasicAuthMiddleware` answers browser navigations with a `303` to
 `/login` instead of a `401` challenge, so a creds-in-URL navigation would
 silently land on the login page and report a false "all clean". After each
 navigation the script also asserts the page did **not** bounce to `/login`, so a
-wrong password or broken auth fails loudly instead of passing green.
+wrong password or broken auth fails loudly instead of passing green. The password
+is typed into the form field (never embedded in a URL) and redacted from any
+diagnostic/exception text, so `WEB_PASS` never leaks into a log or a failure.
 
 ### Run it via pytest
 
@@ -60,12 +76,15 @@ pytest tests/e2e/test_console_smoke.py -m e2e
 ```
 
 Without `RUN_E2E_CONSOLE_SMOKE=1` the test is skipped, so it never breaks the
-default `pytest` run.
+default `pytest` run. Once the gate is open the test only skips for one
+intentional case — Playwright / its Chromium build is not installed; every other
+failure (dead server, wrong password, hung navigation) fails loudly.
 
 ### Layout
 
-- `console_smoke.py` — reusable logic (page list, `playwright-cli` calls, parsing)
-  plus a `__main__` CLI entry point.
-- `test_console_smoke.py` — opt-in pytest wrapper (live server required).
-- `test_console_smoke_parsing.py` — pure-logic unit tests for the helpers; these
-  run in normal CI (no browser, no server).
+- `console_smoke.py` — reusable logic (page list, Playwright browser walk, console
+  collection, redaction/auth guards) plus a `__main__` CLI entry point.
+- `test_console_smoke.py` — opt-in pytest wrapper (live server + Chromium required).
+- `test_console_smoke_parsing.py` — pure-logic unit tests for the helpers
+  (redaction, the `/login` bounce guard, the dead-server guard, console-error
+  collection); these run in normal CI against fakes — no browser, no server.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -56,6 +56,10 @@ It prints a per-page summary (✓ clean / ✗ N errors) and exits non-zero if an
 page logged an error. Drop `--web-pass` if the panel runs without a password.
 Add `--headed` to watch the run in a visible browser window (default: headless).
 
+Add `--settle N` (or `E2E_SETTLE=N`) to wait N seconds after each page load
+before reading the console — useful when a page logs errors asynchronously a
+moment after load (the default reads the console immediately).
+
 **Auth note:** when a password is set, the script logs in through the real
 `/login` form (which sets a session cookie) rather than embedding credentials in
 the URL — `BasicAuthMiddleware` answers browser navigations with a `303` to

--- a/tests/e2e/console_smoke.py
+++ b/tests/e2e/console_smoke.py
@@ -1,4 +1,4 @@
-"""Console-error smoke check for the web panel, driven by ``playwright-cli``.
+"""Console-error smoke check for the web panel, driven by ``pytest-playwright``.
 
 Why a standalone module (issue #792): a manual ``playwright-cli console`` pass on
 one page already found 0 errors (#788), but regressions are inevitable. This
@@ -6,14 +6,22 @@ walks **every** main panel page in a real browser and asserts that none of them
 logs a JS error to the console. The check is opt-in (a live server must be
 running) and intentionally lives next to ``tests/e2e/test_collection_flow.py``.
 
-Design notes:
+Design notes (issue #1014 — migrated off the external ``playwright-cli`` binary):
 
-- We shell out to the already-installed ``playwright-cli`` binary rather than
-  pulling in ``pytest-playwright`` + uvicorn-in-a-thread fixtures. The CLI keeps
-  a persistent browser session between invocations, so the flow is just
-  ``open`` → (login once) → ``goto`` (per page) → ``console error`` → ``close``.
-- ``playwright-cli`` clears its console buffer on navigation, so after a
-  ``goto`` the buffer holds only that page's messages — exactly what we want.
+- We drive the **Playwright Python API** (a declared ``[dev]`` dependency; the
+  browser is installed locally with ``playwright install --with-deps chromium``)
+  instead of shelling out to the ``playwright-cli`` binary. This removes the
+  "undeclared external dependency" and the brittle text-parsing of the CLI's
+  stdout: console errors are read directly off ``page.on("console")`` /
+  ``page.on("pageerror")`` and the landed path off ``page.url`` — no regex over
+  CLI output. This check is run **locally** (gate ``RUN_E2E_CONSOLE_SMOKE=1``
+  against a server started with ``python -m src.main serve``); it is not wired
+  into CI.
+- Console capture: Playwright does NOT buffer console events across navigations
+  the way the CLI did, so we attach a listener once per page and ``goto`` with
+  that listener live, collecting only that page's messages. ``pageerror`` catches
+  uncaught JS exceptions (which Chromium also logs to the console, but the
+  dedicated event is the robust source).
 - Auth: ``BasicAuthMiddleware`` only sends a ``401`` Basic challenge for
   non-HTML requests; a browser navigation (``Accept: text/html``) instead gets a
   ``303`` redirect to ``/login``, and Chromium never replays URL-embedded
@@ -23,21 +31,30 @@ Design notes:
   which authenticates every later navigation, and after each ``goto`` we assert
   the page did NOT bounce back to ``/login`` so a broken auth fails loudly rather
   than passing green. With no password configured the panel is open and we skip
-  the login step. The password is typed into the form field (never embedded in a
-  navigation URL); ``playwright-cli`` diagnostics are redacted so it never leaks
-  into log/exception text (it can still be visible in local process args while
-  the ``fill`` runs — an inherent limit of any CLI that takes the value as argv).
+  the login step. The password is typed into the form field (``page.fill``) and
+  never embedded in a navigation URL; Playwright never echoes the value back, but
+  we still redact it from any diagnostic/exception text as a belt-and-braces
+  guard so ``WEB_PASS`` can never leak into a log or a failure message.
+- Dead server: ``page.goto`` raises a Playwright error (``ERR_CONNECTION_REFUSED``,
+  a timeout, …) which we wrap in :class:`ConsoleSmokeError`. A mute/misconfigured
+  server therefore fails loudly instead of walking every page and reporting "0
+  errors" (the silent false-negative the gated test must never produce) — the
+  Python-API equivalent of the old "exit 0 + ``### Error``" guard.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
-import re
-import subprocess
 import sys
+from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generator
 from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Browser, ConsoleMessage, Page
+    from playwright.sync_api import Error as PlaywrightError
 
 # The main panel pages to walk. Originally mirrored the list in issue #792;
 # extended in #1013 to cover newer full-page routes (incl. the session features
@@ -75,30 +92,24 @@ PANEL_PATHS: tuple[str, ...] = (
     "/scheduler",
 )
 
-# "Total messages: 4 (Errors: 2, Warnings: 1)" — the summary line that
-# ``playwright-cli console`` always prints. We read the error count from it
-# rather than counting "[ERROR]" lines, so the parse is robust even when the
-# CLI truncates or reformats the message bodies.
-_ERROR_COUNT_RE = re.compile(r"Errors:\s*(\d+)", re.IGNORECASE)
-
-PLAYWRIGHT_CLI = "playwright-cli"
 LOGIN_PATH = "/login"
 # CSS selector for the panel's login form field (src/web/templates/web_login.html).
 _PASSWORD_FIELD = "#password"
 _REDACTED = "***"
-# ``playwright-cli`` reports operational failures (connection refused, element not
-# found, failed eval, …) by printing a ``### Error`` block to stdout while still
-# exiting 0 — so a non-zero exit code alone misses them. We treat this marker as a
-# failure too, otherwise a dead/misconfigured server would walk every page and
-# report "0 errors" (a silent false-negative the gated test must never produce).
-_CLI_ERROR_MARKER = "### Error"
+# Per-action navigation/console timeout (ms). A hung navigation against a wedged
+# server must fail the gated run loudly rather than block forever — pytest's own
+# 120s deadlock guard is the outer backstop.
+_DEFAULT_TIMEOUT_MS = 30_000
 
 
-class PlaywrightCliError(RuntimeError):
-    """Raised when a ``playwright-cli`` invocation fails.
+class ConsoleSmokeError(RuntimeError):
+    """Raised when a Playwright operation fails (dead server, bad navigation, …).
 
-    Covers both a non-zero exit and the exit-0 ``### Error`` stdout block the CLI
-    emits for operational failures (connection refused, missing element, …).
+    This is the Python-API equivalent of the old CLI's "exit 0 + ``### Error``"
+    guard: it turns an operational failure (connection refused, navigation
+    timeout, missing login field, …) into a loud error so a dead/misconfigured
+    server can never walk every page and report "0 errors" — a silent
+    false-negative the gated test must never produce.
     """
 
 
@@ -124,54 +135,22 @@ class PageResult:
 
 
 def _redact(text: str, secrets: tuple[str, ...]) -> str:
-    """Replace each non-empty secret in ``text`` with ``***``."""
+    """Replace each non-empty secret in ``text`` with ``***``.
+
+    The Playwright Python API never puts the password on a process argv (unlike
+    the old ``playwright-cli``), but we still scrub it from any diagnostic or
+    exception text as a belt-and-braces guard so ``WEB_PASS`` can never leak into
+    a log or a failure message via a caller that interpolates the error.
+    """
     for secret in secrets:
         if secret:
             text = text.replace(secret, _REDACTED)
     return text
 
 
-def _run_cli(*args: str, session: str | None = None, secrets: tuple[str, ...] = ()) -> str:
-    """Run ``playwright-cli`` and return its stdout; raise on failure.
-
-    Failure is either a non-zero exit OR an exit-0 ``### Error`` stdout block (the
-    CLI reports operational errors that way — see ``_CLI_ERROR_MARKER``).
-
-    ``secrets`` are redacted from EVERYTHING this function returns or raises (the
-    echoed command, captured stdout/stderr, the success-path return value, and a
-    timeout diagnostic), so a password passed to ``fill`` — which the CLI echoes
-    back verbatim on success (``…fill('<pw>')``) — never leaks into the returned
-    text, logs, or exceptions. NOTE: ``subprocess.TimeoutExpired`` is converted to
-    ``PlaywrightCliError`` here because its own ``str()`` embeds the raw argv
-    (cleartext password); letting it propagate would leak the secret via any caller
-    that interpolates the exception (e.g. the gated pytest fixture).
-    """
-    cmd = [PLAYWRIGHT_CLI]
-    if session:
-        cmd.append(f"-s={session}")
-    cmd.extend(args)
-    cmd_shown = _redact(" ".join(cmd), secrets)
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    except subprocess.TimeoutExpired as exc:
-        out = _redact(exc.stdout or "", secrets) if isinstance(exc.stdout, str) else ""
-        err = _redact(exc.stderr or "", secrets) if isinstance(exc.stderr, str) else ""
-        raise PlaywrightCliError(f"`{cmd_shown}` timed out after {exc.timeout}s:\n{out}\n{err}") from None
-    stdout = _redact(proc.stdout, secrets)
-    if proc.returncode != 0 or _CLI_ERROR_MARKER in proc.stdout:
-        stderr = _redact(proc.stderr, secrets)
-        raise PlaywrightCliError(f"`{cmd_shown}` failed (exit {proc.returncode}):\n{stdout}\n{stderr}")
-    return stdout
-
-
-def current_path(*, session: str | None = None) -> str:
-    """Return the browser's current ``location.pathname`` (no query/host)."""
-    output = _run_cli("eval", "() => location.pathname", session=session)
-    # ``eval`` prints the JSON result on its own line, e.g. `"/settings/"`.
-    match = re.search(r'"([^"]*)"', output)
-    if match is None:
-        raise PlaywrightCliError(f"could not read location.pathname from:\n{output}")
-    return match.group(1)
+def _path_of(url: str) -> str:
+    """Return just the ``location.pathname`` of a full URL (no scheme/host/query)."""
+    return urlsplit(url).path
 
 
 def _is_login_path(path: str) -> bool:
@@ -179,52 +158,121 @@ def _is_login_path(path: str) -> bool:
     return path.rstrip("/") == LOGIN_PATH
 
 
-def login(base_url: str, password: str, *, session: str | None = None) -> None:
+def _console_error_text(msg: "ConsoleMessage") -> str:
+    """Render a console error message in the old ``[ERROR] ...`` reporting shape.
+
+    The location (URL:line) mirrors the ``@ file:line`` suffix the CLI printed,
+    so ``format_summary`` output stays familiar across the migration.
+    """
+    loc = msg.location or {}
+    where = loc.get("url", "") if isinstance(loc, dict) else ""
+    line = loc.get("lineNumber", 0) if isinstance(loc, dict) else 0
+    suffix = f" @ {where}:{line}" if where else ""
+    return f"[ERROR] {msg.text}{suffix}"
+
+
+def _attach_error_listeners(page: "Page", sink: list[str]) -> None:
+    """Collect console *errors* and uncaught page errors into ``sink``.
+
+    Mirrors the old ``console error`` filter: only ``console.error`` calls and
+    uncaught JS exceptions count — warnings/info/log are ignored.
+    """
+
+    def _on_console(msg: "ConsoleMessage") -> None:
+        if msg.type == "error":
+            sink.append(_console_error_text(msg))
+
+    def _on_pageerror(exc: "PlaywrightError") -> None:
+        # Uncaught JS exception (e.g. a thrown Error). ``exc.message`` is the
+        # error text; Chromium also surfaces these on the console, but the
+        # dedicated event is the robust source.
+        sink.append(f"[ERROR] {exc.message}")
+
+    page.on("console", _on_console)
+    page.on("pageerror", _on_pageerror)
+
+
+@contextmanager
+def browser_session(*, headless: bool = True) -> Generator["Browser", None, None]:
+    """Launch a headless Chromium and always close it, even on error.
+
+    A failed run must not leave a zombie browser process behind, mirroring the
+    old ``finally: close`` contract. Import is local so merely importing this
+    module (e.g. for the pure-logic unit tests) does not require Playwright. A
+    missing Chromium build (``playwright install`` not run) raises a Playwright
+    error at launch, which we wrap in :class:`ConsoleSmokeError` so the caller
+    sees the same operational-failure type as a navigation error.
+    """
+    from playwright.sync_api import Error as PlaywrightError
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        try:
+            browser = pw.chromium.launch(headless=headless)
+        except PlaywrightError as exc:
+            raise ConsoleSmokeError(f"failed to launch Chromium: {exc.message}") from None
+        try:
+            yield browser
+        finally:
+            browser.close()
+
+
+def _goto(page: "Page", url: str, *, secrets: tuple[str, ...] = ()) -> None:
+    """Navigate, converting any Playwright error into a redacted ConsoleSmokeError.
+
+    A dead/misconfigured server raises here (``ERR_CONNECTION_REFUSED``, a
+    navigation timeout, …) rather than silently walking on — the Python-API
+    equivalent of the old "exit 0 + ``### Error``" guard.
+    """
+    from playwright.sync_api import Error as PlaywrightError
+
+    try:
+        page.goto(url, wait_until="load")
+    except PlaywrightError as exc:
+        raise ConsoleSmokeError(_redact(f"navigation to {url} failed: {exc.message}", secrets)) from None
+
+
+def login(page: "Page", base_url: str, password: str) -> None:
     """Authenticate the browser session via the real ``/login`` form.
 
     Navigates to ``/login``, fills the password field and submits; the panel
     responds with a session cookie that authenticates every later navigation.
-    Raises if the form did not authenticate (still on ``/login`` afterwards).
+    Raises :class:`RedirectedToLoginError` if the form did not authenticate
+    (still on ``/login`` afterwards). The password is typed into the field and
+    never embedded in a URL; it is redacted from any error text as a guard.
     """
+    from playwright.sync_api import Error as PlaywrightError
+
     base = base_url.rstrip("/")
     secrets = (password,)
-    _run_cli("goto", f"{base}{LOGIN_PATH}", session=session, secrets=secrets)
-    _run_cli("fill", _PASSWORD_FIELD, password, "--submit", session=session, secrets=secrets)
-    if _is_login_path(current_path(session=session)):
+    _goto(page, f"{base}{LOGIN_PATH}", secrets=secrets)
+    try:
+        page.fill(_PASSWORD_FIELD, password)
+        # Submitting reloads to the target page; wait for that navigation so the
+        # session cookie is set before we read the landed path.
+        with page.expect_navigation(wait_until="load"):
+            page.press(_PASSWORD_FIELD, "Enter")
+    except PlaywrightError as exc:
+        raise ConsoleSmokeError(_redact(f"login form interaction failed: {exc.message}", secrets)) from None
+    if _is_login_path(_path_of(page.url)):
         raise RedirectedToLoginError("login failed: still on /login after submitting the password (wrong WEB_PASS?)")
 
 
-def parse_error_count(console_output: str) -> int:
-    """Extract the error count from ``playwright-cli console`` output."""
-    match = _ERROR_COUNT_RE.search(console_output)
-    if match is None:
-        raise PlaywrightCliError(f"could not find an error count in console output:\n{console_output}")
-    return int(match.group(1))
-
-
-def _error_lines(console_output: str) -> list[str]:
-    """Collect the ``[ERROR] ...`` lines, for human-readable reporting."""
-    return [line.strip() for line in console_output.splitlines() if line.lstrip().startswith("[ERROR]")]
-
-
-def check_page(base_url: str, path: str, *, session: str | None = None, settle: float = 0.0) -> PageResult:
+def check_page(page: "Page", base_url: str, path: str) -> PageResult:
     """Navigate to one page and read back its console errors.
 
     Raises :class:`RedirectedToLoginError` if the navigation bounced to ``/login``
     (an unauthenticated session) — otherwise a broken auth would silently report
-    the clean login form as a clean panel page. ``settle`` optionally sleeps after
-    navigation so console errors emitted shortly after load (async/deferred) are
-    still captured before the one-shot console read.
+    the clean login form as a clean panel page.
     """
     base = base_url.rstrip("/")
-    _run_cli("goto", f"{base}{path}", session=session)
-    landed = current_path(session=session)
+    errors: list[str] = []
+    _attach_error_listeners(page, errors)
+    _goto(page, f"{base}{path}")
+    landed = _path_of(page.url)
     if _is_login_path(landed) and not _is_login_path(path):
         raise RedirectedToLoginError(f"navigation to {path!r} bounced to {landed!r}: session is not authenticated")
-    if settle > 0:
-        _run_cli("eval", f"() => new Promise(r => setTimeout(r, {int(settle * 1000)}))", session=session)
-    output = _run_cli("console", "error", session=session)
-    return PageResult(path=path, error_count=parse_error_count(output), errors=_error_lines(output))
+    return PageResult(path=path, error_count=len(errors), errors=list(errors))
 
 
 def run_smoke(
@@ -232,25 +280,26 @@ def run_smoke(
     password: str | None = None,
     paths: tuple[str, ...] = PANEL_PATHS,
     *,
-    session: str | None = None,
-    settle: float = 0.0,
+    headless: bool = True,
+    timeout_ms: int = _DEFAULT_TIMEOUT_MS,
 ) -> list[PageResult]:
     """Open a browser, (log in if needed,) walk every panel page, return results.
 
-    The browser session is always closed, even on error, so a failed run does
-    not leave a zombie ``playwright-cli`` process behind.
+    The browser is always closed, even on error (see :func:`browser_session`),
+    so a failed run does not leave a zombie process behind. A fresh page is used
+    per panel path so each page's console listener only sees its own messages.
     """
     base = base_url.rstrip("/")
-    _run_cli("open", base, session=session)
-    try:
-        if password:
-            login(base, password, session=session)
-        return [check_page(base, path, session=session, settle=settle) for path in paths]
-    finally:
+    with browser_session(headless=headless) as browser:
+        context = browser.new_context()
+        context.set_default_timeout(timeout_ms)
+        context.set_default_navigation_timeout(timeout_ms)
         try:
-            _run_cli("close", session=session)
-        except PlaywrightCliError:
-            pass
+            if password:
+                login(context.new_page(), base, password)
+            return [check_page(context.new_page(), base, path) for path in paths]
+        finally:
+            context.close()
 
 
 def format_summary(results: list[PageResult]) -> str:
@@ -293,18 +342,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Panel password (defaults to the WEB_PASS env var; omit if the panel is open).",
     )
     parser.add_argument(
-        "--settle",
-        type=float,
-        default=float(os.environ.get("E2E_SETTLE", "0") or "0"),
-        help="Seconds to wait after each page load before reading the console "
-        "(catches async errors fired shortly after load; default: %(default)s).",
+        "--headed",
+        action="store_true",
+        help="Run with a visible browser window (default: headless).",
     )
     args = parser.parse_args(argv)
     # Basic sanity on the base URL so a typo fails clearly rather than mid-walk.
     if not urlsplit(args.base_url).scheme:
         parser.error(f"--base-url must include a scheme, got {args.base_url!r}")
 
-    results = run_smoke(args.base_url, args.web_pass, settle=args.settle)
+    results = run_smoke(args.base_url, args.web_pass, headless=not args.headed)
     print(format_summary(results))
     return 0 if all(r.clean for r in results) else 1
 

--- a/tests/e2e/console_smoke.py
+++ b/tests/e2e/console_smoke.py
@@ -98,7 +98,11 @@ _PASSWORD_FIELD = "#password"
 _REDACTED = "***"
 # Per-action navigation/console timeout (ms). A hung navigation against a wedged
 # server must fail the gated run loudly rather than block forever — pytest's own
-# 120s deadlock guard is the outer backstop.
+# 120s deadlock guard is the outer backstop. NOTE: a single wedged navigation can
+# burn up to this whole budget, so against a genuinely slow (but working) server
+# the 12-page walk could approach the 120s pytest timeout; this check is run by
+# hand against a local server, so that trade-off is acceptable — lower this or the
+# page set if a slow target trips the outer guard.
 _DEFAULT_TIMEOUT_MS = 30_000
 
 
@@ -258,12 +262,16 @@ def login(page: "Page", base_url: str, password: str) -> None:
         raise RedirectedToLoginError("login failed: still on /login after submitting the password (wrong WEB_PASS?)")
 
 
-def check_page(page: "Page", base_url: str, path: str) -> PageResult:
+def check_page(page: "Page", base_url: str, path: str, *, settle: float = 0.0) -> PageResult:
     """Navigate to one page and read back its console errors.
 
     Raises :class:`RedirectedToLoginError` if the navigation bounced to ``/login``
     (an unauthenticated session) — otherwise a broken auth would silently report
-    the clean login form as a clean panel page.
+    the clean login form as a clean panel page. ``settle`` optionally waits that
+    many seconds after the ``load`` event before reading the console, so errors
+    emitted asynchronously a moment after load (a deferred fetch that rejects,
+    say) are still captured while the listener is live. The default (``0.0``)
+    reads immediately, matching the old CLI behaviour.
     """
     base = base_url.rstrip("/")
     errors: list[str] = []
@@ -272,6 +280,10 @@ def check_page(page: "Page", base_url: str, path: str) -> PageResult:
     landed = _path_of(page.url)
     if _is_login_path(landed) and not _is_login_path(path):
         raise RedirectedToLoginError(f"navigation to {path!r} bounced to {landed!r}: session is not authenticated")
+    if settle > 0:
+        # The listener stays attached, so errors fired during this window land in
+        # ``errors`` too. ``wait_for_timeout`` takes milliseconds.
+        page.wait_for_timeout(settle * 1000)
     return PageResult(path=path, error_count=len(errors), errors=list(errors))
 
 
@@ -282,12 +294,15 @@ def run_smoke(
     *,
     headless: bool = True,
     timeout_ms: int = _DEFAULT_TIMEOUT_MS,
+    settle: float = 0.0,
 ) -> list[PageResult]:
     """Open a browser, (log in if needed,) walk every panel page, return results.
 
     The browser is always closed, even on error (see :func:`browser_session`),
     so a failed run does not leave a zombie process behind. A fresh page is used
     per panel path so each page's console listener only sees its own messages.
+    ``settle`` is forwarded to :func:`check_page` (seconds to wait after each
+    page load before reading the console; default reads immediately).
     """
     base = base_url.rstrip("/")
     with browser_session(headless=headless) as browser:
@@ -297,7 +312,7 @@ def run_smoke(
         try:
             if password:
                 login(context.new_page(), base, password)
-            return [check_page(context.new_page(), base, path) for path in paths]
+            return [check_page(context.new_page(), base, path, settle=settle) for path in paths]
         finally:
             context.close()
 
@@ -346,12 +361,19 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run with a visible browser window (default: headless).",
     )
+    parser.add_argument(
+        "--settle",
+        type=float,
+        default=float(os.environ.get("E2E_SETTLE", "0") or "0"),
+        help="Seconds to wait after each page load before reading the console "
+        "(catches async errors fired shortly after load; default: %(default)s).",
+    )
     args = parser.parse_args(argv)
     # Basic sanity on the base URL so a typo fails clearly rather than mid-walk.
     if not urlsplit(args.base_url).scheme:
         parser.error(f"--base-url must include a scheme, got {args.base_url!r}")
 
-    results = run_smoke(args.base_url, args.web_pass, headless=not args.headed)
+    results = run_smoke(args.base_url, args.web_pass, headless=not args.headed, settle=args.settle)
     print(format_summary(results))
     return 0 if all(r.clean for r in results) else 1
 

--- a/tests/e2e/test_console_smoke.py
+++ b/tests/e2e/test_console_smoke.py
@@ -66,8 +66,9 @@ def smoke_results() -> list[console_smoke.PageResult]:
 
     base_url = os.environ.get("E2E_BASE_URL", "http://localhost:8080")
     password = os.environ.get("WEB_PASS") or None
+    settle = float(os.environ.get("E2E_SETTLE", "0") or "0")
     try:
-        return console_smoke.run_smoke(base_url, password)
+        return console_smoke.run_smoke(base_url, password, settle=settle)
     except console_smoke.RedirectedToLoginError as exc:
         raise AssertionError(f"console smoke run failed against {base_url}: {exc}") from exc
     except console_smoke.ConsoleSmokeError as exc:

--- a/tests/e2e/test_console_smoke.py
+++ b/tests/e2e/test_console_smoke.py
@@ -1,8 +1,9 @@
-"""Opt-in e2e: assert no panel page logs a JS console error (issue #792).
+"""Opt-in e2e: assert no panel page logs a JS console error (issues #792, #1014).
 
 This test is **opt-in** and skipped by default — it needs a live web server
-(``python -m src.main serve``) plus the installed ``playwright-cli`` binary,
-neither of which exists in the standard CI run. Enable it with::
+(``python -m src.main serve``) plus the Playwright browser binaries
+(``playwright install --with-deps chromium``), neither of which exists in the
+standard CI run. Enable it with::
 
     RUN_E2E_CONSOLE_SMOKE=1 E2E_BASE_URL=http://localhost:8080 WEB_PASS=secret \
         pytest tests/e2e/test_console_smoke.py -m e2e
@@ -11,17 +12,16 @@ The actual browser-walking logic lives in ``tests/e2e/console_smoke.py`` so it
 can also be run by hand: ``python -m tests.e2e.console_smoke --base-url ... --web-pass ...``.
 
 Once the gate is open, an infrastructure failure (dead server, wrong password,
-broken ``playwright-cli`` invocation, hung navigation) must FAIL the test, not
-skip it — the user explicitly asked for the check, so silence cannot read as
-"all clean". We therefore only skip for the two intentional cases: the gate is
-closed (handled by ``pytestmark``) or the binary is simply not installed.
+hung navigation, missing browser binary at runtime) must FAIL the test, not
+silently pass — the user explicitly asked for the check, so silence cannot read
+as "all clean". We therefore only skip for the two intentional cases: the gate
+is closed (handled by ``pytestmark``) or Playwright / its Chromium build is
+simply not installed.
 """
 
 from __future__ import annotations
 
 import os
-import shutil
-import subprocess
 
 import pytest
 
@@ -48,29 +48,35 @@ pytestmark = [
 def smoke_results() -> list[console_smoke.PageResult]:
     """Walk every panel page once and share the results across the test(s).
 
-    Skips ONLY when the ``playwright-cli`` binary is missing (an intentional
-    "not installed" case). Once the gate is open, any live-run failure
-    (``PlaywrightCliError``, a redirect-to-login) is re-raised so the test fails
+    Skips ONLY when Playwright (or its bundled Chromium) is not installed — an
+    intentional "not installed" case. Once the gate is open, any live-run failure
+    (a :class:`~tests.e2e.console_smoke.ConsoleSmokeError` from a dead server /
+    hung navigation, or a :class:`~tests.e2e.console_smoke.RedirectedToLoginError`
+    from a broken auth) is re-raised as an ``AssertionError`` so the test fails
     loudly instead of masquerading as a skip/pass.
 
-    ``_run_cli`` converts a ``subprocess.TimeoutExpired`` into a redacted
-    ``PlaywrightCliError``; we still catch the raw ``TimeoutExpired`` here as a
-    belt-and-braces guard but deliberately do NOT interpolate the exception (its
-    ``str()`` embeds the raw argv, i.e. the cleartext password) — so a hung run
-    can never leak ``WEB_PASS`` into the failure message.
+    The failure message never interpolates the password: ``console_smoke``
+    redacts ``WEB_PASS`` from every error it raises, and we only ever surface the
+    base URL here — so a failing/hung run can never leak the secret.
     """
-    if shutil.which(console_smoke.PLAYWRIGHT_CLI) is None:
-        pytest.skip(f"{console_smoke.PLAYWRIGHT_CLI} binary not found on PATH")
+    try:
+        import playwright.sync_api  # noqa: F401
+    except ImportError:
+        pytest.skip("playwright not installed; `pip install -e .[dev]` to enable the console smoke test")
+
     base_url = os.environ.get("E2E_BASE_URL", "http://localhost:8080")
     password = os.environ.get("WEB_PASS") or None
-    settle = float(os.environ.get("E2E_SETTLE", "0") or "0")
     try:
-        return console_smoke.run_smoke(base_url, password, settle=settle)
-    except (console_smoke.PlaywrightCliError, console_smoke.RedirectedToLoginError) as exc:
+        return console_smoke.run_smoke(base_url, password)
+    except console_smoke.RedirectedToLoginError as exc:
         raise AssertionError(f"console smoke run failed against {base_url}: {exc}") from exc
-    except subprocess.TimeoutExpired:
-        # Never interpolate the exception — its str() leaks the password argv.
-        raise AssertionError(f"console smoke run timed out against {base_url}") from None
+    except console_smoke.ConsoleSmokeError as exc:
+        # A missing Chromium build raises ConsoleSmokeError at launch — treat that
+        # one operational failure as an intentional "not installed" skip; every
+        # other ConsoleSmokeError (dead server, hung nav) is a loud failure.
+        if "Executable doesn't exist" in str(exc) or "playwright install" in str(exc):
+            pytest.skip("playwright Chromium not installed; run `playwright install --with-deps chromium`")
+        raise AssertionError(f"console smoke run failed against {base_url}: {exc}") from exc
 
 
 def test_no_console_errors_on_any_page(smoke_results: list[console_smoke.PageResult]) -> None:

--- a/tests/e2e/test_console_smoke_parsing.py
+++ b/tests/e2e/test_console_smoke_parsing.py
@@ -1,57 +1,142 @@
-"""Pure-logic tests for the console-smoke helpers (issue #792).
+"""Pure-logic tests for the console-smoke helpers (issues #792, #1014).
 
-These run in normal CI (no browser, no live server) and cover the parsing /
-redaction / auth-guard logic in ``tests/e2e/console_smoke.py``. The actual
-browser-walking is exercised by the opt-in ``test_console_smoke.py``.
+These run in normal CI (no browser, no live server) and cover the
+redaction / auth-guard / dead-server / console-collection logic in
+``tests/e2e/console_smoke.py``. The actual browser-walking is exercised by the
+opt-in ``test_console_smoke.py``.
+
+Since #1014 the module drives the Playwright Python API instead of shelling out
+to ``playwright-cli``, so the old text-parsing tests (CLI stdout regex, argv
+redaction, ``### Error`` marker) are gone — but the *behaviours* they protected
+are preserved here against fake ``Page`` / ``ConsoleMessage`` objects:
+
+- secret redaction (``WEB_PASS`` never in diagnostics/exceptions),
+- the ``/login`` bounce guard (``RedirectedToLoginError`` — the false-negative fix),
+- the dead-server guard (``ConsoleSmokeError`` from a failed navigation — the
+  Python-API equivalent of the old "exit 0 + ``### Error``" guard),
+- console *error* collection (only ``console.error`` + uncaught exceptions count).
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, cast
+
 import pytest
 
 from tests.e2e import console_smoke
-from tests.e2e.console_smoke import PageResult, RedirectedToLoginError
+from tests.e2e.console_smoke import ConsoleSmokeError, PageResult, RedirectedToLoginError
 
-# Real ``playwright-cli console error`` output captured from a live run.
-_OUTPUT_WITH_ERRORS = (
-    "### Result\n"
-    "Total messages: 4 (Errors: 2, Warnings: 1)\n"
-    'Returning 2 messages for level "error"\n'
-    "\n"
-    "[ERROR] boom1 @ :0\n"
-    "[ERROR] boom2 @ :0\n"
-)
-_OUTPUT_CLEAN = "### Result\nTotal messages: 0 (Errors: 0, Warnings: 0)\n"
+if TYPE_CHECKING:
+    from playwright.sync_api import ConsoleMessage, Page
 
 
-# --- error-count parsing ----------------------------------------------------
+# --- fakes mirroring the Playwright sync API surface we use ------------------
+#
+# The console_smoke functions are typed against the real Playwright ``Page`` /
+# ``ConsoleMessage`` classes. Our fakes are structurally compatible but not
+# subclasses, so we ``cast`` them at the call site — these helpers keep the casts
+# in one place and the tests readable. The fakes never touch a real browser.
 
 
-def test_parse_error_count_with_errors() -> None:
-    assert console_smoke.parse_error_count(_OUTPUT_WITH_ERRORS) == 2
+def _as_page(page: _FakePage) -> "Page":
+    return cast("Page", page)
 
 
-def test_parse_error_count_clean() -> None:
-    assert console_smoke.parse_error_count(_OUTPUT_CLEAN) == 0
+def _as_msg(msg: _FakeConsoleMessage) -> "ConsoleMessage":
+    return cast("ConsoleMessage", msg)
 
 
-def test_parse_error_count_missing_raises() -> None:
-    with pytest.raises(console_smoke.PlaywrightCliError):
-        console_smoke.parse_error_count("garbage with no summary line")
+class _FakeConsoleMessage:
+    """Stand-in for ``playwright.sync_api.ConsoleMessage``."""
+
+    def __init__(self, type_: str, text: str, location: dict | None = None) -> None:
+        self.type = type_
+        self.text = text
+        self.location = location or {}
 
 
-def test_error_lines_extracted() -> None:
-    assert console_smoke._error_lines(_OUTPUT_WITH_ERRORS) == [
-        "[ERROR] boom1 @ :0",
-        "[ERROR] boom2 @ :0",
-    ]
+class _FakePageError(Exception):
+    """Stand-in for a ``pageerror`` payload (carries a ``.message``)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class _NavCtx:
+    """No-op stand-in for Playwright's ``expect_navigation`` context manager."""
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+class _FakePage:
+    """Minimal fake ``Page`` recording listeners and serving a scripted ``url``.
+
+    ``goto`` can be told to raise (dead-server simulation), to land on a fixed URL
+    regardless of the target (server-redirect simulation, e.g. a bounce to
+    ``/login``), or — by default — to land on exactly the requested URL.
+    ``fill`` / ``press`` / ``expect_navigation`` are no-op stand-ins so the login
+    flow can run without a browser.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str = "http://host/",
+        goto_raises: Exception | None = None,
+        lands_on: str | None = None,
+    ) -> None:
+        self.url = url
+        self._goto_raises = goto_raises
+        self._lands_on = lands_on
+        self._console_handlers: list = []
+        self._pageerror_handlers: list = []
+        self.filled: dict[str, str] = {}
+
+    def on(self, event: str, handler) -> None:  # noqa: ANN001 - test fake
+        if event == "console":
+            self._console_handlers.append(handler)
+        elif event == "pageerror":
+            self._pageerror_handlers.append(handler)
+
+    def goto(self, url: str, **_kwargs: object) -> None:
+        if self._goto_raises is not None:
+            raise self._goto_raises
+        # ``lands_on`` models a server-side redirect: the browser ends up there
+        # no matter where we asked to go (e.g. an unauthenticated bounce to /login).
+        self.url = self._lands_on if self._lands_on is not None else url
+
+    def fill(self, selector: str, value: str) -> None:
+        self.filled[selector] = value
+
+    def press(self, selector: str, key: str) -> None:  # noqa: D401 - test fake
+        pass
+
+    def expect_navigation(self, **_kwargs: object) -> "_NavCtx":
+        # The login flow only needs the ``with`` block to run the body; the
+        # navigation itself is driven by the press() side-effect in the tests.
+        return _NavCtx()
+
+    # --- helpers used only by the tests to drive the captured listeners ----
+
+    def emit_console(self, msg: _FakeConsoleMessage) -> None:
+        for handler in self._console_handlers:
+            handler(msg)
+
+    def emit_pageerror(self, exc: _FakePageError) -> None:
+        for handler in self._pageerror_handlers:
+            handler(exc)
 
 
 # --- secret redaction (no WEB_PASS in diagnostics) --------------------------
 
 
 def test_redact_replaces_secret() -> None:
-    assert console_smoke._redact("fill #password hunter2 --submit", ("hunter2",)) == "fill #password *** --submit"
+    assert console_smoke._redact("login with hunter2 now", ("hunter2",)) == "login with *** now"
 
 
 def test_redact_ignores_empty_secret() -> None:
@@ -63,90 +148,7 @@ def test_redact_handles_multiple_secrets() -> None:
     assert console_smoke._redact("a=p1 b=p2", ("p1", "p2")) == "a=*** b=***"
 
 
-def _fake_proc(returncode: int, stdout: str, stderr: str = ""):
-    class _Proc:
-        pass
-
-    p = _Proc()
-    p.returncode = returncode  # type: ignore[attr-defined]
-    p.stdout = stdout  # type: ignore[attr-defined]
-    p.stderr = stderr  # type: ignore[attr-defined]
-    return p
-
-
-def test_run_cli_redacts_secret_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A failing playwright-cli call must not echo the password into the exception.
-    monkeypatch.setattr(
-        console_smoke.subprocess, "run", lambda *a, **k: _fake_proc(1, "boom with hunter2 in output", "stderr hunter2")
-    )
-    with pytest.raises(console_smoke.PlaywrightCliError) as excinfo:
-        console_smoke._run_cli("fill", "#password", "hunter2", secrets=("hunter2",))
-    assert "hunter2" not in str(excinfo.value)
-    assert "***" in str(excinfo.value)
-
-
-def test_run_cli_redacts_secret_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
-    # CRITICAL: `fill --submit` echoes the cleartext password in its SUCCESS stdout
-    # (`...fill('hunter2')`), exit 0. _run_cli must redact the returned value too.
-    monkeypatch.setattr(
-        console_smoke.subprocess,
-        "run",
-        lambda *a, **k: _fake_proc(0, "### Ran Playwright code\nawait page.locator('#password').fill('hunter2');\n"),
-    )
-    out = console_smoke._run_cli("fill", "#password", "hunter2", "--submit", secrets=("hunter2",))
-    assert "hunter2" not in out
-    assert "***" in out
-
-
-def test_run_cli_raises_on_error_marker_despite_exit_zero(monkeypatch: pytest.MonkeyPatch) -> None:
-    # CRITICAL: playwright-cli prints `### Error` and exits 0 for a dead server /
-    # missing element / failed eval. _run_cli must treat that as a failure, else
-    # the gated smoke test passes green against a dead server.
-    monkeypatch.setattr(
-        console_smoke.subprocess,
-        "run",
-        lambda *a, **k: _fake_proc(0, "### Error\nError: net::ERR_CONNECTION_REFUSED at http://x/\n"),
-    )
-    with pytest.raises(console_smoke.PlaywrightCliError):
-        console_smoke._run_cli("goto", "http://x/")
-
-
-def test_run_cli_console_output_not_mistaken_for_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    # A normal `console error` result contains `[ERROR]` lines but NOT the literal
-    # `### Error` marker, so it must NOT be treated as a CLI failure.
-    monkeypatch.setattr(
-        console_smoke.subprocess,
-        "run",
-        lambda *a, **k: _fake_proc(0, "### Result\nTotal messages: 1 (Errors: 1, Warnings: 0)\n\n[ERROR] boom @ :0\n"),
-    )
-    out = console_smoke._run_cli("console", "error")
-    assert console_smoke.parse_error_count(out) == 1
-
-
-def test_run_cli_redacts_secret_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    # CRITICAL: subprocess.TimeoutExpired's str() embeds the raw argv (the
-    # cleartext password). _run_cli must convert it to a redacted PlaywrightCliError
-    # so a hung `fill` can't leak WEB_PASS via any caller that interpolates it.
-    def _raise_timeout(*a: object, **k: object):
-        raise console_smoke.subprocess.TimeoutExpired(
-            cmd=["playwright-cli", "fill", "#password", "hunter2", "--submit"], timeout=120
-        )
-
-    monkeypatch.setattr(console_smoke.subprocess, "run", _raise_timeout)
-    with pytest.raises(console_smoke.PlaywrightCliError) as excinfo:
-        console_smoke._run_cli("fill", "#password", "hunter2", "--submit", secrets=("hunter2",))
-    assert "hunter2" not in str(excinfo.value)
-    assert "***" in str(excinfo.value)
-    # The original TimeoutExpired (whose str() leaks the password argv) must be
-    # suppressed from the chained traceback via `raise ... from None`, so it cannot
-    # resurface through a "During handling…" context line. (We assert the chaining
-    # flags rather than scanning the formatted traceback, which here would show the
-    # test's own source line containing the literal "hunter2".)
-    assert excinfo.value.__cause__ is None
-    assert excinfo.value.__suppress_context__ is True
-
-
-# --- login-path detection / current_path ------------------------------------
+# --- login-path detection / path extraction ---------------------------------
 
 
 def test_is_login_path() -> None:
@@ -156,52 +158,123 @@ def test_is_login_path() -> None:
     assert console_smoke._is_login_path("/") is False
 
 
-def test_current_path_extracts_pathname(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(console_smoke, "_run_cli", lambda *a, **k: '### Result\n"/settings/"\n')
-    assert console_smoke.current_path() == "/settings/"
+def test_path_of_strips_host_and_query() -> None:
+    assert console_smoke._path_of("http://host:8080/channels?view=all") == "/channels"
+    assert console_smoke._path_of("http://host/settings/") == "/settings/"
+    assert console_smoke._path_of("http://host") == ""
 
 
-def test_current_path_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(console_smoke, "_run_cli", lambda *a, **k: "### Result\nno-json-here\n")
-    with pytest.raises(console_smoke.PlaywrightCliError):
-        console_smoke.current_path()
+# --- console error collection (only errors + uncaught exceptions count) -----
+
+
+def test_console_error_text_includes_location() -> None:
+    msg = _FakeConsoleMessage("error", "boom", {"url": "http://host/app.js", "lineNumber": 12})
+    assert console_smoke._console_error_text(_as_msg(msg)) == "[ERROR] boom @ http://host/app.js:12"
+
+
+def test_console_error_text_without_location() -> None:
+    msg = _FakeConsoleMessage("error", "boom", {})
+    assert console_smoke._console_error_text(_as_msg(msg)) == "[ERROR] boom"
+
+
+def test_attach_listeners_collects_only_errors() -> None:
+    page = _FakePage()
+    sink: list[str] = []
+    console_smoke._attach_error_listeners(_as_page(page), sink)
+    page.emit_console(_FakeConsoleMessage("log", "just a log"))
+    page.emit_console(_FakeConsoleMessage("warning", "just a warning"))
+    page.emit_console(_FakeConsoleMessage("error", "boom1", {"url": "u", "lineNumber": 1}))
+    page.emit_pageerror(_FakePageError("uncaught boom2"))
+    assert sink == ["[ERROR] boom1 @ u:1", "[ERROR] uncaught boom2"]
 
 
 # --- check_page auth guard (the critical false-negative fix) ----------------
 
 
-def test_check_page_raises_when_redirected_to_login(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Simulate an unauthenticated session: navigating to /settings lands on /login.
-    monkeypatch.setattr(console_smoke, "_run_cli", lambda *a, **k: "")
-    monkeypatch.setattr(console_smoke, "current_path", lambda **k: "/login")
+def test_check_page_raises_when_redirected_to_login() -> None:
+    # Simulate an unauthenticated session: navigating to /settings bounces to /login.
+    page = _FakePage(lands_on="http://host/login")
     with pytest.raises(RedirectedToLoginError):
-        console_smoke.check_page("http://host", "/settings")
+        console_smoke.check_page(_as_page(page), "http://host", "/settings")
 
 
-def test_check_page_ok_when_landed_on_target(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls: list[tuple[str, ...]] = []
-
-    def fake_run(*args: str, **kwargs: object) -> str:
-        calls.append(args)
-        if args[:1] == ("console",):
-            return _OUTPUT_CLEAN
-        return ""
-
-    monkeypatch.setattr(console_smoke, "_run_cli", fake_run)
-    monkeypatch.setattr(console_smoke, "current_path", lambda **k: "/settings/")
-    result = console_smoke.check_page("http://host", "/settings")
+def test_check_page_ok_when_landed_on_target() -> None:
+    page = _FakePage(url="http://host/")
+    result = console_smoke.check_page(_as_page(page), "http://host", "/settings")
     assert result.clean is True
     assert result.path == "/settings"
+    assert result.error_count == 0
+
+
+def test_check_page_login_page_itself_is_allowed_to_land_on_login() -> None:
     # The login page itself is allowed to "land on /login" (path == /login).
-    monkeypatch.setattr(console_smoke, "current_path", lambda **k: "/login")
-    assert console_smoke.check_page("http://host", "/login").clean is True
+    page = _FakePage(url="http://host/login")
+    assert console_smoke.check_page(_as_page(page), "http://host", "/login").clean is True
 
 
-def test_login_raises_on_wrong_password(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(console_smoke, "_run_cli", lambda *a, **k: "")
-    monkeypatch.setattr(console_smoke, "current_path", lambda **k: "/login")
+def test_check_page_collects_console_errors() -> None:
+    # A page that fires a console error should report it (not raise).
+    class _ErroringPage(_FakePage):
+        def goto(self, url: str, **kwargs: object) -> None:
+            super().goto(url, **kwargs)
+            # Errors arrive during/after navigation while the listener is live.
+            self.emit_console(_FakeConsoleMessage("error", "boom", {"url": "u", "lineNumber": 3}))
+
+    page = _ErroringPage(url="http://host/settings")
+    result = console_smoke.check_page(_as_page(page), "http://host", "/settings")
+    assert result.clean is False
+    assert result.error_count == 1
+    assert result.errors == ["[ERROR] boom @ u:3"]
+
+
+# --- dead-server guard (Python-API equivalent of "exit 0 + ### Error") ------
+
+
+def test_check_page_raises_console_smoke_error_on_dead_server() -> None:
+    # CRITICAL: a navigation failure (connection refused / timeout) must raise so
+    # a dead server can't walk every page and report "0 errors".
+    from playwright.sync_api import Error as PlaywrightError
+
+    page = _FakePage(goto_raises=PlaywrightError("net::ERR_CONNECTION_REFUSED"))
+    with pytest.raises(ConsoleSmokeError):
+        console_smoke.check_page(_as_page(page), "http://host", "/settings")
+
+
+def test_goto_redacts_secret_in_error() -> None:
+    # CRITICAL: a navigation error during login must not leak the password into
+    # the raised ConsoleSmokeError (belt-and-braces, even though the API never
+    # puts the secret on the message).
+    from playwright.sync_api import Error as PlaywrightError
+
+    page = _FakePage(goto_raises=PlaywrightError("failed near hunter2 boundary"))
+    with pytest.raises(ConsoleSmokeError) as excinfo:
+        console_smoke._goto(_as_page(page), "http://host/login", secrets=("hunter2",))
+    assert "hunter2" not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
+
+
+# --- login flow -------------------------------------------------------------
+
+
+def test_login_fills_password_and_authenticates() -> None:
+    # After a successful login the page is NOT on /login and the field was filled.
+    page = _FakePage(url="http://host/login")
+
+    # Submitting "navigates" away from /login — emulate by flipping url on press.
+    def _press(selector: str, key: str) -> None:
+        page.url = "http://host/"
+
+    page.press = _press  # type: ignore[method-assign]
+    console_smoke.login(_as_page(page), "http://host", "hunter2")
+    assert page.filled["#password"] == "hunter2"
+    assert console_smoke._path_of(page.url) == "/"
+
+
+def test_login_raises_on_wrong_password() -> None:
+    # Wrong password: the form re-renders and we stay on /login → loud failure.
+    page = _FakePage(url="http://host/login")
     with pytest.raises(RedirectedToLoginError):
-        console_smoke.login("http://host", "wrong-pass")
+        console_smoke.login(_as_page(page), "http://host", "wrong-pass")
 
 
 # --- result model / summary -------------------------------------------------

--- a/tests/e2e/test_console_smoke_parsing.py
+++ b/tests/e2e/test_console_smoke_parsing.py
@@ -19,7 +19,7 @@ are preserved here against fake ``Page`` / ``ConsoleMessage`` objects:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Callable, cast
 
 import pytest
 
@@ -96,6 +96,10 @@ class _FakePage:
         self._console_handlers: list = []
         self._pageerror_handlers: list = []
         self.filled: dict[str, str] = {}
+        self.waited_ms: list[float] = []
+        # Optional callback fired when wait_for_timeout runs, to model an error
+        # emitted asynchronously during the settle window.
+        self.on_wait: "Callable[[], None] | None" = None
 
     def on(self, event: str, handler) -> None:  # noqa: ANN001 - test fake
         if event == "console":
@@ -120,6 +124,11 @@ class _FakePage:
         # The login flow only needs the ``with`` block to run the body; the
         # navigation itself is driven by the press() side-effect in the tests.
         return _NavCtx()
+
+    def wait_for_timeout(self, ms: float) -> None:
+        self.waited_ms.append(ms)
+        if self.on_wait is not None:
+            self.on_wait()
 
     # --- helpers used only by the tests to drive the captured listeners ----
 
@@ -225,6 +234,24 @@ def test_check_page_collects_console_errors() -> None:
     assert result.clean is False
     assert result.error_count == 1
     assert result.errors == ["[ERROR] boom @ u:3"]
+
+
+def test_check_page_settle_zero_does_not_wait() -> None:
+    # The default (settle=0) must read the console immediately — no wait call.
+    page = _FakePage(url="http://host/settings")
+    console_smoke.check_page(_as_page(page), "http://host", "/settings")
+    assert page.waited_ms == []
+
+
+def test_check_page_settle_waits_and_captures_async_errors() -> None:
+    # settle>0 waits the configured window (ms) AND errors fired during it are
+    # still captured, since the listener stays attached.
+    page = _FakePage(url="http://host/settings")
+    page.on_wait = lambda: page.emit_console(_FakeConsoleMessage("error", "late", {"url": "u", "lineNumber": 9}))
+    result = console_smoke.check_page(_as_page(page), "http://host", "/settings", settle=0.5)
+    assert page.waited_ms == [500]  # 0.5s -> 500ms
+    assert result.error_count == 1
+    assert result.errors == ["[ERROR] late @ u:9"]
 
 
 # --- dead-server guard (Python-API equivalent of "exit 0 + ### Error") ------


### PR DESCRIPTION
## Что и зачем

Closes #1014 (часть #1011 · P1b — устойчивость).

Переписал `tests/e2e/console_smoke.py` с shell-out на внешний бинарь `playwright-cli` + regex-парсинг текстового вывода — на **объявленную dev-зависимость `pytest-playwright` / `playwright`** (нативный `page.goto` + `page.on("console")` / `page.on("pageerror")`). Это убирает «незаявленную внешнюю зависимость» и хрупкий парсинг CLI-вывода, даёт прямые ассерты на DOM/console.

## Сохранена ВСЯ протестированная логика (главный риск задачи)

#1011 прямо предупреждает: при переписывании теряется уже написанная и протестированная логика redaction/auth-guard — её надо аккуратно перенести. Все три гаранта сохранены и **переперекрыты** unit-тестами в `test_console_smoke_parsing.py`:

- **Redaction пароля** — `WEB_PASS` вычищается из всех диагностик/исключений модуля (belt-and-braces: Python API не кладёт пароль в argv, как старый CLI).
- **Auth через реальную форму** (POST `/login` → cookie), не creds-in-URL → 303-ловушка не пройдёт молча; после каждого `goto` ассертим, что страница не отскочила на `/login` (`RedirectedToLoginError`).
- **Мёртвый сервер** — упавшая навигация бросает `ConsoleSmokeError` (Python-эквивалент старого «exit 0 + `### Error`»): немой/сломанный сервер падает громко, а не рапортует «0 ошибок».

## Изменения

- `tests/e2e/console_smoke.py` — переписано ядро на Playwright Python API.
- `tests/e2e/test_console_smoke.py` — опт-ин wrapper (gate `RUN_E2E_CONSOLE_SMOKE=1`): скипает только если Playwright/Chromium не установлен, иначе любой live-сбой — громкий fail.
- `tests/e2e/test_console_smoke_parsing.py` — устаревшие CLI-stdout-тесты заменены на фейки, упражняющие те же поведения; guard `test_panel_paths_match_issue_list` сохранён.
- `pyproject.toml` — `[dev] += playwright, pytest-playwright`.
- `tests/e2e/README.md` — обновлён раздел запуска + установка браузера.

## CI намеренно не тронут

`.github/workflows/ci.yml` **не изменён**. e2e CI-job из P1a был откатан на main (#1018), и задача поставлена как **локальная** (gate + локальный `python -m src.main serve`). Проверка остаётся local-only.

## Проверки

- `pytest` весь suite: **8413 passed (parallel) + 898 passed (serial), 0 failed**, e2e-обёртка скипается (gate закрыт).
- `ruff check` — clean.
- `mypy` — чисто на всех трёх e2e-файлах (baseline сохранён).
- `filterwarnings=["error"]` соблюдён — playwright не сыпет DeprecationWarning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)